### PR TITLE
 Support for copy and compare of automate class, instance and methods

### DIFF
--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -113,6 +113,16 @@ class MiqAeClass < ActiveRecord::Base
     ae_namespace.editable?
   end
 
+  def field_names
+    ae_fields.collect { |x| x.name.downcase }
+  end
+
+  def field_hash(name)
+    field = ae_fields.detect { |f| f.name.casecmp(name) == 0 }
+    raise "field #{name} not found in class #{@name}" if field.nil?
+    field.attributes
+  end
+
   private
 
   def scoped_methods(s)

--- a/vmdb/app/models/miq_ae_class_compare_fields.rb
+++ b/vmdb/app/models/miq_ae_class_compare_fields.rb
@@ -1,0 +1,87 @@
+class MiqAeClassCompareFields
+  attr_reader :compatibilities
+  attr_reader :incompatibilities
+  attr_reader :fields_in_use
+  attr_reader :adds
+  IGNORE_PROPERTY_NAMES  = %w(name owner created_on updated_on updated_by
+                              updated_by_user_id id class_id)
+  WARNING_PROPERTY_NAMES = %w(priority message display_name default_value substitute
+                              visibility collect scope description condition on_entry
+                              on_exit on_error max_retries max_time)
+  ERROR_PROPERTY_NAMES   = %w(aetype datatype)
+
+  CONGRUENT_SCHEMA = 1
+  COMPATIBLE_SCHEMA = 2
+  INCOMPATIBLE_SCHEMA = 4
+
+  def initialize(new_class, old_class)
+    @new_class = new_class
+    @old_class = old_class
+  end
+
+  def compare
+    load_field_names
+    initialize_results
+    venn_list
+    validate_similar
+    status
+  end
+
+  def status
+    return CONGRUENT_SCHEMA if congruent?
+    return COMPATIBLE_SCHEMA if compatible?
+    INCOMPATIBLE_SCHEMA
+  end
+
+  def congruent?
+    @adds.empty? && @incompatibilities.empty? &&
+    @compatibilities.empty? && @fields_in_use.empty? &&
+    @deletes.empty?
+  end
+
+  def compatible?
+    @incompatibilities.empty? && @deletes.empty?
+  end
+
+  private
+
+  def initialize_results
+    @incompatibilities = []
+    @compatibilities   = []
+    @fields_in_use     = []
+    @adds              = []
+    @deletes           = []
+  end
+
+  def load_field_names
+    @old_names = @old_class.field_names
+    @new_names = @new_class.field_names
+  end
+
+  def venn_list
+    @similar = @new_names & @old_names
+    @adds    = @new_names - @old_names
+    @deletes = @old_names - @new_names
+  end
+
+  def validate_similar
+    @similar.each do |name|
+      old_field = @old_class.field_hash(name)
+      new_field = @new_class.field_hash(name)
+      compare_field_properties(name, old_field, new_field)
+    end
+  end
+
+  def compare_field_properties(field_name, old_field, new_field)
+    old_field.each do |property, value|
+      next if IGNORE_PROPERTY_NAMES.include?(property)
+      next if value == new_field[property]
+      hash = {'property'   => property,
+              'old_value'  => value,
+              'new_value'  => new_field[property],
+              'field_name' => field_name}
+      @compatibilities   << hash if WARNING_PROPERTY_NAMES.include?(property)
+      @incompatibilities << hash if ERROR_PROPERTY_NAMES.include?(property)
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_class_copy.rb
+++ b/vmdb/app/models/miq_ae_class_copy.rb
@@ -1,0 +1,80 @@
+class MiqAeClassCopy
+  include MiqAeCopyMixin
+  DELETE_PROPERTIES = %w(updated_by updated_by_user_id updated_on id
+                         created_on updated_on method_id owner class_id)
+
+  def initialize(class_fqname)
+    @class_fqname = class_fqname
+    @src_domain, @partial_ns, @ae_class = MiqAeClassCopy.split(@class_fqname, false)
+    @src_class = MiqAeClass.find_by_fqname(@class_fqname)
+    raise "Source class not found #{@class_fqname}" unless @src_class
+  end
+
+  def to_domain(domain, ns = nil, overwrite = false)
+    check_duplicity(domain, ns, @src_class.name)
+    @overwrite        = overwrite
+    @target_ns_fqname = target_ns(domain, ns)
+    @target_name      = @src_class.name
+    copy
+  end
+
+  def as(new_name, ns = nil, overwrite = false)
+    check_duplicity(@src_domain, ns, new_name)
+    @overwrite        = overwrite
+    @target_ns_fqname = target_ns(@src_domain, ns)
+    @target_name      = new_name
+    copy
+  end
+
+  private
+
+  def target_ns(domain, ns)
+    return "#{domain}/#{@partial_ns}" if ns.nil?
+    MiqAeNamespace.find_by_fqname(ns, false).nil? ? "#{domain}/#{ns}" : ns
+  end
+
+  def copy
+    validate
+    create_class
+    copy_schema
+    @dest_class
+  end
+
+  def create_class
+    ns = MiqAeNamespace.find_or_create_by_fqname(@target_ns_fqname, false)
+    ns.save!
+    @dest_class = MiqAeClass.create!(:namespace_id => ns.id,
+                                     :name         => @target_name,
+                                     :description  => @src_class.description,
+                                     :type         => @src_class.type,
+                                     :display_name => @src_class.display_name,
+                                     :inherits     => @src_class.inherits,
+                                     :visibility   => @src_class.visibility)
+  end
+
+  def copy_schema
+    @dest_class.ae_fields = add_fields
+    @dest_class.save!
+  end
+
+  def add_fields
+    @src_class.ae_fields.collect do |src_field|
+      attrs = src_field.attributes.reject { |k, _| DELETE_PROPERTIES.include?(k) }
+      MiqAeField.new(attrs)
+    end
+  end
+
+  def validate
+    dest_class = MiqAeClass.find_by_fqname("#{@target_ns_fqname}/#{@target_name}")
+    if dest_class
+      dest_class.destroy if @overwrite
+      raise "Destination Class already exists #{dest_class.fqname}" unless @overwrite
+    end
+  end
+
+  def check_duplicity(domain, ns, classname)
+    if domain.downcase == @src_domain.downcase && classname.downcase == @ae_class.downcase
+      raise "Cannot copy class onto itself" if ns.nil? || ns.downcase == @partial_ns.downcase
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_class_yaml.rb
+++ b/vmdb/app/models/miq_ae_class_yaml.rb
@@ -1,0 +1,19 @@
+class MiqAeClassYaml
+  attr_accessor :ae_class_obj
+  def initialize(filename = nil)
+    @filename     = filename
+    @ae_class_obj = YAML.load_file(filename) if filename
+  end
+
+  def field_names
+    raise "class object has not been set" unless @ae_class_obj
+    @ae_class_obj['object']['schema'].collect { |x| x['field']['name'].downcase }
+  end
+
+  def field_hash(name)
+    raise "class object has not been set" unless @ae_class_obj
+    field = @ae_class_obj['object']['schema'].detect { |f| f['field']['name'].casecmp(name) == 0 }
+    raise "field #{name} not found in yaml class #{@filename}" if field.nil?
+    field['field']
+  end
+end

--- a/vmdb/app/models/miq_ae_instance.rb
+++ b/vmdb/app/models/miq_ae_instance.rb
@@ -102,8 +102,20 @@ class MiqAeInstance < ActiveRecord::Base
     ae_class.ae_namespace.editable?
   end
 
-  private
+  def field_names
+    fields = ae_values.collect { |v| v.field_id }
+    ae_class.ae_fields.select { |x| fields.include?(x.id) }.collect { |f| f.name.downcase }
+  end
 
+  def field_value_hash(name)
+    field = ae_class.ae_fields.detect { |f| f.name.casecmp(name) == 0 }
+    raise "Field #{name} not found in class #{ae_class.fqname}" if field.nil?
+    value = ae_values.detect { |v| v.field_id == field.id }
+    raise "Field #{name} not found in instance #{self.name} in class #{ae_class.fqname}" if value.nil?
+    value.attributes
+  end
+
+  private
 
   def validate_field(field)
     if field.kind_of?(MiqAeField)

