### PR TITLE
Add build:image support using 'brew image-build'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -264,7 +264,10 @@ namespace :build do
 
     KICKSTARTS = "git://git.app.eng.bos.redhat.com/cfme_productization.git?manageiq/build/productization/kickstarts#"
 
-    def brew_cmd(config_file, kickstart_file)
+    def brew_cmd(kickstart_file, config_file_name)
+      raise "must set ENV['PUDDLE'] to point to the source RPMs" if ENV['PUDDLE'].nil?
+      config_file = File.join(File.dirname(__FILE__), "build/productization/config/#{config_file_name}")
+
       brew_cmd_string = "brew image-build --nowait --config #{config_file} --repo #{ENV['PUDDLE']} "
       brew_cmd_string << "--repo http://download.eng.bos.redhat.com/devel/cfme/repos/rhel-6.5.z-x86_64-latest-pkgs "
       brew_cmd_string << "--kickstart #{kickstart_file} "
@@ -282,30 +285,22 @@ namespace :build do
 
     desc "Perform the vsphere brew image build without installing cfme for diagnosing package dependencies"
     task :no_cfme_vsphere => [:kerberos_init, :kickstart_sha] do
-      raise "must set ENV['PUDDLE'] to point to the source RPMs" if ENV['PUDDLE'].nil?
-      config_file = File.join(File.dirname(__FILE__), 'build/productization/config/image_build_vsphere')
-      system(brew_cmd(config_file, "no-cfme-vsphere.ks"))
+      system(brew_cmd("no-cfme-vsphere.ks", "image_build_vsphere"))
     end
 
     desc "Perform the vsphere brew image build"
     task :vsphere => [:kerberos_init, :kickstart_sha] do
-      raise "must set ENV['PUDDLE'] to point to the source RPMs" if ENV['PUDDLE'].nil?
-      config_file = File.join(File.dirname(__FILE__), 'build/productization/config/image_build_vsphere')
-      system(brew_cmd(config_file, "base-vsphere.ks"))
+      system(brew_cmd("base-vsphere.ks", "image_build_vsphere"))
     end
 
     desc "Perform the rhevm brew image build"
     task :rhevm => [:kerberos_init, :kickstart_sha] do
-      raise "must set ENV['PUDDLE'] to point to the source RPMs" if ENV['PUDDLE'].nil?
-      config_file = File.join(File.dirname(__FILE__), 'build/productization/config/image_build_rhevm')
-      system(brew_cmd(config_file, "base-rhevm.ks"))
+      system(brew_cmd("base-rhevm.ks", "image_build_rhevm"))
     end
 
     desc "Perform the rhos brew image build"
     task :rhos => [:kerberos_init, :kickstart_sha] do
-      raise "must set ENV['PUDDLE'] to point to the source RPMs" if ENV['PUDDLE'].nil?
-      config_file = File.join(File.dirname(__FILE__), 'build/productization/config/image_build_rhos')
-      system(brew_cmd(config_file, "base-rhos.ks"))
+      system(brew_cmd("base-rhos.ks", "image_build_rhos"))
     end
 
     desc "Perform all of the brew image builds, excluding no_cfme_vsphere"


### PR DESCRIPTION
This is the first crack at adding support for building image using 'brew image-build'.

In the future functionality may need to change as issues with 'brew image-build' are resolved:
- 1119813 - Access to images built with 'brew image-build' should not require manually opening a brewweb URL
  https://bugzilla.redhat.com/show_bug.cgi?id=1119813
- 1119825 - Allow the 'brew image-build' kickstart it to be passed on the command line for non-scratch builds.
  https://bugzilla.redhat.com/show_bug.cgi?id=1119825
- 1119835 - 'brew image-build' config file and command line arguments should be fully intermingle.
  https://bugzilla.redhat.com/show_bug.cgi?id=1119835
-  1119837 - 'brew image-build' should provide checksums for image file
  https://bugzilla.redhat.com/show_bug.cgi?id=1119837

We could investigate generating the config files on the fly and using the brew API.
The brew CLI had been used as instructions and examples for using 'brew image-build'
all used the CLI. The API solution was just introduced as a possibility in reply to 
bugzilla ticket https://bugzilla.redhat.com/show_bug.cgi?id=1119813.

So although functionality may change in the future this pull request represents
a major simplification of the CFME image build workflow.
