### PR TITLE
Reset target_id when "None" is selected in Type pull-down.

### DIFF
--- a/vmdb/app/controllers/miq_ae_tools_controller.rb
+++ b/vmdb/app/controllers/miq_ae_tools_controller.rb
@@ -259,6 +259,7 @@ class MiqAeToolsController < ApplicationController
         @resolve[:new][:target_id] = nil
       end
     end
+    @resolve[:new][:target_id] = nil if params[:target_class] == ""
     @resolve[:new][:target_id] = params[:target_id] if params.has_key?(:target_id)
     @resolve[:button_text] = params[:button_text] if params.has_key?(:button_text)
     @resolve[:button_number] = params[:button_number] if params.has_key?(:button_number)

--- a/vmdb/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe MiqAeToolsController do
+  before(:each) do
+    set_user_privileges
+  end
+
+  context "#form_field_changed" do
+    it "resets target id to nil, when target class is <none>" do
+      new = {
+        :target_class => "EmsCluster",
+        :target_id    => 1
+      }
+      controller.instance_variable_set(:@resolve, :throw_ready => true, :new => new)
+      controller.should_receive(:render)
+      controller.instance_variable_set(:@_params, :target_class => '', :id => 'new')
+      controller.send(:form_field_changed)
+      assigns(:resolve)[:new][:target_class].should eq('')
+      assigns(:resolve)[:new][:target_id].should eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
- Reset target_id key to nil when target_class selection is set to none.
- Added spec test to verify value of target_id key

https://bugzilla.redhat.com/show_bug.cgi?id=1097876

@dclarizio please review/test.