--- a/vmdb/app/models/miq_ae_instance_compare_values.rb
+++ b/vmdb/app/models/miq_ae_instance_compare_values.rb
@@ -1,0 +1,87 @@
+class MiqAeInstanceCompareValues
+  attr_reader :compatibilities
+  attr_reader :incompatibilities
+  attr_reader :fields_in_use
+  attr_reader :adds
+  IGNORE_PROPERTY_NAMES  = %w(name owner created_on updated_on updated_by
+                              updated_by_user_id id class_id instance_id field_id)
+  WARNING_PROPERTY_NAMES = %w(priority message display_name default_value substitute
+                              visibility collect scope description condition on_entry
+                              on_exit on_error max_retries max_time)
+  ERROR_PROPERTY_NAMES   = %w(aetype datatype)
+
+  CONGRUENT_INSTANCE = 1
+  COMPATIBLE_INSTANCE = 2
+  INCOMPATIBLE_INSTANCE = 4
+
+  def initialize(new_instance, old_instance)
+    @new_instance = new_instance
+    @old_instance = old_instance
+  end
+
+  def compare
+    load_field_names
+    initialize_results
+    venn_list
+    validate_similar
+    status
+  end
+
+  def status
+    return CONGRUENT_INSTANCE if congruent?
+    return COMPATIBLE_INSTANCE if compatible?
+    INCOMPATIBLE_INSTANCE
+  end
+
+  def congruent?
+    @adds.empty? && @incompatibilities.empty? &&
+    @compatibilities.empty? && @fields_in_use.empty? &&
+    @deletes.empty?
+  end
+
+  def compatible?
+    @incompatibilities.empty? && @deletes.empty?
+  end
+
+  private
+
+  def initialize_results
+    @incompatibilities = []
+    @compatibilities   = []
+    @fields_in_use     = []
+    @adds              = []
+    @deletes           = []
+  end
+
+  def load_field_names
+    @old_names = @old_instance.field_names
+    @new_names = @new_instance.field_names
+  end
+
+  def venn_list
+    @similar = @new_names & @old_names
+    @adds    = @new_names - @old_names
+    @deletes = @old_names - @new_names
+  end
+
+  def validate_similar
+    @similar.each do |name|
+      old_value = @old_instance.field_value_hash(name)
+      new_value = @new_instance.field_value_hash(name)
+      compare_value_properties(name, old_value, new_value)
+    end
+  end
+
+  def compare_value_properties(field_name, old_value, new_value)
+    old_value.each do |property, data|
+      next if IGNORE_PROPERTY_NAMES.include?(property)
+      next if data == new_value[property]
+      hash = {'property'   => property,
+              'old_data'   => data,
+              'new_data'   => new_value[property],
+              'field_name' => field_name}
+      @compatibilities   << hash if WARNING_PROPERTY_NAMES.include?(property)
+      @incompatibilities << hash if ERROR_PROPERTY_NAMES.include?(property)
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_instance_copy.rb
+++ b/vmdb/app/models/miq_ae_instance_copy.rb
@@ -1,0 +1,94 @@
+class MiqAeInstanceCopy
+  attr_accessor :flags
+  include MiqAeCopyMixin
+  DELETE_PROPERTIES = %w(id instance_id field_id updated_on created_on
+                         updated_by updated_by_user_id)
+
+  def initialize(instance_fqname)
+    @src_domain, @partial_ns, @ae_class, @instance_name = MiqAeInstanceCopy.split(instance_fqname, true)
+    @class_fqname = "#{@src_domain}/#{@partial_ns}/#{@ae_class}"
+    @src_class = MiqAeClass.find_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
+    raise "Source class not found #{@class_fqname}" unless @src_class
+    @src_instance = MiqAeInstance.find_by_name_and_class_id(@instance_name, @src_class.id)
+    raise "Source instance #{@instance_name} not found #{@class_fqname}" unless @src_instance
+    @target_class_name = @ae_class
+    @flags = MiqAeClassCompareFields::CONGRUENT_SCHEMA | MiqAeClassCompareFields::COMPATIBLE_SCHEMA
+  end
+
+  def to_domain(domain, ns = nil, overwrite = false)
+    check_duplicity(domain, ns, @instance_name)
+    @overwrite        = overwrite
+    @target_ns        = ns.nil? ? @partial_ns : ns
+    @target_name      = @instance_name
+    @target_domain    = domain
+    copy
+  end
+
+  def as(new_name, ns = nil, overwrite = false)
+    check_duplicity(@src_domain, ns, new_name)
+    @overwrite        = overwrite
+    @target_ns        = ns.nil? ? @partial_ns : ns
+    @target_name      = new_name
+    @target_domain    = @src_domain
+    copy
+  end
+
+  private
+
+  def find_or_create_class
+    @dest_class = MiqAeClass.find_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
+    return unless @dest_class.nil?
+    @dest_class = MiqAeClassCopy.new(@class_fqname).to_domain(@target_domain, @target_ns)
+  end
+
+  def copy
+    validate
+    create_instance
+    @dest_instance.ae_values << add_values
+    @dest_instance.save!
+    @dest_instance
+  end
+
+  def add_values
+    @src_instance.ae_values.collect do |v|
+      attrs = v.attributes.delete_if { |k, _| DELETE_PROPERTIES.include?(k) }
+      field_id = get_new_field_id(v.field_id)
+      next if field_id.nil?
+      MiqAeValue.new({:field_id => field_id}.merge(attrs))
+    end.compact
+  end
+
+  def get_new_field_id(field_id)
+    src_field = @src_class.ae_fields.detect { |f| f.id == field_id }
+    raise "Field id #{field_id} not found in source class #{@src_class.name}" if src_field.nil?
+    dest_field = @dest_class.ae_fields.detect { |f| f.name == src_field.name }
+    return nil if dest_field.nil? && @class_schema_status & @flags > 0
+    raise "Field name #{src_field.name} not found in target class #{@dest_class.name}" if dest_field.nil?
+    dest_field.id
+  end
+
+  def create_instance
+    @dest_instance = MiqAeInstance.find_by_class_id_and_name(@dest_class.id, @target_name)
+    if @dest_instance
+      @dest_instance.destroy if @overwrite
+      raise "Instance #{@target_name} exists in #{@target_ns_fqname} class #{@target_class_name}" unless @overwrite
+    end
+    @dest_instance = MiqAeInstance.create!(:name         => @target_name,
+                                           :description  => @src_instance.description,
+                                           :display_name => @src_instance.display_name,
+                                           :inherits     => @src_instance.inherits,
+                                           :class_id     => @dest_class.id)
+  end
+
+  def validate
+    find_or_create_class
+    @class_schema_status = MiqAeClassCompareFields.new(@src_class, @dest_class).compare
+    raise "Instance cannot be copied, automation class schema mismatch" if @flags & @class_schema_status == 0
+  end
+
+  def check_duplicity(domain, ns, instance_name)
+    if domain.downcase == @src_domain.downcase  && instance_name.downcase == @instance_name.downcase
+      raise "Cannot copy instance onto itself" if ns.nil? || ns.downcase == @partial_ns.downcase
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_instance_yaml.rb
+++ b/vmdb/app/models/miq_ae_instance_yaml.rb
@@ -1,0 +1,19 @@
+class MiqAeInstanceYaml
+  attr_accessor :ae_instance_obj
+  def initialize(filename = nil)
+    @filename = filename
+    @ae_instance_obj = YAML.load_file(@filename) if @filename
+  end
+
+  def field_names
+    raise "ae instance object has not been initialize" unless @ae_instance_obj
+    @ae_instance_obj['object']['fields'].collect { |item| item.keys }.flatten
+  end
+
+  def field_value_hash(name)
+    raise "ae instance object has not been initialize" unless @ae_instance_obj
+    value = @ae_instance_obj['object']['fields'].detect { |item| item.keys[0].casecmp(name) == 0 }
+    raise "field name #{name} not found in instance #{@filename}" if value.nil?
+    value[name]
+  end
+end

--- a/vmdb/app/models/miq_ae_method.rb
+++ b/vmdb/app/models/miq_ae_method.rb
@@ -77,4 +77,14 @@ class MiqAeMethod < ActiveRecord::Base
   def editable?
     ae_class.ae_namespace.editable?
   end
+
+  def field_names
+    inputs.collect { |f| f.name.downcase }
+  end
+
+  def field_value_hash(name)
+    field = inputs.detect { |f| f.name.casecmp(name) == 0 }
+    raise "Field #{name} not found in method #{self.name}" if field.nil?
+    field.attributes
+  end
 end

--- a/vmdb/app/models/miq_ae_method_compare.rb
+++ b/vmdb/app/models/miq_ae_method_compare.rb
@@ -1,0 +1,100 @@
+class MiqAeMethodCompare
+  attr_reader :compatibilities
+  attr_reader :incompatibilities
+  attr_reader :fields_in_use
+  attr_reader :adds
+  IGNORE_PROPERTY_NAMES  = %w(name owner created_on updated_on updated_by
+                              updated_by_user_id id class_id instance_id field_id)
+  WARNING_PROPERTY_NAMES = %w(priority message display_name default_value substitute
+                              visibility collect scope description condition on_entry
+                              on_exit on_error max_retries max_time)
+  ERROR_PROPERTY_NAMES   = %w(aetype datatype)
+  MAIN_METHOD_ATTRIBUTES = %w(scope language location data)
+
+  CONGRUENT_METHOD = 1
+  COMPATIBLE_METHOD = 2
+  INCOMPATIBLE_METHOD = 4
+
+  def initialize(new_method, old_method)
+    @new_method = new_method
+    @old_method = old_method
+  end
+
+  def compare
+    load_field_names
+    initialize_results
+    venn_list
+    validate_similar
+    compare_main_attributes
+    status
+  end
+
+  def status
+    return CONGRUENT_METHOD  if congruent?
+    return COMPATIBLE_METHOD if compatible?
+    INCOMPATIBLE_METHOD
+  end
+
+  def congruent?
+    @adds.empty? && @incompatibilities.empty? &&
+    @compatibilities.empty? && @fields_in_use.empty? &&
+    @deletes.empty?
+  end
+
+  def compatible?
+    @incompatibilities.empty? && @deletes.empty?
+  end
+
+  private
+
+  def initialize_results
+    @incompatibilities = []
+    @compatibilities   = []
+    @fields_in_use     = []
+    @adds              = []
+    @deletes           = []
+  end
+
+  def compare_main_attributes
+    MAIN_METHOD_ATTRIBUTES.each { |f| add_to_incompatibilities_if_different(f) }
+  end
+
+  def add_to_incompatibilities_if_different(method)
+    old_value = @old_method.send(method) if @old_method.respond_to? method
+    new_value = @new_method.send(method) if @new_method.respond_to? method
+    return if old_value == new_value
+    @incompatibilities << {'attribute' => method, 'old_data' => old_value, 'new_data' => new_value}
+  end
+
+  def load_field_names
+    @old_names = @old_method.field_names
+    @new_names = @new_method.field_names
+  end
+
+  def venn_list
+    @similar = @new_names & @old_names
+    @adds    = @new_names - @old_names
+    @deletes = @old_names - @new_names
+  end
+
+  def validate_similar
+    @similar.each do |name|
+      old_value = @old_method.field_value_hash(name)
+      new_value = @new_method.field_value_hash(name)
+      compare_value_properties(name, old_value, new_value)
+    end
+  end
+
+  def compare_value_properties(field_name, old_value, new_value)
+    old_value.each do |property, data|
+      next if IGNORE_PROPERTY_NAMES.include?(property)
+      next if data == new_value[property]
+      hash = {'property'   => property,
+              'old_data'   => data,
+              'new_data'   => new_value[property],
+              'field_name' => field_name}
+      @compatibilities   << hash if WARNING_PROPERTY_NAMES.include?(property)
+      @incompatibilities << hash if ERROR_PROPERTY_NAMES.include?(property)
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_method_copy.rb
+++ b/vmdb/app/models/miq_ae_method_copy.rb
@@ -1,0 +1,82 @@
+class MiqAeMethodCopy
+  include MiqAeCopyMixin
+  DELETE_PROPERTIES = %w(id class_id method_id field_id updated_on created_on
+                         updated_by updated_by_user_id)
+
+  def initialize(method_fqname)
+    @src_domain, @partial_ns, @ae_class, @method_name = MiqAeMethodCopy.split(method_fqname, true)
+    @class_fqname = "#{@src_domain}/#{@partial_ns}/#{@ae_class}"
+    @src_class = MiqAeClass.find_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
+    raise "Source class not found #{@class_fqname}" unless @src_class
+    @src_method = MiqAeMethod.find_by_name_and_class_id(@method_name, @src_class.id)
+    raise "Source method #{@method_name} not found #{@class_fqname}" unless @src_method
+    @target_class_name = @ae_class
+  end
+
+  def to_domain(domain, ns = nil, overwrite = false)
+    check_duplicity(domain, ns, @method_name)
+    @overwrite        = overwrite
+    @target_ns        = ns.nil? ? @partial_ns : ns
+    @target_name      = @method_name
+    @target_domain    = domain
+    copy
+  end
+
+  def as(new_name, ns = nil, overwrite = false)
+    check_duplicity(@src_domain, ns, new_name)
+    @overwrite        = overwrite
+    @target_ns        = ns.nil? ? @partial_ns : ns
+    @target_name      = new_name
+    @target_domain    = @src_domain
+    copy
+  end
+
+  private
+
+  def find_or_create_class
+    @dest_class = MiqAeClass.find_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
+    return unless @dest_class.nil?
+    @dest_class = MiqAeClassCopy.new(@class_fqname).to_domain(@target_domain, @target_ns)
+  end
+
+  def copy
+    validate
+    create_method
+    @dest_method.inputs << add_inputs
+    @dest_method.save!
+    @dest_method
+  end
+
+  def add_inputs
+    @src_method.inputs.collect do |v|
+      attrs = v.attributes.delete_if { |k, _| DELETE_PROPERTIES.include?(k) }
+      MiqAeField.new(attrs)
+    end
+  end
+
+  def create_method
+    @dest_method = MiqAeMethod.find_by_class_id_and_name(@dest_class.id, @target_name)
+    if @dest_method
+      @dest_method.destroy if @overwrite
+      raise "Instance #{@target_name} exists in #{@target_ns_fqname} class #{@target_class_name}" unless @overwrite
+    end
+    @dest_method = MiqAeMethod.create!(:name         => @target_name,
+                                       :display_name => @src_method.display_name,
+                                       :description  => @src_method.description,
+                                       :scope        => @src_method.scope,
+                                       :language     => @src_method.language,
+                                       :location     => @src_method.location,
+                                       :data         => @src_method.data,
+                                       :class_id     => @dest_class.id)
+  end
+
+  def validate
+    find_or_create_class
+  end
+
+  def check_duplicity(domain, ns, method_name)
+    if domain.downcase == @src_domain.downcase && method_name.downcase == @method_name.downcase
+      raise "Cannot copy method onto itself" if ns.nil? || ns.downcase == @partial_ns.downcase
+    end
+  end
+end

--- a/vmdb/app/models/miq_ae_method_yaml.rb
+++ b/vmdb/app/models/miq_ae_method_yaml.rb
@@ -1,0 +1,45 @@
+class MiqAeMethodYaml
+  attr_accessor :ae_method_obj
+  attr_accessor :data
+  def initialize(filename = nil)
+    @filename = filename
+    @ae_method_obj = YAML.load_file(@filename) if @filename
+    load_method_file if @filename
+  end
+
+  def define_instance_variables
+    @ae_method_obj['object']['attributes'].each do |k, v|
+      instance_variable_set("@#{k}", v)
+      singleton_class.class_eval { attr_accessor "#{k}" }
+      send("#{k}=", v)
+    end
+  end
+
+  def load_method_file
+    define_instance_variables
+    file_name = method_file_name
+    contents  = ""
+    contents = File.open(file_name) { |f| f.read } if file_name
+    instance_variable_set("@data", contents)
+  end
+
+  def method_file_name
+    return nil if location.casecmp('builtin') == 0
+    return nil if location.casecmp('uri') == 0
+    return @filename.gsub('.yaml', '.rb') if language.casecmp('ruby') == 0
+  end
+
+  def field_names
+    raise "ae_method_obj has not been set" unless @ae_method_obj
+    define_instance_variables
+    @ae_method_obj['object']['inputs'].collect { |item| item['field']['name'] }.flatten
+  end
+
+  def field_value_hash(name)
+    raise "ae_method_obj has not been set" unless @ae_method_obj
+    define_instance_variables
+    value = @ae_method_obj['object']['inputs'].detect { |item| item['field']['name'].casecmp(name) == 0 }
+    raise "field name #{name} not found in instance #{@filename}" if value.nil?
+    value['field']
+  end
+end

--- a/vmdb/app/models/miq_ae_namespace.rb
+++ b/vmdb/app/models/miq_ae_namespace.rb
@@ -19,16 +19,16 @@ class MiqAeNamespace < ActiveRecord::Base
     query.where(low_name.eq(last)).detect { |namespace| namespace.fqname.downcase == fqname }
   end
 
-  def self.find_or_create_by_fqname(fqname)
+  def self.find_or_create_by_fqname(fqname, include_classes = true)
     return nil if fqname.blank?
 
-    found = self.find_by_fqname(fqname)
+    found = find_by_fqname(fqname, include_classes)
     return found unless found.nil?
 
     parts = fqname.split('/')
     new_parts = [parts.pop]
     loop do
-      found = self.find_by_fqname(parts.join('/'))
+      found = find_by_fqname(parts.join('/'), include_classes)
       break unless found.nil?
       new_parts.unshift(parts.pop)
       break if parts.empty?

--- a/vmdb/app/models/mixins/miq_ae_copy_mixin.rb
+++ b/vmdb/app/models/mixins/miq_ae_copy_mixin.rb
@@ -1,0 +1,20 @@
+module MiqAeCopyMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def split(fqname, has_instance_name)
+      ns, ae_class, ae_instance, _  = MiqAeEngine::MiqAePath.split(fqname, :has_instance_name => has_instance_name)
+      parts = ns.split('/')
+      domain = parts.shift
+      partial_ns = parts.join('/')
+      return domain, partial_ns, ae_class, ae_instance if has_instance_name
+      return domain, partial_ns, ae_class
+    end
+
+    def same_class(from_class, to_class)
+      diff_obj = MiqAeClassCompareFields.new(from_class, to_class)
+      diff_obj.compare
+      diff_obj.congruent?
+    end
+  end
+end

