### PR TITLE
Export and Import from a single YAML file

### DIFF
--- a/vmdb/app/models/miq_ae_datastore.rb
+++ b/vmdb/app/models/miq_ae_datastore.rb
@@ -38,7 +38,7 @@ module MiqAeDatastore
   end
 
   def self.convert(filename, domain_name = temp_domain, export_options = {})
-    if export_options['zip_file'].blank? && export_options['export_dir'].blank?
+    if export_options['zip_file'].blank? && export_options['export_dir'].blank? && export_options['yaml_file'].blank?
       export_options['export_dir'] = TMP_DIR
     end
 

--- a/vmdb/app/models/miq_ae_export.rb
+++ b/vmdb/app/models/miq_ae_export.rb
@@ -2,10 +2,12 @@
 # calls either the ZIP or the Fileystem class
 class MiqAeExport
   def self.new(domain, options)
-    if options['zip_file'].blank?
-      @inst = MiqAeYamlExportFs.new(domain, options)
-    else
+    if options['zip_file'].present?
       @inst = MiqAeYamlExportZipfs.new(domain, options)
+    elsif options['export_dir'].present?
+      @inst = MiqAeYamlExportFs.new(domain, options)
+    elsif options['yaml_file'].present?
+      @inst = MiqAeYamlExportConsolidated.new(domain, options)
     end
   end
 end

--- a/vmdb/app/models/miq_ae_import.rb
+++ b/vmdb/app/models/miq_ae_import.rb
@@ -1,9 +1,11 @@
 class MiqAeImport
   def self.new(domain, options)
-    if options['zip_file'].blank?
-      MiqAeYamlImportFs.new(domain, options)
-    else
+    if options['zip_file'].present?
       MiqAeYamlImportZipfs.new(domain, options)
+    elsif options['import_dir'].present?
+      MiqAeYamlImportFs.new(domain, options)
+    elsif options['yaml_file'].present?
+      MiqAeYamlImportConsolidated.new(domain, options)
     end
   end
 end

