### PR TITLE
EmsRefresh of Amazon Images for EBS only instances

### DIFF
--- a/vmdb/app/helpers/flavor_helper/textual_summary.rb
+++ b/vmdb/app/helpers/flavor_helper/textual_summary.rb
@@ -5,7 +5,7 @@ module FlavorHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w(cpus cpu_cores memory supports_32_bit supports_64_bit supports_hvm supports_paravirtual)
+    items = %w(cpus cpu_cores memory supports_32_bit supports_64_bit supports_hvm supports_paravirtual block_storage_based_only)
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -36,23 +36,28 @@ module FlavorHelper::TextualSummary
   end
 
   def textual_supports_32_bit
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_32_bit.nil?
+    return nil if @record.supports_32_bit.nil?
     {:label => "32 Bit Architecture ", :value => @record.supports_32_bit?}
   end
 
   def textual_supports_64_bit
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_64_bit.nil?
+    return nil if @record.supports_64_bit.nil?
     {:label => "64 Bit Architecture ", :value => @record.supports_64_bit?}
   end
 
   def textual_supports_hvm
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_hvm.nil?
+    return nil if @record.supports_hvm.nil?
     {:label => "HVM (Hardware Virtual Machine)", :value => @record.supports_hvm?}
   end
 
   def textual_supports_paravirtual
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_paravirtual.nil?
+    return nil if @record.supports_paravirtual.nil?
     {:label => "Paravirtualization", :value => @record.supports_paravirtual?}
+  end
+
+  def textual_block_storage_based_only
+    return nil if @record.block_storage_based_only.nil?
+    {:label => "Block Storage Based", :value => @record.block_storage_based_only?}
   end
 
   def textual_ems_cloud

--- a/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module VmCloudHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w{name region server description ipaddress custom_1 container tools_status osinfo architecture advanced_settings resources guid}
+    items = %w(name region server description ipaddress custom_1 container tools_status osinfo architecture advanced_settings resources guid virtualization_type root_device_type)
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -555,5 +555,17 @@ module VmCloudHelper::TextualSummary
       h[:link]  = url_for(:action => 'security_groups', :id => @record, :display => "security_groups")
     end
     h
+  end
+
+  def textual_virtualization_type
+    return nil if @record.kind_of?(VmOpenstack) || @record.kind_of?(TemplateOpenstack)
+    v_type = @record.hardware.try(:virtualization_type)
+    {:label => "Virtualization Type", :value => v_type.to_s}
+  end
+
+  def textual_root_device_type
+    return nil if @record.kind_of?(VmOpenstack) || @record.kind_of?(TemplateOpenstack)
+    rd_type = @record.hardware.try(:root_device_type)
+    {:label => "Root Device Type", :value => rd_type.to_s}
   end
 end

--- a/vmdb/db/migrate/20140908201058_add_block_storage_only_to_flavor.rb
+++ b/vmdb/db/migrate/20140908201058_add_block_storage_only_to_flavor.rb
@@ -1,0 +1,5 @@
+class AddBlockStorageOnlyToFlavor < ActiveRecord::Migration
+  def change
+    add_column :flavors, :block_storage_based_only, :boolean
+  end
+end

--- a/vmdb/db/migrate/20140908211826_add_root_device_type_to_hardware.rb
+++ b/vmdb/db/migrate/20140908211826_add_root_device_type_to_hardware.rb
@@ -1,0 +1,5 @@
+class AddRootDeviceTypeToHardware < ActiveRecord::Migration
+  def change
+    add_column :hardwares, :root_device_type, :string
+  end
+end

--- a/vmdb/product/views/Flavor.yaml
+++ b/vmdb/product/views/Flavor.yaml
@@ -27,6 +27,7 @@ cols:
 - supports_64_bit
 - supports_hvm
 - supports_paravirtual
+- block_storage_based_only
 - total_vms
 
 # Included tables (joined, has_one, has_many) and columns
@@ -50,6 +51,7 @@ col_order:
 - supports_64_bit
 - supports_hvm
 - supports_paravirtual
+- block_storage_based_only
 - total_vms
 
 col_formats:
@@ -70,6 +72,7 @@ headers:
 - 64 Bit Architecture
 - HVM (Hardware Virtual Machine)
 - Paravirtualization
+- Block Storage Based
 - Instances
 
 # Condition(s) string for the SQL query

--- a/vmdb/product/views/TemplateCloud.yaml
+++ b/vmdb/product/views/TemplateCloud.yaml
@@ -33,6 +33,8 @@ include:
   hardware:
     columns:
     - bitness
+    - virtualization_type
+    - root_device_type
 
 # Included tables and columns for query performance
 include_for_find:
@@ -48,6 +50,8 @@ col_order:
 - last_compliance_status
 - allocated_disk_storage
 - hardware.bitness
+- hardware.virtualization_type
+- hardware.root_device_type
 - last_scan_on
 - region_description
 
@@ -58,6 +62,8 @@ headers:
 - Compliant
 - Allocated Size
 - Architecture
+- Virtualization Type
+- Root Device Type
 - Last Analysis Time
 - Region
 

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -84,16 +84,17 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     @flavor = Flavor.where(:name => "t1.micro").first
     @flavor.should be_kind_of(FlavorAmazon)
     @flavor.should have_attributes(
-      :name                 => "t1.micro",
-      :description          => "T1 Micro",
-      :enabled              => true,
-      :cpus                 => 1,
-      :cpu_cores            => 1,
-      :memory               => 613.megabytes.to_i,
-      :supports_32_bit      => true,
-      :supports_64_bit      => true,
-      :supports_hvm         => false,
-      :supports_paravirtual => true
+      :name                     => "t1.micro",
+      :description              => "T1 Micro",
+      :enabled                  => true,
+      :cpus                     => 1,
+      :cpu_cores                => 1,
+      :memory                   => 613.megabytes.to_i,
+      :supports_32_bit          => true,
+      :supports_64_bit          => true,
+      :supports_hvm             => false,
+      :supports_paravirtual     => true,
+      :block_storage_based_only => true,
     )
 
     @flavor.ext_management_system.should == @ems
@@ -247,7 +248,8 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
       :memory_cpu          => nil,
       :disk_capacity       => nil,
       :bitness             => 64,
-      :virtualization_type => "paravirtual"
+      :virtualization_type => "paravirtual",
+      :root_device_type    => "ebs"
     )
 
     @template.hardware.disks.size.should         == 0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1139383

This is the first part of the ticket, it pertains to storing the
block_storage_only for flavors and root_device_type for images.
Once this data is filled in by the ems_refresh we will be able to
filter out invalid instance types during provisioning.
