### PR TITLE
Provisioning dialog styling and conversion to CodeMirror

### DIFF
--- a/vmdb/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -251,7 +251,11 @@ module MiqAeCustomizationController::OldDialogs
       if !@edit[:new][:dialog_type]
         add_flash(I18n.t("flash.edit.select_required", :selection=>"Dialog Type"), :error)
       end
-
+      begin
+        YAML.parse(@edit[:new][:content])
+      rescue YAML::SyntaxError => ex
+        add_flash("#{I18n.t("flash.edit.field_syntax_error.yaml")}#{ex.message}", :error)
+      end
       if @flash_array
         render :update do |page|
           page.replace("flash_msg_div", :partial=>"layouts/flash_msg")

--- a/vmdb/app/views/layouts/_global_header.html.erb
+++ b/vmdb/app/views/layouts/_global_header.html.erb
@@ -54,6 +54,9 @@
       'SlickGrid-2.1/slick.grid', 'SlickGrid-2.1/slick.dataview', 'SlickGrid-2.1/plugins/slick.autotooltips',
       'cfme_slickgrid' %>
 
+    <%= javascript_include_tag 'codemirror-4.2/lib/codemirror.js', 'codemirror-4.2/mode/yaml/yaml.js' %>
+    <%= stylesheet_link_tag 'codemirror-4.2/lib/codemirror.css' %>
+
     <% if @timeline %>
       <%= javascript_include_tag '/javascripts/timeline/api/timeline-api.js' %>
       <% if @timeline_filter %>

--- a/vmdb/app/views/layouts/_my_code_mirror.html.erb
+++ b/vmdb/app/views/layouts/_my_code_mirror.html.erb
@@ -9,7 +9,6 @@
 <% read_only ||= false					%><%# Edit box height in pixels %>
 <% multi_mode ||= false         %><%# to load/switch between multiple modes, for customization template editor %>
 
-<%= javascript_include_tag "codemirror-4.2/lib/codemirror.js" %>
 <% if multi_mode %>
   <% modes.each do |mode| %>
     <%= javascript_include_tag "codemirror-4.2/mode/#{mode}/#{mode}.js" %>
@@ -23,7 +22,6 @@
   <%= javascript_include_tag "codemirror-4.2/mode/#{mode}/#{mode}.js" %>
 <% end %>
 
-<%= stylesheet_link_tag "codemirror-4.2/lib/codemirror.css" %>
 <% unless theme == "default" %>
 	<%= stylesheet_link_tag "codemirror-4.2/theme/#{theme}.css" %>
 <% end %>

--- a/vmdb/app/views/miq_ae_customization/_dialog_info.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_dialog_info.html.erb
@@ -1,27 +1,24 @@
 <%# if dialogs is selected %>
-
-		<div id="info_div" style="<%=display%>">
-
-		<p class="legend">Basic Information</p>
-			<table class="style1">
-				<tbody>
-					<tr>
-						<td class="key">Label</td>
-						<td><%= h(@record.label) %></td>
-					</tr>
-					<tr>
-						<td class="key">Description</td>
-						<td><%= h(@record.description) %></td>
-					</tr>
-					<tr>
-						<td class="key">Created On</td>
-						<td><%= h(format_timezone(@record.created_at,Time.zone,"gtl")) %></td>
-					</tr>
-					<tr>
-						<td class="key">Updated On</td>
-						<td><%= h(format_timezone(@record.updated_at,Time.zone,"gtl")) %></td>
-					</tr>
-				</tbody>
-			</table>
-
-		</div>
+<div id="info_div" style="<%=display%>">
+  <p class="legend">Basic Information</p>
+  <table class="style1">
+    <tbody>
+      <tr>
+        <td class="key">Label</td>
+        <td><%= h(@record.label) %></td>
+      </tr>
+      <tr>
+        <td class="key">Description</td>
+        <td><%= h(@record.description) %></td>
+      </tr>
+      <tr>
+        <td class="key">Created On</td>
+        <td><%= h(format_timezone(@record.created_at,Time.zone,"gtl")) %></td>
+      </tr>
+      <tr>
+        <td class="key">Updated On</td>
+        <td><%= h(format_timezone(@record.updated_at,Time.zone,"gtl")) %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/vmdb/app/views/miq_ae_customization/_old_dialogs_details.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_old_dialogs_details.html.erb
@@ -1,27 +1,35 @@
-<% h = @winH - 500 %>
 <%# if dialogs is selected %>
 <% if @dialog %>
-	<% unless @edit %>
-	<%= render(:partial=>"layouts/flash_msg", :locals=>{:top_pad=>10}) %>
-
-
-			<p class="legend">Basic Information</p>
-			<table class="style1">
-				<tbody>
-					<tr>
-						<td class="key">Name</td>
-						<td><%= h(@dialog.name) %></td>
-					</tr>
-					<tr>
-						<td class="key">Description</td>
-						<td><%= h(@dialog.description) %></td>
-					</tr>
-				</table>
-				<hr>
-				<p class="legend">Content</p>
-          <%= text_area_tag("script", h(@dialog.content.to_yaml), :readonly=>"readonly",  :style => "height: #{h}px") %>
-	<% else %>
-		<%= render(:partial=>"old_dialogs_form") %>
-	<% end %>
+  <% unless @edit %>
+    <%= render(:partial => "layouts/flash_msg") %>
+    <p class="legend">Basic Information</p>
+    <table class="style1">
+      <tbody>
+        <tr>
+          <td class="key">Name</td>
+          <td><%= h(@dialog.name) %></td>
+        </tr>
+        <tr>
+          <td class="key">Description</td>
+          <td><%= h(@dialog.description) %></td>
+        </tr>
+      </table>
+      <hr>
+      <p class="legend">Content</p>
+      <%= text_area("script",
+                    "data",
+                    :value    => h(@dialog.content.to_yaml),
+                    :readonly => "readonly",
+                    :style    => "display:none;")
+      %>
+      <%= render :partial => "layouts/my_code_mirror",
+                 :locals  => { :text_area_id => "script_data",
+                               :mode         => "yaml",
+                               :line_numbers => true,
+                               :read_only    => true
+                             }
+      %>
+  <% else %>
+    <%= render(:partial=>"old_dialogs_form") %>
+  <% end %>
 <% end %>
