### PR TITLE
Allow for search with leading / for namespace and classes

### DIFF
--- a/vmdb/app/models/miq_ae_namespace.rb
+++ b/vmdb/app/models/miq_ae_namespace.rb
@@ -12,6 +12,9 @@ class MiqAeNamespace < ActiveRecord::Base
   validate :uniqueness_of_fqname
 
   def self.find_by_fqname(fqname, include_classes = true)
+    return nil if fqname.blank?
+
+    fqname   = fqname[1..-1] if fqname[0] == '/'
     fqname   = fqname.downcase
     last     = fqname.split('/').last
     low_name = arel_table[:name].lower
@@ -22,6 +25,7 @@ class MiqAeNamespace < ActiveRecord::Base
   def self.find_or_create_by_fqname(fqname, include_classes = true)
     return nil if fqname.blank?
 
+    fqname   = fqname[1..-1] if fqname[0] == '/'
     found = find_by_fqname(fqname, include_classes)
     return found unless found.nil?
 

--- a/vmdb/spec/models/miq_ae_namespace_spec.rb
+++ b/vmdb/spec/models/miq_ae_namespace_spec.rb
@@ -61,4 +61,14 @@ describe MiqAeNamespace do
     n1.should be_editable
   end
 
+  it 'find_by_fqname works with and without leading slash' do
+    n1 = MiqAeNamespace.find_or_create_by_fqname("foo/bar")
+    MiqAeNamespace.find_by_fqname('/foo/bar').id == n1.id
+  end
+
+  it 'empty namespace string should return nil' do
+    MiqAeNamespace.find_by_fqname(nil).should be_nil
+    MiqAeNamespace.find_by_fqname('').should be_nil
+  end
+
 end


### PR DESCRIPTION
Fix #236
MiqAeNamespace.find_by_fqname works with or without leading slash.
Without leading slash is the recommended way.
