### PR TITLE
Fixed save/cancel buttons when edititng VM thru relationships.

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1291,11 +1291,10 @@ module VmCommon
     get_form_vars
     changed = (@edit[:new] != @edit[:current])
     render :update do |page|                    # Use JS to update the display
-      page.replace_html("main_div", :partial=>"vm_common/form") if ["allright","left","right"].include?(params[:button])
-      if changed != session[:changed]
-        session[:changed] = changed
-        page << javascript_for_miq_button_visibility(changed)
-      end
+      page.replace_html("main_div",
+                        :partial => "vm_common/form") if %w(allright left right).include?(params[:button])
+      page << javascript_for_miq_button_visibility(changed) if changed
+      page << "miqSparkle(false);"
     end
   end
 
@@ -1378,7 +1377,6 @@ module VmCommon
         end
       end
     else
-      get_vm_child_selection if params["right.x"] || params["left.x"] || params["allright.x"]
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
       build_edit_screen
       if @edit[:explorer]

--- a/vmdb/app/views/vm_common/_form.html.erb
+++ b/vmdb/app/views/vm_common/_form.html.erb
@@ -1,9 +1,6 @@
-<% url = url_for(:action => 'form_field_changed',
-                 :id     => "#{@record.id || "new"}")
-%>
-  <%= form_tag({:action => 'edit_vm', 
-                :id     => @record}, 
-               {:id => "vm_form"}) do 
+<div id = 'main_div'>
+  <% url = url_for(:action => 'form_field_changed',
+                   :id     => "#{@record.id || "new"}")
   %>
     <%= render :partial => "layouts/flash_msg" %>
     <p class="legend">Basic Information</p>
@@ -83,54 +80,42 @@
         </div>
       </td>
       <td width="20">
-        <% if !@edit[:explorer] %>
-          <%= image_submit_tag("/images/toolbars/right.png", 
-                               :name  => "right", 
-                               :class => "rollover small")
-          %>
-          <%= image_submit_tag("/images/toolbars/allright.png", 
-                               :name  => "allright", 
-                               :class => "rollover small")
-          %>
-          <%= image_submit_tag("/images/toolbars/left.png", 
-                               :name  => "left", 
-                               :class => "rollover small")
-          %>
-        <% else %>
-          <%= link_to(image_tag("/images/toolbars/right.png", 
-                                :class => "rollover small",
-                                :style => "width: 28px; height: 28px",
-                                :alt   => "Move selected VMs to right"),
-                      {:action => 'form_field_changed', 
-                       :button => 'right', 
-                       :id     => "#{@record.id || "new"}"},
-                      "data-submit" => 'main_div',
-                      :remote       => true,
-                      :title        => 'Move selected VMs to right')
-          %>
-          <%= link_to(image_tag("/images/toolbars/allright.png", 
-                                :class => "rollover small",
-                                :style => "width: 28px; height: 28px", 
-                                :alt   => "Move all VMs to right"),
-                      {:action => 'form_field_changed', 
-                       :button => 'allright', 
-                       :id     => "#{@record.id || "new"}"},
-                      "data-submit" => 'main_div',
-                      :remote       => true,
-                      :title        => 'Move all VMs to right')
-          %>
-          <%= link_to(image_tag("/images/toolbars/left.png",
-                                :class => "rollover small",
-                                :style => "width: 28px; height: 28px",
-                                :alt   => "Move selected VMs to left"),
-                      {:action => 'form_field_changed', 
-                       :button => 'left', 
-                       :id     => "#{@record.id || "new"}"},
-                      "data-submit" => 'main_div',
-                      :remote       => true,
-                      :title        => 'Move all selected VMs to left')
-          %>
-        <% end %>
+        <%= link_to(image_tag("/images/toolbars/right.png",
+                              :class => "rollover small",
+                              :style => "width: 28px; height: 28px",
+                              :alt   => "Move selected VMs to right"),
+                    {:action => 'form_field_changed',
+                     :button => 'right',
+                     :id     => "#{@record.id || "new"}"},
+                    "data-submit" => 'main_div',
+                    "data-miq_sparkle_on" => true,
+                    :remote       => true,
+                    :title        => 'Move selected VMs to right')
+        %>
+        <%= link_to(image_tag("/images/toolbars/allright.png",
+                              :class => "rollover small",
+                              :style => "width: 28px; height: 28px",
+                              :alt   => "Move all VMs to right"),
+                    {:action => 'form_field_changed',
+                     :button => 'allright',
+                     :id     => "#{@record.id || "new"}"},
+                    "data-submit" => 'main_div',
+                    "data-miq_sparkle_on" => true,
+                    :remote       => true,
+                    :title        => 'Move all VMs to right')
+        %>
+        <%= link_to(image_tag("/images/toolbars/left.png",
+                              :class => "rollover small",
+                              :style => "width: 28px; height: 28px",
+                              :alt   => "Move selected VMs to left"),
+                    {:action => 'form_field_changed',
+                     :button => 'left',
+                     :id     => "#{@record.id || "new"}"},
+                    "data-submit" => 'main_div',
+                    "data-miq_sparkle_on" => true,
+                    :remote       => true,
+                    :title        => 'Move all selected VMs to left')
+        %>
       </td>
       <td align="left" valign="top">
         <div style="
@@ -149,7 +134,6 @@
         </div>
       </td>
     </tr>
-    </div>
   </table>
 
     <% if !@edit[:explorer] %>
@@ -159,4 +143,4 @@
                               :record_id    => @record.id
                  } %>
     <% end %>
-<% end %>
+</div>


### PR DESCRIPTION
- Fixed save/cancel button on Edit VM screen that broke when button_tag was added to the form, had to remove form_tag tag to fix the issue.
- Removed image_submit_tag tags inside the if block to move fields left/right that were no longer needed, link_to tags to move fields left/right work for both explorer and non-explorer screens.

https://bugzilla.redhat.com/show_bug.cgi?id=1140360

@dclarizio please review/test.
