### PR TITLE
remove some REXML monkey patches

### DIFF
--- a/lib/test/xml/tc_nokogiri.rb
+++ b/lib/test/xml/tc_nokogiri.rb
@@ -154,12 +154,6 @@ class NokogiriXmlMethods < Test::Unit::TestCase
   def test_find_each()
     xml = @xml
     row_order = %w{8 7 6 4 5}
-    REXML::XPath::each(xml, "//row") do |e|
-      assert_equal(e.attributes["id"].to_s, row_order.delete_at(0))
-    end
-    assert_equal(0, row_order.length)
-
-    row_order = %w{8 7 6 4 5}
     xml.find_each("//row") do |e|
       assert_equal(e.attributes["id"].to_s, row_order.delete_at(0))
     end
@@ -168,10 +162,6 @@ class NokogiriXmlMethods < Test::Unit::TestCase
 
   def test_find_first()
     xml = @xml
-    x = REXML::XPath.first(xml, "//row")
-    assert_not_nil(x)
-    assert_equal("8", x.attributes["id"].to_s)
-
     x = xml.find_first("//row")
     assert_not_nil(x)
     assert_equal("8", x.attributes["id"].to_s)
@@ -179,12 +169,6 @@ class NokogiriXmlMethods < Test::Unit::TestCase
 
   def test_find_match()
     xml = @xml
-    x = REXML::XPath.match(xml, "//row")
-    assert_not_nil(x)
-    assert_equal(5, x.length)
-    assert_equal("8", x[0].attributes["id"].to_s)
-    assert_equal("4", x[3].attributes["id"].to_s)
-
     x = xml.find_match("//row")
     assert_not_nil(x)
     assert_equal(5, x.length)

--- a/lib/util/xml/miq_rexml.rb
+++ b/lib/util/xml/miq_rexml.rb
@@ -215,15 +215,15 @@ module REXML
 		end
 
 		def find_first(xpath, ns=nil)
-			REXML::XPath.first_orig(self, xpath, ns)
+			REXML::XPath.first(self, xpath, ns)
 		end
 
 		def find_each(name, &blk)
-			REXML::XPath.each_orig(self, name, &blk)
+			REXML::XPath.each(self, name, &blk)
 		end
 
 		def find_match(name, &blk)
-			REXML::XPath.match_orig(self, name, &blk)
+			REXML::XPath.match(self, name, &blk)
 		end
 
     alias :doc :document
@@ -364,11 +364,11 @@ module REXML
 		end
 
 		def find_first(xpath, ns=nil)
-			REXML::XPath.first_orig(self, xpath, ns)
+			REXML::XPath.first(self, xpath, ns)
 		end
 
 		def find_each(name, &blk)
-			REXML::XPath.each_orig(self, name, &blk)
+			REXML::XPath.each(self, name, &blk)
 		end
 
     def deep_clone()
@@ -392,25 +392,4 @@ module REXML
       File.open(filename, "w") {|f| self.write(f, indent, transitive, ie_hack); f.close}
     end
 	end
-
-  # Wrapper class.  Use this class to access the XPath functions.
-  class XPath
-    class << self
-      alias :first_orig :first
-      alias :each_orig :each
-      alias :match_orig :match
-
-      def XPath::first(*args)
-          args.delete_at(0).find_first(*args)
-      end
-
-      def XPath::each(*args, &block)
-          args.delete_at(0).find_each(*args, &block)
-      end
-
-      def XPath::match(*args)
-          args.delete_at(0).find_match(*args)
-      end
-    end
-  end
 end


### PR DESCRIPTION
We don't directly use REXML::XPath, so it doesn't make sense to test that
against nokogiri.
