### PR TITLE
Upgrade CertificateAuthority to use certmonger

### DIFF
--- a/lib/appliance_console/certificate.rb
+++ b/lib/appliance_console/certificate.rb
@@ -1,0 +1,143 @@
+require "appliance_console/principal"
+require "awesome_spawn"
+
+module ApplianceConsole
+  class Certificate
+    STATUS_COMPLETE = :complete
+
+    # map `getcert status` return codes to something more descriptive
+    # 0 => :complete -- keys/certs generated
+    # 1 => :no_key   -- either certmonger is down, or we havent asked for the key yet. (assuming the latter)
+    # 2 => :rejected -- request failed. we need to resubmit once we fix stuff
+    # 3 => :waiting  -- couldn't contact CA, will try again
+    # 4 => :error    -- certmonger is not configured properly
+    # 5 => :waiting  -- waiting for CA to send back the certificate
+    STATUS_RETURN_CODES = [:complete, :no_key, :rejected, :waiting, :error, :waiting]
+
+    attr_accessor :cert_filename
+    # root certificate filename
+    attr_accessor :root_filename
+    attr_accessor :service
+    # 509 v3 extesions for stuff to signify purpose of this certificate (e.g.: client)
+    attr_accessor :extensions
+    attr_accessor :owner
+
+    # hostname of current machine
+    attr_accessor :hostname
+    # ipa realm
+    attr_accessor :realm
+    # name of certificate authority
+    attr_accessor :ca_name
+
+    def initialize(options = {})
+      options.each { |n, v| public_send("#{n}=", v) }
+      @ca_name ||= "ipa"
+      @extensions ||= %w(server client)
+      @realm   ||= hostname.split(".")[1..-1].join(".").upcase if hostname
+    end
+
+    def request
+      if should_request_key?
+        principal.register
+        request_certificate
+        # NOTE: status probably changed
+        set_owner_of_key unless rejected?
+      end
+
+      if complete?
+        make_certs_world_readable
+        yield if block_given?
+      end
+      self
+    end
+
+    def principal
+      @principal ||= Principal.new(:hostname => hostname, :realm => realm, :service => service, :ca_name => ca_name)
+    end
+
+    def request_certificate
+      if rejected?
+        request_again
+      else
+        request_first
+      end
+      clear_status
+    end
+
+    # workaround
+    # currently, the -C is not run after the root certificate is written
+    def make_certs_world_readable
+      FileUtils.chmod(0644, [root_filename, cert_filename].compact)
+    end
+
+    def set_owner_of_key
+      FileUtils.chown(owner.split(".").first, owner.split(".")[1], key_filename) if owner && (owner != "root")
+      self
+    end
+
+    # statuses
+
+    def should_request_key?
+      no_key? || rejected?
+    end
+
+    def no_key?
+      status == :no_key
+    end
+
+    def rejected?
+      status == :rejected
+    end
+
+    def complete?
+      status == :complete
+    end
+
+    def clear_status
+      @status = nil
+    end
+
+    def status
+      @status ||= key_status
+    end
+
+    private
+
+    def request_first
+      params = {
+        nil  => "request",
+        "-c" => ca_name,
+        "-v" => nil, # verbose
+        "-w" => nil, # wait til completion if possible
+        "-k" => key_filename,
+        "-f" => cert_filename,
+        "-N" => principal.subject_name,
+        "-K" => principal.name,
+        "-C" => "chmod 644 #{cert_filename} #{root_filename}",
+        "-U" => key_ext_usage
+      }
+      params["-F"] = root_filename if root_filename
+
+      AwesomeSpawn.run!("/usr/bin/getcert", :params => params)
+      self
+    end
+
+    def request_again
+      AwesomeSpawn.run!("/usr/bin/getcert", :params => ["resubmit", "-w", "-f", cert_filename])
+      self
+    end
+
+    def key_filename
+      "#{cert_filename.chomp(File.extname(cert_filename))}.key"
+    end
+
+    def key_status
+      ret = AwesomeSpawn.run("/usr/bin/getcert", :params => ["status", "-f", cert_filename])
+      STATUS_RETURN_CODES[ret.exit_status]
+    end
+
+    def key_ext_usage
+      extensions.collect { |n| "id-kp-#{n}Auth" }.join(",")
+    end
+  end
+end

