### PR TITLE
Updating External Authentication to support new AwesomeSpawn 1.2.1 usage...

### DIFF
--- a/lib/appliance_console/external_httpd_configuration.rb
+++ b/lib/appliance_console/external_httpd_configuration.rb
@@ -36,22 +36,20 @@ EOS
       def ipa_client_configure(realm, domain, server, principal, password)
         say("Configuring the IPA Client ...")
         AwesomeSpawn.run!(IPA_INSTALL_COMMAND,
-                          :params => {"-N"              => nil,
-                                      "--force-join"    => nil,
-                                      "--realm="        => realm,
-                                      "--domain="       => domain,
-                                      "--server="       => server,
-                                      "--principal="    => principal,
-                                      "--password="     => password,
-                                      "--fixed-primary" => nil,
-                                      "--unattended"    => nil})
+                          :params => [
+                            "-N", :force_join, :fixed_primary, :unattended, {
+                              :realm=     => realm,
+                              :domain=    => domain,
+                              :server=    => server,
+                              :principal= => principal,
+                              :password=  => password
+                            }
+                          ])
       end
 
       def ipa_client_unconfigure
         say("Un-Configuring the IPA Client ...")
-        AwesomeSpawn.run(IPA_INSTALL_COMMAND,
-                         :params => {"--uninstall"  => nil,
-                                     "--unattended" => nil})
+        AwesomeSpawn.run(IPA_INSTALL_COMMAND, :params => [:uninstall, :unattended])
       end
 
       #


### PR DESCRIPTION
....
- Using the new AwesomeSpawn using symbols for
  parameters, i.e. :fixed_primary instead of "--fixed-primary"
  and eliminating the need for nil for options with no values.
