### PR TITLE
Default priority for domain, set priority based on ordered domain ids

### DIFF
--- a/vmdb/app/models/miq_ae_domain.rb
+++ b/vmdb/app/models/miq_ae_domain.rb
@@ -1,12 +1,29 @@
 class MiqAeDomain < MiqAeNamespace
   default_scope where(:parent_id => nil).where(arel_table[:name].not_eq("$"))
   validates_inclusion_of :parent_id, :in => [nil], :message => 'should be nil for Domain'
+  after_destroy :squeeze_priorities
+  default_value_for(:priority) { MiqAeDomain.highest_priority + 1 }
+  default_value_for :system,  false
+  default_value_for :enabled, false
 
   def self.enabled
     where(:enabled => true)
   end
 
+  def self.reset_priority_by_ordered_ids(ids)
+    ids.each_with_index do |id, priority|
+      MiqAeDomain.where(:id => id).first.try(:update_attributes, :priority => priority + 1)
+    end
+  end
+
   def self.highest_priority
-    MiqAeDomain.order('priority DESC').first.priority
+    MiqAeDomain.order('priority DESC').first.try(:priority).to_i
+  end
+
+  private
+
+  def squeeze_priorities
+    ids = MiqAeDomain.where('priority > 0').order('priority ASC').collect(&:id)
+    MiqAeDomain.reset_priority_by_ordered_ids(ids)
   end
 end

--- a/vmdb/spec/models/miq_ae_domain_spec.rb
+++ b/vmdb/spec/models/miq_ae_domain_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe MiqAeDomain do
+  it "should use the highest priority when not specified" do
+    MiqAeDomain.create(:name => 'TEST1')
+    MiqAeDomain.create(:name => 'TEST2', :priority => 10)
+    d3 = MiqAeDomain.create(:name => 'TEST3')
+    d3.priority.should eql(11)
+  end
+
+  context "reset priority" do
+    before do
+      initial = {'TEST1' => 11, 'TEST2' => 12, 'TEST3' => 13, 'TEST4' => 14}
+      initial.each { |dom, pri| MiqAeDomain.create(:name => dom, :priority => pri) }
+    end
+
+    it "should change priority based on ordered list of ids" do
+      after = {'TEST4' => 1, 'TEST3' => 2, 'TEST2' => 3, 'TEST1' => 4}
+      ids   = after.collect { |dom, _| MiqAeDomain.find_by_fqname(dom).id }
+      MiqAeDomain.reset_priority_by_ordered_ids(ids)
+      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+    end
+
+    it "after a domain with lowest priority is deleted" do
+      MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST1').id)
+      after = {'TEST2' => 1, 'TEST3' => 2, 'TEST4' => 3}
+      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+    end
+
+    it "after a domain with middle priority is deleted" do
+      MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST3').id)
+      after = {'TEST1' => 1, 'TEST2' => 2, 'TEST4' => 3}
+      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+    end
+
+    it "after a domain with highest priority is deleted" do
+      MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST4').id)
+      after = {'TEST1' => 1, 'TEST2' => 2, 'TEST3' => 3}
+      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+    end
+
+    it "after all domains are deleted" do
+      %w(TEST1 TEST2 TEST3 TEST4).each { |name| MiqAeDomain.find_by_fqname(name).destroy }
+      d1 = MiqAeDomain.create(:name => 'TEST1')
+      d1.priority.should eql(1)
+    end
+  end
+end


### PR DESCRIPTION
Ability to set domain properties for the following scenarios

(1) Priority not passed in when creating a new instance, set the priority to be highest priority + 1
(2) Reset the priorities for a ordered array of domain ids, based on the array index
(3) When a domain is deleted squeeze priorities based on (2) 
