### PR TITLE
BZ 1105342 Corrected the hover text for host's cluster from vm's to host's

### DIFF
--- a/vmdb/app/helpers/host_helper/textual_summary.rb
+++ b/vmdb/app/helpers/host_helper/textual_summary.rb
@@ -218,7 +218,7 @@ module HostHelper::TextualSummary
     cluster = @record.ems_cluster
     h = {:label => "Cluster", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
     if cluster && role_allows(:feature => "ems_cluster_show")
-      h[:title] = "Show this VM's Cluster"
+      h[:title] = "Show this Host's Cluster"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h


### PR DESCRIPTION
Fixed the incorrect hover text that is shown for 'Cluster' in the Relationships section on host summary page.

https://bugzilla.redhat.com/show_bug.cgi?id=1105342
