### PR TITLE
Add optional regexp validation to service dialogs

### DIFF
--- a/vmdb/app/models/dialog_field_text_box.rb
+++ b/vmdb/app/models/dialog_field_text_box.rb
@@ -18,4 +18,11 @@ class DialogFieldTextBox < DialogField
     super
   end
 
+  def validate(dialog_tab, dialog_group)
+    case validator_type
+    when 'regex'
+      return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.match(/#{validator_rule}/)
+    end
+    super
+  end
 end

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -71,6 +71,24 @@
               = check_box_tag('field_required', 'true',
                             @edit[:field_required],
                             "data-miq_observe_checkbox"=>{:url=>url}.to_json)
+          - if @edit[:field_typ].include?('TextBox')
+            %tr
+              %td.key Validator Type
+              %td
+                = select_tag('field_validator_type',
+                              options_for_select([["None", nil], ["Regular Expression", 'regex']],
+                                                 @edit[:field_validator_type]),
+                              "data-miq_sparkle_on" => true,
+                              "data-miq_observe"    => {:url => url}.to_json)
+            %tr
+              %td.key Validator Rule
+              %td
+                \/
+                = text_field_tag("field_validator_rule", @edit[:field_validator_rule],
+                                 "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+                                 :disabled          => @edit[:field_validator_type].blank?,
+                                 :maxlength         => 250)
+                \/
         - elsif ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(@edit[:field_typ])
           %tr
             %td.key Show Past Dates

--- a/vmdb/db/migrate/20140428145436_add_validator_to_service_dialog_field.rb
+++ b/vmdb/db/migrate/20140428145436_add_validator_to_service_dialog_field.rb
@@ -1,0 +1,6 @@
+class AddValidatorToServiceDialogField < ActiveRecord::Migration
+  def change
+    add_column :dialog_fields, :validator_type, :string
+    add_column :dialog_fields, :validator_rule, :string
+  end
+end

--- a/vmdb/spec/models/dialog_field_text_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_box_spec.rb
@@ -61,4 +61,35 @@ describe DialogFieldTextBox do
 
   end
 
+  context "validation" do
+    let(:df) { FactoryGirl.build(:dialog_field_text_box, :label => 'test field', :name => 'test field') }
+
+    context "#validate" do
+      let(:dt) { active_record_instance_double('DialogTab', :label => 'tab') }
+      let(:dg) { active_record_instance_double('DialogGroup', :label => 'group') }
+
+      before(:each) do
+        df.validator_type = 'regex'
+        df.validator_rule = '[aA]bc'
+        df.required = true
+      end
+
+      it "should return nil when no error is detected" do
+        df.value = 'Abc'
+        df.validate(dt, dg).should be_nil
+      end
+
+      it "should return an error when the value doesn't match the regex rule" do
+        df.value = '123'
+        df.validate(dt, dg).should == 'tab/group/test field is invalid'
+      end
+
+      it "should return an error when a required value is not provided" do
+        df.value = ''
+        df.validator_rule = ''
+        df.validate(dt, dg).should == 'tab/group/test field is required'
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Text boxes now expose a drop-down for validator type and
a text field for validator rule. When 'Regular Expression'
is selected for the validator type, user input will be
matched against the provided validator rule. This is similar
to how Foreman validates user input for Smart Variables.

https://bugzilla.redhat.com/show_bug.cgi?id=1085158
