### PR TITLE
Add backend method vm_reconfigure on RHEV.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1080,19 +1080,19 @@ module ApplicationController::CiProcessing
   # Build the ownership assignment screen
   def reconfigure_build_screen
     @reconfigureitems = Vm.find(@edit[:reconfigure_items]).sort_by(&:name)  # Get the db records that are being tagged
+    set_memory_cpu
     if !@edit[:req_id]
-      set_memory_cpu
       @edit[:new][:memory] = @edit[:new][:old_memory]
       @edit[:new][:mem_typ] = @edit[:new][:old_mem_typ]
     else
       @req = MiqRequest.find_by_id(@edit[:req_id])
       @edit[:new][:memory], @edit[:new][:mem_typ] = reconfigure_calculations(@req.options[:vm_memory]) if @req.options[:vm_memory]
-      @edit[:new][:cpu_count] = @req.options[:number_of_sockets]
-      @edit[:new][:cores_per_socket_count] = @req.options[:cores_per_socket]
+      @edit[:new][:cores_per_socket_count] = @req.options[:cores_per_socket] if @req.options[:cores_per_socket]
+      @edit[:new][:cpu_count] = @req.options[:number_of_cpus] / @edit[:new][:cores_per_socket_count] if @req.options[:number_of_cpus]
     end
 
     @edit[:new][:cb_memory] = @req && @req.options[:vm_memory] ? true : false       # default for checkbox is false for new request
-    @edit[:new][:cb_cpu] = @req && @req.options[:number_of_sockets] ? true : false     # default for checkbox is false for new request
+    @edit[:new][:cb_cpu] = @req && @req.options[:number_of_cpus] ? true : false     # default for checkbox is false for new request
     @edit[:new][:cb_cores_per_socket] = @req && @req.options[:cores_per_socket] ? true : false     # default for checkbox is false for new request
 
     @edit[:options] = VmReconfigureRequest.request_limits(:src_ids => @edit[:reconfigure_items])

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -425,7 +425,7 @@ module ApplicationController::CiProcessing
       end
 
       if @edit[:new][:cb_cpu] && @edit[:new][:old_cpu_count].to_s == @edit[:new][:cpu_count].to_s
-        add_flash(_("Change %s value to submit reconfigure request") % "Processors", :error)
+        add_flash(_("Change %s value to submit reconfigure request") % "Processor Sockets", :error)
       end
 
       if @edit[:new][:cb_cores_per_socket] && @edit[:new][:old_cores_per_socket_count].to_s == @edit[:new][:cores_per_socket_count].to_s

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -370,22 +370,13 @@ module ApplicationController::CiProcessing
       if @edit[:new][:cb_cpu]
         page << javascript_show("cpu_div")
       else
-        @edit[:new][:cpu_count] = @edit[:new][:old_cpu_count]
-        page << "$('#cpu_count').val('#{@edit[:new][:cpu_count]}');"
         page << javascript_hide("cpu_div")
-      end
-      if @edit[:new][:cb_cores_per_socket]
-        page << javascript_show("cores_div")
-      else
-        @edit[:new][:cores_per_socket_count] = @edit[:new][:old_cores_per_socket_count]
-        page << "$('#cores_per_socket_count').val('#{@edit[:new][:cores_per_socket_count]}');"
-        page << javascript_hide("cores_div")
       end
 
       @vccores = @edit[:new][:cores_per_socket_count].nil? ? 1 : @edit[:new][:cores_per_socket_count]
-      @vcpus = @edit[:new][:cpu_count].nil? ? 1 : @edit[:new][:cpu_count]
+      @vsockets = @edit[:new][:socket_count].nil? ? 1 : @edit[:new][:socket_count]
 
-      @total_cpus = @vccores.to_i * @vcpus.to_i
+      @total_cpus = @vccores.to_i * @vsockets.to_i
       page << "$('#total_cpus').val('#{@total_cpus}');"
     end
   end
@@ -406,7 +397,7 @@ module ApplicationController::CiProcessing
         end
       end
     when "submit"
-      if !@edit[:new][:cb_cpu] && !@edit[:new][:cb_memory] && !@edit[:new][:cb_cores_per_socket]
+      if !@edit[:new][:cb_cpu] && !@edit[:new][:cb_memory]
         add_flash(_("At least one option must be selected to reconfigure"), :error)
         render :update do |page|
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
@@ -424,12 +415,8 @@ module ApplicationController::CiProcessing
         end
       end
 
