### PR TITLE
Change MiqApproval#approver to use a nil user when roles should be used.

### DIFF
--- a/vmdb/app/models/miq_approval.rb
+++ b/vmdb/app/models/miq_approval.rb
@@ -3,19 +3,13 @@ class MiqApproval < ActiveRecord::Base
   belongs_to :stamper,  :class_name => "User"
   belongs_to :miq_request
 
-  validates_presence_of :approver
-
   include ReportableMixin
 
   default_value_for :state, "pending"
 
-  before_create :set_approver_delegates
-
-  def set_approver_delegates
-    if self.approver
-      self.approver_type = self.approver.class.name
-      self.approver_name = self.approver.name
-    end
+  def approver=(approver)
+    super
+    self.approver_name = approver.try(:name)
   end
 
   def approve(userid, reason)
@@ -42,11 +36,9 @@ class MiqApproval < ActiveRecord::Base
   def authorized?(userid)
     user = userid.kind_of?(User) ? userid : User.find_by_userid(userid)
     return false unless user
-    return false unless self.approver
 
-    return true if user.role_allows?(:identifier=>"miq_request_approval")
+    return true if user.role_allows?(:identifier => "miq_request_approval")
     return true if self.approver.kind_of?(User) && self.approver == user
-    return true if self.approver.kind_of?(UiTaskSet) && self.approver == user.role
 
     return false
   end

--- a/vmdb/spec/automation/unit/method_validation/validate_quota_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/validate_quota_spec.rb
@@ -3,12 +3,10 @@ require "spec_helper"
 describe "Quota Validation" do
 
   before(:each) do
-    @group         = FactoryGirl.create(:miq_group, :description => 'Test Group')
-    @fred          = FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred', :email => 'tester@miq.com', :miq_groups => [@group])
-    @approver_role = FactoryGirl.create(:ui_task_set_approver)
+    @user          = FactoryGirl.create(:user_miq_request_approver)
     @vm_template   = FactoryGirl.create(:template_vmware, :name => "template1")
     @vm1           = FactoryGirl.create(:vm_vmware)
-    @vm1.miq_group = @group
+    @vm1.miq_group = @user.current_group
   end
 
   let(:ws) { MiqAeEngine.instantiate("/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestQuotaVerification/Default?MiqProvisionRequest::miq_provision_request=#{@miq_provision_request.id}&MiqRequest::miq_request=#{@miq_provision_request.id}&max_group_cpu=#{@max_group_cpu}") }
@@ -16,7 +14,7 @@ describe "Quota Validation" do
   context "validate vcpus quota limit, using number of cpus" do
     before do
       prov_options = {:number_of_vms => 1, :owner_email => 'tester@miq.com', :vm_memory => ['1024', '1024'], :number_of_sockets => [2, '2'], :cores_per_socket => [2, '2'], :number_of_cpus => [2, '2']}
-      @miq_provision_request    = FactoryGirl.create(:miq_provision_request, :userid => @fred.userid, :src_vm_id => @vm_template.id, :options => prov_options)
+      @miq_provision_request    = FactoryGirl.create(:miq_provision_request, :userid => @user.userid, :src_vm_id => @vm_template.id, :options => prov_options)
       @miq_request = @miq_provision_request.create_request
       @miq_request.save!
     end
@@ -40,7 +38,7 @@ describe "Quota Validation" do
   context "validate vcpus quota limit, using cores_per_socket and number_of_sockets" do
     before do
       prov_options = {:number_of_vms => 1, :owner_email => 'tester@miq.com', :vm_memory => ['1024', '1024'], :number_of_sockets => [2, '2'], :cores_per_socket => [2, '2']}
-      @miq_provision_request    = FactoryGirl.create(:miq_provision_request, :userid => @fred.userid, :src_vm_id => @vm_template.id, :options => prov_options)
+      @miq_provision_request    = FactoryGirl.create(:miq_provision_request, :userid => @user.userid, :src_vm_id => @vm_template.id, :options => prov_options)
       @miq_request = @miq_provision_request.create_request
       @miq_request.save!
     end

--- a/vmdb/spec/factories/miq_group.rb
+++ b/vmdb/spec/factories/miq_group.rb
@@ -2,4 +2,8 @@ FactoryGirl.define do
   factory :miq_group do
     sequence(:description) { |n| "Test Group #{n}" }
   end
+
+  factory :miq_group_miq_request_approver, :parent => :miq_group do
+    miq_user_role { FactoryGirl.create(:miq_user_role_miq_request_approver) }
+  end
 end

