### PR TITLE
Added support to prompt for support case for RH Dropbox log collection

### DIFF
--- a/vmdb/app/assets/javascripts/miq_dhtmlxtoolbar.js
+++ b/vmdb/app/assets/javascripts/miq_dhtmlxtoolbar.js
@@ -159,6 +159,17 @@ function miqToolbarOnClick(id){
 		else
 			tb_url += button.pressed;
 	}
+
+  collect_log_buttons = ['support_vmdb_choice__collect_logs',
+                         'support_vmdb_choice__collect_current_logs',
+                         'support_vmdb_choice__zone_collect_logs',
+                         'support_vmdb_choice__zone_collect_current_logs'
+  ]
+  if (collect_log_buttons.indexOf(button.name) >= 0 && button.prompt) {
+    tb_url = miqSupportCasePrompt(tb_url);
+    if (!tb_url) return false;
+  }
+
 	// put url_parms into params var, if defined
 	var params;
 	if (typeof button.url_parms != "undefined") {
@@ -207,6 +218,20 @@ function miqToolbarOnClick(id){
 	}	}
 	return false;
 }
+
+function miqSupportCasePrompt(tb_url) {
+  var support_case = prompt('Enter Support Case:', '');
+  if (support_case == null) return false;
+  else if (support_case.trim() == '') {
+    alert('Support Case must be provided to collect logs');
+    return false;
+  }
+  else {
+    tb_url = tb_url + '&support_case=' + encodeURIComponent(support_case);
+    return tb_url;
+  }
+}
+
 
 // Handle chart context menu clicks
 function miqWidgetToolbarClick(itemId, itemValue) {

--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -689,6 +689,7 @@ module OpsController::Diagnostics
 
   # Collect the current logs from the selected zone or server
   def logs_collect(options={})
+    options[:support_case] = params[:support_case] if params[:support_case]
     obj, id  = x_node.split("-")
     assert_privileges("#{obj == "z" ? "zone_" : ""}collect_logs")
     klass    = obj == "svr" ? MiqServer : Zone

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1499,6 +1499,16 @@ module ApplicationHelper
         end
       end
     end
+
+    collect_log_buttons = %w(support_vmdb_choice__collect_logs
+                             support_vmdb_choice__collect_current_logs
+                             support_vmdb_choice__zone_collect_logs
+                             support_vmdb_choice__zone_collect_current_logs
+    )
+
+    if tb_buttons[button][:name].in?(collect_log_buttons) && @record.try(:log_depot).try(:requires_support_case?)
+      tb_buttons[button][:prompt] = true
+    end
     eval("parms = \"#{item[:url_parms]}\"") if item[:url_parms]
     tb_buttons[button][:url_parms] = parms if item[:url_parms]
     # doing eval for ui_lookup in confirm message

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -16,6 +16,10 @@ class FileDepot < ActiveRecord::Base
     true
   end
 
+  def requires_support_case?
+    false
+  end
+
   def depot_hash=(hsh = {})
     return if hsh == self.depot_hash
     self.update_authentication( {:default => {:userid => hsh[:username], :password => hsh[:password]} } )

--- a/vmdb/app/models/miq_server/log_management.rb
+++ b/vmdb/app/models/miq_server/log_management.rb
@@ -125,6 +125,8 @@ module MiqServer::LogManagement
 
     # the current queue item and task must be errored out on exceptions so re-raise any caught errors
     raise "Log depot settings not configured" unless self.log_depot_configured?
+    log_depot.update_attributes(:support_case => options[:support_case].presence)
+
     self.post_historical_logs(taskid) unless options[:only_current]
     self.post_current_logs(taskid)
     task.update_status("Finished", "Ok", "Log files were successfully collected")
@@ -225,6 +227,10 @@ module MiqServer::LogManagement
   def log_collection_active?
     return true if self.log_files.exists?(:state => "collecting")
     return MiqTask.exists?(["miq_server_id = ? and name like ? and state != ?", self.id, "Zipped log retrieval for %", "Finished"])
+  end
+
+  def log_depot
+    log_file_depot || zone.log_file_depot
   end
 
   def log_depot_uri

--- a/vmdb/app/models/zone.rb
+++ b/vmdb/app/models/zone.rb
@@ -6,7 +6,8 @@ class Zone < ActiveRecord::Base
 
   serialize :settings, Hash
 
-  belongs_to :log_file_depot, :class_name => "FileDepot"
+  belongs_to      :log_file_depot, :class_name => "FileDepot"
+  alias_attribute :log_depot, :log_file_depot
 
   has_many :miq_servers
   has_many :active_miq_servers, :class_name => "MiqServer", :conditions => {:status => MiqServer::STATUSES_ACTIVE}

--- a/vmdb/spec/models/log_file_spec.rb
+++ b/vmdb/spec/models/log_file_spec.rb
@@ -5,6 +5,8 @@ describe LogFile do
   context "With server and zone" do
     before do
       _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server.create_log_file_depot!(:type => "FileDepotFtpAnonymous", :uri => "test")
+      @miq_server.save
     end
 
     it "logs_from_server will queue _request_logs with correct args" do
@@ -99,7 +101,6 @@ describe LogFile do
           it "#post_logs will only post current logs if flag enabled" do
             message.deliver
             message.args.first[:only_current] = true
-            MiqServer.any_instance.stub(:log_depot_configured?).and_return(true)
             MiqServer.any_instance.should_receive(:post_historical_logs).never
             MiqServer.any_instance.should_receive(:post_current_logs).once
             message.delivered(*message.deliver)
@@ -107,7 +108,6 @@ describe LogFile do
 
           it "#post_logs will post both historical and current logs if flag nil" do
             message.deliver
-            MiqServer.any_instance.stub(:log_depot_configured?).and_return(true)
             MiqServer.any_instance.should_receive(:post_historical_logs).once
             MiqServer.any_instance.should_receive(:post_current_logs).once
             message.delivered(*message.deliver)
@@ -116,7 +116,6 @@ describe LogFile do
           it "#post_logs will post both historical and current logs if flag false" do
             message.deliver
             message.args.first[:only_current] = false
-            MiqServer.any_instance.stub(:log_depot_configured?).and_return(true)
             MiqServer.any_instance.should_receive(:post_historical_logs).once
             MiqServer.any_instance.should_receive(:post_current_logs).once
             message.delivered(*message.deliver)


### PR DESCRIPTION
- Changes to prompt with JS pop up box for support case when file_log_depot type is "FileDepotFtpAnonymousRedhatDropbox".
- Changed logs_collect method to pass support_case in options that is being store in args column of miq_queue table.

https://bugzilla.redhat.com/show_bug.cgi?id=965889

@brandondunne @dclarizio please review/test.
