### PR TITLE
Dump the type of top-level VIM object.

### DIFF
--- a/lib/VMwareWebService/MiqVimDump.rb
+++ b/lib/VMwareWebService/MiqVimDump.rb
@@ -3,6 +3,10 @@ module MiqVimDump
     def dumpObj(obj, level=0)
         @globalIndent = "" if !@globalIndent
         @dumpToLog = false if @dumpToLog.nil?
+        if level == 0 && obj.respond_to?(:xsiType) && !obj.xsiType.nil?
+        	indentedPrint("#{obj.class.name} <#{obj.xsiType}>:", 0)
+        	@globalIndent = @globalIndent + "    "
+        end
 	    if obj.kind_of? Array
             dumpArray(obj, level)
         elsif obj.kind_of? Hash


### PR DESCRIPTION
@Fryguy @chessbyte please review.

In the MiqVimDump module, modify dumpObj() to print the type of the top-level object.
While generally useful, it's being added to help debug the VirtualE1000e mapping registry issue.
