### PR TITLE
Fixed an error when reload is pressed on VM filter with user input.

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1481,7 +1481,7 @@ module VmCommon
       listnav_search_selected(search_id) unless params.has_key?(:search_text) # Clear or set the adv search filter
       if @edit[:adv_search_applied] &&
           MiqExpression.quick_search?(@edit[:adv_search_applied][:exp]) &&
-          params[:action] == "tree_select"
+          %w(reload tree_select).include?(params[:action])
         self.x_node = params[:id]
         quick_search_show
         return


### PR DESCRIPTION
Changed to show quick search pop up box, when Reload button is pressed on a VM filter screen that prompts for user input.

https://bugzilla.redhat.com/show_bug.cgi?id=1082569
https://bugzilla.redhat.com/show_bug.cgi?id=1112392

@dclarizio please review/test
