### PR TITLE
To avoid noisy output, use StringIO instead of STDOUT for logging.

### DIFF
--- a/lib/spec/util/duplicate_blocker_spec.rb
+++ b/lib/spec/util/duplicate_blocker_spec.rb
@@ -24,7 +24,8 @@ describe DuplicateBlocker do
       end
 
       dedup_handler do |handler|
-        handler.logger              = Logger.new(STDOUT)
+        require 'stringio'
+        handler.logger              = Logger.new(StringIO.new)
         handler.duplicate_threshold = THRESHOLD
         handler.duplicate_window    = TIME_WINDOW
         handler.window_slot_width   = SLOT_WIDTH


### PR DESCRIPTION
#### Before

```
bundle exec rspec spec/util/duplicate_blocker_spec.rb -f p
W, [2014-08-18T16:57:58.103542 #24990]  WARN -- : Breaker for .target_method with arguments ["arg"] is tripped. Further calls are blocked.
D, [2014-08-18T16:57:58.103542 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
.W, [2014-08-18T16:57:58.106559 #24990]  WARN -- : Breaker for .target_class_method with arguments ["arg"] is tripped. Further calls are blocked.
D, [2014-08-18T16:57:58.106559 #24990] DEBUG -- : .target_class_method with arguments ["arg"] is blocked because it is duplicated.
..W, [2014-08-18T16:57:58.111936 #24990]  WARN -- : Breaker for .target_method with arguments ["arg"] is tripped. Further calls are blocked.
D, [2014-08-18T16:57:58.111936 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.113241 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
I, [2014-08-18T16:57:58.140468 #24990]  INFO -- : Tripped condition for .target_method with arguments ["arg"] is now reset. Total 2 calls were blocked.
..W, [2014-08-18T16:57:58.118401 #24990]  WARN -- : Breaker for .target_method with arguments ["arg"] is tripped. Further calls are blocked.
D, [2014-08-18T16:57:58.118401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.119401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.120401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.121401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.122401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.123401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
D, [2014-08-18T16:57:58.124401 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
.W, [2014-08-18T16:57:58.122227 #24990]  WARN -- : Breaker for .target_method with arguments ["arg"] is tripped. Further calls are blocked.
D, [2014-08-18T16:57:58.122227 #24990] DEBUG -- : .target_method with arguments ["arg"] is blocked because it is duplicated.
.W, [2014-08-18T16:57:58.123866 #24990]  WARN -- : Breaker for call with redefined user key is tripped. Further calls are blocked.
D, [2014-08-18T16:57:58.123866 #24990] DEBUG -- : call with redefined user key is blocked because it is duplicated.
..
```
#### After

```
bundle exec rspec spec/util/duplicate_blocker_spec.rb -f p
..........
```
