### PR TITLE
Change Timecop to use blocks (easy changes)

### DIFF
--- a/vmdb/spec/models/miq_alert_spec.rb
+++ b/vmdb/spec/models/miq_alert_spec.rb
@@ -96,16 +96,8 @@ describe MiqAlert do
           @alert.options.store_path(:notifications, :delay_next_evaluation, 5.minutes)
         end
 
-        context "in 4 minutes" do
-          before(:each) do
-            Timecop.travel 4.minutes
-          end
-
-          after(:each) do
-            Timecop.return
-          end
-
-          it "should always perform evaluation if not previously evaluated" do
+        it "should always perform evaluation if not previously evaluated (after 4 minutes)" do
+          Timecop.travel 4.minutes do
             @alert.postpone_evaluation?(@vm).should be_false
           end
         end
@@ -166,30 +158,14 @@ describe MiqAlert do
           @alert.save
         end
 
-        context "in 10 minutes" do
-          before(:each) do
-            Timecop.travel 10.minutes
-          end
-
-          after(:each) do
-            Timecop.return
-          end
-
-          it "should retry evaluation" do
+        it "should retry evaluation (after 10 minutes)" do
+          Timecop.travel 10.minutes do
             @alert.postpone_evaluation?(@vm).should be_false
           end
         end
 
-        context "in 4 minutes" do
-          before(:each) do
-            Timecop.travel 4.minutes
-          end
-
-          after(:each) do
-            Timecop.return
-          end
-
-          it "should skip evaluation" do
+        it "should skip evaluation (after 4 minutes)" do
+          Timecop.travel 4.minutes do
             @alert.postpone_evaluation?(@vm).should be_true
           end
         end

--- a/vmdb/spec/models/miq_server/server_monitor_spec.rb
+++ b/vmdb/spec/models/miq_server/server_monitor_spec.rb
@@ -327,9 +327,9 @@ describe "Server Monitor" do
         context "where Non-Master is not responding" do
           before(:each) do
             @miq_server1.monitor_servers
-            Timecop.travel 5.minutes
-            @miq_server1.monitor_servers
-            Timecop.return
+            Timecop.travel 5.minutes do
+              @miq_server1.monitor_servers
+            end
           end
 
           it "should mark server as not responding" do

--- a/vmdb/spec/models/miq_server/worker_monitor_spec.rb
+++ b/vmdb/spec/models/miq_server/worker_monitor_spec.rb
@@ -125,9 +125,9 @@ describe "MiqWorker Monitor" do
           @worker.messages.should        have_same_elements @messages
           @worker.active_messages.should have_same_elements @actives
 
-          Timecop.travel 5.minutes
-          @worker.validate_active_messages
-          Timecop.return
+          Timecop.travel 5.minutes do
+            @worker.validate_active_messages
+          end
 
           @worker.reload
           (@messages - @worker.messages).length.should        == 1
@@ -150,9 +150,9 @@ describe "MiqWorker Monitor" do
           actives = MiqQueue.find(:all, :conditions => {:state => 'dequeue'})
           actives.length.should == @actives.length
 
-          Timecop.travel 5.minutes
-          @miq_server.validate_active_messages
-          Timecop.return
+          Timecop.travel 5.minutes do
+            @miq_server.validate_active_messages
+          end
 
           actives = MiqQueue.find(:all, :conditions => {:state => 'dequeue'})
           actives.length.should == @actives.length - 1
@@ -175,9 +175,9 @@ describe "MiqWorker Monitor" do
           actives = MiqQueue.find(:all, :conditions => {:state => 'dequeue'})
           actives.length.should == @actives.length
 
-          Timecop.travel 5.minutes
-          @miq_server.validate_active_messages
-          Timecop.return
+          Timecop.travel 5.minutes do
+            @miq_server.validate_active_messages
+          end
 
           actives = MiqQueue.find(:all, :conditions => {:state => 'dequeue'})
           actives.length.should == @actives.length - 1
@@ -185,9 +185,9 @@ describe "MiqWorker Monitor" do
 
           @miq_server2.update_attribute(:status, 'stopped')
 
-          Timecop.travel 5.minutes
-          @miq_server.validate_active_messages
-          Timecop.return
+          Timecop.travel 5.minutes do
+            @miq_server.validate_active_messages
+          end
 
           actives = MiqQueue.find(:all, :conditions => {:state => 'dequeue'})
           actives.length.should == 0

--- a/vmdb/spec/models/miq_server_spec.rb
+++ b/vmdb/spec/models/miq_server_spec.rb
@@ -234,9 +234,9 @@ describe MiqServer do
         @miq_server.instance_variable_set(:@quiesce_loop_timeout, 10.minutes)
         @miq_server.quiesce_workers_loop_timeout?.should_not be_true
 
-        Timecop.travel 10.minutes
-        @miq_server.quiesce_workers_loop_timeout?.should be_true
-        Timecop.return
+        Timecop.travel 10.minutes do
+          @miq_server.quiesce_workers_loop_timeout?.should be_true
+        end
       end
 
       it "quiesce_workers_loop_timeout? will return false if timeout is not reached" do
@@ -258,11 +258,10 @@ describe MiqServer do
         MiqWorker.any_instance.stub(:quiesce_time_allowance).and_return(10.minutes)
         @miq_server.kill_timed_out_worker_quiesce
 
-        Timecop.travel 10.minutes
-        MiqWorker.any_instance.should_receive(:kill).once
-        @miq_server.kill_timed_out_worker_quiesce
-
-        Timecop.return
+        Timecop.travel 10.minutes do
+          MiqWorker.any_instance.should_receive(:kill).once
+          @miq_server.kill_timed_out_worker_quiesce
+        end
       end
 
       context "with an active messsage and a second server" do


### PR DESCRIPTION
It is best to avoid `Timecop.travel` with `Timecop.return`. Instead, the prefered syntax is to use `Timecop.travel` with a block.

I've had to track down a number of tests where there is a `travel`/`freeze` but no `return`. Very hard to find and sporadic.

This PR converts the `travel` to use the safer block format for some easy cases.
At some future date I may dive into converting all the more difficult ones and successfully convert out app to `Timecop.safe` mode.
