### PR TITLE
SCVMM scheduled EMS refresh.

### DIFF
--- a/vmdb/app/models/ems_refresh/refreshers/scvmm_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/scvmm_refresher.rb
@@ -7,7 +7,7 @@ module EmsRefresh::Refreshers
   class ScvmmRefresher < BaseRefresher
     def refresh
       log_header = "MIQ(#{self.class.name}.refresh)"
-      $log.info "#{log_header} Refreshing all targets..."
+      $log.info "#{log_header} Refreshing Scvmm..."
 
       @targets_by_ems_id.each do |ems_id, targets|
         # Get the ems object
@@ -35,7 +35,7 @@ module EmsRefresh::Refreshers
         end
       end
 
-      $log.info "#{log_header} Refreshing all targets...Complete"
+      $log.info "#{log_header} Refreshing Scvmm...Complete"
     end
   end
 end

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -185,14 +185,8 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def self.refresh_all_ems_timer
-    ems_ids = []
-
-    MiqServer.my_server.zone.ext_management_systems.each do |ems|
-      ems.reset_vim_cache_queue if ems.respond_to?(:reset_vim_cache_queue)
-      ems_ids << ems.id
-    end
-
-    self.refresh_ems(ems_ids) unless ems_ids.empty?
+    ems_ids = self.where(:zone_id => MiqServer.my_server.zone.id).pluck(:id)
+    self.refresh_ems(ems_ids, true) unless ems_ids.empty?
   end
 
   def self.refresh_ems(ems_ids, reload = false)

--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -70,6 +70,8 @@ ems_refresh:
     get_shared_images: true
     get_public_images: false
     ignore_terminated_instances: true
+  scvmm:
+    :refresh_interval: 15.minutes
   full_refresh_threshold: 100
   raise_vm_snapshot_complete_if_created_within: 15.minutes
   refresh_interval: 24.hours

--- a/vmdb/lib/workers/schedule_worker.rb
+++ b/vmdb/lib/workers/schedule_worker.rb
@@ -209,6 +209,14 @@ class ScheduleWorker < WorkerBase
       end
     end
 
+    eri = VMDB::Config.new("vmdb").config.fetch_path(:ems_refresh, :scvmm, :refresh_interval)
+    eri = eri.respond_to?(:to_i_with_method) ? eri.to_i_with_method : eri.to_i
+    unless eri == 0
+      @schedules[:scheduler] << self.system_schedule_every(eri, :first_in => eri) do |rufus_job|
+        @queue.enq :ems_refresh_all_scvmm_timer
+      end
+    end
+
     # Schedule - Hourly Alert Evaluation Timer
     @schedules[:scheduler] << self.system_schedule_every(1.hour, :first_in => 5.minutes) do |job_id, at, params|
       @queue.enq :miq_alert_evaluate_hourly_timer

--- a/vmdb/lib/workers/schedule_worker/jobs.rb
+++ b/vmdb/lib/workers/schedule_worker/jobs.rb
@@ -73,6 +73,10 @@ class ScheduleWorker < WorkerBase
       queue_work_on_each_zone(:class_name  => "ExtManagementSystem", :method_name => "refresh_all_ems_timer")
     end
 
+    def ems_refresh_all_scvmm_timer
+      queue_work_on_each_zone(:class_name  => "EmsMicrosoft", :method_name => "refresh_all_ems_timer")
+    end
+
     def miq_alert_evaluate_hourly_timer
       queue_work_on_each_zone(:class_name  => "MiqAlert", :method_name => "evaluate_hourly_timer")
     end

--- a/vmdb/spec/models/ext_management_system_spec.rb
+++ b/vmdb/spec/models/ext_management_system_spec.rb
@@ -52,14 +52,14 @@ describe ExtManagementSystem do
     it "refresh_all_ems_timer will refresh for all emses in zone1" do
       @ems1 = @zone1.ext_management_systems.first
       MiqServer.stub(:my_server).and_return(@zone1.miq_servers.first)
-      ExtManagementSystem.should_receive(:refresh_ems).with([@ems1.id])
+      ExtManagementSystem.should_receive(:refresh_ems).with([@ems1.id], true)
       ExtManagementSystem.refresh_all_ems_timer
     end
 
     it "refresh_all_ems_timer will refresh for all emses in zone2" do
       @ems2 = @zone2.ext_management_systems.first
       MiqServer.stub(:my_server).and_return(@zone2.miq_servers.first)
-      ExtManagementSystem.should_receive(:refresh_ems).with([@ems2.id])
+      ExtManagementSystem.should_receive(:refresh_ems).with([@ems2.id], true)
       ExtManagementSystem.refresh_all_ems_timer
     end
   end


### PR DESCRIPTION
A mechanism was needed to refresh the SCVMM provider given that event support will not be in the 3.1 release. I have configured a 4 minute schedule but am open to negotiation on the frequency. On one hand we need to bear in mind that an EMS refresh can take more than 4 minutes but on the other hand we can't wait too long after a VM power operation.
