### PR TITLE
Replace prototype with jquery - references to focus function

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -39,9 +39,9 @@ function miqOnLoad() {
   if (typeof miq_after_onload == "string") eval(miq_after_onload);  // Run MIQ after onload code if present
 
   // Focus on search box, if it's there and allows focus
-  if ($('search_text')) {
+  if ($j('#search_text').length) {
     try{
-      $('search_text').focus();
+      $j('#search_text').focus();
     }
     catch(er){}
   }

--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -911,30 +911,30 @@ module ApplicationController::CiProcessing
           temp = params[:from_first].gsub(/[\.]/,"")
           field_shift = true if params[:from_first] =~ /[\.]/ && params[:from_first].gsub(/[\.]/,"") =~ /[0-9]/ && temp.gsub!(/[\D]/,"").nil?
           page << "$('from_first').value= '#{j_str(params[:from_first]).gsub(/[\D]/,"")}';"
-          page << "$('from_second').focus();" if field_shift
+          page << "$j('#from_second').focus();" if field_shift
         else
           page << "$('to_first').value='#{j_str(params[:from_first])}';"
-          page << "$('from_second').focus();" if params[:from_first].length == 3
+          page << "$j('#from_second').focus();" if params[:from_first].length == 3
         end
       elsif params[:from_second]
         if params[:from_second] =~ /[\D]/
           temp = params[:from_second].gsub(/[\.]/,"")
           field_shift = true if params[:from_second] =~ /[\.]/ && params[:from_second].gsub(/[\.]/,"") =~ /[0-9]/ && temp.gsub!(/[\D]/,"").nil?
           page << "$('from_second').value= '#{j_str(params[:from_second].gsub(/[\D]/,""))}';"
-          page << "$('from_third').focus();" if field_shift
+          page << "$j('#from_third').focus();" if field_shift
         else
           page << "$('to_second').value='#{j_str(params[:from_second])}';"
-          page << "$('from_third').focus();" if params[:from_second].length == 3
+          page << "$j('#from_third').focus();" if params[:from_second].length == 3
         end
       elsif params[:from_third]
         if params[:from_third] =~ /[\D]/
           temp = params[:from_third].gsub(/[\.]/,"")
           field_shift = true if params[:from_third] =~ /[\.]/ && params[:from_third].gsub(/[\.]/,"") =~ /[0-9]/ && temp.gsub!(/[\D]/,"").nil?
           page << "$('from_third').value= '#{j_str(params[:from_third].gsub(/[\D]/,""))}';"
-          page << "$('from_fourth').focus();" if field_shift
+          page << "$j('#from_fourth').focus();" if field_shift
         else
           page << "$('to_third').value='#{j_str(params[:from_third])}';"
-          page << "$('from_fourth').focus();" if params[:from_third].length == 3
+          page << "$j('#from_fourth').focus();" if params[:from_third].length == 3
         end
       elsif params[:from_fourth] && params[:from_fourth] =~ /[\D]/
         page << "$('from_fourth').value= '#{j_str(params[:from_fourth].gsub(/[\D]/,""))}';"

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -431,7 +431,7 @@ class DashboardController < ApplicationController
         @more = true
         render :update do |page|
           page.replace("login_more_div", :partial=>"login_more")
-          page << "$('user_new_password').focus();"
+          page << "$j('#user_new_password').focus();"
           page << "$('back_button').show();"
           page << "$('more_button').hide();"
         end
@@ -439,7 +439,7 @@ class DashboardController < ApplicationController
       elsif params[:button] == "back"
         render :update do |page|
           page.replace("login_more_div", :partial=>"login_more")
-          page << "$('user_name').focus();"
+          page << "$j('#user_name').focus();"
           page << "$('back_button').hide();"
           page << "$('more_button').show();"
         end

--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -1755,10 +1755,10 @@ exit MIQ_OK"
       page.replace_html(@refresh_div, :partial=>@refresh_partial) if @refresh_div
       if row_selected_in_grid?
         page << "$('class_methods_div').show();"
-        page << "$('cls_field_name').focus();"
+        page << "$j('#cls_field_name').focus();"
       else
         page << "$('method_inputs_div').show();"
-        page << "$('field_name').focus();"
+        page << "$j('#field_name').focus();"
       end
       page << javascript_for_miq_button_visibility(@changed)
       page << "$('inputs_div').show();"

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -438,7 +438,7 @@ module MiqAeCustomizationController::Dialogs
       render :update do |page|
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("field_values_div", :partial=>"field_values", :locals=>{:entry=>"new", :edit=>true})
-        page << "$('entry_name').focus();"
+        page << "$j('#entry_name').focus();"
         page << "$('entry_name').select();"
       end
       session[:entry] = "new"
@@ -452,7 +452,7 @@ module MiqAeCustomizationController::Dialogs
       render :update do |page|
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("field_values_div", :partial=>"field_values", :locals=>{:entry=>entry, :edit=>true})
-        page << "$('entry_#{j_str(params[:field])}').focus();"
+        page << "$j('#entry_#{j_str(params[:field])}').focus();"
         page << "$('entry_#{j_str(params[:field])}').select();"
 
      end
@@ -478,7 +478,7 @@ module MiqAeCustomizationController::Dialogs
         if key[:values].include?([params["entry"]["value"],params["entry"]["description"]])
           add_flash(I18n.t("flash.edit.field_value_in_use", :field=>params["entry"]["description"], :value=>params["entry"]["value"]), :error)
           render_flash do |page|
-            page << "$('entry_name').focus();"
+            page << "$j('#entry_name').focus();"
           end
           return
         else
@@ -489,7 +489,7 @@ module MiqAeCustomizationController::Dialogs
       else
         add_flash(I18n.t("flash.edit.field_value_and_description_reuired", :field1=>"Value", :field2=>"Description"), :error)
         render_flash do |page|
-          page << "$('entry_value').focus();"
+          page << "$j('#entry_value').focus();"
         end
         return
       end
@@ -502,7 +502,7 @@ module MiqAeCustomizationController::Dialogs
           add_flash(I18n.t("flash.edit.field_value_in_use", :field=>params["entry"]["description"], :value=>params["entry"]["value"]), :error)
 
           render_flash do |page|
-            page << "$('entry_name').focus();"
+            page << "$j('#entry_name').focus();"
           end
           return
         else

--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -773,7 +773,7 @@ class OpsController < ApplicationController
 
       page << "cfmeDynatree_activateNodeSilently('#{x_active_tree.to_s}', '#{x_node}');"
       page << "miqSparkle(false);"
-      page << "if ($('server_company')) $('server_company').focus();"
+      page << "if ($j('#server_company').length) $j('#server_company').focus();"
       page << "if ($('flash_msg_div')) {"
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "}"

--- a/vmdb/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/vmdb/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -61,7 +61,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace_html("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>session[:edit_filename], :edit=>true})
-        page << "$('entry_#{j_str(params[:field])}').focus();"
+        page << "$j('#entry_#{j_str(params[:field])}').focus();"
         page << "$('entry_#{j_str(params[:field])}').select();"
       end
     elsif params[:edit_entry] == "edit_registry"
@@ -71,7 +71,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>session[:reg_data], :edit=>true})
-        page << "$('entry_#{j_str(params[:field])}').focus();"
+        page << "$j('#entry_#{j_str(params[:field])}').focus();"
         page << "$('entry_#{j_str(params[:field])}').select();"
       end
     elsif params[:edit_entry] == "edit_nteventlog"
@@ -91,7 +91,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>session[:nteventlog_data], :edit=>true})
-        page << "$('entry_#{j_str(params[:field])}').focus();"
+        page << "$j('#entry_#{j_str(params[:field])}').focus();"
         page << "$('entry_#{j_str(params[:field])}').select();"
       end
     else