--- a/vmdb/app/models/miq_ae_yaml_export_consolidated.rb
+++ b/vmdb/app/models/miq_ae_yaml_export_consolidated.rb
@@ -1,0 +1,32 @@
+# Class to Export Automate Model into a single YAML file
+class MiqAeYamlExportConsolidated < MiqAeYamlExport
+  include MiqAeYamlImportExportMixin
+
+  def initialize(domain, options)
+    super
+    @temp_file_name = File.join(Dir.tmpdir, "temp_file.yaml")
+    @yaml_file_name = options['yaml_file'].blank? ? "#{@domain}.yaml" : options['yaml_file']
+    options['overwrite'] ||= false
+    if File.exist?(@yaml_file_name) && !options['overwrite']
+      raise MiqAeException::FileExists, "File [#{@yaml_file_name}] exists, to overwrite it use OVERWRITE=true"
+    end
+    @yaml_model = {}
+  end
+
+  def write_data(base_path, export_hash)
+    path = File.join(base_path, export_hash['output_filename']).split('/')
+    data = export_hash['export_data']
+    data = YAML.load(data) if export_hash['output_filename'].ends_with?('.yaml')
+    path << data
+    @yaml_model.store_path(*path)
+  end
+
+  def export
+    File.open(@temp_file_name, 'w') do |fd|
+      write_model
+      fd.write(@yaml_model.to_yaml)
+      fd.close
+      FileUtils.mv(@temp_file_name, @options['yaml_file'])
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_yaml_import_consolidated.rb
+++ b/vmdb/app/models/miq_ae_yaml_import_consolidated.rb
@@ -1,0 +1,99 @@
+class MiqAeYamlImportConsolidated < MiqAeYamlImport
+  include MiqAeYamlImportExportMixin
+  def initialize(domain, options)
+    super
+    @fn_flags  = File::FNM_CASEFOLD | File::FNM_PATHNAME
+    load_yaml
+  end
+
+  def load_yaml
+    unless File.exist?(@options['yaml_file'])
+      raise MiqAeException::FileNotFound, "import file: #{@options['yaml_file']} not found"
+    end
+    @yaml_model = YAML.load_file(@options['yaml_file'])
+  end
+
+  def domain_entry(domain_name)
+    domain_entries(domain_name).first
+  end
+
+  def domain_entries(dom_name)
+    entries = domain_files(dom_name)
+    if entries.empty?
+      $log.info("#{self.class} domain: <#{dom_name}> yaml file not found") if $log
+      raise MiqAeException::NamespaceNotFound, "domain: #{dom_name}"
+    end
+    entries
+  end
+
+  def domain_folder(domain_name)
+    entries = domain_files(domain_name)
+    entries.empty? ? domain_name : File.dirname(entries.first)
+  end
+
+  def read_domain_yaml(_domainfolder, domain_name)
+    load_file(domain_entry(domain_name))
+  end
+
+  def domain_files(domain)
+    keys = @yaml_model.keys
+    return [] if keys.empty?
+    keys.select! do |key|
+      File.fnmatch(domain, key, @fn_flags) && @yaml_model.has_key_path?(*[key, DOMAIN_YAML_FILENAME])
+    end
+    keys.collect { |key| "#{key}/#{DOMAIN_YAML_FILENAME}" }
+  end
+
+  def namespace_files(parent_path)
+    get_filenames(parent_path, NAMESPACE_YAML_FILENAME)
+  end
+
+  def class_files(parent_path)
+    get_filenames(parent_path, CLASS_YAML_FILENAME)
+  end
+
+  def get_method_files(parent_path)
+    get_filenames_with_proc("#{parent_path}/#{METHOD_FOLDER_NAME}") do |item|
+      item.ends_with?('.yaml')
+    end
+  end
+
+  def get_instance_files(parent_path)
+    get_filenames_with_proc(parent_path) do |item|
+      item != CLASS_YAML_FILENAME && item != METHOD_FOLDER_NAME
+    end
+  end
+
+  def load_file(file)
+    @yaml_model.fetch_path(*file.split('/'))
+  end
+
+  def load_method_ruby(method_file_name)
+    load_file(method_file_name.gsub('.yaml', '.rb'))
+  end
+
+  def load_class_schema(class_folder)
+    class_file = "#{class_folder}/#{CLASS_YAML_FILENAME}"
+    @yaml_model.fetch_path(*class_file.split('/'))
+  end
+
+  private
+
+  def get_filenames(parent_path, file_name)
+    paths = get_filenames_with_proc(parent_path) do |key, hash|
+      hash.has_key_path?(*[key, file_name])
+    end
+    paths.collect { |path| "#{path}/#{file_name}" }
+  end
+
+  def get_filenames_with_proc(parent_path)
+    path_list = parent_path.split('/')
+    return [] unless @yaml_model.has_key_path?(*path_list)
+
+    hash = @yaml_model.fetch_path(*path_list)
+    selected_keys = hash.keys.select do |key|
+      yield(key, hash)
+    end
+    selected_keys.sort.collect { |key| "#{parent_path}/#{key}" }
+  end
+end

--- a/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -28,41 +28,39 @@ describe MiqAeDatastore do
     end
 
     it "non existing namespace" do
-      expect { export_model(@manageiq_domain.name, false, 'namespace' => "UNKNOWN") }
-      .to raise_error(MiqAeException::NamespaceNotFound)
+      options = {'namespace' => 'UNKNOWN'}
+      options['export_dir'] = @export_dir
+      expect { export_model(@manageiq_domain.name, options) }
+        .to raise_error(MiqAeException::NamespaceNotFound)
     end
 
     it "non existing class" do
       options = {'namespace' => @aen1.name, 'class' => 'UNKNOWN'}
-      expect { export_model(@manageiq_domain.name, false, options) }
-      .to raise_error(MiqAeException::ClassNotFound)
+      options['export_dir'] = @export_dir
+      expect { export_model(@manageiq_domain.name, options) }
+        .to raise_error(MiqAeException::ClassNotFound)
     end
 
     it "missing domain yaml file should raise exception" do
-      export_model(@manageiq_domain.name, false, 'overwrite' => true)
+      options = {'overwrite' => true, 'export_dir' => @export_dir}
+      export_model(@manageiq_domain.name, options)
       FileUtils.rm Dir.glob("#{@export_dir}/**/__domain__.yaml"), :force => true
       expect { reset_and_import(@export_dir, @manageiq_domain.name) }
-      .to raise_error(MiqAeException::NamespaceNotFound)
+        .to raise_error(MiqAeException::NamespaceNotFound)
     end
 
     it "invalid zip file should raise exception" do
       create_bogus_zip_file
