### PR TITLE
Process derived storage cap&u fields

### DIFF
--- a/vmdb/app/models/metric/finders.rb
+++ b/vmdb/app/models/metric/finders.rb
@@ -42,7 +42,7 @@ module Metric::Finders
       res_cond << '(resource_type = ? AND resource_id IN (?))'
       res_params << t << id
     end
-    res_cond = res_cond.join(' AND ')
+    res_cond = res_cond.join(' OR ')
 
     cond.nil? ? cond = [res_cond] : cond[0] << " AND #{res_cond}"
     cond += res_params

--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -602,6 +602,14 @@ describe Metric do
           Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:timestamp)[1..5]
         end
 
+        it "should find multiple resource types" do
+          @host1.metric_rollups << FactoryGirl.create(:metric_rollup_host_hr,
+                                                      :resource  => @host1,
+                                                      :timestamp => "2010-04-14T22:00:00Z")
+          metrics = Metric::Finders.find_all_by_day([@vm1, @host1], "2010-04-14T00:00:00Z", 'hourly', @time_profile)
+          metrics.collect { |m| m.resource_type }.uniq.sort.should == %w(VmOrTemplate Host).uniq.sort
+        end
+
         context "calling perf_rollup to daily on the Vm" do
           before(:each) do
             @vm1.perf_rollup("2010-04-14T00:00:00Z", 'daily', @time_profile.id)


### PR DESCRIPTION
**Update: Sept 5, 2014**

Squash specs with code changes

---

Derived storage metrics were not being calculated because the `Metric::Finders.find_all_by_range` method had a bug preventing the method from finding metrics records for different resource types in the same query.

It appears that this type of functionality was only used when processing derived storage metrics.  All other callers of this method appear to pass in only a single resource type at a time.

The erroneous part was that the query builder attempted to use the SQL `AND` operator to join `resource_type` conditions in the where clause.  The problem is that no single metrics record be of more than one resource type.  So, querying for rows where the the resource type is `"VmOrTemplate" AND "Storage"` will always fail.  Now, the query attempts to find rows where resource type is `"VmOrTemplate" OR "Storage"`.

https://bugzilla.redhat.com/show_bug.cgi?id=1138442
