### PR TITLE
[WIP] Ensure more_core_extensions is always loaded

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -23,7 +23,7 @@ gem "httpclient",           "~>2.2.4",   :require => false
 gem "io-extra",             "=1.2.6",    :require => false
 gem "linux_admin",          "~>0.9",     :require => false
 gem "log4r",                "=1.1.8",    :require => false
-gem "more_core_extensions", "~>1.2.0",   :require => false
+gem "more_core_extensions", "~>1.2.0",   :require => "more_core_extensions/all"
 gem "nokogiri",             "~>1.5.0",   :require => false
 gem "parallel",             "~>0.5.21",  :require => false
 gem "Platform",             "=0.4.0",    :require => false

--- a/lib/cfme_client/Gemfile
+++ b/lib/cfme_client/Gemfile
@@ -4,7 +4,7 @@ gem "rack"
 gem "faraday"
 gem "faraday_middleware"
 gem "activesupport", "~>3.2.17"
-gem "more_core_extensions", "~>1.2.0"
+gem "more_core_extensions", "~>1.2.0", :require => "more_core_extensions/all"
 
 group :test do
   gem "rspec",      "~>2.12.0", :require => false

--- a/lib/cfme_client/lib/cfme_client.rb
+++ b/lib/cfme_client/lib/cfme_client.rb
@@ -7,7 +7,6 @@ require 'faraday'
 require 'faraday_middleware'
 require 'uri'
 require 'active_support/all'
-require 'more_core_extensions/all'
 
 require 'cfme_client/net'
 

--- a/lib/util/extensions/miq-array.rb
+++ b/lib/util/extensions/miq-array.rb
@@ -1,5 +1,3 @@
-require 'more_core_extensions/core_ext/array'
-
 class Object #:nodoc:
   def to_miq_a
     [*self]

--- a/lib/util/extensions/miq-hash.rb
+++ b/lib/util/extensions/miq-hash.rb
@@ -1,5 +1,3 @@
-require 'more_core_extensions/core_ext/hash'
-
 class Hash #:nodoc:
 
   # The following fixes a bug in Ruby where if subclasses of String are

--- a/lib/util/extensions/miq-string.rb
+++ b/lib/util/extensions/miq-string.rb
@@ -2,7 +2,6 @@ $:.push("#{File.dirname(__FILE__)}/..")
 require 'miq-encode'
 
 require 'active_support/inflector'
-require 'more_core_extensions/core_ext/string'
 
 class String
   alias original_less_than_less_than <<

--- a/lib/util/miq-extensions.rb
+++ b/lib/util/miq-extensions.rb
@@ -1,5 +1,4 @@
 require_relative "../bundler_setup"
-require 'more_core_extensions/all'
 
 $:.push("#{File.dirname(__FILE__)}/extensions")
 Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), "extensions", "*.rb"))) { |f| require File.basename(f, ".*") }


### PR DESCRIPTION
Based on the discussion here: http://talk.manageiq.org/t/how-not-to-run-specs-in-the-lib-directory/111/3