@@ -101,7 +101,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>"new", :edit=>true})
-        page << "$('entry_name').focus();"
+        page << "$j('#entry_name').focus();"
         page << "$('entry_name').select();"
       end
     end

--- a/vmdb/app/controllers/ops_controller/settings/ldap.rb
+++ b/vmdb/app/controllers/ops_controller/settings/ldap.rb
@@ -316,7 +316,7 @@ module OpsController::Settings::Ldap
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ldap_server_entries_div", :partial=>"ldap_server_entries", :locals=>{:entry=>"new", :edit=>true,:domain_id=>params[:domain_id]})
-        page << "$('entry_name').focus();"
+        page << "$j('#entry_name').focus();"
         page << "$('entry_name').select();"
       end
       session[:entry] = "new"
@@ -325,7 +325,7 @@ module OpsController::Settings::Ldap
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ldap_server_entries_div", :partial=>"ldap_server_entries", :locals=>{:entry=>entry, :edit=>true,:domain_id=>params[:domain_id]})
-        page << "$('entry_#{j_str(params[:field])}').focus();"
+        page << "$j('#entry_#{j_str(params[:field])}').focus();"
         page << "$('entry_#{j_str(params[:field])}').select();"
       end
       session[:entry] = entry

--- a/vmdb/app/controllers/ops_controller/settings/tags.rb
+++ b/vmdb/app/controllers/ops_controller/settings/tags.rb
@@ -165,7 +165,7 @@ module OpsController::Settings::Tags
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("classification_entries_div", :partial=>"classification_entries", :locals=>{:entry=>"new", :edit=>true})
-        page << "$('entry_name').focus();"
+        page << "$j('#entry_name').focus();"
         page << "$('entry_name').select();"
       end
       session[:entry] = "new"
@@ -174,7 +174,7 @@ module OpsController::Settings::Tags
       render :update do |page|                    # Use JS to update the display
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("classification_entries_div", :partial=>"classification_entries", :locals=>{:entry=>entry, :edit=>true})
-        page << "$('entry_#{j_str(params[:field])}').focus();"
+        page << "$j('#entry_#{j_str(params[:field])}').focus();"
         page << "$('entry_#{j_str(params[:field])}').select();"
       end
       session[:entry] = entry
