### PR TITLE
Openstack cloud network setting during provisioning

### DIFF
--- a/vmdb/app/models/miq_provision_openstack_workflow.rb
+++ b/vmdb/app/models/miq_provision_openstack_workflow.rb
@@ -17,6 +17,11 @@ class MiqProvisionOpenstackWorkflow < MiqProvisionCloudWorkflow
     end
   end
 
+  def validate_cloud_network(field, values, dlg, fld, value)
+    return nil if allowed_cloud_networks.length <= 1
+    validate_placement(field, values, dlg, fld, value)
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')

--- a/vmdb/product/dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -166,7 +166,7 @@
           :description: Cloud Network
           :auto_select_single: false
           :required: true
-          :required_method: :validate_placement
+          :required_method: :validate_cloud_network
           :display: :edit
           :data_type: :integer
         :security_groups:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1138417

During openstack provisioning the cloud network needs to be
set only if there are more than 1 available cloud networks.
