### PR TITLE
Add event network update vm interface for rhev/ovirt post provision functions

### DIFF
--- a/vmdb/config/event_handling.tmpl.yml
+++ b/vmdb/config/event_handling.tmpl.yml
@@ -954,6 +954,9 @@ event_handling:
   NETWORK_UPDATE_TEMPLATE_INTERFACE:
   - refresh:
     - src_vm
+  NETWORK_UPDATE_VM_INTERFACE:
+  - refresh:
+    - src_vm:
   PowerOnVM_Task_Complete:
   - policy:
     - src_vm


### PR DESCRIPTION
A RHEV/OVIRT+MIQ environment where ip addresses are picked up after a new vm is created the rhev/ovirt manager will emit the event 'NETWORK_UPDATE_VM_INTERFACE' on first boot. Any post-provisioning activity dependent on that ip address existing in the VMDB will fail unless a full provider refresh were to happen.  Adding the NETWORK_UPDATE_VM_INTERFACE event to force a refresh of the provider. 

https://bugzilla.redhat.com/show_bug.cgi?id=1097393
