### PR TITLE
Handle Openstack 404 Errors

### DIFF
--- a/lib/spec/openstack/openstack_handle/handle_spec.rb
+++ b/lib/spec/openstack/openstack_handle/handle_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+$LOAD_PATH.push(File.expand_path(File.join(File.dirname(__FILE__), %w(.. .. .. openstack))))
+require 'openstack_handle/handle'
+require 'fog/openstack'
+
+describe OpenstackHandle::Handle do
+
+  context "errors from services" do
+    before do
+      @original_log = $fog_log
+      $fog_log = double.as_null_object
+    end
+
+    after do
+      $fog_log = @original_log
+    end
+
+    it "ignores 404 errors from services" do
+      openstack_svc = double('newtork_service')
+      expect(openstack_svc).to receive(:security_groups).and_raise(Fog::Network::OpenStack::NotFound)
+
+      handle = OpenstackHandle::Handle.new("dummy", "dummy", "dummy")
+      expect(handle).to receive(:service_for_each_accessible_tenant).and_yield(openstack_svc)
+
+      data = handle.accessor_for_accessible_tenants("Network", :security_groups, :id)
+      data.should be_empty
+    end
+  end
+end


### PR DESCRIPTION
Openstack can be configured to return 404 errors for certain API requests.  The
one that has been encountered is when Openstack Neutron is configured with the
NoOpFirewall handler.  In this case, calls to get_security_groups will return a
404 HTTP error.

ManageIQ codebase does not handle non-successful API HTTP return codes.  This is
an attempt to simply ignore (and log) any 404 return codes.

https://bugzilla.redhat.com/show_bug.cgi?id=1140191
