### PR TITLE
Change Travis runs to always have a region number.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
   postgresql: '9.3'
 before_install:
 - "echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc"
+- echo "1" > vmdb/REGION
 - psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
 - rake build:shared_objects
 - cd $TEST_ROOT

--- a/vmdb/spec/migrations/20100310182434_add_priority_to_assigned_server_roles_spec.rb
+++ b/vmdb/spec/migrations/20100310182434_add_priority_to_assigned_server_roles_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20100310182434_add_priority_to_assigned_server_roles.rb")
 
 describe AddPriorityToAssignedServerRoles do
+  before do
+    pending("spec can only run on region 0")  unless ActiveRecord::Base.my_region_number == 0
+  end
+
   migration_context :up do
     let(:assigned_server_role_stub)  { migration_stub(:AssignedServerRole) }
 

--- a/vmdb/spec/migrations/20100407192439_add_responds_to_events_to_miq_alerts_spec.rb
+++ b/vmdb/spec/migrations/20100407192439_add_responds_to_events_to_miq_alerts_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20100407192439_add_responds_to_events_to_miq_alerts.rb")
 
 describe AddRespondsToEventsToMiqAlerts do
+  before do
+    pending("spec can only run on region 0")  unless ActiveRecord::Base.my_region_number == 0
+  end
+
   migration_context :up do
     let(:miq_alert_stub)  { migration_stub(:MiqAlert) }
 
@@ -13,5 +17,4 @@ describe AddRespondsToEventsToMiqAlerts do
       alert.reload.enabled.should be_false
     end
   end
-
 end

--- a/vmdb/spec/migrations/20100408131912_update_system_schedules_spec.rb
+++ b/vmdb/spec/migrations/20100408131912_update_system_schedules_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require Rails.root.join('db/migrate/20100408131912_update_system_schedules.rb')
 
 describe UpdateSystemSchedules do
+  before do
+    pending("spec can only run on region 0")  unless ActiveRecord::Base.my_region_number == 0
+  end
+
   migration_context :up do
     let(:schedule_stub) { migration_stub(:MiqSchedule) }
 

--- a/vmdb/spec/migrations/20100413003434_remove_miq_alert_contents_spec.rb
+++ b/vmdb/spec/migrations/20100413003434_remove_miq_alert_contents_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20100413003434_remove_miq_alert_contents.rb")
 
 describe RemoveMiqAlertContents do
+  before do
+    pending("spec can only run on region 0")  unless ActiveRecord::Base.my_region_number == 0
+  end
+
   migration_context :up do
     let(:alert_stub)         { migration_stub(:MiqAlert) }
     let(:action_stub)        { migration_stub(:MiqAction) }

--- a/vmdb/spec/migrations/20100515003009_remove_vim_performance_metrics_spec.rb
+++ b/vmdb/spec/migrations/20100515003009_remove_vim_performance_metrics_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20100515003009_remove_vim_performance_metrics.rb")
 
 describe RemoveVimPerformanceMetrics do
+  before do
+    pending("spec can only run on region 0")  unless ActiveRecord::Base.my_region_number == 0
+  end
+
   migration_context :up do
     let(:queue_stub)  { migration_stub(:MiqQueue) }
     let(:metric_stub) { migration_stub(:VimPerformanceMetric) }


### PR DESCRIPTION
Subtle bugs can occur when the REGION is not the default of 0,
specifically, if someone creates a migration and does not specify
a bigint column when it needs to contain an id (e.g. *_id columns).

Very early migrations specs can only run on REGION 0, because the column
is created as an integer, but the sequence is created as a bigint.  This
situation only occurs in testing because normally, when migrating from 0,
we always go all the way to the end where this situation is resolved.
Testing, on the other hand, stops mid-migration to run the tests. Users
on old versions, prior to the 64bit key change, are always considered to
be REGION 0 (i.e. you can't upgrade and not be REGION 0), thus they
don't have this issue.

@brandondunne @jrafanie Please review.  This PR is also serving as a testbed for the initial round of non-0 region testing.