--- a/vmdb/spec/models/miq_ae_class_compare_fields_spec.rb
+++ b/vmdb/spec/models/miq_ae_class_compare_fields_spec.rb
@@ -1,0 +1,201 @@
+require "spec_helper"
+include MiqAeYamlImportExportMixin
+describe MiqAeClassCompareFields do
+
+  before do
+    @domain = 'SPEC_DOMAIN'
+    @namespace   = 'NS1'
+    @yaml_folder = File.join(File.dirname(__FILE__), 'miq_ae_copy_data')
+    MiqAeDatastore.reset
+    @export_dir = File.join(Dir.tmpdir, 'rspec_copy_tests')
+  end
+
+  context "same fields" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy1.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS1")
+    end
+
+    it "both class in DB should be equivalent" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class_check_status(class1, class1, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be equivalent" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class1_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+    end
+
+  end
+
+  context "same fields mixed case" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy2.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS1", "MIXED_CASE_NAMES")
+    end
+
+    it "both class in DB should be equivalent" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be equivalent" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+    end
+  end
+
+  context "same field but aetype changes" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy3.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS1", "CLASS_AETYPE_OFF")
+    end
+
+    it "both classes in DB should be incompatible" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be incompatible" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+  end
+
+  context "same field but datatype changes" do
+    before(:each) do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy4.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS1", "CLASS_DATATYPE_OFF")
+    end
+
+    it "both classes in DB should be incompatible" do
+      ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
+      class1 = MiqAeClass.find_by_namespace_id_and_name(ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be incompatible" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+  end
+
+  context "same fields but priority changes" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy5.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS1", "CLASS_PRIORITY_OFF")
+    end
+
+    it "both classes in DB should be compatible" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be compatible" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
+    end
+  end
+
+  context "mostly same fields except a new additon" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy6.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS_ADD_A_FIELD", "CLASS1")
+    end
+
+    it "both classes in DB should be compatible" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be compatible" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
+    end
+  end
+
+  context "mostly same fields except a deletion of a in use field" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy7.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS_IN_USE_FIELD_DELETED", "CLASS1")
+    end
+
+    it "both classes in DB should be incompatible" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be incompatible" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+  end
+
+  context "mostly same fields except a deletion of a field not in use" do
+    before do
+      @yaml_file   = File.join(@yaml_folder, 'class_copy8.yaml')
+      EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+      prep_class_file_names("CLASS_FIELD_DELETED", "CLASS1")
+    end
+
+    it "both classes in DB should be incompatible" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+
+    it "one class in DB and other in YAML should be incompatible" do
+      export_model(@domain)
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClassYaml.new(@class2_file)
+      class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
+    end
+  end
+
+  def class_check_status(class1, class2, status)
+    diff_obj = MiqAeClassCompareFields.new(class1, class2)
+    diff_obj.compare
+    diff_obj.status.should equal(status)
+  end
+
+  def prep_class_file_names(class1 = nil, class2 = nil)
+    @first_class = class1 if class1
+    @second_class = class2 if class2
+    @class1_file = File.join(@export_dir, @domain, @namespace, "#{@first_class}.class", "__class__.yaml") if class1
+    @class2_file = File.join(@export_dir, @domain, @namespace, "#{@second_class}.class", "__class__.yaml") if class2
+    @ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
+  end
+
+  def export_model(domain, export_options = {})
+    FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)
+    export_options['export_dir'] = @export_dir if export_options.empty?
+    MiqAeExport.new(domain, export_options).export
+  end
+end

--- a/vmdb/spec/models/miq_ae_class_copy_spec.rb
+++ b/vmdb/spec/models/miq_ae_class_copy_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper"
+
+describe MiqAeClassCopy do
+
+  before do
+    @src_domain  = 'SPEC_DOMAIN'
+    @dest_domain = 'FRED'
+    @src_ns      = 'NS1'
+    @dest_ns     = 'NS1'
+    @src_class   = 'CLASS1'
+    @dest_class  = 'CLASS1'
+    @src_fqname  = "#{@src_domain}/#{@src_ns}/#{@src_class}"
+    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'class_copy1.yaml')
+    MiqAeDatastore.reset
+    EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @src_domain)
+  end
+
+  context "clone the class to a new domain" do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+    end
+
+    it "after copy both classes in DB should be congruent" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class2 = MiqAeClassCopy.new(@src_fqname).to_domain(@dest_domain)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+      @ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, @src_class)
+      class2.should_not be_nil
+    end
+  end
+
+  context "clone the class to a new domain with a different namespace" do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+    end
+
+    it "after copy both classes in DB should be congruent" do
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      new_ns   = "NS3/NS4"
+      class2 = MiqAeClassCopy.new(@src_fqname).to_domain(@dest_domain, new_ns)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+      @ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{new_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, @src_class)
+      class2.should_not be_nil
+    end
+  end
+
+  context "copy to a new classname in the same domain" do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+    end
+
+    it "after copy both classes in DB should be congruent" do
+      new_name = "SAME_AS_#{@src_class}"
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class2 = MiqAeClassCopy.new(@src_fqname).as(new_name)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, new_name)
+      class2.should_not be_nil
+    end
+  end
+
+  context "copy to a existing class in the same domain" do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+    end
+
+    it "copy should fail with error" do
+      expect { MiqAeClassCopy.new(@src_fqname).as(@src_class) }.to raise_error(RuntimeError)
+    end
+  end
+
+  context "copy to a new class name in the same domain but different namespace" do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+    end
+
+    it "after copy both classes in DB should be congruent" do
+      new_name = "SAME_AS_#{@src_class}"
+      new_ns   = "NS3/NS4"
+      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class2 = MiqAeClassCopy.new(@src_fqname).as(new_name, new_ns)
+      class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
+      @ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{new_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, new_name)
+      class2.should_not be_nil
+    end
+  end
+
+  context "copy class onto itself" do
+    it "pass in same domain" do
+      expect { MiqAeClassCopy.new(@src_fqname).to_domain(@src_domain, nil, true) }.to raise_error(RuntimeError)
+    end
+
+    it "pass in same classname" do
+      expect { MiqAeClassCopy.new(@src_fqname).as(@src_class, nil, true) }.to raise_error(RuntimeError)
+    end
+  end
+
+  def class_check_status(class1, class2, status)
+    diff_obj = MiqAeClassCompareFields.new(class1, class2)
+    diff_obj.compare
+    diff_obj.status.should equal(status)
+  end
+
+end

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy1.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy1.yaml
@@ -1,0 +1,245 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 1
+      instances: 1
+      created_on: 2014-06-30 20:47:01.376685000 Z
+      updated_on: 2014-06-30 20:47:01.376685000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:47:01.839006000 Z
+      updated_on: 2014-06-30 20:47:01.839006000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:47:01.913797000 Z
+      updated_on: 2014-06-30 20:47:01.913797000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:47:01.940447000 Z
+      updated_on: 2014-06-30 20:47:01.940447000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy2.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy2.yaml
@@ -1,0 +1,442 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    MIXED_CASE_NAMES.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: MIXED_CASE_NAMES
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: MfIeld1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: RfIeLd1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: MfIeLd2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: RfIeLd2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: MfiEld3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: AfIeLd1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: AfIeLd2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      created_on: 2014-06-30 20:48:47.569569000 Z
+      updated_on: 2014-06-30 20:48:47.569569000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:48:48.054027000 Z
+      updated_on: 2014-06-30 20:48:48.054027000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:48:48.093772000 Z
+      updated_on: 2014-06-30 20:48:48.093772000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:48:48.151685000 Z
+      updated_on: 2014-06-30 20:48:48.151685000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/MIXED_CASE_NAMES.class/__class__.yaml:
+      created_on: 2014-06-30 20:48:48.181252000 Z
+      updated_on: 2014-06-30 20:48:48.181252000 Z
+      size: 3466
+      sha1: Hrp9Abma0d8W3/UX3lOmnosi4E8=
+    NS1/MIXED_CASE_NAMES.class/default.yaml:
+      created_on: 2014-06-30 20:48:48.201399000 Z
+      updated_on: 2014-06-30 20:48:48.201399000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy3.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy3.yaml
@@ -1,0 +1,444 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    CLASS_AETYPE_OFF.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_AETYPE_OFF
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: attribute
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      created_on: 2014-06-30 20:50:45.629912000 Z
+      updated_on: 2014-06-30 20:50:45.629912000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:50:46.114955000 Z
+      updated_on: 2014-06-30 20:50:46.114955000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:50:46.157703000 Z
+      updated_on: 2014-06-30 20:50:46.157703000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:50:46.219414000 Z
+      updated_on: 2014-06-30 20:50:46.219414000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_AETYPE_OFF.class/__class__.yaml:
+      created_on: 2014-06-30 20:50:46.250173000 Z
+      updated_on: 2014-06-30 20:50:46.250173000 Z
+      size: 3470
+      sha1: fW1gMEn1/upePurHX7exFp4Kk+w=
+    NS1/CLASS_AETYPE_OFF.class/default.yaml:
+      created_on: 2014-06-30 20:50:46.271145000 Z
+      updated_on: 2014-06-30 20:50:46.271145000 Z
+      size: 176
+      sha1: oF3mUKYqXKWIJ8NgnLkoUcdgyfU=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy4.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy4.yaml
@@ -1,0 +1,442 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    CLASS_DATATYPE_OFF.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_DATATYPE_OFF
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: integer
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: integer
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: integer
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: integer
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: integer
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: integer
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: string
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      created_on: 2014-06-30 20:52:26.234109000 Z
+      updated_on: 2014-06-30 20:52:26.234109000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:52:26.972154000 Z
+      updated_on: 2014-06-30 20:52:26.972154000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:52:27.041224000 Z
+      updated_on: 2014-06-30 20:52:27.041224000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:52:27.123759000 Z
+      updated_on: 2014-06-30 20:52:27.123759000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_DATATYPE_OFF.class/__class__.yaml:
+      created_on: 2014-06-30 20:52:27.164758000 Z
+      updated_on: 2014-06-30 20:52:27.164758000 Z
+      size: 3473
+      sha1: D1AMoYjXDgT+P+hV/HMxxIJw3sE=
+    NS1/CLASS_DATATYPE_OFF.class/default.yaml:
+      created_on: 2014-06-30 20:52:27.195341000 Z
+      updated_on: 2014-06-30 20:52:27.195341000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy5.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy5.yaml
@@ -1,0 +1,442 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    CLASS_PRIORITY_OFF.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_PRIORITY_OFF
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 4
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 7
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 21
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 51
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      created_on: 2014-06-30 20:54:20.787936000 Z
+      updated_on: 2014-06-30 20:54:20.787936000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:54:21.275082000 Z
+      updated_on: 2014-06-30 20:54:21.275082000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:54:21.315737000 Z
+      updated_on: 2014-06-30 20:54:21.315737000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:54:21.374196000 Z
+      updated_on: 2014-06-30 20:54:21.374196000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_PRIORITY_OFF.class/__class__.yaml:
+      created_on: 2014-06-30 20:54:21.403790000 Z
+      updated_on: 2014-06-30 20:54:21.403790000 Z
+      size: 3470
+      sha1: HoemsQComxh371c5U2mTqrnQ0bM=
+    NS1/CLASS_PRIORITY_OFF.class/default.yaml:
+      created_on: 2014-06-30 20:54:21.423972000 Z
+      updated_on: 2014-06-30 20:54:21.423972000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy6.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy6.yaml
@@ -1,0 +1,462 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    CLASS_ADD_A_FIELD.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_ADD_A_FIELD
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield3
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      created_on: 2014-06-30 20:55:48.586481000 Z
+      updated_on: 2014-06-30 20:55:48.586481000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:55:49.073003000 Z
+      updated_on: 2014-06-30 20:55:49.073003000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:55:49.114112000 Z
+      updated_on: 2014-06-30 20:55:49.114112000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:55:49.172615000 Z
+      updated_on: 2014-06-30 20:55:49.172615000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_ADD_A_FIELD.class/__class__.yaml:
+      created_on: 2014-06-30 20:55:49.203880000 Z
+      updated_on: 2014-06-30 20:55:49.203880000 Z
+      size: 3845
+      sha1: OIZEqQZrQaF7ieQ4hwjkI6AQ1EA=
+    NS1/CLASS_ADD_A_FIELD.class/default.yaml:
+      created_on: 2014-06-30 20:55:49.226735000 Z
+      updated_on: 2014-06-30 20:55:49.226735000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy7.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy7.yaml
@@ -1,0 +1,432 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    CLASS_IN_USE_FIELD_DELETED.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_IN_USE_FIELD_DELETED
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield1:
+              value: barney
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      created_on: 2014-06-30 20:56:59.016859000 Z
+      updated_on: 2014-06-30 20:56:59.016859000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:56:59.516294000 Z
+      updated_on: 2014-06-30 20:56:59.516294000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:56:59.556772000 Z
+      updated_on: 2014-06-30 20:56:59.556772000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:56:59.617518000 Z
+      updated_on: 2014-06-30 20:56:59.617518000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_IN_USE_FIELD_DELETED.class/__class__.yaml:
+      created_on: 2014-06-30 20:56:59.649731000 Z
+      updated_on: 2014-06-30 20:56:59.649731000 Z
+      size: 3098
+      sha1: /uv7doHWvGzmpJgJgKNFAqAkif8=
+    NS1/CLASS_IN_USE_FIELD_DELETED.class/default.yaml:
+      created_on: 2014-06-30 20:56:59.671554000 Z
+      updated_on: 2014-06-30 20:56:59.671554000 Z
+      size: 320
+      sha1: c9vQ5PLWam6NFmfkBbIv/WCOPgo=

