### PR TITLE
Check if VM status is not "Host Not Responding" before getting IPs

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -11,8 +11,10 @@ function get_vm_temps {
   $id = $_.ID
   
   $vm_hash["Properties"] = $_
-  $networks = Read-SCGuestInfo -VM $_ -Key "NetworkAddressIPv4"
-  $vm_hash["Networks"] = $networks.KvpMap["NetworkAddressIPv4"]
+  if ($_.StatusString -ne "Host Not Responding"){
+   $networks = Read-SCGuestInfo -VM $_ -Key "NetworkAddressIPv4"
+   $vm_hash["Networks"] = $networks.KvpMap["NetworkAddressIPv4"]
+  }
   $dvds = Get-SCVirtualDVDDrive -VM $_ | Select-Object -ExpandProperty "ISO"
   $vm_hash["DVDs"] = $dvds
   $results[$id]= $vm_hash


### PR DESCRIPTION
Running the Read-SCGuestInfo cmdlet to gather VM IP addresses causes a WinRM Error 500 to be generated when the VM Status is "Host Not Responding". This status occurs when a VM and Host are not communicating over WinRM / HTTPS preventing the VM heartbeat from being exchanged.
To Do: Add event support for a change in VM status so we can kick off an EMS refresh.
