### PR TITLE
Uncaught Exception displays error screen in UI

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_uri.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_uri.rb
@@ -30,6 +30,8 @@ module MiqAeEngine
       scheme = 'miqaews' if scheme.downcase == 'miqae'
       scheme.downcase!
       return scheme, userinfo, host, port, registry, path, opaque, query, fragment
+    rescue URI::Error => err
+      raise MiqAeException::InvalidPathFormat, err.message
     end
 
     def self.scheme_supported?(scheme)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1133747

When the user enters an invalid,incomplete path in simulation
during parsing we get the Ruby URI::InvalidURIError. Caught this error
and converted it to MiqAeException::InvalidPathFormat
The Simuation UI code only catches the MiqAeException and throws up the
error window for others.
