### PR TITLE
Fix connection issue when EmsOpenstack#port is nil.

### DIFF
--- a/lib/openstack/openstack_handle.rb
+++ b/lib/openstack/openstack_handle.rb
@@ -34,14 +34,18 @@ class OpenstackHandle
     @connection_options
   end
 
-  def initialize(username, password, address, port = 5000)
+  def initialize(username, password, address, port = nil)
     @username = username
     @password = password
     @address  = address
-    @port     = port
+    @port     = port || 5000
 
     @connection_cache   = {}
     @connection_options = self.class.connection_options
+  end
+
+  def auth_url
+    self.class.auth_url(address, port)
   end
 
   def browser_url

--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -33,8 +33,12 @@ class EmsOpenstack < EmsCloud
     raise
   end
 
-  def self.auth_url(address, port = 5000)
-    "http://#{address}:#{port}/v2.0/tokens"
+  def self.auth_url(address, port = nil)
+    "http://#{address}:#{port || 5000}/v2.0/tokens"
+  end
+
+  def auth_url
+    self.class.auth_url(address, port)
   end
 
   def browser_url
@@ -48,7 +52,6 @@ class EmsOpenstack < EmsCloud
     password = options[:pass] || self.authentication_password(options[:auth_type])
 
     service  = (options[:service] || "Compute").to_s.camelize
-    auth_url = self.class.auth_url(self.address, self.port)
 
     self.class.raw_connect(username, password, auth_url, service)
   end


### PR DESCRIPTION
Also fixed the new OpenstackHandle, which currently is not yet used.

---

Another approach is to override the port accessor to always return 5000 when it is nil.  Is that a better implementation? @roliveri @chessbyte
