### PR TITLE
Fixed enablement of Save/Reset button on RHN Updates tab.

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/rhn.rb
+++ b/vmdb/app/controllers/ops_controller/settings/rhn.rb
@@ -226,7 +226,6 @@ module OpsController::Settings::RHN
   end
 
   def repo_default_name
-    reset_repo_name_from_default
     settings_form_field_changed
   end
 
@@ -327,14 +326,15 @@ module OpsController::Settings::RHN
       :proxy_password    => proxy_password,
       :proxy_verify      => '',
     }
-
+    @edit[:key] = "#{@sb[:active_tab]}__rhn_edit"
+    @edit[:current] = copy_hash(@edit[:new])
+    reset_repo_name_from_default
     replace_right_cell('rhn')
   end
 
   private
 
   def reset_repo_name_from_default
-    register_to_from_edit = session.fetch_path(:edit, :new, :register_to)
-    session.store_path(:edit, :new, :repo_name, MiqDatabase.registration_default_value_for_update_repo_name(register_to_from_edit))
+    MiqDatabase.registration_default_value_for_update_repo_name(@edit[:new][:register_to])
   end
 end

--- a/vmdb/app/views/ops/_settings_rhn_edit_tab.haml
+++ b/vmdb/app/views/ops/_settings_rhn_edit_tab.haml
@@ -30,7 +30,7 @@
               =button_tag('Default',
                         :id      => 'rhn_default_button',
                         :class   => 'upload',
-                        :onclick => "miqAjaxButton('#{url_for( :action => 'rhn_default_server')}');")
+                        :onclick => "miqAjaxButton('#{url_for( :action => 'rhn_default_server', :id => 'rhn_edit')}');")
 
         %tr
           %td.key Repository Name:
@@ -40,7 +40,7 @@
             =button_tag('Default',
                       :id      => 'repo_default_name',
                       :class   => 'upload',
-                      :onclick => "miqAjaxButton('#{url_for( :action => 'repo_default_name')}');")
+                      :onclick => "miqAjaxButton('#{url_for(:action => 'repo_default_name', :id => 'rhn_edit')}');")
 
         %tr
           %td.key HTTP Proxy:
@@ -60,7 +60,7 @@
 
           = render :partial => '/layouts/auth_credentials2',
                    :locals  => { :prefix     => 'proxy', :record_id => 'new',
-                                 :change_url => 'settings_form_field_changed',
+                                 :change_url => url,
                                  :validate   => false }
 
     %br
@@ -69,7 +69,7 @@
       %table.style1
         = render :partial => '/layouts/auth_credentials2',
                  :locals  => { :prefix       => 'customer', :record_id => 'new',
-                               :change_url   => 'settings_form_field_changed',
+                               :change_url   => url,
                                :validate_url => 'rhn_validate',
                                :validate     => rhn_validate_enabled,
                                :labels       => { :user => 'Login' } }


### PR DESCRIPTION
- Changed haml view to pass in id on default buttons and some of the fields that were missing that, id is used to load @edit from session using load_edit method.
- Changed edit_rhn method to save initial data in @edit[:current] so it can be used to determine whether to enable/disable save/reset buttons on screen.
- Removed code from "reset_repo_name_from_default" method that was setting values directly into session[:edit] hash, changed it to return the default repo name and let "settings_get_form_vars" save the data in @edit[:new] hash.

Issue #254

@dclarizio please review/test.
