### PR TITLE
Fixed the crash when the accordions in compare/drift are clicked.

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -183,6 +183,7 @@ class ApplicationController < ActionController::Base
 
   # Control blinds effects on nav panel divs
   def panel_control
+    @keep_compare = true
     panel = params[:panel]
     render :update do |page|
       @panels[panel] = !@panels[panel]


### PR DESCRIPTION
A setting for @keep_compare = true was missing for the panel_control
action causing @compare to have a nil value which was causing the crash.

https://bugzilla.redhat.com/show_bug.cgi?id=1114700
