### PR TITLE
Upgrade net-ldap for fix for LDAP Controls.

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -19,7 +19,7 @@ gem "ruport",                         "=1.7.0",                          :git =>
 
 # Vendored but not required
 gem "actionwebservice",               "=3.1.0",       :require => false, :git => "git://github.com/ManageIQ/actionwebservice.git", :tag => "v3.1.0-1"
-gem "net-ldap",                       "=0.2.20110317223538",  :require => false, :git => "git://github.com/ManageIQ/ruby-net-ldap.git", :tag => "v0.2-1"
+gem "net-ldap",                       "~>0.7.0",      :require => false
 gem "rubyrep",                        "=1.2.0",       :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-2"
 gem "soap4r",                         "=1.6.0",       :require => false, :git => "git://github.com/ManageIQ/soap4r.git", :tag => "v1.6.0-2"
 gem "simple-rss",                     "=1.2.3",       :require => false, :git => "git://github.com/ManageIQ/simple-rss.git", :tag => "v1.2.3-8"
@@ -50,7 +50,7 @@ gem "elif",                           "=0.1.0",       :require => false
 gem 'haml-rails',                     "~> 0.4",       :require => false
 gem "inifile",                        "~>2.0.2",      :require => false
 gem "logging",                        "~>1.6.1",      :require => false  # Ziya depends on this
-gem "net-ping",                       "~>1.5.3",      :require => false
+gem "net-ping",                       "~>1.7.4",      :require => false
 gem "net-sftp",                       "~>2.0.5",      :require => false
 gem "net-ssh",                        "~>2.6.5",      :require => false  # fog 1.13 wants net-ssh 2.6.5
 gem "open4",                          "~>1.3.0",      :require => false


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=956833

net-ping at 1.5.3 required net-ldap at ~>0.2.2, so we need to upgrade net-ping also.

See: ruby-ldap/ruby-net-ldap#18

In upgrading from 0.2.2 to latest, 0.7.0, the change we need is here:
https://github.com/ruby-ldap/ruby-net-ldap/compare/v0.2.2...v0.7.0#diff-724e0b3130dc49ca34eadc7c25d28b18R1647.
We want to be able to compact any nil control_codes.