--- a/vmdb/spec/factories/miq_product_feature.rb
+++ b/vmdb/spec/factories/miq_product_feature.rb
@@ -9,4 +9,12 @@ FactoryGirl.define do
     protected    false
     feature_type "node"
   end
+
+  factory :miq_product_feature_miq_request_approval, :parent => :miq_product_feature do
+    identifier   "miq_request_approval"
+    name         "Approve and Deny"
+    description  "Approve and Deny Requests"
+    protected    false
+    feature_type "control"
+  end
 end

--- a/vmdb/spec/factories/miq_user_role.rb
+++ b/vmdb/spec/factories/miq_user_role.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
   factory :miq_user_role do
-    name            "Test Role"
+    name "Test Role"
+  end
+
+  factory :miq_user_role_miq_request_approver, :parent => :miq_user_role do
+    sequence(:name) { |n| "Request Approver #{n}" }
+
+    miq_product_features { [FactoryGirl.create(:miq_product_feature_miq_request_approval)] }
   end
 end

--- a/vmdb/spec/factories/user.rb
+++ b/vmdb/spec/factories/user.rb
@@ -20,7 +20,13 @@ FactoryGirl.define do
                                           :description   => "EvmGroup-super_administrator",
                                           :miq_user_role => FactoryGirl.create(:miq_user_role,
                                                                                :name => 'EvmRole-super_administrator'
-                                                                              ))]
-    }
+                                                                              ))]}
+  end
+
+  factory :user_miq_request_approver, :parent => :user do
+    sequence(:name)   { |n| "Request Approver #{n}" }
+    sequence(:userid) { |n| "request_approver_#{n}" }
+
+    miq_groups { [FactoryGirl.create(:miq_group_miq_request_approver)] }
   end
 end

--- a/vmdb/spec/models/automation_request_spec.rb
+++ b/vmdb/spec/models/automation_request_spec.rb
@@ -4,9 +4,8 @@ describe AutomationRequest do
   before(:each) do
     MiqServer.stub(:my_zone).and_return("default")
     User.any_instance.stub(:role).and_return("admin")
-    @user        = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
-    @approver    = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
-    UiTaskSet.stub(:find_by_name).and_return(@approver)
+    @user        = FactoryGirl.create(:user)
+    @approver    = FactoryGirl.create(:user_miq_request_approver)
 
     @version     = 1
     @ae_instance = "IIII"

--- a/vmdb/spec/models/miq_approval_spec.rb
+++ b/vmdb/spec/models/miq_approval_spec.rb
@@ -1,49 +1,59 @@
 require "spec_helper"
 
 describe MiqApproval do
-
-  it "#set_approver_delegates" do
+  it "#approver= also sets approver_name" do
     approval = FactoryGirl.build(:miq_approval)
+    user     = FactoryGirl.create(:user)
+
     approval.approver_name.should be_nil
-    approval.approver_type.should be_nil
-    approver_role = UiTaskSet.create(:name => "approver", :description => "Approver")
-    approval.approver = approver_role
-    approval.set_approver_delegates
-    approval.approver_name.should == approver_role.name
-    approval.approver_type.should == approver_role.class.name
+
+    approval.approver = user
+    approval.approver_name.should == user.name
+
+    approval.approver = nil
+    approval.approver_name.should be_nil
   end
 
-  it "#approve" do
-    user          = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
-    approver      = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
-    approver_role = UiTaskSet.create(:name => "approver", :description => "Approver")
+  context "#approve" do
+    it "works" do
+      user     = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
+      approver = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
 
-    approval = FactoryGirl.create(:miq_approval, :approver => approver_role)
-    reason   = "Why Not?"
+      approval = FactoryGirl.create(:miq_approval)
+      reason   = "Why Not?"
 
-    approval.stub(:authorized?).and_return(false)
-    lambda { approval.approve(approver.userid, reason) }.should raise_error("not authorized")
+      approval.stub(:authorized?).and_return(false)
+      lambda { approval.approve(approver.userid, reason) }.should raise_error("not authorized")
 
