### PR TITLE
Add export notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,30 @@ We respectfully ask that you do not directly email any manageiq committers with 
 ## License
 
 See [LICENSE.txt](LICENSE.txt)
+
+## Export notice
+
+By downloading ManageIQ software, you acknowledge that you
+understand all of the following: ManageIQ software and
+technical information may be subject to the U.S. Export
+Administration Regulations (the “EAR”) and other U.S. and
+foreign laws and may not be exported, re-exported or
+transferred (a) to any country listed in Country Group E:1 in
+Supplement No. 1 to part 740 of the EAR (currently, Cuba,
+Iran, North Korea, Sudan &amp; Syria); (b) to any prohibited
+destination or to any end user who has been prohibited from
+participating in U.S. export transactions by any federal
+agency of the U.S. government; or (c) for use in connection
+with the design, development or production of nuclear,
+chemical or biological weapons, or rocket systems, space
+launch vehicles, or sounding rockets, or unmanned air vehicle
+systems. You may not download ManageIQ software or technical
+information if you are located in one of these countries or
+otherwise subject to these restrictions. You may not provide
+ManageIQ software or technical information to individuals or
+entities located in one of these countries or otherwise
+subject to these restrictions. You are also responsible for
+compliance with foreign law requirements applicable to the
+import, export and use of ManageIQ software and technical
+information.
+


### PR DESCRIPTION
As advised by Red Hat expert compliance officers, add export notices to README.md for ManageIQ source code in addition to the notice on the website.