-      if @edit[:new][:cb_cpu] && @edit[:new][:old_cpu_count].to_s == @edit[:new][:cpu_count].to_s
-        add_flash(_("Change %s value to submit reconfigure request") % "Processor Sockets", :error)
-      end
-
-      if @edit[:new][:cb_cores_per_socket] && @edit[:new][:old_cores_per_socket_count].to_s == @edit[:new][:cores_per_socket_count].to_s
-        add_flash(_("Change %s value to submit reconfigure request") % "Cores Per Socket", :error)
+      if @edit[:new][:cb_cpu] && @edit[:new][:old_socket_count].to_s == @edit[:new][:socket_count].to_s && @edit[:new][:old_cores_per_socket_count].to_s == @edit[:new][:cores_per_socket_count].to_s
+        add_flash(_("Change %s value to submit reconfigure request") % "Processor Sockets or Cores Per Socket", :error)
       end
 
       if @flash_array
@@ -444,9 +431,15 @@ module ApplicationController::CiProcessing
       }
       # Convert memory to MB before passing on to model, don't multiply by 1024, if value is not numeric
       options[:vm_memory] = @edit[:new][:mem_typ] == "MB" ? @edit[:new][:memory] : (@edit[:new][:memory].to_i.zero? ? @edit[:new][:memory] : @edit[:new][:memory].to_i * 1024) if @edit[:new][:cb_memory]
-      options[:cores_per_socket]  = @edit[:new][:cores_per_socket_count].to_i if @edit[:new][:cb_cores_per_socket]
-      options[:number_of_cpus]    = @edit[:new][:cpu_count].to_i * @edit[:new][:cores_per_socket_count].to_i if @edit[:new][:cb_cpu] || @edit[:new][:cb_cores_per_socket]
-      valid = VmReconfigureRequest.validate_request(options)
+      if @edit[:new][:cb_cpu]
+        options[:cores_per_socket]  = @edit[:new][:cores_per_socket_count].nil? ? 1 : @edit[:new][:cores_per_socket_count].to_i
+        options[:number_of_sockets] =@edit[:new][:socket_count].nil? ? 1 : @edit[:new][:socket_count].to_i
+        vccores = @edit[:new][:cores_per_socket_count].nil? ? 1 : @edit[:new][:cores_per_socket_count]
+        vsockets = @edit[:new][:socket_count].nil? ? 1 : @edit[:new][:socket_count]
+        options[:number_of_cpus]    = vccores.to_i * vsockets.to_i
+      end
+
+        valid = VmReconfigureRequest.validate_request(options)
       if valid
         valid.each do |v|
           add_flash(v, :error)
@@ -1066,44 +1059,43 @@ module ApplicationController::CiProcessing
     memory = @reconfigureitems.first.mem_cpu
     memory = nil unless @reconfigureitems.all? { |vm| vm.mem_cpu == memory }
 
-    cpu_count = @reconfigureitems.first.logical_cpus
-    cpu_count = nil unless @reconfigureitems.all? { |vm| vm.logical_cpus == cpu_count }
+    socket_count = @reconfigureitems.first.num_cpu
+    socket_count = nil unless @reconfigureitems.all? { |vm| vm.num_cpu == socket_count }
 
     cores_per_socket = @reconfigureitems.first.cores_per_socket
     cores_per_socket = nil unless @reconfigureitems.all? { |vm| vm.cores_per_socket == cores_per_socket }
 
     @edit[:new][:old_memory], @edit[:new][:old_mem_typ] = reconfigure_calculations(memory)
-    @edit[:new][:old_cpu_count] = @edit[:new][:cpu_count] = cpu_count
+    @edit[:new][:old_socket_count] = @edit[:new][:socket_count] = socket_count
     @edit[:new][:old_cores_per_socket_count] = @edit[:new][:cores_per_socket_count] = cores_per_socket
   end
 
   # Build the ownership assignment screen
   def reconfigure_build_screen
     @reconfigureitems = Vm.find(@edit[:reconfigure_items]).sort_by(&:name)  # Get the db records that are being tagged
-    set_memory_cpu
     if !@edit[:req_id]
+      set_memory_cpu
       @edit[:new][:memory] = @edit[:new][:old_memory]
       @edit[:new][:mem_typ] = @edit[:new][:old_mem_typ]
     else
       @req = MiqRequest.find_by_id(@edit[:req_id])
       @edit[:new][:memory], @edit[:new][:mem_typ] = reconfigure_calculations(@req.options[:vm_memory]) if @req.options[:vm_memory]
       @edit[:new][:cores_per_socket_count] = @req.options[:cores_per_socket] if @req.options[:cores_per_socket]
-      @edit[:new][:cpu_count] = @req.options[:number_of_cpus] / @edit[:new][:cores_per_socket_count] if @req.options[:number_of_cpus]
+      @edit[:new][:socket_count] = @req.options[:number_of_sockets] if @req.options[:number_of_sockets]
     end
 
     @edit[:new][:cb_memory] = @req && @req.options[:vm_memory] ? true : false       # default for checkbox is false for new request
