### PR TITLE
Fix hover text for datastores in VM's overview

### DIFF
--- a/vmdb/app/helpers/vm_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_helper/textual_summary.rb
@@ -329,13 +329,13 @@ module VmHelper::TextualSummary
     elsif storages.length == 1
       storage = storages.first
       h[:value] = storage.name
-      h[:title] = "Show this #{label}"
+      h[:title] = "Show this VM's #{label}"
       h[:link]  = url_for(:controller => 'storage', :action => 'show', :id => storage)
     else
       h.delete(:image) # Image will be part of each line item, instead
       main = @record.storage
       h[:value] = storages.sort_by { |s| s.name.downcase }.collect do |s|
-        {:image => "storage", :value => "#{s.name}#{" (main)" if s == main}", :title => "Show this #{label}", :link => url_for(:controller => 'storage', :action => 'show', :id => s)}
+        {:image => "storage", :value => "#{s.name}#{" (main)" if s == main}", :title => "Show this VM's #{label}", :link => url_for(:controller => 'storage', :action => 'show', :id => s)}
       end
     end
     h


### PR DESCRIPTION
Add missing "VM's".

https://bugzilla.redhat.com/show_bug.cgi?id=1114706
