### PR TITLE
Custom Button UI - Description replaced with "Button Hover Text"

### DIFF
--- a/vmdb/app/controllers/application_controller/buttons.rb
+++ b/vmdb/app/controllers/application_controller/buttons.rb
@@ -521,8 +521,9 @@ module ApplicationController::Buttons
           ab_get_node_info(x_node) if x_active_tree == :ab_tree
           replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
         else
-          @custom_button.errors.each do |field,msg|
-            add_flash(I18n.t("flash.error_during", :task=>"add") << "#{field.to_s.capitalize} #{msg}", :error)
+          @custom_button.errors.each do |field, msg|
+            add_flash(I18n.t("flash.error_during", :task => "add") <<
+                      @custom_button.errors.full_message(field, msg), :error)
           end
           @lastaction = "automate_button"
           @layout = "miq_ae_automate_button"

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -4,7 +4,6 @@
 en:
   product:
     name: ManageIQ
-
   # Flash messages shown in the UI
   flash:
     add:
@@ -593,6 +592,8 @@ en:
       ext_management_system:
         hostname: "Host Name"
         ipaddress: "IP Address"
+      custom_button:
+        description: "Button Hover Text"
     errors:
       template:
         header:


### PR DESCRIPTION
Add description attribute to locales/en.yml,
changed method to full_message, when calling add_flash

https://bugzilla.redhat.com/show_bug.cgi?id=1011263
