### PR TITLE
Add support for service hierarchies

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_dynatree.js
+++ b/vmdb/app/assets/javascripts/cfme_dynatree.js
@@ -73,7 +73,7 @@ function cfme_bind_hover_event(tree_name) {
 // OnClick handler to run tree_select server method
 function cfmeOnClick_SelectTreeNode(id) {
   rec_id = id.split('__')
-  new Ajax.Request(encodeURI("tree_select/?id=" + rec_id[0]),
+  new Ajax.Request(encodeURI("/" + miq_controller + "/tree_select/?id=" + rec_id[0]),
     {asynchronous:true, evalScripts:true,
       onLoading:function(request){miqSparkle(true);}}
   );

--- a/vmdb/app/controllers/service_controller.rb
+++ b/vmdb/app/controllers/service_controller.rb
@@ -76,6 +76,11 @@ class ServiceController < ApplicationController
       return
     end
 
+    if params[:id]  # If a tree node id came in, show in one of the trees
+      nodetype, id = params[:id].split("-")
+      self.x_node = "#{nodetype}-#{to_cid(id)}"
+    end
+
     # Build the Explorer screen from scratch
     @built_trees   = []
     @accords = []
@@ -91,10 +96,6 @@ class ServiceController < ApplicationController
     params.merge!(session[:exp_parms]) if session[:exp_parms]  # Grab any explorer parm overrides
     session.delete(:exp_parms)
 
-    if params[:id]  # If a tree node id came in, show in one of the trees
-      nodetype, id = params[:id].split("-")
-      self.x_node = "#{nodetype}-#{to_cid(id)}"
-    end
     get_node_info(x_node)
     @in_a_form = false
 

--- a/vmdb/app/helpers/service_helper/textual_summary.rb
+++ b/vmdb/app/helpers/service_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    items = %w{catalog_item}
+    items = %w(catalog_item parent_service)
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -80,6 +80,17 @@ module ServiceHelper::TextualSummary
       s[:link]  = url_for(:controller => 'catalog', :action => 'show', :id => st)
     end
     s
+  end
+
+  def textual_parent_service
+    parent = @record.parent_service
+    {
+      :label => "Parent Service",
+      :image => parent.picture ? "/pictures/#{parent.picture.basename}" : 'service',
+      :value => parent.name,
+      :title => "Show this Service's Parent Service",
+      :link  => url_for(:controller => 'service', :action => 'show', :id => parent)
+    } if parent
   end
 
   def textual_owner

--- a/vmdb/app/models/service.rb
+++ b/vmdb/app/models/service.rb
@@ -1,10 +1,10 @@
 class Service < ActiveRecord::Base
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
 
-  belongs_to      :service_template  # Template this service was cloned from
-  belongs_to      :service           # Parent Service
-  has_many        :services          # Child services
-  has_many        :ems_events
+  belongs_to :service_template               # Template this service was cloned from
+  belongs_to :service                        # Parent Service
+  has_many :services, :dependent => :destroy # Child services
+  has_many :ems_events
 
   virtual_belongs_to :parent_service
   virtual_has_many   :direct_service_children
@@ -19,6 +19,8 @@ class Service < ActiveRecord::Base
   include_concern 'Aggregation'
 
   virtual_column :has_parent,                               :type => :boolean
+
+  validates_presence_of :name
 
   def add_resource(rsc, options={})
     raise MiqException::Error, "Vm <#{rsc.name}> is already connected to a service." if rsc.kind_of?(Vm) && !rsc.service.nil?

--- a/vmdb/app/models/service/retirement_management.rb
+++ b/vmdb/app/models/service/retirement_management.rb
@@ -10,6 +10,9 @@ module Service::RetirementManagement
   end
 
   def before_retirement
+    services.each do |s|
+      s.retire_now
+    end
     self.service_resources.each do |sr|
       sr.resource.retire_now if sr.resource.respond_to?(:retire_now)
     end

--- a/vmdb/app/models/service_template.rb
+++ b/vmdb/app/models/service_template.rb
@@ -53,6 +53,9 @@ class ServiceTemplate < ActiveRecord::Base
     nh = self.attributes.dup
     (nh.keys - Service.column_names + %w{created_at guid service_template_id updated_at id type prov_type}).each {|key| nh.delete(key)}
 
+    # Hide child services by default
+    nh[:display] = false if parent_svc
+
     # Determine service name
     # target_name = self.get_option(:target_name)
     # nh.merge!('name' => target_name) unless target_name.blank?

--- a/vmdb/app/presenters/tree_builder.rb
+++ b/vmdb/app/presenters/tree_builder.rb
@@ -203,6 +203,7 @@ class TreeBuilder
                                                     x_get_tree_g_kids(object, options) : nil
                         when MiqRegion           then x_get_tree_region_kids(object, options)
                         when PxeServer           then x_get_tree_pxe_server_kids(object, options)
+                        when Service             then x_get_tree_service_kids(object, options)
                         when ServiceTemplateCatalog
                                                  then x_get_tree_stc_kids(object, options)
                         when ServiceTemplate		 then x_get_tree_st_kids(object, options)

--- a/vmdb/app/presenters/tree_builder_services.rb
+++ b/vmdb/app/presenters/tree_builder_services.rb
@@ -20,4 +20,9 @@ class TreeBuilderServices < TreeBuilder
   def x_get_tree_roots(options)
     count_only_or_objects(options[:count_only], rbac_filtered_objects(Service.where(:service_id => nil)), "name")
   end
+
+  def x_get_tree_service_kids(object, options)
+    objects = rbac_filtered_objects(object.direct_service_children.select(&:display).sort_by { |o| o.name.downcase })
+    count_only_or_objects(options[:count_only], objects, 'name')
+  end
 end

--- a/vmdb/app/views/shared/summary/_textual.html.erb
+++ b/vmdb/app/views/shared/summary/_textual.html.erb
@@ -20,7 +20,7 @@
         <td class="label"><%= item[:label] %></td>
         <td>
           <% if item[:image] %>
-            <img src="/images/icons/new/<%= item[:image] %>.png" />
+            <img src="<%= File.absolute_path("#{item[:image]}#{'.png' if File.extname(item[:image]).blank?}", '/images/icons/new')%>" />
           <% end %>
           <%= !item[:value].kind_of?(Array) ? item[:value] : render(:partial => "shared/summary/textual_multivalue", :locals => {:items => item[:value]}) %>
         </td>

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1344,6 +1344,7 @@ Vmdb::Application.routes.draw do
         service_form_field_changed
         service_tag
         tag_edit_form_field_changed
+        tree_autoload_dynatree
         tree_select
         x_button
         x_history

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
@@ -41,6 +41,90 @@ module MiqAeServiceServiceSpec
       @service.description.should == 'new_test_description'
     end
 
+    context "#display=" do
+      it "updates the display visibility" do
+        @service.display = true
+        @service.save
+
+        method = "$evm.root['service'].display = false"
+        @ae_method.update_attributes(:data => method)
+        invoke_ae
+
+        @service.reload
+        @service.display.should be_false
+      end
+    end
+
+    context "#parent_service=" do
+      before(:each) do
+        @parent = FactoryGirl.create(:service, :name => "parent_service")
+      end
+
+      it "updates the parent service" do
+        method = "$evm.root['service'].parent_service = $evm.vmdb('service').find(#{@parent.id})"
+        @ae_method.update_attributes(:data => method)
+        invoke_ae
+
+        @parent.reload
+        @parent.direct_service_children.collect(&:id).should == [@service.id]
+      end
+
+      it "clears the parent service" do
+        method = "$evm.root['service'].parent_service = nil"
+        @ae_method.update_attributes(:data => method)
+        invoke_ae
+
+        @parent.reload
+        @parent.direct_service_children.should == []
+      end
+
+      it "validates the parent service" do
+        method = "$evm.root['service'].parent_service = 'validate'"
+        @ae_method.update_attributes(:data => method)
+
+        expect { invoke_ae }.to raise_error(MiqAeException::AbortInstantiation)
+      end
+    end
+
+    context "#self.create" do
+      it "creates a new service" do
+        service_template = FactoryGirl.create(:service_template, :name => 'Dummy')
+        service_name = 'service name'
+        description = 'description'
+        method = <<EOF
+  service_template = $evm.vmdb('service_template').find(#{service_template.id})
+  $evm.vmdb('service').create(:name             => '#{service_name}',
+                              :description      => '#{description}',
+                              :service_template => service_template)
+EOF
+        @ae_method.update_attributes(:data => method)
+        invoke_ae
+
+        service = Service.find_by_name(service_name)
+        service.should_not be_nil
+        service.name.should be == service_name
+        service.description.should be == description
+        service.service_template.should_not be_nil
+        service.service_template.id.should be == service_template.id
+      end
+
+      it "requires a service name" do
+        method = "$evm.vmdb('service').create()"
+        @ae_method.update_attributes(:data => method)
+
+        expect { invoke_ae }.to raise_error(MiqAeException::AbortInstantiation)
+      end
+
+      it "ignores attributes that cannot be overridden" do
+        service_name = 'test service name'
+        method = "$evm.vmdb('service').create(:name => '#{service_name}', :some_invalid_attr => 1)"
+        @ae_method.update_attributes(:data => method)
+
+        expect { invoke_ae }.to_not raise_error
+        Service.find_by_name(service_name).should_not be_nil
+      end
+    end
+
     pending "Not yet implemented: specs" do
       it "#retires_on="
       it "#retirement_warn="

--- a/vmdb/spec/models/service/retirement_management_spec.rb
+++ b/vmdb/spec/models/service/retirement_management_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe "Service Retirement Management" do
+
   before(:each) do
     @guid = MiqUUID.new_guid
     MiqServer.stub(:my_guid).and_return(@guid)
@@ -37,5 +38,33 @@ describe "Service Retirement Management" do
     service.retires_on = Date.today - 1.day
     service.save!
     service.retirement_due?.should be_true
+  end
+
+  context "multi-tier service" do
+    before(:each) do
+      @svc1 = FactoryGirl.create(:service, :name => 'svc1')
+      @svc2 = FactoryGirl.create(:service, :name => 'svc2', :service => @svc1)
+      @svc3 = FactoryGirl.create(:service, :name => 'svc3', :service => @svc2)
+    end
+
+    context "#retire_now" do
+      it "retires all child and grandchild services" do
+        @svc1.retire_now
+        @svc2.reload
+        @svc3.reload
+        @svc1.retired?.should be_true
+        @svc2.retired?.should be_true
+        @svc3.retired?.should be_true
+      end
+
+      it "retires children but not the parent" do
+        @svc2.retire_now
+        @svc1.reload
+        @svc3.reload
+        @svc1.retired?.should be_false
+        @svc2.retired?.should be_true
+        @svc3.retired?.should be_true
+      end
+    end
   end
 end

--- a/vmdb/spec/routing/service_routing_spec.rb
+++ b/vmdb/spec/routing/service_routing_spec.rb
@@ -101,6 +101,14 @@ describe 'routes for ServiceController' do
     end
   end
 
+  describe '#tree_autoload_dynatree' do
+    it 'routes with POST' do
+      expect(
+        post("/#{controller_name}/tree_autoload_dynatree")
+      ).to route_to("#{controller_name}#tree_autoload_dynatree")
+    end
+  end
+
   describe "#tree_select" do
     it "routes with POST" do
       expect(post("/service/tree_select")).to route_to("service#tree_select")


### PR DESCRIPTION
For multipart service deployments, parent/child
relationships between services can now be visualized
in the 'My Services' tree view.

The visibility of child services needs to be enabled
via the "display" attribute on MiqAeServiceService
for child services to appear in the hierarchy, by
default they are hidden. Also added an explicit
method for create new Service records via automation.

https://bugzilla.redhat.com/show_bug.cgi?id=1059834