-      reset_options = {}
-      expect { reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true) }
-      .to raise_error(MiqAeException::NamespaceNotFound)
+      export_options = {'zip_file' => @zip_file}
+      expect { reset_and_import(@export_dir, @manageiq_domain.name, export_options) }
+        .to raise_error(MiqAeException::NamespaceNotFound)
     end
 
-    it "an existing file should raise exception" do
-      File.open(@zip_file, 'w') { |f| f.write("dummy domain data") }
-      expect { export_model(@manageiq_domain.name, true) }
-      .to raise_error(MiqAeException::FileExists)
-      File.exist?(@zip_file).should be_true
-    end
-
-    it "an existing file with overwrite should not raise exception" do
-      File.open(@zip_file, 'w') { |f| f.write("dummy domain data") }
-      export_model(@manageiq_domain.name, true, 'overwrite' => true)
-      File.exist?(@zip_file).should be_true
+    it "invalid yaml file should raise exception" do
+      create_bogus_yaml_file
+      export_options = {'yaml_file' => @yaml_file}
+      expect { reset_and_import(@export_dir, @manageiq_domain.name, export_options) }
+        .to raise_error(MiqAeException::NamespaceNotFound)
     end
 
     it "an existing directory should raise exception" do
@@ -70,29 +68,67 @@ describe MiqAeDatastore do
       expect { export_model(@manageiq_domain.name) }.to raise_error(MiqAeException::DirectoryExists)
     end
 
+    it "an existing zip file should raise exception" do
+      File.open(@zip_file, 'w') { |f| f.write("dummy domain data") }
+      options = {'zip_file' => @zip_file}
+      expect { export_model(@manageiq_domain.name, options) }
+        .to raise_error(MiqAeException::FileExists)
+      File.exist?(@zip_file).should be_true
+    end
+
+    it "an existing yaml file should raise exception" do
+      create_bogus_yaml_file
+      options = {'yaml_file' => @yaml_file}
+      expect { export_model(@manageiq_domain.name, options) }
+        .to raise_error(MiqAeException::FileExists)
+      File.exist?(@yaml_file).should be_true
+    end
+
     it "an existing directory with overwrite should not raise exception" do
       FileUtils.mkdir_p(File.join(@export_dir, @manageiq_domain.name))
