### PR TITLE
Removed validation for group existence from controller

### DIFF
--- a/vmdb/app/controllers/ops_controller/ops_rbac.rb
+++ b/vmdb/app/controllers/ops_controller/ops_rbac.rb
@@ -1194,10 +1194,6 @@ module OpsController::OpsRbac
       add_flash(I18n.t("flash.ops.settings.user_group_assign_role"), :error)
       valid = false
     end
-    if params[:button] == "add" && MiqGroup.find_by_description(@edit[:new][:description])
-      add_flash(I18n.t("flash.already_taken", :field=>"Description"), :error)
-      valid = false
-    end
     return valid
   end
 end


### PR DESCRIPTION
This validation is already being done by model, removed it from controller this was causing 2 flash messages on the screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1092381

@dclarizio please review/test.
