### PR TITLE
Add routes for repository tag editing.

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1286,6 +1286,7 @@ Vmdb::Application.routes.draw do
         show_list
         tag_edit_form_field_changed
         tagging_edit
+        toggle_dash
         update
       )
     },

--- a/vmdb/spec/routing/repository_routing_spec.rb
+++ b/vmdb/spec/routing/repository_routing_spec.rb
@@ -11,6 +11,7 @@ describe "routes for AvailabilityZoneController" do
   it_behaves_like "A controller that has policy protect routes"
   it_behaves_like "A controller that has show list routes"
   it_behaves_like "A controller that has CRUD routes"
+  it_behaves_like "A controller that has tagging routes"
 
   describe "#button" do
     it "routes with POST" do


### PR DESCRIPTION
This is to fix the following error:

Error caught: [ActionController::RoutingError] No route matches
{:action=>"tagging_edit",
 :id=>nil,
 :db=>Repository(...),
 :escape=>false,
 :controller=>"repository"}

http://bugzilla.redhat.com/show_bug.cgi?id=1138120
