### PR TITLE
Remove ssh key pair now that we're public.

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -136,63 +136,12 @@ ruby193-rubygem-qpid_messaging
 
 %post --log=/root/anaconda-post.log
 
-# Setup private/public ssh throwaway keys while we're private:
-mkdir -p /root/.ssh
-cat <<'EOF' > /root/.ssh/id_rsa
------BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAsS9AzeaSc/mjB2o+/v4HmAqn/Hrq8U630qYlHu3ctfP32SYf
-OyseR5pfgXWf2H+/85y6XCgv7AMMNpnWKeDfAWhMw5dmjrcWrqBPRvcjkApLQii4
-gnlQpsxn342LTcY2LYAA/81l1cCniSUIkWT3HAkV1EhnAn7Goqbsy3Rh10qf2UiN
-teto6oQ73BGDsFrNMZdGq9gIfCp17QpFdjjnKEyCRzH9VoRrMsFLE6Trq1qe2j7E
-9qwGsi6he+4Lp8uU6PByfaR/5GTQ6msGrtNadAUxcerb+UWgY6Jutk/sF3Lx7Sa8
-ddpXNC7KF6OiFMt55jHynq0UsFb9OhcXQ3s4KwIBIwKCAQEAiK9sgZSc3R+ppqJr
-HHrSqH0/wsU45gmGfe3iHyyFsO9nbQAmuJ2bBAlfnmINmGKMwz5j4LFJii48nyY3
-f2RUQuoPVQ5lDwJEspjssxZr5CUyvgIn759qGkXpuxVrdoL2mCDq0/Y4nZSef717
-o1yEHPEQ1vYGUmHMbtiKyNYfl3LMEDxkcYSm+kUB6sd2Jm4LPAGGUns6EDcYAYpW
-4sMNngFNnW4XvkvWqE9vwgTppVLJAzwmwmQ8hXIqz3DB41LxQ9Z3fyw9gTj7lQJ7
-xNx6vyyvRud/ZTgIvUXVejl+uugFdYEugSnrfTapT0ZffMlevZsP+to1+FE+kAhs
-r5YGqwKBgQDdicX//GoUGrCgWEvZzo2d5eAI43si8Op4K1FTFal3AOGFQqf2VloG
-/TF7Tr+F7JtYu2EDCv1apCtWUa4dM2dLpZEF1C6rXg7HjbRY2mqIh1LAmZjfeleC
-UCKkeqCmf7P6ieN/X1DqHlKNVm2ial8Q4DwWZxoS4BULsDXcTO+UUQKBgQDMvzRE
-aLjuIxtWqMMaNLnLZjoBcGfTKmDeo0f9AbiEbY85l0cql7UeisoGAkdTULxBjHNW
-ycRwkG9Mjx+K0nQHB+EdnE9x1VgFm42Ipc/BB9dUvscU+7hxj+xgK3e0RqUpMzz3
-UqhrOqhXzDmW2UFy87sTWrEHtEpnjMzT//iRuwKBgQDXNWFB0KGP32nAVcYGyKbT
-5p8ek9a0On1eyv6LOZ1PCCuIxGimJ/+vBJZ3yNdO5di8mMSj3so6y11MidxW4XpJ
-fEO8hPoi0GYg8A5Hr5qwg3T1nIXgaDfAaxpWowJ12yPdcAGRrQzGLBWt3u4ovxqF
-bB0dE7Ltw7ysRMabffAMawKBgQCd8pYI4xJRTkhKKmqfL/0Kn1FRkTomjmf8NNEi
-QyfxIVE7DkzXttwtgQI/JlRHlg2RptyiCV0GYMrjSdaBCL/oKqZYq8hB3xgEU20u
-5k/PbHLpmnxSBANQSnSEs9FfLy7z5bKwKdJhWSLHYwfaxNq3w1XNGhOJmbW9mIDA
-zMcRVQKBgQCmVmD7x85hx+nT1cKnnMKTFRGUh9ktMT0pqOnQJP8l94YeL4lbPwuP
-PoXdJ9T/6oTuYFG4EHtPsyxQevSzvei7BynnLan9CyaLdyES4xLMvq4u5hoOZAfD
-ccRY31BgLZl2Gr5/rsnppgNZg0GJ1LfGd4Bb8HDSW9aplsT2uqakLg==
------END RSA PRIVATE KEY-----
-EOF
-
-cat <<'EOF' > /root/.ssh/id_rsa.pub
-ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAsS9AzeaSc/mjB2o+/v4HmAqn/Hrq8U630qYlHu3ctfP32SYfOyseR5pfgXWf2H+/85y6XCgv7AMMNpnWKeDfAWhMw5dmjrcWrqBPRvcjkApLQii4gnlQpsxn342LTcY2LYAA/81l1cCniSUIkWT3HAkV1EhnAn7Goqbsy3Rh10qf2UiNteto6oQ73BGDsFrNMZdGq9gIfCp17QpFdjjnKEyCRzH9VoRrMsFLE6Trq1qe2j7E9qwGsi6he+4Lp8uU6PByfaR/5GTQ6msGrtNadAUxcerb+UWgY6Jutk/sF3Lx7Sa8ddpXNC7KF6OiFMt55jHynq0UsFb9OhcXQ3s4Kw== cfme.build@gmail.com
-EOF
-
-cat <<'EOF' > /root/.ssh/known_hosts
-github.com,www.github.com,192.30.252.131 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-EOF
-
-# Make the private key unreadable by others
-chmod 600 /root/.ssh/id_rsa
-
-ls -l /root/.ssh/*
-
-ping -c 3 -i 1 www.github.com
-echo "ping returned: $?"
-
-ssh -vT -o StrictHostKeyChecking=no git@www.github.com
-echo "ssh to github returned: $?"
-
 www_root="/var/www"
 app_root="$www_root/miq"
 
 rm -rf $app_root
 
-git clone git@github.com:ManageIQ/manageiq.git $app_root
+git clone https://github.com/ManageIQ/manageiq.git $app_root
 pushd $app_root
 
 #### TODO: Refactor this so the cfme rpm and the upstream share much of this code.


### PR DESCRIPTION
@chessbyte @Fryguy Before we go public, we need to remove/revoke this key, then we can go public, merge this PR, and test building appliances with the public repository.