@@ -201,7 +201,7 @@ module OpsController::Settings::Tags
       entry.errors.each { |field,msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-        page << "$('entry_name').focus();"
+        page << "$j('#entry_name').focus();"
       end
       return
     end
@@ -232,7 +232,7 @@ module OpsController::Settings::Tags
       entry.errors.each { |field,msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
       render :update do |page|
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
-        page << "$('entry_name').focus();"
+        page << "$j('#entry_name').focus();"
       end
     end
   end

--- a/vmdb/app/views/alert/_rss_list.html.erb
+++ b/vmdb/app/views/alert/_rss_list.html.erb
@@ -19,7 +19,7 @@
                 :multiple                   => false,
                 "data-miq_observe" => {:url => url_for(:action => 'role_selected')}.to_json)
             %>
-            <%= javascript_tag("$('role').focus()") %>
+            <%= javascript_tag("$j('#role').focus()") %>
           </th>
         </tr>
         <tr>

--- a/vmdb/app/views/catalog/_form_basic_info.html.erb
+++ b/vmdb/app/views/catalog/_form_basic_info.html.erb
@@ -35,7 +35,7 @@
             &nbsp;Display in Catalog
         </td>
       </tr>
-      <%= javascript_tag("$('name').focus()") %>
+      <%= javascript_tag("$j('#name').focus()") %>
       <% if @edit[:new][:display] %>
       <tr>
         <td class="key">Catalog</td>

--- a/vmdb/app/views/catalog/_stcat_form.html.erb
+++ b/vmdb/app/views/catalog/_stcat_form.html.erb
@@ -1,4 +1,4 @@
-<% url = url_for(:action => "st_catalog_form_field_changed", 
+<% url = url_for(:action => "st_catalog_form_field_changed",
                  :id     => "#{@edit[:rec_id] || "new"}")
 %>
 <div id="form_div">
@@ -20,7 +20,7 @@
         </div>
       </td>
     </tr>
-    <%= javascript_tag("$('name').focus()") %>
+    <%= javascript_tag("$j('#name').focus()") %>
     <tr>
       <td class="key">Description</td>
       <td class="wider">

--- a/vmdb/app/views/chargeback/_cb_rate_edit.html.erb
+++ b/vmdb/app/views/chargeback/_cb_rate_edit.html.erb
@@ -12,7 +12,7 @@
                                     @edit[:new][:description],
                                     :maxlength=>MAX_NAME_LEN,
                                     "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-              <%= javascript_tag("$('description').focus()") %>
+              <%= javascript_tag("$j('#description').focus()") %>
             </td>
           </tr>
       </table>

--- a/vmdb/app/views/configuration/_ui_5.html.erb
+++ b/vmdb/app/views/configuration/_ui_5.html.erb
@@ -10,7 +10,7 @@
 					<%= form_tag(url_for(:action => 'mytag_create', :id => "newtags_form"), :remote=>true) do %>
 					 <strong>Type one or more tags to create and press "Enter":</strong>
 						<%= text_field_tag("newtags", nil, :maxlength=>"50","data-miq_focus"=>true) %>
-						<%= javascript_tag("$('newtags').focus()") %>
+						<%= javascript_tag("$j('#newtags').focus()") %>
 					<% end %>
 				</td>
 			</tr>

--- a/vmdb/app/views/dashboard/login.html.haml
+++ b/vmdb/app/views/dashboard/login.html.haml
@@ -12,7 +12,7 @@
           %label Username
           = text_field_tag('user_name', @user_name,:onkeypress=>"if(miqEnterPressed(event)) miqAjaxAuth();")
           :javascript
-            $('user_name').focus();
+            $j('#user_name').focus();
         %p
           %label Password
           = password_field_tag('user_password', @user_password,:onkeypress=>"if(miqEnterPressed(event)) miqAjaxAuth();",:autocomplete => "off")

--- a/vmdb/app/views/layouts/_adv_searchbox.html.erb
+++ b/vmdb/app/views/layouts/_adv_searchbox.html.erb
@@ -18,7 +18,7 @@
 											:alt=>"Search by Name within results",
 											:title=>"Search by Name within results",
 											:class=>"#{nameonly ? "nameonly" : nil}") %>
-		<%= javascript_tag("$('search_text').focus();") %>
+		<%= javascript_tag("$j('#search_text').focus();") %>
 		<%= link_to(image_tag('/images/layout/search.gif',
 													:id=>"searchicon", :name=>"search_button",
 													:alt=>"Search by Name within results",

--- a/vmdb/app/views/layouts/_ae_resolve_options.html.erb
+++ b/vmdb/app/views/layouts/_ae_resolve_options.html.erb
@@ -24,7 +24,7 @@
                                     :maxlength=>MAX_NAME_LEN,
                                     "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
 								<% if !is_browser_ie? %>
-									<%= javascript_tag("$('other_name').focus()") %>
+									<%= javascript_tag("$j('#other_name').focus()") %>
 								<% end %>
 							<% end %>
 <% end %>
@@ -40,7 +40,7 @@
                                     "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
 							<%# unless resolve[:new][:instance_name].blank? %>
 								<% if !is_browser_ie? %>
-									<%= javascript_tag("if (!$('description')) $('object_message').focus()") %>
+									<%= javascript_tag("if (!$j('#description').length) $j('#object_message').focus()") %>
 								<% end %>
 							<%# end %>
 						</td>

--- a/vmdb/app/views/layouts/_dhtmlxlayout_explorer.html.erb
+++ b/vmdb/app/views/layouts/_dhtmlxlayout_explorer.html.erb
@@ -151,7 +151,7 @@
 
     <% if show_searchbar %>
       $('control_searchbar').show();
-      $('search_text').focus();
+      $j('#search_text').focus();
     <% end %>
 	};
 </script>

--- a/vmdb/app/views/layouts/_discover.html.erb
+++ b/vmdb/app/views/layouts/_discover.html.erb
@@ -33,7 +33,7 @@
           </td>
         </tr>
         <% i += 1 %>
-          <%#= javascript_tag("$('from_first').focus()") %>
+          <%#= javascript_tag("$j('#from_first').focus()") %>
         <% end %>
     </table>
     <hr>

--- a/vmdb/app/views/layouts/_edit_log_depot_settings.html.erb
+++ b/vmdb/app/views/layouts/_edit_log_depot_settings.html.erb
@@ -52,7 +52,7 @@
               }.to_json
             ) %>
           </td>
