### PR TITLE
Don't allow to set service retirement date to the past

### DIFF
--- a/vmdb/app/controllers/service_controller.rb
+++ b/vmdb/app/controllers/service_controller.rb
@@ -415,6 +415,8 @@ class ServiceController < ApplicationController
             locals = {:action_url => action, :record_id => @record ? @record.id : nil}
             locals[:no_reset] = true
             locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there
+            date_tz = Time.now.in_time_zone(session[:user_tz]).strftime("%Y,%m,%d")
+            page << "miq_cal_dateFrom = new Date('#{date_tz}');"
             page << "miqBuildCalendar();"
           elsif action == "tag"
             locals = {:action_url => action_url}


### PR DESCRIPTION
This fix initializes the dhtmlXCalendarObject when setting
service retirement date in such a way that it would not
render past days as selectable.

This effectively disallows to select a date in the past
for service retirement.

https://bugzilla.redhat.com/show_bug.cgi?id=1124555
