### PR TITLE
Added a custom serialize method for dhtmlxgrid.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_dynatree.js
+++ b/vmdb/app/assets/javascripts/cfme_dynatree.js
@@ -505,7 +505,7 @@ function miqMenuChangeRow(grid,action,click_url) {
       }
       break;
     case "serialize":
-      new Ajax.Request(click_url + "?tree=" + encodeURIComponent(folder_list_grid.serialize()),
+      new Ajax.Request(click_url + "?tree=" + encodeURIComponent(miqDhtmlxgridSerialize(folder_list_grid)),
         {asynchronous:true, evalScripts:true,
           onComplete:function(request){miqSparkle(false);},
           onLoading:function(request){miqSparkle(true);}}

--- a/vmdb/app/assets/javascripts/miq_dhtmlxgrid.js
+++ b/vmdb/app/assets/javascripts/miq_dhtmlxgrid.js
@@ -263,3 +263,17 @@ function miqOrderService(id){
   );
 }
 
+function miqDhtmlxgridSerialize(gridObj) {
+  dhtmlxgridXml = "<?xml version='1.0'?>";
+  dhtmlxgridXml += "<rows>";
+  rowIds = gridObj.getAllRowIds().split(',');
+  for (i = 0; i < rowIds.length; i++) {
+    dhtmlxgridXml += "<row id=" + "'" + rowIds[i] + "'>";
+    for (j = 0; j < gridObj.getColumnCount(); j++) {
+      dhtmlxgridXml += "<cell>" + gridObj.cells(rowIds[i], j).getValue() + "</cell>";
+    }
+    dhtmlxgridXml += "</row>";
+  }
+  dhtmlxgridXml += "</rows>";
+  return dhtmlxgridXml;
+}


### PR DESCRIPTION
DHTMLX libs GPL version 3.6 do not support .serialize(). It is 
available only in the PRO version.
Refer - http://docs.dhtmlx.com/api__dhtmlxgrid_serialize.html
Therefore a simple custom serialize method has been added to support the
missing serialize functionality.

https://bugzilla.redhat.com/show_bug.cgi?id=1101250