-          <%= javascript_tag("$('uri').focus()") %>
+          <%= javascript_tag("$j('#uri').focus()") %>
         </tr>
         <% if @edit[:new][:requires_credentials] %>
           <%= render(

--- a/vmdb/app/views/layouts/_quick_search.html.erb
+++ b/vmdb/app/views/layouts/_quick_search.html.erb
@@ -94,8 +94,6 @@
         </td>
       </tr>
     </table>
-    <script type="text/javascript">
-      if ($('value_1')) $('value_1').focus();
-    </script>
+    <%= javascript_tag("if ($j('#value_1').length) $j('#value_1').focus()") %>
   <% end %>
 </div>

--- a/vmdb/app/views/layouts/_searchbarYUI.html.erb
+++ b/vmdb/app/views/layouts/_searchbarYUI.html.erb
@@ -15,7 +15,7 @@
 	<div id="searchbox"><%# Name based search box %>
 		<%= form_tag( {:action=>'show_list'}) do %>
 			<%= text_field("search", "text", :id=>"search_text", :value=>@search_text,:alt=>"Search by Name within results", :title=>"Search by Name within results") %>
-			<%= javascript_tag("$('search_text').focus()") %>
+			<%= javascript_tag("$j('#search_text').focus()") %>
 			<%= image_submit_tag("/images/layout/search.gif", :id=>"searchicon", :name=>"search", :alt=>"Search by Name within results", :title=>"Search by Name within results")%>
 		<% end %>
 	</div>

--- a/vmdb/app/views/layouts/_x_adv_searchbox.html.erb
+++ b/vmdb/app/views/layouts/_x_adv_searchbox.html.erb
@@ -18,7 +18,7 @@
 											:alt=>"Search by Name within results",
 											:title=>"Search by Name within results",
 											:class=>"#{nameonly ? "nameonly" : nil}") %>
-		<%= javascript_tag("$('search_text').focus();") %>
+		<%= javascript_tag("$j('#search_text').focus();") %>
 		<%= link_to(image_tag('/images/layout/search.gif',
 													:id=>"searchicon", :name=>"search_button",
 													:alt=>"Search by Name within results",

--- a/vmdb/app/views/miq_ae_class/_class_form.html.erb
+++ b/vmdb/app/views/miq_ae_class/_class_form.html.erb
@@ -21,7 +21,7 @@
               "data-miq_observe" => {:interval => '.5', 
                                      :url      => url}.to_json)
           %>
-          <%= javascript_tag("$('name').focus()") %>
+          <%= javascript_tag("$j('#name').focus()") %>
         </td>
       </tr>
       <tr>

--- a/vmdb/app/views/miq_ae_class/_instance_form.html.erb
+++ b/vmdb/app/views/miq_ae_class/_instance_form.html.erb
@@ -21,7 +21,7 @@
                            "data-miq_observe" => {:interval => '.5',
                                                   :url      => url}.to_json)
         %>
-        <%= javascript_tag("$('#{prefix}inst_name').focus()") %>
+        <%= javascript_tag("$j('##{prefix}inst_name').focus()") %>
        </td>
     </tr>
     <tr>

