### PR TITLE
Enhancement to Show External Authentication Configuration

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -222,6 +222,7 @@ To modify the configuration, use a web browser to access the management page.
         Local Database:    #{ApplianceConsole::Utilities.pg_status}
         EVM Database:      #{dbtype} @ #{dbhost}
         Database/Region:   #{database} / #{region || 0}
+        External Auth:     #{ExternalHttpdAuthentication.config_status}
         EVM Version:       #{version}
         EVM Console:       https://#{ip}
         EOL

--- a/lib/appliance_console/external_httpd_authentication.rb
+++ b/lib/appliance_console/external_httpd_authentication.rb
@@ -2,7 +2,7 @@ require_relative "external_httpd_configuration"
 
 module ApplianceConsole
   class ExternalHttpdAuthentication
-    include ApplianceConsole::ExternalHttpdConfiguration
+    include ExternalHttpdConfiguration
 
     def initialize(host = nil)
       @ipaserver, @domain, @password = nil
@@ -29,6 +29,15 @@ module ApplianceConsole
       say("  Realm:          #{realm}\n")
       say("  Naming Context: #{domain_naming_context}\n")
       say("  Principal:      #{@principal}\n")
+    end
+
+    def show_current_configuration
+      return unless ipa_client_configured?
+      config = config_file_read(SSSD_CONFIG)
+      say("\nCurrent External Authentication (httpd) Configuration:\n")
+      say("IPA Server Details:\n")
+      say("  Hostname:       #{fetch_ipa_configuration("ipa_server", config)}\n")
+      say("  Domain:         #{fetch_ipa_configuration("ipa_domain", config)}\n")
     end
 
     def activate

--- a/lib/appliance_console/external_httpd_configuration.rb
+++ b/lib/appliance_console/external_httpd_configuration.rb
@@ -1,67 +1,64 @@
 module ApplianceConsole
-  module ExternalHttpdConfiguration
-    #
-    # External Authentication Definitions
-    #
-    IPA_INSTALL_COMMAND = "/usr/sbin/ipa-client-install"
+  class ExternalHttpdAuthentication
+    module ExternalHttpdConfiguration
+      #
+      # External Authentication Definitions
+      #
+      IPA_INSTALL_COMMAND = "/usr/sbin/ipa-client-install"
 
-    PAM_MODULE          = "httpd-auth"
-    PAM_CONFIG          = "/etc/pam.d/#{PAM_MODULE}"
-    PAM_CONFIGURATION   = <<EOS
+      PAM_MODULE          = "httpd-auth"
+      PAM_CONFIG          = "/etc/pam.d/#{PAM_MODULE}"
+      PAM_CONFIGURATION   = <<EOS
 auth    required pam_sss.so
 account required pam_sss.so
 EOS
-    SSSD_CONFIG         = "/etc/sssd/sssd.conf"
+      SSSD_CONFIG         = "/etc/sssd/sssd.conf"
 
-    EXTERNAL_AUTH_FILE  = "conf.d/cfme-external-auth"
-    HTTPD_EXTERNAL_AUTH = "/etc/httpd/#{EXTERNAL_AUTH_FILE}"
-    HTTPD_CONFIG        = "/etc/httpd/conf.d/cfme-https-application.conf"
+      EXTERNAL_AUTH_FILE  = "conf.d/cfme-external-auth"
+      HTTPD_EXTERNAL_AUTH = "/etc/httpd/#{EXTERNAL_AUTH_FILE}"
+      HTTPD_CONFIG        = "/etc/httpd/conf.d/cfme-https-application.conf"
 
-    GETSEBOOL_COMMAND   = "/usr/sbin/getsebool"
-    SETSEBOOL_COMMAND   = "/usr/sbin/setsebool"
+      GETSEBOOL_COMMAND   = "/usr/sbin/getsebool"
+      SETSEBOOL_COMMAND   = "/usr/sbin/setsebool"
 
-    INTERCEPT_FORM      = "/dashboard/authenticate"
+      INTERCEPT_FORM      = "/dashboard/authenticate"
 
-    LDAP_ATTRS          = {
-      "mail"        => "REMOTE_USER_EMAIL",
-      "givenname"   => "REMOTE_USER_FIRSTNAME",
-      "sn"          => "REMOTE_USER_LASTNAME",
-      "displayname" => "REMOTE_USER_FULLNAME"
-    }
+      LDAP_ATTRS          = {
+        "mail"        => "REMOTE_USER_EMAIL",
+        "givenname"   => "REMOTE_USER_FIRSTNAME",
+        "sn"          => "REMOTE_USER_LASTNAME",
+        "displayname" => "REMOTE_USER_FULLNAME"
+      }
 
