### PR TITLE
Changed default scan_via_host value to false.

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -871,7 +871,7 @@ class VmOrTemplate < ActiveRecord::Base
     return self.class.proxy_host_for_repository_scans
   end
 
-  DEFAULT_SCAN_VIA_HOST = true
+  DEFAULT_SCAN_VIA_HOST = false
   cache_with_timeout(:scan_via_host?, 30.seconds) do
     via_host = VMDB::Config.new("vmdb").config.fetch_path(:coresident_miqproxy, :scan_via_host)
     via_host = DEFAULT_SCAN_VIA_HOST unless (via_host.class == TrueClass) || (via_host.class == FalseClass)

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -38,7 +38,7 @@ authentication:
 coresident_miqproxy:
   concurrent_per_ems: 1
   concurrent_per_host: 1
-  scan_via_host: true
+  scan_via_host: false
   use_vim_broker: true
 database:
   metrics_collection:


### PR DESCRIPTION
This value was originally set to true to ensure vddk scanning did not send all disk data through the VC.  This is not a realistic concern as VC returns a handle the the host for communication.

Switching the default value also removes the need to add host credentials solely for the purpose of VM scanning on VMware.
