### PR TITLE
Exclude files with no extension from precompile

### DIFF
--- a/vmdb/lib/vmdb/productization.rb
+++ b/vmdb/lib/vmdb/productization.rb
@@ -27,7 +27,7 @@ module Vmdb
       Rails.application.config.assets.precompile = [
         Proc.new do |path|
           include =
-            !File.extname(path).in?(['.js', '.css']) ||
+            !File.extname(path).in?(['.js', '.css', '']) ||
             path =~ /(?:\/|\\|\A)(application|productization)\.(css|js)$/
 
           resolved = Rails.application.assets.resolve(path)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1135050

Fixes the issue precompiling assets with sprockets >= 2.4.4:
"Asset logical path has no extension: codemirror-4.2/AUTHORS"

See the reported upstream issue here[1].
The commit that started this issue is here [2].

This has been an issue in many versions of sprockets since v2.4.4:
v2.12.1  v2.12.0 v2.11.1 v2.11.0 v2.10.1 v2.10.0 v2.9.3 v2.9.2 v2.9.1 v2.9.0 v2.8.2 v2.8.1 v2.8.0 v2.7.0 v2.6.0 v2.5.0 v2.4.5 v2.4.4

The solutions found in [1] were to either:
a) rename assets to add a file extension (such as AUTHORS -> AUTHORS.txt)
b) modify the config.assets.precompile Proc to whitelist which file extensions that were desired or to exclude files without an extension.

[1] sstephenson/sprockets#347
[2] sstephenson/sprockets@5dbd7c6
