### PR TITLE
Retrieve same named method, instances and classes across domains

### DIFF
--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -94,6 +94,10 @@ class MiqAeClass < ActiveRecord::Base
     @class_methods ||= scoped_methods("class")
   end
 
+  def self.get_homonymic_across_domains(fqname, enabled = nil)
+    MiqAeDatastore.get_homonymic_across_domains(::MiqAeClass, fqname, enabled)
+  end
+
   def self.find_homonymic_instances_across_domains(fqname)
     return [] if fqname.blank?
     path = MiqAeEngine::MiqAeUri.path(fqname, "miqaedb")

--- a/vmdb/app/models/miq_ae_instance.rb
+++ b/vmdb/app/models/miq_ae_instance.rb
@@ -121,6 +121,10 @@ class MiqAeInstance < ActiveRecord::Base
     MiqAeInstanceCopy.copy_multiple(ids, domain, namespace, overwrite_location)
   end
 
+  def self.get_homonymic_across_domains(fqname, enabled = nil)
+    MiqAeDatastore.get_homonymic_across_domains(::MiqAeInstance, fqname, enabled)
+  end
+
   private
 
   def validate_field(field)

--- a/vmdb/app/models/miq_ae_method.rb
+++ b/vmdb/app/models/miq_ae_method.rb
@@ -91,4 +91,8 @@ class MiqAeMethod < ActiveRecord::Base
   def self.copy(ids, domain, namespace, overwrite_location)
     MiqAeMethodCopy.copy_multiple(ids, domain, namespace, overwrite_location)
   end
+
+  def self.get_homonymic_across_domains(fqname, enabled = nil)
+    MiqAeDatastore.get_homonymic_across_domains(::MiqAeMethod, fqname, enabled)
+  end
 end

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_path.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_path.rb
@@ -52,5 +52,14 @@ module MiqAeEngine
       return false if path.nil?
       return path.last == "*"
     end
+
+    def self.get_domain_ns_klass_inst(fqname, options = {})
+      path = MiqAeUri.path(fqname, "miqaedb")
+      ns, klass, inst = split(path, options)
+      ns_parts = ns.split('/')
+      domain   = ns_parts.shift
+      ns_sans_domain = ns_parts.join('/')
+      return domain, ns_sans_domain, klass, inst
+    end
   end
 end

--- a/vmdb/spec/models/miq_ae_domain_spec.rb
+++ b/vmdb/spec/models/miq_ae_domain_spec.rb
@@ -47,13 +47,13 @@ describe MiqAeDomain do
   end
 
   context "any_unlocked?" do
-    it "should return unlocked_domains? as true if the there are any unloacked doamins available" do
+    it "should return unlocked_domains? as true if the there are any unlocked domains available" do
       FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => false)
       MiqAeDomain.any_unlocked?.should be_true
     end
 
-    it "should return unlocked_domains? as false if the there are no unloacked doamins available" do
+    it "should return unlocked_domains? as false if the there are no unlocked domains available" do
       FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => true)
       MiqAeDomain.any_unlocked?.should be_false
@@ -75,4 +75,110 @@ describe MiqAeDomain do
       MiqAeDomain.all_unlocked.count.should eq(0)
     end
   end