-      export_model(@manageiq_domain.name, false, 'overwrite' => true)
-      reset_and_import(@export_dir, @manageiq_domain.name)
+      export_options = {'export_dir' => @export_dir, 'overwrite' => true}
+      assert_existing_exported_model(export_options, {})
+    end
+
+    it "an existing zip file with overwrite should not raise exception" do
+      File.open(@zip_file, 'w') { |f| f.write("dummy domain data") }
+      export_options = {'zip_file' => @zip_file, 'overwrite' => true}
+      import_options = {'zip_file' => @zip_file}
+      assert_existing_exported_model(export_options, import_options)
+    end
+
+    it "an existing yaml file with overwrite should not raise exception" do
+      File.open(@yaml_file, 'w') { |f| f.write("dummy domain data") }
+      export_options = {'yaml_file' => @yaml_file, 'overwrite' => true}
+      import_options = {'yaml_file' => @yaml_file}
+      assert_existing_exported_model(export_options, import_options)
+    end
+
+    def assert_existing_exported_model(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
     end
+
   end
 
   context "yaml import" do
     it "an existing domain from zip should fail" do
-      export_model(@manageiq_domain.name, true)
-      File.exist?(@zip_file).should be_true
-      reset_options = {'import_as' => 'Manageiq'}
-      expect { reset_and_import(@export_dir, @manageiq_domain.name, reset_options,  true) }
-      .to raise_error(MiqAeException::InvalidDomain)
+      export_options = {'zip_file' => @zip_file}
+      import_options = {'zip_file' => @zip_file, 'import_as' => 'ManageIQ'}
+      assert_existing_domain_fails(export_options, import_options)
+    end
+
+    it "an existing domain from yaml should fail" do
+      export_options = {'yaml_file' => @yaml_file}
+      import_options = {'yaml_file' => @yaml_file, 'import_as' => 'ManageIQ'}
+      assert_existing_domain_fails(export_options, import_options)
     end
 
     it "an existing domain from directory should fail" do
-      export_model(@manageiq_domain.name)
-      reset_options = {'import_as' => 'Manageiq'}
-      expect { reset_and_import(@export_dir, @manageiq_domain.name, reset_options) }
-      .to raise_error(MiqAeException::InvalidDomain)
+      import_options = {'import_dir' => @export_dir, 'import_as' => 'ManageIQ'}
+      assert_existing_domain_fails({}, import_options)
     end
 
     it "a non existing folder should fail" do
@@ -103,9 +139,25 @@ describe MiqAeDatastore do
 
     it "a non existing zip file should fail" do
       import_options = {'zip_file' => "missing_zip_file", 'preview' => true, 'mode' => 'add'}
+      assert_import_failure_with_missing_file(import_options)
+    end
+
+    it "a non existing yaml file should fail" do
+      import_options = {'yaml_file' => "missing_yaml_file", 'preview' => true, 'mode' => 'add'}
+      assert_import_failure_with_missing_file(import_options)
+    end
+
+    def assert_existing_domain_fails(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      expect { reset_and_import(@export_dir, @manageiq_domain.name, import_options) }
+      .to raise_error(MiqAeException::InvalidDomain)
+    end
+
+    def assert_import_failure_with_missing_file(import_options)
       expect { MiqAeImport.new("fred", import_options).import }
       .to raise_error(MiqAeException::FileNotFound)
     end
+
   end
 
   context "export import roundtrip" do
@@ -117,42 +169,46 @@ describe MiqAeDatastore do
       end
 
       it "import all domains, from directory" do
-        export_model(ALL_DOMAINS)
-        reset_and_import(@export_dir, ALL_DOMAINS)
-        check_counts('ns'   => 8, 'class' => 8, 'inst'  => 20,
-                     'meth' => 6, 'field' => 24, 'value' => 16)
+        assert_all_domains_imported({}, {})
       end
 
       it "import all domains, from zip" do
-        export_model(ALL_DOMAINS, true)
-        File.exist?(@zip_file).should be_true
-        reset_options = {}
-        reset_and_import(@export_dir, ALL_DOMAINS, reset_options, true)
+        options = {'zip_file' => @zip_file}
+        assert_all_domains_imported(options, options)
+      end
+
+      it "import all domains, from yaml" do
+        options = {'yaml_file' => @yaml_file}
+        assert_all_domains_imported(options, options)
+      end
+
+      def assert_all_domains_imported(export_options, import_options)
+        export_model(ALL_DOMAINS, export_options)
+        reset_and_import(@export_dir, ALL_DOMAINS, import_options)
         check_counts('ns'   => 8, 'class' => 8, 'inst'  => 20,
                      'meth' => 6, 'field' => 24, 'value' => 16)
       end
 
       it "import single domain, from directory" do
-        export_model(ALL_DOMAINS)
-        reset_and_import(@export_dir, @customer_domain.name)
-        check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
-                     'meth' => 3, 'field' => 12, 'value' => 8)
+        assert_single_domain_import({}, {})
       end
 
       it "import single domain, from zip" do
-        export_model(ALL_DOMAINS, true)
-        reset_options = {}
-        reset_and_import(@export_dir, @customer_domain.name, reset_options, true)
+        options = {'zip_file' => @zip_file}
+        assert_single_domain_import(options, options)
+      end
+
+      it "import single domain, from yaml" do
+        options = {'yaml_file' => @yaml_file}
+        assert_single_domain_import(options, options)
+      end
+
+      def assert_single_domain_import(export_options, import_options)
+        export_model(ALL_DOMAINS, export_options)
+        reset_and_import(@export_dir, @customer_domain.name, import_options)
         check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
                      'meth' => 3, 'field' => 12, 'value' => 8)
       end
-    end
-
-    it "domain, as directory" do
-      export_model(@manageiq_domain.name)
-      reset_and_import(@export_dir, @manageiq_domain.name)
-      check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
-                   'meth' => 3, 'field' => 12, 'value' => 8)
     end
 
     it "domain, check password field is not in clear text" do
@@ -169,11 +225,23 @@ describe MiqAeDatastore do
       password_field_hash.fetch_path('field', 'default_value').should eq(MiqAePassword.encrypt(@clear_default_password))
     end
 
+    it "domain, as directory" do
+      assert_export_import_roundtrip({}, {})
+    end
+
     it "domain, as zip" do
