### PR TITLE
Use active_record_instance_double for MiqServer instance stub

### DIFF
--- a/vmdb/spec/models/widget_importer_spec.rb
+++ b/vmdb/spec/models/widget_importer_spec.rb
@@ -5,7 +5,7 @@ describe WidgetImporter do
   let(:widget_import_validator) { instance_double("WidgetImporter::Validator") }
 
   before do
-    MiqServer.stub(:my_server).and_return(instance_double("MiqServer", :zone_id => 1))
+    MiqServer.stub(:my_server).and_return(active_record_instance_double("MiqServer", :zone_id => 1))
   end
 
   describe "#cancel_import" do


### PR DESCRIPTION
This was causing test failures since the zone_id method didn't appear to exist since I didn't use active_record_instance_double.
