### PR TITLE
Request details page to be consistent with request list

### DIFF
--- a/vmdb/app/views/miq_request/_request.html.erb
+++ b/vmdb/app/views/miq_request/_request.html.erb
@@ -31,21 +31,31 @@
               <% end %>
             </td>
           </tr>
+          <tr>
+            <td class="key">Request Type</td>
+            <td class="wide" nowrap>
+              <%= h(@miq_request.request_type_display) %>
+            </td>
+          </tr>
         </table>
       </dd>
       <dd>
         <table class="style1">
           <tr>
-            <td class="key">Submitted On</td>
+            <td class="key">Description</td>
+            <td class="wide" nowrap><%= h(@miq_request.description) %></td>
+          </tr>
+          <tr>
+            <td class="key">Last Message</td>
+            <td class="wide"><%= h(@miq_request.message) %></td>
+          </tr>
+          <tr>
+            <td class="key">Created On</td>
             <td class="wide" nowrap><%= h(format_timezone(@miq_request.created_on)) %></td>
           </tr>
           <tr>
             <td class="key">Last Update</td>
             <td class="wide" nowrap><%= h(format_timezone(@miq_request.updated_on)) %></td>
-          </tr>
-          <tr>
-            <td class="key">Last Message</td>
-            <td class="wide"><%= h(@miq_request.message) %></td>
           </tr>
           <tr>
             <td class="key">Completed</td>


### PR DESCRIPTION
Before: 
![cf-before](https://cloud.githubusercontent.com/assets/6648365/3779567/87982808-1983-11e4-9d4f-16857fb7759a.jpg)

After:
![cf-after](https://cloud.githubusercontent.com/assets/6648365/3779572/8ddca590-1983-11e4-9ea6-51ab8f93c507.jpg)

For the request details page to be consistent with page listing all
request, this adds the following items:
- Request ID
- Status
- Approval State

and renames the following items:
- Status -> Request State
- Requested by -> Requester

https://bugzilla.redhat.com/show_bug.cgi?id=1062382
