### PR TITLE
Better v1_key not found error, plus miq_ae_password_spec

### DIFF
--- a/lib/spec/util/miq-password_spec.rb
+++ b/lib/spec/util/miq-password_spec.rb
@@ -172,6 +172,20 @@ describe MiqPassword do
     end
   end
 
+  context "with missing v1_key" do
+    it "should report decent error when decryption with missing an encryption key" do
+      MiqPassword.v1_key = nil
+      File.should_receive(:exist?).with(/v1_key/).and_return false
+      expect { described_class.decrypt("v1:{KSOqhNiOWJbR0lz7v6PTJg==}") }.to raise_error("no encryption key v1_key")
+    end
+
+    it "should remember keyfile is not found" do
+      MiqPassword.v1_key = nil
+      File.should_receive(:exist?).with(/v1_key/).and_return false
+      expect(MiqPassword.v1_key).to be_false
+    end
+  end
+
   context ".md5crypt" do
     it "with an unencrypted string" do
       expect(MiqPassword.md5crypt("password")).to eq("$1$miq$Ho9GNOzRsxMpJSsgwG/y01")

--- a/lib/util/miq-password.rb
+++ b/lib/util/miq-password.rb
@@ -34,6 +34,7 @@ class MiqPassword
 
       decrypt_method = "decrypt_version_#{ver}"
       raise "unknown encryption version, '#{ver}'" if ver.nil? || !self.respond_to?(decrypt_method, true)
+      raise "no encryption key v#{ver}_key" unless self.class.send("v#{ver}_key")
 
       send(decrypt_method, enc)
     end

--- a/vmdb/spec/models/miq_ae_password_spec.rb
+++ b/vmdb/spec/models/miq_ae_password_spec.rb
@@ -8,39 +8,59 @@ describe MiqAePassword do
     MiqPassword.key_root = Rails.root.join("certs")
   end
 
-  it "should find v2_key" do
-    expect(described_class.v2_key).not_to be_nil
+  describe ".v0_key" do
+    it "does not have v0_key" do
+      expect(described_class.v0_key).to be_false
+    end
   end
 
-  it "should not find v1_key" do
-    expect(described_class.v1_key).to be_false
+  describe ".v1_key" do
+    it "does not have v1_key" do
+      expect(described_class.v1_key).to be_false
+    end
   end
 
-  it "should not find v0_key" do
-    expect(described_class.v1_key).to be_false
+  describe ".v2_key" do
+    it "should find v2_key" do
+      expect(described_class.v2_key).not_to be_nil
+    end
   end
 
-  it "should encrypt like miqpassword" do
+  describe "#v2_key" do
+    subject { described_class.new(plaintext) }
+
+    it "is hidden to_s" do
+      expect(subject.to_s).to eq("********")
+    end
+  end
+
+  it "produces a key decryptable by MiqPassword" do
     expect(MiqPassword.decrypt(described_class.encrypt(plaintext))).to eq(plaintext)
   end
 
-  it "should decrypt miqpassword strings" do
-    expect(described_class.decrypt(MiqPassword.encrypt(plaintext))).to eq(plaintext)
+  describe ".decrypt" do
+    it "reads password encrypted by MiqPassword" do
+      expect(described_class.decrypt(MiqPassword.encrypt(plaintext))).to eq(plaintext)
+    end
+
+    it "throws understandable error" do
+      expect { described_class.decrypt("v1:{something}") }.to raise_error("no encryption key v1_key")
+    end
   end
 
-  context "with v2_key" do
-    subject { described_class.new(plaintext) }
-
-    it "should have hidden to_s" do
-      expect(subject.to_s).to eq("********")
+  describe ".decrypt_if_password" do
+    context "with encrypted password" do
+      subject { described_class.new(plaintext) }
+      it "decrypts" do
+        expect(MiqAePassword.decrypt_if_password(subject)).to eq(plaintext)
+      end
     end
 
-    it "should decrypt MiqAePassword" do
-      expect(MiqAePassword.decrypt_if_password(subject)).to eq(plaintext)
-    end
-
-    it "should decrypt plaintext" do
-      expect(MiqAePassword.decrypt_if_password("string")).to eq("string")
+    context "with plaintext password" do
+      subject { "string" }
+      it "decrypts" do
+        expect(MiqAePassword.decrypt_if_password(subject)).to eq(subject)
+      end
     end
   end
 end


### PR DESCRIPTION
1 line of code change
1. better error message when a legacy key is not present (e.g.: missing `v1_key` throws decrypt64 error)
2. fix running specs via ./bin/rspec (5.2.x and 5.3 throw VCR errors)
3. more specs around passwords
