### PR TITLE
Automate - Service check_provisioned method change.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -13,6 +13,13 @@ result = task.status
 
 $evm.log('info', "Service ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task_status}>")
 
+if result == 'ok'
+  if task.miq_request_tasks.any? { |t| t.state != 'finished' }
+    result = 'retry'
+    $evm.log('info', "Child tasks not finished. Setting retry for task: #{task.id} ")
+  end
+end
+
 case result
 when 'error'
   $evm.root['ae_result'] = 'error'


### PR DESCRIPTION
Service provisioning was not waiting for all of the child provisioning
 to finish.  It was waiting only until the child provision(s)
advanced past the check_provision state which would have had a
provision state of 'provisioned'. The very last step of the state
machine sets the state to "finished".  This method change forces
the service task to wait and retry until all of the children
state machines are completely "finished".

https://bugzilla.redhat.com/show_bug.cgi?id=1128890
