### PR TITLE
Add support for OpenLDAP as implementation for authentication mechanism.

### DIFF
--- a/vmdb/lib/miq_ldap.rb
+++ b/vmdb/lib/miq_ldap.rb
@@ -285,7 +285,7 @@ class MiqLdap
     user_type ||= @user_type.split("-").first
     user_type = "dn" if self.is_dn?(username)
     begin
-      search_opts = {:base => @basedn, :scope => :sub}
+      search_opts = {:base => @basedn, :scope => :sub, :attributes => ["*", "memberof"]}
 
       case user_type
       when "upn", "userprincipalname", "mail"


### PR DESCRIPTION
OpenLDAP only returns memberof attribute for users when it's specifically requested
in the ldap query as it's considered an "operational attribute".

https://bugzilla.redhat.com/show_bug.cgi?id=1093739