-    #
-    # IPA Configuration Methods
-    #
-    def ipa_client_configured?
-      File.exist?(SSSD_CONFIG)
-    end
+      #
+      # IPA Configuration Methods
+      #
+      def ipa_client_configure(realm, domain, server, principal, password)
+        say("Configuring the IPA Client ...")
+        AwesomeSpawn.run!(IPA_INSTALL_COMMAND,
+                          :params => {"-N"              => nil,
+                                      "--force-join"    => nil,
+                                      "--realm="        => realm,
+                                      "--domain="       => domain,
+                                      "--server="       => server,
+                                      "--principal="    => principal,
+                                      "--password="     => password,
+                                      "--fixed-primary" => nil,
+                                      "--unattended"    => nil})
+      end
 
-    def ipa_client_configure(realm, domain, server, principal, password)
-      say("Configuring the IPA Client ...")
-      AwesomeSpawn.run!(IPA_INSTALL_COMMAND,
-                        :params => {"-N"              => nil,
-                                    "--force-join"    => nil,
-                                    "--realm="        => realm,
-                                    "--domain="       => domain,
-                                    "--server="       => server,
-                                    "--principal="    => principal,
-                                    "--password="     => password,
-                                    "--fixed-primary" => nil,
-                                    "--unattended"    => nil})
-    end
+      def ipa_client_unconfigure
+        say("Un-Configuring the IPA Client ...")
+        AwesomeSpawn.run(IPA_INSTALL_COMMAND,
+                         :params => {"--uninstall"  => nil,
+                                     "--unattended" => nil})
+      end
 
-    def ipa_client_unconfigure
-      say("Un-Configuring the IPA Client ...")
-      AwesomeSpawn.run(IPA_INSTALL_COMMAND,
-                       :params => {"--uninstall"  => nil,
-                                   "--unattended" => nil})
-    end
-
-    #
-    # HTTPD Configuration Methods
-    #
-    def httpd_mod_intercept_config
-      config = "
+      #
+      # HTTPD Configuration Methods
+      #
+      def httpd_mod_intercept_config
+        config = "
 LoadModule authnz_pam_module modules/mod_authnz_pam.so
 LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
 LoadModule lookup_identity_module modules/mod_lookup_identity.so
@@ -76,131 +73,152 @@ LoadModule lookup_identity_module modules/mod_lookup_identity.so
 
 <Location #{INTERCEPT_FORM}>
 "
-      LDAP_ATTRS.each { |ldap, http| config << "  LookupUserAttr #{ldap} #{http}\n" }
-      config << "
+        LDAP_ATTRS.each { |ldap, http| config << "  LookupUserAttr #{ldap} #{http}\n" }
+        config << "
   LookupUserGroups        REMOTE_USER_GROUPS \":\"
   LookupDbusTimeout       5000
 </Location>
 "
-    end
-
-    def httpd_external_auth_config
-      config = "RequestHeader unset X_REMOTE_USER\n"
-      attrs = %w(REMOTE_USER EXTERNAL_AUTH_ERROR) + LDAP_ATTRS.values + %w(REMOTE_USER_GROUPS)
-      attrs.each { |attr| config << "RequestHeader set X_#{attr} %{#{attr}}e env=#{attr}\n" }
-      config.chomp!
-    end
-
-    def configure_httpd_application(config)
-      ext_auth_include = "Include #{EXTERNAL_AUTH_FILE}"
-      unless config.include?(ext_auth_include)
-        config[/(\n)<VirtualHost/, 1] = "\n#{ext_auth_include}\n\n"
       end
 
-      if config.include?("set X_REMOTE_USER")
-        config[/RequestHeader unset X_REMOTE_USER(\n.*)+env=REMOTE_USER_GROUPS/] = httpd_external_auth_config
-      else
-        config[/set X_FORWARDED_PROTO 'https'(\n)/, 1] = "\n\n#{httpd_external_auth_config}\n"
+      def httpd_external_auth_config
+        config = "RequestHeader unset X_REMOTE_USER\n"
+        attrs = %w(REMOTE_USER EXTERNAL_AUTH_ERROR) + LDAP_ATTRS.values + %w(REMOTE_USER_GROUPS)
+        attrs.each { |attr| config << "RequestHeader set X_#{attr} %{#{attr}}e env=#{attr}\n" }
+        config.chomp!
       end
