### PR TITLE
Return VixDiskLib Load Error to DRB Client

### DIFF
--- a/lib/VixDiskLib/VixDiskLibServer.rb
+++ b/lib/VixDiskLib/VixDiskLibServer.rb
@@ -41,6 +41,11 @@ class VDDKFactory
   end
 
   def connect(connect_parms)
+    load_error = FFI::VixDiskLib::API.load_error
+    unless load_error.nil?
+      @shutdown = true
+      raise VixDiskLibError, load_error
+    end
     @running = true
     VixDiskLibServer.connect(connect_parms)
   end

--- a/lib/VixDiskLib/VixDiskLib_FFI/api.rb
+++ b/lib/VixDiskLib/VixDiskLib_FFI/api.rb
@@ -11,6 +11,10 @@ module FFI
         warn "unable to attach #{args.first}"
       end
 
+      def self.load_error
+        @load_error
+      end
+
       #
       # Make sure we load one and only one version of VixDiskLib
       #
@@ -24,7 +28,7 @@ module FFI
           VERSION_MAJOR, VERSION_MINOR = loaded_library.first.name.split(".")[2, 2].collect(&:to_i)
           if bad_versions.keys.include?(version)
             loaded_library = ""
-            raise LoadError, "VixDiskLib #{version} is not supported: #{bad_versions[version]}"
+            @load_error = "VixDiskLib #{version} is not supported: #{bad_versions[version]}"
           end
           break
         rescue LoadError => err
@@ -33,9 +37,9 @@ module FFI
         end
       end
 
-      unless loaded_library.length > 0
+      unless @load_error || loaded_library.length > 0
         STDERR.puts load_errors.join("\n")
-        raise LoadError, "ffi-vixdisklib: failed to load any version of VixDiskLib!"
+        @load_error = "ffi-vixdisklib: failed to load any version of VixDiskLib!"
       end
       LOADED_LIBRARY = loaded_library
 


### PR DESCRIPTION
When VixDiskLibServer fails to successfully load any
version of the VixDiskLib, cache the failure reason.  
Interrogate for the error once the DRB service is started 
so that the failure reason can be passed back to the client 
for presentation in the UI. Then shut down the DRB service.

@roliveri, @jrafanie, @chessbyte please review