--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -9,12 +9,14 @@ require 'appliance_console/external_database_configuration'
 require 'appliance_console/external_httpd_authentication'
 require 'appliance_console/service_group'
 require 'appliance_console/key_configuration'
+require 'appliance_console/principal'
+require 'appliance_console/certificate'
 require 'appliance_console/certificate_authority'
 
 # support for appliance_console methods
 unless defined?(say)
-  def say(*args)
-    puts(*args)
+  def say(arg)
+    puts(arg)
   end
 end
 
@@ -22,13 +24,14 @@ module ApplianceConsole
   class Cli
     attr_accessor :options
 
-    def hostname
-      options[:internal] ? "localhost" : options[:hostname]
+    # machine host
+    def host
+      options[:host] || Env["host"]
     end
 
-    def cahost
-      return unless options[:ca]
-      options[:cahost] || hostname || "localhost"
+    # database hostname
+    def hostname
+      options[:internal] ? "localhost" : options[:hostname]
     end
 
     def local?(name = hostname)
@@ -37,7 +40,11 @@ module ApplianceConsole
 
     # currently, only creates the key for a local CA
     def key?
-      options[:key] || (options[:ca] && local?(cahost))
+      options[:key]
+    end
+
+    def certs?
+      options[:postgres_client_cert] || options[:postgres_server_cert] || options[:api_cert]
     end
 
     def initialize(options = {})
@@ -69,16 +76,17 @@ module ApplianceConsole
         opt :username, "Database Username",  :type => :string,  :short => 'U', :default => "root"
         opt :password, "Database Password",  :type => :string,  :short => "p"
         opt :dbname,   "Database Name",      :type => :string,  :short => "d", :default => "vmdb_production"
-        opt :ca,       "Setup CA",                              :short => 'c'
         opt :key,      "Create master key",  :type => :boolean, :short => "k"
-        opt :cahost,   "CA host",            :type => :string,  :short => nil
-        opt :company,  "CA company name",    :type => :string,  :short => nil, :default => "cfme demo"
-        opt :causer,   "CA User",            :type => :string,                 :default => "root"
+        opt :verbose,  "Verbose",            :type => :boolean, :short => "v"
         opt :dbdisk,   "Database Disk Path", :type => :string
         opt :uninstall_ipa, "Uninstall IPA Client", :type => :boolean,         :default => false
         opt :ipaserver,  "IPA Server FQDN",  :type => :string
         opt :ipaprincipal,  "IPA Server principal", :type => :string,          :default => "admin"
         opt :ipapassword,   "IPA Server password",  :type => :string
+        opt :ca,                   "CA name used for certmonger",       :type => :string,  :default => "ipa"
+        opt :postgres_client_cert, "install certs for postgres client", :type => :boolean
+        opt :postgres_server_cert, "install certs for postgres server", :type => :boolean
+        opt :api_cert,             "install certs for regional api",    :type => :boolean
       end
       Trollop.die :region, "needed when setting up a local database" if options[:region].nil? && hostname && local?
       self
@@ -87,10 +95,15 @@ module ApplianceConsole
     def run
       Env[:host] = options[:host] if options[:host]
       create_key if key?
-      set_ca if options[:ca]
       set_db if hostname
       uninstall_ipa if options[:uninstall_ipa]
       install_ipa if options[:ipaserver]
+      install_certs if certs?
+    rescue AwesomeSpawn::CommandResultError => e
+      say e.result.output
+      say e.result.error
+      say ""
+      raise
     end
 
     def set_db
