### PR TITLE
restore selinux label for dhcp network scripts

### DIFF
--- a/system/LINK/bin/miqnet.sh
+++ b/system/LINK/bin/miqnet.sh
@@ -327,6 +327,8 @@ NETMASK=${2}" >> ${cfg}.tmp
   # Truncate the temporary io file
   :> $TMP_IO
 
+  /sbin/restorecon -R /etc/sysconfig
+
   # 2) reload config and bring up the interface to see if it worked
   service network reload > /dev/null 2>> $ERR_FILE
   ifup eth0 >> $TMP_IO 2 >> $ERR_FILE
@@ -464,6 +466,8 @@ set_redhat_dhcp() {
 
   # Truncate the temporary io file
   :> $TMP_IO
+
+  /sbin/restorecon -R /etc/sysconfig
 
   # 4) Start the interface to see if it worked
   ifup eth0 >> $TMP_IO 2>> $ERR_FILE


### PR DESCRIPTION
The `ifcfg-eth0` script does not have the correct selinux label.

This PR corrects the label after modifying network files in `miqnet.sh`
There may be another lingering issue with this file. But since cfme-setup.sh does the same restorecon, it should probably be covered.

Sample Error:

```
type=AVC msg=audit(1410252632.122:1117): avc:  denied  { getattr } for  pid=20072 comm="grep" path="/etc/sysconfig/network-scripts/ifcfg-eth0" dev=dm-0 ino=131095 scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:object_r:file_t:s0 tclass=file
```

/cc @jrafanie @abellotti 
