### PR TITLE
Add key generation to appliance console

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -447,6 +447,16 @@ Date and Time Configuration
             raise MiqSignalError
           end
 
+        when I18n.t("advanced_settings.key_gen")
+          say("#{selection}\n\n")
+          key_config = ApplianceConsole::KeyConfiguration.new
+
+          if !key_config.key_exist? || agree("Overwrite existing v2_key? (Y/N): ")
+            key_config.create_key(true)
+            say("\nCustom encryption Key generated\n")
+            press_any_key
+          end
+
         when I18n.t("advanced_settings.db_config")
           say("#{selection}\n\n")
           loc_selection = ask_with_menu("Database Location", %w(Internal External), nil, false)

--- a/lib/appliance_console/key_configuration.rb
+++ b/lib/appliance_console/key_configuration.rb
@@ -7,8 +7,12 @@ module ApplianceConsole
   KEY_FILE = "#{CERT_DIR}/v2_key"
 
   class KeyConfiguration
+    def key_exist?
+      File.exist?(KEY_FILE)
+    end
+
     def create_key(force = true)
-      if File.exist?(KEY_FILE)
+      if key_exist?
         return self unless force
         FileUtils.rm(KEY_FILE)
       end

--- a/lib/appliance_console/locales/en.yml
+++ b/lib/appliance_console/locales/en.yml
@@ -9,6 +9,7 @@ en:
     - datetime
     - dbrestore
     - httpdauth
+    - key_gen
     - evmstop
     - evmstart
     - restart
@@ -23,6 +24,7 @@ en:
     dbrestore: Restore Database From Backup
     httpdauth: Configure External Authentication (httpd)
     evmstop: Stop EVM Server Processes
+    key_gen: Generate Custom Encryption Key
     evmstart: Start EVM Server Processes
     restart: Restart Appliance
     shutdown: Shut Down Appliance


### PR DESCRIPTION
Give the appliance console the ability to generate `v2_key`

~~(WIP because I want to fully test.)~~ tested

related to a better user migration story and https://bugzilla.redhat.com/show_bug.cgi?id=1132893

/cc @Fryguy related to #447
