### PR TITLE
remove bullet

### DIFF
--- a/vmdb/Gemfile.appliance_excludes.rb
+++ b/vmdb/Gemfile.appliance_excludes.rb
@@ -9,7 +9,6 @@ end
 
 group :test do
   gem "brakeman",         "~>2.0",    :require => false
-  gem "bullet",                       :require => false
 
   gem "vcr",              "~>2.4.0",  :require => false
   gem "webmock",          "~>1.11.0", :require => false # Although VCR complains, we're forced to use 1.11.0 since we're locked

--- a/vmdb/config/environments/test.rb
+++ b/vmdb/config/environments/test.rb
@@ -50,19 +50,3 @@ require "timecop"
 require "vcr"
 require "webmock/rspec"
 require "capybara"
-
-if ENV['CC_BUILD_ARTIFACTS']
-  require "bullet"
-  Bullet.enable = true
-
-  # Use a log file in the CC_BUILD_ARTIFACTS directory so they're available automatically
-  Bullet.bullet_logger = true
-  logger = UniformNotifier::CustomizedLogger.instance_variable_get(:@logger)
-  logger.close
-  UniformNotifier::CustomizedLogger.instance_variable_set(:@logger, nil)
-
-  bullet_log = File.expand_path(File.join(ENV['CC_BUILD_ARTIFACTS'], "bullet.log"))
-  bullet_log_file = File.open(bullet_log, 'a+')
-  bullet_log_file.sync
-  UniformNotifier.customized_logger = bullet_log_file
-end

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -63,15 +63,7 @@ RSpec.configure do |config|
   }
   config.include RakeTaskExampleGroup, :type => :rake_task
 
-  config.before(:each) do
-    Bullet.start_request if defined?(Bullet)
-  end
-
   config.after(:each) do
-    if defined?(Bullet)
-      Bullet.perform_out_of_channel_notifications if Bullet.notification?
-      Bullet.end_request
-    end
     EvmSpecHelper.clear_caches
   end
 end


### PR DESCRIPTION
1. people aren't using bullet
2. running bullet on tests display results on optimizing tests not the appliane
3. we are getting false positives that the test suite is failing, when it is just `whoami` failures.

/cc @jrafanie

I can pull the spec_helper.rb stuff back in if you want
