### PR TITLE
Let the user know an encryption key is required

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -459,6 +459,23 @@ Date and Time Configuration
 
         when I18n.t("advanced_settings.db_config")
           say("#{selection}\n\n")
+
+          key_config = ApplianceConsole::KeyConfiguration.new
+          unless key_config.key_exist?
+            say "No Encryption key is found.\n"
+            say "For migrations, please copy encryption key (v2_key) from a hardened appliance"
+            say "For worker and multi-region setups please copy key from another appliance\n"
+            say "If this is your first appliance, just generate one now\n\n"
+
+            if agree("Generate an encryption key now? (Y/N): ")
+              key_config.create_key(true)
+              say("\nCustom encryption Key generated\n")
+            else
+              press_any_key
+              raise MiqSignalError
+            end
+          end
+
           loc_selection = ask_with_menu("Database Location", %w(Internal External), nil, false)
 
           ApplianceConsole::Logging.logger = VMDBLogger.new(LOGFILE)

--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -111,6 +111,7 @@ module ApplianceConsole
     end
 
     def set_db
+      raise "No v2_key present" unless KeyConfiguration.new.key_exist?
       if local?(hostname)
         set_internal_db
       else

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -19,7 +19,15 @@ describe ApplianceConsole::Cli do
     subject.parse([]).run
   end
 
+  context "#database" do
+    it "requires v2_key" do
+      expect_any_instance_of(ApplianceConsole::KeyConfiguration).to receive(:key_exist?).and_return(false)
+      expect { subject.parse(%w(--internal -r 1 --dbdisk x)).run }.to raise_error("No v2_key present")
+    end
+  end
+
   it "should set database host to localhost if running locally" do
+    expect_v2_key
     subject.should_receive(:disk_from_string).with('x').and_return('/dev/x')
     subject.should_receive(:say)
     ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
@@ -34,6 +42,7 @@ describe ApplianceConsole::Cli do
   end
 
   it "should pass username and password when configuring database locally" do
+    expect_v2_key
     subject.should_receive(:disk_from_string).and_return('x')
     subject.should_receive(:say)
     ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
@@ -49,6 +58,7 @@ describe ApplianceConsole::Cli do
   end
 
   it "should handle remote databases (and setup region)" do
+    expect_v2_key
     subject.should_receive(:say)
     ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
       .with(:host        => 'host',
@@ -63,6 +73,7 @@ describe ApplianceConsole::Cli do
   end
 
   it "should handle remote databases (not setting up region)" do
+    expect_v2_key
     subject.should_receive(:say)
     ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
       .with(:host        => 'host',
@@ -267,4 +278,9 @@ describe ApplianceConsole::Cli do
     end
   end
 
+  private
+
+  def expect_v2_key
+    expect_any_instance_of(ApplianceConsole::KeyConfiguration).to receive(:key_exist?).and_return(true)
+  end
 end


### PR DESCRIPTION
When a user is creating a database, but has not created a v2_key yet, let them know

https://bugzilla.redhat.com/show_bug.cgi?id=1136573
