### PR TITLE
Corrected basic authentication logic in vmdbws controller

### DIFF
--- a/vmdb/app/apis/vmdbws_support.rb
+++ b/vmdb/app/apis/vmdbws_support.rb
@@ -1,6 +1,8 @@
 require 'actionwebservice'
 
 module VmdbwsSupport
+  SYSTEM_USER = "system"
+
   class MiqActionWebServiceStruct < ActionWebService::Struct
     def to_h
       ret = {}

--- a/vmdb/spec/controllers/vmdbws_controller_spec.rb
+++ b/vmdb/spec/controllers/vmdbws_controller_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe VmdbwsController do
+  # NOTE: VmdbwsInvetorySpec relies upon @username and authenticate returning true
+  #       change those tests too
+
+  it "handles security turned off" do
+    controller.should_receive(:get_vmdb_config).and_return(mock(:fetch_path => "none"))
+    controller.should_not_receive(:authenticate_or_request_with_http_basic)
+    expect(controller.send(:authenticate)).to eq(true)
+    expect(assigns(:username)).to eq(VmdbwsSupport::SYSTEM_USER)
+  end
+
+  it "handles ssl certs" do
+    controller.should_receive(:get_vmdb_config).and_return(mock(:fetch_path => "basic"))
+    request.env["SERVER_PORT"] = "8443"
+    controller.should_not_receive(:authenticate_or_request_with_http_basic)
+
+    expect(controller.send(:authenticate)).to eq(true)
+    expect(assigns(:username)).to eq(VmdbwsSupport::SYSTEM_USER)
+  end
+
+  it "handles username password" do
+    user = FactoryGirl.create(:user, :password => "dummy")
+    http_login user.userid, user.password
+
+    controller.should_receive(:get_vmdb_config).and_return(mock(:fetch_path => "basic"))
+
+    expect(controller.send(:authenticate)).to eq(true)
+    expect(assigns(:username)).to eq(user.userid)
+  end
+end

--- a/vmdb/spec/models/user_spec.rb
+++ b/vmdb/spec/models/user_spec.rb
@@ -468,6 +468,23 @@ describe User do
     end
   end
 
+  context ".authenticate_with_http_basic" do
+    let(:user) { FactoryGirl.create(:user, :password => "dummy") }
+
+    it "should login with good username/password" do
+      User.authenticate_with_http_basic(user.userid, user.password).should eq([true, user.userid])
+    end
+
+    it "should fail with bad username" do
+      bad_userid = "bad_userid"
+      User.authenticate_with_http_basic(bad_userid, user.password).should eq([false, bad_userid])
+    end
+
+    it "should fail with bad password" do
+      User.authenticate_with_http_basic(user.userid, "bad_pwd").should eq([false, user.userid])
+    end
+  end
+
   context ".seed" do
     before { MiqRegion.seed }
 

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -62,6 +62,8 @@ RSpec.configure do |config|
   config.include ControllerSpecHelper, :type => :controller
   config.include ViewSpecHelper, :type => :view
   config.include UiConstants, :type => :controller
+  config.include AuthHelper,  :type => :controller
+  config.include AuthRequestHelper, :type => :request
   config.include UiConstants, :type => :view
 
   config.include AutomationSpecHelper, :type => :automation

--- a/vmdb/spec/support/auth_helper.rb
+++ b/vmdb/spec/support/auth_helper.rb
@@ -1,0 +1,17 @@
+module AuthHelper
+  def http_login(username = 'username', password = 'password')
+    request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+  end
+end
+
+module AuthRequestHelper
+  #
+  # pass the @env along with your request, eg:
+  #
+  # GET '/labels', {}, @env
+  #
+  def http_login(username = 'username', password = 'password')
+    @env ||= {}
+    @env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+  end
+end


### PR DESCRIPTION
Ensure username instance variable gets set in controller.
Fixed authenticate_or_request_with_http_basic block so it returns true/false
Updated authenticate logic in User.authenticate_with_http_basic to return false
for a bad password so the controller returns 401 Unauthorized error instead of raise error.
Added test to user spec for authenticate_with_http_basic.
Added http_login helper methods.

https://bugzilla.redhat.com/show_bug.cgi?id=1118831
