### PR TITLE
Fixed eligible_resources to pass updated options when creating workflow

### DIFF
--- a/vmdb/app/models/mixins/miq_provision_mixin.rb
+++ b/vmdb/app/models/mixins/miq_provision_mixin.rb
@@ -45,15 +45,15 @@ module MiqProvisionMixin
     end
   end
 
-  def workflow(flags = {})
-    MiqProvisionWorkflow.class_for_source(source).new(options, userid, flags)
+  def workflow(prov_options = options, flags = {})
+    MiqProvisionWorkflow.class_for_source(source).new(prov_options, userid, flags)
   end
 
   def eligible_resources(rsc_type)
     log_header = "MIQ(#{self.class.name}.eligible_resources)"
-    options = self.options.dup
-    options[:placement_auto] = [false, 0]
-    prov_wf = workflow(:skip_dialog_load => true)
+    prov_options = options.dup
+    prov_options[:placement_auto] = [false, 0]
+    prov_wf = workflow(prov_options, :skip_dialog_load => true)
 
     klass = case rsc_type
       when :clusters                then EmsCluster

--- a/vmdb/spec/models/miq_provision_spec.rb
+++ b/vmdb/spec/models/miq_provision_spec.rb
@@ -124,4 +124,21 @@ describe MiqProvision do
       end
     end
   end
+
+  context "#eligible_resources" do
+    it "workflow should be called with placement_auto = false and skip_dialog_load = true" do
+      prov     = FactoryGirl.build(:miq_provision)
+      host     = active_record_instance_double('Host', :id => 1, :name => 'my_host')
+      workflow = instance_double("MiqProvisionWorkflow", :allowed_hosts => [host])
+
+      prov.should_receive(:eligible_resource_lookup).and_return(host)
+
+      prov.should_receive(:workflow).with do |options, flags|
+        options[:placement_auto].should eq([false, 0])
+        flags[:skip_dialog_load].should be_true
+      end.and_return(workflow)
+
+      prov.eligible_resources(:hosts)
+    end
+  end
 end


### PR DESCRIPTION
When placement_auto is true the workflow will not perform resource lookups
as a performance improvement for the UI.  When specifically requesting the
resources through the same methods the option needs to be forced to false.

https://bugzilla.redhat.com/show_bug.cgi?id=1123380
