### PR TITLE
Reset @display when viewing drift history screen.

### DIFF
--- a/vmdb/app/controllers/application_controller/compare.rb
+++ b/vmdb/app/controllers/application_controller/compare.rb
@@ -797,6 +797,7 @@ module ApplicationController::Compare
     @showtype = "drift_history"
     drop_breadcrumb( {:name=>"Drift History", :url=>"/#{@sb[:compare_db].downcase}/drift_history/#{@drift_obj.id}"} )
     @lastaction = "drift_history"
+    @display = "main"
     @button_group = "common_drift"
     if @explorer || request.xml_http_request? # Is this an Ajax request?
       @sb[:action] = params[:action]

--- a/vmdb/spec/controllers/application_controller/compare_spec.rb
+++ b/vmdb/spec/controllers/application_controller/compare_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe ApplicationController do
+  context "#drift_history" do
+    it "resets @display to main" do
+      vm = FactoryGirl.create(:vm_vmware, :name => "My VM")
+      controller.instance_variable_set(:@display, "vms")
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@drift_obj, vm)
+      controller.stub(:identify_obj)
+      controller.stub(:drift_state_timestamps)
+      controller.stub(:drop_breadcrumb)
+      controller.should_receive(:render)
+      controller.send(:drift_history)
+      assigns(:display).should eq("main")
+    end
+  end
+end


### PR DESCRIPTION
Added change to reset @display when viewing drift history screen to fix an issue where @display was still being set to vms/storages etc after clicking on links to relationships from host summary screen and then clicking on Drift History link from listnav on left side it was trying to render incorrect partial due to @display being set incorrectly. Drift History link from right side of the summary screen was working fine because going to summary screen resets @display back to "main"

https://bugzilla.redhat.com/show_bug.cgi?id=1123144
https://bugzilla.redhat.com/show_bug.cgi?id=1126085

@dclarizio please review/test.
