### PR TITLE
Moved enable/disable download buttons code to a generic method.

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1427,12 +1427,12 @@ module ApplicationHelper
   end
 
   def check_for_utilization_download_buttons
-    if (x_active_tree.nil? && @sb[:planning] && @sb[:planning][:rpt] && !@sb[:planning][:rpt].table.data.empty?) ||
-        (x_active_tree == :utilization_tree && @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary])
-      return false
-    else
-      return "No records found for this report"
-    end
+    return false if x_active_tree.nil? &&
+                    @sb.fetch_path(:planning, :rpt) &&
+                    !@sb[:planning][:rpt].table.data.empty?
+    return false if @sb.fetch_path(:util, :trend_rpt) &&
+                    @sb.fetch_path(:util, :summary)
+    "No records found for this report"
   end
 
   def get_record_cls(record)


### PR DESCRIPTION
Changed code to enable/disable Download buttons on Reports tab in Utilization explorer. Buttons were not getting enabled/disabled based upon result data when user sent up tree_select transaction while user was on Reports tab. Existing code was only handling enable/disable of download buttons when switching tabs.

https://bugzilla.redhat.com/show_bug.cgi?id=1113062
https://bugzilla.redhat.com/show_bug.cgi?id=1114659

@dclarizio please review/test
This issue only happened when user is on Reports tab with data, and then switching to tree node to one that has no data, Download buttons were still showing as enabled when clicking on them it was blowing up.
