### PR TITLE
SCVMM: Gracefully handle empty results from Powershell

### DIFF
--- a/vmdb/app/models/ems_microsoft/powershell.rb
+++ b/vmdb/app/models/ems_microsoft/powershell.rb
@@ -11,9 +11,11 @@ class EmsMicrosoft
         log_header = "MIQ(#{self.class.name}.#{__method__})"
         File.open(script, "r") do |file|
           begin
-            connection.run_powershell_script(file)
+            results = connection.run_powershell_script(file)
+            log_dos_error_results(results)
+            results
           rescue Errno::ECONNREFUSED => err
-            $scvmm_log.error "MIQ(#{log_header} Unable to connect to VMM. #{err.message})"
+            $scvmm_log.error "MIQ(#{log_header} Unable to connect to SCVMM. #{err.message})"
             raise
           end
         end


### PR DESCRIPTION
1) Now log the error messages returned from Powershell.
2) In Scvmm.rb - Now check if the hash (@inventory) is empty
3) Now handle empty datasets within the @inventory hash (e.g. vms)

https://bugzilla.redhat.com/show_bug.cgi?id=1134064
