### PR TITLE
Import/Export changes to allow for setting of ENABLE/SYSTEM

### DIFF
--- a/vmdb/app/models/miq_ae_yaml_export.rb
+++ b/vmdb/app/models/miq_ae_yaml_export.rb
@@ -223,7 +223,7 @@ class MiqAeYamlExport
   end
 
   def reset_manifest
-    @manifest = {}
+    @manifest = {DOMAIN_YAML_FILENAME => {}}
     @counts   = Hash.new { |h, k| h[k] = 0 }
   end
 

--- a/vmdb/app/models/miq_ae_yaml_import.rb
+++ b/vmdb/app/models/miq_ae_yaml_import.rb
@@ -4,6 +4,7 @@ class MiqAeYamlImport
   def initialize(domain, options)
     @domain_name = domain
     @options     = options
+    @restore     = @options.fetch('restore', false)
   end
 
   def import
@@ -21,6 +22,7 @@ class MiqAeYamlImport
     $log.info("#{self.class} Import options: <#{@options}> preview: <#{@preview}>")
     $log.info("#{self.class} Importing domain:    <#{domain_name}>")
     reset_stats
+    @single_domain = true
     domain_name == ALL_DOMAINS ? import_all_domains : import_domain(domain_folder(domain_name), domain_name)
     log_stats
   end
@@ -41,19 +43,29 @@ class MiqAeYamlImport
   end
 
   def import_all_domains
-    domain_files(ALL_DOMAINS).sort.each do |file|
+    @single_domain = false
+    sorted_domain_files.each do |file|
       directory = File.dirname(file)
       @domain_name = directory.split("/").last
       import_domain(directory, @domain_name)
     end
+    MiqAeDatastore.reset_default_namespace if @restore && !@preview
+  end
+
+  def sorted_domain_files
+    domains = {}
+    domain_files(ALL_DOMAINS).sort.each do |file|
+      directory = File.dirname(file)
+      domain_name = directory.split("/").last
+      domain_yaml = read_domain_yaml(directory, domain_name)
+      domains[file] = domain_yaml.fetch_path('object', 'attributes', 'priority')
+    end
+    domains.keys.sort { |a, b| domains[a] <=> domains[b] }
   end
 
   def import_domain(domain_folder, domain_name)
-    domain_yaml = read_domain_yaml(domain_folder, domain_name)
-    if @options['import_as']
-      domain_name = @options['import_as']
-      domain_yaml.store_path('object', 'attributes', 'name', domain_name)
-    end
+    domain_yaml = domain_properties(domain_folder, domain_name)
+    domain_name = domain_yaml.fetch_path('object', 'attributes', 'name')
     domain_obj = MiqAeDomain.find_by_fqname(domain_name, false)
     track_stats('domain', domain_obj)
     domain_obj ||= add_domain(domain_yaml) unless @preview
@@ -62,6 +74,30 @@ class MiqAeYamlImport
     else
       import_all_namespaces(domain_folder, domain_obj, domain_name)
     end
+    update_attributes(domain_obj) if @single_domain && domain_obj
+  end
+
+  def domain_properties(domain_folder, name)
+    domain_yaml = read_domain_yaml(domain_folder, name)
+    if @options['import_as'] && @single_domain
+      name = @options['import_as']
+      domain_yaml.store_path('object', 'attributes', 'name', name)
+    end
+    miq = name.downcase == MiqAeDatastore::MANAGEIQ_DOMAIN.downcase
+    miq ? reset_manageiq_attributes(domain_yaml) : reset_domain_attributes(domain_yaml)
+    domain_yaml
+  end
+
+  def reset_manageiq_attributes(domain_yaml)
+    domain_yaml.store_path('object', 'attributes', 'name', MiqAeDatastore::MANAGEIQ_DOMAIN)
+    domain_yaml.store_path('object', 'attributes', 'priority', MiqAeDatastore::MANAGEIQ_PRIORITY)
+    domain_yaml.store_path('object', 'attributes', 'system', true)
+    domain_yaml.store_path('object', 'attributes', 'enabled', true)
+  end
+
+  def reset_domain_attributes(domain_yaml)
+    domain_yaml.delete_path('object', 'attributes', 'enabled') unless @restore
+    domain_yaml.delete_path('object', 'attributes', 'priority')
   end
 
   def import_all_namespaces(namespace_folder, domain_obj, domain_name)
@@ -80,7 +116,7 @@ class MiqAeYamlImport
     $log.info("#{self.class} Importing namespace: <#{fqname}>")
     namespace_obj = MiqAeNamespace.find_by_fqname(fqname, false)
     track_stats('namespace', namespace_obj)
-    namespace_obj ||= add_namespace(fqname, namespace_yaml) unless @preview
+    namespace_obj ||= add_namespace(fqname) unless @preview
     if @options['class_name']
       import_class(File.join(namespace_folder, "#{@options['class_name']}#{CLASS_DIR_SUFFIX}"), namespace_obj)
     else
@@ -159,5 +195,11 @@ class MiqAeYamlImport
       return false
     end
     true
+  end
+
+  def update_attributes(domain_obj)
+    return if domain_obj.name.downcase == MiqAeDatastore::MANAGEIQ_DOMAIN.downcase
+    attrs = @options.slice('enabled', 'system')
+    domain_obj.update_attributes(attrs) unless attrs.empty?
   end
 end # class

--- a/vmdb/app/models/mixins/miq_ae_yaml_import_export_mixin.rb
+++ b/vmdb/app/models/mixins/miq_ae_yaml_import_export_mixin.rb
@@ -11,7 +11,6 @@ module MiqAeYamlImportExportMixin
   METHOD_OBJ_TYPE         = 'method'
   ALL_DOMAINS             = '*'
   VERSION                 = 1.0
-  DEFAULT_DOMAIN_PRIORITY = 1
 
   EXPORT_EXCLUDE_KEYS     = [/^id$/, /_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/]
 
@@ -24,18 +23,10 @@ module MiqAeYamlImportExportMixin
   end
 
   def add_domain(domain_yaml)
-    reset_system_domain(domain_yaml)
-    domain_yaml['object']['attributes'].delete('enabled')
-    MiqAeNamespace.create!(domain_yaml['object']['attributes'])
+    MiqAeDomain.create!(domain_yaml['object']['attributes'])
   end
 
-  def reset_system_domain(domain_obj)
-    return if domain_obj.fetch_path('object', 'attributes', 'priority').to_i > 0
-    $log.info("#{self.class} Cannot import domain as system. Changing priority to #{DEFAULT_DOMAIN_PRIORITY}.")
-    domain_obj['object']['attributes']['priority'] = DEFAULT_DOMAIN_PRIORITY
-  end
-
-  def add_namespace(fqname, namespace_yaml)
+  def add_namespace(fqname)
     MiqAeNamespace.find_or_create_by_fqname(fqname)
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1105113

The import export has been changed to support the following
1. ManageIQ domain will be automatically set to
SYSTEM=true,ENABLED=true,PRIORITY=0
2. Support for restore, during restore the ENABLED attribute from domain
yaml file will be honored.
3. PRIORITY will never be honored from the domain yaml file, it is only
used to set the import order when doing a multi domain import
4. By default for single domain imports the domain will be created as
disabled (ENABLED=false).
5. ManageIQ domain will be called ManageIQ even if IMPORT_AS=manageiq
6. During restore create the $ namespace
7. rake script allows for ENABLED=true|false
8. rake script allows for SYSTEM=true|false
