### PR TITLE
Changed identify_record call to pass in model.

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -2798,7 +2798,7 @@ class ApplicationController < ActionController::Base
   end
 
   def identify_tl_or_perf_record
-    identify_record(params[:id])
+    identify_record(params[:id], controller_to_model)
   end
 
   def assert_privileges(feature)

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -74,6 +74,15 @@ module ApplicationHelper
     record.class.base_model.name.underscore
   end
 
+  def controller_to_model
+    case self.class.model.to_s
+    when "TemplateCloud", "VmCloud", "TemplateInfra", "VmInfra"
+      VmOrTemplate
+    else
+      self.class.model
+    end
+  end
+
   def url_for_record(record, action="show") # Default action is show
     @id = to_cid(record.id)
     if record.kind_of?(VmOrTemplate)


### PR DESCRIPTION
Added a new method controller_to_model that can be used to pass in model to identify_record call to fix an issue where find for VmInfra record was blowing up for MiqTemplate record.

https://bugzilla.redhat.com/show_bug.cgi?id=1110964
https://bugzilla.redhat.com/show_bug.cgi?id=1113186

@dclarizio please review/test
