### PR TITLE
Fixed delete button on namespace summary screen.

### DIFF
--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -2072,7 +2072,8 @@ private
     @sb[:row_selected] = find_checked_items
     ae_ns = []
     ae_cs = []
-    if params[:id] && params[:pressed] == "miq_ae_domain_delete"
+    if params[:id] && params[:miq_grid_checks] == "" &&
+        %w(miq_ae_domain_delete miq_ae_namespace_delete).include?(params[:pressed])
       ae_ns.push(params[:id])
       self.x_node = "root"
     elsif @sb[:row_selected]


### PR DESCRIPTION
Delete namespace button on namespace summary screen was throwing an error, fixed code to delete correct record.

@dclarizio please review/test
