### PR TITLE
Same Storage connected to multiple datacenters corrupts data

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -82,9 +82,9 @@ module EmsRefresh::SaveInventoryInfra
 
     hashes.each do |h|
       found = if h[:location]
-        locs.detect { |s| s.location == h[:location] }
+        locs.detect { |s| s.location == h[:location] && s.ems_ref == h[:ems_ref] }
       else
-        names.detect { |s| s.name == h[:name] }
+        names.detect { |s| s.name == h[:name] && s.ems_ref == h[:ems_ref] }
       end
 
       if found.nil?


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=936238
https://bugzilla.redhat.com/show_bug.cgi?id=942068

In our vCenter enviornment we have the same storage connected
to multiple datacenters. e.g. Thecus-N7700 is connected to 3 datacenters
Datacenter   ems_ref             location
Dev         datastore-23856     4f3bfdf8-a67ee163-f50b-0010187f00da
Prod        datastore-22781     4f3bfdf8-a67ee163-f50b-0010187f00da
Yoda        datastore-112796    4f3bfdf8-a67ee163-f50b-0010187f00da

They all point to the same location, so when we update the storage table
based on location we corrupt the ems_ref and during provisioning the
ems_ref that is sent over points to the incorrect datacenter and the
provision fails.
This fix tries to update storage rows based on location and ems_ref.
