### PR TITLE
Fix Openstack Refresh with no volumes

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack.rb
@@ -217,6 +217,7 @@ module EmsRefresh::Parsers
     end
 
     def process_collection(collection, key, &block)
+      @data[key] ||= []
       collection.each { |item| process_collection_item(item, key, &block) }
     end
 
@@ -261,7 +262,7 @@ module EmsRefresh::Parsers
         base_snapshot_uid = cv.delete(:snapshot_uid)
         base_snapshot = @data_index.fetch_path(:cloud_volume_snapshots, base_snapshot_uid)
         cv[:base_snapshot] = base_snapshot unless base_snapshot.nil?
-      end
+      end if @data[:cloud_volumes]
     end
 
     def parse_flavor(flavor)


### PR DESCRIPTION
If no volumes are present in Cinder, then the "#process_collection_item" method
is never called, and that method creates the entry in the "@data" object in the
ems_refresh parser.

Part of the fix here is to add the "@data[key] ||= []" to "#process_collection"
so that the "@data" object at least contains an empty array instead of simply
nil.

Secondly, it's still necessary to protect the "#link_storage_associations" from
attempting to dereference the array because it's possible that the Cinder
service may not even be available.

https://bugzilla.redhat.com/show_bug.cgi?id=1130118
