### PR TITLE
Persist automate state data between retries

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -88,6 +88,7 @@ module MiqAeEngine
     ae_fsm_started   = options[:ae_fsm_started]
     ae_state_started = options[:ae_state_started]
     ae_state_retries = options[:ae_state_retries]
+    ae_state_data    = options[:ae_state_data]
     vmdb_object      = nil
     ae_result        = 'error'
 
@@ -106,6 +107,7 @@ module MiqAeEngine
       automate_attrs[:ae_fsm_started]   = ae_fsm_started     unless ae_fsm_started.nil?
       automate_attrs[:ae_state_started] = ae_state_started   unless ae_state_started.nil?
       automate_attrs[:ae_state_retries] = ae_state_retries   unless ae_state_retries.nil?
+      automate_attrs['ae_state_data']   = ae_state_data      unless ae_state_data.nil?
 
       create_automation_object_options = {}
       create_automation_object_options[:vmdb_object] = vmdb_object                unless vmdb_object.nil?
@@ -133,6 +135,7 @@ module MiqAeEngine
           options[:ae_fsm_started]   = ws.root['ae_fsm_started']
           options[:ae_state_started] = ws.root['ae_state_started']
           options[:ae_state_retries] = ws.root['ae_state_retries']
+          options[:ae_state_data]    = YAML.dump(ws.persist_state_hash) unless ws.persist_state_hash.empty?
 
           message = "Requeuing #{options.inspect} for object [#{object_name}] with state [#{options[:state]}] to Automate for delivery in [#{ae_retry_interval}] seconds"
           $log.info("#{log_header} #{message}")

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -31,10 +31,11 @@ module MiqAeMethodService
 
     def initialize(ws)
       @drb_server_references = []
-      @inputs         = {}
-      @workspace      = ws
-      @preamble_lines = 0
-      @body           = []
+      @inputs                = {}
+      @workspace             = ws
+      @preamble_lines        = 0
+      @body                  = []
+      @persist_state_hash    = ws.persist_state_hash
       self.class.add(self)
     end
 
@@ -112,6 +113,18 @@ module MiqAeMethodService
 
     def log(level, msg)
       $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{msg}")
+    end
+
+    def set_state_var(name, value)
+      @persist_state_hash[name] = value
+    end
+
+    def state_var_exist?(name)
+      @persist_state_hash.key?(name)
+    end
+
+    def get_state_var(name)
+      @persist_state_hash[name]
     end
 
     def instantiate(uri)

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -35,7 +35,7 @@ module MiqAeEngine
   end
 
   class MiqAeWorkspaceRuntime
-    attr_accessor :graph, :num_drb_methods, :class_methods, :datastore_cache
+    attr_accessor :graph, :num_drb_methods, :class_methods, :datastore_cache, :persist_state_hash
     DEFAULTS = {
       :readonly => false
     }
@@ -49,6 +49,7 @@ module MiqAeEngine
       @datastore_cache   = Hash.new
       @class_methods     = Hash.new
       @dom_search        = MiqAeDomainSearch.new
+      @persist_state_hash = HashWithIndifferentAccess.new
     end
 
     def readonly?
@@ -115,6 +116,9 @@ module MiqAeEngine
 
       message = fragment.blank? ? "create" : fragment.downcase
       args = MiqAeUri.query2hash(query)
+      if (ae_state_data = args.delete('ae_state_data'))
+        @persist_state_hash.merge!(YAML.load(ae_state_data))
+      end
 
       ns, klass, instance = MiqAePath.split(path)
       ns = overlay_namespace(scheme, uri, ns, klass, instance)

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -126,6 +126,7 @@ module MiqAeEngineSpec
             root = { 'ae_result' => 'retry' }
             @ws = double('ws')
             @ws.stub(:root => root)