-    @edit[:new][:cb_cpu] = @req && @req.options[:number_of_cpus] ? true : false     # default for checkbox is false for new request
-    @edit[:new][:cb_cores_per_socket] = @req && @req.options[:cores_per_socket] ? true : false     # default for checkbox is false for new request
+    @edit[:new][:cb_cpu] = @req && ( @req.options[:number_of_sockets] || @req.options[:cores_per_socket]) ? true : false     # default for checkbox is false for new request
 
     @edit[:options] = VmReconfigureRequest.request_limits(:src_ids => @edit[:reconfigure_items])
     mem1, fmt1 = reconfigure_calculations(@edit[:options][:min__vm_memory])
     mem2, fmt2 = reconfigure_calculations(@edit[:options][:max__vm_memory])
     @edit[:memory_note] = "Between #{mem1}#{fmt1} and #{mem2}#{fmt2}"
 
-    @edit[:cpu_options] = Array.new
+    @edit[:socket_options] = Array.new
     @edit[:options][:max__number_of_sockets].times do |tidx|
       idx = tidx + @edit[:options][:min__number_of_sockets]
-      @edit[:cpu_options].push(idx) if idx <= @edit[:options][:max__number_of_sockets]
+      @edit[:socket_options].push(idx) if idx <= @edit[:options][:max__number_of_sockets]
     end
 
     @edit[:cores_options] = []
@@ -1130,10 +1122,9 @@ module ApplicationController::CiProcessing
   def reconfigure_get_form_vars
     @edit[:new][:cb_memory] = params[:cb_memory] == "1" if params[:cb_memory]
     @edit[:new][:cb_cpu] = params[:cb_cpu] == "1" if params[:cb_cpu]
-    @edit[:new][:cb_cores_per_socket] = params[:cb_cores_per_socket] == "1" if params[:cb_cores_per_socket]
     @edit[:new][:mem_typ] = params[:mem_typ] if params[:mem_typ]
     @edit[:new][:memory] = params[:memory] if params[:memory]
-    @edit[:new][:cpu_count] = params[:cpu_count] if params[:cpu_count]
+    @edit[:new][:socket_count] = params[:socket_count] if params[:socket_count]
     @edit[:new][:cores_per_socket_count] = params[:cores_per_socket_count] if params[:cores_per_socket_count]
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -188,4 +188,21 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
     @version_3_0
   end
+
+  def vm_reconfigure(vm, options = {})
+    log_header = "EMS: [#{name}] #{vm.class.name}: id [#{vm.id}], name [#{vm.name}], ems_ref [#{vm.ems_ref}]"
+    spec       = options[:spec]
+
+    vm.with_provider_object do |rhevm_vm|
+      _log.info("#{log_header} Started...")
+      rhevm_vm.memory = spec["memoryMB"] * 1.megabyte   if spec["memoryMB"]
+
+      cpu_options = {}
+      cpu_options[:cores]   = spec["numCoresPerSocket"] if spec["numCoresPerSocket"]
+      cpu_options[:sockets] = spec["numCPUs"] / (cpu_options[:cores] || vm.cores_per_socket) if spec["numCPUs"]
+
+      rhevm_vm.cpu_topology = cpu_options if cpu_options.present?
+    end
+    _log.info("#{log_header} Completed.")
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -47,4 +47,28 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   def validate_smartstate_analysis
     validate_supported
   end
+
+  # Show Reconfigure VM task
+  def reconfigurable?
+    true
+  end
+
+  def max_total_vcpus
+    # the default value of MaxNumOfVmCpusTotal for RHEV 3.1 - 3.4
+    160
+  end
+
+  def max_cores_per_socket
+    # the default value of MaxNumOfCpuPerSocket for RHEV 3.1 - 3.4
+    16
+  end
+
+  def max_vcpus
+    # the default value of MaxNumofVmSockets for RHEV 3.1 - 3.4
+    16
+  end
+
+  def max_memory_cpu
+    2.terabyte / 1.megabyte
+  end
 end

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -10,33 +10,34 @@ class VmReconfigureRequest < MiqRequest
     # Memory values are in megabytes
     default_max_vm_memory = 255.gigabyte / 1.megabyte
     result = {
-      :min__number_of_cpus   => 1,
-      :max__number_of_cpus   => nil,
-      :min__vm_memory        => 4,
-      :max__vm_memory        => nil,
-      :min__cores_per_socket => 1,
-      :max__cores_per_socket => nil,
-      :max__total_vcpus      => nil
+      :min__number_of_sockets => 1,
+      :max__number_of_sockets => nil,
+      :min__vm_memory         => 4,
+      :max__vm_memory         => nil,
+      :min__cores_per_socket  => 1,
+      :max__cores_per_socket  => nil,
+      :min__total_vcpus       => 1,
+      :max__total_vcpus       => nil
     }
 
     all_memory, all_vcpus, all_cores_per_socket, all_total_vcpus = [], [], [], []
     options[:src_ids].to_miq_a.each do |idx|
       vm = Vm.find_by_id(idx)