-      export_model(@manageiq_domain.name, true)
-      File.exist?(@zip_file).should be_true
-      reset_options = {}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
+      options = {'zip_file' => @zip_file}
+      assert_export_import_roundtrip(options, options)
+    end
+
+    it "domain, as yaml" do
+      options = {'yaml_file' => @yaml_file}
+      assert_export_import_roundtrip(options, options)
+    end
+
+    def assert_export_import_roundtrip(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
     end
@@ -190,135 +258,250 @@ describe MiqAeDatastore do
     end
 
     it "domain, using import_as (new domain name), to directory" do
-      export_model(@manageiq_domain.name)
-      reset_options = {'import_as' => 'fred'}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options)
-      check_counts('ns'   => 8, 'class' => 8,  'inst'  => 20,
-                   'meth' => 6, 'field' => 24, 'value' => 16)
+      import_options = {'import_as' => 'fred', 'import_dir' => @export_dir}
+      assert_import_as({}, import_options)
     end
 
     it "domain, using import_as (new domain name), as zip" do
-      export_model(@manageiq_domain.name, true)
-      File.exist?(@zip_file).should be_true
-      reset_options = {'import_as' => 'fred'}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
+      export_options = {'zip_file' => @zip_file}
+      import_options = {'zip_file' => @zip_file, 'import_as' => 'fred'}
+      assert_import_as(export_options, import_options)
+    end
+
+    it "domain, using import_as (new domain name), as yaml" do
+      export_options = {'yaml_file' => @yaml_file}
+      import_options = {'yaml_file' => @yaml_file, 'import_as' => 'fred'}
+      assert_import_as(export_options, import_options)
+    end
+
+    def assert_import_as(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 8, 'class' => 8,  'inst'  => 20,
                    'meth' => 6, 'field' => 24, 'value' => 16)
+      MiqAeDomain.all.include?(import_options['import_as'])
     end
 
     it "domain, using export_as (new domain name), to directory" do
-      options = {'export_as' => @export_as}
-      export_model(@manageiq_domain.name, false, options)
-      Dir.exist?(File.join(@export_dir, @export_as)).should be_true
-      reset_options = {}
-      reset_and_import(@export_dir, @export_as, reset_options, false)
-      check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
-                   'meth' => 3, 'field' => 12, 'value' => 8)
-      MiqAeDomain.all.include?(@export_as)
+      export_options = {'export_dir' => @export_dir, 'export_as' => @export_as}
+      assert_export_as(export_options, {})
     end
 
     it "domain, using export_as (new domain name), as zip" do
-      options = {'export_as' => @export_as}
-      export_model(@manageiq_domain.name, true, options)
-      File.exist?(@zip_file).should be_true
-      reset_options = {}
-      reset_and_import(@export_dir, @export_as, reset_options, true)
+      export_options = {'zip_file' => @zip_file, 'export_as' => @export_as}
+      import_options = {'zip_file' => @zip_file}
+      assert_export_as(export_options, import_options)
+    end
+
+    it "domain, using export_as (new domain name), as yaml" do
+      export_options = {'yaml_file' => @yaml_file, 'export_as' => @export_as}
+      import_options = {'yaml_file' => @yaml_file}
+      assert_export_as(export_options, import_options)
+    end
+
+    def assert_export_as(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @export_as, import_options)
       check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
       MiqAeDomain.all.include?(@export_as)
     end
 
     it "domain, import only namespace, to directory" do
-      export_model(@manageiq_domain.name)
-      reset_options = {'namespace' => @aen1.name}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options)
+      import_options = {'namespace' => @aen1.name, 'import_dir' => @export_dir}
+      assert_import_namespace_only({}, import_options)
+    end
+
+    it "domain, import only namespace, to zip" do
+      export_options = {'zip_file' => @zip_file}
+      import_options = {'namespace' => @aen1.name, 'zip_file' => @zip_file}
+      assert_import_namespace_only(export_options, import_options)
+    end
+
+    it "domain, import only namespace, to yaml" do
+      export_options = {'yaml_file' => @yaml_file}
+      import_options = {'namespace' => @aen1.name, 'yaml_file' => @yaml_file}
+      assert_import_namespace_only(export_options, import_options)
+    end
+
+    def assert_import_namespace_only(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 3, 'class' => 3, 'inst'  => 6,
                    'meth' => 2, 'field' => 6, 'value' => 4)
     end
 
     it "domain, import only multi-part namespace, to directory" do
