### PR TITLE
Update VCR to see errors disguised by "UnusedHTTPInteractionError"

### DIFF
--- a/vmdb/Gemfile.appliance_excludes.rb
+++ b/vmdb/Gemfile.appliance_excludes.rb
@@ -10,7 +10,7 @@ end
 group :test do
   gem "brakeman",         "~>2.0",    :require => false
 
-  gem "vcr",              "~>2.4.0",  :require => false
+  gem "vcr",              "~>2.6",    :require => false
   gem "webmock",          "~>1.11.0", :require => false # Although VCR complains, we're forced to use 1.11.0 since we're locked
                                                         #   on excon 0.20.0.  webmock 1.11.0 is the only version that works
                                                         #   properly against excon 0.20.0.

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -90,7 +90,7 @@ VCR.configure do |c|
 
   c.allow_http_connections_when_no_cassette = false
   c.default_cassette_options = {
-    :allow_unused_http_interactions => !ENV['CI']
+    :allow_unused_http_interactions => false
   }
 
   #c.debug_logger = File.open(Rails.root.join("log", "vcr_debug.log"), "w")


### PR DESCRIPTION
VCR fixed by: https://github.com/vcr/vcr/pull/336
discussion: http://talk.manageiq.org/t/travis-vcr-cassettes-and-unused-http-interactions/97/2
