### PR TITLE
Revisiting rspec verbose

### DIFF
--- a/host/Rakefile
+++ b/host/Rakefile
@@ -23,6 +23,7 @@ task :rcov do
       t.test_files = FileList['test/ts_*.rb']
       t.output_dir = File.join(ENV['CC_BUILD_ARTIFACTS'], "coverage") if ENV['CC_BUILD_ARTIFACTS'] != nil
       t.rcov_opts = ['--text-report', '--exclude', 'spec,/usr/lib/ruby']
+      t.verbose = false
     end
   rescue LoadError
     puts 'Rcov is not available. Proceeding without...'

--- a/lib/lib/tasks/rspec.rake
+++ b/lib/lib/tasks/rspec.rake
@@ -12,6 +12,7 @@ desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec => spec_prereq) do |t|
   rspec_opts_file = ".rspec#{"_cc" if ENV['CC_BUILD_ARTIFACTS']}"
   t.rspec_opts = ['--options', "\"#{File.expand_path(File.join(File.dirname(__FILE__), rspec_opts_file))}\""]
+  t.verbose = false
 end
 
 namespace :spec do
@@ -19,6 +20,7 @@ namespace :spec do
   RSpec::Core::RakeTask.new(:rcov => spec_prereq) do |t|
     rspec_opts_file = ".rspec#{"_cc" if ENV['CC_BUILD_ARTIFACTS']}"
     t.rspec_opts = ['--options', "\"#{File.expand_path(File.join(File.dirname(__FILE__), rspec_opts_file))}\""]
+    t.verbose = false
     t.rcov = true
     t.rcov_opts = lambda do
       rcov_opts_file = File.expand_path(File.join(File.dirname(__FILE__), "spec", "rcov.opts"))

--- a/vmdb/lib/resource_feeder/Rakefile
+++ b/vmdb/lib/resource_feeder/Rakefile
@@ -9,6 +9,7 @@ desc 'Test the resource_feed plugin.'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
 end
 
 desc 'Generate documentation for the resource_feed plugin.'

--- a/vmdb/lib/tasks/coverage.rake
+++ b/vmdb/lib/tasks/coverage.rake
@@ -1,5 +1,4 @@
 
-
 namespace :test do
   namespace :coverage do
     desc "Delete aggregate coverage data."
@@ -18,9 +17,9 @@ namespace :test do
           t.libs << "test"
           t.test_files = FileList["test/#{target}/*_test.rb"]
           t.output_dir = File.join(ENV['CC_BUILD_ARTIFACTS'], "coverage") if ENV['CC_BUILD_ARTIFACTS'] != nil
+          t.verbose = false
           if target == "unit"
             t.rcov_opts = ['--rails --aggregate coverage.data --text-report --sort coverage --no-html']
-#            t.rcov_opts = ['--rails --aggregate coverage.data --text-report --sort coverage ']
           else
             t.rcov_opts = ['--rails --aggregate coverage.data --no-html --text-summary']
           end

--- a/vmdb/lib/tasks/spec_evm.rake
+++ b/vmdb/lib/tasks/spec_evm.rake
@@ -27,6 +27,7 @@ namespace :spec do
     def initialize_task(t, rspec_opts = [])
       rspec_opts_file = ".rspec#{"_cc" if ENV['CC_BUILD_ARTIFACTS']}"
       t.rspec_opts = ['--options', "\"#{Rails.root.join(rspec_opts_file)}\""] + rspec_opts
+      t.verbose = false
     end
 
     desc "Run the backend code examples"


### PR DESCRIPTION
`t.verbose = false` is not the same as leaving it blank

Vmdb specifically, will remove 2 pages from cruise control results. And those 2 pages make loading the html page quicker.

This furthers #34 along the road