-      all_vcpus << (vm.host ? vm.host.hardware.logical_cpus : vm.max_vcpus)
+      all_vcpus            << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_vcpus].min : vm.max_vcpus)
+      all_cores_per_socket << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_cores_per_socket].min : vm.max_cores_per_socket)
+      all_total_vcpus      << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_total_vcpus].min : vm.max_total_vcpus)
       all_memory << (vm.respond_to?(:max_memory_cpu) ? vm.max_memory_cpu : default_max_vm_memory)
-      all_cores_per_socket << vm.max_cores_per_socket
-      all_total_vcpus << vm.max_total_vcpus
     end
 
-    result[:max__number_of_cpus] = all_vcpus.min
+    result[:max__number_of_sockets] = all_vcpus.min
     result[:max__vm_memory]      = all_memory.min
     result[:max__cores_per_socket] = all_cores_per_socket.min
     result[:max__total_vcpus] = all_total_vcpus.min
 
-    result[:max__number_of_cpus] = 1 if result[:max__number_of_cpus].nil?
+    result[:max__number_of_sockets] = 1 if result[:max__number_of_sockets].nil?
     result[:max__cores_per_socket] = 1 if result[:max__cores_per_socket].nil?
     result[:max__vm_memory] ||= default_max_vm_memory
-    result[:max__total_vcpus] = 1 if result[:max__number_of_cpus].nil? && result[:max__cores_per_socket].nil?
+    result[:max__total_vcpus] = 1 if result[:max__number_of_sockets].nil? && result[:max__cores_per_socket].nil?
     result
   end
 
@@ -54,11 +55,11 @@ class VmReconfigureRequest < MiqRequest
     end
 
     # Check if cpu value is within the allowed limits
-    cpus = options[:number_of_cpus]
+    cpus = options[:number_of_sockets]
     unless cpus.blank?
       cpus = cpus.to_i
-      errors << "Processor value must be less than #{limits[:max__number_of_cpus]}.  Current value: #{cpus}"    if cpus > limits[:max__number_of_cpus]
-      errors << "Processor value must be greater than #{limits[:min__number_of_cpus]}.  Current value: #{cpus}" if cpus < limits[:min__number_of_cpus]
+      errors << "Processor value must be less than #{limits[:max__number_of_sockets]}.  Current value: #{cpus}"    if cpus > limits[:max__number_of_sockets]
+      errors << "Processor value must be greater than #{limits[:min__number_of_sockets]}.  Current value: #{cpus}" if cpus < limits[:min__number_of_sockets]
     end
 
     # Check if cpu value is within the allowed limits

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -29,7 +29,7 @@ class VmReconfigureTask < MiqRequestTask
     unless req_obj.options[:vm_memory].blank?
       new_settings << "Memory: #{req_obj.options[:vm_memory].to_i} MB"
     end
-    new_settings << "Processor Sockets #{req_obj.options[:number_of_cpus].to_i}" unless req_obj.options[:number_of_cpus].blank?
+    new_settings << "Processor Sockets #{req_obj.options[:number_of_sockets].to_i}" unless req_obj.options[:number_of_cpus].blank?
     new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" unless req_obj.options[:cores_per_socket].blank?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -29,8 +29,9 @@ class VmReconfigureTask < MiqRequestTask
     unless req_obj.options[:vm_memory].blank?
       new_settings << "Memory: #{req_obj.options[:vm_memory].to_i} MB"
     end
-    new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" unless req_obj.options[:number_of_cpus].blank?
+    new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" unless req_obj.options[:number_of_sockets].blank?
     new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" unless req_obj.options[:cores_per_socket].blank?
+    new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" unless req_obj.options[:number_of_cpus].blank?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end
 

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -29,7 +29,7 @@ class VmReconfigureTask < MiqRequestTask
     unless req_obj.options[:vm_memory].blank?
       new_settings << "Memory: #{req_obj.options[:vm_memory].to_i} MB"
     end
-    new_settings << "Processor Sockets #{req_obj.options[:number_of_sockets].to_i}" unless req_obj.options[:number_of_cpus].blank?
+    new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" unless req_obj.options[:number_of_cpus].blank?
     new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" unless req_obj.options[:cores_per_socket].blank?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end

