### PR TITLE
Missing Virtualization Type column for Amazon Images

### DIFF
--- a/vmdb/app/helpers/flavor_helper/textual_summary.rb
+++ b/vmdb/app/helpers/flavor_helper/textual_summary.rb
@@ -36,22 +36,22 @@ module FlavorHelper::TextualSummary
   end
 
   def textual_supports_32_bit
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_32_bit.nil?
+    return nil if @record.supports_32_bit.nil?
     {:label => "32 Bit Architecture ", :value => @record.supports_32_bit?}
   end
 
   def textual_supports_64_bit
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_64_bit.nil?
+    return nil if @record.supports_64_bit.nil?
     {:label => "64 Bit Architecture ", :value => @record.supports_64_bit?}
   end
 
   def textual_supports_hvm
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_hvm.nil?
+    return nil if @record.supports_hvm.nil?
     {:label => "HVM (Hardware Virtual Machine)", :value => @record.supports_hvm?}
   end
 
   def textual_supports_paravirtual
-    return nil if @record.kind_of?(FlavorOpenstack) || @record.supports_paravirtual.nil?
+    return nil if @record.supports_paravirtual.nil?
     {:label => "Paravirtualization", :value => @record.supports_paravirtual?}
   end
 

--- a/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module VmCloudHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w{name region server description ipaddress custom_1 container tools_status osinfo architecture advanced_settings resources guid}
+    items = %w(name region server description ipaddress custom_1 container tools_status osinfo architecture advanced_settings resources guid virtualization_type)
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -555,5 +555,11 @@ module VmCloudHelper::TextualSummary
       h[:link]  = url_for(:action => 'security_groups', :id => @record, :display => "security_groups")
     end
     h
+  end
+
+  def textual_virtualization_type
+    return nil if @record.kind_of?(VmOpenstack) || @record.kind_of?(TemplateOpenstack)
+    v_type = @record.hardware.try(:virtualization_type)
+    {:label => "Virtualization Type", :value => v_type.to_s}
   end
 end

--- a/vmdb/product/views/TemplateCloud.yaml
+++ b/vmdb/product/views/TemplateCloud.yaml
@@ -33,6 +33,7 @@ include:
   hardware:
     columns:
     - bitness
+    - virtualization_type
 
 # Included tables and columns for query performance
 include_for_find:
@@ -48,6 +49,7 @@ col_order:
 - last_compliance_status
 - allocated_disk_storage
 - hardware.bitness
+- hardware.virtualization_type
 - last_scan_on
 - region_description
 
@@ -58,6 +60,7 @@ headers:
 - Compliant
 - Allocated Size
 - Architecture
+- Virtualization Type
 - Last Analysis Time
 - Region
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1139835

The UI was not displaying the Virtualization Type for
Amazon Images.
