### PR TITLE
Fix issue importing policy sets that attempt to be saved during import

### DIFF
--- a/vmdb/app/models/import_file_upload.rb
+++ b/vmdb/app/models/import_file_upload.rb
@@ -2,7 +2,7 @@ class ImportFileUpload < ActiveRecord::Base
   has_one :binary_blob, :as => :resource, :dependent => :destroy
 
   def policy_import_data
-    MiqPolicy.import_from_array(uploaded_yaml_content)
+    MiqPolicy.import_from_array(uploaded_yaml_content, :preview => true)
   end
 
   def service_dialog_json

--- a/vmdb/app/services/miq_policy_import_service.rb
+++ b/vmdb/app/services/miq_policy_import_service.rb
@@ -24,7 +24,7 @@ class MiqPolicyImportService
   private
 
   def create_import_file_upload(file_contents)
-    uploaded_content, _ = MiqPolicy.import(file_contents)
+    uploaded_content, _ = MiqPolicy.import(file_contents, :preview => true)
 
     ImportFileUpload.create.tap do |import_file_upload|
       import_file_upload.store_policy_import_data(uploaded_content.to_yaml)

--- a/vmdb/spec/models/import_file_upload_spec.rb
+++ b/vmdb/spec/models/import_file_upload_spec.rb
@@ -8,7 +8,7 @@ describe ImportFileUpload do
 
     before do
       import_file_upload.create_binary_blob(:binary => "---\n- :file: contents\n")
-      MiqPolicy.stub(:import_from_array).with([{:file => "contents"}]).and_return(policy_array)
+      MiqPolicy.stub(:import_from_array).with([{:file => "contents"}], :preview => true).and_return(policy_array)
     end
 
     it "returns the imported policy array" do

--- a/vmdb/spec/services/miq_policy_import_service_spec.rb
+++ b/vmdb/spec/services/miq_policy_import_service_spec.rb
@@ -68,7 +68,7 @@ describe MiqPolicyImportService do
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload", :id => 1).as_null_object }
 
     before do
-      MiqPolicy.stub(:import).with("file contents").and_return(:uploaded => "content")
+      MiqPolicy.stub(:import).with("file contents", :preview => true).and_return(:uploaded => "content")
       MiqQueue.stub(:put_or_update)
       ImportFileUpload.stub(:create).and_return(import_file_upload)
     end


### PR DESCRIPTION
This PR fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1106456

Before, MiqPolicySets were trying to be saved to the db during the intermediate step of importing, and was throwing an error because the parent object had not yet been saved.
