### PR TITLE
Deleted line that was not being used and causing a crash on C&U screen

### DIFF
--- a/vmdb/app/models/vim_performance_tag.rb
+++ b/vmdb/app/models/vim_performance_tag.rb
@@ -49,8 +49,6 @@ class VimPerformanceTag < MetricRollup
       h
     end
 
-    interval = recs.first.capture_interval_name == "daily" ? 1.day : 1.hour
-
     results[:res].each do |rec|
       # Default nil values in tag cols to 0 for records with timestamp that falls inside the time profile
       results[:tcols].each {|c| rec.send("#{c}=", 0) if rec.send(c).nil?} if rec.inside_time_profile == true


### PR DESCRIPTION
Deleted code that was setting 'interval' local variable that was not even being used in the method and was causing a crash when changing a value in "Group By" pull down on Host C&U screen when there is no C&U data available for the chosen group, it is mostly happening on the fresh appliance.

https://bugzilla.redhat.com/show_bug.cgi?id=1123195
https://bugzilla.redhat.com/show_bug.cgi?id=1127765

@dclarizio please review/test.
