### PR TITLE
Workaround for Fog Swift bug

### DIFF
--- a/lib/openstack/openstack_handle/handle.rb
+++ b/lib/openstack/openstack_handle/handle.rb
@@ -32,6 +32,12 @@ module OpenstackHandle
       }
       opts.merge!(extra_opts) if extra_opts
 
+      # Workaround for a bug in Fog
+      # https://github.com/fog/fog/issues/3112
+      # Ensure the that if the Storage service is not available, it will not
+      # throw an error trying to build an connection error message.
+      opts[:openstack_service_type] = ["object-store"] if service == "Storage"
+
       Fog.const_get(service).new(opts)
     rescue Fog::Errors::NotFound => err
       raise MiqException::ServiceNotAvailable if err.message.include?("Could not find service")


### PR DESCRIPTION
This patch works around a bug in Fog where, if Swift is unavailable, Fog will
throw an unexpected error instead of simply indicating that the service is
unavailable.

This patch will have to suffice until we can get a patch into Fog and update to
the latest community version.

https://bugzilla.redhat.com/show_bug.cgi?id=1130309
