### PR TITLE
EMS Refresh of Amazon Virtualization Type

### DIFF
--- a/vmdb/app/helpers/flavor_helper/textual_summary.rb
+++ b/vmdb/app/helpers/flavor_helper/textual_summary.rb
@@ -5,7 +5,7 @@ module FlavorHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w{cpus cpu_cores memory supports_32_bit supports_64_bit}
+    items = %w(cpus cpu_cores memory supports_32_bit supports_64_bit supports_hvm supports_paravirtual)
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -43,6 +43,16 @@ module FlavorHelper::TextualSummary
   def textual_supports_64_bit
     return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_64_bit.nil?
     {:label => "64 Bit Architecture ", :value => @record.supports_64_bit?}
+  end
+
+  def textual_supports_hvm
+    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_hvm.nil?
+    {:label => "HVM (Hardware Virtual Machine)", :value => @record.supports_hvm?}
+  end
+
+  def textual_supports_paravirtual
+    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_paravirtual.nil?
+    {:label => "Paravirtualization", :value => @record.supports_paravirtual?}
   end
 
   def textual_ems_cloud

--- a/vmdb/db/migrate/20140903194919_add_virtualization_type_to_hardware.rb
+++ b/vmdb/db/migrate/20140903194919_add_virtualization_type_to_hardware.rb
@@ -1,0 +1,5 @@
+class AddVirtualizationTypeToHardware < ActiveRecord::Migration
+  def change
+    add_column :hardwares, :virtualization_type, :string
+  end
+end

--- a/vmdb/db/migrate/20140903195524_add_supports_hvm_to_flavor.rb
+++ b/vmdb/db/migrate/20140903195524_add_supports_hvm_to_flavor.rb
@@ -1,0 +1,6 @@
+class AddSupportsHvmToFlavor < ActiveRecord::Migration
+  def change
+    add_column :flavors, :supports_hvm, :boolean
+    add_column :flavors, :supports_paravirtual, :boolean
+  end
+end

--- a/vmdb/product/views/Flavor.yaml
+++ b/vmdb/product/views/Flavor.yaml
@@ -25,6 +25,8 @@ cols:
 - memory
 - supports_32_bit
 - supports_64_bit
+- supports_hvm
+- supports_paravirtual
 - total_vms
 
 # Included tables (joined, has_one, has_many) and columns
@@ -46,6 +48,8 @@ col_order:
 - memory
 - supports_32_bit
 - supports_64_bit
+- supports_hvm
+- supports_paravirtual
 - total_vms
 
 col_formats:
@@ -64,6 +68,8 @@ headers:
 - Memory
 - 32 Bit Architecture
 - 64 Bit Architecture
+- HVM (Hardware Virtual Machine)
+- Paravirtualization
 - Instances
 
 # Condition(s) string for the SQL query

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
@@ -75,14 +75,16 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     @flavor = Flavor.where(:name => "t1.micro").first
     @flavor.should be_kind_of(FlavorAmazon)
     @flavor.should have_attributes(
-      :name            => "t1.micro",
-      :description     => "T1 Micro",
-      :enabled         => true,
-      :cpus            => 1,
-      :cpu_cores       => 1,
-      :memory          => 613.megabytes.to_i,
-      :supports_32_bit => true,
-      :supports_64_bit => true
+      :name                 => "t1.micro",
+      :description          => "T1 Micro",
+      :enabled              => true,
+      :cpus                 => 1,
+      :cpu_cores            => 1,
+      :memory               => 613.megabytes.to_i,
+      :supports_32_bit      => true,
+      :supports_64_bit      => true,
+      :supports_hvm         => false,
+      :supports_paravirtual => true
     )
 
     @flavor.ext_management_system.should == @ems

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -84,14 +84,16 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     @flavor = Flavor.where(:name => "t1.micro").first
     @flavor.should be_kind_of(FlavorAmazon)
     @flavor.should have_attributes(
-      :name            => "t1.micro",
-      :description     => "T1 Micro",
-      :enabled         => true,
-      :cpus            => 1,
-      :cpu_cores       => 1,
-      :memory          => 613.megabytes.to_i,
-      :supports_32_bit => true,
-      :supports_64_bit => true
+      :name                 => "t1.micro",
+      :description          => "T1 Micro",
+      :enabled              => true,
+      :cpus                 => 1,
+      :cpu_cores            => 1,
+      :memory               => 613.megabytes.to_i,
+      :supports_32_bit      => true,
+      :supports_64_bit      => true,
+      :supports_hvm         => false,
+      :supports_paravirtual => true
     )
 
     @flavor.ext_management_system.should == @ems
@@ -237,14 +239,15 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     @template.snapshots.size.should         == 0
 
     @template.hardware.should have_attributes(
-      :guest_os           => "linux",
-      :guest_os_full_name => nil,
-      :bios               => nil,
-      :annotation         => nil,
-      :numvcpus           => 1, # wtf
-      :memory_cpu         => nil,
-      :disk_capacity      => nil,
-      :bitness            => 64
+      :guest_os            => "linux",
+      :guest_os_full_name  => nil,
+      :bios                => nil,
+      :annotation          => nil,
+      :numvcpus            => 1, # wtf
+      :memory_cpu          => nil,
+      :disk_capacity       => nil,
+      :bitness             => 64,
+      :virtualization_type => "paravirtual"
     )
 
     @template.hardware.disks.size.should         == 0
@@ -299,14 +302,15 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     v.snapshots.size.should         == 0
 
     v.hardware.should have_attributes(
-      :guest_os           => "linux",
-      :guest_os_full_name => nil,
-      :bios               => nil,
-      :annotation         => nil,
-      :numvcpus           => 1,
-      :memory_cpu         => 613, # MB
-      :disk_capacity      => 0, # TODO: Change to a flavor that has disks
-      :bitness            => 64
+      :guest_os            => "linux",
+      :guest_os_full_name  => nil,
+      :bios                => nil,
+      :annotation          => nil,
+      :numvcpus            => 1,
+      :memory_cpu          => 613, # MB
+      :disk_capacity       => 0, # TODO: Change to a flavor that has disks
+      :bitness             => 64,
+      :virtualization_type => "paravirtual"
     )
 
     v.hardware.disks.size.should         == 0 # TODO: Change to a flavor that has disks


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1133780

This is the code changes to populate the hardwares and flavors
table with the virtualization type for Amazon Images and for the Amazon
flavor types. 2 new columns have been added to the flavors table and
a single column has been added to the hardwares table
The virtualization type is documented on the amazon web page at
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html
