### PR TITLE
Truncate long RHEV custom attributes

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/rhevm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/rhevm.rb
@@ -748,10 +748,10 @@ module EmsRefresh::Parsers::Rhevm
 
     custom_attrs.each do |ca|
       new_result = {
-        :section  => 'custom_field',
-        :name  => ca[:name],
-        :value => ca[:value] ,
-        :source => "VC",
+        :section => 'custom_field',
+        :name    => ca[:name],
+        :value   => ca[:value].try(:truncate, 255),
+        :source  => "VC",
       }
       result << new_result
     end

--- a/vmdb/spec/models/ems_refresh/parsers/rhevm_spec.rb
+++ b/vmdb/spec/models/ems_refresh/parsers/rhevm_spec.rb
@@ -59,4 +59,23 @@ describe EmsRefresh::Parsers::Rhevm do
 
   end
 
+  context "#vm_inv_to_custom_attribute_hashes" do
+    it "should truncate the custom attribute value" do
+      inv = {
+        :custom_attributes => [
+          :name  => 'custom_attribute',
+          :value => "0" * 1000
+        ]
+      }
+      result = EmsRefresh::Parsers::Rhevm.vm_inv_to_custom_attribute_hashes(inv)
+      result.should == [
+        {
+          :section => "custom_field",
+          :name    => "custom_attribute",
+          :value   => "#{"0" * 252}...",
+          :source  => "VC"
+        }
+      ]
+    end
+  end
 end


### PR DESCRIPTION
Using the RHEV DirectLUN hook in support for CFME SmartState
Analysis, it is very easy to have a RHEV custom attribute
which exceeds the 255 character limit.  This prevents the
affected VMs from being updated and also prevents deleted RHEV
VMs from being being flagged as deleted in the VMDB. Updated the
RHEV inventory parser to truncate custom attribute values that
exceed the DB limit.

https://bugzilla.redhat.com/show_bug.cgi?id=1122259
