### PR TITLE
Fix SmartState Analysis failures on non-English VMs.

### DIFF
--- a/lib/Verbs/implementations/SharedOps.rb
+++ b/lib/Verbs/implementations/SharedOps.rb
@@ -177,7 +177,7 @@ module SharedOps
 				statusCode = 16 if categoriesProcessed.zero?
 				scanMessage = lastErr.to_s
         $log.error "ScanMetadata error status:[#{statusCode}]:  message:[#{lastErr.to_s}]"
-        lastErr.backtrace.each {|m| $log.debug m} if categoriesProcessed.zero?
+        lastErr.backtrace.each {|m| $log.debug m} if $log.debug?
 			end
 			xmlNodeScan.add_attributes("end_time"=>Time.now.utc.iso8601, "status"=>status, "status_code"=>statusCode.to_s, "message"=>scanMessage)
 			#File.open("d:/temp/#{Time.now.iso8601.gsub(":", "")} scan summary.xml", "w") {|f| xml_summary.write(f, 0)}

--- a/lib/util/xml/miq_rexml.rb
+++ b/lib/util/xml/miq_rexml.rb
@@ -127,7 +127,12 @@ module REXML
         bracket_equal_old(name.to_s, value)
       rescue => err
         if err.class == ::Encoding::CompatibilityError
-          bracket_equal_old(name.to_s, value.dup.force_encoding('UTF-8'))
+          nv = value.dup.force_encoding('UTF-8')
+          unless nv.valid_encoding?
+            nv.force_encoding('UTF-16')
+            nv.encode!('UTF-8', 'UTF-16', :invalid => :replace, :replace => '')
+          end
+          bracket_equal_old(name.to_s, nv)
         else
           raise
         end

--- a/vmdb/app/models/vm_or_template/scanning.rb
+++ b/vmdb/app/models/vm_or_template/scanning.rb
@@ -313,7 +313,7 @@ module VmOrTemplate::Scanning
         statusCode = 16 if categoriesProcessed.zero?
         scanMessage = lastErr.to_s
         $log.error "#{log_pref} ScanMetadata error status:[#{statusCode}]:  message:[#{lastErr.to_s}]"
-        lastErr.backtrace.each {|m| $log.debug m} if categoriesProcessed.zero?
+        lastErr.backtrace.each {|m| $log.debug m} if $log.debug?
       end
 
       xmlNodeScan.add_attributes("end_time"=>Time.now.utc.iso8601, "status"=>status, "status_code"=>statusCode.to_s, "message"=>scanMessage)


### PR DESCRIPTION
@chessbyte please review.

Text retrieved from non-English Windows VMs may be encoded in
UTF-16. This text may contain byte sequences that are not valid
in UTF-8. Check the text for valid encoding, and convert to UTF-8
as needed.

https://bugzilla.redhat.com/show_bug.cgi?id=1126476
Fixes #293
Fixes #332
