### PR TITLE
Display correct set of buttons while adding a new customization template

### DIFF
--- a/vmdb/app/controllers/pxe_controller.rb
+++ b/vmdb/app/controllers/pxe_controller.rb
@@ -283,7 +283,7 @@ class PxeController < ApplicationController
         when :pxe_image_types_tree
           "pxe_image_type_edit"
         else
-          ["template_create_update", true]
+          "template_create_update"
         end
 
         presenter[:update_partials][:form_buttons_div] = r[


### PR DESCRIPTION
multi_record should not be set to true in order to display the Add/Cancel buttons

https://bugzilla.redhat.com/show_bug.cgi?id=1099808
