### PR TITLE
Glyphicons not rendering in production

### DIFF
--- a/vmdb/app/assets/stylesheets/glyphicons.css.erb
+++ b/vmdb/app/assets/stylesheets/glyphicons.css.erb
@@ -127,11 +127,11 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('<%= asset_path("fontawesome-webfont.eot?v=4.0.3") %>');
-  src: url('<%= asset_path("fontawesome-webfont.eot?#iefix&v=4.0.3") %>') format('embedded-opentype'), 
-    url('<%= asset_path("fontawesome-webfont.woff?v=4.0.3") %>') format('woff'), 
-    url('<%= asset_path("fontawesome-webfont.ttf?v=4.0.3") %>') format('truetype'), 
-    url('<%= asset_path("fontawesome-webfont.svg?v=4.0.3#fontawesomeregular") %>') format('svg');
+  src: url('<%= asset_path("fontawesome-webfont.eot") %>');
+  src: url('<%= asset_path("fontawesome-webfont.eot?#iefix") %>') format('embedded-opentype'), 
+    url('<%= asset_path("fontawesome-webfont.woff") %>') format('woff'), 
+    url('<%= asset_path("fontawesome-webfont.ttf") %>') format('truetype'), 
+    url('<%= asset_path("fontawesome-webfont.svg") %>') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Fixed font names, which were causing images to not render in production

Before:
![screen shot 2014-07-18 at 10 47 03 am](https://cloud.githubusercontent.com/assets/1287144/3627473/2b9f3c20-0e8a-11e4-8287-e195cdd68995.png)
After:
![screen shot 2014-07-18 at 10 47 15 am](https://cloud.githubusercontent.com/assets/1287144/3627472/2b9ab376-0e8a-11e4-8c56-75bacc22bbc8.png)
