### PR TITLE
Strip off any leading/trailing whitespace such as a newline.

### DIFF
--- a/vmdb/app/models/product_update.rb
+++ b/vmdb/app/models/product_update.rb
@@ -351,7 +351,7 @@ class ProductUpdate < ActiveRecord::Base
   end
 
   def self.get_smartproxy_version(filename)
-    Zip::ZipFile.open(filename) {|z| z.file.read("/host/miqhost/VERSION")}
+    Zip::ZipFile.open(filename) { |z| z.file.read("/host/miqhost/VERSION").strip }
   rescue => err
     raise "Error <#{err}> for file <#{filename}>"
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1126071

We shouldn't require the VERSION file to be absent of all whitespace such as a trailing
newline at the end of the file as many editors will insert this and it's easy to do this without realizing it matters.

Adding a newline causes the comparison of the rpm version information to NOT match the
VERSION provided by the contents of the smartproxy executable.

This causes the product_updates table to NOT be seeded with the smartproxy found in the filesystem.
:bomb:
