### PR TITLE
remove tests for missing exes

### DIFF
--- a/lib/test/extract/tc_versioninfo.rb
+++ b/lib/test/extract/tc_versioninfo.rb
@@ -10,37 +10,6 @@ class TestVersionInfo < Test::Unit::TestCase
     @noFile   = File.expand_path(File.join(@dataPath, "nofile.txt"))
   end
 
-  def test_exes
-    get_versioninfo(File.join(@dataPath, "VMwareTray.exe")) # This is the VMware tray module from VM Server
-    get_versioninfo(File.join(@dataPath, "frhed.exe"))       # This is the Free Hex Editor module
-  end
-
-  def get_versioninfo(filename)
-    vi = File.getVersionInfo(filename)
-    
-    # Validate that we get a Hash back
-    assert_instance_of(Hash, vi)
-    
-    # Validate the basic fields are not nil
-    assert_not_nil(vi['sig'])
-    assert_not_nil(vi['PRODUCTVERSION_HEADER'])
-    assert_not_nil(vi['FILEVERSION_HEADER'])
-    assert_not_nil(vi['code_page'])
-    assert_not_nil(vi['lang'])
-    assert_not_nil(vi['data_length'])
-    assert_equal("StringFileInfo", vi['sig'])
-
-    # Validate that the string data is within a range.  (400-1000 chars)
-    assert_in_delta(700, vi['data_length'], 300)
-
-    # Validate that the external name matches the internal name
-    assert_equal(File.basename(filename), vi['OriginalFilename'])
-
-    # Check that we can sort the hash into an array
-    sortedArray = vi.sort {|a,b| a<=>b}
-    assert_instance_of(Array, sortedArray)
-  end
-  
   def test_textFile
     assert_raise(RuntimeError) {File.getVersionInfo(__FILE__)}  # Test this ruby source file, which does not have version info
   end


### PR DESCRIPTION
We no longer have exe's in our tree.

Not sure what this is testing, but I don't think we need.

It is breaking the build
