### PR TITLE
Setup certmonger privileges

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -86,6 +86,11 @@ mod_authnz_pam
 mod_lookup_identity
 mod_lookup_identity-selinux      # Only needed for CentOS 6.5.  It will not be needed on CentOS 6.6 and later.
 
+# IPA RPMs for certificate support
+ipa-admintools
+certmonger
+sneakernet_ca
+
 # bundler has some downstream patches we need or shared objects are not found
 ruby193-rubygem-bundler
 ruby193-rubygem-net-http-persistent # bundler rpm dependency

--- a/system/COPY/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_ident.conf
+++ b/system/COPY/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_ident.conf
@@ -1,7 +1,4 @@
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
-sslmap          root                    root
-sslmap          root                    postgres
 # users can login as themselves
 usermap         /^(.*)$                 \1
-# root user can also login as user postgres
 usermap         root                    postgres

--- a/system/TEMPLATE/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf.erb
+++ b/system/TEMPLATE/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf.erb
@@ -1,4 +1,4 @@
 # TYPE  DATABASE USER  ADDRESS       METHOD
 local   all      all                 peer map=usermap
 <%= "#" if ssl%>host    all      all   all           md5
-<%= "#" unless ssl %>hostssl all      all   all           cert map=sslmap
+<%= "#" unless ssl %>hostssl all      all   all           md5

--- a/system/cfme-setup.sh
+++ b/system/cfme-setup.sh
@@ -38,6 +38,11 @@ EOF
 # relabel the pg_log directory in postgresql datadir, but defer restorecon
 # until after the database is initialized during firstboot configuration
 /usr/sbin/semanage fcontext -a -t var_log_t "/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log(/.*)?"
+# setup label for postgres client certs, but relabel after dir is created
+/usr/sbin/semanage fcontext -a -t cert_t "/root/.postgresql(/.*)?"
+# will remove this once app is no longer running as root
+/usr/sbin/semanage fcontext -a -t user_home_dir_t "/root(/)?"
+/sbin/restorecon /root
 
 # Copy the postgres template yml to database.yml if it doesn't exist
 db_yml="/var/www/miq/vmdb/config/database.yml"


### PR DESCRIPTION
- Install rpms necessary for certmonger.
- Tell database to use passwords when using ssl.
  (removing code that leverages client side certificates)
- setup privileges so certmonger can write to the certificate directories

https://bugzilla.redhat.com/show_bug.cgi?id=1130658

/cc/@jrafanie
