### PR TITLE
load vcr in test mode

### DIFF
--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/autorun'
 require 'rspec/rails'
 require 'rspec/fire'
+require 'vcr'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
I use binstubs for my bundler. This fixes the following error:

```
$ ./bin/rspec spec/models/tag_spec.rb 
/Users/kbrock/src/manageiq/vmdb/spec/spec_helper.rb:89:in `<top (required)>': uninitialized constant VCR (NameError)
```

This does not install any different gems and does not affect the appliance since it is in the non appliance/test block

/cc @jrafanie
