### PR TITLE
REST API Support for Service Requests as subcollections

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -38,6 +38,7 @@ class ApiController < ApplicationController
   include_concern 'ProvisionRequests'
   include_concern 'AutomationRequests'
   include_concern 'RequestTasks'
+  include_concern 'ServiceRequests'
 
   #
   # Api Controller Hooks

--- a/vmdb/app/controllers/api_controller/service_requests.rb
+++ b/vmdb/app/controllers/api_controller/service_requests.rb
@@ -1,0 +1,11 @@
+class ApiController
+  module ServiceRequests
+    #
+    # Service Requests Subcollection Supporting Methods
+    #
+    def service_requests_query_resource(object)
+      klass = collection_config[:service_requests][:klass].constantize
+      object ? klass.where(:source_id => object.id) : {}
+    end
+  end
+end

--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -363,8 +363,12 @@
     :description: Service Requests
     :options:
     - :collection
+    - :subcollection
     :methods: *70174834086080
     :klass: ServiceTemplateProvisionRequest
+    :subcollections:
+    - :request_tasks
+    - :tasks
   :service_templates:
     :description: Service Templates
     :options:
@@ -376,6 +380,7 @@
     :klass: ServiceTemplate
     :subcollections:
     - :tags
+    - :service_requests
     :collection_actions:
       :post:
       - :name: edit


### PR DESCRIPTION
- Supporting /api/service_templates/#/service_requests
- Supporting /api/service_templates/#/service_requests/#
- Supporting /api/service_templates/#/service_requests/# --expand=request_tasks
- Supporting /api/service_requests/#/request_tasks (or tasks)
