### PR TITLE
Changed credentials validation check command

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -56,7 +56,7 @@ class EmsMicrosoft < EmsInfra
     raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(options[:auth_type])
 
     begin
-      run_dos_command("uname -a")
+      run_dos_command("hostname")
     rescue WinRM::WinRMHTTPTransportError # Error 401
       raise MiqException::MiqHostError, "Login failed due to a bad username or password."
     end


### PR DESCRIPTION
Since SCVMM power operations support was implemented we are using Powershell to execute commands on the SCVMM box. The arbitrary command 'uname -a' was used to check if credentials are valid, however this command is not supported in a powershell session causing an error to be returned in the log files.
This PR updates that command to 'hostname' which is supported in Powershell.
