### PR TITLE
Upgrade Haml to prevent it from mutating our strings.

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -47,6 +47,7 @@ gem "ancestry",                       "~>1.2.4",      :require => false
 gem "aws-sdk",                        "~>1.11.3",     :require => false
 gem 'dalli',                          "~>2.2.1",      :require => false
 gem "elif",                           "=0.1.0",       :require => false
+gem "haml",                           "~>4.0.5",      :require => false
 gem 'haml-rails',                     "~> 0.4",       :require => false
 gem "inifile",                        "~>2.0.2",      :require => false
 gem "logging",                        "~>1.6.1",      :require => false  # Ziya depends on this


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1134863

Haml 4.0.3 was doing gsub! on provided strings and was broken with frozen Strings.  It was fixed in 4.0.4 and 4.0.5 in this commit: https://github.com/haml/haml/commit/5bb46925b2b5211c7cb2052b8772872689e25346

Note: I had to run `bundle update haml brakeman` to get upgraded to 4.0.5 haml locally.