-    miq_request = FactoryGirl.create(:miq_request, :requester => user)
-    approval.miq_request = miq_request
-    approval.stub(:authorized?).and_return(true)
-    now = Time.now
-    Time.stub(:now).and_return(now)
-    miq_request.should_receive(:approval_approved).once
-    approval.approve(approver.userid, reason)
-    approval.state.should        == 'approved'
-    approval.reason.should       == reason
-    approval.stamper.should      == approver
-    approval.stamper_name.should == approver.name
-    approval.stamped_on.should   == now.utc
+      miq_request = FactoryGirl.create(:miq_request, :requester => user)
+      approval.miq_request = miq_request
+      approval.stub(:authorized?).and_return(true)
+      Timecop.freeze do
+        miq_request.should_receive(:approval_approved).once
+        approval.approve(approver.userid, reason)
+        approval.state.should        == 'approved'
+        approval.reason.should       == reason
+        approval.stamper.should      == approver
+        approval.stamper_name.should == approver.name
+        approval.stamped_on.should   == Time.now.utc
+      end
+    end
+
+    it "with an approver's own request" do
+      vm_template = FactoryGirl.create(:template_vmware)
+      user        = FactoryGirl.create(:user_miq_request_approver)
+      request     = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => vm_template.id, :userid => user.userid)
+      approval    = FactoryGirl.create(:miq_approval, :miq_request => request)
+
+      expect { approval.approve(user.userid, 'Why Not') }.to_not raise_error
+    end
   end
 
   it "#deny" do
-    user          = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
-    approver      = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
-    approver_role = UiTaskSet.create(:name => "approver", :description => "Approver")
+    user     = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
+    approver = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
 
-    approval = FactoryGirl.create(:miq_approval, :approver => approver_role)
+    approval = FactoryGirl.create(:miq_approval)
     reason   = "Why Not?"
 
     approval.stub(:authorized?).and_return(false)
@@ -52,74 +62,57 @@ describe MiqApproval do
     miq_request = FactoryGirl.create(:miq_request, :requester => user)
     approval.miq_request = miq_request
     approval.stub(:authorized?).and_return(true)
-    now = Time.now
-    Time.stub(:now).and_return(now)
-    miq_request.should_receive(:approval_denied).once
-    approval.deny(approver.userid, reason)
-    approval.state.should        == 'denied'
-    approval.reason.should       == reason
-    approval.stamper.should      == approver
-    approval.stamper_name.should == approver.name
-    approval.stamped_on.should   == now.utc
+    Timecop.freeze do
+      miq_request.should_receive(:approval_denied).once
+      approval.deny(approver.userid, reason)
+      approval.state.should        == 'denied'
+      approval.reason.should       == reason
+      approval.stamper.should      == approver
+      approval.stamper_name.should == approver.name
+      approval.stamped_on.should   == Time.now.utc
+    end
   end
 
-  it "#authorized?" do
-    MiqRegion.seed
-    MiqProductFeature.seed
-    MiqUserRole.seed
+  context "#authorized?" do
+    let(:approval) { FactoryGirl.create(:miq_approval) }
+    let(:user)     { FactoryGirl.create(:user, :userid => "user1") }
+    let(:user2)    { FactoryGirl.create(:user, :userid => "user2") }
+    let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
 
-    user          = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
-    approver      = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
-    approver_role = UiTaskSet.create(:name => "approver", :description => "Approver")
-    approval      = FactoryGirl.create(:miq_approval, :approver => approver_role)
-
-    approval.authorized?(nil).should be_false
-    approval.authorized?('anyone').should be_false
-
-    approver.stub(:miq_user_role).and_return(MiqUserRole.find_by_name('EvmRole-super_administrator'))
-    approval.authorized?(approver).should be_true
-    approver.stub(:miq_user_role).and_return(MiqUserRole.find_by_name('EvmRole-administrator'))
-    approval.authorized?(approver).should be_true
-
-    approver.stub(:miq_user_role).and_return(MiqUserRole.find_by_name('foo'))
-
-    approval.approver = approver
-    approval.authorized?(approver).should be_true
-    approval.authorized?(user).should be_false
-
-    approval.approver = approver_role
-    approver.stub(:role).and_return(approver_role)
-    approval.authorized?(approver).should be_true
-
-    approver.stub(:role).and_return(nil)
-    approval.authorized?(approver).should be_false
-  end
-
-  context "should approve an approver's own request (FB15633)" do
-    before(:each) do
-      MiqRegion.seed
-      MiqProductFeature.seed
-
-      idents = ["miq_request_view", "miq_request_control"]
-      @miq_user_role  = FactoryGirl.create(:miq_user_role, :name => 'cloud', :miq_product_features => MiqProductFeature.find_all_by_identifier(idents))
-
-      @group = FactoryGirl.create(:miq_group, :description => 'Cloud Group', :miq_user_role => @miq_user_role)
-      @user  = FactoryGirl.create(:user, :name => 'cloud', :miq_groups => [@group])
-
-      @approver_role = UiTaskSet.create(:name => "approver", :description => "Approver")
-      @vm_template   = FactoryGirl.create(:template_vmware)
-      @request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :userid => @user.userid)
-
-      @approval = FactoryGirl.create(:miq_approval, :approver => @approver_role)
-      @approval.miq_request = @request
+    it "with nil" do
+      approval.authorized?(nil).should be_false
     end
 
