### PR TITLE
Fix db regioning escapement with new awesome spawn

### DIFF
--- a/lib/appliance_console/database_configuration.rb
+++ b/lib/appliance_console/database_configuration.rb
@@ -72,7 +72,11 @@ module ApplianceConsole
 
     def create_region
       log_and_feedback(__method__) do
-        AwesomeSpawn.run!("script/rails runner script/rake", :params => ["evm:db:region", "--", {:region => region}], :chdir => RAILS_ROOT)
+        AwesomeSpawn.run!(
+          "script/rails runner script/rake",
+          :params => ["evm:db:region", "--", {:region => region}],
+          :chdir  => RAILS_ROOT
+        )
       end
     end
 


### PR DESCRIPTION
Split up each option value properly.
"evm:db:region --" was previously intended as a single unescaped option key with no value.

AwesomeSpawn was changed to escape keys in addition to values that it had done previously.
This caused the command line to be built like this:
script/rails runner script/rake evm:db:region\ -- --region 0

"dvm:db:region" and "--" are now separate option values with no key.
