### PR TITLE
Fix replication with a migration for databases upgraded from v4.

### DIFF
--- a/vmdb/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
+++ b/vmdb/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
@@ -1,0 +1,171 @@
+class FixReplicationOnUpgradeFromVersionFour < ActiveRecord::Migration
+  include MigrationHelper
+  include MigrationHelper::SharedStubs
+
+  class Configuration < ActiveRecord::Base
+    serialize :settings
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  V5_DEFAULT_EXCLUDE_TABLES = %w{
+    assigned_server_roles
+    audit_events
+    binary_blobs
+    binary_blob_parts
+    chargeback_rate_details
+    chargeback_rates
+    conditions
+    conditions_miq_policies
+    configurations
+    custom_buttons
+    customization_specs
+    database_backups
+    event_logs
+    file_depots
+    jobs
+    log_files
+    metrics
+    metrics_00
+    metrics_01
+    metrics_02
+    metrics_03
+    metrics_04
+    metrics_05
+    metrics_06
+    metrics_07
+    metrics_08
+    metrics_09
+    metrics_10
+    metrics_11
+    metrics_12
+    metrics_13
+    metrics_14
+    metrics_15
+    metrics_16
+    metrics_17
+    metrics_18
+    metrics_19
+    metrics_20
+    metrics_21
+    metrics_22
+    metrics_23
+    metric_rollups
+    miq_actions
+    miq_ae_classes
+    miq_ae_fields
+    miq_ae_instances
+    miq_ae_methods
+    miq_ae_namespaces
+    miq_ae_values
+    miq_ae_workspaces
+    miq_alert_statuses
+    miq_alerts
+    miq_databases
+    miq_enterprises
+    miq_events
+    miq_globals
+    miq_groups
+    miq_license_contents
+    miq_policies
+    miq_policy_contents
+    miq_product_features
+    miq_proxies_product_updates
+    miq_proxies
+    miq_queue
+    miq_roles_features
+    miq_report_result_details
+    miq_report_results
+    miq_reports
+    miq_searches
+    miq_servers_product_updates
+    miq_sets
+    miq_schedules
+    miq_tasks
+    miq_user_roles
+    miq_widgets
+    miq_widget_contents
+    miq_workers
+    product_updates
+    proxy_tasks
+    rss_feeds
+    schema_migrations
+    server_roles
+    sessions
+    ui_tasks
+    vim_performances
+    vim_performance_states
+    vim_performance_tag_values
+    vmdb_database_metrics
+    vmdb_databases
+    vmdb_indexes
+    vmdb_metrics
+    vmdb_tables
+  }
+
+  RENAMED_TABLES = {
+    "states"                => "drift_states",
+    "miq_cim_derived_stats" => "miq_cim_derived_metrics",
+    "miq_provisions"        => "miq_request_tasks",
+    "miq_cim_stats"         => "miq_storage_metrics",
+    "storages_vms"          => "storages_vms_and_templates",
+  }
+
+  REMOVED_TABLES = %w{
+    automation_requests
+    automation_tasks
+    miq_provision_requests
+    vim_performances
+  }
+
+  def up
+    say_with_time("Updating configurations for replication") do
+      path = ["workers", "worker_base", :replication_worker, :replication]
+      Configuration.where(:typ => "vmdb").each do |c|
+        settings_path = path.dup.push(:include_tables)
+        Rails.logger.info("Removing the path [#{settings_path.join(", ")}] from Configuration id [#{c.id}].")
+        Rails.logger.info("Current value is:\n#{c.settings.fetch_path(settings_path).to_yaml}")
+        c.settings.delete_path(settings_path)
+
+        settings_path = path.dup.push(:exclude_tables)
+        Rails.logger.info("Replacing the path [#{settings_path.join(", ")}] from Configuration id [#{c.id}].")
+        Rails.logger.info("Current value is:\n#{c.settings.fetch_path(settings_path).to_yaml}")
+        c.settings.store_path(settings_path, V5_DEFAULT_EXCLUDE_TABLES)
+
+        c.save!
+      end
+    end
+
+    if RrSyncState.table_exists?
+      prefix = "rr#{ActiveRecord::Base.my_region_number}"
+      RENAMED_TABLES.each do |old_name, new_name|
+        drop_trigger(new_name, "#{prefix}_#{old_name}")
+      end
+
+      say_with_time("Updating #{RrPendingChange.table_name} for renamed tables") do
+        RENAMED_TABLES.each do |old_name, new_name|
+          RrPendingChange.where(:change_table => old_name).update_all(:change_table => new_name)
+        end
+      end
+
+      say_with_time("Updating #{RrSyncState.table_name} for renamed tables") do
+        RENAMED_TABLES.each do |old_name, new_name|
+          RrSyncState.where(:table_name => old_name).update_all(:table_name => new_name)
+        end
+      end
+
+      say_with_time("Updating #{RrSyncState.table_name} for removed tables") do
+        RrSyncState.where(:table_name => REMOVED_TABLES).delete_all
+      end
+
+      require 'awesome_spawn'
+
+      say_with_time("Preparing rubyrep") do
+        AwesomeSpawn.run!("bin/rake evm:dbsync:prepare_replication_without_sync")
+      end
+
+      say_with_time("Uninstalling rubyrep for renamed tables") do
+        AwesomeSpawn.run!("bin/rake evm:dbsync:uninstall #{RENAMED_TABLES.values.join(" ")}")
+      end
+    end
+  end
+end

