### PR TITLE
Fixed tree name being passed in x_build_node_id call.

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -246,7 +246,7 @@ class CatalogController < ApplicationController
     else
       identify_catalog(from_cid(params[:id]))
       @record = ServiceTemplateCatalog.find_by_id(from_cid(params[:id])) if @record.nil?
-      params[:id] = x_build_node_id(@record,nil,x_tree(:sandt_tree))  # Get the tree node id
+      params[:id] = x_build_node_id(@record, nil, x_tree(x_active_tree))  # Get the tree node id
     end
     tree_select
   end


### PR DESCRIPTION
Fixed to pass in correct tree name to x_build_node_id method, it was blowing up when logged in user didnt have access to :sandt_tree.

https://bugzilla.redhat.com/show_bug.cgi?id=1115717
https://bugzilla.redhat.com/show_bug.cgi?id=1117993

@dclarizio please review/test.