--- a/vmdb/spec/models/miq_ae_copy_data/class_copy8.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/class_copy8.yaml
@@ -1,0 +1,449 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+    CLASS_FIELD_DELETED.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_FIELD_DELETED
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      default2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default2
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 3
+      created_on: 2014-06-30 20:58:10.989511000 Z
+      updated_on: 2014-06-30 20:58:10.989511000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:58:11.489027000 Z
+      updated_on: 2014-06-30 20:58:11.489027000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:58:11.530114000 Z
+      updated_on: 2014-06-30 20:58:11.530114000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:58:11.589995000 Z
+      updated_on: 2014-06-30 20:58:11.589995000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_FIELD_DELETED.class/__class__.yaml:
+      created_on: 2014-06-30 20:58:11.624508000 Z
+      updated_on: 2014-06-30 20:58:11.624508000 Z
+      size: 3091
+      sha1: 70GhR5SEeJL3TARWCEpkw8Gev38=
+    NS1/CLASS_FIELD_DELETED.class/default.yaml:
+      created_on: 2014-06-30 20:58:11.646293000 Z
+      updated_on: 2014-06-30 20:58:11.646293000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_FIELD_DELETED.class/default2.yaml:
+      created_on: 2014-06-30 20:58:11.657176000 Z
+      updated_on: 2014-06-30 20:58:11.657176000 Z
+      size: 178
+      sha1: 9EHeX/gPnTi5mg4uVrroUeYUMmo=

--- a/vmdb/spec/models/miq_ae_copy_data/miq_ae_copy_classes.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/miq_ae_copy_classes.yaml
@@ -1,0 +1,2829 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      default2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default2
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+      delete1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: delete1
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+      instance1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: instance1
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      one_field.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: one_field
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+      __methods__:
+        send_email.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: send_email
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: builtin
+            inputs:
+            - field:
+                aetype: 
+                name: to
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: subject
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: body
+                display_name: 
+                datatype: string
+                priority: 3
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method.rb: ! 'puts "Hello World"
+
+'
+        test_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: couchdb
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method_diff_parameter.rb: ! 'puts "Hello World"
+
+'
+        test_method_diff_parameter.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method_diff_parameter
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: redis
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method_diff_script.rb: ! 'puts "Hello Morld"
+
+'
+        test_method_diff_script.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method_diff_script
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: couchdb
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+    CLASS_ADD_A_FIELD.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_ADD_A_FIELD
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield3
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+    CLASS_AETYPE_OFF.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_AETYPE_OFF
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: attribute
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+    CLASS_DATATYPE_OFF.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_DATATYPE_OFF
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: integer
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: integer
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: integer
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: integer
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: integer
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: integer
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: string
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+    CLASS_FIELD_DELETED.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_FIELD_DELETED
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      default2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default2
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+    CLASS_IN_USE_FIELD_DELETED.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_IN_USE_FIELD_DELETED
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield1:
+              value: barney
+    CLASS_PRIORITY_OFF.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS_PRIORITY_OFF
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 4
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 7
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 21
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 51
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+    MIXED_CASE_NAMES.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: MIXED_CASE_NAMES
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: MfIeld1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: RfIeLd1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: MfIeLd2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: RfIeLd2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: MfiEld3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: AfIeLd1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: AfIeLd2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields: []
+      __methods__:
+        send_email.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: send_email
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: builtin
+            inputs:
+            - field:
+                aetype: 
+                name: to
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: subject
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: body
+                display_name: 
+                datatype: string
+                priority: 3
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method.rb: ! 'puts "Hello World"
+
+'
+        test_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: couchdb
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method_diff_parameter.rb: ! 'puts "Hello World"
+
+'
+        test_method_diff_parameter.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method_diff_parameter
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: redis
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method_diff_script.rb: ! 'puts "Hello Morld"
+
+'
+        test_method_diff_script.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method_diff_script
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: couchdb
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+  NS2:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS2
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: attribute
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 9
+      instances: 14
+      method_instances: 8
+      method_files: 6
+      created_on: 2014-06-23 18:57:19.884194000 Z
+      updated_on: 2014-06-23 18:57:19.884194000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-23 18:57:20.278041000 Z
+      updated_on: 2014-06-23 18:57:20.278041000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:20.523547000 Z
+      updated_on: 2014-06-23 18:57:20.523547000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-23 18:57:20.550704000 Z
+      updated_on: 2014-06-23 18:57:20.550704000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS1.class/default2.yaml:
+      created_on: 2014-06-23 18:57:20.564058000 Z
+      updated_on: 2014-06-23 18:57:20.564058000 Z
+      size: 178
+      sha1: 9EHeX/gPnTi5mg4uVrroUeYUMmo=
+    NS1/CLASS1.class/delete1.yaml:
+      created_on: 2014-06-23 18:57:20.587093000 Z
+      updated_on: 2014-06-23 18:57:20.587093000 Z
+      size: 287
+      sha1: curqnhUE1FXeiK33uidHVzdR1VY=
+    NS1/CLASS1.class/instance1.yaml:
+      created_on: 2014-06-23 18:57:20.571308000 Z
+      updated_on: 2014-06-23 18:57:20.571308000 Z
+      size: 321
+      sha1: kp2xNMz/vNNYuKoSS1yCJEU03gs=
+    NS1/CLASS1.class/one_field.yaml:
+      created_on: 2014-06-23 18:57:20.597059000 Z
+      updated_on: 2014-06-23 18:57:20.597059000 Z
+      size: 179
+      sha1: VlZH2Wv7MwDG967YVH4sDZrT89I=
+    NS1/CLASS1.class/__methods__/send_email.yaml:
+      created_on: 2014-06-23 18:57:20.671558000 Z
+      updated_on: 2014-06-23 18:57:20.671558000 Z
+      size: 1269
+      sha1: d8T7CTsfDT3hbBLzcwMZWE5qoHc=
+    NS1/CLASS1.class/__methods__/test_method.rb:
+      created_on: 2014-06-23 18:57:20.608141000 Z
+      updated_on: 2014-06-23 18:57:20.608141000 Z
+      size: 19
+      sha1: yQWqqJJtskjOtTFDwpQ96adU1z0=
+    NS1/CLASS1.class/__methods__/test_method.yaml:
+      created_on: 2014-06-23 18:57:20.608141000 Z
+      updated_on: 2014-06-23 18:57:20.608141000 Z
+      size: 2064
+      sha1: vIrEIKekZ0T6IGv3MVjCZodWZfA=
+    NS1/CLASS1.class/__methods__/test_method_diff_parameter.rb:
+      created_on: 2014-06-23 18:57:20.654061000 Z
+      updated_on: 2014-06-23 18:57:20.654061000 Z
+      size: 19
+      sha1: yQWqqJJtskjOtTFDwpQ96adU1z0=
+    NS1/CLASS1.class/__methods__/test_method_diff_parameter.yaml:
+      created_on: 2014-06-23 18:57:20.654061000 Z
+      updated_on: 2014-06-23 18:57:20.654061000 Z
+      size: 2077
+      sha1: cj2xuKlC4AZ+npIK2PdstWawxPQ=
+    NS1/CLASS1.class/__methods__/test_method_diff_script.rb:
+      created_on: 2014-06-23 18:57:20.633523000 Z
+      updated_on: 2014-06-23 18:57:20.633523000 Z
+      size: 19
+      sha1: BVvFyPC7YOv1NP49ttoH30DW1yo=
+    NS1/CLASS1.class/__methods__/test_method_diff_script.yaml:
+      created_on: 2014-06-23 18:57:20.633523000 Z
+      updated_on: 2014-06-23 18:57:20.633523000 Z
+      size: 2076
+      sha1: 1zZEqljbwx8zT98U4fGeY8EhDG8=
+    NS1/CLASS_ADD_A_FIELD.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:21.037967000 Z
+      updated_on: 2014-06-23 18:57:21.037967000 Z
+      size: 3845
+      sha1: ygtgunIGxrj29yn+D8YIusovHgw=
+    NS1/CLASS_ADD_A_FIELD.class/default.yaml:
+      created_on: 2014-06-23 18:57:21.060688000 Z
+      updated_on: 2014-06-23 18:57:21.060688000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=
+    NS1/CLASS_AETYPE_OFF.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:20.920763000 Z
+      updated_on: 2014-06-23 18:57:20.920763000 Z
+      size: 3470
+      sha1: fW1gMEn1/upePurHX7exFp4Kk+w=
+    NS1/CLASS_AETYPE_OFF.class/default.yaml:
+      created_on: 2014-06-23 18:57:20.942250000 Z
+      updated_on: 2014-06-23 18:57:20.942250000 Z
+      size: 176
+      sha1: oF3mUKYqXKWIJ8NgnLkoUcdgyfU=
+    NS1/CLASS_DATATYPE_OFF.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:20.961073000 Z
+      updated_on: 2014-06-23 18:57:20.961073000 Z
+      size: 3473
+      sha1: D1AMoYjXDgT+P+hV/HMxxIJw3sE=
+    NS1/CLASS_DATATYPE_OFF.class/default.yaml:
+      created_on: 2014-06-23 18:57:20.981727000 Z
+      updated_on: 2014-06-23 18:57:20.981727000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=
+    NS1/CLASS_FIELD_DELETED.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:21.133142000 Z
+      updated_on: 2014-06-23 18:57:21.133142000 Z
+      size: 3091
+      sha1: 70GhR5SEeJL3TARWCEpkw8Gev38=
+    NS1/CLASS_FIELD_DELETED.class/default.yaml:
+      created_on: 2014-06-23 18:57:21.154630000 Z
+      updated_on: 2014-06-23 18:57:21.154630000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS_FIELD_DELETED.class/default2.yaml:
+      created_on: 2014-06-23 18:57:21.165502000 Z
+      updated_on: 2014-06-23 18:57:21.165502000 Z
+      size: 178
+      sha1: 9EHeX/gPnTi5mg4uVrroUeYUMmo=
+    NS1/CLASS_IN_USE_FIELD_DELETED.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:21.080595000 Z
+      updated_on: 2014-06-23 18:57:21.080595000 Z
+      size: 3098
+      sha1: /uv7doHWvGzmpJgJgKNFAqAkif8=
+    NS1/CLASS_IN_USE_FIELD_DELETED.class/default.yaml:
+      created_on: 2014-06-23 18:57:21.102394000 Z
+      updated_on: 2014-06-23 18:57:21.102394000 Z
+      size: 320
+      sha1: c9vQ5PLWam6NFmfkBbIv/WCOPgo=
+    NS1/CLASS_PRIORITY_OFF.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:20.998956000 Z
+      updated_on: 2014-06-23 18:57:20.998956000 Z
+      size: 3470
+      sha1: HoemsQComxh371c5U2mTqrnQ0bM=
+    NS1/CLASS_PRIORITY_OFF.class/default.yaml:
+      created_on: 2014-06-23 18:57:21.019398000 Z
+      updated_on: 2014-06-23 18:57:21.019398000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=
+    NS1/MIXED_CASE_NAMES.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:20.732322000 Z
+      updated_on: 2014-06-23 18:57:20.732322000 Z
+      size: 3466
+      sha1: Hrp9Abma0d8W3/UX3lOmnosi4E8=
+    NS1/MIXED_CASE_NAMES.class/default.yaml:
+      created_on: 2014-06-23 18:57:20.753229000 Z
+      updated_on: 2014-06-23 18:57:20.753229000 Z
+      size: 144
+      sha1: xQRcXVq5zXQFu4eo8J7bkb4w0MU=
+    NS1/MIXED_CASE_NAMES.class/__methods__/send_email.yaml:
+      created_on: 2014-06-23 18:57:20.893698000 Z
+      updated_on: 2014-06-23 18:57:20.893698000 Z
+      size: 1269
+      sha1: d8T7CTsfDT3hbBLzcwMZWE5qoHc=
+    NS1/MIXED_CASE_NAMES.class/__methods__/test_method.rb:
+      created_on: 2014-06-23 18:57:20.762892000 Z
+      updated_on: 2014-06-23 18:57:20.762892000 Z
+      size: 19
+      sha1: yQWqqJJtskjOtTFDwpQ96adU1z0=
+    NS1/MIXED_CASE_NAMES.class/__methods__/test_method.yaml:
+      created_on: 2014-06-23 18:57:20.762892000 Z
+      updated_on: 2014-06-23 18:57:20.762892000 Z
+      size: 2064
+      sha1: vIrEIKekZ0T6IGv3MVjCZodWZfA=
+    NS1/MIXED_CASE_NAMES.class/__methods__/test_method_diff_parameter.rb:
+      created_on: 2014-06-23 18:57:20.875782000 Z
+      updated_on: 2014-06-23 18:57:20.875782000 Z
+      size: 19
+      sha1: yQWqqJJtskjOtTFDwpQ96adU1z0=
+    NS1/MIXED_CASE_NAMES.class/__methods__/test_method_diff_parameter.yaml:
+      created_on: 2014-06-23 18:57:20.875782000 Z
+      updated_on: 2014-06-23 18:57:20.875782000 Z
+      size: 2077
+      sha1: cj2xuKlC4AZ+npIK2PdstWawxPQ=
+    NS1/MIXED_CASE_NAMES.class/__methods__/test_method_diff_script.rb:
+      created_on: 2014-06-23 18:57:20.853962000 Z
+      updated_on: 2014-06-23 18:57:20.853962000 Z
+      size: 19
+      sha1: BVvFyPC7YOv1NP49ttoH30DW1yo=
+    NS1/MIXED_CASE_NAMES.class/__methods__/test_method_diff_script.yaml:
+      created_on: 2014-06-23 18:57:20.853962000 Z
+      updated_on: 2014-06-23 18:57:20.853962000 Z
+      size: 2076
+      sha1: 1zZEqljbwx8zT98U4fGeY8EhDG8=
+    NS2/__namespace__.yaml:
+      created_on: 2014-06-23 18:57:21.203492000 Z
+      updated_on: 2014-06-23 18:57:21.203492000 Z
+      size: 155
+      sha1: +bli10RLw4va4CY+FkUXTkSG614=
+    NS2/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-23 18:57:21.222951000 Z
+      updated_on: 2014-06-23 18:57:21.222951000 Z
+      size: 3079
+      sha1: 2iu8PtXEjFUEZ2BDNSJt2iYVARY=
+    NS2/CLASS1.class/default.yaml:
+      created_on: 2014-06-23 18:57:21.242171000 Z
+      updated_on: 2014-06-23 18:57:21.242171000 Z
+      size: 176
+      sha1: oF3mUKYqXKWIJ8NgnLkoUcdgyfU=

