### PR TITLE
Fix user for db connect from root to postgres.

### DIFF
--- a/vmdb/config/database.pg.yml
+++ b/vmdb/config/database.pg.yml
@@ -14,7 +14,7 @@
 base: &base
   adapter: postgresql
   encoding: utf8
-  username: root
+  username: postgres
   pool: 1
   wait_timeout: 5
   min_messages: warning


### PR DESCRIPTION
Connection attempts with user root from the application cause exceptions.
(It's probably caused because the schema is created with user postgres based on the instructions
posted on the website)

Signed-off-by: Alissa Bonas abonas@redhat.com
