### PR TITLE
Fix temp directory path and File exists error at server startup

### DIFF
--- a/vmdb/lib/vmdb_helper.rb
+++ b/vmdb/lib/vmdb_helper.rb
@@ -23,9 +23,9 @@ $:.push("#{File.dirname(__FILE__)}/patches")
 require 'active_support_string_patch'
 require 'ruport_patch'
 
-APPLIANCE_DATA_VOL = File.exists?('/var/www/miq/vmdb') ? "/var/lib/data" : File.expand_path(Rails.root + "/tmp")
-MIQ_TEMP = File.join(APPLIANCE_DATA_VOL, "miq_temp")
-Dir.mkdir(MIQ_TEMP) if !File.exist?(MIQ_TEMP) && File.exist?(APPLIANCE_DATA_VOL)
+APPLIANCE_DATA_VOL = File.directory?("/var/www/miq/vmdb") ? "/var/lib/data" : Rails.root.join("tmp")
+MIQ_TEMP           = File.join(APPLIANCE_DATA_VOL, "miq_temp")
+FileUtils.mkdir_p(MIQ_TEMP)
 
 module VMDB
   def self.model_loaded?(name)


### PR DESCRIPTION
1. Temp directory was sometimes at `/tmp/miq_temp` and should be based on the rails root.
2. Also, the mkdir shouldn't raise if the directory already exists.

```
/home/bdunne/projects/redhat/manageiq/vmdb/lib/vmdb_helper.rb:28:in `mkdir': File exists - /tmp/miq_temp (Errno::EEXIST)
    from /home/bdunne/projects/redhat/manageiq/vmdb/lib/vmdb_helper.rb:28:in `<top (required)>'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:251:in `require'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:251:in `block in require'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:251:in `require'
    from /home/bdunne/projects/redhat/manageiq/vmdb/lib/vmdb/logging.rb:2:in `<top (required)>'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:251:in `require'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:251:in `block in require'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/activesupport/lib/active_support/dependencies.rb:251:in `require'
    from /home/bdunne/projects/redhat/manageiq/vmdb/config/application.rb:103:in `<class:Application>'
    from /home/bdunne/projects/redhat/manageiq/vmdb/config/application.rb:15:in `<module:Vmdb>'
    from /home/bdunne/projects/redhat/manageiq/vmdb/config/application.rb:14:in `<top (required)>'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/railties/lib/rails/commands.rb:53:in `require'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/railties/lib/rails/commands.rb:53:in `block in <top (required)>'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/railties/lib/rails/commands.rb:50:in `tap'
    from /home/bdunne/.gem/ruby/1.9.3/bundler/gems/rails-f9749c2ef83b/railties/lib/rails/commands.rb:50:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```
