### PR TITLE
REST API Enhancement to support Provisioning

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -35,6 +35,8 @@ class ApiController < ApplicationController
   include_concern 'Generic'
   include_concern 'ServiceTemplates'
   include_concern 'Tags'
+  include_concern 'ProvisionRequests'
+  include_concern 'RequestTasks'
 
   #
   # Api Controller Hooks

--- a/vmdb/app/controllers/api_controller/manager.rb
+++ b/vmdb/app/controllers/api_controller/manager.rb
@@ -89,15 +89,27 @@ class ApiController
     end
 
     def get_and_update_one_collection(is_subcollection, target, type, id)
-      resource = json_body["resource"]
+      resource = json_body_resource
       update_one_collection(is_subcollection, target, type, id, resource) unless resource.blank?
     end
 
     def get_and_update_multiple_collections(is_subcollection, target, type)
       resources = []
-      resources << json_body["resource"]  if json_body["resource"]
-      resources += json_body["resources"] if json_body["resources"]
+      if json_body.key?("resources")
+        resources += json_body["resources"]
+      else
+        resources << json_body_resource
+      end
       update_multiple_collections(is_subcollection, target, type, resources)
+    end
+
+    def json_body_resource
+      resource = json_body["resource"]
+      unless resource
+        resource = json_body.dup
+        resource.delete("action")
+      end
+      resource
     end
 
     def update_one_collection(is_subcollection, target, type, id, resource)
@@ -110,6 +122,8 @@ class ApiController
     end
 
     def update_multiple_collections(is_subcollection, target, type, resources)
+      action = @req[:action]
+
       processed = 0
       results = resources.each.collect do |r|
         next if r.blank?

--- a/vmdb/app/controllers/api_controller/parser.rb
+++ b/vmdb/app/controllers/api_controller/parser.rb
@@ -146,18 +146,18 @@ class ApiController
     end
 
     def validate_post_api_action(cname, mname, cspec, type, target)
-      if json_body.key?("action")
-        aname = @req[:action] = json_body["action"]
-        aspecnames = "#{target}_actions"
-        raise BadRequestError, "No actions are supported for #{cname} #{type}" unless cspec.key?(aspecnames.to_sym)
+      # for basic HTTP POST, default action is "create" with data being the POST body
+      aname = @req[:action] = json_body["action"] || "create"
 
-        aspec = cspec[aspecnames.to_sym]
-        action_hash = fetch_action_hash(aspec, mname, aname)
-        raise BadRequestError, "Unsupported Action #{aname} for the #{cname} #{type} specified" if action_hash.blank?
-        raise Forbidden, "Use of Action #{aname} is forbidden" unless api_user_role_allows?(action_hash[:identifier])
+      aspecnames = "#{target}_actions"
+      raise BadRequestError, "No actions are supported for #{cname} #{type}" unless cspec.key?(aspecnames.to_sym)
 
-        validate_post_api_action_as_subcollection(cname, mname, aname)
-      end
+      aspec = cspec[aspecnames.to_sym]
+      action_hash = fetch_action_hash(aspec, mname, aname)
+      raise BadRequestError, "Unsupported Action #{aname} for the #{cname} #{type} specified" if action_hash.blank?
+      raise Forbidden, "Use of Action #{aname} is forbidden" unless api_user_role_allows?(action_hash[:identifier])
+
+      validate_post_api_action_as_subcollection(cname, mname, aname)
     end
 
     def validate_api_request_collection

