### PR TITLE
Fix EmsOpenstack.verify_credentials sleeper bug

### DIFF
--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -111,7 +111,7 @@ class EmsOpenstack < EmsCloud
 
     raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(auth_type)
 
-    options.merge(:auth_type => auth_type)
+    options.merge!(:auth_type => auth_type)
     case auth_type.to_s
     when 'default'; verify_api_credentials(options)
     when 'amqp';    verify_amqp_credentials(options)


### PR DESCRIPTION
There's a bug in the way that the auth_type is merged into the options used by
EmsOpenstack.verify_credentials.  Fortunately, it's obscured by the conditional
assignment operator on the first line of the method.

Now the options are merged into the original hash.

This fix will be hard to test since there is no demonstrable way to produce an
actual problem.