--- a/vmdb/app/views/miq_ae_class/_method_form.html.erb
+++ b/vmdb/app/views/miq_ae_class/_method_form.html.erb
@@ -25,7 +25,7 @@
                                                        :url      => url}.to_json)
             %>
           </td>
-            <%#= javascript_tag("$('method_name').focus()") %>
+            <%#= javascript_tag("$j('#method_name').focus()") %>
         </tr>
         <tr>
           <td class="key">Display Name</td>
@@ -196,7 +196,7 @@
               </td>
               <td>
                 <%= select_tag("#{prefix}field_datatype",
-                               options_for_select(@edit[:new][:available_datatypes], 
+                               options_for_select(@edit[:new][:available_datatypes],
                                session[:field_data][:datatype]),
                                "data-miq_observe" => {:url => url}.to_json)
                 %>

--- a/vmdb/app/views/miq_ae_class/_ns_list.html.erb
+++ b/vmdb/app/views/miq_ae_class/_ns_list.html.erb
@@ -53,7 +53,7 @@
                                 "data-miq_observe" => {:interval => '.5', 
                                                        :url      => url}.to_json)
             %>
-            <%= javascript_tag("$('ns_name').focus()") %>
+            <%= javascript_tag("$j('#ns_name').focus()") %>
           </td>
         </tr>
         <tr>

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -10,7 +10,7 @@
                             @edit[:field_label],
                             :maxlength=>MAX_NAME_LEN,
                             "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json)
-          = javascript_tag("$('field_label').focus()")
+          = javascript_tag("$j('#field_label').focus()")
       %tr
         %td.key Name
         %td.wide

--- a/vmdb/app/views/miq_ae_customization/_dialog_group_form.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_dialog_group_form.html.erb
@@ -9,7 +9,7 @@
                             @edit[:group_label],
                             :maxlength=>MAX_NAME_LEN,
                             "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-        <%= javascript_tag("$('group_label').focus()") %>
+        <%= javascript_tag("$j('#group_label').focus()") %>
       </td>
     </tr>
     <tr>

--- a/vmdb/app/views/miq_ae_customization/_dialog_info_form.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_dialog_info_form.html.erb
@@ -10,7 +10,7 @@
                             @edit[:new][:label],
                             :maxlength=>MAX_NAME_LEN,
                             "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-        <%= javascript_tag("$('label').focus()") %>
+        <%= javascript_tag("$j('#label').focus()") %>
       </td>
     </tr>
     <tr>

--- a/vmdb/app/views/miq_ae_customization/_dialog_tab_form.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_dialog_tab_form.html.erb
@@ -9,7 +9,7 @@
                             @edit[:tab_label],
                             :maxlength=>MAX_NAME_LEN,
                             "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-        <%= javascript_tag("$('tab_label').focus()") %>
+        <%= javascript_tag("$j('#tab_label').focus()") %>
       </td>
     </tr>
     <tr>

--- a/vmdb/app/views/miq_ae_customization/_old_dialogs_form.html.erb
+++ b/vmdb/app/views/miq_ae_customization/_old_dialogs_form.html.erb
@@ -11,10 +11,10 @@
           <%= text_field_tag("name",
                              @edit[:new][:name],
                              :maxlength         => MAX_NAME_LEN,
-                             "data-miq_observe" => {:interval => '.5', 
+                             "data-miq_observe" => {:interval => '.5',
                                                    :url       => url}.to_json)
           %>
-          <%= javascript_tag("$('name').focus()") %>
+          <%= javascript_tag("$j('#name').focus()") %>
         </td>
       </tr>
       <tr>
@@ -23,7 +23,7 @@
           <%= text_field_tag("description",
                              @edit[:new][:description],
                              :maxlength         => 100,
-                             "data-miq_observe" => {:interval => '.5', 
+                             "data-miq_observe" => {:interval => '.5',
                                                     :url      => url}.to_json)
           %>
         </td>

--- a/vmdb/app/views/miq_policy/_action_details.html.erb
+++ b/vmdb/app/views/miq_policy/_action_details.html.erb
@@ -22,7 +22,7 @@
                                      "data-miq_observe" => {:interval => '.5', 
                                                             :url      => url}.to_json) 
                   %>
-                  <%= javascript_tag("$('description').focus()") %>
+                  <%= javascript_tag("$j('#description').focus()") %>
                 </td>
               <% end %>
                 </td>

--- a/vmdb/app/views/miq_policy/_alert_details.html.erb
+++ b/vmdb/app/views/miq_policy/_alert_details.html.erb
@@ -22,7 +22,7 @@
                                    "data-miq_observe" => {:interval => '.5', 
                                                           :url      => url}.to_json) 
                 %>
-                <%= javascript_tag("$('description').focus()") %>
+                <%= javascript_tag("$j('#description').focus()") %>
               </td>
             </tr>
           <% end %>
@@ -333,7 +333,7 @@
                           <th class="icon"></th>
                           <th></th>
                         </tr>