--- a/vmdb/lib/migration_helper.rb
+++ b/vmdb/lib/migration_helper.rb
@@ -1,3 +1,11 @@
+# MigrationHelper is a module that can be included into migrations to add
+# additional helper methods, thus eliminating some duplication and database
+# specific coding.
+#
+# If mixed into a non-migration class, the module expects the following methods
+# to be defined as in a migration: connection, say, say_with_time.  Additionally,
+# any "extension" methods will need the original method defined.  For example,
+# remove_index_ex expects remove_index to be defined.
 module MigrationHelper
   BULK_COPY_DIRECTORY = File.expand_path(File.join(Rails.root, %w{tmp bulk_copy}))
 
@@ -320,7 +328,7 @@ module MigrationHelper
   def drop_trigger_postgresql(table, name)
     say_with_time("drop_trigger(:#{table}, :#{name})") do
       connection.execute("DROP TRIGGER IF EXISTS #{name} ON #{table};", 'Drop trigger')
-      connection.execute("DROP FUNCTION #{name}();", 'Drop trigger function')
+      connection.execute("DROP FUNCTION IF EXISTS #{name}();", 'Drop trigger function')
     end
   end
 

--- a/vmdb/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
+++ b/vmdb/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
@@ -1,0 +1,117 @@
+require_relative '../spec_helper'
+require Rails.root.join("db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb")
+
+describe FixReplicationOnUpgradeFromVersionFour do
+  let(:configuration_stub)  { migration_stub(:Configuration) }
+  let(:pending_change_stub) { migration_stub(:RrPendingChange) }
+  let(:sync_state_stub)     { migration_stub(:RrSyncState) }
+
+  migration_context :up do
+    it "updates the configuration to have the new replication settings" do
+      old_settings = {
+        "workers" => {
+          "worker_base" => {
+            :replication_worker => {
+              :replication => {
+                :include_tables => ["."],
+                :exclude_tables => [
+                  "doesn't",
+                  "really",
+                  "matter"
+                ]
+              }
+            }
+          }
+        }
+      }
+      configuration_stub.create!(:typ => 'vmdb', :settings => old_settings)
+
+      migrate
+
+      settings = configuration_stub.first.settings
+      settings.key_path?("workers", "worker_base", :replication_worker, :replication, :include_tables).should be_false
+      settings.fetch_path("workers", "worker_base", :replication_worker, :replication, :exclude_tables).should eq(described_class::V5_DEFAULT_EXCLUDE_TABLES)
+    end
+
+    context "handles replication" do
+      before do
+        pending_change_stub.create_table
+        sync_state_stub.create_table
+      end
+
+      def expect_replication_shell_calls
+        # HACK: Just verify that the callouts are made...we can't actually run
+        # them unless we have replication set up, which is not yet possible in a
+        # migration spec.
+        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:dbsync:prepare_replication_without_sync")
+        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:dbsync:uninstall drift_states miq_cim_derived_metrics miq_request_tasks miq_storage_metrics storages_vms_and_templates")
+      end
+
+      it "for renamed tables in rr_pending_changes" do
+        changed = [
+          pending_change_stub.create!(:change_table => "states"),
+          pending_change_stub.create!(:change_table => "miq_cim_derived_stats"),
+          pending_change_stub.create!(:change_table => "miq_provisions"),
+          pending_change_stub.create!(:change_table => "miq_cim_stats"),
+          pending_change_stub.create!(:change_table => "storages_vms")
+        ]
+        ignored = pending_change_stub.create!(:change_table => "accounts")
+
+        expect_replication_shell_calls
+
+        migrate
+
+        changed.collect { |c| c.reload.change_table }.should == %w{
+          drift_states
+          miq_cim_derived_metrics
+          miq_request_tasks
+          miq_storage_metrics
+          storages_vms_and_templates
+        }
+        ignored.reload.change_table.should == "accounts"
+      end
+
+      it "for renamed tables in rr_sync_states" do
+        changed = [
+          sync_state_stub.create!(:table_name => "states"),
+          sync_state_stub.create!(:table_name => "miq_cim_derived_stats"),
+          sync_state_stub.create!(:table_name => "miq_provisions"),
+          sync_state_stub.create!(:table_name => "miq_cim_stats"),
+          sync_state_stub.create!(:table_name => "storages_vms")
+        ]
+        ignored = sync_state_stub.create!(:table_name => "accounts")
+
+        expect_replication_shell_calls
+
+        migrate
+
+        changed.collect { |c| c.reload.table_name }.should == %w{
+          drift_states
+          miq_cim_derived_metrics
+          miq_request_tasks
+          miq_storage_metrics
+          storages_vms_and_templates
+        }
+        ignored.reload.table_name.should == "accounts"
+      end
+
+      it "for removed tables in rr_sync_states" do
+        deleted = [
+          sync_state_stub.create!(:table_name => "automation_requests"),
+          sync_state_stub.create!(:table_name => "automation_tasks"),
+          sync_state_stub.create!(:table_name => "miq_provision_requests"),
+          sync_state_stub.create!(:table_name => "vim_performances")
+        ]
+        ignored = sync_state_stub.create!(:table_name => "accounts")
+
+        expect_replication_shell_calls
+
+        migrate
+
+        deleted.each { |c| expect { c.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+        ignored.reload.table_name.should == "accounts"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Fix configurations for included_tables and excluded_tables.
Fix triggers on for renamed tables.
Fix rr_pending_changes and rr_sync_states entries for renamed tables.
Fix rr_sync_states entries for removed tables

https://bugzilla.redhat.com/show_bug.cgi?id=1034987

---

@jrafanie Please review.  This has been moved from the old repo with the logging fixes.  Note that some of the specs fail, but I think it's the part where it shells out, so I think my PG configuration is wrong.  @kbrock, help?