@@ -102,6 +115,7 @@ module ApplianceConsole
     end
 
     def set_internal_db
+      say "configuring internal database"
       config = ApplianceConsole::InternalDatabaseConfiguration.new({
         :database    => options[:dbname],
         :region      => options[:region],
@@ -122,6 +136,7 @@ module ApplianceConsole
     end
 
     def set_external_db
+      say "configuring external database"
       config = ApplianceConsole::ExternalDatabaseConfiguration.new({
         :host        => options[:hostname],
         :database    => options[:dbname],
@@ -141,21 +156,32 @@ module ApplianceConsole
     # force creating the key if user specifies -key
     # otherwise, only create if it does not exist locally
     def create_key
+      say "creating encryption key"
       KeyConfiguration.new.create_key(options[:key])
     end
 
-    def set_ca
-      ca = CertificateAuthority.new(Env[:host], Env[:ip])
-      if local?(cahost)
-        ca.local(options[:company]).create.run
-      else
-        ca.remote(cahost, options[:causer]).run
+    def install_certs
+      say "creating ssl certificates"
+      config = CertificateAuthority.new(
+        :hostname => host,
+        :ca_name  => options[:ca],
+        :pgclient => options[:postgres_client_cert],
+        :pgserver => options[:postgres_server_cert],
+        :api      => options[:api_cert],
+        :verbose  => options[:verbose],
+      )
+
+      config.activate
+      say "\ncertificate result: #{config.status_string}"
+      unless config.complete?
+        say "After the certificates are retrieved, rerun to update service configuration files"
       end
     end
 
     def install_ipa
+      raise "please uninstall ipa before reinstalling" if ExternalHttpdAuthentication.ipa_client_configured?
       config = ExternalHttpdAuthentication.new(
-        options[:host] || Env["HOST"],
+        host,
         :ipaserver => options[:ipaserver],
         :principal => options[:ipaprincipal],
         :password  => options[:ipapassword],
@@ -165,6 +191,7 @@ module ApplianceConsole
     end
 
     def uninstall_ipa
+      say "Uninstalling IPA-client"
       config = ExternalHttpdAuthentication.new
       config.ipa_client_unconfigure if config.ipa_client_configured?
     end

--- a/lib/appliance_console/principal.rb
+++ b/lib/appliance_console/principal.rb
@@ -1,0 +1,43 @@
+require 'awesome_spawn'
+
+module ApplianceConsole
+  # Kerberos principal
+  class Principal
+    attr_accessor :ca_name
+    attr_accessor :hostname
+    attr_accessor :realm
+    attr_accessor :service
+    # kerberos principal name
+    attr_accessor :name
+
+    def initialize(options = {})
+      options.each { |n, v| public_send("#{n}=", v) }
+      @ca_name ||= "ipa"
+      @name ||= "#{service}/#{hostname}@#{realm}"
+    end
+
+    def register
+      request if ipa? && !exist?
+    end
+
+    def subject_name
+      "CN=#{hostname},OU=#{service},O=#{realm}"
+    end
+
+    def ipa?
+      @ca_name == "ipa"
+    end
+
+    private
+
+    def exist?
+      AwesomeSpawn.run("/usr/bin/ipa", :params => ["service-find", "--principal", name]).success?
+    end
+
+    def request
+      # using --force because these services tend not to be in dns
+      # this is like VERIFY_NONE
+      AwesomeSpawn.run!("/usr/bin/ipa", :params => ["service-add", "--force", name])
+    end
+  end
+end

--- a/lib/spec/appliance_console/certificate_authority_spec.rb
+++ b/lib/spec/appliance_console/certificate_authority_spec.rb
@@ -1,38 +1,103 @@
 require "spec_helper"
+require "appliance_console/internal_database_configuration"
+require "appliance_console/external_httpd_authentication"
+require 'appliance_console/principal'
+require 'appliance_console/certificate'
 require "appliance_console/certificate_authority"
 
 describe ApplianceConsole::CertificateAuthority do
-  subject { described_class.new('localhost', '127.0.0.1') }
+  let(:host)  { "client.network.com" }
+  let(:realm) { "NETWORK.COM" }
+  subject { described_class.new(:ca_name => 'ipa', :hostname => host) }
 
-  context "with local ca" do
-    before do
-      subject.local('Red Hat')
+  context "#status" do
+    it "should have no status if no services called" do
+      expect(subject.status_string).to eq("")
+      expect(subject).to be_complete
     end
 
-    it "should know is local" do
-      expect(subject).to be_local
+    it "should have status for waiting and complete services (not complete)" do
+      subject.pgserver = :complete
+      subject.pgclient = :waiting
+      expect(subject).not_to be_complete
+      expect(subject.status_string).to eq("pgclient: waiting pgserver: complete")
     end
 
-    it "should create a ca" do
-      AwesomeSpawn.should_receive(:run!).with(
-        /so_ca.sh/,
-        :params => {
-          "-r" => ApplianceConsole::CertificateAuthority::CA_ROOT,
-          "-C" => "/O=Red Hat"})
-      FileUtils.stub(:rm)
-      MiqPassword.stub(:generate_symmetric)
+    it "should be complete if all statuses are complete" do
+      subject.pgserver = :complete
+      expect(subject).to be_complete
+      expect(subject.status_string).to eq("pgserver: complete")
+    end
 
-      subject.create
+    it "should not be complete if any statuses have issues" do
+      subject.pgserver = :complete
+      subject.pgclient = :waiting
     end
   end
 
-  context "with remote ca" do
+  context "#postgres server" do
     before do
-      subject.remote('otherhost', 'user')
+      subject.pgserver = true
     end
 
-    it "should know it is remote" do
-      expect(subject).not_to be_local
+    it "without ipa client should not install" do
+      ipa_configured(false)
+      expect { subject.activate }.to raise_error(ArgumentError, /ipa client/)
     end
+
+    it "should install postgres server" do
+      ipa_configured(true)
+      expect_run(/getcert/, anything, response) # getcert returns: the certificate already exist
+
+      ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
+        .and_return(double("config", :activate => true, :configure_postgres => true))
+      LinuxAdmin::Service.should_receive(:new).and_return(double("Service", :restart => true))
+      FileUtils.should_receive(:chmod).with(0644, anything)
+
+      subject.should_receive(:say)
+      subject.activate
+      expect(subject.pgserver).to eq(:complete)
+      expect(subject.status_string).to eq("pgserver: complete")
+      expect(subject).to be_complete
+    end
+
+    it "should not change postgres if service not responding" do
+      ipa_configured(true)
+      expect_run(/getcert/, anything, response(3)) # getcert returns: waiting on the CA
+
+      ApplianceConsole::InternalDatabaseConfiguration.should_not_receive(:new)
+      LinuxAdmin::Service.should_not_receive(:new)
+      subject.activate
+      expect(subject.pgserver).to eq(:waiting)
+      expect(subject.status_string).to eq("pgserver: waiting")
+      expect(subject).not_to be_complete
+    end
+  end
+
+  private
+
+  def ipa_configured(ipa_client_installed)
+    expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:ipa_client_configured?)
+      .and_return(ipa_client_installed)
+  end
+
+  def expect_not_run(cmd = nil, params = anything)
+    expect(AwesomeSpawn).not_to receive(:run).tap { |stmt| stmt.with(cmd, params) if cmd }
+  end
+
+  def expect_run(cmd, params, *responses)
+    expectation = receive(:run).and_return(*(responses.empty? ? response : responses))
+    if :none == params
+      expectation.with(cmd)
+    elsif params == anything || params == {}
+      expectation.with(cmd, params)
+    else
+      expectation.with(cmd, :params => params)
+    end
+    expect(AwesomeSpawn).to(expectation)
+  end
+
+  def response(ret_code = 0)
+    double("CommandResult", :success? => ret_code == 0, :failure? => ret_code != 0, :exit_status => ret_code)
   end
 end

--- a/lib/spec/appliance_console/certificate_spec.rb
+++ b/lib/spec/appliance_console/certificate_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+require "fileutils"
+require "appliance_console/certificate"
+
+RAILS_ROOT ||= File.expand_path("../../../vmdb", Pathname.new(__FILE__).realpath)
+
+describe ApplianceConsole::Certificate do
+  before { Open3.should_not_receive(:capture) }
+  let(:host)  { "client.network.com" }
+  let(:realm) { "NETWORK.COM" }
+  let(:service) { "postgres" }
+  let(:key_filename) { "/tmp/certs/filename.key" }
+  let(:cert_filename) { "/tmp/certs/filename.crt" }
+  let(:root_filename) { "/tmp/certs/root.crt" }
+
+  subject do
+    described_class.new(:ca_name       => 'ipa',
+                        :hostname      => host,
+                        :service       => service,
+                        :cert_filename => cert_filename)
+  end
+
+  it "should set proper realm" do
+    expect(subject.realm).to eq(realm)
+  end
+
+  # not sure if we care about this (it is probably allowing us to neglect )
+  it "should have a principal" do
+    expect(subject.principal.name).to eq("postgres/#{host}@#{realm}")
+    expect(subject.principal).to be_ipa
+  end
+
+  it "should go through all if smooth sailing with chown" do
+    subject.owner = "user.group"
+    expect_getcert_status(response(1), response(0))
+    expect_principal_register
+    expect_request
+    expect_chown
+    expect_chmod([cert_filename])
+
+    expect(subject.request).to be_complete
+    expect(subject.status).to eq(:complete)
+  end
+
+  it "should try again if key was rejected - and not complete if rejected again" do
+    subject.owner = "user.group"
+    expect_getcert_status(response(2), response(2))
+    expect_principal_register
+    expect_request_again
+
+    expect(subject.request).not_to be_complete
+    expect(subject.status).to eq(:rejected)
+  end
+
+  it "should only run complete block if keys already exist" do
+    expect_getcert_status(response)
+    expect_chmod([cert_filename])
+    yielded = false
+
+    subject.request { yielded = true }
+    expect(yielded).to eq(true)
+    expect(subject).to be_complete
+  end
+
+  # private methods
+
+  it "should create key filename from certificate" do
+    expect(subject.send(:key_filename)).to eq(key_filename)
+  end
+
+  private
+
+  def expect_run(cmd, params, *responses)
+    AwesomeSpawn.should_receive(:run).with(cmd, :params => params)
+      .and_return(*(responses.empty? ? response : responses))
+  end
+
+  def expect_principal_register
+    expect_run(/ipa/, anything)
+  end
+
+  def expect_request
+    expect_run(/getcert/, hash_including(nil => "request"))
+  end
+
+  def expect_request_again
+    expect_run(/getcert/, ["resubmit", "-w", "-f", cert_filename])
+  end
+
+  def expect_getcert_status(*responses)
+    expect_run(/getcert/, ["status", "-f", cert_filename], *responses)
+  end
+
+  def expect_chmod(files)
+    FileUtils.should_receive(:chmod).with(0644, files)
+  end
+
+  def expect_chown
+    FileUtils.should_receive(:chown).with("user", "group", key_filename)
+  end
+
+  def response(ret_code = 0)
+    double("CommandResult", :success? => ret_code == 0, :failure => ret_code != 0, :exit_status => ret_code)
+  end
+end

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -10,17 +10,18 @@ describe ApplianceConsole::Cli do
   it "should set hostname if defined" do
     ApplianceConsole::Env.should_receive(:[]=).with(:host, 'host1')
 
-    subject.parse(%w{--host host1}).run
+    subject.parse(%w(--host host1)).run
   end
 
   it "should not set hostname if none specified" do
     ApplianceConsole::Env.should_not_receive(:[]=).with(:host, anything)
 
-    subject.parse(%w{}).run
+    subject.parse([]).run
   end
 
   it "should set database host to localhost if running locally" do
     subject.should_receive(:disk_from_string).and_return('x')
+    subject.should_receive(:say)
     ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
       .with(:region      => 1,
             :database    => 'vmdb_production',
@@ -29,11 +30,12 @@ describe ApplianceConsole::Cli do
             :disk        => 'x')
       .and_return(double(:activate => true, :post_activation => true))
 
-    subject.parse(%w{--internal -r 1 --dbdisk x}).run
+    subject.parse(%w(--internal -r 1 --dbdisk x)).run
   end
 
   it "should pass username and password when configuring database locally" do
     subject.should_receive(:disk_from_string).and_return('x')
+    subject.should_receive(:say)
     ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
       .with(:region      => 1,
             :database    => 'vmdb_production',
@@ -41,12 +43,13 @@ describe ApplianceConsole::Cli do
             :password    => 'pass',
             :interactive => false,
             :disk        => 'x')
-      .and_return(stub(:activate => true, :post_activation => true))
+      .and_return(double(:activate => true, :post_activation => true))
 
     subject.parse(%w(--internal --username user --password pass -r 1 --dbdisk x)).run
   end
 
   it "should handle remote databases (and setup region)" do
+    subject.should_receive(:say)
     ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
       .with(:host        => 'host',
             :database    => 'db',
@@ -56,10 +59,11 @@ describe ApplianceConsole::Cli do
             :interactive => false)
       .and_return(double(:activate => true, :post_activation => true))
 
-    subject.parse(%w{--hostname host --dbname db --username user --password pass -r 1}).run
+    subject.parse(%w(--hostname host --dbname db --username user --password pass -r 1)).run
   end
 
   it "should handle remote databases (not setting up region)" do
+    subject.should_receive(:say)
     ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
       .with(:host        => 'host',
             :database    => 'db',
@@ -68,7 +72,91 @@ describe ApplianceConsole::Cli do
             :interactive => false)
       .and_return(double(:activate => true, :post_activation => true))
 
-    subject.parse(%w{--hostname host --dbname db --username user --password pass}).run
+    subject.parse(%w(--hostname host --dbname db --username user --password pass)).run
+  end
+
+  context "#ipa" do
+    it "should handle uninstalling ipa" do
+      subject.should_receive(:say)
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+        .and_return(double(:ipa_client_configured? => true, :ipa_client_unconfigure => nil))
+      subject.parse(%w(--uninstall-ipa)).run
+    end
+
+    it "should skip uninstalling ipa if not installed" do
+      subject.should_receive(:say)
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+        .and_return(double(:ipa_client_configured? => false))
+      subject.parse(%w(--uninstall-ipa)).run
+    end
+
+    it "should install ipa" do
+      ApplianceConsole::Env.should_receive(:[]).with("host").and_return('client.domain.com')
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+          .with('client.domain.com',
+                :ipaserver => 'ipa.domain.com',
+                :principal => 'admin',
+                :password  => 'pass').and_return(double(:activate => true, :post_activation => nil))
+      subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass)).run
+    end
+
+    it "should not post_activate install ipa (aside: testing passing in host" do
+      ApplianceConsole::Env.should_receive(:[]=).with(:host, "client.domain.com")
+      ApplianceConsole::Env.should_not_receive(:[]).with(:host)
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+          .with('client.domain.com',
+                :ipaserver => 'ipa.domain.com',
+                :principal => 'admin',
+                :password  => 'pass').and_return(double(:activate => false))
+      subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass --host client.domain.com)).run
+    end
+
+    it "should complain if installing ipa-client when ipa is already installed" do
+      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(true)
+      expect do
+        subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass)).run
+      end.to raise_error(/uninstall/)
+    end
+  end
+
+  context "#install_certs" do
+    it "should basic install completed (default ca_name, non verbose)" do
+      subject.should_receive(:say).with(/creating/)
+      ApplianceConsole::Env.should_receive(:[]).with("host").and_return('client.domain.com')
+      subject.should_receive(:say).with(/certificate result/)
+      subject.should_not_receive(:say).with(/rerun/)
+      ApplianceConsole::CertificateAuthority.should_receive(:new)
+        .with(
+          :hostname => "client.domain.com",
+          :ca_name  => "ipa",
+          :pgclient => true,
+          :pgserver => false,
+          :api      => true,
+          :verbose  => false,
+        ).and_return(double(:activate => true, :status_string => "good", :complete? => true))
+
+      subject.parse(%w(--postgres-client-cert --api-cert)).run
+    end
+
+    it "should basic install waiting (manual ca_name, verbose)" do
+      subject.should_receive(:say).with(/creating/)
+      ApplianceConsole::Env.should_receive(:[]).with("host").and_return('client.domain.com')
+      subject.should_receive(:say).with(/certificate result/)
+      subject.should_receive(:say).with(/rerun/)
+      ApplianceConsole::CertificateAuthority.should_receive(:new)
+        .with(
+          :hostname => "client.domain.com",
+          :ca_name  => "super",
+          :pgclient => false,
+          :pgserver => true,
+          :api      => false,
+          :verbose  => true,
+        ).and_return(double(:activate => true, :status_string => "good", :complete? => false))
+
+      subject.parse(%w(--postgres-server-cert --verbose --ca super)).run
+    end
   end
 
   context "parse" do