-                      </head>
+                      </thead>
                       <tbody>
                         <% @alert_profiles.each do |ap| %>
                           <% id = "xx-#{@alert.db}_ap-#{to_cid(ap.id)}" %>
@@ -374,7 +374,7 @@
                           <th class="icon"></th>
                           <th></th>
                         </tr>
-                      </head>
+                      </thead>
                       <tbody>
                         <% @alert.owning_miq_actions.each do |oa| %>
                           <% id = "a-#{to_cid(oa.id)}" %>

--- a/vmdb/app/views/miq_policy/_alert_profile_details.html.erb
+++ b/vmdb/app/views/miq_policy/_alert_profile_details.html.erb
@@ -25,7 +25,7 @@
                                                              :url      => url}.to_json) 
                   %>
                 </td>
-                <%= javascript_tag("$('description').focus()") %>
+                <%= javascript_tag("$j('#description').focus()") %>
               <% end %>
             </tr>
         </table>

--- a/vmdb/app/views/miq_policy/_condition_details.html.erb
+++ b/vmdb/app/views/miq_policy/_condition_details.html.erb
@@ -24,7 +24,7 @@
                                                             :url      => url}.to_json) 
                   %>
                 </td>
-                <%= javascript_tag("$('description').focus()") %>
+                <%= javascript_tag("$j('#description').focus()") %>
               <% end %>
             </tr>
         </table>

--- a/vmdb/app/views/miq_policy/_policy_details.html.erb
+++ b/vmdb/app/views/miq_policy/_policy_details.html.erb
@@ -44,7 +44,7 @@
                                         "data-miq_observe" => {:interval => '.5', 
                                                                :url => url}.to_json) 
                     %>
-                    <%= javascript_tag("$('description').focus()") %>
+                    <%= javascript_tag("$j('#description').focus()") %>
                   </td>
                 <% end %>
               </tr>
@@ -369,7 +369,7 @@
                     <th class="icon"></th>
                     <th></th>
                   </tr>
-                </head>
+                </thead>
                 <tbody>
                   <% @policy_profiles.each do |pp| %>
                     <% id = "pp-#{to_cid(pp.id)}" %>

--- a/vmdb/app/views/miq_policy/_profile_details.html.erb
+++ b/vmdb/app/views/miq_policy/_profile_details.html.erb
@@ -24,7 +24,7 @@
                                                           :url      => url}.to_json) 
                 %>
               </td>
-              <%= javascript_tag("$('description').focus()") %>
+              <%= javascript_tag("$j('#description').focus()") %>
             <% end %>
           </tr>
         </table>

--- a/vmdb/app/views/miq_policy/_searchbar.html.erb
+++ b/vmdb/app/views/miq_policy/_searchbar.html.erb
@@ -7,7 +7,7 @@
 						<%= text_field("search", "text", :style=>"width: 255px; height: 16px; position: absolute; top: 0px; right: 14px; z-index:50", :value=>@search_text,
 													:alt=>"Search by Name within results", :title=>"Search by Name within results") %>
 				</div>
-				<%#= javascript_tag("$('search_text').focus()") Moved to miqOnLoad in sprint 60, was failing in IE %>
+				<%#= javascript_tag("$j('#search_text').focus()") Moved to miqOnLoad in sprint 60, was failing in IE %>
 				<div id="control_searchicon">
 					<%= image_submit_tag("/images/layout/search.gif", :name=>"search_button", :alt=>"Search by Name within results", :title=>"Search by Name within results")%>
 				</div>

--- a/vmdb/app/views/ops/_ap_form.html.erb
+++ b/vmdb/app/views/ops/_ap_form.html.erb
@@ -16,7 +16,7 @@
 					</td>
 				</tr>
 					<% if !params[:add] && params[:add] != "new"  %>
-						<%= javascript_tag("$('name').focus()") %>
+						<%= javascript_tag("$j('#name').focus()") %>
 					<% end %>
 				<tr>
 					<td class="key">Description</td>

--- a/vmdb/app/views/ops/_category_form.html.erb
+++ b/vmdb/app/views/ops/_category_form.html.erb
@@ -76,9 +76,9 @@
 						</td>
 					</tr>
 					<% if @category.nil? %>
-						<%= javascript_tag("$('name').focus()") %>
+						<%= javascript_tag("$j('#name').focus()") %>
 					<% else %>
-						<%= javascript_tag("$('description').focus()") %>
+						<%= javascript_tag("$j('#description').focus()") %>
 					<% end %>
 					<tr>
 						<td class="key">Description</td>

--- a/vmdb/app/views/ops/_ldap_domain_form.html.erb
+++ b/vmdb/app/views/ops/_ldap_domain_form.html.erb
@@ -12,7 +12,7 @@
                                 @edit[:new][:name],
                                 :maxlength=>MAX_NAME_LEN,
                                 "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-            <%= javascript_tag("$('name').focus()") %>
