### PR TITLE
fix region to region communication

### DIFF
--- a/vmdb/app/apis/vmdbws_client.rb
+++ b/vmdb/app/apis/vmdbws_client.rb
@@ -1,11 +1,16 @@
 class VmdbwsClient < EvmWebservicesClient
   def initialize(host_name)
-    super(
-      host_name,
-      'protocol.http.ssl_config.verify_mode' => 'OpenSSL::SSL::VERIFY_PEER',
-      'protocol.http.ssl_config.client_key'  => Rails.root.join("certs/apiclient.key").to_s,
-      'protocol.http.ssl_config.client_cert' => Rails.root.join("certs/apiclient.crt").to_s,
-      'protocol.http.ssl_config.ca_file'     => Rails.root.join("certs/root.crt").to_s,
-    )
+    driver_options = {}
+    protocol = nil
+    if File.exist?(Rails.root.join("certs/apiclient.crt"))
+      driver_options = {
+        'protocol.http.ssl_config.verify_mode' => 'OpenSSL::SSL::VERIFY_PEER',
+        'protocol.http.ssl_config.client_key'  => Rails.root.join("certs/apiclient.key").to_s,
+        'protocol.http.ssl_config.client_cert' => Rails.root.join("certs/apiclient.crt").to_s,
+        'protocol.http.ssl_config.ca_file'     => Rails.root.join("certs/root.crt").to_s,
+      }
+      protocol = "https"
+    end
+    super(host_name, protocol, VmdbwsSupport::SYSTEM_USER, VmdbwsSupport.system_password, driver_options)
   end
 end

--- a/vmdb/app/apis/vmdbws_support.rb
+++ b/vmdb/app/apis/vmdbws_support.rb
@@ -2,6 +2,13 @@ require 'actionwebservice'
 
 module VmdbwsSupport
   SYSTEM_USER = "system"
+  SYSTEM_PASSWORD_ROOT = "password"
+
+  # used by region to region communication.
+  # since the encryption key used is different for each installation, the result is different per installation
+  def self.system_password
+    MiqPassword.encrypt(VmdbwsSupport::SYSTEM_PASSWORD_ROOT)
+  end
 
   class MiqActionWebServiceStruct < ActionWebService::Struct
     def to_h

--- a/vmdb/spec/controllers/vmdbws_controller_spec.rb
+++ b/vmdb/spec/controllers/vmdbws_controller_spec.rb
@@ -5,29 +5,47 @@ describe VmdbwsController do
   #       change those tests too
 
   it "handles security turned off" do
-    controller.should_receive(:get_vmdb_config).and_return(double(:fetch_path => "none"))
-    controller.should_not_receive(:authenticate_or_request_with_http_basic)
+    expect(controller).to receive(:get_vmdb_config).and_return(:webservices => {:integrate => {:security => "none"}})
+    expect(controller).not_to receive(:authenticate_or_request_with_http_basic)
     expect(controller.send(:authenticate)).to eq(true)
     expect(assigns(:username)).to eq(VmdbwsSupport::SYSTEM_USER)
   end
 
-  it "handles ssl certs" do
-    controller.should_receive(:get_vmdb_config).and_return(double(:fetch_path => "basic"))
-    request.env["SERVER_PORT"] = "8443"
-    controller.should_not_receive(:authenticate_or_request_with_http_basic)
+  it "handles region to region password" do
+    expect(controller).to receive(:get_vmdb_config).and_return(:webservices => {:integrate => {:security => "basic"}})
+    http_login VmdbwsSupport::SYSTEM_USER, VmdbwsSupport.system_password
 
+    expect(User).not_to receive(:authenticate_with_http_basic)
     expect(controller.send(:authenticate)).to eq(true)
     expect(assigns(:username)).to eq(VmdbwsSupport::SYSTEM_USER)
+  end
+
+  it "handles bad region to region passwords" do
+    expect(controller).to receive(:get_vmdb_config).twice
+      .and_return(:webservices => {:integrate => {:security => "basic"}})
+    http_login VmdbwsSupport::SYSTEM_USER, "bad"
+
+    expect(User).not_to receive(:authenticate_with_http_basic)
+    expect { controller.send(:authenticate) }.to raise_error
   end
 
   it "handles username password" do
     user = FactoryGirl.create(:user, :password => "dummy")
     http_login user.userid, user.password
 
-    controller.should_receive(:get_vmdb_config).and_return(double(:fetch_path => "basic"))
-    controller.should_receive(:get_vmdb_config).and_return(double(:fetch_path => "30.seconds"))
-
+    expect(controller).to receive(:get_vmdb_config).twice
+      .and_return(:webservices => {:integrate => {:security => "basic"}, :authentication_timeout => "30.seconds"})
     expect(controller.send(:authenticate)).to eq(true)
     expect(assigns(:username)).to eq(user.userid)
+  end
+
+  it "handles bad username password" do
+    http_login "joe", "password"
+
+    expect(controller).to receive(:get_vmdb_config).twice
+      .and_return(:webservices => {:integrate => {:security => "basic"}, :authentication_timeout => "30.seconds"})
+
+    expect { controller.send(:authenticate) }.to raise_error
+    expect(assigns(:username)).to eq("joe")
   end
 end


### PR DESCRIPTION
A little sad to introduce user/password into the cross region communication.
But we currently can not rely upon client side certs providing that protection layer, so username, password is our strategy for anand/5.3.

I'm leveraging the `v2_key` to generate a password. This will be unique per installation and requires that both machines have the same `v2_key`. This allows us to avoid having yet another shared secret between machines.

Added the non "happy path" for `vmdbws_controller`, so that is better tested.
No automated tests around the soap stuff in vmdbws_client.

If your machine has a server side cert, then that is saying you were locked down by ipa, and you can assume the server was locked down by ipa. If the server is locked down by verisign, then that will work too.

https://bugzilla.redhat.com/show_bug.cgi?id=1135072

/cc @gmcculloug @Fryguy 