-    end
 
-    #
-    # SSSD File Methods
-    #
-    def configure_sssd_domain(config, domain)
-      ldap_user_extra_attrs = LDAP_ATTRS.keys.join(", ")
-      if config.include?("ldap_user_extra_attrs = ")
-        pattern = "[domain/#{domain}](\n.*)+ldap_user_extra_attrs = (.*)"
-        config[/#{pattern}/, 2] = ldap_user_extra_attrs
-      else
-        pattern = "[domain/#{domain}].*(\n)"
-        config[/#{pattern}/, 1] = "\nldap_user_extra_attrs = #{ldap_user_extra_attrs}\n"
+      def configure_httpd_application(config)
+        ext_auth_include = "Include #{EXTERNAL_AUTH_FILE}"
+        unless config.include?(ext_auth_include)
+          config[/(\n)<VirtualHost/, 1] = "\n#{ext_auth_include}\n\n"
+        end
+
+        if config.include?("set X_REMOTE_USER")
+          config[/RequestHeader unset X_REMOTE_USER(\n.*)+env=REMOTE_USER_GROUPS/] = httpd_external_auth_config
+        else
+          config[/set X_FORWARDED_PROTO 'https'(\n)/, 1] = "\n\n#{httpd_external_auth_config}\n"
+        end
       end
-    end
 
-    def configure_sssd_service(config)
-      services = config.match(/\[sssd\](\n.*)+services = (.*)/)[2]
-      services = "#{services}, ifp" unless services.include?("ifp")
-      config[/\[sssd\](\n.*)+services = (.*)/, 2] = services
-    end
+      #
+      # SSSD File Methods
+      #
+      def configure_sssd_domain(config, domain)
+        ldap_user_extra_attrs = LDAP_ATTRS.keys.join(", ")
+        if config.include?("ldap_user_extra_attrs = ")
+          pattern = "[domain/#{domain}](\n.*)+ldap_user_extra_attrs = (.*)"
+          config[/#{pattern}/, 2] = ldap_user_extra_attrs
+        else
+          pattern = "[domain/#{domain}].*(\n)"
+          config[/#{pattern}/, 1] = "\nldap_user_extra_attrs = #{ldap_user_extra_attrs}\n"
+        end
+      end
 
-    def configure_sssd_ifp(config)
-      user_attributes = LDAP_ATTRS.keys.collect { |k| "+#{k}" }.join(", ")
-      ifp_config      = "
+      def configure_sssd_service(config)
+        services = config.match(/\[sssd\](\n.*)+services = (.*)/)[2]
+        services = "#{services}, ifp" unless services.include?("ifp")
+        config[/\[sssd\](\n.*)+services = (.*)/, 2] = services
+      end
+
+      def configure_sssd_ifp(config)
+        user_attributes = LDAP_ATTRS.keys.collect { |k| "+#{k}" }.join(", ")
+        ifp_config      = "
   allowed_uids = apache, root
   user_attributes = #{user_attributes}
 "
-      if config.include?("[ifp]")
-        if config[/\[ifp\](\n.*)+user_attributes = (.*)/]
-          config[/\[ifp\](\n.*)+user_attributes = (.*)/, 2] = user_attributes
+        if config.include?("[ifp]")
+          if config[/\[ifp\](\n.*)+user_attributes = (.*)/]
+            config[/\[ifp\](\n.*)+user_attributes = (.*)/, 2] = user_attributes
+          else
+            config[/\[ifp\](\n)/, 1] = ifp_config
+          end
         else
-          config[/\[ifp\](\n)/, 1] = ifp_config
+          config << "\n[ifp]#{ifp_config}\n"
         end
-      else
-        config << "\n[ifp]#{ifp_config}\n"
+      end
+
+      #
+      # Validation Methods
+      #
+      def installation_valid?
+        installed_rpm_packages = LinuxAdmin::Rpm.list_installed.keys
+        rpm_packages = %w(ipa-client sssd-dbus mod_intercept_form_submit mod_authnz_pam mod_lookup_identity)
+
+        missing = rpm_packages.count do |package|
+          installed = installed_rpm_packages.include?(package)
+          say("#{package} RPM is not installed") unless installed
+          !installed
+        end
+
+        if missing > 0
+          say("\nAppliance Installation is not valid for enabling External Authentication\n")
+          return false
+        end
+
+        true
+      end
+
+      def valid_environment?
+        return false unless installation_valid?
+        if ipa_client_configured?
+          show_current_configuration
+          return false unless agree("\nIPA Client already configured on this Appliance, Un-Configure first? (Y/N): ")
+          ipa_client_unconfigure
+          return false unless agree("\nProceed with External Authentication Configuration? (Y/N): ")
+        end
+        true
+      end
+
+      def valid_parameters?(ipaserver)
+        host_reachable?(ipaserver, "IPA Server")
+      end
+
+      #
+      # Config File I/O Methods
+      #
+      def config_file_write(config, path, timestamp)
+        FileUtils.copy(path, "#{path}.#{timestamp}") if File.exist?(path)
+        File.open(path, "w") { |f| f.write(config) }
+      end
+
+      #
+      # Network validation
+      #
+      def host_reachable?(host, what = "Server")
+        require 'net/ping'
+        say("Checking connectivity to #{host} ... ")
+        unless Net::Ping::External.new(host).ping
+          say("Failed.\nCould not connect to #{host},")
+          say("the #{what} must be reachable by name.")
+          return false
+        end
+        say("Succeeded.")
+        true
       end
     end
 
-    #
-    # Validation Methods
-    #
-    def installation_valid?
-      installed_rpm_packages = LinuxAdmin::Rpm.list_installed.keys
-      rpm_packages = %w(ipa-client sssd-dbus mod_intercept_form_submit mod_authnz_pam mod_lookup_identity)
+    def self.config_status
+      fetch_ipa_configuration("ipa_server") || "not configured"
+    end
 
-      missing = rpm_packages.count do |package|
-        installed = installed_rpm_packages.include?(package)
-        say("#{package} RPM is not installed") unless installed
-        !installed
+    def self.ipa_client_configured?
+      File.exist?(SSSD_CONFIG)
+    end
+
+    def self.config_file_read(path)
+      File.read(path)
+    end
+
+    def self.fetch_ipa_configuration(what, config = nil)
+      unless config
+        return nil unless ipa_client_configured?
+        config = config_file_read(SSSD_CONFIG)
       end
-
-      if missing > 0
-        say("\nAppliance Installation is not valid for enabling External Authentication\n")
-        return false
-      end
-
-      true
+      pattern = "[domain/.*].*(\n.*)+#{Regexp.escape(what)} = (.*)"
+      config[/#{pattern}/, 2]
     end
 
-    def valid_environment?
-      return false unless installation_valid?
-      if ipa_client_configured?
-        return false unless agree("\nIPA Client already configured on this Appliance, Un-Configure first? (Y/N): ")
-        ipa_client_unconfigure
-        return false unless agree("\nProceed with External Authentication Configuration? (Y/N): ")
-      end
-      true
-    end
-
-    def valid_parameters?(ipaserver)
-      host_reachable?(ipaserver, "IPA Server")
-    end
-
-    #
-    # Config File I/O Methods
-    #
-    def config_file_read(path)
-      File.open(path, "r") { |f| f.read }
-    end
-
-    def config_file_write(config, path, timestamp)
-      FileUtils.copy(path, "#{path}.#{timestamp}") if File.exist?(path)
-      File.open(path, "w") { |f| f.write(config) }
-    end
-
-    #
-    # Network validation
-    #
-    def host_reachable?(host, what = "Server")
-      require 'net/ping'
-      say("Checking connectivity to #{host} ... ")
-      unless Net::Ping::External.new(host).ping
-        say("Failed.\nCould not connect to #{host},")
-        say("the #{what} must be reachable by name.")
-        return false
-      end
-      say("Succeeded.")
-      true
-    end
+    delegate :ipa_client_configured?, :config_file_read, :fetch_ipa_configuration, :config_status, :to => self
   end
 end


### PR DESCRIPTION
- Added new entry in the appliance console summary screen
  to show a new "External Auth:" entry indiciating either
  "not configured" or the IPA Server hostname.
- Also showing current external authentication configuration
  before giving the option to unconfigure.

Note: diff best viewed/understood while ignoring whitespace via https://github.com/ManageIQ/manageiq/pull/202/files?w=1
