### PR TITLE
When encrypting passwords, dont generate newlines

### DIFF
--- a/lib/spec/util/miq-password_spec.rb
+++ b/lib/spec/util/miq-password_spec.rb
@@ -36,7 +36,7 @@ describe MiqPassword do
     ], [
       "`~!@\#$%^&*()_+-=[]{}\\|;:\"'<>,./?",
       "v1:{ziplwo+PA+gmKTNpJTRQtfRk+nPL2A2g3nnHdRRv86fBjyziiQ1V//g5u+dJ\nRyjl}",
-      "v2:{zad43i0dQB+8z45ZYMVmpFcagbt40T0aFddhHlj6YtPgoOJ5N3uBYAp8WwuZ\nQkar}",
+      "v2:{zad43i0dQB+8z45ZYMVmpFcagbt40T0aFddhHlj6YtPgoOJ5N3uBYAp8WwuZQkar}",
       "JilJmiBufmyWjlAGLStE7+KEfwxCzZOS38ZSjH8JXEPCqdeQzWsXEddlqvzL\n0PpW",
     ], [
       "abc\t\n\vzabc",
@@ -163,6 +163,12 @@ describe MiqPassword do
 
     it "should fail on recrypt bad password" do
       expect { MiqPassword.new.recrypt("v2:{55555}") }.to raise_error
+    end
+
+    it "should decrypt passwords with newlines" do
+      expect(MiqPassword.decrypt("v2:{zad43i0dQB+8z45ZYMVmpFcagbt40T0aFddhHlj6YtPgoOJ5N3uBYAp8WwuZ\nQkar}")).to(
+        eq("`~!@\#$%^&*()_+-=[]{}\\|;:\"'<>,./?")
+      )
     end
   end
 

--- a/lib/util/miq-password.rb
+++ b/lib/util/miq-password.rb
@@ -157,7 +157,7 @@ class MiqPassword
 
   def encrypt_version_2(str)
     return "v2:{}" if str.nil? || str.empty?
-    "v2:{#{self.class.v2_key.encrypt64(str).chomp}}"
+    "v2:{#{self.class.v2_key.encrypt64(str).chomp.gsub("\n", "")}}"
   end
 
   def encrypt_version_1(str)


### PR DESCRIPTION
/cc @fryguy here you go

I had thought there was another method to avoid newlines, but this seemed the safest route.
