### PR TITLE
Add missing recent versions of vddk to library load list

### DIFF
--- a/lib/VixDiskLib/VixDiskLib_FFI/api.rb
+++ b/lib/VixDiskLib/VixDiskLib_FFI/api.rb
@@ -14,7 +14,7 @@ module FFI
       #
       # Make sure we load one and only one version of VixDiskLib
       #
-      version_load_order = %w( 5.5.0 5.1.0 5.0.0 1.2.0 1.1.2 )
+      version_load_order = %w( 5.5.2 5.5.1 5.5.0 5.1.3 5.1.2 5.1.1 5.1.0 5.0.4 5.0.0 1.2.0 1.1.2 )
       load_errors = []
       loaded_library = ""
       version_load_order.each do |version|


### PR DESCRIPTION
Add the following versions of vddk to the list to search:
5.5.2
5.5.1
5.1.3
5.1.2
5.1.1
5.0.4
The initial FFI-binding to VixDiskLib attempted to load a representative version of each major release from VMware.  This PR adds all the most recent versions for completeness.

@Fryguy @roliveri please review