--- a/vmdb/app/controllers/api_controller/provision_requests.rb
+++ b/vmdb/app/controllers/api_controller/provision_requests.rb
@@ -1,0 +1,24 @@
+class ApiController
+  module ProvisionRequests
+    def create_resource_provision_requests(type, _id, data)
+      if data.key?("id") || data.key?("href")
+        raise BadRequestError,
+              "Resource id or href should not be specified for creating a new #{type}"
+      end
+
+      version_str       = data["version"] || "1.1"
+      template_fields   = hash_fetch(data, "template_fields")
+      vm_fields         = hash_fetch(data, "vm_fields")
+      requester         = hash_fetch(data, "requester")
+      tags              = hash_fetch(data, "tags")
+      additional_values = hash_fetch(data, "additional_values")
+      ems_custom_attrs  = hash_fetch(data, "ems_custom_attributes")
+      miq_custom_attrs  = hash_fetch(data, "miq_custom_attributes")
+
+      user_name = requester["user_name"] || @auth_user
+
+      MiqProvisionWorkflow.from_ws(version_str, user_name, template_fields, vm_fields, requester, tags,
+                                   additional_values, ems_custom_attrs, miq_custom_attrs)
+    end
+  end
+end

--- a/vmdb/app/controllers/api_controller/request_tasks.rb
+++ b/vmdb/app/controllers/api_controller/request_tasks.rb
@@ -1,0 +1,13 @@
+class ApiController
+  module RequestTasks
+    #
+    # Tasks/Request Tasks Subcollection Supporting Methods
+    #
+    def request_tasks_query_resource(object)
+      klass = collection_config[:request_tasks][:klass].constantize
+      object ? klass.where(:miq_request_id => object.id) : {}
+    end
+
+    alias_method :tasks_query_resource, :request_tasks_query_resource
+  end
+end

--- a/vmdb/app/helpers/api_helper.rb
+++ b/vmdb/app/helpers/api_helper.rb
@@ -29,6 +29,10 @@ module ApiHelper
     end
   end
 
+  def hash_fetch(hash, element, default = {})
+    hash[element] || default
+  end
+
   def sqlfilter_param
     params['sqlfilter']
   end

--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -310,6 +310,7 @@ class MiqRequestWorkflow
   end
 
   def self.parse_ws_string(text_input, options={})
+    return parse_request_parameter_hash(text_input, options) if text_input.kind_of?(Hash)
     return {} unless text_input.kind_of?(String)
     result = {}
     text_input.split('|').each do |value|
@@ -320,6 +321,15 @@ class MiqRequestWorkflow
       result[key] = value[idx+1..-1].strip
     end
     return result
+  end
+
+  def self.parse_request_parameter_hash(parameter_hash, options = {})
+    parameter_hash.each_with_object({}) do |param, hash|
+      key, value = param
+      next if value.blank?
+      key = key.strip.downcase.to_sym unless options[:modify_key_name] == false
+      hash[key] = value
+    end
   end
 
   def set_ws_tags(values, tag_string, parser=:parse_ws_string)

--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -20,6 +20,9 @@
   :sets:
     :g: &70174834086080
     - :get
+    :gp: &70174834085860
+    - :get
+    - :post
     :gpd: &70174834085620
     - :get
     - :post
@@ -246,10 +249,24 @@
         :identifier: ems_infra_tag
       - :name: unassign
         :identifier: ems_infra_tag
+  :provision_requests:
+    :description: Provision Requests
+    :options:
+    - :collection
+    :methods: *70174834085860
+    :klass: MiqProvisionRequest
+    :subcollections:
+    - :request_tasks
+    - :tasks
+    :collection_actions:
+      :post:
+      - :name: create
+        :identifier: vm_miq_request_new
   :request_tasks:
     :description: Request Tasks
     :options:
     - :collection
+    - :subcollection
     :methods: *70174834086080
     :klass: MiqRequestTask
   :requests:
@@ -436,6 +453,12 @@
       :post:
       - :name: assign
       - :name: unassign
+  :tasks:
+    :description: Request Tasks
+    :options:
+    - :subcollection
+    :methods: *70174834086080
+    :klass: MiqRequestTask
   :templates:
     :description: Templates
     :options:


### PR DESCRIPTION
- new /api/provision_requests
- support POST (create requests) and GET (query requests)
- support /api/provision_request/#/request_tasks subcollection.
- support /api/provision_request/#/tasks subcollection.
- support /api/request_tasks collection