@@ -78,18 +166,18 @@ describe ApplianceConsole::Cli do
       end
 
       it "should have 'localhost' for internal databases" do
-        subject.parse(%w{--internal --region 1})
+        subject.parse(%w(--internal --region 1))
         expect(subject.hostname).to eq("localhost")
         expect(subject).to be_local
       end
 
       it "should be local (even if explicitly setting hostname" do
-        subject.parse(%w{--hostname localhost --region 1})
+        subject.parse(%w(--hostname localhost --region 1))
         expect(subject).to be_local
       end
 
       it "should respect parameter " do
-        subject.parse(%w{--hostname abc  --region 1})
+        subject.parse(%w(--hostname abc  --region 1))
         expect(subject.hostname).to eq("abc")
         expect(subject).not_to be_local
       end
@@ -105,42 +193,38 @@ describe ApplianceConsole::Cli do
       end
     end
 
-    context "#cahost" do
-      it "should ignore cahost if not setting up a ca" do
-        subject.parse(%w{--cahost x})
-        expect(subject.cahost).to be_blank
-      end
-
-      it "should default to localhost when setting up a ca" do
-        subject.parse(%w{--ca})
-        expect(subject.cahost).to eq("localhost")
-      end
-
-      it "should ignore cahost if not setting up a ca" do
-        subject.parse(%w{--ca --cahost x})
-        expect(subject.cahost).to eq("x")
-      end
-    end
-
     context "#key" do
       it "should setup a key if passing --key" do
         subject.parse(%w(--key))
         expect(subject).to be_key
       end