--- a/app/views/miq_request/_reconfigure_show.html.haml
+++ b/app/views/miq_request/_reconfigure_show.html.haml
@@ -13,7 +13,7 @@
       - if @options[:number_of_cpus]
         %tr
           %td.key
-            = _("Processor Sockets")
+            = _("Total Processors")
           %td
             = h(@options[:number_of_cpus])
       - if @options[:cores_per_socket]

--- a/app/views/miq_request/_reconfigure_show.html.haml
+++ b/app/views/miq_request/_reconfigure_show.html.haml
@@ -10,18 +10,25 @@
             = h(@options[:vm_memory])
             &nbsp;
             = @options[:mem_typ]
-      - if @options[:number_of_cpus]
+      - if @options[:number_of_sockets]
         %tr
           %td.key
-            = _("Total Processors")
+            = _("Processor Sockets")
           %td
-            = h(@options[:number_of_cpus])
+            = h(@options[:number_of_sockets])
       - if @options[:cores_per_socket]
         %tr
           %td.key
             = _("Processor Cores_Per_Socket")
           %td
             = h(@options[:cores_per_socket])
+      - if @options[:number_of_cpus]
+        %tr
+          %td.key
+            = _("Total Processors")
+          %td
+            = h(@options[:number_of_cpus])
+
   %fieldset
     %h3
       = _("Affected VMs")

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -33,9 +33,10 @@
             miqInitSelectPicker();
             miqSelectPickerEvent("mem_typ", "#{url}")
           (#{@edit[:memory_note]})
+
     .form-group
       %label.col-md-2.control-label
-        = _('Processor Sockets')
+        = _('Processors')
       .col-md-1
         = check_box_tag("cb_cpu",
                           1,
@@ -43,59 +44,53 @@
                           "data-miq_sparkle_on" => true,
                           "data-miq_sparkle_off" => true,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-      .col-md-4
+      .col-md-12.control-label
+        &nbsp;
+        .form-group
         - display = @edit[:new][:cb_cpu] ? "" : "display:none"
         #cpu_div{:style => display}
-          - if @edit[:cpu_options].length > 1
-            = select_tag("cpu_count",
-                          options_for_select((@edit[:new][:cpu_count].nil? ? [["<#{_('Choose')}>", nil]] : []) + @edit[:cpu_options], @edit[:new][:cpu_count].to_i),
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :class    => "selectpicker")
-            :javascript
-              miqInitSelectPicker();
-              miqSelectPickerEvent("cpu_count", "#{url}")
-          - else
-            = @edit[:cpu_options][0]
+          .form-group
+            %label.col-sm-offset-1.col-sm-2.control-label
+              = _('Sockets')
+            .col-md-4
+              - if @edit[:socket_options].length > 1
+                = select_tag("socket_count",
+                              options_for_select((@edit[:new][:socket_count].nil? ? [["<#{_('Choose')}>", nil]] : []) + @edit[:socket_options], @edit[:new][:socket_count].to_i),
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              :class    => "selectpicker")
+                :javascript
+                  miqInitSelectPicker();
+                  miqSelectPickerEvent("socket_count", "#{url}")
+              - else
+                = @edit[:socket_options][0]
 
-    - if @edit[:cores_options].length > 1
-      .form-group
-        %label.col-md-2.control-label
-          = _('Processor Cores Per socket')
-        .col-md-1
-          = check_box_tag("cb_cores_per_socket",
-                          1,
-                          @edit[:new][:cb_cores_per_socket],
-                          "data-miq_sparkle_on" => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
-
-        .col-md-4
-          - display = @edit[:new][:cb_cores_per_socket] ? "" : "display:none"
-          #cores_div{:style => display}
+          .form-group
             - if @edit[:cores_options].length > 1
-              = select_tag("cores_per_socket_count",
-                           options_for_select((@edit[:new][:cores_per_socket_count].nil? ? [["<#{_('Choose')}>",nil]] : []) + @edit[:cores_options],
-                           @edit[:new][:cores_per_socket_count].to_i),
-                           "data-miq_sparkle_on"  => true,
-                           "data-miq_sparkle_off" => true,
-                           :class                 => "selectpicker")
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent("cores_per_socket_count", "#{url}")
-            - else
-              = @edit[:cores_options][0]
-
-      .form-group
-        %label.col-md-2.control-label
-          = _('Total Processors')
-        .col-md-8
-          = text_field_tag("total_cpus",
-                            @edit[:new][:cpu_count].to_i * (@edit[:new][:cores_per_socket_count].to_i > 0 ? @edit[:new][:cores_per_socket_count].to_i : 1),
-                            :maxlength => MAX_NAME_LEN,
-                            :class            => "form-control",
-                            :readonly => '',
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+              %label.col-md-offset-1.col-md-2.control-label
+                = _('Cores Per socket')
+              .col-md-4
+                - if @edit[:cores_options].length > 1
+                  = select_tag("cores_per_socket_count",
+                               options_for_select((@edit[:new][:cores_per_socket_count].nil? ? [["<#{_('Choose')}>",nil]] : []) + @edit[:cores_options], @edit[:new][:cores_per_socket_count].to_i),
+                               "data-miq_sparkle_on"  => true,
+                               "data-miq_sparkle_off" => true,
+                               :class                 => "selectpicker")
+                  :javascript
+                    miqInitSelectPicker();
+                    miqSelectPickerEvent("cores_per_socket_count", "#{url}")
+                - else
+                  = @edit[:cores_options][0]
+          .form-group
+            - if @edit[:cores_options].length > 1
+              %label.col-md-offset-1.col-md-2.control-label
+                = _('Total Processors')
+              .col-md-4
+                = text_field_tag("total_cpus",
+                                  @edit[:new][:socket_count].to_i * (@edit[:new][:cores_per_socket_count].to_i > 0 ? @edit[:new][:cores_per_socket_count].to_i : 1),
+                                  :class            => "form-control",
+                                  :readonly => '',
+                                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
   - if !@edit[:explorer]
     #buttons_div

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -44,53 +44,53 @@
                           "data-miq_sparkle_on" => true,
                           "data-miq_sparkle_off" => true,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-      .col-md-12.control-label
-        &nbsp;
-        .form-group
-        - display = @edit[:new][:cb_cpu] ? "" : "display:none"
-        #cpu_div{:style => display}
-          .form-group
-            %label.col-sm-offset-1.col-sm-2.control-label
-              = _('Sockets')
-            .col-md-4
-              - if @edit[:socket_options].length > 1
-                = select_tag("socket_count",
-                              options_for_select((@edit[:new][:socket_count].nil? ? [["<#{_('Choose')}>", nil]] : []) + @edit[:socket_options], @edit[:new][:socket_count].to_i),
-                              "data-miq_sparkle_on"  => true,
-                              "data-miq_sparkle_off" => true,
-                              :class    => "selectpicker")
-                :javascript
-                  miqInitSelectPicker();
-                  miqSelectPickerEvent("socket_count", "#{url}")
-              - else
-                = @edit[:socket_options][0]
+    - display = @edit[:new][:cb_cpu] ? "" : "display:none"
+    #cpu_div{:style => display}
+      %hr
+      %h3
+        = _('Processor Options')
+      .form-group
+        %label.col-sm-2.control-label
+          = _('Sockets')
+        .col-md-4
+          - if @edit[:socket_options].length > 1
+            = select_tag("socket_count",
+                          options_for_select((@edit[:new][:socket_count].nil? ? [["<#{_('Choose')}>", nil]] : []) + @edit[:socket_options], @edit[:new][:socket_count].to_i),
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("socket_count", "#{url}")
+          - else
+            = @edit[:socket_options][0]
 
-          .form-group
+      .form-group
+        - if @edit[:cores_options].length > 1
+          %label.col-md-2.control-label
+            = _('Cores Per socket')
+          .col-md-4
             - if @edit[:cores_options].length > 1
-              %label.col-md-offset-1.col-md-2.control-label
-                = _('Cores Per socket')
-              .col-md-4
-                - if @edit[:cores_options].length > 1
-                  = select_tag("cores_per_socket_count",
-                               options_for_select((@edit[:new][:cores_per_socket_count].nil? ? [["<#{_('Choose')}>",nil]] : []) + @edit[:cores_options], @edit[:new][:cores_per_socket_count].to_i),
-                               "data-miq_sparkle_on"  => true,
-                               "data-miq_sparkle_off" => true,
-                               :class                 => "selectpicker")
-                  :javascript
-                    miqInitSelectPicker();
-                    miqSelectPickerEvent("cores_per_socket_count", "#{url}")
-                - else
-                  = @edit[:cores_options][0]
-          .form-group
-            - if @edit[:cores_options].length > 1
-              %label.col-md-offset-1.col-md-2.control-label
-                = _('Total Processors')
-              .col-md-4
-                = text_field_tag("total_cpus",
-                                  @edit[:new][:socket_count].to_i * (@edit[:new][:cores_per_socket_count].to_i > 0 ? @edit[:new][:cores_per_socket_count].to_i : 1),
-                                  :class            => "form-control",
-                                  :readonly => '',
-                                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+              = select_tag("cores_per_socket_count",
+                           options_for_select((@edit[:new][:cores_per_socket_count].nil? ? [["<#{_('Choose')}>",nil]] : []) + @edit[:cores_options], @edit[:new][:cores_per_socket_count].to_i),
+                           "data-miq_sparkle_on"  => true,
+                           "data-miq_sparkle_off" => true,
+                           :class                 => "selectpicker")
+              :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent("cores_per_socket_count", "#{url}")
+            - else
+              = @edit[:cores_options][0]
+      .form-group
+        - if @edit[:cores_options].length > 1
+          %label.col-md-2.control-label
+            = _('Total Processors')
+          .col-md-4
+            = text_field_tag("total_cpus",
+                              @edit[:new][:socket_count].to_i * (@edit[:new][:cores_per_socket_count].to_i > 0 ? @edit[:new][:cores_per_socket_count].to_i : 1),
+                              :class            => "form-control",
+                              :readonly => '',
+                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
   - if !@edit[:explorer]
     #buttons_div

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -77,7 +77,7 @@ describe ApplicationController do
       edit_new = assigns(:edit)[:new]
       edit_new[:old_memory].should == ""
       edit_new[:old_mem_typ].should == "MB"
-      edit_new[:old_cpu_count] == 1
+      edit_new[:old_socket_count] == 1
     end
 
     it "set_memory_cpu should use vms value to set old values when both vms have same memory/cpu values" do
@@ -91,7 +91,7 @@ describe ApplicationController do
       edit_new = assigns(:edit)[:new]
       edit_new[:old_memory].should == "2"
       edit_new[:old_mem_typ].should == "GB"
-      edit_new[:old_cpu_count] == 2
+      edit_new[:old_socket_count] == 2
     end
 
     it "check reconfigure_calculations returns memory in string format" do
@@ -151,11 +151,10 @@ describe ApplicationController do
       vm = FactoryGirl.create(:vm_vmware)
       edit = {}
       edit[:key] = "reconfigure__new"
-      edit[:new] = {}
-      edit[:new][:new_cpu_count] = "4"
+      edit[:new] = Hash.new
+      edit[:new][:new_socket_count] = "4"
       edit[:new][:new_cores_per_socket_count] = "4"
       edit[:new][:cb_cpu] = true
-      edit[:new][:cb_cores_per_socket] = true
       edit[:errors] = []
       controller.instance_variable_set(:@_params, :id => vm.id)
       controller.instance_variable_set(:@edit, edit)
@@ -172,11 +171,10 @@ describe ApplicationController do
       vm = FactoryGirl.create(:vm_vmware)
       edit = {}
       edit[:key] = "reconfigure__new"
-      edit[:new] = {}
-      edit[:new][:new_cpu_count] = "15"
+      edit[:new] = Hash.new
+      edit[:new][:new_socket_count] = "15"
       edit[:new][:new_cores_per_socket_count] = "15"
       edit[:new][:cb_cpu] = true
-      edit[:new][:cb_cores_per_socket] = true
       edit[:errors] = []
       controller.instance_variable_set(:@_params, :id => vm.id)
       controller.instance_variable_set(:@edit, edit)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -61,8 +61,27 @@ describe VmInfraController do
   end
 
   it 'can open the reconfigure tab' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 1))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 1, :virtual_hw_version => '04'))
+    host = FactoryGirl.create(:host,
+                              :vmm_vendor  => 'vmware',
+                              :vmm_product => "ESX",
+                              :hardware    => FactoryGirl.create(:hardware,
+                                                                 :memory_cpu       => 1024,
+                                                                 :logical_cpus     => 1,
+                                                                 :cores_per_socket => 1,
+                                                                 :numvcpus         => 1
+                                                                )
+                             )
+    vm = FactoryGirl.create(:vm_vmware,
+                            :name     => 'b_name',
+                            :host     => host,
+                            :hardware => FactoryGirl.create(:hardware,
+                                                            :memory_cpu         => 1024,
+                                                            :logical_cpus       => 1,
+                                                            :cores_per_socket   => 1,
+                                                            :numvcpus           => 1,
+                                                            :virtual_hw_version => '04'
+                                                           )
+                           )
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
@@ -76,8 +95,27 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cores_per_socket <= 1 should not display the cores_per_socket dropdown' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 1))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 1, :virtual_hw_version => "04"))
+    host = FactoryGirl.create(:host,
+                              :vmm_vendor  => 'vmware',
+                              :vmm_product => "ESX",
+                              :hardware    => FactoryGirl.create(:hardware,
+                                                                 :memory_cpu       => 1024,
+                                                                 :logical_cpus     => 1,
+                                                                 :cores_per_socket => 1,
+                                                                 :numvcpus         => 1
+                                                                )
+                             )
+    vm = FactoryGirl.create(:vm_vmware,
+                            :name     => 'b_name',
+                            :host     => host,
+                            :hardware => FactoryGirl.create(:hardware,
+                                                            :memory_cpu         => 1024,
+                                                            :logical_cpus       => 1,
+                                                            :cores_per_socket   => 1,
+                                                            :numvcpus           => 1,
+                                                            :virtual_hw_version => "04"
+                                                           )
+                           )
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
@@ -92,8 +130,8 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cores_per_socket > 1 should display the cores_per_socket dropdown' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 4))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 1, :virtual_hw_version => "07"))
+    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 4, :cores_per_socket => 4, :numvcpus => 1))
+    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_cpu => 1024, :logical_cpus => 1, :virtual_hw_version => "07", :cores_per_socket => 1, :numvcpus => 1))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1290,7 +1290,7 @@ describe ApplicationHelper do
         @user.stub(:role_allows?).and_return(true)
       end
 
