### PR TITLE
Change the security context of the script so logrotate can read it.

### DIFF
--- a/system/cfme-setup.sh
+++ b/system/cfme-setup.sh
@@ -32,9 +32,13 @@ EOF
 
 /usr/sbin/semanage fcontext -a -t httpd_log_t "/var/www/miq/vmdb/log(/.*)?"
 /usr/sbin/semanage fcontext -a -t cert_t "/var/www/miq/vmdb/certs(/.*)?"
+/usr/sbin/semanage fcontext -a -t logrotate_exec_t /var/www/miq/system/logrotate_free_space_check.sh
+
 [ -x /sbin/restorecon ] && /sbin/restorecon -R -v /var/www/miq/vmdb/log
 [ -x /sbin/restorecon ] && /sbin/restorecon -R -v /etc/sysconfig
 [ -x /sbin/restorecon ] && /sbin/restorecon -R -v /var/www/miq/vmdb/certs
+[ -x /sbin/restorecon ] && /sbin/restorecon -R -v /var/www/miq/system/logrotate_free_space_check.sh
+
 # relabel the pg_log directory in postgresql datadir, but defer restorecon
 # until after the database is initialized during firstboot configuration
 /usr/sbin/semanage fcontext -a -t var_log_t "/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log(/.*)?"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1138477
Fixes #219

The shell script was inheriting a resource context of "httpd_sys_content_t" from the parent directory.
Logrotate runs as logrotate_t and was getting audit failures in the /var/log/audit/audit.log:

type=AVC msg=audit(1410073682.664:105): avc:  denied  { read } for  pid=9812 comm="sh" name="logrotate_free_space_check.sh" dev=dm-0 ino=548602 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:httpd_sys_content_t:s0 tclass=file
