### PR TITLE
only allow root to connect to db as root

### DIFF
--- a/system/COPY/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_ident.conf
+++ b/system/COPY/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_ident.conf
@@ -1,3 +1,7 @@
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 sslmap          root                    root
 sslmap          root                    postgres
+# users can login as themselves
+usermap         /^(.*)$                 \1
+# root user can also login as user postgres
+usermap         root                    postgres

--- a/system/TEMPLATE/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf.erb
+++ b/system/TEMPLATE/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf.erb
@@ -1,5 +1,5 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
-local    all             postgres,root                           trust
-<% if ssl -%>
-hostssl  all             all            all                      cert map=sslmap
-<% end -%>
+local    all            all                                     peer map=usermap
+#host    all            all             127.0.0.1/32            ident map=usermap
+#host    all            all             all                     md5
+<%= "#" unless ssl %>hostssl all             all            all                     cert map=sslmap


### PR DESCRIPTION
We were letting anyone locally connect as anyone.
Now we only let someone connect as the particular user

also make configuration easier to manipulate, since it now comments out unused rules instead of removing them
