### PR TITLE
defer garbage collection in specs

### DIFF
--- a/lib/spec/spec_helper.rb
+++ b/lib/spec/spec_helper.rb
@@ -10,4 +10,10 @@ $:.push(LIB_ROOT)
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
 
 RSpec.configure do |config|
+  config.before(:all) do
+    DeferredGarbageCollection.start
+  end
+  config.after(:all) do
+    DeferredGarbageCollection.reconsider
+  end
 end

--- a/lib/spec/support/deferred_garbage_collection.rb
+++ b/lib/spec/support/deferred_garbage_collection.rb
@@ -1,0 +1,26 @@
+class DeferredGarbageCollection
+  DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 10.0).to_f
+
+  class << self
+    attr_accessor :last_gc_run
+  end
+
+  @last_gc_run = Time.now
+
+  def self.start
+    GC.disable if DEFERRED_GC_THRESHOLD > 0
+  end
+
+  def self.should_run_gc?
+    DEFERRED_GC_THRESHOLD > 0 && (Time.now - last_gc_run) >= DEFERRED_GC_THRESHOLD
+  end
+
+  def self.reconsider
+    if should_run_gc?
+      GC.enable
+      GC.start
+      GC.disable
+      self.last_gc_run = Time.now
+    end
+  end
+end

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/fire'
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 # include the lib matchers
 Dir[Rails.root.join("../lib/spec/support/custom_matchers/*.rb")].each { |f| require f }
+Dir[Rails.root.join("../lib/spec/support/deferred_garbage_collection.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   # == Mock Framework
@@ -65,6 +66,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Bullet.start_request if defined?(Bullet)
+    DeferredGarbageCollection.start if defined?(DeferredGarbageCollection)
   end
 
   config.after(:each) do
@@ -73,6 +75,7 @@ RSpec.configure do |config|
       Bullet.end_request
     end
     EvmSpecHelper.clear_caches
+    DeferredGarbageCollection.reconsider if defined?(DeferredGarbageCollection)
   end
 end
 


### PR DESCRIPTION
To speed up test time, do we want to mess with the garbage collection?

A bunch of sites suggested deferring the garbage collection
