### PR TITLE
Nullify the cluster_id on hosts when deleted

### DIFF
--- a/vmdb/app/models/ems_cluster.rb
+++ b/vmdb/app/models/ems_cluster.rb
@@ -6,7 +6,7 @@ class EmsCluster < ActiveRecord::Base
   acts_as_miq_taggable
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
-  has_many    :hosts
+  has_many    :hosts, :dependent => :nullify
   has_many    :vms_and_templates
   has_many    :miq_templates
   has_many    :vms


### PR DESCRIPTION
**Update: Sept 9, 2014**

Reverted to original change

**Update: Sept 8, 2014**

When a host is updated in EMS Refresh, it's possible for a residual EMS Cluster ID to exist on the host.  The only scenario that can show this is when an EMS is deleted and then re-added.

When an EMS is deleted, the hosts for the EMS are _not_ deleted.  And, in order to avoid a performance hit, the ems_cluster_id (belonging to a deleted EMS Cluster) is not removed from the host record.

When the EMS is re-added, the EMS Refresh code attempts to update the host record with the new EMS Cluster ID (as well as all the other attributes from the refresh).

When the EMS Cluster id is updated on the host, an after_save callback is initiated that attempts to emit events for the old EMS Cluster being removed and the new EMS Cluster being added.

However, when the after_save callback is attempted for the (now non-existent) old EMS Cluster, active record fails to find the record and throws a RecordNotFound error.

This fix allows the host to update its attributes and ignore a residual EMS Cluster ID in the after_save callback if necessary.

---

When Clusters are deleted, the ems_cluster_id should be nullified on residual
hosts.

As a performance concern, hosts are not automatically deleted when an
infrastructure provider is deleted.  However, the clusters may be.  In such
cases, the old ems_cluster_id will remain on the host record.

Then, if the same infrastructure provider is added back, and an ems_refresh is
initiated, the hosts attempt to resolve the ems_cluster_id (which points to
nothing now) and ends up with an object not found error from active record.

https://bugzilla.redhat.com/show_bug.cgi?id=1087476
