### PR TITLE
Create default Time Profile with profile_type as global.

### DIFF
--- a/vmdb/app/models/time_profile.rb
+++ b/vmdb/app/models/time_profile.rb
@@ -33,6 +33,7 @@ class TimeProfile < ActiveRecord::Base
         TimeProfile.create!(
           :description          => DEFAULT_TZ,
           :tz                   => DEFAULT_TZ,
+          :profile_type         => "global",
           :rollup_daily_metrics => true
         )
       end


### PR DESCRIPTION
When adding a new default Time Profile set profile_type as global. There is already a migration in place to update profile_type of existing default UTC TimeProfile to be set as global.

https://bugzilla.redhat.com/show_bug.cgi?id=1035197

@dclarizio please review/test.
