### PR TITLE
Unlock the Edit Report Menus tree once the editing is done and the menu is saved

### DIFF
--- a/vmdb/app/controllers/report_controller.rb
+++ b/vmdb/app/controllers/report_controller.rb
@@ -800,6 +800,7 @@ class ReportController < ApplicationController
       # lock schedules tree when jumping from reports to add a schedule for a report
       presenter[:lock_unlock_trees][:schedules_tree] = true if params[:pressed] == 'miq_report_schedules'
     else
+      presenter[:lock_unlock_trees][x_active_tree] = false
       [:db_tree, :reports_tree, :savedreports_tree, :schedules_tree, :widgets_tree, :roles_tree].each do |tree|
         presenter[:lock_unlock_trees][tree] = false
       end

--- a/vmdb/app/controllers/report_controller/menus.rb
+++ b/vmdb/app/controllers/report_controller/menus.rb
@@ -746,7 +746,7 @@ module ReportController::Menus
   def menu_get_all
     roles,title = get_group_roles
     @sb[:menu] = Hash.new
-    roles.sort{|a,b| a.name <=> b.name}.each do |r|
+    roles.sort_by { |a| a.name.downcase }.each do |r|
       @sb[:menu][r.id] = r.name
     end
     @right_cell_text = title == "My #{ui_lookup(:model=>"MiqGroup")}" ?

--- a/vmdb/app/views/report/_role_list.html.erb
+++ b/vmdb/app/views/report/_role_list.html.erb
@@ -51,7 +51,7 @@
           <th class="icon"></th><th></th>
         </thead>
         <tbody>
-        <% @sb[:menu].invert.sort.each do |pp| %>
+        <% @sb[:menu].invert.each do |pp| %>
           <tr class="<%= cycle('row0', 'row1') %>"
             onclick="cfmeDynatree_activateNode('<%= @sb[:active_tree] %>', 'g-<%=to_cid(pp[1])%>');"
             onmouseover="this.style.cursor='pointer'" title="View this Profile">


### PR DESCRIPTION
1. Added code to unlock the Edit Report Menus tree once the editing is done
   and the menu is saved
2. Fixed sorting on the right side list view

issue #183
