### PR TITLE
Allow user to specify the ipa server realm

### DIFF
--- a/lib/appliance_console/certificate_authority.rb
+++ b/lib/appliance_console/certificate_authority.rb
@@ -14,6 +14,7 @@ module ApplianceConsole
 
     # hostname of current machine
     attr_accessor :hostname
+    attr_accessor :realm
     # name of certificate authority
     attr_accessor :ca_name
     # true if we should configure postgres client
@@ -60,6 +61,7 @@ module ApplianceConsole
         :extensions    => %w(client),
         :ca_name       => ca_name,
         :hostname      => hostname,
+        :realm         => realm,
       ).request.status
     end
 
@@ -71,6 +73,7 @@ module ApplianceConsole
         :extensions    => %w(server),
         :ca_name       => ca_name,
         :hostname      => hostname,
+        :realm         => realm,
         :owner         => "postgres.postgres"
       ).request
 

--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -83,6 +83,7 @@ module ApplianceConsole
         opt :ipaserver,  "IPA Server FQDN",  :type => :string
         opt :ipaprincipal,  "IPA Server principal", :type => :string,          :default => "admin"
         opt :ipapassword,   "IPA Server password",  :type => :string
+        opt :iparealm,      "IPA Server realm (optional)", :type => :string
         opt :ca,                   "CA name used for certmonger",       :type => :string,  :default => "ipa"
         opt :postgres_client_cert, "install certs for postgres client", :type => :boolean
         opt :postgres_server_cert, "install certs for postgres server", :type => :boolean
@@ -164,6 +165,7 @@ module ApplianceConsole
       say "creating ssl certificates"
       config = CertificateAuthority.new(
         :hostname => host,
+        :realm    => options[:iparealm],
         :ca_name  => options[:ca],
         :pgclient => options[:postgres_client_cert],
         :pgserver => options[:postgres_server_cert],
@@ -183,6 +185,7 @@ module ApplianceConsole
       config = ExternalHttpdAuthentication.new(
         host,
         :ipaserver => options[:ipaserver],
+        :realm     => options[:iparealm],
         :principal => options[:ipaprincipal],
         :password  => options[:ipapassword],
       )

--- a/lib/appliance_console/external_httpd_authentication.rb
+++ b/lib/appliance_console/external_httpd_authentication.rb
@@ -8,6 +8,7 @@ module ApplianceConsole
       @ipaserver, @domain, @password = nil
       @host      = host
       @domain    = options[:domain] || domain_from_host(host)
+      @realm     = options[:realm]
       @ipaserver = options[:ipaserver]
       @principal = options[:principal] || "admin"
       @password  = options[:password]
@@ -20,6 +21,7 @@ module ApplianceConsole
       say("\nIPA Server Parameters:\n\n")
       @ipaserver = ask_for_hostname("IPA Server Hostname", @ipaserver)
       @domain    = ask_for_domain("IPA Server Domain", @domain)
+      @realm     = ask_for_realm("IPA Server Realm", realm)
       @principal = just_ask("IPA Server Principal", @principal)
       @password  = ask_for_password("IPA Server Principal Password", @password)
 
@@ -62,6 +64,12 @@ module ApplianceConsole
         configure_httpd_external_auth
         configure_httpd
         configure_selinux
+      rescue AwesomeSpawn::CommandResultError => e
+        say e.result.output
+        say e.result.error
+        say ""
+        say("Failed to Configure External Authentication - #{e}")
+        return false
       rescue => e
         say("Failed to Configure External Authentication - #{e}")
         return false
@@ -92,7 +100,7 @@ module ApplianceConsole
     end
 
     def realm
-      @domain.upcase
+      (@realm || @domain).upcase
     end
 
     def configure_ipa

--- a/lib/appliance_console/principal.rb
+++ b/lib/appliance_console/principal.rb
@@ -13,6 +13,7 @@ module ApplianceConsole
     def initialize(options = {})
       options.each { |n, v| public_send("#{n}=", v) }
       @ca_name ||= "ipa"
+      @realm = @realm.upcase if @realm
       @name ||= "#{service}/#{hostname}@#{realm}"
     end
 

--- a/lib/spec/appliance_console/certificate_spec.rb
+++ b/lib/spec/appliance_console/certificate_spec.rb
@@ -17,6 +17,7 @@ describe ApplianceConsole::Certificate do
     described_class.new(:ca_name       => 'ipa',
                         :hostname      => host,
                         :service       => service,
+                        :realm         => realm,
                         :cert_filename => cert_filename)
   end
 

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -97,8 +97,9 @@ describe ApplianceConsole::Cli do
           .with('client.domain.com',
                 :ipaserver => 'ipa.domain.com',
                 :principal => 'admin',
+                :realm     => 'domain.com',
                 :password  => 'pass').and_return(double(:activate => true, :post_activation => nil))
-      subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass)).run
+      subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass --iparealm domain.com)).run
     end
 
     it "should not post_activate install ipa (aside: testing passing in host" do
@@ -109,6 +110,7 @@ describe ApplianceConsole::Cli do
           .with('client.domain.com',
                 :ipaserver => 'ipa.domain.com',
                 :principal => 'admin',
+                :realm     => nil,
                 :password  => 'pass').and_return(double(:activate => false))
       subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass --host client.domain.com)).run
     end
@@ -130,6 +132,7 @@ describe ApplianceConsole::Cli do
       ApplianceConsole::CertificateAuthority.should_receive(:new)
         .with(
           :hostname => "client.domain.com",
+          :realm    => nil,
           :ca_name  => "ipa",
           :pgclient => true,
           :pgserver => false,
@@ -148,6 +151,7 @@ describe ApplianceConsole::Cli do
       ApplianceConsole::CertificateAuthority.should_receive(:new)
         .with(
           :hostname => "client.domain.com",
+          :realm    => "realm.domain.com",
           :ca_name  => "super",
           :pgclient => false,
           :pgserver => true,
@@ -155,7 +159,7 @@ describe ApplianceConsole::Cli do
           :verbose  => true,
         ).and_return(double(:activate => true, :status_string => "good", :complete? => false))
 
-      subject.parse(%w(--postgres-server-cert --verbose --ca super)).run
+      subject.parse(%w(--postgres-server-cert --verbose --ca super --iparealm realm.domain.com)).run
     end
   end
 


### PR DESCRIPTION
We automatically determine the ipa realm. This allows the customer to override the default.
- this adds to the cli and appliance_console
- realm is also passed to ssl certificates
- better display of error messages

this change is needed by QE to test IPA integration. Probably most customers as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1134540

/cc @abellotti @dajohnso 
