### PR TITLE
Added support for buttons from Cloud Tenant summary screen.

### DIFF
--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -194,10 +194,10 @@ module ApplicationController::CiProcessing
       return
     end
     # check to see if coming from show_list or drilled into vms from another CI
-    if request.parameters[:controller] == "vm" || ["all_vms","vms"].include?(params[:display])
+    if request.parameters[:controller] == "vm" || %w(all_vms instances vms).include?(params[:display])
       rec_cls = "vm"
     elsif request.parameters[:controller] == "service"
-    rec_cls =  "service"
+      rec_cls =  "service"
     else
       rec_cls = "vm_vdi"
     end

--- a/vmdb/app/views/layouts/_edit_form_buttons.html.erb
+++ b/vmdb/app/views/layouts/_edit_form_buttons.html.erb
@@ -126,9 +126,9 @@
                              :class   => 'btn btn-default',
                              :alt     => "Reset Changes",
                              :title   => "Reset Changes",
-                             :onclickb => "miqAjaxButton('#{url_for(:action  => action_url,
-                                                                    :id      => record_id,
-                                                                    :button  => "reset")}');")
+                             :onclick => "miqAjaxButton('#{url_for(:action  => action_url,
+                                                                   :id      => record_id,
+                                                                   :button  => "reset")}');")
               %>
 
             <% else %>

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -147,15 +147,34 @@ Vmdb::Application.routes.draw do
 
     :cloud_tenant            => {
       :get => %w(
+        compare_miq
+        compare_to_csv
+        compare_to_pdf
+        compare_to_txt
+        edit
         index
+        protect
         show
         show_list
-        edit
+        tagging_edit
       ),
       :post => %w(
         button
+        compare_choose_base
+        compare_compress
+        compare_miq
+        compare_miq_all
+        compare_miq_differences
+        compare_miq_same
+        compare_mode
+        compare_remove
+        compare_set_state
+        protect
+        sections_field_changed
         show
         show_list
+        tagging_edit
+        tag_edit_form_field_changed
         update
         panel_control
       )

--- a/vmdb/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/vmdb/spec/controllers/cloud_tenant_controller_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe CloudTenantController do
+  context "#button" do
+    it "when Instance Retire button is pressed" do
+      controller.instance_variable_set(:@_params, :pressed => "instance_retire")
+      controller.should_receive(:retirevms).once
+      controller.button
+      controller.send(:flash_errors?).should_not be_true
+    end
+
+    it "when Instance Tag is pressed" do
+      controller.instance_variable_set(:@_params, :pressed => "instance_tag")
+      controller.should_receive(:tag).with(VmOrTemplate)
+      controller.button
+      controller.send(:flash_errors?).should_not be_true
+    end
+  end
+end

--- a/vmdb/spec/routing/cloud_tenant_routing_spec.rb
+++ b/vmdb/spec/routing/cloud_tenant_routing_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "routing/shared_examples"
+
+describe EmsCloudController do
+  let(:controller_name) { "ems_cloud" }
+
+  it_behaves_like "A controller that has column width routes"
+  it_behaves_like "A controller that has compare routes"
+  it_behaves_like "A controller that has tagging routes"
+
+  describe "#button" do
+    it "routes with POST" do
+      expect(post("/cloud_tenant/button")).to route_to("cloud_tenant#button")
+    end
+  end
+
+  describe "#sections_field_changed" do
+    it "routes with POST" do
+      expect(post("/cloud_tenant/sections_field_changed")).to route_to("cloud_tenant#sections_field_changed")
+    end
+  end
+
+  describe "#show_list" do
+    it "routes with GET" do
+      expect(get("/cloud_tenant/show_list")).to route_to("cloud_tenant#show_list")
+    end
+
+    it "routes with POST" do
+      expect(post("/cloud_tenant/show_list")).to route_to("cloud_tenant#show_list")
+    end
+  end
+end


### PR DESCRIPTION
- Added support for buttons when going to list of Instance/Images thru relationships from Cloud Tenant summary screen.
- Added spec tests for routes under cloud tenants and spec test to verify that button method is added to cloud tenant controller.
- Fixed a typo in edit_form_buttons view for reset button.

https://bugzilla.redhat.com/show_bug.cgi?id=1138838
https://bugzilla.redhat.com/show_bug.cgi?id=1138188

@dclarizio please review/test.
