### PR TITLE
Snapshot creation disabled for Templates

### DIFF
--- a/vmdb/app/helpers/vm_helper/graphical_summary.rb
+++ b/vmdb/app/helpers/vm_helper/graphical_summary.rb
@@ -93,7 +93,7 @@ module VmHelper::GraphicalSummary
 
   def graphical_snapshots
     h = {:label => "Snapshots", :value => @record.number_of(:snapshots), :image => "snapshot"}
-    if role_allows(:feature => "vm_snapshot_show_list")
+    if role_allows(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
       h[:link] = link_to("", {:action => 'show', :id => @record, :display => 'snapshot_info'}, :remote => @explorer, :title => "Show virtual machine snapshot information")
     end
     h

--- a/vmdb/app/helpers/vm_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_helper/textual_summary.rb
@@ -221,7 +221,7 @@ module VmHelper::TextualSummary
   def textual_snapshots
     num = @record.number_of(:snapshots)
     h = {:label => "Snapshots", :image => "snapshot", :value => (num == 0 ? "None" : num)}
-    if role_allows(:feature => "vm_snapshot_show_list")
+    if role_allows(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
       h[:title] = "Show the snapshot info for this VM"
       h[:explorer] = true
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'snapshot_info')


### PR DESCRIPTION
Noted that several VMWare Templates have a snapshot in my database, so only disabled snapshots for RedHat Templates.  This issue seems loosely related: https://github.com/ManageIQ/manageiq/issues/253.

https://bugzilla.redhat.com/show_bug.cgi?id=1005285