-      export_model(@manageiq_domain.name)
-      reset_options = {'namespace' => @aen1_1.ns_fqname}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options)
+      import_options = {'namespace' => @aen1_1.ns_fqname, 'import_dir' => @export_dir}
+      assert_import_multipart_namespace_only({}, import_options)
+    end
+
+    it "domain, import only multi-part namespace, to zip" do
+      import_options = {'namespace' => @aen1_1.ns_fqname, 'zip_file' => @zip_file}
+      export_options = {'zip_file' => @zip_file}
+      assert_import_multipart_namespace_only(export_options, import_options)
+    end
+
+    it "domain, import only multi-part namespace, to yaml" do
+      import_options = {'namespace' => @aen1_1.ns_fqname, 'yaml_file' => @yaml_file}
+      export_options = {'yaml_file' => @yaml_file}
+      assert_import_multipart_namespace_only(export_options, import_options)
+    end
+
+    def assert_import_multipart_namespace_only(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 3, 'class' => 1, 'inst'  => 1,
                    'meth' => 0, 'field' => 0, 'value' => 0)
     end
 
     it "domain, import only class, to directory" do
-      export_model(@manageiq_domain.name)
-      reset_options = {'namespace' => @aen1.name, 'class_name' => @aen1_aec1.name}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options)
+      import_options = {'import_dir' => @export_dir, 'namespace' => @aen1.name,
+                        'class_name' => @aen1_aec1.name}
+      assert_import_class_only({}, import_options)
+    end
+
+    it "domain, import only class, to zip" do
+      export_options = {'zip_file' => @zip_file}
+      import_options = {'zip_file' => @zip_file, 'namespace' => @aen1.name,
+                        'class_name' => @aen1_aec1.name}
+      assert_import_class_only(export_options, import_options)
+    end
+
+    it "domain, import only class, to yaml" do
+      export_options = {'yaml_file' => @yaml_file}
+      import_options = {'yaml_file'  => @yaml_file, 'namespace' => @aen1.name,
+                        'class_name' => @aen1_aec1.name}
+      assert_import_class_only(export_options, import_options)
+    end
+
+    def assert_import_class_only(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 2, 'class' => 1, 'inst'  => 2,
                    'meth' => 2, 'field' => 6, 'value' => 4)
     end
 
     it "namespace, to directory" do
-      options = {'namespace' => @aen1.name}
-      export_model(@manageiq_domain.name, false, options)
-      reset_and_import(@export_dir, @manageiq_domain.name)
-      check_counts('ns'   => 3, 'class' => 3, 'inst'  => 6,
-                   'meth' => 2, 'field' => 6, 'value' => 4)
+      export_options = {'namespace' => @aen1.name, 'export_dir' => @export_dir}
+      import_options = {'import_dir' => @export_dir}
+      assert_single_namespace_export(export_options, import_options)
     end
 
     it "namespace, as zip" do
-      options = {'namespace' => @aen1.name}
-      export_model(@manageiq_domain.name, true, options)
-      reset_options = {}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
+      export_options = {'namespace' => @aen1.name, 'zip_file' => @zip_file}
+      import_options = {'zip_file' => @zip_file}
+      assert_single_namespace_export(export_options, import_options)
+    end
+
+    it "namespace, as yaml" do
+      export_options = {'namespace' => @aen1.name, 'yaml_file' => @yaml_file}
+      import_options = {'yaml_file' => @yaml_file}
+      assert_single_namespace_export(export_options, import_options)
+    end
+
+    def assert_single_namespace_export(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 3, 'class' => 3, 'inst'  => 6,
                    'meth' => 2, 'field' => 6, 'value' => 4)
     end
 
     it "namespace, multi-part, to directory" do
-      options = {'namespace' => @aen1_1.ns_fqname}
-      export_model(@manageiq_domain.name, false, options)
-      reset_and_import(@export_dir, @manageiq_domain.name)
-      check_counts('ns'   => 3, 'class' => 1, 'inst'  => 1,
-                   'meth' => 0, 'field' => 0, 'value' => 0)
+      export_options = {'namespace' => @aen1_1.ns_fqname, 'export_dir' => @export_dir}
+      assert_multi_namespace_export(export_options, {})
     end
 
     it "namespace, multi-part, as zip" do
-      options = {'namespace' => @aen1_1.ns_fqname}
-      export_model(@manageiq_domain.name, true, options)
-      reset_options = {}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
+      export_options = {'namespace' => @aen1_1.ns_fqname, 'zip_file' => @zip_file}
+      import_options = {'zip_file' => @zip_file}
+      assert_multi_namespace_export(export_options, import_options)
+    end
+
+    it "namespace, multi-part, as yaml" do
+      export_options = {'namespace' => @aen1_1.ns_fqname, 'yaml_file' => @yaml_file}
+      import_options = {'yaml_file' => @yaml_file}
+      assert_multi_namespace_export(export_options, import_options)
+    end
+
+    def assert_multi_namespace_export(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 3, 'class' => 1, 'inst'  => 1,
                    'meth' => 0, 'field' => 0, 'value' => 0)
     end
 
     it "class, with methods, add new instance, export, then import using mode=replace" do
       options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