-

--- a/vmdb/app/views/miq_ae_customization/_old_dialogs_form.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_old_dialogs_form.html.erb
@@ -1,43 +1,56 @@
-<% h = @winH - 500 %>
-<% url = url_for(:action=>'old_dialogs_form_field_changed', :id=>"#{@dialog.id || "new"}") %>
+<% url = url_for(:action => 'old_dialogs_form_field_changed',
+                 :id     => "#{@dialog.id || "new"}")
+%>
 <div id="form_div">
-	<%= render :partial => "layouts/flash_msg" %>
-
-		<p class="legend">Basic Information</p>
-		<table class="style1">
-				<tr>
-					<td class="key">Name</td>
-					<td class="wide">
-						<%= text_field_tag("name",
-																@edit[:new][:name],
-																:maxlength=>MAX_NAME_LEN,
-																"data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-						<%= javascript_tag("$('name').focus()") %>
-					</td>
-				</tr>
-				<tr>
-					<td class="key">Description</td>
-					<td class="wide">
-						<%= text_field_tag("description",
-																@edit[:new][:description],
-																:maxlength=>100,
-																"data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-					</td>
-				</tr>
-				<tr>
-					<td class="key">Type</td>
-					<% dialog_types = @dialog.dialog_type ? MiqDialog::DIALOG_TYPES.sort :  [["<Choose>",nil]] + MiqDialog::DIALOG_TYPES.sort %>
-					<td class="wide">
-					<%= select_tag('dialog_type',
-															options_for_select(dialog_types, @edit[:new][:dialog_type]),
-															"data-miq_observe"=>{:url=>url}.to_json) %>
-				</tr>
-			</table>
-      <hr>
-      <p class="legend">Content</p>
-				<%= text_area_tag("content_data",
-															@edit[:new][:content],
-															:style => "height: #{h}px",
-															"data-miq_send_one_trans"=>true,
-															"data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
+  <%= render :partial => "layouts/flash_msg" %>
+  <p class="legend">Basic Information</p>
+  <table class="style1">
+      <tr>
+        <td class="key">Name</td>
+        <td class="wide">
+          <%= text_field_tag("name",
+                             @edit[:new][:name],
+                             :maxlength         => MAX_NAME_LEN,
+                             "data-miq_observe" => {:interval => '.5', 
+                                                   :url       => url}.to_json)
+          %>
+          <%= javascript_tag("$('name').focus()") %>
+        </td>
+      </tr>
+      <tr>
+        <td class="key">Description</td>
+        <td class="wide">
+          <%= text_field_tag("description",
+                             @edit[:new][:description],
+                             :maxlength         => 100,
+                             "data-miq_observe" => {:interval => '.5', 
+                                                    :url      => url}.to_json)
+          %>
+        </td>
+      </tr>
+      <tr>
+        <td class="key">Type</td>
+        <% dialog_types = @dialog.dialog_type ? MiqDialog::DIALOG_TYPES.sort :  [["<Choose>",nil]] + MiqDialog::DIALOG_TYPES.sort %>
+        <td class="wide">
+          <%= select_tag('dialog_type',
+                         options_for_select(dialog_types,
+                         @edit[:new][:dialog_type]),
+                         "data-miq_observe" => {:url => url}.to_json)
+          %>
+        </td>
+      </tr>
+    </table>
+    <hr>
+    <p class="legend">Content</p>
+    <%= text_area_tag("content_data",
+                      @edit[:new][:content],
+                      :style => "display:none;")
+    %>
+    <%= render :partial => "layouts/my_code_mirror",
+               :locals  => { :text_area_id => "content_data",
+                             :mode         => "yaml",
+                             :line_numbers => true,
+                             :url          => url
+                           }
+    %>
 </div>

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -78,6 +78,8 @@ en:
         first: "Styling for '%{field}', first value is in error: "
         second: "Styling for '%{field}', second value is in error: "
         third: "Styling for '%{field}', third value is in error: "
+      field_syntax_error:
+        yaml: "Syntax error in YAML file: "
       filter:
         current_search_reset: "The current search details have been reset"
         field_value_error: "%{field} Value Error: %{msg}"

--- a/vmdb/product/toolbars/miq_dialog_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_dialog_center_tb.yaml
@@ -15,7 +15,6 @@
       :image: edit
       :text: "Edit this Dialog"
       :title: "Edit this Dialog"
-      :url_parms: 'main_div'
     - :button: old_dialogs_copy
       :image: copy
       :title: "Copy this Dialog"


### PR DESCRIPTION
Updated styling; changed "Content" text field to utilize full width and height

![screen shot 2014-07-10 at 1 45 32 pm](https://cloud.githubusercontent.com/assets/1287144/3542698/091f62d2-085a-11e4-828e-2368bc57ad19.png)
![screen shot 2014-07-10 at 1 45 04 pm](https://cloud.githubusercontent.com/assets/1287144/3542699/091ff594-085a-11e4-9510-991592e16341.png)
