### PR TITLE
[On Hold] Updating rhev events to map to policy events

### DIFF
--- a/vmdb/config/event_handling.tmpl.yml
+++ b/vmdb/config/event_handling.tmpl.yml
@@ -817,9 +817,6 @@ event_handling:
   HOST_ACTIVATE_FAILED:
   - refresh:
     - src_host
-  HOST_DETECTED:
-  - refresh:
-    - ems
   HOST_FAILURE:
   - refresh:
     - src_host
@@ -854,7 +851,7 @@ event_handling:
     - save!
   - refresh:
     - src_host
-  HOST_REGISTER_SUCCEEDED:
+  HOST_DETECTED:
   - policy:
     - src_host
     - host_connect
@@ -867,6 +864,17 @@ event_handling:
     - save!
   - refresh:
     - src_host
+  USER_REMOVE_HOST:
+  - policy:
+    - src_host
+    - host_disconnect
+  - call:
+    - src_host
+    - state=
+    - 'off'
+  - call:
+    - src_host
+    - save!
   HostConnectionLostEvent:
   - policy:
     - src_host


### PR DESCRIPTION
The HOST_REGISTER_SUCCEEDED rhevm event is never thrown from RHEV from what I
can tell in the rhev logs.  The closest rhevm event is HOST_DETECTED.  This
event is emitted from rhev whenever a host is added.  This rhevm event best
correlates with the CFME "host_connect" policy event.

For the "host_disconnect" CFME policy event, the rhevm event USER_REMOVE_HOST is
the closest match.

https://bugzilla.redhat.com/show_bug.cgi?id=1009432
https://bugzilla.redhat.com/show_bug.cgi?id=1009434
