### PR TITLE
Change server monitor_poll default to 5 seconds.

### DIFF
--- a/vmdb/app/models/miq_server.rb
+++ b/vmdb/app/models/miq_server.rb
@@ -318,7 +318,7 @@ class MiqServer < ActiveRecord::Base
   end
 
   def monitor_poll
-    ((@vmdb_config && @vmdb_config.config[:server][:monitor_poll]) || 15.seconds).to_i_with_method
+    ((@vmdb_config && @vmdb_config.config[:server][:monitor_poll]) || 5.seconds).to_i_with_method
   end
 
   def stop_poll

--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -176,9 +176,11 @@ server:
   listening_port: '443'
   mks_classid: 338095E4-1806-4BA3-AB51-38A3179200E9
   mks_version: 2.1.0.0
+  monitor_poll: 5.seconds
   name: EVM
   remote_console_type: VMRC
   role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,web_services
+  server_dequeue_frequency: 5.seconds
   session_store: cache
   startup_timeout: 300
   timezone: UTC


### PR DESCRIPTION
After extensive testing by @akrzos, it was found that this fixes a
number of timing issues which are really just queue timing delays.  C&U
especially gets a lot snappier and the affect on the appliance CPU usage
was found to be negligible.

https://bugzilla.redhat.com/show_bug.cgi?id=1093222
