### PR TITLE
setup password for internal database config

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -227,5 +227,5 @@ export LC_ALL=en_US.UTF-8
 sysctl -p "/etc/sysctl.conf"
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
-appliance_console_cli --region 0 --internal --key
+appliance_console_cli --region 0 --internal --key --password smartvm
 %end

--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -102,11 +102,14 @@ module ApplianceConsole
     end
 
     def set_internal_db
-      config = ApplianceConsole::InternalDatabaseConfiguration.new(
+      config = ApplianceConsole::InternalDatabaseConfiguration.new({
+        :database    => options[:dbname],
         :region      => options[:region],
+        :username    => options[:username],
+        :password    => options[:password],
         :interactive => false,
         :disk        => disk_from_string(options[:dbdisk])
-      )
+      }.delete_if { |_n, v| v.nil? })
 
       # create partition, pv, vg, lv, ext4, update fstab, mount disk
       # initdb, relabel log directory for selinux, update configs,
@@ -119,14 +122,14 @@ module ApplianceConsole
     end
 
     def set_external_db
-      config = ApplianceConsole::ExternalDatabaseConfiguration.new(
+      config = ApplianceConsole::ExternalDatabaseConfiguration.new({
         :host        => options[:hostname],
         :database    => options[:dbname],
         :region      => options[:region],
         :username    => options[:username],
         :password    => options[:password],
         :interactive => false,
-      )
+      }.delete_if { |_n, v| v.nil? })
 
       # call create_or_join_region (depends on region value)
       config.activate

--- a/lib/appliance_console/database_configuration.rb
+++ b/lib/appliance_console/database_configuration.rb
@@ -113,6 +113,13 @@ module ApplianceConsole
       raise MiqSignalError if warn && !agree(CREATE_REGION_AGREE)
     end
 
+    def ask_for_database_credentials
+      self.host     = ask_for_ip_or_hostname("database hostname or IP address", host) if host.blank? || !local?
+      self.database = just_ask("name of the database on #{host}", database) unless local?
+      self.username = just_ask("username", username) unless local?
+      self.password = ask_for_password_or_none("database password on #{host}", password)
+    end
+
     def friendly_inspect
       output = <<-FRIENDLY
 Host:     #{host}

--- a/lib/appliance_console/external_database_configuration.rb
+++ b/lib/appliance_console/external_database_configuration.rb
@@ -18,16 +18,8 @@ module ApplianceConsole
     def ask_questions
       create_new_region_questions if create_or_join_region_question == :create
       clear_screen
-      ask_for_database_credentials
-    end
-
-    def ask_for_database_credentials
       say("Database Configuration\n")
-
-      self.host     = ask_for_ip_or_hostname("database hostname or IP address", host)
-      self.database = just_ask("name of the database on #{@host}", database)
-      self.username = just_ask("username", username) unless local?
-      self.password = ask_for_password_or_none("password ('none' for no value)", password) unless local?
+      ask_for_database_credentials
     end
 
     def create_or_join_region_question

--- a/lib/appliance_console/internal_database_configuration.rb
+++ b/lib/appliance_console/internal_database_configuration.rb
@@ -40,6 +40,7 @@ module ApplianceConsole
       # TODO: Assume we want to create a region for a new internal database disk
       # until we allow for the internal selection against an already initialized disk.
       create_new_region_questions(false)
+      ask_for_database_credentials
     end
 
     def choose_disk

--- a/lib/appliance_console/prompts.rb
+++ b/lib/appliance_console/prompts.rb
@@ -93,6 +93,7 @@ module ApplianceConsole
     end
 
     def ask_for_password_or_none(prompt, default = nil)
+      prompt += " ('none' for no value)" if default && !prompt.include?('none')
       ask_for_password(prompt, default).gsub(/^'?NONE'?$/i, "")
     end
 

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -23,11 +23,27 @@ describe ApplianceConsole::Cli do
     subject.should_receive(:disk_from_string).and_return('x')
     ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
       .with(:region      => 1,
+            :database    => 'vmdb_production',
+            :username    => 'root',
             :interactive => false,
             :disk        => 'x')
       .and_return(stub(:activate => true, :post_activation => true))
 
     subject.parse(%w{--internal -r 1 --dbdisk x}).run
+  end
+
+  it "should pass username and password when configuring database locally" do
+    subject.should_receive(:disk_from_string).and_return('x')
+    ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
+      .with(:region      => 1,
+            :database    => 'vmdb_production',
+            :username    => 'user',
+            :password    => 'pass',
+            :interactive => false,
+            :disk        => 'x')
+      .and_return(stub(:activate => true, :post_activation => true))
+
+    subject.parse(%w(--internal --username user --password pass -r 1 --dbdisk x)).run
   end
 
   it "should handle remote databases (and setup region)" do
@@ -47,7 +63,6 @@ describe ApplianceConsole::Cli do
     ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
       .with(:host        => 'host',
             :database    => 'db',
-            :region      => nil,
             :username    => 'user',
             :password    => 'pass',
             :interactive => false)

--- a/lib/spec/appliance_console/database_configuration_spec.rb
+++ b/lib/spec/appliance_console/database_configuration_spec.rb
@@ -148,7 +148,7 @@ describe ApplianceConsole::DatabaseConfiguration do
       subject.password = nil
 
       subject.should_receive(:just_ask).with(/hostname/i, "defaulthost", anything, anything).and_return("newhost")
-      subject.should_receive(:just_ask).with(/database/i, "defaultdb").and_return("x")
+      subject.should_receive(:just_ask).with(/the database/i, "defaultdb").and_return("x")
       subject.should_receive(:just_ask).with(/user/i, "defaultuser").and_return("x")
       subject.should_receive(:just_ask).with(/password/i, nil).and_return("x")
 
@@ -159,7 +159,7 @@ describe ApplianceConsole::DatabaseConfiguration do
       subject.password = "defaultpass"
 
       subject.should_receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("x")
-      subject.should_receive(:just_ask).with(/database/i, anything).and_return("x")
+      subject.should_receive(:just_ask).with(/the database/i, anything).and_return("x")
       subject.should_receive(:just_ask).with(/user/i,     anything).and_return("x")
       subject.should_receive(:just_ask).with(/password/i, "********").and_return("********")
 
@@ -168,18 +168,33 @@ describe ApplianceConsole::DatabaseConfiguration do
 
     it "should ask for user/password if not local" do
       subject.should_receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("host")
-      subject.should_receive(:just_ask).with(/database/i, anything).and_return("x")
+      subject.should_receive(:just_ask).with(/the database/i, anything).and_return("x")
       subject.should_receive(:just_ask).with(/user/i,     anything).and_return("x")
       subject.should_receive(:just_ask).with(/password/i, anything).and_return("*****")
 
       subject.ask_for_database_credentials
     end
 
-    it "should not ask for user/password if local" do
+    it "should only ask for password if local" do
       subject.should_receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("localhost")
-      subject.should_receive(:just_ask).with(/database/i, anything).and_return("x")
-      subject.should_not_receive(:just_ask).with(/user/i,     anything)
-      subject.should_not_receive(:just_ask).with(/password/i, anything)
+      subject.should_receive(:just_ask).with(/password/i, anything).and_return("the password")
+
+      subject.ask_for_database_credentials
+    end
+  end
+
+  context "#ask_for_database_credentials (internal)" do
+    subject do
+      Class.new(ApplianceConsole::InternalDatabaseConfiguration) do
+        include ApplianceConsole::Prompts
+        # global variable
+        def say(*_args)
+        end
+      end.new
+    end
+
+    it "should ask for password if local" do
+      subject.should_receive(:just_ask).with(/password/i, anything).and_return("the password")
 
       subject.ask_for_database_credentials
     end

--- a/lib/spec/appliance_console/prompts_spec.rb
+++ b/lib/spec/appliance_console/prompts_spec.rb
@@ -211,16 +211,22 @@ describe ApplianceConsole::Prompts do
     end
 
     context "#or_none" do
+      it "should not append none if no default password" do
+        say "secret"
+        expect(subject.ask_for_password_or_none("prompt", nil)).to eq("secret")
+        expect_heard ["Enter the prompt: ", "******", ""]
+      end
+
       it "should not botch passwords" do
         say "secret"
         expect(subject.ask_for_password_or_none("prompt", "defaultpass")).to eq("secret")
-        expect_heard ["Enter the prompt: |********| ", "******", ""]
+        expect_heard ["Enter the prompt ('none' for no value): |********| ", "******", ""]
       end
 
       it "should support 'none' password" do
         say "none"
         expect(subject.ask_for_password_or_none("prompt", "defaultpass")).to eq("")
-        expect_heard ["Enter the prompt: |********| ", "****", ""]
+        expect_heard ["Enter the prompt ('none' for no value): |********| ", "****", ""]
       end
     end
   end

--- a/system/TEMPLATE/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf.erb
+++ b/system/TEMPLATE/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf.erb
@@ -1,5 +1,4 @@
 # TYPE  DATABASE USER  ADDRESS       METHOD
 local   all      all                 peer map=usermap
-host    all      all   localhost     ident map=usermap
 <%= "#" if ssl%>host    all      all   all           md5
 <%= "#" unless ssl %>hostssl all      all   all           cert map=sslmap


### PR DESCRIPTION
## We need to set postgresql database password, and fix postgres network connectivity
- appliance_console: internal database prompts for password.
- CentOS kickstarter: pass password into appliance_console_cli
- appliance_console_cli: relay username/password/databasename
- postgres: prompt passwords on all network connections (ident not installed)

https://bugzilla.redhat.com/show_bug.cgi?id=1128291
