### PR TITLE
Removed a warning message from automation log

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -586,7 +586,6 @@ module MiqAeEngine
         service_model = MiqAeMethodService.const_get("MiqAeService#{SM_LOOKUP[datatype]}")
         return service_model.find(value)
       rescue NameError
-        $miq_ae_logger.warn("Service Model #{datatype} not found")
       end
 
       # default datatype => 'string'


### PR DESCRIPTION
We log a warning everytime a service model is not found. Which includes
basic ruby objects. e.g.
[----] W, [2014-06-20T13:01:03.092624 #3049:3fe521833bdc]  WARN -- :
Service Model string not found
