### PR TITLE
add RSPEC_VERBOSE and RSPEC_OPTIONS

### DIFF
--- a/host/Rakefile
+++ b/host/Rakefile
@@ -21,7 +21,6 @@ task :rcov do
     Rcov::RcovTask.new do |t|
       t.libs << 'test'
       t.test_files = FileList['test/ts_*.rb']
-      t.verbose = true
       t.output_dir = File.join(ENV['CC_BUILD_ARTIFACTS'], "coverage") if ENV['CC_BUILD_ARTIFACTS'] != nil
       t.rcov_opts = ['--text-report', '--exclude', 'spec,/usr/lib/ruby']
     end

--- a/lib/lib/tasks/rspec.rake
+++ b/lib/lib/tasks/rspec.rake
@@ -12,7 +12,6 @@ desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec => spec_prereq) do |t|
   rspec_opts_file = ".rspec#{"_cc" if ENV['CC_BUILD_ARTIFACTS']}"
   t.rspec_opts = ['--options', "\"#{File.expand_path(File.join(File.dirname(__FILE__), rspec_opts_file))}\""]
-  t.verbose = true
 end
 
 namespace :spec do
@@ -20,7 +19,6 @@ namespace :spec do
   RSpec::Core::RakeTask.new(:rcov => spec_prereq) do |t|
     rspec_opts_file = ".rspec#{"_cc" if ENV['CC_BUILD_ARTIFACTS']}"
     t.rspec_opts = ['--options', "\"#{File.expand_path(File.join(File.dirname(__FILE__), rspec_opts_file))}\""]
-    t.verbose = true
     t.rcov = true
     t.rcov_opts = lambda do
       rcov_opts_file = File.expand_path(File.join(File.dirname(__FILE__), "spec", "rcov.opts"))

--- a/vmdb/lib/resource_feeder/Rakefile
+++ b/vmdb/lib/resource_feeder/Rakefile
@@ -9,7 +9,6 @@ desc 'Test the resource_feed plugin.'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.pattern = 'test/**/*_test.rb'
-  t.verbose = true
 end
 
 desc 'Generate documentation for the resource_feed plugin.'

--- a/vmdb/lib/tasks/coverage.rake
+++ b/vmdb/lib/tasks/coverage.rake
@@ -18,7 +18,6 @@ namespace :test do
           t.libs << "test"
           t.test_files = FileList["test/#{target}/*_test.rb"]
           t.output_dir = File.join(ENV['CC_BUILD_ARTIFACTS'], "coverage") if ENV['CC_BUILD_ARTIFACTS'] != nil
-          t.verbose = true
           if target == "unit"
             t.rcov_opts = ['--rails --aggregate coverage.data --text-report --sort coverage --no-html']
 #            t.rcov_opts = ['--rails --aggregate coverage.data --text-report --sort coverage ']

--- a/vmdb/lib/tasks/lib_test.rake
+++ b/vmdb/lib/tasks/lib_test.rake
@@ -3,7 +3,6 @@ namespace :test do
     t.libs << "lib"
     t.libs << "test"
     t.pattern = 'test/lib/**/*_test.rb'
-    t.verbose = true
   end
   Rake::Task['test:lib'].comment = "Run the tests in test/lib"
 end

--- a/vmdb/lib/tasks/spec_evm.rake
+++ b/vmdb/lib/tasks/spec_evm.rake
@@ -27,7 +27,6 @@ namespace :spec do
     def initialize_task(t, rspec_opts = [])
       rspec_opts_file = ".rspec#{"_cc" if ENV['CC_BUILD_ARTIFACTS']}"
       t.rspec_opts = ['--options', "\"#{Rails.root.join(rspec_opts_file)}\""] + rspec_opts
-      t.verbose = true
     end
 
     desc "Run the backend code examples"


### PR DESCRIPTION
with verbose mode turned on, the list of the rspec files are printed up front.

A bunch of blog posts suggest turning this off to pare down the nightly "build" logs.
It would be nice if `RSPEC_VERBOSE=false` for builds.

Also, added `RSPEC_OPTIONS` to let people run their own.
It would be nice if cruise control had `RSPEC_OPTIONS=.rspec_cc` instead of using `CC_BUILD_ARTIFACTS`
