### PR TITLE
Don't sort non-sortable columns

### DIFF
--- a/vmdb/app/assets/javascripts/miq_dhtmlxgrid.js
+++ b/vmdb/app/assets/javascripts/miq_dhtmlxgrid.js
@@ -219,7 +219,7 @@ function miqGridSort(col_id, grid_obj, dir) {
 											onComplete:function(request){miqSparkle(false);}}
 			);
 	} else {
-		if (col_id > 1) {
+		if (grid_obj && col_id > 1) {
 			url = miq_action_url;
 			if (typeof miq_parent_id != "undefined") {
 				url = "/" + miq_parent_class + "/" + url + "/" + miq_parent_id;


### PR DESCRIPTION
Non-sortable columns, such as row_button, would have grid_obj
set to an empty string.

https://bugzilla.redhat.com/show_bug.cgi?id=1132536
