### PR TITLE
Add support for custom attributes for services

### DIFF
--- a/vmdb/app/helpers/service_helper/textual_summary.rb
+++ b/vmdb/app/helpers/service_helper/textual_summary.rb
@@ -31,6 +31,12 @@ module ServiceHelper::TextualSummary
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
+  def textual_group_miq_custom_attributes
+    items = %w(miq_custom_attributes)
+    ret = items.collect { |m| send("textual_#{m}") }.flatten.compact
+    ret.blank? ? nil : ret
+  end
+
   #
   # Items
   #
@@ -109,4 +115,9 @@ module ServiceHelper::TextualSummary
     h
   end
 
+  def textual_miq_custom_attributes
+    attrs = @record.miq_custom_attributes
+    return nil if attrs.blank?
+    attrs.collect { |a| {:label => a.name, :value => a.value} }
+  end
 end

--- a/vmdb/app/models/service.rb
+++ b/vmdb/app/models/service.rb
@@ -14,6 +14,7 @@ class Service < ActiveRecord::Base
 
   include ServiceMixin
   include OwnershipMixin
+  include CustomAttributeMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'

--- a/vmdb/app/views/service/_svcs_show.erb
+++ b/vmdb/app/views/service/_svcs_show.erb
@@ -5,6 +5,7 @@
       <%= render :partial => "shared/summary/textual", :locals => { :title => "Properties", :items => textual_group_properties } %>
       <%= render :partial => "shared/summary/textual", :locals => { :title => "Lifecycle", :items => textual_group_lifecycle } %>
       <%= render :partial => "shared/summary/textual", :locals => { :title => "Relationships", :items => textual_group_relationships } %>
+      <%= render :partial => "shared/summary/textual", :locals => { :title => "Custom Attributes", :items => textual_group_miq_custom_attributes } %>
     </dd>
     <dd>
       <%= render :partial => "shared/summary/textual", :locals => { :title => "Totals for Service VMs", :items => textual_group_vm_totals } %>

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -13,6 +13,9 @@ module MiqAeMethodService
     expose :direct_service_children
     expose :indirect_service_children
     expose :parent_service
+    expose :custom_keys, :method => :miq_custom_keys
+    expose :custom_get, :method => :miq_custom_get
+    expose :custom_set, :method => :miq_custom_set, :override_return => true
 
 
     def name=(new_name)


### PR DESCRIPTION
Automation can now use the "custom_keys", "custom_set", and "custom_get"
methods to manipulate the custom attributes on a service.  Any associated
custom attributes are now visible on the service details page.

https://bugzilla.redhat.com/show_bug.cgi?id=1108331
