### PR TITLE
Show message on login screen when user's group/role has been deleted.

### DIFF
--- a/vmdb/app/views/ops/_rbac_group_details.html.erb
+++ b/vmdb/app/views/ops/_rbac_group_details.html.erb
@@ -39,22 +39,24 @@
                 <td class="key">Role</td>
                 <td style="<%=@edit ? 'padding: 0px' : ''%>">
                   <% unless @edit %>
-                    <table cellpadding="0" cellspacing="0">
-                      <tr
-                        onclick="cfmeDynatree_activateNode('rbac_tree', 'ur-<%= to_cid(@group.miq_user_role.id) %>');"
-                        onmouseover="this.style.cursor='pointer'" title="View this Role">
-                        <td class="image">
-                          <ul class="icons">
-                            <li>
-                              <span class="product product-role"></span>
-                            </li>
-                          </ul>
-                        </td>
-                        <td>
-                          <%= h(@group.miq_user_role.name) %>
-                        </td>
-                      </tr>
-                    </table>
+                    <% if @group.miq_user_role %>
+                      <table cellpadding="0" cellspacing="0">
+                        <tr
+                          onclick="cfmeDynatree_activateNode('rbac_tree', 'ur-<%= to_cid(@group.miq_user_role.id) %>');"
+                          onmouseover="this.style.cursor='pointer'" title="View this Role">
+                          <td class="image">
+                            <ul class="icons">
+                              <li>
+                                <span class="product product-role"></span>
+                              </li>
+                            </ul>
+                          </td>
+                          <td>
+                            <%= h(@group.miq_user_role.name) %>
+                          </td>
+                        </tr>
+                      </table>
+                    <% end %>
                   <% else %>
                     <%= select_tag('group_role',
                                    options_for_select(@edit[:roles].sort, @edit[:new][:role]),

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
       
     authentication:
       error: "Sorry, the username or password you entered is incorrect."
+      missing_role_or_group: "Login not allowed, User's %{model} is missing. Please contact the administrator"
       session_timed_out: "Session was timed out due to inactivity. Please log in again."
 
     automate:


### PR DESCRIPTION
- Changed login screen to show message when trying to login with userid that does not have role or group associated with it or their role/group might have been deleted from database.
- Changed group details screen to not try to show role details of group when group's role has been deleted.
- Fixed/Added spec tests around new changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1090901

@dclarizio please review/test.
