### PR TITLE
remove mixing enumerable into string

### DIFF
--- a/lib/spec/util/extensions/miq-string_spec.rb
+++ b/lib/spec/util/extensions/miq-string_spec.rb
@@ -9,49 +9,6 @@ describe String do
       Kernel.should_receive(:warn).never
       Array('somestring')
     end
-
-    context 'Enumerable' do
-      it 'included' do
-        String.include?(Enumerable).should be_true
-      end
-
-      it '#any? warns' do
-        Kernel.should_receive(:warn).once
-        "one\ntwo".any? { |str| str == 'two'}.should be_true
-      end
-
-      context '#to_a' do
-        it 'defined' do
-          String.method_defined?(:to_a).should be_true
-        end
-
-        it 'does not respond' do
-          String.respond_to?(:to_a).should_not be_true
-        end
-
-        it 'warns' do
-          Kernel.should_receive(:warn).once
-          "one\ntwo".to_a.should == ["one\n", 'two']
-        end
-      end
-    end
-
-    context '#each' do
-      it 'defined' do
-        String.method_defined?(:each).should be_true
-      end
-
-      it 'does not respond' do
-        String.respond_to?(:each).should_not be_true
-      end
-
-      it 'calls each_line and warns' do
-        str = 'one\ntwo'
-        str.should_receive(:each_line).once
-        Kernel.should_receive(:warn).once
-        str.each { |s| s }
-      end
-    end
   end
 
   it '#<<(exception)' do

--- a/lib/util/extensions/miq-string.rb
+++ b/lib/util/extensions/miq-string.rb
@@ -45,26 +45,6 @@ class String
     self.original_plus(str.message)
   end
 
-  unless method_defined?(:each)
-    include Enumerable
-
-    def respond_to?(symbol, include_private=false)
-      method = symbol.to_sym
-      return false if method == :each || method == :to_a
-      super
-    end
-
-    def each(*args, &block)
-      if !defined?(Rails) || !Rails.env.production?
-        msg = "[DEPRECATION] String#each has been removed from ruby 1.9.  Please use String#each_line instead.  At #{caller[0]}"
-        $log.warn msg if $log
-        Kernel.warn msg
-      end
-
-      self.each_line(*args, &block)
-    end
-  end
-
   unless method_defined?(:ord)
     def ord
       raise ArgumentError, "empty string" if self.length == 0


### PR DESCRIPTION
AwesomeSpawn is throwing errors for me because we mix `Enumerable` into `String`.
Infinite recursion nasty stuff.

@jrafanie suggested it was time to remove this crutch?