+            <%= javascript_tag("$j('#name').focus()") %>
           </td>
         </tr>
     </table>

--- a/vmdb/app/views/ops/_ldap_region_form.html.erb
+++ b/vmdb/app/views/ops/_ldap_region_form.html.erb
@@ -11,7 +11,7 @@
                                 @edit[:new][:name],
                                 :maxlength=>MAX_NAME_LEN,
                                 "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-            <%= javascript_tag("$('name').focus()") %>
+            <%= javascript_tag("$j('#name').focus()") %>
           </td>
         </tr>
         <tr>

--- a/vmdb/app/views/ops/_rbac_group_details.html.erb
+++ b/vmdb/app/views/ops/_rbac_group_details.html.erb
@@ -24,7 +24,7 @@
                     <%= check_box_tag("lookup", value="1",
                                         checked=false,
                                         "data-miq_observe_checkbox"=>{:url=>url}.to_json)%>(Look Up LDAP Groups)
-                    <%= javascript_tag("$('description').focus()") %>
+                    <%= javascript_tag("$j('#description').focus()") %>
                   <% end %>
                 </td>
               </tr>

--- a/vmdb/app/views/ops/_rbac_role_details.html.erb
+++ b/vmdb/app/views/ops/_rbac_role_details.html.erb
@@ -18,7 +18,7 @@
                                   @edit[:new][:name],
                                   :maxlength=>50,
                                   "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-                <%= javascript_tag("$('name').focus()") %>
+                <%= javascript_tag("$j('#name').focus()") %>
               <% end %>
             </td>
           </tr>

--- a/vmdb/app/views/ops/_rbac_user_details.html.erb
+++ b/vmdb/app/views/ops/_rbac_user_details.html.erb
@@ -24,7 +24,7 @@
                               :disabled=>disabled,
                               "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
             <% unless @edit[:new][:userid] == "admin" %>
-              <%= javascript_tag("$('name').focus()") %>
+              <%= javascript_tag("$j('#name').focus()") %>
             <% end %>
           <% end %>
         </td>
@@ -54,7 +54,7 @@
                               :maxlength=>50,
                               "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
             <% if @edit[:new][:userid] == "admin" %>
-              <%= javascript_tag("$('password').focus()") %>
+              <%= javascript_tag("$j('#password').focus()") %>
             <% end %>
             <%= password_field_tag("password2",
                               @edit[:new][:password2],

--- a/vmdb/app/views/ops/_schedule_form.html.erb
+++ b/vmdb/app/views/ops/_schedule_form.html.erb
@@ -10,7 +10,7 @@
                             @edit[:new][:name],
                             :maxlength=>MAX_NAME_LEN,
                             "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-        <%= javascript_tag("$('name').focus()") %>
+        <%= javascript_tag("$j('#name').focus()") %>
       </td>
     </tr>
     <tr>

--- a/vmdb/app/views/ops/_settings_details_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_details_tab.html.erb
@@ -16,7 +16,7 @@
 															 @edit[:new][:description],
 															 :maxlength=>50,
 															 "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-										<%= javascript_tag("$('region_description').focus()") %>
+										<%= javascript_tag("$j('#region_description').focus()") %>
 									</td>
 								</tr>
 							</table>

--- a/vmdb/app/views/ops/_settings_host_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_host_tab.html.erb
@@ -12,7 +12,7 @@
 							<% check = @edit[:new][:host][:autoscan].to_s == "1" %>
 								<%= check_box_tag("host_autoscan", value="1", checked=check,
 																			"data-miq_observe_checkbox"=>{:url=>url}.to_json)%>
-								<%= javascript_tag("$('host_autoscan').focus()") %>
+								<%= javascript_tag("$j('#host_autoscan').focus()") %>
 						</td>
 					</tr>
 					<tr>

--- a/vmdb/app/views/ops/_zone_form.html.erb
+++ b/vmdb/app/views/ops/_zone_form.html.erb
@@ -28,7 +28,7 @@
                                       :disabled =>disabled_name,
                                       "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
 									<% if !@zone.id %>
-										<%= javascript_tag("$('name').focus()") %>
+										<%= javascript_tag("$j('#name').focus()") %>
 									<% end %>
 								</td>
 							</tr>
@@ -41,7 +41,7 @@
                                       :disabled =>disabled_desc,
                                       "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
 									<% if @zone.id && @zone.name.downcase != "default" %>
-										<%= javascript_tag("$('description').focus()") %>
+										<%= javascript_tag("$j('#description').focus()") %>
 									<% end %>
 								</td>
 							</tr>
@@ -53,7 +53,7 @@
                                       :maxlength=>50,
                                       "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
 									<% if @zone.id && @zone.name.downcase == "default" %>
-										<%= javascript_tag("$('proxy_server_ip').focus()") %>
+										<%= javascript_tag("$j('#proxy_server_ip').focus()") %>
 									<% end %>
 								</td>
 							</tr>

--- a/vmdb/app/views/pxe/_pxe_form.html.erb
+++ b/vmdb/app/views/pxe/_pxe_form.html.erb
@@ -12,7 +12,7 @@
                                   @edit[:new][:name],
                                   :maxlength=>MAX_NAME_LEN,
                                   "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-            <%= javascript_tag("$('name').focus()") %>
+            <%= javascript_tag("$j('#name').focus()") %>
           </td>
         </tr>
         <tr>

--- a/vmdb/app/views/pxe/_pxe_image_type_form.html.erb
+++ b/vmdb/app/views/pxe/_pxe_image_type_form.html.erb
@@ -12,7 +12,7 @@
                                @edit[:new][:name],
                                :maxlength=>MAX_NAME_LEN,
                                "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-            <%= javascript_tag("$('name').focus()") %>
+            <%= javascript_tag("$j('#name').focus()") %>
           </td>
         </tr>
         <tr>

--- a/vmdb/app/views/pxe/_template_form.html.erb
+++ b/vmdb/app/views/pxe/_template_form.html.erb
@@ -18,7 +18,7 @@
                               "data-miq_observe" => {:interval => '.5',
                                                      :url      => url}.to_json)
           %>