+            @ws.stub(:persist_state_hash => {})
             MiqAeEngine.stub(:resolve_automation_object).and_return(@ws)
           end
 

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_state_machine_retry_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_state_machine_retry_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+describe "MiqAeStateMachineRetry" do
+  before do
+    MiqAeDatastore.reset_default_namespace
+    @method_name     = 'MY_RETRY_METHOD'
+    @method_instance = 'MY_RETRY_INSTANCE'
+    @retry_class     = 'MY_RETRY_CLASS'
+    @domain          = 'SPEC_DOMAIN'
+    @namespace       = 'NS1'
+    @state_class     = 'MY_STATE_MACHINE'
+    @state_instance  = 'MY_STATE_INSTANCE'
+  end
+
+  def method_script
+    <<-'RUBY'
+      root   = $evm.object("/")
+      if $evm.state_var_exist?(:gravy) && $evm.get_state_var('gravy') == 'train'
+        root['finished'] = true
+        $evm.set_state_var(:three, 3)
+        $evm.set_state_var('one', $evm.get_state_var(:one) + 1)
+        status = 'ok'
+      else
+        $evm.set_state_var(:one, 0)
+        $evm.set_state_var(:two, 2)
+        $evm.set_state_var('gravy', 'train')
+        status = 'retry'
+      end
+
+      case status
+        when 'retry'
+          root['ae_result']         = 'retry'
+          root['ae_retry_interval'] = '1.minute'
+        when 'ok'
+          root['ae_result'] = 'ok'
+        end
+      exit MIQ_OK
+    RUBY
+  end
+
+  def setup_model
+    dom = FactoryGirl.create(:miq_ae_domain, :enabled => true, :name => @domain)
+    ns  = FactoryGirl.create(:miq_ae_namespace, :parent_id => dom.id, :name => @namespace)
+    @ns_fqname = ns.fqname
+    create_retry_class(:namespace => @ns_fqname, :name => @retry_class)
+    create_state_class(:namespace => @ns_fqname, :name => @state_class)
+  end
+
+  def create_retry_class(attrs = {})
+    ae_fields = {'execute' => {:aetype => 'method', :datatype => 'string'}}
+    ae_instances = {@method_instance => {'execute' => {:value => @method_name}}}
+    ae_methods = {@method_name => {:scope => 'instance', :location => 'inline',
+                                   :data => method_script,
+                                   :language => 'ruby', 'params' => {}}}
+
+    FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_instances' => ae_instances,
+                                   'ae_methods'   => ae_methods))
+  end
+
+  def create_state_class(attrs = {})
+    ae_fields = {'state1' => {:aetype => 'state', :datatype => 'string', :max_retries => 10, :message => 'create'}}
+    fqname = "/#{@domain}/#{@namespace}/#{@retry_class}/#{@method_instance}"
+    ae_instances = {@state_instance => {'state1' => {:value => fqname}}}
+
+    FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_methods'   => {},
+                                   'ae_instances' => ae_instances))
+  end
+
+  it "check retry" do
+    setup_model
+    MiqServer.stub(:my_zone).and_return('default')
+    @expected = {'three' => 3, 'one'  => 1, 'two'  => 2, 'gravy' => 'train'}
+    args = {
+      :namespace        => @namespace,
+      :class_name       => @state_class,
+      :instance_name    => @state_instance,
+      :automate_message => 'create'
+    }
+    q = MiqQueue.put(
+                    :role        => 'automate',
+                    :class_name  => 'MiqAeEngine',
+                    :method_name => 'deliver',
+                    :args        => [args])
+    delivered_ids = []
+    status, message, ws = q.deliver
+    status.should_not eq(MiqQueue::STATUS_ERROR)
+    ws.should_not be_nil
+    delivered_ids << q.id
+    MiqQueue.count.should eq(2)
+    MiqQueue.all.each do |v|
+      unless delivered_ids.include?(v.id)
+        status, message, ws = v.deliver
+        status.should_not eq(MiqQueue::STATUS_ERROR)
+        ws.should_not be_nil
+        delivered_ids << v.id
+        ws.persist_state_hash.should eq(@expected)
+        ws.root.attributes['finished'].should be_true
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1044175

During the execution of an automate method the following 3 methods
can be called to set/get/check for existence of state data.

$evm.set_state_var     This takes a name and value as the 2 arguments
$evm.get_state_var     This takes a name and returns the corresponding value object
$evm.state_var_exist?  This takes a name and checks if the variable exists

The name in all 3 functions above can be a string or a symbol.
If the name is missing nil is returned.
