### PR TITLE
Updated the valid states for provision requests

### DIFF
--- a/vmdb/app/models/miq_provision_request.rb
+++ b/vmdb/app/models/miq_provision_request.rb
@@ -11,7 +11,9 @@ class MiqProvisionRequest < MiqRequest
   ACTIVE_STATES     = %w{ migrated } + self.base_class::ACTIVE_STATES
 
   validates_inclusion_of :request_type,   :in => REQUEST_TYPES,                          :message => "should be #{REQUEST_TYPES.join(", ")}"
-  validates_inclusion_of :request_state,  :in => %w{ pending finished } + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"
+  validates_inclusion_of :request_state,
+                         :in      => %w(pending provisioned finished) + ACTIVE_STATES,
+                         :message => "should be pending, #{ACTIVE_STATES.join(", ")}, provisioned, or finished"
   validates_presence_of  :source_id,      :message => "must have valid template"
   validate               :must_have_valid_vm
   validate               :must_have_user


### PR DESCRIPTION
The provision task has a state named "provisioned" which is
not currently a valid state for its associated provision request.
As a result, after a provision task has finished provisioning a
VM, the task's status can no longer be bubbled up to its parent
provision request due to a validation error.

https://bugzilla.redhat.com/show_bug.cgi?id=1122123