-      %w(vm_migrate vm_publish vm_reconfigure).each do |id|
+      %w(vm_migrate vm_publish).each do |id|
         context "and id = #{id}" do
           before { @id = id }
 
@@ -1303,6 +1303,22 @@ describe ApplicationHelper do
             @record = FactoryGirl.create(:vm_vmware)
             subject.should == false
           end
+        end
+      end
+
+      context "and id = vm_reconfigure" do
+        before do
+          @id = "vm_reconfigure"
+          @record.stub(:reconfigurable?).and_return(true)
+        end
+
+        it "and !@record.reconfigurable?" do
+          @record.stub(:reconfigurable?).and_return(false)
+          subject.should == true
+        end
+
+        it "and @record.reconfigurable?" do
+          subject.should == false
         end
       end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -70,4 +70,28 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       expect(described_class.calculate_power_state('down')).to eq('off')
     end
   end
+
+  describe "Reconfigure Task" do
+    let(:vm) { FactoryGirl.create(:vm_redhat) }
+
+    it "#reconfigurable?" do
+      expect(vm.reconfigurable?).to be_true
+    end
+
+    it "#max_total_vcpus" do
+      expect(vm.max_total_vcpus).to eq(160)
+    end
+
+    it "#max_cores_per_socket" do
+      expect(vm.max_cores_per_socket).to eq(16)
+    end
+
+    it "#max_vcpus" do
+      expect(vm.max_vcpus).to eq(16)
+    end
+
+    it "#max_memory_cpu" do
+      expect(vm.max_memory_cpu).to eq(2.terabyte / 1.megabyte)
+    end
+  end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -25,4 +25,34 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     h = FactoryGirl.create(:ems_redhat, :hostname => "h")
     h.rhevm_metrics_connect_options(:hostname => "i")[:host].should == "i"
   end