+    end
 
-      it "should setup key for localhost" do
-        subject.parse(%w(--ca))
-        expect(subject).to be_key
+    context "#ca" do
+      it "should default to ipa" do
+        expect(subject.parse(%w()).options[:ca]).to eq("ipa")
       end
 
-      it "should setup key for localhost" do
-        subject.parse(%w(--ca --cahost localhost))
-        expect(subject).to be_key
+      it "should support sneakernet" do
+        expect(subject.parse(%w(--ca sneakernet)).options[:ca]).to eq("sneakernet")
+      end
+    end
+
+    context "#certs?" do
+      it "should install certs if postgres client is specified" do
+        expect(subject.parse(%w(--postgres-client-cert))).to be_certs
       end
 
-      it "should not setup key for remote host" do
-        subject.parse(%w(--ca --cahost x))
-        expect(subject).not_to be_key
+      it "should install certs if postgres server is specified" do
+        expect(subject.parse(%w(--postgres-server-cert))).to be_certs
+      end
+
+      it "should install certs if a api is specified" do
+        expect(subject.parse(%w(--api-cert))).to be_certs
+      end
+
+      it "should install certs if all params are specified" do
+        expect(subject.parse(%w(--postgres-client-cert --postgres-server-cert --api-cert))).to be_certs
       end
     end
   end

