### PR TITLE
Testing .log_status should not blindly call .log_system_status

### DIFF
--- a/vmdb/spec/models/miq_server/status_management_spec.rb
+++ b/vmdb/spec/models/miq_server/status_management_spec.rb
@@ -6,7 +6,8 @@ describe "StatusManagement" do
   end
 
   #for now, just making sure there are no syntax errors
-  it "should log status" do
+  it ".log_status" do
+    MiqServer.should_receive(:log_system_status).once
     MiqServer.log_status
   end
 end


### PR DESCRIPTION
MiqServer.log_system_status does a lot of shelling out

This was detected in failure 78 in https://travis-ci.org/ManageIQ/manageiq/jobs/29378858
