### PR TITLE
Provision based on image root_device_type

### DIFF
--- a/vmdb/app/models/flavor_amazon.rb
+++ b/vmdb/app/models/flavor_amazon.rb
@@ -1,2 +1,12 @@
 class FlavorAmazon < Flavor
+  virtual_column :supports_instance_store, :type => :boolean
+  virtual_column :supports_ebs,            :type => :boolean
+
+  def supports_instance_store?
+    !block_storage_based_only?
+  end
+
+  def supports_ebs?
+    block_storage_based_only?
+  end
 end

--- a/vmdb/app/models/miq_provision_amazon_workflow.rb
+++ b/vmdb/app/models/miq_provision_amazon_workflow.rb
@@ -5,11 +5,15 @@ class MiqProvisionAmazonWorkflow < MiqProvisionCloudWorkflow
     ems = source.try(:ext_management_system)
     architecture = source.try(:hardware).try(:bitness)
     virtualization_type = source.try(:hardware).try(:virtualization_type)
+    root_device_type = source.try(:hardware).try(:root_device_type)
 
     return {} if ems.nil?
     available = ems.flavors
     methods = ["supports_#{architecture}_bit?".to_sym, "supports_#{virtualization_type}?".to_sym]
+    methods << :supports_instance_store? if root_device_type == 'instance_store'
+
     methods.each { |m| available = available.select(&m) if FlavorAmazon.method_defined?(m) }
+
     available.each_with_object({}) { |f, hash| hash[f.id] = display_name_for_name_description(f) }
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1139383

Provision changes for filtering instances which are ebs_only when
deploying images that have root_device_type=instance_store.
