### PR TITLE
Change MiqAeDatastore upload to use yaml_import.

### DIFF
--- a/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -141,7 +141,6 @@ describe MiqAeDatastore do
       it "import single domain, from zip" do
         export_model(ALL_DOMAINS, true)
         reset_options = {}
-        puts "importing domain: #{@customer_domain.name}"
         reset_and_import(@export_dir, @customer_domain.name, reset_options, true)
         check_counts('ns'   => 4, 'class' => 4, 'inst'  => 10,
                      'meth' => 3, 'field' => 8, 'value' => 6)


### PR DESCRIPTION
Modified upload code to use yaml_import for zip file
instead of deprecated xml import. Changed replace option
to mode. Added context and tests for backup, restore and upload.
