### PR TITLE
Added QueryCounter helper class for specs.

### DIFF
--- a/vmdb/spec/support/custom_matchers/exceed_query_limit.rb
+++ b/vmdb/spec/support/custom_matchers/exceed_query_limit.rb
@@ -1,0 +1,15 @@
+# Derived from code found in http://stackoverflow.com/questions/5490411/counting-the-number-of-queries-performed
+#
+# Example usage:
+#   expect { MyModel.do_the_queries }.to_not exceed_query_limit(2)
+
+RSpec::Matchers.define :exceed_query_limit do |expected|
+  match do |block|
+    @query_count = QueryCounter.count(&block)
+    @query_count > expected
+  end
+
+  failure_message_for_should_not do |_actual|
+    "Expected maximum #{expected} queries, got #{@query_count}"
+  end
+end

--- a/vmdb/spec/support/query_counter.rb
+++ b/vmdb/spec/support/query_counter.rb
@@ -1,0 +1,23 @@
+# Derived from code found in http://stackoverflow.com/questions/5490411/counting-the-number-of-queries-performed
+
+class QueryCounter
+  def self.count(&block)
+    new.count(&block)
+  end
+
+  IGNORED_STATEMENTS = %w(CACHE SCHEMA)
+
+  def callback(_name, _start, _finish, _id, payload)
+    @count += 1 unless IGNORED_STATEMENTS.include?(payload[:name])
+  end
+
+  def callback_proc
+    lambda(&method(:callback))
+  end
+
+  def count(&block)
+    @count = 0
+    ActiveSupport::Notifications.subscribed(callback_proc, 'sql.active_record', &block)
+    @count
+  end
+end


### PR DESCRIPTION
This is a simple class for helping us do query counts in specs.  There is also a matcher to allow spec writers to limit the number of queries if desired.

We could potentially use this to count all queries in all specs with something like the following in spec_helper.rb

``` ruby
  config.around do |example|
    puts "Queries: #{QueryCounter.count(&example)}"
  end
```

@jrafanie Please review.