-      export_model(@manageiq_domain.name, false, options)
+      options['export_dir'] = @export_dir
+      export_model(@manageiq_domain.name, options)
       reset_and_import(@export_dir, @manageiq_domain.name)
       check_counts('ns'   => 2, 'class' => 1, 'inst'  => 2,
                    'meth' => 2, 'field' => 6, 'value' => 4)
-      @aen1_aec1_aei2   = FactoryGirl.create(:miq_ae_instance,  :name => 'test_instance2', :class_id => @aen1_aec1.id)
-
+      @aen1_aec1_aei2   = FactoryGirl.create(:miq_ae_instance,
+                                             :name     => 'test_instance2',
+                                             :class_id => @aen1_aec1.id)
       setup_export_dir
-      export_model(@manageiq_domain.name, false, options)
+      export_model(@manageiq_domain.name, options)
       MiqAeImport.new(@manageiq_domain.name, 'preview' => false, 'import_dir' => @export_dir).import
       check_counts('ns'   => 2, 'class' => 1, 'inst'  => 3,
                    'meth' => 2, 'field' => 6, 'value' => 4)
     end
 
     it "class, with methods, to directory" do
-      options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
-      export_model(@manageiq_domain.name, false, options)
-      reset_and_import(@export_dir, @manageiq_domain.name)
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
+      export_options['export_dir'] = @export_dir
+      assert_class_with_methods_export(export_options, {})
+    end
+
+    it "class, with methods, as zip" do
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
+      export_options['zip_file'] = @zip_file
+      import_options = {'zip_file' => @zip_file}
+      assert_class_with_methods_export(export_options, import_options)
+    end
+
+    it "class, with methods, as yaml" do
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
+      export_options['yaml_file'] = @yaml_file
+      import_options = {'yaml_file' => @yaml_file}
+      assert_class_with_methods_export(export_options, import_options)
+    end
+
+    def assert_class_with_methods_export(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 2, 'class' => 1, 'inst'  => 2,
                    'meth' => 2, 'field' => 6, 'value' => 4)
     end
 
+    it "class, with builtin methods, as directory" do
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
+      export_options['export_dir'] = @export_dir
+      assert_class_with_builtin_methods_export(export_options, {})
+    end
+
     it "class, with builtin methods, as zip" do
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
+      export_options['zip_file'] = @zip_file
+      import_options = {'zip_file' => @zip_file}
+      assert_class_with_builtin_methods_export(export_options, import_options)
+    end
+
+    it "class, with builtin methods, as yaml" do
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
+      export_options['yaml_file'] = @yaml_file
+      import_options = {'yaml_file' => @yaml_file}
+      assert_class_with_builtin_methods_export(export_options, import_options)
+    end
+
+    def assert_class_with_builtin_methods_export(export_options, import_options)
       inline_method = @aen1_aec1.ae_methods.first
       inline_method.location.should eql 'inline'
       inline_method.data.should_not be_nil
       inline_method.update_attributes('location' => 'builtin', 'data' => nil)
-
-      options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
-      export_model(@manageiq_domain.name, true, options)
-      reset_options = {}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 2, 'class' => 1, 'inst'  => 2,
                    'meth' => 2, 'field' => 6, 'value' => 4)
       aen1_aec1  = MiqAeClass.find_by_name('manageiq_test_class_1')
@@ -327,45 +510,43 @@ describe MiqAeDatastore do
       builtin_method.data.should be_nil
     end
 
-    it "class, with methods, as zip" do
-      options = {'namespace' => @aen1.name, 'class' => @aen1_aec1.name}
-      export_model(@manageiq_domain.name, true, options)
-      reset_options = {}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
-      check_counts('ns'   => 2, 'class' => 1, 'inst'  => 2,
-                   'meth' => 2, 'field' => 6, 'value' => 4)
-    end
-
     it "class, without methods, to directory" do
