### PR TITLE
Fixed values passed in to get_combo_xml and get_dtype_combo_xml calls.

### DIFF
--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -1720,8 +1720,8 @@ exit MIQ_OK"
   # AJAX driven routine to delete a classification entry
   def field_delete
     fields_get_form_vars
-    @temp[:combo_xml] = get_combo_xml(@ae_class.ae_fields)
-    @temp[:dtype_combo_xml] = get_dtype_combo_xml(@ae_class.ae_fields)    # passing fields because that's how many combo boxes we need
+    @temp[:combo_xml]       = get_combo_xml(@edit[:new][:fields])
+    @temp[:dtype_combo_xml] = get_dtype_combo_xml(@edit[:new][:fields])
     if params[:id].to_i != 0
       #@edit[:new][:fields][params[:id].to_i].id = "0"
       @edit[:new][:fields].sort_by{|a| [a.priority.to_i]}.each_with_index do |flds,i|


### PR DESCRIPTION
Fixed values passed in to get_combo_xml and get_dtype_combo_xml calls methods to rebuild Type and Data Type DhtmlxCombos on schema editor screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1087930
https://bugzilla.redhat.com/show_bug.cgi?id=1109984

@dclarizio please review/test. This was blowing up when trying to delete a schema field after adding a new one.
