### PR TITLE
git ls-remote expects stdin to be open so don't close it.

### DIFF
--- a/build/nightly/bin/nightly_launcher.sh
+++ b/build/nightly/bin/nightly_launcher.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-nohup $NIGHTLY_BUILD_DIR/schedule.rb 0<&- &>/dev/null &
+nohup $NIGHTLY_BUILD_DIR/schedule.rb &>/dev/null &


### PR DESCRIPTION
This fixes the missing git sha1 in the filenames for appliances:

![screen shot 2014-07-16 at 9 42 56 am](https://cloud.githubusercontent.com/assets/19339/3599484/20eaf338-0cef-11e4-9608-aae86fe9cb5f.png)

Don't close stdin in the launcher/daemonized script, which is the parent of all processes during the nightly build including the process that runs git ls-remote.

```
$ git ls-remote upstream master
0951f72dc29b7bda21f4e253eac2ab38ef03a60a  refs/heads/master

$ git ls-remote upstream master 0<&-
$
```

See also: http://git.661346.n2.nabble.com/Bug-Failure-if-stdin-is-closed-td7591627.html
