### PR TITLE
Add the identity copr yum repo for post install updates.

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -200,6 +200,7 @@ popd
 # Add copr repository for any updates
 pushd /etc/yum.repos.d/
   wget http://copr.fedoraproject.org/coprs/jrafanie/manageiq-scl/repo/epel-6-x86_64/jrafanie-manageiq-scl-epel-6-x86_64.repo
+  wget http://copr.fedoraproject.org/coprs/adelton/identity_demo/repo/epel-6/adelton-identity_demo-epel-6.repo
 popd
 
 # Add the rubygems binary path to the PATH so we can find bundle and friends:


### PR DESCRIPTION
While debugging #438, I noticed a OS-only appliance didn't have the following identity repo configured for post-install updates.

http://copr-be.cloud.fedoraproject.org/results/adelton/identity_demo/epel-6-x86_64/
