### PR TITLE
Improve logging in MiqQueue.

### DIFF
--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -97,7 +97,7 @@ class MiqQueue < ActiveRecord::Base
     if (args_size + data_size) > 512
       log_prefix=LOG_PREFIX[:put]
       culprit = caller.detect {|r| ! (r =~ /miq_queue.rb/) } || ""
-      $log.warn("#{log_prefix} #{culprit.split("in").first} called with large payload (args: #{args_size} bytes, data: #{data_size} bytes) #{MiqQueue.format_full_log_msg(self)}")
+      $log.warn("#{log_prefix} #{culprit.split(":in ").first} called with large payload (args: #{args_size} bytes, data: #{data_size} bytes) #{MiqQueue.format_full_log_msg(self)}")
     end
   end
 


### PR DESCRIPTION
The original code does not like if you have ManageIQ under `/home/martin/Projects/manageiq` for example, because `martin` contains `in`. So improving this. But the solution remains a bit fragile if the user uses some very creative path names.