+
+  context "#vm_reconfigure" do
+    before do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      @ems  = FactoryGirl.create(:ems_redhat_with_authentication, :zone => zone)
+      @hw   = FactoryGirl.create(:hardware, :memory_cpu => 1024, :numvcpus => 2, :cores_per_socket => 1)
+      @vm   = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems)
+
+      @cores_per_socket = 2
+      @num_of_sockets   = 3
+      @total_mem_in_mb  = 4096
+
+      @spec             = {"memoryMB"          => @total_mem_in_mb,
+                           "numCPUs"           => @cores_per_socket * @num_of_sockets,
+                           "numCoresPerSocket" => @cores_per_socket}
+
+      @rhevm_vm = double('rhevm_vm').as_null_object
+      @vm.stub(:with_provider_object).and_yield(@rhevm_vm)
+    end
+
+    it "cpu_topology=" do
+      @rhevm_vm.should_receive(:cpu_topology=).with(:cores => @cores_per_socket, :sockets => @num_of_sockets)
+      @ems.vm_reconfigure(@vm, :spec => @spec)
+    end
+
+    it "memory=" do
+      @rhevm_vm.should_receive(:memory=).with(@total_mem_in_mb.megabytes)
+      @ems.vm_reconfigure(@vm, :spec => @spec)
+    end
+  end
 end


### PR DESCRIPTION
This patch adds the backend method for UI task Reconfigure VM on RHEV.

https://bugzilla.redhat.com/show_bug.cgi?id=1065573

To resolve the above ticket, UI changes are required to enable the task for RHEV VMs and **return the result in the format of {:vm_memory  => total_mem_in_mb, :number_of_cpus => total_cpu_cores, :cores_per_socket => cores_per_socket}**. Please contact me for details about UI changes.