### PR TITLE
BZ 1114143 Added host provisioning cancel message when cancelled by the user

### DIFF
--- a/vmdb/app/controllers/application_controller/miq_request_methods.rb
+++ b/vmdb/app/controllers/application_controller/miq_request_methods.rb
@@ -186,7 +186,7 @@ module ApplicationController::MiqRequestMethods
   def prov_edit
     if params[:button] == "cancel"
       req = MiqRequest.find_by_id(from_cid(session[:edit][:req_id])) if session[:edit] && session[:edit][:req_id]
-      add_flash(req && req.id ? I18n.t("flash.edit.cancelled", :model=>"#{session[:edit][:prov_type]} Request", :name=>req.description) : I18n.t("flash.add.cancelled", :model=>"#{session[:edit][:prov_type]} Request"))
+      add_flash(req && req.id ? I18n.t("flash.edit.cancelled", :model=>"#{session[:edit][:prov_type]} Request", :name=>req.description) : I18n.t("flash.provision.cancelled", :model=>"#{session[:edit][:prov_type]} Request"))
       session[:flash_msgs] = @flash_array.dup unless session[:edit][:explorer]  # Put msg in session for next transaction to display
       @explorer = session[:edit][:explorer] ? session[:edit][:explorer] : false
       @edit = session[:edit] =  nil                                               # Clear out session[:edit]

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -244,6 +244,9 @@ en:
       export_generation_error: "Export generation returned: Status [%{status}] Message [%{message}]"
       tags_saved: "Tag edits were successfully saved"
 
+    provision: 
+      cancelled: "Provision %{model} was cancelled by the user"
+
     policy:
       alert_profile_assignments_saved: 'Alert Profile "%{name}" assignments succesfully saved'
       task_cancelled_by_user: "%{task} cancelled by user"


### PR DESCRIPTION
If a user canceled a host provision request the user was presented with "Add of new Host Request was cancelled by the user" created a new message for the host provision cancel action "Provision Host Request was cancelled by the user".

https://bugzilla.redhat.com/show_bug.cgi?id=1114143
