### PR TITLE
Use GUID when creating domains instead of timestamps

### DIFF
--- a/vmdb/app/models/miq_ae_datastore.rb
+++ b/vmdb/app/models/miq_ae_datastore.rb
@@ -18,7 +18,7 @@ module MiqAeDatastore
   TMP_DIR = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine"))
 
   def self.temp_domain
-    "#{TEMP_DOMAIN_PREFIX}-#{Time.now.iso8601(6).tr('.:', '_')}"
+    "#{TEMP_DOMAIN_PREFIX}-#{MiqUUID.new_guid}"
   end
 
   def self.xml_deprecated_warning


### PR DESCRIPTION
When we create a domain name we use a timestamp to get a new temporary name
The timestamp includes a + for timezone component when servers are ahead of GMT

The temporary domain name logic has been changed to use GUIDs instead of timestamps