-    it "#authorized?" do
-      @approval.authorized?(@user).should be_true
+    it "with a user object without approval rights" do
+      approval.authorized?(user).should be_false
     end
 
-    it "#approve" do
-      lambda {@approval.approve(@user.userid, 'Why Not')}.should_not raise_error
+    it "with a user object with approval rights" do
+      approval.authorized?(approver).should be_true
+    end
+
+    it "with a userid without approval rights" do
+      approval.authorized?(user.userid).should be_false
+    end
+
+    it "with a userid with approval rights" do
+      approval.authorized?(approver.userid).should be_true
+    end
+
+    context "with the approver property set to a specific user" do
+      before { approval.approver = user }
+
+      it "and passing the same user" do
+        approval.authorized?(user).should be_true
+      end
+
+      it "and passing a different user with approval rights" do
+        approval.authorized?(approver).should be_true
+      end
+
+      it "and passing a different user without approval rights" do
+        approval.authorized?(user2).should be_false
+      end
     end
   end
 end

--- a/vmdb/spec/models/miq_host_provision_request_spec.rb
+++ b/vmdb/spec/models/miq_host_provision_request_spec.rb
@@ -4,9 +4,8 @@ describe MiqHostProvisionRequest do
   context "A new provision request," do
     before(:each) do
       User.any_instance.stub(:role).and_return("admin")
-      @user        = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
-      @approver    = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
-      UiTaskSet.stub(:find_by_name).and_return(@approver)
+      @user     = FactoryGirl.create(:user)
+      @approver = FactoryGirl.create(:user_miq_request_approver)
     end
 
     it "should not be created without userid being specified" do
@@ -37,13 +36,12 @@ describe MiqHostProvisionRequest do
         @pr.miq_request.valid?.should be_true
         @pr.miq_request.approval_state.should == "pending_approval"
         @pr.miq_request.resource.should == @pr
+        @pr.miq_request.requester_userid.should == @user.userid
+        @pr.miq_request.stamped_on.should be_nil
+
         @pr.miq_request.approved?.should be_false
         MiqApproval.count.should == 1
-        @pr.miq_request.requester_userid.should == @user.userid
-        @pr.miq_request.approver.should == @approver.name
-        @pr.miq_request.approver_role.should == @approver.name
         @pr.miq_request.first_approval.should == @approvals.first
-        @pr.miq_request.stamped_on.should be_nil
       end
 
       it "should return a workflow class" do

--- a/vmdb/spec/models/miq_request_spec.rb
+++ b/vmdb/spec/models/miq_request_spec.rb
@@ -5,7 +5,6 @@ describe MiqRequest do
     before(:each) do
       @fred          = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
       @barney        = FactoryGirl.create(:user, :name => 'Barney Rubble',    :userid => 'barney')
-      @approver_role = UiTaskSet.create(:name => "approver", :description => "Approver")
       @requests_for_fred   = []
       @requests_for_barney = []
       @requests_for_fred   << FactoryGirl.create(:miq_request, :requester => @fred)
@@ -174,13 +173,9 @@ describe MiqRequest do
       end
 
       it "#build_default_approval" do
-        approval = @request.build_default_approval(@barney)
+        approval = @request.build_default_approval
         approval.description.should == "Default Approval"
-        approval.approver.should    == @barney
-
-        approval = @request.build_default_approval(@approver_role)
-        approval.description.should == "Default Approval"
-        approval.approver.should    == @approver_role
+        approval.approver.should    be_nil
       end
 
       it "#v_approved_by" do
@@ -243,14 +238,14 @@ describe MiqRequest do
       it "#approver" do
         @request.approver.should == @wilma.name
         @request.miq_approvals = []
-        @request.approver.should == @approver_role.name
+        @request.approver.should be_nil
       end
 
       # TODO: This is IDENTICAL to #approver method
       it "#approver_role" do
         @request.approver.should == @wilma.name
         @request.miq_approvals = []
-        @request.approver.should == @approver_role.name
+        @request.approver.should be_nil
       end
 
     end


### PR DESCRIPTION
Previously, approver could be set to a UiTaskSet, which meant that
anyone with the approver role could be an approver.  This is now handled
by setting approver to nil, making approver just represent a User
instead of both a User and a UiTaskSet.

Since UiTaskSet is no longer used technically, we instead verify only
against the miq_request_approval MiqUserRole, which
MiqApproval#authorized? had already handled.

Fixes #473
https://bugzilla.redhat.com/show_bug.cgi?id=1130146

@gmcculloug Please review.  I have not testing actual provisioning...we'll have to do that together.
