### PR TITLE
Fixed the breadcrumb link when navigating back to the VM Summary page

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1279,7 +1279,7 @@ module VmCommon
   alias miq_template_edit edit
 
   def build_edit_screen
-    drop_breadcrumb( {:name => "Edit VM '" + @record.name + "'", :url => "/vm/edit"} ) unless @explorer
+    drop_breadcrumb(:name => "Edit VM '" + @record.name + "'", :url => "/vm/edit") unless @explorer
     session[:edit] = @edit
     @in_a_form = true
     @tabs = [ ["edit", @record.id.to_s], ["edit", "Information"] ]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1119487
