### PR TITLE
Fix typo in variable name

### DIFF
--- a/vmdb/app/presenters/tree_builder.rb
+++ b/vmdb/app/presenters/tree_builder.rb
@@ -285,7 +285,7 @@ class TreeBuilder
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 
-  def rbac_filtered_objects(object, options = {})
+  def rbac_filtered_objects(objects, options = {})
     self.class.rbac_filtered_objects(objects, options)
   end
 


### PR DESCRIPTION
Fixes bug introduced in 379e99a in PR https://github.com/ManageIQ/manageiq/pull/120
https://bugzilla.redhat.com/show_bug.cgi?id=1086015

@dclarizio Please review.