--- a/vmdb/spec/models/miq_ae_copy_data/miq_ae_instance_copy.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/miq_ae_instance_copy.yaml
@@ -1,0 +1,458 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: 
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: wilma
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      default2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default2
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+  NS2:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS2
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: attribute
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 3
+      created_on: 2014-06-30 20:06:33.083034000 Z
+      updated_on: 2014-06-30 20:06:33.083034000 Z
+      size: 163
+      sha1: 8CUgrwvnaF6Y2LRqmidR9zfd+ns=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 20:06:33.203413000 Z
+      updated_on: 2014-06-30 20:06:33.203413000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:06:33.302356000 Z
+      updated_on: 2014-06-30 20:06:33.302356000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:06:33.399780000 Z
+      updated_on: 2014-06-30 20:06:33.399780000 Z
+      size: 319
+      sha1: zx4UL7SzOWMSjhJ4+1Q8BFJ7wcQ=
+    NS1/CLASS1.class/default2.yaml:
+      created_on: 2014-06-30 20:06:33.416110000 Z
+      updated_on: 2014-06-30 20:06:33.416110000 Z
+      size: 178
+      sha1: 9EHeX/gPnTi5mg4uVrroUeYUMmo=
+    NS2/__namespace__.yaml:
+      created_on: 2014-06-30 20:06:34.101561000 Z
+      updated_on: 2014-06-30 20:06:34.101561000 Z
+      size: 155
+      sha1: +bli10RLw4va4CY+FkUXTkSG614=
+    NS2/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 20:06:34.121661000 Z
+      updated_on: 2014-06-30 20:06:34.121661000 Z
+      size: 3079
+      sha1: 2iu8PtXEjFUEZ2BDNSJt2iYVARY=
+    NS2/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 20:06:34.148657000 Z
+      updated_on: 2014-06-30 20:06:34.148657000 Z
+      size: 176
+      sha1: oF3mUKYqXKWIJ8NgnLkoUcdgyfU=

