### PR TITLE
Added access to view Request list and copy/delete for OOTB User role.

### DIFF
--- a/vmdb/db/fixtures/miq_user_roles.yml
+++ b/vmdb/db/fixtures/miq_user_roles.yml
@@ -789,6 +789,8 @@
   - miq_report_saved_reports
   - miq_report_schedules
   - miq_report_view
+  - miq_request_admin
+  - miq_request_view
   - miq_template_check_compliance
   - miq_template_compare
   - miq_template_drift


### PR DESCRIPTION
- Added access to view Request list and copy/delete for OOTB User role.
- Moved existing code into a new method to redirect user back to where they initiated Provisioning request from in case they don't have access to view list of Requests to prevent it from crashing in UI.  New method is now being called when Submit/Cancel button is pressed on Add Provisioning request screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1126364

@dclarizio please review/test.
