### PR TITLE
Fixed the routing issue when trying to clone a VM from a non-explorer layout

### DIFF
--- a/vmdb/app/controllers/application_controller/miq_request_methods.rb
+++ b/vmdb/app/controllers/application_controller/miq_request_methods.rb
@@ -118,7 +118,7 @@ module ApplicationController::MiqRequestMethods
         else
           render :update do |page|
             page.redirect_to :controller     => @redirect_controller,
-                             :action         => @refresh_partial,
+                             :action         => "prov_edit",
                              :src_vm_id      => @src_vm_id,
                              :org_controller => "vm",
                              :vdi_users      => @vdi_users


### PR DESCRIPTION
Routing error seen - "Error caught: [ActionController::RoutingError] No route matches {:controller=>"miq_request", :action=>"miq_request/prov_edit", :src_vm_id=>10000000000100, :org_controller=>"vm", :vdi_users=>nil}"

The action specified for page rendering was changed from "miq_request/prov_edit" to simply "prov_edit" since it was throwing off the ActionController and causing a routing error