--- a/vmdb/spec/models/miq_ae_copy_data/miq_ae_method_copy.yaml
+++ b/vmdb/spec/models/miq_ae_copy_data/miq_ae_method_copy.yaml
@@ -1,0 +1,782 @@
+---
+SPEC_DOMAIN:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: SPEC_DOMAIN
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: false
+  NS1:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: NS1
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    CLASS1.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: CLASS1
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: state
+              name: CustomizeRequest
+              display_name: 
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: update_provision_status(status => 'Customizing Request',status_state
+                => 'on_entry')
+              on_exit: update_provision_status(status => 'Customized Request',status_state
+                => 'on_exit')
+              on_error: update_provision_status(status => 'error in Customizing Request',status_state
+                => 'on_error')
+              max_retries: '100'
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield1
+              display_name: 
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield1
+              display_name: 
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield2
+              display_name: 
+              datatype: string
+              priority: 4
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: rfield2
+              display_name: 
+              datatype: string
+              priority: 5
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: mfield3
+              display_name: 
+              datatype: string
+              priority: 6
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield1
+              display_name: 
+              datatype: integer
+              priority: 7
+              owner: 
+              default_value: wilma
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: afield2
+              display_name: 
+              datatype: string
+              priority: 8
+              owner: 
+              default_value: barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      default.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: pebbles
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      default2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: default2
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+      delete1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: delete1
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: pebbles
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+      instance1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: instance1
+            inherits: 
+            description: 
+          fields:
+          - mfield1:
+              value: dinosaur
+          - rfield1:
+              value: pebbles
+          - mfield2:
+              value: woolly mammoth
+          - mfield3:
+              value: saber tooth
+          - afield2:
+              value: betty
+      one_field.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: one_field
+            inherits: 
+            description: 
+          fields:
+          - afield2:
+              value: betty lou
+      __methods__:
+        send_email.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: send_email
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: builtin
+            inputs:
+            - field:
+                aetype: 
+                name: to
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: subject
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: body
+                display_name: 
+                datatype: string
+                priority: 3
+                owner: 
+                default_value: 
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method.rb: ! 'puts "Hello World"
+
+'
+        test_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: couchdb
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method_diff_parameter.rb: ! 'puts "Hello World"
+
+'
+        test_method_diff_parameter.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method_diff_parameter
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: redis
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        test_method_diff_script.rb: ! 'puts "Hello Morld"
+
+'
+        test_method_diff_script.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: test_method_diff_script
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: database
+                display_name: 
+                datatype: string
+                priority: 1
+                owner: 
+                default_value: couchdb
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: username
+                display_name: 
+                datatype: string
+                priority: 2
+                owner: 
+                default_value: fred
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: password
+                display_name: 
+                datatype: password
+                priority: 3
+                owner: 
+                default_value: v2:{rLoUV68K3awm6YlKoQnAYg==}
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: procedure_name
+                display_name: 
+                datatype: string
+                priority: 4
+                owner: 
+                default_value: larry
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+            - field:
+                aetype: 
+                name: params
+                display_name: 
+                datatype: string
+                priority: 5
+                owner: 
+                default_value: curly
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 1
+      instances: 5
+      method_instances: 4
+      method_files: 3
+      created_on: 2014-06-30 18:23:27.258317000 Z
+      updated_on: 2014-06-30 18:23:27.258317000 Z
+      size: 168
+      sha1: 9g2g8XRTYab2z9EphoFs6xKZgoM=
+    NS1/__namespace__.yaml:
+      created_on: 2014-06-30 18:23:27.599205000 Z
+      updated_on: 2014-06-30 18:23:27.599205000 Z
+      size: 155
+      sha1: cq/oyFF9/djhEY2xkPvpL3ugqUM=
+    NS1/CLASS1.class/__class__.yaml:
+      created_on: 2014-06-30 18:23:27.859243000 Z
+      updated_on: 2014-06-30 18:23:27.859243000 Z
+      size: 3456
+      sha1: 0NpGjj70OxNuYohgW9A/uOgBjsc=
+    NS1/CLASS1.class/default.yaml:
+      created_on: 2014-06-30 18:23:27.893947000 Z
+      updated_on: 2014-06-30 18:23:27.893947000 Z
+      size: 321
+      sha1: HnK8Z2bkWmOiKYB4Tq7em6G2scc=
+    NS1/CLASS1.class/default2.yaml:
+      created_on: 2014-06-30 18:23:27.932947000 Z
+      updated_on: 2014-06-30 18:23:27.932947000 Z
+      size: 178
+      sha1: 9EHeX/gPnTi5mg4uVrroUeYUMmo=
+    NS1/CLASS1.class/delete1.yaml:
+      created_on: 2014-06-30 18:23:27.953109000 Z
+      updated_on: 2014-06-30 18:23:27.953109000 Z
+      size: 289
+      sha1: kqi1EDrslBBTPVIClAZDrzzQvxs=
+    NS1/CLASS1.class/instance1.yaml:
+      created_on: 2014-06-30 18:23:27.939892000 Z
+      updated_on: 2014-06-30 18:23:27.939892000 Z
+      size: 323
+      sha1: 3S5HOs9kKMykymTPUJFS3wF16HQ=
+    NS1/CLASS1.class/one_field.yaml:
+      created_on: 2014-06-30 18:23:27.962777000 Z
+      updated_on: 2014-06-30 18:23:27.962777000 Z
+      size: 179
+      sha1: VlZH2Wv7MwDG967YVH4sDZrT89I=
+    NS1/CLASS1.class/__methods__/send_email.yaml:
+      created_on: 2014-06-30 18:23:28.042187000 Z
+      updated_on: 2014-06-30 18:23:28.042187000 Z
+      size: 1269
+      sha1: d8T7CTsfDT3hbBLzcwMZWE5qoHc=
+    NS1/CLASS1.class/__methods__/test_method.rb:
+      created_on: 2014-06-30 18:23:27.973718000 Z
+      updated_on: 2014-06-30 18:23:27.973718000 Z
+      size: 19
+      sha1: yQWqqJJtskjOtTFDwpQ96adU1z0=
+    NS1/CLASS1.class/__methods__/test_method.yaml:
+      created_on: 2014-06-30 18:23:27.973718000 Z
+      updated_on: 2014-06-30 18:23:27.973718000 Z
+      size: 2064
+      sha1: vIrEIKekZ0T6IGv3MVjCZodWZfA=
+    NS1/CLASS1.class/__methods__/test_method_diff_parameter.rb:
+      created_on: 2014-06-30 18:23:28.024860000 Z
+      updated_on: 2014-06-30 18:23:28.024860000 Z
+      size: 19
+      sha1: yQWqqJJtskjOtTFDwpQ96adU1z0=
+    NS1/CLASS1.class/__methods__/test_method_diff_parameter.yaml:
+      created_on: 2014-06-30 18:23:28.024860000 Z
+      updated_on: 2014-06-30 18:23:28.024860000 Z
+      size: 2077
+      sha1: cj2xuKlC4AZ+npIK2PdstWawxPQ=
+    NS1/CLASS1.class/__methods__/test_method_diff_script.rb:
+      created_on: 2014-06-30 18:23:28.004688000 Z
+      updated_on: 2014-06-30 18:23:28.004688000 Z
+      size: 19
+      sha1: BVvFyPC7YOv1NP49ttoH30DW1yo=
+    NS1/CLASS1.class/__methods__/test_method_diff_script.yaml:
+      created_on: 2014-06-30 18:23:28.004688000 Z
+      updated_on: 2014-06-30 18:23:28.004688000 Z
+      size: 2076
+      sha1: 1zZEqljbwx8zT98U4fGeY8EhDG8=

--- a/vmdb/spec/models/miq_ae_instance_compare_values_spec.rb
+++ b/vmdb/spec/models/miq_ae_instance_compare_values_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+include MiqAeYamlImportExportMixin
+describe MiqAeInstanceCompareValues do
+
+  before do
+    @domain = 'SPEC_DOMAIN'
+    @namespace   = 'NS1'
+    @classname   = 'CLASS1'
+    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
+    MiqAeDatastore.reset
+    EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+    @export_dir = File.join(Dir.tmpdir, 'rspec_copy_tests')
+    @yaml_model = YAML.load_file(@yaml_file)
+  end
+
+  context "same instances" do
+    before do
+      prep_instance_file_names("instance1")
+    end
+
+    it "both instances in DB should be equivalent" do
+      inst1  = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      instance_check_status(inst1, inst1, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
+    end
+
+    it "one instance in DB and other in YAML should be equivalent" do
+      export_model(@domain)
+      inst1 = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      inst2 = MiqAeInstanceYaml.new(@instance1_file)
+      instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
+    end
+  end
+
+  context 'add a field in one of the instances' do
+    before do
+      prep_instance_file_names('instance1', 'delete1')
+    end
+
+    it 'both instances in DB should be compatible' do
+      inst1  = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      inst2  = MiqAeInstance.find_by_class_id_and_name(@class.id, @second_instance)
+      instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
+    end
+
+    it "one instance in DB and other in YAML should be compatible" do
+      export_model(@domain)
+      inst1 = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      inst2 = MiqAeInstanceYaml.new(@instance2_file)
+      instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
+    end
+
+  end
+
+  def instance_check_status(instance1, instance2, status)
+    diff_obj = MiqAeInstanceCompareValues.new(instance1, instance2)
+    diff_obj.compare
+    diff_obj.status.should equal(status)
+  end
+
+  def prep_instance_file_names(inst1 = nil, inst2 = nil)
+    @first_instance = inst1 if inst1
+    @second_instance = inst2 if inst2
+    @instance1_file = File.join(@export_dir, @domain, @namespace, "#{@classname}.class", "#{inst1}.yaml") if inst1
+    @instance2_file = File.join(@export_dir, @domain, @namespace, "#{@classname}.class", "#{inst2}.yaml") if inst2
+    @ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
+    @class = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @classname)
+  end
+
+  def export_model(domain, export_options = {})
+    FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)
+    export_options['export_dir'] = @export_dir if export_options.empty?
+    MiqAeExport.new(domain, export_options).export
+  end
+end

