### PR TITLE
Set current tag assignments to blank when tag/category has been deleted ...

### DIFF
--- a/vmdb/app/controllers/chargeback_controller.rb
+++ b/vmdb/app/controllers/chargeback_controller.rb
@@ -620,8 +620,13 @@ class ChargebackController < ApplicationController
     end
     if @edit[:new][:cbshow_typ] && @edit[:new][:cbshow_typ].ends_with?("-tags")
       get_categories_all
-      @edit[:new][:cbtag_cat] = @edit[:current_assignment][0][:tag][0]["parent_id"].to_s
-      get_tags_all(@edit[:current_assignment][0][:tag][0]["parent_id"])
+      tag = @edit[:current_assignment][0][:tag][0]
+      if tag
+        @edit[:new][:cbtag_cat] = tag["parent_id"].to_s
+        get_tags_all(tag["parent_id"])
+      else
+        @edit[:current_assignment] = []
+      end
     elsif @edit[:new][:cbshow_typ]
       get_cis_all
     end
@@ -654,7 +659,8 @@ class ChargebackController < ApplicationController
 
   def get_tags_all(category)
     @edit[:cb_assign][:tags] = Hash.new
-    Classification.find(category.to_s).entries.each{|e| @edit[:cb_assign][:tags][e.id.to_s] = e.description}
+    classification = Classification.find_by_id(category.to_s)
+    classification.entries.each { |e| @edit[:cb_assign][:tags][e.id.to_s] = e.description } if classification
   end
 
   def get_cis_all

--- a/vmdb/spec/controllers/chargeback_controller_spec.rb
+++ b/vmdb/spec/controllers/chargeback_controller_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe ChargebackController do
+  before(:each) do
+    set_user_privileges
+  end
+
+  context "returns current rate assignments or set them to blank if category/tag is deleted" do
+    before(:each) do
+      @category = FactoryGirl.create(:classification, :description => "Environment", :name => "environment")
+      @tag = FactoryGirl.create(:classification,
+                                :description => "Test category",
+                                :name        => "test_category",
+                                :parent_id   => @category.id)
+      options = {:parent_id => @tag.id, :name => "test_entry", :description => "Test entry under test category"}
+      @entry = FactoryGirl.create(:classification, options)
+      cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage")
+      temp = {:cb_rate => cbr, :tag => [@tag, "vm"]}
+      ChargebackRate.set_assignments(:Storage, [temp])
+    end
+
+    context "#get_tags_all" do
+      it "returns the classification entry record" do
+        controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
+        controller.send(:get_tags_all, @tag.id)
+        assigns(:edit)[:cb_assign][:tags].should eq(@entry.id.to_s => @entry.description)
+      end
+
+      it "returns empty hash when classification entry is not found" do
+        controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
+        controller.send(:get_tags_all, 1)
+        assigns(:edit)[:cb_assign][:tags].should eq({})
+      end
+    end
+
+    context "#cb_assign_set_form_vars" do
+      it "returns tag for current assignments" do
+        controller.instance_variable_set(:@sb,
+                                         :active_tree => :cb_assignments_tree,
+                                         :trees       => {:cb_assignments_tree => {:active_node => 'xx-Storage'}})
+        controller.send(:cb_assign_set_form_vars)
+        tag = assigns(:edit)[:current_assignment][0][:tag][0]
+        tag['parent_id'].should eq(@category.id)
+      end
+
+      it "returns empty array for current_assignment when tag/category is not found" do
+        @tag.destroy
+        controller.instance_variable_set(:@sb,
+                                         :active_tree => :cb_assignments_tree,
+                                         :trees       => {:cb_assignments_tree => {:active_node => 'xx-Storage'}})
+        controller.send(:cb_assign_set_form_vars)
+        assigns(:edit)[:current_assignment].should eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
...from table.
- To prevent a crash in UI when category/tag that chargeback is currently assigned to is deleted from table, set current assignments to blank.
- Added spec tests to verify the fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1129289

@dclarizio please review/test.
