### PR TITLE
Post substitution the extra URL encode will be skipped

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -619,7 +619,11 @@ module MiqAeEngine
         value = value.gsub(RE_SUBST) { |s|
           subst   = uri2value($1)
           subst &&= subst.to_s
-          subst &&= URI.escape(subst, RE_URI_ESCAPE)  if type == :aetype_relationship
+          # This encoding of relationship is not needed, until we can get a valid use case
+          # Based on RFC 3986 Section 2.4 "When to Encode or Decode"
+          # We are properly encoding when we send URL requests to external systems
+          # or building an automate request
+          # subst &&= URI.escape(subst, RE_URI_ESCAPE)  if type == :aetype_relationship
           subst
         } unless value.nil?
         return value

--- a/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/.manifest.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/.manifest.yaml
@@ -1,108 +1,118 @@
 ---
 __domain__.yaml:
   classes: 2
-  instances: 17
-  created_on: 2014-05-19 16:30:22.491467000 Z
-  updated_on: 2014-05-19 16:30:22.491467000 Z
-  size: 163
-  sha1: 8CUgrwvnaF6Y2LRqmidR9zfd+ns=
+  instances: 19
+  created_on: 2014-08-07 21:36:24.444192000 Z
+  updated_on: 2014-08-07 21:51:54.898900000 Z
+  size: 165
+  sha1: d+9tDlPt7tSuD65y7kDrHUdJij8=
 EVM/__namespace__.yaml:
-  created_on: 2014-05-19 16:30:22.602524000 Z
-  updated_on: 2014-05-19 16:30:22.602524000 Z
+  created_on: 2014-08-07 21:36:24.617792000 Z
+  updated_on: 2014-08-07 21:36:24.617792000 Z
   size: 155
   sha1: sRy02EsdO3HlNqjIjlMq4Hek8YU=
 EVM/A.class/__class__.yaml:
-  created_on: 2014-05-19 16:30:22.687890000 Z
-  updated_on: 2014-05-19 16:30:22.687890000 Z
-  size: 947
-  sha1: ZIbSHt6OP9VPhy+vyeMlFAepdJQ=
+  created_on: 2014-08-07 21:36:24.740872000 Z
+  updated_on: 2014-08-07 21:36:24.740872000 Z
+  size: 1344
+  sha1: TIfZOfv2CVE1dRG31lxHB1B1Olk=
 EVM/A.class/a1.yaml:
-  created_on: 2014-05-19 16:30:22.741457000 Z
-  updated_on: 2014-05-19 16:30:22.741457000 Z
+  created_on: 2014-08-07 21:36:24.791809000 Z
+  updated_on: 2014-08-07 21:36:24.791809000 Z
   size: 179
   sha1: UKCSeo0vNbQnuDbf1vrsAnfXI5Q=
+EVM/A.class/a10.yaml:
+  created_on: 2014-08-07 21:40:21.127210000 Z
+  updated_on: 2014-08-07 21:40:21.127210000 Z
+  size: 285
+  sha1: Z9xoiktqKszd/6cWKaxETNIlCkY=
 EVM/A.class/a2.yaml:
-  created_on: 2014-05-19 16:30:22.754210000 Z
-  updated_on: 2014-05-19 16:30:22.754210000 Z
+  created_on: 2014-08-07 21:36:24.803915000 Z
+  updated_on: 2014-08-07 21:36:24.803915000 Z
   size: 206
   sha1: 3rUhgwdDgKITvaqKU7o+sppfc7g=
 EVM/A.class/a4.yaml:
-  created_on: 2014-05-19 16:30:22.764592000 Z
-  updated_on: 2014-05-19 16:30:22.764592000 Z
+  created_on: 2014-08-07 21:36:24.814565000 Z
+  updated_on: 2014-08-07 21:36:24.814565000 Z
   size: 206
   sha1: g8Vr87x0c52fhnG22xsJG6Ezso8=
 EVM/A.class/a5.yaml:
-  created_on: 2014-05-19 16:30:22.775824000 Z
-  updated_on: 2014-05-19 16:30:22.775824000 Z
+  created_on: 2014-08-07 21:36:24.825248000 Z
+  updated_on: 2014-08-07 21:36:24.825248000 Z
   size: 206
   sha1: EB3pn34q05qe5+icLiSIKDehy+s=
 EVM/A.class/a6.yaml:
-  created_on: 2014-05-19 16:30:22.813820000 Z
-  updated_on: 2014-05-19 16:30:22.813820000 Z
+  created_on: 2014-08-07 21:36:24.835528000 Z
+  updated_on: 2014-08-07 21:36:24.835528000 Z
   size: 206
   sha1: h09vNsyoDFtvyvCoHiS3BCLfrsI=
 EVM/A.class/a7.yaml:
-  created_on: 2014-05-19 16:30:22.824500000 Z
-  updated_on: 2014-05-19 16:30:22.824500000 Z
+  created_on: 2014-08-07 21:36:24.845566000 Z
+  updated_on: 2014-08-07 21:36:24.845566000 Z
   size: 206
   sha1: jIrVT3SxY3TOum4m2EWYX+gb/7Y=
 EVM/A.class/a8.yaml:
-  created_on: 2014-05-19 16:30:22.836564000 Z
-  updated_on: 2014-05-19 16:30:22.836564000 Z
+  created_on: 2014-08-07 21:36:24.855559000 Z
+  updated_on: 2014-08-07 21:36:24.855559000 Z
   size: 206
   sha1: HkAu1MhO18n1/7sifAZD45nNcqY=
 EVM/A.class/a9.yaml:
-  created_on: 2014-05-19 16:30:22.846743000 Z
-  updated_on: 2014-05-19 16:30:22.846743000 Z
+  created_on: 2014-08-07 21:36:24.865575000 Z
+  updated_on: 2014-08-07 21:36:24.865575000 Z
   size: 222
   sha1: 0Nk+ZUyfbmKKf1+wq5NW4Kxp3Iw=
 EVM/B.class/__class__.yaml:
-  created_on: 2014-05-19 16:30:22.888777000 Z
-  updated_on: 2014-05-19 16:30:22.888777000 Z
+  created_on: 2014-08-07 21:36:24.879265000 Z
+  updated_on: 2014-08-07 21:36:24.879265000 Z
   size: 1335
   sha1: SCemrvX+Q0Tf8H9nXSmPjwqVUds=
 EVM/B.class/b1.yaml:
-  created_on: 2014-05-19 16:30:22.903817000 Z
-  updated_on: 2014-05-19 16:30:22.903817000 Z
+  created_on: 2014-08-07 21:36:24.893373000 Z
+  updated_on: 2014-08-07 21:36:24.893373000 Z
   size: 171
   sha1: NOoFrpInXAj7zeBjdZAjTIfxyRI=
+EVM/B.class/b10.yaml:
+  created_on: 2014-08-07 21:50:04.170105000 Z
+  updated_on: 2014-08-07 21:50:04.170105000 Z
+  size: 178
+  sha1: zpdARo1KOcX2J+yFZPoVq0t5iWk=
 EVM/B.class/b2.yaml:
-  created_on: 2014-05-19 16:30:22.912127000 Z
-  updated_on: 2014-05-19 16:30:22.912127000 Z
+  created_on: 2014-08-07 21:36:24.901325000 Z
+  updated_on: 2014-08-07 21:36:24.901325000 Z
   size: 171
   sha1: NpaUTyp46EM+3ozmhsHvepY2HXw=
 EVM/B.class/b3.yaml:
-  created_on: 2014-05-19 16:30:22.922215000 Z
-  updated_on: 2014-05-19 16:30:22.922215000 Z
+  created_on: 2014-08-07 21:36:24.910046000 Z
+  updated_on: 2014-08-07 21:36:24.910046000 Z
   size: 197
   sha1: MXTq7OHBagfKAP8FMcchFrzpv6Q=
 EVM/B.class/b4.yaml:
-  created_on: 2014-05-19 16:30:22.931469000 Z
-  updated_on: 2014-05-19 16:30:22.931469000 Z
+  created_on: 2014-08-07 21:36:24.919301000 Z
+  updated_on: 2014-08-07 21:36:24.919301000 Z
   size: 175
   sha1: 1yeYwZOOaK3Xg0+bHUeH7oyZrN0=
 EVM/B.class/b5.yaml:
-  created_on: 2014-05-19 16:30:22.940046000 Z
-  updated_on: 2014-05-19 16:30:22.940046000 Z
+  created_on: 2014-08-07 21:36:24.927223000 Z
+  updated_on: 2014-08-07 21:36:24.927223000 Z
   size: 176
   sha1: EkmtC9hQIjBe1vfi+jBAQluudXE=
 EVM/B.class/b6.yaml:
-  created_on: 2014-05-19 16:30:22.949161000 Z
-  updated_on: 2014-05-19 16:30:22.949161000 Z
+  created_on: 2014-08-07 21:36:24.935224000 Z
+  updated_on: 2014-08-07 21:36:24.935224000 Z
   size: 176
   sha1: TGCoxuXPQosLPdE79ugXYt5iRm8=
 EVM/B.class/b7.yaml:
-  created_on: 2014-05-19 16:30:22.957040000 Z
-  updated_on: 2014-05-19 16:30:22.957040000 Z
+  created_on: 2014-08-07 21:36:24.943166000 Z
+  updated_on: 2014-08-07 21:36:24.943166000 Z
   size: 181
   sha1: m+cgl+vfm4qAc1YB3t3CMNH4b4I=
 EVM/B.class/b8.yaml:
-  created_on: 2014-05-19 16:30:22.964799000 Z
-  updated_on: 2014-05-19 16:30:22.964799000 Z
+  created_on: 2014-08-07 21:36:24.989625000 Z
+  updated_on: 2014-08-07 21:36:24.989625000 Z
   size: 164
   sha1: MBmRPtJ4YwrFcEtkkK8u4lV4fKA=
 EVM/B.class/b9.yaml:
-  created_on: 2014-05-19 16:30:22.973057000 Z
-  updated_on: 2014-05-19 16:30:22.973057000 Z
+  created_on: 2014-08-07 21:36:24.997758000 Z
+  updated_on: 2014-08-07 21:36:24.997758000 Z
   size: 164
   sha1: sOTc9prJ+s264No5k6+lBD8+lxA=

--- a/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/EVM/A.class/__class__.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/EVM/A.class/__class__.yaml
@@ -13,10 +13,30 @@ object:
   schema:
   - field:
       aetype: attribute
+      name: attr2
+      display_name: Substituted Value
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
       name: attr1
       display_name: Sample Attribute
-      datatype: 
-      priority: 1
+      datatype: string
+      priority: 2
       owner: 
       default_value: defaultA
       substitute: true
@@ -35,10 +55,10 @@ object:
       aetype: relationship
       name: rel1
       display_name: Sample Relationship
-      datatype: 
-      priority: 2
+      datatype: string
+      priority: 3
       owner: 
-      default_value: ''
+      default_value: 
       substitute: true
       message: create
       visibility: 

--- a/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/EVM/A.class/a10.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/EVM/A.class/a10.yaml
@@ -1,0 +1,16 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: a10
+    inherits: 
+    description: 
+  fields:
+  - attr2:
+      value: /SPEC_DOMAIN/EVM/B/b10
+  - attr1:
+      value: Pearl/Slaghoople
+  - rel1:
+      value: miqaedb:///${#attr2}?attr3=${#attr1}

--- a/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/EVM/B.class/b10.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/EVM/B.class/b10.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: b10
+    inherits: 
+    description: 
+  fields:
+  - attr1:
+      value: Bamm Bamm Rubble

--- a/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/__domain__.yaml
+++ b/vmdb/spec/lib/miq_automation_engine/data/substitution/SPEC_DOMAIN/__domain__.yaml
@@ -7,5 +7,5 @@ object:
     description: 
     display_name: 
     system: 
-    priority: 100
-    enabled: 
+    priority: 2
+    enabled: true

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -650,6 +650,16 @@ module MiqAeEngineSpec
       b9 = a9.children[0]
       b9.attributes["attr1"].should == "foo"
 
+      ws = MiqAeEngine.instantiate("/EVM/A/a10")
+      ws.should_not be_nil
+      roots = ws.roots
+      roots.should_not be_nil
+      roots.should be_a_kind_of(Array)
+      roots.length.should eql(1)
+      a10 = roots[0]
+      b10 = a10.children[0]
+      b10.attributes["attr1"].should eql('Bamm Bamm Rubble')
+      b10.attributes["attr3"].should eql('Pearl/Slaghoople')
     end
 
     it "properly processes substitution with methods" do


### PR DESCRIPTION
Fix #1705

When we do a substitution each component of the substituted string
was subjected to an extra round of URL encoding. This was happening
just for relationships. This extra URL encoding has been removed
till we have a valid usecase for it. With the extra substitution we
would convert a string like TEST/DEMO to TEST%2FDEMO, which is incorrect
without the knowledge about how the string is going to be used.

https://bugzilla.redhat.com/show_bug.cgi?id=1128864