-        <%= javascript_tag("$('name').focus()") %>
+        <%= javascript_tag("$j('#name').focus()") %>
       </td>
     </tr>
     <tr>

--- a/vmdb/app/views/report/_db_form.html.erb
+++ b/vmdb/app/views/report/_db_form.html.erb
@@ -13,7 +13,7 @@
                              :disabled=>read_only,
                              "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
             <% if !read_only %>
-              <%= javascript_tag("$('name').focus()") %>
+              <%= javascript_tag("$j('#name').focus()") %>
           <% end %>
         </td>
       </tr>

--- a/vmdb/app/views/report/_form.html.erb
+++ b/vmdb/app/views/report/_form.html.erb
@@ -16,7 +16,7 @@
             </div>
           </td>
         </tr>
-        <%= javascript_tag("$('name').focus()") %>
+        <%= javascript_tag("$j('#name').focus()") %>
         <tr>
           <td class="key">Title</td>
           <td class="wider">

--- a/vmdb/app/views/report/_schedule_form.html.erb
+++ b/vmdb/app/views/report/_schedule_form.html.erb
@@ -10,7 +10,7 @@
                                  @edit[:new][:name],
                                  :maxlength=>MAX_NAME_LEN,
                                  "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
-          <%= javascript_tag("$('name').focus()") %>
+          <%= javascript_tag("$j('#name').focus()") %>
         </td>
       </tr>
       <tr>

--- a/vmdb/app/views/report/_widget_form.html.erb
+++ b/vmdb/app/views/report/_widget_form.html.erb
@@ -12,7 +12,7 @@
                             :maxlength=>40,
                             "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
         <% unless @edit[:read_only] %>
-          <%= javascript_tag("$('title').focus()") %>
+          <%= javascript_tag("$j('#title').focus()") %>
         <% end %>
       </td>
     </tr>

--- a/vmdb/app/views/service/_service_form.html.erb
+++ b/vmdb/app/views/service/_service_form.html.erb
@@ -17,7 +17,7 @@
               </div>
             </td>
           </tr>
-          <%= javascript_tag("$('name').focus()") %>
+          <%= javascript_tag("$j('#name').focus()") %>
           <tr>
             <td class="key">Description</td>
             <td class="wider">

--- a/vmdb/app/views/service/_st_form.html.erb
+++ b/vmdb/app/views/service/_st_form.html.erb
@@ -16,7 +16,7 @@
               </div>
             </td>
           </tr>
-          <%= javascript_tag("$('name').focus()") %>
+          <%= javascript_tag("$j('#name').focus()") %>
           <tr>
             <td class="key">Description</td>
             <td class="wider">

--- a/vmdb/app/views/shared/buttons/_ab_form.html.erb
+++ b/vmdb/app/views/shared/buttons/_ab_form.html.erb
@@ -42,7 +42,7 @@
         &nbsp;Display on Button
       </td>
       <% if !is_browser_ie? %>
-        <%= javascript_tag("$('name').focus()") %>
+        <%= javascript_tag("$j('#name').focus()") %>
       <% end %>
     </tr>
     <tr>

--- a/vmdb/app/views/shared/buttons/_group_form.html.erb
+++ b/vmdb/app/views/shared/buttons/_group_form.html.erb
@@ -21,7 +21,7 @@
         &nbsp;Display on Button
       </td>
       <% if !is_browser_ie? %>
-        <%= javascript_tag("$('name').focus()") %>
+        <%= javascript_tag("$j('#name').focus()") %>
       <% end %>
     </tr>
     <tr>


### PR DESCRIPTION
Replaced prototype references to the focus function with the equivalent in jquery following the pattern below:
prototype: $('id').focus()
jquery:    $j('#id').focus()

https://github.com/ManageIQ/manageiq/issues/214