--- a/vmdb/spec/models/miq_ae_instance_copy_spec.rb
+++ b/vmdb/spec/models/miq_ae_instance_copy_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+describe MiqAeInstanceCopy do
+
+  before do
+    @src_domain    = 'SPEC_DOMAIN'
+    @dest_domain   = 'FRED'
+    @src_ns        = 'NS1'
+    @dest_ns       = 'NS1'
+    @src_class     = 'CLASS1'
+    @dest_class    = 'CLASS1'
+    @src_instance  = 'default'
+    @dest_instance = 'default2'
+    @dest_ns       = 'NSX/NSY'
+    @src_fqname    = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{@src_instance}"
+    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_instance_copy.yaml')
+    MiqAeDatastore.reset
+    EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @src_domain)
+  end
+
+  context 'clone instance' do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      @inst1  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @src_instance)
+    end
+
+    it 'after copy both instances in DB should be congruent' do
+      MiqAeInstanceCopy.new(@src_fqname).to_domain(@dest_domain)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
+      validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
+    end
+
+    it 'with overwrite an existing instance should get updated' do
+      inst2  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @dest_instance)
+      validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
+      MiqAeInstanceCopy.new(@src_fqname).as(@dest_instance, nil, true)
+      inst2  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @dest_instance)
+      validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
+    end
+
+    it 'without overwrite an existing instance should raise error' do
+      inst2  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @dest_instance)
+      validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
+      expect { MiqAeInstanceCopy.new(@src_fqname).as(@dest_instance) }.to raise_error(RuntimeError)
+    end
+
+    it 'copy instance to a different namespace in the same domain' do
+      MiqAeInstanceCopy.new(@src_fqname).as(@src_instance, @dest_ns, true)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
+      validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
+    end
+
+    it 'copy instance to a different namespace in a different domain' do
+      MiqAeInstanceCopy.new(@src_fqname).to_domain(@dest_domain, @dest_ns, true)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
+      validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
+    end
+
+  end
+
+  context 'incompatible schema' do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      @inst1  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @src_instance)
+    end
+
+    it 'by default copy should fail' do
+      expect { MiqAeInstanceCopy.new(@src_fqname).as('incompatible_one', 'NS2', true) }.to raise_error(RuntimeError)
+    end
+
+    it 'allow if the incompatible flag is set' do
+      cp = MiqAeInstanceCopy.new(@src_fqname)
+      cp.flags = MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA
+      cp.as('incompatible_one', 'NS2', true)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/ns2", false)
+      ic_class = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      MiqAeInstance.find_by_class_id_and_name(ic_class.id, 'incompatible_one').should_not be_nil
+    end
+  end
+
+  context 'copy onto itself' do
+    it 'copy into the same domain' do
+      expect { MiqAeInstanceCopy.new(@src_fqname).to_domain(@src_domain, nil, true) }.to raise_error(RuntimeError)
+    end
+
+    it 'copy with the same name' do
+      expect { MiqAeInstanceCopy.new(@src_fqname).as(@src_instance, nil, true) }.to raise_error(RuntimeError)
+    end
+  end
+
+  def validate_instance(instance1, instance2, status)
+    obj = MiqAeInstanceCompareValues.new(instance1, instance2)
+    obj.compare
+    obj.status.should eq(status)
+  end
+
+end

--- a/vmdb/spec/models/miq_ae_method_compare_spec.rb
+++ b/vmdb/spec/models/miq_ae_method_compare_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+include MiqAeYamlImportExportMixin
+
+describe MiqAeMethodCompare do
+
+  before do
+    @domain = 'SPEC_DOMAIN'
+    @namespace   = 'NS1'
+    @classname   = 'CLASS1'
+    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
+    MiqAeDatastore.reset
+    EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
+    @export_dir = File.join(Dir.tmpdir, 'rspec_copy_tests')
+    @yaml_model = YAML.load_file(@yaml_file)
+  end
+
+  context 'same methods' do
+    before do
+      prep_method_file_names('test_method')
+    end
+
+    it 'both methods in DB should be equivalent' do
+      meth1  = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      method_check_status(meth1, meth1, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+
+    it 'one method in DB and other in YAML should be equivalent' do
+      export_model(@domain)
+      meth1 = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth2 = MiqAeMethodYaml.new(@method1_file)
+      method_check_status(meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+  end
+
+  context 'method slightly off' do
+    before do
+      prep_method_file_names('test_method', 'test_method_diff_script')
+    end
+
+    it 'both method in DB should be incompatible' do
+      meth1  = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(@class.id, @second_method)
+      method_check_status(meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
+    end
+
+    it 'one method in DB and other in YAML should be incompatible' do
+      export_model(@domain)
+      meth1 = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth2 = MiqAeMethodYaml.new(@method2_file)
+      method_check_status(meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
+    end
+  end
+
+  context 'one parameter slightly off' do
+    before do
+      prep_method_file_names('test_method', 'test_method_diff_parameter')
+    end
+
+    it 'both method in DB should be compatible' do
+      meth1  = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(@class.id, @second_method)
+      method_check_status(meth1, meth2, MiqAeMethodCompare::COMPATIBLE_METHOD)
+    end
+
+    it 'one method in DB and other in YAML should be compatible' do
+      export_model(@domain)
+      meth1 = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth2 = MiqAeMethodYaml.new(@method2_file)
+      method_check_status(meth1, meth2, MiqAeMethodCompare::COMPATIBLE_METHOD)
+    end
+  end
+
+  def method_check_status(method1, method2, status)
+    diff_obj = MiqAeMethodCompare.new(method1, method2)
+    diff_obj.compare
+    diff_obj.status.should equal(status)
+  end
+
+  def prep_method_file_names(meth1 = nil, meth2 = nil)
+    @first_method = meth1 if meth1
+    @second_method = meth2 if meth2
+    @method1_file = File.join(@export_dir, @domain, @namespace,
+                              "#{@classname}.class", '__methods__', "#{meth1}.yaml") if meth1
+    @method2_file = File.join(@export_dir, @domain, @namespace,
+                              "#{@classname}.class", '__methods__', "#{meth2}.yaml") if meth2
+    @ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
+    @class = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @classname)
+  end
+
+  def export_model(domain, export_options = {})
+    FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)
+    export_options['export_dir'] = @export_dir if export_options.empty?
+    MiqAeExport.new(domain, export_options).export
+  end
+end

--- a/vmdb/spec/models/miq_ae_method_copy_spec.rb
+++ b/vmdb/spec/models/miq_ae_method_copy_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe MiqAeMethodCopy do
+
+  before do
+    @src_domain     = 'SPEC_DOMAIN'
+    @dest_domain    = 'FRED'
+    @src_ns         = 'NS1'
+    @dest_ns        = 'NS1'
+    @src_class      = 'CLASS1'
+    @dest_class     = 'CLASS1'
+    @src_method     = 'test_method'
+    @dest_method    = 'test_method_diff_script'
+    @builtin_method = 'send_email'
+    @dest_ns        = 'NSX/NSY'
+    @src_fqname     = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{@src_method}"
+    @yaml_file      = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
+    MiqAeDatastore.reset
+    EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @src_domain)
+  end
+
+  context 'clone method' do
+    before do
+      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      @meth1  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @src_method)
+    end
+
+    it 'after copy both inline methods in DB should be congruent' do
+      MiqAeMethodCopy.new(@src_fqname).to_domain(@dest_domain)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
+      validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+
+    it 'after copy both builtin methods in DB should be congruent' do
+      builtin_fqname = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{@builtin_method}"
+      meth1  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @builtin_method)
+      MiqAeMethodCopy.new(builtin_fqname).to_domain(@dest_domain)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @builtin_method)
+      validate_method(meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+
+    it 'overwrite an existing method' do
+      meth2  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @dest_method)
+      validate_method(@meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
+      MiqAeMethodCopy.new(@src_fqname).as(@dest_method, nil, true)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @dest_method)
+      validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+
+    it 'overwrite an existing method should raise error' do
+      meth2  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @dest_method)
+      validate_method(@meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
+      expect { MiqAeMethodCopy.new(@src_fqname).as(@dest_method) }.to raise_error(RuntimeError)
+    end
+
+    it 'copy method to a different namespace in the same domain' do
+      MiqAeMethodCopy.new(@src_fqname).as(@src_method, @dest_ns, true)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
+      validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+
+    it 'copy method to a different namespace in a different domain' do
+      MiqAeMethodCopy.new(@src_fqname).to_domain(@dest_domain, @dest_ns, true)
+      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
+      validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
+    end
+
+  end
+
+  context 'copy onto itself' do
+    it 'copy into the same domain' do
+      expect { MiqAeMethodCopy.new(@src_fqname).to_domain(@src_domain, nil, true) }.to raise_error(RuntimeError)
+    end
+
+    it 'copy with the same name' do
+      expect { MiqAeMethodCopy.new(@src_fqname).as(@src_method, nil, true) }.to raise_error(RuntimeError)
+    end
+
+  end
+
+  def validate_method(meth1, meth2, status)
+    obj = MiqAeMethodCompare.new(meth1, meth2)
+    obj.compare
+    obj.status.should eq(status)
+  end
+
+end

--- a/vmdb/spec/support/evm_spec_helper.rb
+++ b/vmdb/spec/support/evm_spec_helper.rb
@@ -130,6 +130,15 @@ module EvmSpecHelper
 
   def self.import_yaml_model(dirname, domain, attrs = {})
     options = {'import_dir' => dirname, 'preview' => false, 'domain' => domain}
+    yaml_import(domain, options, attrs)
+  end
+
+  def self.import_yaml_model_from_file(yaml_file, domain, attrs = {})
+    options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => domain}
+    yaml_import(domain, options, attrs)
+  end
+
+  def self.yaml_import(domain, options, attrs = {})
     MiqAeImport.new(domain, options).import
     dom = MiqAeNamespace.find_by_fqname(domain)
     dom.update_attributes!(attrs.reverse_merge(:enabled => true)) if dom


### PR DESCRIPTION
 The UI needs backend support for copying classes, instances and methods from a readonly domain like ManageIQ to an editable customer domain. Before an instance can be copied we have to compare the class schema, before overlaying an instance or a method we need to compare the values and the scripts. Comparison is a precursor to copying the automation components.
The comparison functions can also be used to compare automation components stored in YAML when importing automation models.

The comparison functions return 3 status values
- CONGRUENT to indicate that the component matches completely (class schema is identical, instance values are identical, method parameters and scripts are identical)
- COMPATIBLE to indicate that the component doesn't have a identical match but is compatible (e.g. class schema has new fields, instances have new values)
- INCOMPATIBLE to indicate that the components don't match at all(e.g datatype/aetype are different in class schema)

By default an instance can only be copied if the Class Schema is either CONGRUENT or COMPATIBLE. A user can still force a copy of instances with INCOMPATIBLE schemas but would have to edit the instance after it has been created. 
