### PR TITLE
sneakernet_ca requires a newer certmonger not hosted publicly.

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -90,7 +90,6 @@ mod_lookup_identity-selinux      # Only needed for CentOS 6.5.  It will not be n
 # IPA RPMs for certificate support
 ipa-admintools
 certmonger
-sneakernet_ca
 
 # bundler has some downstream patches we need or shared objects are not found
 ruby193-rubygem-bundler


### PR DESCRIPTION
For a few nights since c106830031e5e17c43fc84f862e3b0bb5a29c882, nightly builds were failing with an dependency error in the installer:

![screen shot 2014-08-21 at 4 51 27 pm](https://cloud.githubusercontent.com/assets/19339/4003288/41b03356-2975-11e4-8013-62ab05be5f0d.png)

So, yesterday @jvlcek @kbrock and I packaged the [sneakernet_ca in copr](http://copr-be.cloud.fedoraproject.org/results/jrafanie/manageiq-scl/epel-6-x86_64/).

Then, it failed again, with a different error.  The imagefactory screenshot shows this:
![screen shot 2014-08-21 at 4 51 44 pm](https://cloud.githubusercontent.com/assets/19339/4003307/724f2ac6-2975-11e4-9553-fb03cce45eef.png)

After doing an OS-only appliance build, yum install indicated the real error:

Error: Package: sneakernet_ca-0.1-2.el6.noarch (jrafanie-manageiq-scl)
           Requires: certmonger >= 0.75.8
           Installing: certmonger-0.61-3.el6.x86_64 (base)
               certmonger = 0.61-3.el6

Once this is available publicly, we can re-add sneakernet_ca.
