### PR TITLE
Re-enable GC after the spec.

### DIFF
--- a/vmdb/spec/models/metric/ci_mixin/capture/openstack_spec.rb
+++ b/vmdb/spec/models/metric/ci_mixin/capture/openstack_spec.rb
@@ -20,6 +20,10 @@ describe Metric::CiMixin::Capture::Openstack do
     @vm.stub(:perf_init_openstack).and_return(@ems_openstack)
   end
 
+  after do
+    GC.enable
+  end
+
   context "with non-aggregated data" do
     before :each do
       @ems_openstack.stub(:get_statistics) { |name, options| OpenstackApiResult.new(@mock_stats_data.get_statistics(name)) }


### PR DESCRIPTION
Depending on when this spec was run, the remaining tests in the suite would run without GC.
Whether this GC.disable was needed in the first place is secondary.

Example run utilizing our scvmm_refresher spec (since we know it uses lots of memory):

```
bundle exec rspec --order rand:32474 spec/models/metric/ci_mixin/capture/openstack_spec.rb spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
```

Before:
Process exits with around 1.25+ GB of memory (OSX activity monitor)

After:
Process exits with around 290 MB of memory (OSX activity monitor)
