### PR TITLE
Fixed typo in admin role features list

### DIFF
--- a/vmdb/db/fixtures/miq_user_roles.yml
+++ b/vmdb/db/fixtures/miq_user_roles.yml
@@ -29,7 +29,7 @@
   - job_all_smartproxy
   - job_my_smartproxy
   - miq_ae_class_explorer
-  - miq_ae_customization
+  - miq_ae_customization_explorer
   - miq_ae_class_import_export
   - miq_ae_class_log
   - miq_ae_class_simulation


### PR DESCRIPTION
Latest upstream RBAC changes introduced a typo into the new hidden features added for the admin role.

https://bugzilla.redhat.com/show_bug.cgi?id=1127325
