### PR TITLE
Dont ship default v2_key on cfme appliance

### DIFF
--- a/build/config/tarball/exclude
+++ b/build/config/tarball/exclude
@@ -13,6 +13,7 @@
 *vmdb/.bundle
 *vmdb/bin
 *vmdb/config/database.yml
+*vmdb/certs/v2_key
 *vmdb/log/*.log
 *vmdb/tmp/miq_temp
 *lib/disk/modules/MiqBlockDevOps/Makefile


### PR DESCRIPTION
manageiq appliance:

No change.  Default `v2_key` to make out of box experience as smooth as possible.

cfme appliance:

Don't ship with a default `v2_key`. Focus on flexibility over customer experience.

This is intended to help address https://bugzilla.redhat.com/show_bug.cgi?id=1132893

/cc @chessbyte @jrafanie @Fryguy 
