### PR TITLE
Created refactored x_button_response method so spec can stub it

### DIFF
--- a/vmdb/app/controllers/application_controller/explorer.rb
+++ b/vmdb/app/controllers/application_controller/explorer.rb
@@ -126,6 +126,10 @@ module ApplicationController::Explorer
     # no need to render anything, method will render flash message when async task is completed
     return if 'mark_vdi' == action
 
+    x_button_response(model, action)
+  end
+
+  def x_button_response(model, action)
     if @refresh_partial == "layouts/flash_msg"
       render :update do |page|
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")

--- a/vmdb/spec/controllers/vm_cloud_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_cloud_controller_spec.rb
@@ -25,6 +25,7 @@ describe VmCloudController do
               method.to_s
             end
           it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
+            controller.stub(:x_button_response)
             controller.should_receive(actual_method)
             get :x_button, :id => FactoryGirl.create(:template_redhat), :pressed => actual_action
           end

--- a/vmdb/spec/controllers/vm_or_template_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_or_template_controller_spec.rb
@@ -23,6 +23,7 @@ describe VmOrTemplateController do
                           method.to_s
                         end
         it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
+          controller.stub(:x_button_response)
           controller.should_receive(actual_method)
           get :x_button, :id => FactoryGirl.create(:vm_redhat), :pressed => actual_action
         end


### PR DESCRIPTION
Code was rendering responses due to test stubbing of actual button methods, so broke the rendering code out into a new method and stubbed that method in the spec.

@Fryguy This fixes the issue brought up in an email where the CC output had the controller name prefixing all of the test lines in the output.