-      options = {'namespace' => @aen1.name, 'class' => @aen1_aec2.name}
-      export_model(@manageiq_domain.name, false, options)
-      reset_and_import(@export_dir, @manageiq_domain.name)
-      check_counts('ns'   => 2, 'class' => 1, 'inst'  => 3,
-                   'meth' => 0, 'field' => 0, 'value' => 0)
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec2.name}
+      export_options['export_dir'] = @export_dir
+      assert_class_without_methods(export_options, {})
     end
 
     it "class, without methods, as zip" do
-      options = {'namespace' => @aen1.name, 'class' => @aen1_aec2.name}
-      export_model(@manageiq_domain.name, true, options)
-      reset_options = {}
-      reset_and_import(@export_dir, @manageiq_domain.name, reset_options, true)
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec2.name}
+      export_options['zip_file'] = @zip_file
+      import_options = {'zip_file' => @zip_file}
+      assert_class_without_methods(export_options, import_options)
+    end
+
+    it "class, without methods, as yaml" do
+      export_options = {'namespace' => @aen1.name, 'class' => @aen1_aec2.name}
+      export_options['yaml_file'] = @yaml_file
+      import_options = {'yaml_file' => @yaml_file}
+      assert_class_without_methods(export_options, import_options)
+    end
+
+    def assert_class_without_methods(export_options, import_options)
+      export_model(@manageiq_domain.name, export_options)
+      reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('ns'   => 2, 'class' => 1, 'inst'  => 3,
                    'meth' => 0, 'field' => 0, 'value' => 0)
     end
   end
 
-  def reset_and_import(import_dir, domain, options = {}, read_zip = false)
+  def reset_and_import(import_dir, domain, options = {})
+    options = {'import_dir' => import_dir} if options.empty?
     import_as = options['import_as'].presence
     if import_as.blank?
       MiqAeDatastore.reset
       [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| k.count.should == 0 }
     end
-    import_options = {'preview'    => true,
-                      'mode'       => 'add',
-                      'namespace'  => options['namespace'],
-                      'class_name' => options['class_name']}
-    read_zip ? import_options['zip_file'] = @zip_file : import_options['import_dir'] = import_dir
-    import_options['import_as'] = import_as unless import_as.blank?
+    import_options = {'preview' => true,
+                      'mode'    => 'add'}.merge(options)
     MiqAeImport.new(domain, import_options).import
 
     if import_as.blank?
@@ -375,12 +556,8 @@ describe MiqAeDatastore do
     MiqAeImport.new(domain, import_options).import
   end
 
-  def export_model(domain, zipit = false, options = {})
-    export_options = zipit ? {'zip_file' => @zip_file} : {'export_dir' => @export_dir}
-    export_options['class'] = options['class'] if options['class'].present?
-    export_options['namespace'] = options['namespace'] if options['namespace'].present?
-    export_options['overwrite'] = options['overwrite'] if options['overwrite'].present?
-    export_options['export_as'] = options['export_as'] if options['export_as'].present?
+  def export_model(domain, export_options = {})
+    export_options['export_dir'] = @export_dir if export_options.empty?
     MiqAeExport.new(domain, export_options).export
   end
 
@@ -522,8 +699,10 @@ describe MiqAeDatastore do
     @export_dir = File.join(Dir.tmpdir, "rspec_export_tests")
     @export_as  = "barney"
     @zip_file   = File.join(Dir.tmpdir, "yaml_model.zip")
+    @yaml_file  = File.join(Dir.tmpdir, "yaml_model.yml")
     FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)
     FileUtils.rm_rf(@zip_file)   if File.exist?(@zip_file)
+    FileUtils.rm_rf(@yaml_file)  if File.exist?(@yaml_file)
   end
 
   def check_counts(counts)
@@ -559,6 +738,13 @@ describe MiqAeDatastore do
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")
       zh.file.open("mydir/second.txt", "w") { |f| f.puts "Hello again" }
+    end
+  end
+
+  def create_bogus_yaml_file
+    open(@yaml_file, 'w') do |fd|
+      a = {'A' => 1, 'B' => '2', 'C' => 3}
+      fd.write(a.to_yaml)
     end
   end
 end


### PR DESCRIPTION
@Fryguy @gmcculloug @chessbyte @tinaafitz 
For export and import of automate models we have 3 ways to store the data based on YAML. We currently have (1) ZIP file that can store all the YAML's or (2) store all the YAML's in a directory. This PR adds a 3rd one which is to have all the model into a single consolidated YAML. The single consolidated YAML helps us with our specs where we don't have to store all the model YAML files separately in a directory.
