### PR TITLE
SCVMM linux VMs have error message in their hostname

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -298,10 +298,22 @@ module EmsRefresh::Parsers
     def process_hostname_and_ip(vm)
       [
         {
-          :hostname  => vm[:Properties][:Props][:ComputerName],
+          :hostname  => process_computer_name(vm[:Properties][:Props][:ComputerName]),
           :ipaddress => vm[:Networks]
         }
       ]
+    end
+
+    def process_computer_name(computername)
+      return if computername.nil?
+      log_header = "MIQ(#{self.class.name}.#{__method__})"
+
+      if computername.start_with?("getaddrinfo failed_")
+        $scvmm_log.warn("#{log_header} Invalid hostname value returned from SCVMM: #{computername}")
+        "Unavailable"
+      else
+        computername
+      end
     end
 
     def process_disks(vm)


### PR DESCRIPTION
Linux VMs that do not have the Integration Services installed cannot communicate guest information back to the Hyper-v server. The 'hostname' is one example of this, instead of displaying a blank value or a descriptive warning for the hostname, powershell displays the following ugly error:
 "getaddrinfo failed_x000A_ "
This PR addresses this by gracefully replacing this error message with the string "Unavailable" as the hostname property value. I am open to enhancing this to "Integration Services not installed" or something along those lines.

https://bugzilla.redhat.com/show_bug.cgi?id=1138774
