### PR TITLE
Correct initial issues discovered with Service Reconfigure

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -629,7 +629,7 @@ module ApplicationHelper
   def build_toolbar_hide_button_service(id)
     case id
     when "service_reconfigure"
-      ra = @record.service_template.resource_actions.find_by_action('Reconfigure')
+      ra = @record.service_template.resource_actions.find_by_action('Reconfigure') if @record.service_template
       return true if ra.nil? || ra.fqname.blank?
     end
     false

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -86,7 +86,7 @@
                                                       :loading  => "miqSparkle(true);",
                                                       :complete => "miqSparkle(false);"))
         - else
-          = h(field.values.detect { |_v, k| k == wf.value(field.name) }.try(:first) || wf.value(field.name))
+          = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
 
       - when 'DialogFieldDropDownList', 'DialogFieldRadioButton'
         - if edit
@@ -117,7 +117,7 @@
           - else
             = h(field.values[0].last) if !field.values.empty?
         - else
-          = h(field.values.detect { |_v, k| k == wf.value(field.name) }.try(:first) || wf.value(field.name))
+          = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
 
       - when 'DialogFieldButton'
         = image_tag("/images/formbuttons/save.png",


### PR DESCRIPTION
(1) Crash when determining whether to hide the reconfigure button for services
    created through automation w/o an associated service template.
(2) Service dialog lists and radio buttons show the keys instead of the
    human-readable values.
