### PR TITLE
Remove the GC disable/enable in the before/after blocks.

### DIFF
--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -4,16 +4,9 @@ require "spec_helper"
 
 describe Metric do
   before(:each) do
-    GC.disable
-
     MiqRegion.seed
 
     guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-  end
-
-  after(:each) do
-    GC.enable
-    GC.start
   end
 
   context "as vmware" do


### PR DESCRIPTION
It's not clear why were were doing this but the code was implemented in commit:
ff4b5f010ab115a3eec40703b40096ecbe44db34

And refined in commit: 3e637725c2c2ce1fea69c5a1491046370f8d7408, with a message including:
"...Hopefully this doesn't reintroduce the GC segfault."

I believe this was added back when we were using ruby 1.8.7 and possibly libxml-ruby/rexml with soap4r.  Since we're way beyond 1.8.7 with 1.9.3 and soon 2.0, we should remove this and fix it if it re-occurs.