--- a/lib/spec/appliance_console/principal_spec.rb
+++ b/lib/spec/appliance_console/principal_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require "appliance_console/principal"
+
+RAILS_ROOT ||= File.expand_path("../../../vmdb", Pathname.new(__FILE__).realpath)
+
+describe ApplianceConsole::Principal do
+  before { Open3.should_not_receive(:capture3) }
+  let(:hostname) { "machine.network.com" }
+  let(:realm)    { "NETWORK.COM" }
+  let(:service)  { "postgres" }
+  let(:principal_name) { "postgres/machine.network.com@NETWORK.COM" }
+
+  subject { described_class.new(:hostname => hostname, :realm => realm, :service => service) }
+
+  it { expect(subject.hostname).to eq(hostname) }
+  it { expect(subject.realm).to eq(realm) }
+  it { expect(subject.service).to eq(service) }
+
+  it { expect(subject.name).to eq(principal_name) }
+  it { expect(subject.subject_name).to match(/CN=#{hostname}.*O=#{realm}/) }
+  it { expect(subject).to be_ipa }
+
+  it "should register if not yet registered" do
+    expect_run(/ipa/, ["service-find", "--principal", principal_name], response(1))
+    expect_run(/ipa/, ["service-add", "--force", principal_name], response)
+
+    subject.register
+  end
+
+  it "should not register if already registered" do
+    expect_run(/ipa/, ["service-find", "--principal", principal_name], response)
+
+    subject.register
+  end
+
+  it "should not register if not ipa" do
+    subject.ca_name = "other"
+    subject.register
+  end
+
+  private
+
+  def expect_run(cmd, params, *responses)
+    AwesomeSpawn.should_receive(:run).with(cmd, :params => params)
+      .and_return(*(responses.empty? ? response : responses))
+  end
+
+  def response(ret_code = 0)
+    double("CommandResult", :success? => ret_code == 0, :failure => ret_code != 0, :exit_status => ret_code)
+  end
+end


### PR DESCRIPTION
This modifies our certificate authority to speak with ipa and certmonger.
- modifies cli to provide help when no parameters are available
- adds `--postgres-client-cert`, `--postgres-server-cert`, and `--api-cert`.

The switches speak with IdM/IPA to register a service principle and download a certificate. This leverages the ipa and kerberos. Hence additions were made to the kerberos `Principal`, ssl `Certificate`, the orchestrator `CertificateAuthority` and the `Cli` that handles the user input.

User Flow.
1. Install an appliance.
2. Configures database connectivity (or creates an internal database)
3. Install `ipa-client` either in `appliance_console` or `appliance_console_cli`.

From an ssh prompt, verify your kerberos credentials and install the certificates:

```
kinit
appliance_console_cli --postgres-client-cert --postgres-server-cert
```

An appliance with a database needs the `postgres-server-cert`, and an appliances without a database only need the `postgres-client-cert`. An appliance with replication needs both the client and the server cert.

split out of #204

https://bugzilla.redhat.com/show_bug.cgi?id=1130658
