### PR TITLE
[WIP] Update default_value_for to latest 3.0.0+

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -37,7 +37,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # See miq_expression_spec Date/Time Support examples.
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
-gem "default_value_for",              "~>2.0.3"
+gem "default_value_for",              "~>3.0.1"
 gem "thin",                           "~>1.3.1"  # Used by rails server through rack
 gem "bcrypt-ruby",                    "~> 3.0.1"
 gem 'outfielding-jqplot-rails',       "= 1.0.8"


### PR DESCRIPTION
https://github.com/FooBarWidget/default_value_for/commit/6f5a7ff4eea5ec446d43fe82deab47a7d77aada4
Available in these git tags: release-3.0.0.1 release-3.0.0 release-2.0.3 release-2.0.2

Came from this PR:
https://github.com/FooBarWidget/default_value_for/pull/29