### PR TITLE
Export button click will now be disabled until a report is selected

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -291,6 +291,26 @@ function miqValidateButtons(h_or_s, prefix) {
       if($(on_id)) $(on_id).hide();
 }   }
 
+// Convert Button image to hyperlink
+function toggleConvertButtonToLink(button, url, toggle) {
+  if (toggle == true) {
+    if(button.hasClass('dimmed')) {
+      button.removeClass('dimmed')
+    }
+    if(button[0].parentNode.outerHTML.indexOf('<a href') == -1) {
+      button[0].outerHTML = "<a href=" + url + " title='" + button[0].getAttribute('alt') + "'>" + button[0].outerHTML + "</a>";
+    }
+  }
+  else {
+    if(!button.hasClass('dimmed')) {
+      button.addClass('dimmed')
+    }
+    if(button[0].parentNode.outerHTML.indexOf('<a href') > -1) {
+      button[0].parentNode.outerHTML = button[0].outerHTML;
+    }
+  }
+}
+
 // update all checkboxes on a form when the masterToggle checkbox is changed
 // parms: button_div=<id of div with buttons to update>, override=<forced state>
 function miqUpdateAllCheckboxes(button_div,override) {

--- a/vmdb/app/views/layouts/_x_edit_buttons.html.erb
+++ b/vmdb/app/views/layouts/_x_edit_buttons.html.erb
@@ -200,10 +200,13 @@
 																																	:item=>0)}');")
 								%>
               <% elsif export_button %>
-                <%= link_to(image_tag("/images/formbuttons/export.png", :class=>"button", :border=>"0", :type=>"application/txt",
-                                      :alt=>"Download Report to YAML"),
-                            {:action=>action_url},
-                            {:title=>"Download Report to YAML"})
+                <%= image_tag("/images/formbuttons/export.png",
+                              :class  => "button dimmed",
+                              :border => "0",
+                              :type   => "application/txt",
+                              :id     => "export_button",
+                              :alt    => "Download Report to YAML")
+
                 %>
 							<% else %>
 								<%#= image_tag('/images/formbuttons/back2.png', :border=>"0", :class=>"button",

--- a/vmdb/app/views/report/_export.html.erb
+++ b/vmdb/app/views/report/_export.html.erb
@@ -30,11 +30,13 @@
             >
               <%= select_tag('choices_chosen',
                               options_for_select(@temp[:export_reports].sort),
-                              :style=>"width:auto; min-width:375px; background-color:#fff; border: 0px;",
-                              :size=>15,
-                              :style=>"width: 400px",
-                              :multiple=> true,
-                              "data-miq_observe"=>{:url=>url}.to_json) %>
+                              :style             => "width:auto; min-width:375px; background-color:#fff; border: 0px;",
+                              :size              => 15,
+                              :style             => "width: 400px",
+                              :multiple          => true,
+                              :onchange          => "toggleConvertButtonToLink($j('#export_button'),
+                                                      'download_report', $j('#choices_chosen').val() != null);",
+                              "data-miq_observe" => {:url => url}.to_json) %>
             </div>
           </td>
         </tr>


### PR DESCRIPTION
Prevented a user click on the Export button by graying and disabling it.
The button will be enabled only when a report is selected from the
Available Reports list.

https://bugzilla.redhat.com/show_bug.cgi?id=1110244
