### PR TITLE
Check the user's access right when creating a chargeback report by tag.

### DIFF
--- a/vmdb/app/models/user.rb
+++ b/vmdb/app/models/user.rb
@@ -771,6 +771,16 @@ class User < ActiveRecord::Base
     !!miq_user_role
   end
 
+  def accessible_vms
+    if limited_self_service_user?
+      vms
+    elsif self_service_user?
+      (vms + miq_groups.includes(:vms).collect(&:vms).flatten).uniq
+    else
+      Vm.all
+    end
+  end
+
   protected
 
   def on_changed_admin_password

--- a/vmdb/spec/models/chargeback_spec.rb
+++ b/vmdb/spec/models/chargeback_spec.rb
@@ -20,6 +20,7 @@ describe Chargeback do
 
     @ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => @ems)
     @ems_cluster.hosts << @host1
+    @admin = FactoryGirl.create(:user_admin)
 
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "compute")
     temp = { :cb_rate => @cbr, :tag => [c, "vm"] }
@@ -39,7 +40,8 @@ describe Chargeback do
     @options = {:interval_size       => 1,
                 :end_interval_offset => 0,
                 :tag                 => "/managed/environment/prod",
-                :ext_options         => { :tz => "Pacific Time (US & Canada)" }
+                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
+                :userid              => @admin.userid
                 }
 
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))


### PR DESCRIPTION
Chargeback reports are based on the metrics tables.  The metrics tables don't have owners or tags, they point to the VM that the metric is for. To create a chargeback report that lists only the VMs (or other records) that belong to the user, we would have to disqualify metrics records based on the owner of the VM that the metrics records are pointing to. 

https://bugzilla.redhat.com/show_bug.cgi?id=1138234