### PR TITLE
Method override for Automate Domains

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -354,5 +354,9 @@ module MiqAeEngine
     def overlay_namespace(scheme, uri, ns, klass, instance)
       @dom_search.get_alternate_domain(scheme, uri, ns, klass, instance)
     end
+
+    def overlay_method(ns, klass, method)
+      @dom_search.get_alternate_domain_method('miqaedb', "#{ns}/#{klass}/#{method}", ns, klass, method)
+    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/data/domain_test.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/domain_test.yaml
@@ -1,0 +1,830 @@
+---
+evm1:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: evm1
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: 
+  test:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: test
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    AUTOMATE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: AUTOMATE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: method
+              name: overlay_method
+              display_name: overlay method
+              datatype: 
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: connect_to
+              display_name: Relationship
+              datatype: 
+              priority: 2
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      _missing.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: .missing
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: evm1_missing_method
+      __methods__:
+        evm1_missing_method.rb: ! '$evm.root[''method_executed'']  = "evm1_missing_method"
+
+'
+        evm1_missing_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: evm1_missing_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs: []
+evm2:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: evm2
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: 
+  test:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: test
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    AUTOMATE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: AUTOMATE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: method
+              name: overlay_method
+              display_name: overlay method
+              datatype: 
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: connect_to
+              display_name: Relationship
+              datatype: 
+              priority: 2
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      _missing.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: .missing
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: evm2_missing_method
+      __methods__:
+        evm2_missing_method.rb: ! '$evm.root[''method_executed'']  = "evm2_missing_method"
+
+'
+        evm2_missing_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: evm2_missing_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs: []
+user:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: user
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: 
+  evm:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: evm
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    AUTOMATE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: AUTOMATE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: method
+              name: overlay_method
+              display_name: overlay method
+              datatype: 
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: attr1
+              display_name: Attribute1
+              datatype: 
+              priority: 2
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: connect_to
+              display_name: Relationship
+              datatype: 
+              priority: 3
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      test1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test1
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: user_method
+      test2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test2
+            inherits: 
+            description: 
+          fields:
+          - connect_to:
+              value: /root/evm/AUTOMATE/test3*
+      test31.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test31
+            inherits: 
+            description: 
+          fields:
+          - attr1:
+              value: test31
+      test32.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test32
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: user_method
+          - attr1:
+              value: test32
+      test_wildcard.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test_wildcard
+            inherits: 
+            description: 
+          fields:
+          - connect_to:
+              value: /evm/AUTOMATE/test3*
+      __methods__:
+        user_method.rb: ! "begin\n              $evm.log(\"info\", \"#{@method} -
+          Root:<$evm.root> Begin Attributes\")\n              $evm.root.attributes.sort.each
+          do |k, v|\n                $evm.log(\"info\", \"#{@method} - Root:<$evm.root>
+          Attributes - #{k}: #{v}\")\n              end\n              $evm.log(\"info\",
+          \"#{@method} - Root:<$evm.root> End Attributes\")\n              $evm.log(\"info\",
+          \"#{$evm.class.name}\")\n              $evm.root['method_executed']  = \"user\"\n
+          \           end\n"
+        user_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: user_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs: []
+root:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: root
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: 
+  evm:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: evm
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    AUTOMATE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: AUTOMATE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: method
+              name: overlay_method
+              display_name: overlay method
+              datatype: 
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: attr1
+              display_name: Attribute1
+              datatype: 
+              priority: 2
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: connect_to
+              display_name: Relationship
+              datatype: 
+              priority: 3
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      test1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test1
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: root_method
+      test2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test2
+            inherits: 
+            description: 
+          fields:
+          - connect_to:
+              value: /root/evm/AUTOMATE/test1
+      __methods__:
+        root_method.rb: ! "begin\n          $evm.log(\"info\", \"#{@method} - Root:<$evm.root>
+          Begin Attributes\")\n          $evm.root.attributes.sort.each do |k, v|\n
+          \           $evm.log(\"info\", \"#{@method} - Root:<$evm.root> Attributes
+          - #{k}: #{v}\")\n          end\n          $evm.log(\"info\", \"#{@method}
+          - Root:<$evm.root> End Attributes\")\n          $evm.log(\"info\", \"#{$evm.class.name}\")\n
+          \         $evm.root['method_executed']  = \"root\"\n        end\n"
+        root_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: root_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs: []
+inert:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: inert
+        description: 
+        display_name: 
+        system: 
+        priority: 100
+        enabled: 
+  evm:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: evm
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    AUTOMATE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: AUTOMATE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: method
+              name: overlay_method
+              display_name: overlay method
+              datatype: 
+              priority: 1
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: attr1
+              display_name: Attribute1
+              datatype: 
+              priority: 2
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: relationship
+              name: connect_to
+              display_name: Relationship
+              datatype: 
+              priority: 3
+              owner: 
+              default_value: ''
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      should_get_used.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: should_get_used
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: inert_method
+          - attr1:
+              value: test32
+      should_not_get_used.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: should_not_get_used
+            inherits: 
+            description: 
+          fields:
+          - attr1:
+              value: test31
+      test1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test1
+            inherits: 
+            description: 
+          fields:
+          - overlay_method:
+              value: inert_method
+      test2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test2
+            inherits: 
+            description: 
+          fields:
+          - connect_to:
+              value: /root/evm/AUTOMATE/test3*
+      test_wildcard.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test_wildcard
+            inherits: 
+            description: 
+          fields:
+          - connect_to:
+              value: /evm/AUTOMATE/test3*
+      __methods__:
+        inert_method.rb: ! '$evm.root[''method_executed'']  = "inert"
+
+'
+        inert_method.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: inert_method
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs: []
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 5
+      instances: 14
+      method_files: 5
+      method_instances: 5
+      created_on: 2014-06-26 17:14:43.278393000 Z
+      updated_on: 2014-06-26 17:14:43.278393000 Z
+      size: 157
+      sha1: YUFsxVaUKYDhHt7r4baY65iB4Dc=
+    test/__namespace__.yaml:
+      created_on: 2014-06-26 17:15:32.246479000 Z
+      updated_on: 2014-06-26 17:15:32.246479000 Z
+      size: 156
+      sha1: BycJ+oOIr4pkFVz5mF3tVC3CIL8=
+    test/AUTOMATE.class/__class__.yaml:
+      created_on: 2014-06-26 17:15:32.302677000 Z
+      updated_on: 2014-06-26 17:15:32.302677000 Z
+      size: 949
+      sha1: I1rcCYksURWFdA70yLl68+uwtHE=
+    test/AUTOMATE.class/_missing.yaml:
+      created_on: 2014-06-26 17:15:32.320393000 Z
+      updated_on: 2014-06-26 17:15:32.320393000 Z
+      size: 195
+      sha1: 1pjwMe+hU3dPKmtv1Fk4rDHTSLc=
+    test/AUTOMATE.class/__methods__/evm1_missing_method.rb:
+      created_on: 2014-06-26 17:15:18.717320000 Z
+      updated_on: 2014-06-26 17:15:18.717320000 Z
+      size: 54
+      sha1: OLaNrLxBDHKUSHI0rqQkW9FO8i8=
+    test/AUTOMATE.class/__methods__/evm1_missing_method.yaml:
+      created_on: 2014-06-26 17:15:18.717320000 Z
+      updated_on: 2014-06-26 17:15:18.717320000 Z
+      size: 199
+      sha1: XFJAqUk0kgQM/a6fgPfLbYP4KK8=
+    test/AUTOMATE.class/__methods__/evm2_missing_method.rb:
+      created_on: 2014-06-26 17:15:32.330560000 Z
+      updated_on: 2014-06-26 17:15:32.330560000 Z
+      size: 54
+      sha1: 5s0baPkOdN/FzLJ7EIE3yH3bpxs=
+    test/AUTOMATE.class/__methods__/evm2_missing_method.yaml:
+      created_on: 2014-06-26 17:15:32.330560000 Z
+      updated_on: 2014-06-26 17:15:32.330560000 Z
+      size: 199
+      sha1: z4VAPlObr4barDG9iyn6M4GNHPI=
+    evm/__namespace__.yaml:
+      created_on: 2014-06-26 17:14:43.391726000 Z
+      updated_on: 2014-06-26 17:14:43.391726000 Z
+      size: 155
+      sha1: Ugj4UH0RSS4/JizAws9eIjjPH68=
+    evm/AUTOMATE.class/__class__.yaml:
+      created_on: 2014-06-26 17:14:43.479822000 Z
+      updated_on: 2014-06-26 17:14:43.479822000 Z
+      size: 1325
+      sha1: 2EYrMxY28Wveyl8dDq1fOYJ+E1w=
+    evm/AUTOMATE.class/test1.yaml:
+      created_on: 2014-06-26 17:14:43.586939000 Z
+      updated_on: 2014-06-26 17:21:08.891183000 Z
+      size: 185
+      sha1: 6pxBq2d8dbQlicMeBvXJfxahS0c=
+    evm/AUTOMATE.class/test2.yaml:
+      created_on: 2014-06-26 17:14:43.595254000 Z
+      updated_on: 2014-06-26 17:14:43.595254000 Z
+      size: 194
+      sha1: Koa/GR7+eWS+rCVaAuQByrJ+8Zc=
+    evm/AUTOMATE.class/test31.yaml:
+      created_on: 2014-06-26 17:15:57.363128000 Z
+      updated_on: 2014-06-26 17:15:57.363128000 Z
+      size: 171
+      sha1: Oc/sSP30VxJDycnXk9tJKUuHKq8=
+    evm/AUTOMATE.class/test32.yaml:
+      created_on: 2014-06-26 17:15:57.371494000 Z
+      updated_on: 2014-06-26 17:54:49.854040000 Z
+      size: 216
+      sha1: wCR4QClQJFilesGkXleplw0hHl4=
+    evm/AUTOMATE.class/test_wildcard.yaml:
+      created_on: 2014-06-26 17:14:43.603217000 Z
+      updated_on: 2014-06-26 17:14:43.603217000 Z
+      size: 197
+      sha1: m8v35Y7IPBUKsGELGEyRZrr9Nh8=
+    evm/AUTOMATE.class/__methods__/user_method.rb:
+      created_on: 2014-06-26 17:15:57.388791000 Z
+      updated_on: 2014-06-26 17:19:45.646606000 Z
+      size: 451
+      sha1: fgeSObNlDCzUlnch8P2G0zWFA+I=
+    evm/AUTOMATE.class/__methods__/user_method.yaml:
+      created_on: 2014-06-26 17:15:57.388791000 Z
+      updated_on: 2014-06-26 17:19:45.646606000 Z
+      size: 191
+      sha1: EMV0Pb+kmpqpro3QrT7KleFjkNs=
+    evm/AUTOMATE.class/__methods__/root_method.rb:
+      created_on: 2014-06-26 17:16:12.017793000 Z
+      updated_on: 2014-06-26 17:16:12.017793000 Z
+      size: 419
+      sha1: wcEu+61yqeH/nb7rvP1ACoYuKvI=
+    evm/AUTOMATE.class/__methods__/root_method.yaml:
+      created_on: 2014-06-26 17:16:12.017793000 Z
+      updated_on: 2014-06-26 17:16:12.017793000 Z
+      size: 191
+      sha1: JN6zLbHI1Uop5bQJmcWU6jfITzE=
+    evm/AUTOMATE.class/should_get_used.yaml:
+      created_on: 2014-06-26 17:14:43.534232000 Z
+      updated_on: 2014-06-26 17:20:48.369567000 Z
+      size: 226
+      sha1: 6YD88mz2kZx7FgL7szKGPNSVcX4=
+    evm/AUTOMATE.class/should_not_get_used.yaml:
+      created_on: 2014-06-26 17:14:43.578442000 Z
+      updated_on: 2014-06-26 17:14:43.578442000 Z
+      size: 184
+      sha1: 1Q1N66tdhkVD8bqt/YRSfotgp5U=
+    evm/AUTOMATE.class/__methods__/inert_method.rb:
+      created_on: 2014-06-26 17:14:43.635273000 Z
+      updated_on: 2014-06-26 17:20:30.068350000 Z
+      size: 40
+      sha1: Mh/FFmC73YL0uGnVWpIO/mrTceU=
+    evm/AUTOMATE.class/__methods__/inert_method.yaml:
+      created_on: 2014-06-26 17:14:43.635273000 Z
+      updated_on: 2014-06-26 17:20:30.068350000 Z
+      size: 192
+      sha1: oSmOh/rGTc9Ea2Isgroy694pLNs=

--- a/vmdb/spec/lib/miq_automation_engine/data/method_override.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/method_override.yaml
@@ -1,0 +1,380 @@
+---
+MIQ:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: MIQ
+        description: 
+        display_name: 
+        system: 
+        priority: 1
+        enabled: 
+  EVM:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: EVM
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    SAMPLE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: SAMPLE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: attribute
+              name: attr1
+              display_name: Attribute1
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: Barney
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: attr2
+              display_name: Attribute2
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: Fred
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: method1
+              display_name: Method Connection
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      test1.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test1
+            inherits: 
+            description: 
+          fields:
+          - method1:
+              value: evm1
+      __methods__:
+        evm1.rb: ! '$evm.root[''method_executed'']  = ''miq''
+
+'
+        evm1.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: evm1
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: offspring
+                display_name: 
+                datatype: 
+                priority: 1
+                owner: 
+                default_value: Bamm-Bamm
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+        evm2.rb: ! '$evm.root[''method_executed''] = $evm.object[''attr1'']
+
+          exit MIQ_OK
+
+'
+        evm2.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: evm2
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: CatchPhrase
+                display_name: 
+                datatype: 
+                priority: 1
+                owner: 
+                default_value: Yabba Dabba Doo
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+RHT:
+  __domain__.yaml:
+    object_type: domain
+    version: 1.0
+    object:
+      attributes:
+        name: RHT
+        description: 
+        display_name: 
+        system: 
+        priority: 2
+        enabled: 
+  EVM:
+    __namespace__.yaml:
+      object_type: namespace
+      version: 1.0
+      object:
+        attributes:
+          name: EVM
+          description: 
+          display_name: 
+          system: 
+          priority: 
+          enabled: 
+    SAMPLE.class:
+      __class__.yaml:
+        object_type: class
+        version: 1.0
+        object:
+          attributes:
+            description: 
+            display_name: 
+            name: SAMPLE
+            type: 
+            inherits: 
+            visibility: 
+            owner: 
+          schema:
+          - field:
+              aetype: attribute
+              name: attr1
+              display_name: Last Name
+              datatype: string
+              priority: 1
+              owner: 
+              default_value: Flintstone
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: attribute
+              name: attr2
+              display_name: Last Name
+              datatype: string
+              priority: 2
+              owner: 
+              default_value: Rubble
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+          - field:
+              aetype: method
+              name: method1
+              display_name: Method Connection
+              datatype: string
+              priority: 3
+              owner: 
+              default_value: 
+              substitute: true
+              message: create
+              visibility: 
+              collect: 
+              scope: 
+              description: 
+              condition: 
+              on_entry: 
+              on_exit: 
+              on_error: 
+              max_retries: 
+              max_time: 
+      test2.yaml:
+        object_type: instance
+        version: 1.0
+        object:
+          attributes:
+            display_name: 
+            name: test2
+            inherits: 
+            description: 
+          fields:
+          - method1:
+              value: evm2
+      __methods__:
+        evm1.rb: ! '$evm.root[''method_executed'']  = $evm.inputs[''nickname'']
+
+'
+        evm1.yaml:
+          object_type: method
+          version: 1.0
+          object:
+            attributes:
+              name: evm1
+              display_name: 
+              description: 
+              scope: instance
+              language: ruby
+              location: inline
+            inputs:
+            - field:
+                aetype: 
+                name: nickname
+                display_name: 
+                datatype: 
+                priority: 1
+                owner: 
+                default_value: TwinkleToes
+                substitute: true
+                message: create
+                visibility: 
+                collect: 
+                scope: 
+                description: 
+                condition: 
+                on_entry: 
+                on_exit: 
+                on_error: 
+                max_retries: 
+                max_time: 
+  .manifest.yaml:
+    __domain__.yaml:
+      classes: 2
+      instances: 2
+      method_files: 3
+      method_instances: 3
+      created_on: 2014-06-26 14:55:22.563391000 Z
+      updated_on: 2014-06-26 14:55:22.563391000 Z
+      size: 153
+      sha1: 9Uw1gnbk3buA6tWGz5nlNGP+dRA=
+    EVM/__namespace__.yaml:
+      created_on: 2014-06-26 14:55:22.586085000 Z
+      updated_on: 2014-06-26 14:55:22.586085000 Z
+      size: 155
+      sha1: sRy02EsdO3HlNqjIjlMq4Hek8YU=
+    EVM/SAMPLE.class/__class__.yaml:
+      created_on: 2014-06-26 14:55:22.597728000 Z
+      updated_on: 2014-06-26 14:55:22.597728000 Z
+      size: 1337
+      sha1: gsGXg9GTsTxhi8DRXE1LK9jHYIc=
+    EVM/SAMPLE.class/test1.yaml:
+      created_on: 2014-06-26 14:55:22.472359000 Z
+      updated_on: 2014-06-26 14:55:22.472359000 Z
+      size: 170
+      sha1: 29Ii+59/jpz1iTkMLcpzAerXoeE=
+    EVM/SAMPLE.class/__methods__/evm1.rb:
+      created_on: 2014-06-26 14:55:22.619601000 Z
+      updated_on: 2014-06-26 14:59:46.483104000 Z
+      size: 56
+      sha1: ey72xIGcrUidZihDZKEjv3qn08A=
+    EVM/SAMPLE.class/__methods__/evm1.yaml:
+      created_on: 2014-06-26 14:55:22.619601000 Z
+      updated_on: 2014-06-26 14:59:46.483104000 Z
+      size: 550
+      sha1: REFHs1Kgu36Y5+mc3RcT/EPG+Wg=
+    EVM/SAMPLE.class/__methods__/evm2.rb:
+      created_on: 2014-06-26 14:55:22.555586000 Z
+      updated_on: 2014-06-26 14:59:14.512727000 Z
+      size: 64
+      sha1: Gkqcfk8D1PKBlYqOfHkzhlHepGw=
+    EVM/SAMPLE.class/__methods__/evm2.yaml:
+      created_on: 2014-06-26 14:55:22.555586000 Z
+      updated_on: 2014-06-26 14:59:14.512727000 Z
+      size: 557
+      sha1: Y/m6D/N2D3EM7idqrx1mTwuwkjA=
+    EVM/SAMPLE.class/test2.yaml:
+      created_on: 2014-06-26 14:55:22.611646000 Z
+      updated_on: 2014-06-26 14:55:22.611646000 Z
+      size: 170
+      sha1: O87SckuVvWx5FIJPmtyYUS9ycmM=

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
@@ -1,132 +1,99 @@
 require "spec_helper"
+include AutomationSpecHelper
 
-module MiqAeDomainSpec
-  include MiqAeEngine
-  describe "MiqAeDomain" do
-    before(:each) do
-      MiqServer.my_server_clear_cache
-      MiqAeDatastore.reset
-      @model_data_dir = File.join(File.dirname(__FILE__), "data")
+describe MiqAeDomain do
+  before do
+    setup_model
+  end
+
+  def setup_model
+    yaml_file = File.join(File.dirname(__FILE__), 'data', 'domain_test.yaml')
+    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*'}
+    MiqAeImport.new('*', import_options).import
+    update_domain_attributes('root', :priority => 10, :system => true, :enabled => true)
+    update_domain_attributes('user', :priority => 20, :enabled => true)
+    update_domain_attributes('inert', :priority => 10, :system => true, :enabled => false)
+    update_domain_attributes('evm1', :priority => 100, :enabled => true)
+    update_domain_attributes('evm2', :priority => 100, :enabled => true)
+    @enabled_domains = %w(evm2 evm1 user root)
+    @all_domains = %w(evm2 evm1 inert user root)
+  end
+
+  def update_domain_attributes(domain_name, attrs)
+    dom = MiqAeDomain.find_by_fqname(domain_name)
+    dom.update_attributes!(attrs)
+  end
+
+  context 'Domain Checks' do
+    it 'cannot set parent_id in a domain object' do
+      domain = MiqAeDomain.create!(:name => 'Fred')
+      ns = MiqAeNamespace.create!(:name => 'NS1')
+      expect { domain.update_attributes!(:parent_id => ns.id) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
-    after(:each) do
-      MiqAeDatastore.reset
+    it 'can set other attributes in a domain object' do
+      domain = MiqAeDomain.create!(:name => 'Fred')
+      domain.update_attributes!(:priority => 10, :system => false).should be_true
     end
 
-    context 'Domain Checks' do
-      it 'cannot set parent_id in a domain object' do
-        domain = MiqAeDomain.create!(:name => 'Fred')
-        ns = MiqAeNamespace.create!(:name => 'NS1')
-        expect { domain.update_attributes!(:parent_id => ns.id) }.to raise_error(ActiveRecord::RecordInvalid)
-      end
+  end
 
-      it 'can set other attributes in a domain object' do
-        domain = MiqAeDomain.create!(:name => 'Fred')
-        domain.update_attributes!(:priority => 10, :system => false).should be_true
-      end
-
+  context "Domain Overlays" do
+    it "partial namespace should use the higher priority user instance" do
+      ns = MiqAeNamespace.find_by_fqname('evm')
+      ns.should be_nil
+      assert_method_executed('evm/AUTOMATE/test1', 'user')
     end
 
-    context "Domain Overlays" do
-      before(:each) do
-        base_dir = File.join(File.dirname(__FILE__), "data")
-        attrs = {:priority => 10, :system => true}
-        EvmSpecHelper.import_yaml_model(File.join(base_dir, "root_domain"), "root", attrs)
-        attrs = {:priority => 20}
-        EvmSpecHelper.import_yaml_model(File.join(base_dir, "user_domain"), "user", attrs)
+    it "fully qualified namespace should execute the root method" do
+      ns = MiqAeNamespace.find_by_fqname('root/evm')
+      ns.should_not be_nil
+      assert_method_executed('root/evm/AUTOMATE/test2', 'root')
+    end
 
-        attrs = {:priority => 10, :system => true, :enabled => false}
-        EvmSpecHelper.import_yaml_model(File.join(base_dir, "inert_domain"), "inert", attrs)
-        attrs = {:priority => 100}
-        EvmSpecHelper.import_yaml_model(File.join(base_dir, "evm1_domain"), "evm1", attrs)
-        attrs = {:priority => 100}
-        EvmSpecHelper.import_yaml_model(File.join(base_dir, "evm2_domain"), "evm2", attrs)
-        @enabled_domains = %w(evm2 evm1 user root)
-        @all_domains = %w(evm2 evm1 inert user root)
-      end
+    it "partial namespace with wild card in relationship" do
+      ns = MiqAeNamespace.find_by_fqname('evm')
+      ns.should be_nil
+      assert_method_executed('evm/AUTOMATE/test_wildcard', 'user')
+    end
 
-      it "partial namespace should use the higher priority user instance" do
-        ns = MiqAeNamespace.find_by_fqname('evm')
-        ns.should be_nil
-        ws = MiqAeEngine.instantiate('evm/AUTOMATE/test1')
-        ws.should_not be_nil
-        roots = ws.roots
-        roots.should have(1).item
-        roots.first.attributes['method_executed'].should == 'user'
-      end
+    it "a non existent partial namespace instance should fail" do
+      ws = MiqAeEngine.instantiate('evm/AUTOMATE/non_existent')
+      roots = ws.roots
+      roots.should have(0).item
+    end
 
-      it "fully qualified namespace should execute the root method" do
-        ns = MiqAeNamespace.find_by_fqname('root/evm')
-        ns.should_not be_nil
-        ws = MiqAeEngine.instantiate("root/evm/AUTOMATE/test2")
-        ws.should_not be_nil
-        roots = ws.roots
-        roots.should have(1).item
-        roots.first.attributes['method_executed'].should == 'root'
-      end
+    it "a disabled namespace should not get picked up even if the instance exists" do
+      ws = MiqAeEngine.instantiate('evm/AUTOMATE/should_not_get_used')
+      roots = ws.roots
+      roots.should have(0).item
+    end
 
-      it "partial namespace with wild card in relationship" do
-        ns = MiqAeNamespace.find_by_fqname('evm')
-        ns.should be_nil
-        ws = MiqAeEngine.instantiate('evm/AUTOMATE/test_wildcard')
-        ws.should_not be_nil
-        roots = ws.roots
-        roots.should have(1).item
-        roots.first.attributes['method_executed'].should == 'user'
-      end
+    it "an enabled namespace should get picked up if the instance exists" do
+      n3 = MiqAeNamespace.find_by_fqname('inert')
+      n3.enabled?.should be_false
+      n3.update_attributes!(:enabled => true)
+      assert_method_executed('evm/AUTOMATE/should_get_used', 'inert')
+    end
 
-      it "a non existent partial namespace instance should fail" do
-        ws = MiqAeEngine.instantiate('evm/AUTOMATE/non_existent')
-        roots = ws.roots
-        roots.should have(0).item
-      end
+    it "partial namespace should use the higher priority users case insensitive instance" do
+      ns = MiqAeNamespace.find_by_fqname('evm')
+      ns.should be_nil
+      assert_method_executed('evm/AUTOMATE/TeSt1', 'user')
+    end
 
-      it "a disabled namespace should not get picked up even if the instance exists" do
-        ws = MiqAeEngine.instantiate('evm/AUTOMATE/should_not_get_used')
-        roots = ws.roots
-        roots.should have(0).item
-      end
+    it "an enabled namespace should pick up .missing if the instance is missing" do
+      update_domain_attributes('evm2', :priority => 10)
+      update_domain_attributes('evm1', :priority => 40)
+      assert_method_executed('test/AUTOMATE/does_not_exist', 'evm1_missing_method')
+    end
 
-      it "an enabled namespace should get picked up if the instance exists" do
-        n3 = MiqAeNamespace.find_by_fqname('inert')
-        n3.enabled?.should be_false
-        n3.update_attributes!(:enabled => true)
-        ws = MiqAeEngine.instantiate('evm/AUTOMATE/should_get_used')
-        ws.should_not be_nil
-        roots = ws.roots
-        roots.should have(1).item
-        roots.first.attributes['method_executed'].should == 'inert'
-      end
+    it "check list of enabled domains" do
+      MiqAeDomain.enabled.collect(&:name).should match_array(@enabled_domains)
+    end
 
-      it "partial namespace should use the higher priority users case insensitive instance" do
-        ns = MiqAeNamespace.find_by_fqname('evm')
-        ns.should be_nil
-        ws = MiqAeEngine.instantiate('evm/AUTOMATE/TeSt1')
-        ws.should_not be_nil
-        roots = ws.roots
-        roots.should have(1).item
-        roots.first.attributes['method_executed'].should == 'user'
-      end
-
-      it "an enabled namespace should pick up .missing if the instance is missing" do
-        n3 = MiqAeNamespace.find_by_fqname('evm2')
-        n3.update_attributes!(:priority => 10)
-        n3 = MiqAeNamespace.find_by_fqname('evm1')
-        n3.update_attributes!(:priority => 40)
-        ws = MiqAeEngine.instantiate('test/AUTOMATE/does_not_exist')
-        ws.should_not be_nil
-        roots = ws.roots
-        roots.should have(1).item
-        roots.first.attributes['method_executed'].should == 'evm1_missing_method'
-      end
-
-      it "check list of enabled domains" do
-        MiqAeDomain.enabled.collect(&:name).should match_array(@enabled_domains)
-      end
-
-      it "check list of all domains" do
-        MiqAeDomain.all.collect(&:name).should match_array(@all_domains)
-      end
+    it "check list of all domains" do
+      MiqAeDomain.all.collect(&:name).should match_array(@all_domains)
     end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/miq_method_override_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_method_override_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+include AutomationSpecHelper
+
+describe MiqAeDomain do
+  before do
+    yaml_file = File.join(File.dirname(__FILE__), 'data', 'method_override.yaml')
+    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*'}
+    MiqAeImport.new('*', import_options).import
+  end
+
+  context 'Method Override' do
+    it 'with only one domain pick the miq method' do
+      set_enabled('RHT', false)
+      set_enabled('MIQ', true)
+      assert_method_executed('evm/SAMPLE/test1', 'miq')
+    end
+
+    it 'pick the higher priority method in rht domain' do
+      set_enabled('RHT', true)
+      set_enabled('MIQ', true)
+      assert_method_executed('evm/SAMPLE/test1', 'TwinkleToes')
+    end
+
+    it 'method missing pick the method from lower priority domain' do
+      set_enabled('RHT', true)
+      set_enabled('MIQ', true)
+      assert_method_executed('evm/SAMPLE/test2', 'Flintstone')
+    end
+
+    def set_enabled(domain, state)
+      dom = MiqAeDomain.find_by_fqname(domain)
+      dom.update_attributes!(:enabled => state)
+    end
+  end
+end

--- a/vmdb/spec/support/automation_spec_helper.rb
+++ b/vmdb/spec/support/automation_spec_helper.rb
@@ -20,5 +20,12 @@ module AutomationSpecHelper
     fields
   end
 
+  def assert_method_executed(uri, value)
+    ws = MiqAeEngine.instantiate(uri)
+    ws.should_not be_nil
+    roots = ws.roots
+    roots.should have(1).item
+    roots.first.attributes['method_executed'].should == value
+  end
 end
 


### PR DESCRIPTION
If a similar named method  exists in a
high priority domain that will overlay the existing method.
The usecase for this is a user wants to modify a single method from
the ManageIQ domain to the Customer domain. During resolution the
method from higher priority Customer domain will be used.
