### PR TITLE
Service Catalog tree fixed to not show Actions nodes below Service nodes

### DIFF
--- a/vmdb/app/presenters/tree_builder_catalog_items.rb
+++ b/vmdb/app/presenters/tree_builder_catalog_items.rb
@@ -46,4 +46,10 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
     end
     count_only_or_objects(options[:count_only], objects, nil)
   end
+
+  def x_get_tree_st_kids(object, options)
+    count = options[:type] == :svvcat ? 0 : object.custom_button_sets.count + object.custom_buttons.count
+    objects = count > 0 ? [{:id => object.id.to_s, :text => 'Actions', :image => 'folder', :tip => 'Actions'}] : []
+    count_only_or_objects(options[:count_only], objects, nil)
+  end
 end

--- a/vmdb/app/presenters/tree_builder_catalogs_class.rb
+++ b/vmdb/app/presenters/tree_builder_catalogs_class.rb
@@ -14,19 +14,6 @@ class TreeBuilderCatalogsClass < TreeBuilder
     end
   end
 
-  def x_get_tree_st_kids(object, options)
-  # if options[:count_only]
-  #  return options[:type] = :svccat ? 0 : (object.vms_and_templates.count + object.service_templates.count)
-  # else
-  #  return options[:type] = :svccat ? [] : (object.vms_and_templates.sort{|a,b| a.name.downcase <=> b.name.downcase} +
-  #      object.service_templates.sort{|a,b| a.name.downcase <=> b.name.downcase})
-  # end
-
-    count = options[:type] == :svvcat ? 0 : object.custom_button_sets.count + object.custom_buttons.count
-    objects = count > 0 ? [{:id => object.id.to_s, :text => 'Actions', :image => 'folder', :tip => 'Actions'}] : []
-    count_only_or_objects(options[:count_only], objects, nil)
-  end
-
   # TODO: De-duplicate the following methods from tree_builder_buttons.rb
   def get_custom_buttons(object)
     # FIXME: don't we have a method for the splits?

--- a/vmdb/app/presenters/tree_builder_service_catalog.rb
+++ b/vmdb/app/presenters/tree_builder_service_catalog.rb
@@ -28,4 +28,8 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
     objects = rbac_filtered_objects(object.service_templates.sort_by { |o| o.name.downcase })
     count_only_or_objects(options[:count_only], objects, 'name')
   end
+
+  def x_get_tree_st_kids(_object, options)
+    options[:count_only] ? 0 : []
+  end
 end


### PR DESCRIPTION
Moved x_get_tree_st_kids method from parent TreeBuilderCatalogsClass to subclasses TreeBuilderCatalogItems and TreeBuilderServiceCatalog, so each can determine what to draw in the tree.

Screenshot of Actions tree node that shouldn't be there:
![screen shot 2014-07-08 at 1 22 41 pm](https://cloud.githubusercontent.com/assets/3433754/3516176/b47f521e-06dd-11e4-82e6-850fff409054.png)

@h-kataria please test
