### PR TITLE
Prevent browser from autofilling form information

### DIFF
--- a/vmdb/app/views/ops/_rbac_user_details.html.erb
+++ b/vmdb/app/views/ops/_rbac_user_details.html.erb
@@ -20,6 +20,7 @@
           <% else %>
             <%= text_field_tag("name",
                               @edit[:new][:name],
+                              :autocomplete => 'off',
                               :maxlength=>50,
                               :disabled=>disabled,
                               "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
@@ -37,6 +38,7 @@
           <% else %>
             <%= text_field_tag("userid",
                               @edit[:new][:userid],
+                              :autocomplete => 'off',
                               :maxlength=>50,
                               :disabled=>disabled,
                               "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
@@ -72,6 +74,7 @@
           <% else %>
             <%= text_field_tag("email",
                                 @edit[:new][:email],
+                                :autocomplete => 'off',
                                 :maxlength=>50,
                                 "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
           <% end %>


### PR DESCRIPTION
Implemented fix for all text entry fields on this form to prevent unexpected results for the user.

https://bugzilla.redhat.com/show_bug.cgi?id=1124052
