### PR TITLE
Upgrade to Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: ruby
-rvm: 1.9.3
+rvm:
+- "2.0"
+- "2.1"
 env:
   global:
   - BUNDLE_WITHOUT=development:metric_fu:qpid
   - RUBY_GC_MALLOC_LIMIT=90000000
   matrix:
-  - TEST_SUITE=lib         TEST_ROOT=lib
-  - TEST_SUITE=vmdb        TEST_ROOT=vmdb
-  - TEST_SUITE=migrations  TEST_ROOT=vmdb
-  - TEST_SUITE=replication TEST_ROOT=vmdb
-  - TEST_SUITE=automation  TEST_ROOT=vmdb
-  - TEST_SUITE=javascript  TEST_ROOT=vmdb
+  - "TEST_SUITE=lib         TEST_ROOT=lib"
+  - "TEST_SUITE=vmdb        TEST_ROOT=vmdb"
+  - "TEST_SUITE=migrations  TEST_ROOT=vmdb"
+  - "TEST_SUITE=replication TEST_ROOT=vmdb"
+  - "TEST_SUITE=automation  TEST_ROOT=vmdb"
+  - "TEST_SUITE=javascript  TEST_ROOT=vmdb"
+matrix:
+  allow_failures:
+  - rvm: "2.1"
+    env: "TEST_SUITE=vmdb        TEST_ROOT=vmdb"
+  fast_finish: true
 addons:
   postgresql: '9.3'
 before_install:


### PR DESCRIPTION
MERGE AFTER #933

We're now ready to merge this and run travis against ruby 2.0 and 1.9.3.

Links to related issues:

UTF-8 default encoding of ruby scripts:
#218
#465
#589
#715
#732
#804

Protected methods don't respond_to?
#685

File descriptors are closed on exec (when spawning a new process)
#459
#682

Others:
#233
#581

Patches/extensions:
#535
#536
#714
#728
#826

There are remaining open ruby 2 issues unrelated to getting ruby 2.0 on travis:
https://github.com/ManageIQ/manageiq/labels/ruby%202

**EDIT**
Added screenshot showing travis build matrix with ruby 2.1 allowing the vmdb suite to fail (and thereby finish fast)... Thanks @Fryguy for getting the .travis.yml to work.
![screen shot 2014-10-21 at 6 54 55 pm](https://cloud.githubusercontent.com/assets/19339/4728387/4ea60d8a-5975-11e4-885f-3561f9e5c555.png)