+
+  context "same class names across domains" do
+    before(:each) do
+      create_model(:name => 'DOM1', :priority => 10)
+    end
+
+    it "missing class should get empty array" do
+      result = MiqAeClass.get_homonymic_across_domains('DOM1/CLASS1')
+      result.should be_empty
+    end
+
+    it "get same named classes" do
+      create_multiple_domains
+      expected = %w(DOM2/A/b/C/cLaSS1 DOM1/A/B/C/CLASS1 DOM3/a/B/c/CLASs1)
+      result = MiqAeClass.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1', true)
+      expected.should match_array(result.each.collect(&:fqname))
+    end
+  end
+
+  context "same instance names across domains" do
+    before(:each) do
+      create_model(:name => 'DOM1', :priority => 10)
+    end
+
+    it "missing instance should get empty array" do
+      result = MiqAeInstance.get_homonymic_across_domains('DOM1/CLASS1/nothing')
+      result.should be_empty
+    end
+
+    it "get same named instances" do
+      create_multiple_domains
+      expected = %w(
+        DOM5/A/B/C/CLASS1/instance1
+        DOM2/A/b/C/cLaSS1/instance1
+        DOM1/A/B/C/CLASS1/instance1
+        DOM3/a/B/c/CLASs1/instance1
+      )
+      result = MiqAeInstance.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/instance1')
+      expected.should match_array(result.each.collect(&:fqname))
+    end
+  end
+
+  context "same method names across domains" do
+    before(:each) do
+      create_model_with_methods(:name => 'DOM1', :priority => 10)
+    end
+
+    it "missing method should get empty array" do
+      result = MiqAeMethod.get_homonymic_across_domains('DOM1/CLASS1/nothing')
+      result.should be_empty
+    end
+
+    it "get same named methods" do
+      create_multiple_domains_with_methods
+      expected = %w(DOM2/A/b/C/cLaSS1/method1 DOM1/A/B/C/CLASS1/method1 DOM3/a/B/c/CLASs1/method1)
+      result = MiqAeMethod.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/method1', true)
+      expected.should match_array(result.each.collect(&:fqname))
+    end
+  end
+
+  def create_model(attrs = {})
+    attrs = default_attributes(attrs)
+    ae_fields = {'field1' => {:aetype => 'relationship', :datatype => 'string'}}
+    ae_instances = {'instance1' => {'field1' => {:value => 'hello world'}}}
+
+    FactoryGirl.create(:miq_ae_domain, :with_small_model, :with_instances,
+                       attrs.merge('ae_fields' => ae_fields, 'ae_instances' => ae_instances))
+  end
+
+  def create_model_with_methods(attrs = {})
+    attrs = default_attributes(attrs)
+    ae_methods = {'method1' => {:scope => 'instance', :location => 'inline',
+                                :data => 'puts "Hello World"',
+                                :language => 'ruby', 'params' => {}}}
+    FactoryGirl.create(:miq_ae_domain, :with_small_model, :with_methods,
+                       attrs.merge('ae_methods' => ae_methods))
+  end
+
+  def create_multiple_domains
+    create_model(:name => 'DOM2', :priority => 20, :ae_class => 'cLaSS1',
+                 :ae_namespace => 'A/b/C')
+    create_model(:name => 'DOM3', :priority => 5, :ae_class => 'CLASs1',
+                 :ae_namespace => 'a/B/c')
+    create_model(:name => 'DOM4', :priority => 2, :ae_class => 'CLASs1',
+                 :ae_namespace => 'a/B')
+    create_model(:name => 'DOM5', :priority => 50, :enabled => false)
+  end
+
+  def create_multiple_domains_with_methods
+    create_model_with_methods(:name => 'DOM2', :priority => 20, :ae_class => 'cLaSS1',
+                              :ae_namespace => 'A/b/C')
+    create_model_with_methods(:name => 'DOM3', :priority => 5, :ae_class => 'CLASs1',
+                              :ae_namespace => 'a/B/c')
+    create_model_with_methods(:name => 'DOM4', :priority => 2, :ae_class => 'CLASs1',
+                              :ae_namespace => 'a/B')
+    create_model_with_methods(:name => 'DOM5', :priority => 50, :enabled => false)
+  end
+
+  def default_attributes(attrs = {})
+    attrs[:ae_class] = 'CLASS1' unless attrs.key?(:ae_class)
+    attrs[:ae_namespace] = 'A/B/C' unless attrs.key?(:ae_namespace)
+    attrs[:priority] = 10 unless attrs.key?(:priority)
+    attrs[:enabled] = true unless attrs.key?(:enabled)
+    attrs
+  end
+
 end


### PR DESCRIPTION
This feature allows the UI to display a list of overridden instances
and methods from different domains. The functions return an array of classes or instances or methods ordered based on the domain priority. The UI should be
able to guide the end user to the highest priority instances and methods
