### PR TITLE
Remove detect_type from various models

### DIFF
--- a/lib/HyperV/MiqHypervInventoryParser.rb
+++ b/lib/HyperV/MiqHypervInventoryParser.rb
@@ -112,6 +112,7 @@ module MiqHypervInventoryParser
       storages = storage_uids[:storage_id].collect {|k,v| v}
 
       new_result = {
+        :type => "HostMicrosoft",
         :name => hostname,
         :hostname => hostname,
         :ipaddress => ipaddress,
@@ -477,6 +478,7 @@ module MiqHypervInventoryParser
 #      hardware[:networks] = self.vm_inv_to_network_hashes(vm_inv, guest_device_uids[mor])
 
       new_result = {
+        :type => "VmMicrosoft",
         :uid_ems => mor,
         :name => URI.decode(vm_inv[:display_name].to_s.AsciiToUtf8),
         :vendor => "microsoft",

--- a/lib/libvirt/MiqLibvirt.rb
+++ b/lib/libvirt/MiqLibvirt.rb
@@ -316,7 +316,7 @@ module MiqLibvirt
     def get_os_information(shell)
       os = {}
       os[:name] = @hostname
-      
+
       result = run_command("cat /etc/issue", shell)
       result = result.split("\n")
       os[:product_name] = result[0]
@@ -363,12 +363,13 @@ module MiqLibvirt
     def host_to_inv_h(ems)
       h = {}
 
+      h[:type] = "HostKvm"
       h[:ipaddress] = @server
       h[:power_state] = 'on'
       h[:name] = @hostname
       h[:hostname] = @hostname
       h[:vmm_vendor] = @type.to_s.downcase
-      
+
       hypervisor = @version[:hypervisor].split(' ')
       h[:vmm_product] = hypervisor[0]
       h[:vmm_version] = hypervisor[1]
@@ -415,6 +416,7 @@ module MiqLibvirt
 
     def vm_to_inv_h(domain, ems)
       v = {}
+      v[:type] = "VmKvm"
       v[:connection_state] = 'connected'
       v[:vendor] = domain[:type].to_s.downcase
       v[:name] = domain[:name]
@@ -489,7 +491,7 @@ module MiqLibvirt
           end
           vm_storages << storage unless storage.nil?
         end
-        
+
         block_dev.each do |b|
           @storages.each do |s|
             if b.include?(s[:target][:path])
@@ -531,7 +533,7 @@ module MiqLibvirt
 
       File.join(paths.first, "#{domain[:name]}.vmss")
     end
-    
+
     def debug_time()
       Time.now.strftime("%I:%M:%S")
     end
@@ -641,7 +643,7 @@ module MiqLibvirt
           libvirt_state = "suspended"
         end
       end
-      
+
       return libvirt_state
     end
 

--- a/vmdb/app/models/ems_amazon.rb
+++ b/vmdb/app/models/ems_amazon.rb
@@ -2,14 +2,6 @@ require 'Amazon/ec2/regions'
 require 'Amazon/amazon_connection'
 
 class EmsAmazon < EmsCloud
-  def self.default_vm_type
-    @default_vm_type ||= "VmAmazon".freeze
-  end
-
-  def self.default_template_type
-    @default_template_type ||= "TemplateAmazon".freeze
-  end
-
   def self.ems_type
     @ems_type ||= "ec2".freeze
   end

--- a/vmdb/app/models/ems_kvm.rb
+++ b/vmdb/app/models/ems_kvm.rb
@@ -1,19 +1,6 @@
 $:.push(File.expand_path(File.join(Rails.root, %w{.. lib kvm} )))
 
 class EmsKvm < EmsInfra
-
-  def self.default_host_type
-    @default_host_type ||= "HostKvm".freeze
-  end
-
-  def self.default_vm_type
-    @default_vm_type ||= "VmKvm".freeze
-  end
-
-  def self.default_template_type
-    @default_template_type ||= "TemplateKvm".freeze
-  end
-
   def self.ems_type
     @ems_type ||= "kvm".freeze
   end

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -4,18 +4,6 @@ $:.push(File.expand_path(File.join(Rails.root, %w{.. lib Scvmm})))
 class EmsMicrosoft < EmsInfra
   include_concern "Powershell"
 
-  def self.default_host_type
-    @default_host_type ||= "HostMicrosoft".freeze
-  end
-
-  def self.default_vm_type
-    @default_vm_type ||= "VmMicrosoft".freeze
-  end
-
-  def self.default_template_type
-    @default_template_type ||= "TemplateMicrosoft".freeze
-  end
-
   def self.ems_type
     @ems_type ||= "scvmm".freeze
   end

--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -1,12 +1,4 @@
 class EmsOpenstack < EmsCloud
-  def self.default_vm_type
-    @default_vm_type ||= "VmOpenstack".freeze
-  end
-
-  def self.default_template_type
-    @default_template_type ||= "TemplateOpenstack".freeze
-  end
-
   def self.ems_type
     @ems_type ||= "openstack".freeze
   end

--- a/vmdb/app/models/ems_redhat.rb
+++ b/vmdb/app/models/ems_redhat.rb
@@ -1,16 +1,4 @@
 class EmsRedhat < EmsInfra
-  def self.default_host_type
-    @default_host_type ||= "HostRedhat".freeze
-  end
-
-  def self.default_vm_type
-    @default_vm_type ||= "VmRedhat".freeze
-  end
-
-  def self.default_template_type
-    @default_template_type ||= "TemplateRedhat".freeze
-  end
-
   def self.ems_type
     @ems_type ||= "rhevm".freeze
   end

--- a/vmdb/app/models/ems_refresh/parsers/rhevm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/rhevm.rb
@@ -168,10 +168,10 @@ module EmsRefresh::Parsers::Rhevm
       end
 
       new_result = {
+        :type => 'HostRedhat',
         :ems_ref => host_inv[:href],
         :ems_ref_obj => host_inv[:href],
         :name => host_inv[:name] || hostname,
-        :type => 'HostRedhat',
         :hostname => hostname,
         :ipaddress => ipaddress,
         :uid_ems => host_inv[:id],
@@ -539,6 +539,7 @@ module EmsRefresh::Parsers::Rhevm
 #      uid = hardware[:bios]
 
       new_result = {
+        :type => template ? "TemplateRedhat" : "VmRedhat",
         :ems_ref => vm_inv[:href],
         :ems_ref_obj => vm_inv[:href],
         :uid_ems => vm_inv[:id],
@@ -551,6 +552,7 @@ module EmsRefresh::Parsers::Rhevm
 #        :standby_action => standby_act,
         :connection_state => 'connected',
 #        :cpu_affinity => cpu_affinity,
+        :template => template,
 
 #        :memory_reserve => memory["reservation"],
 #        :memory_reserve_expand => memory["expandableReservation"].to_s.downcase == "true",
@@ -572,7 +574,6 @@ module EmsRefresh::Parsers::Rhevm
         :hardware => hardware,
         :custom_attributes => self.vm_inv_to_custom_attribute_hashes(vm_inv),
         :snapshots => self.vm_inv_to_snapshot_hashes(vm_inv),
-        :template => template,
       }
 
       # Attach to the cluster's default resource pool

--- a/vmdb/app/models/ems_refresh/parsers/vc.rb
+++ b/vmdb/app/models/ems_refresh/parsers/vc.rb
@@ -188,6 +188,7 @@ module EmsRefresh::Parsers::Vc
       end
 
       new_result = {
+        :type             => %w(esx esxi).include?(product_name.to_s.downcase) ? "HostVmwareEsx" : "HostVmware",
         :ems_ref          => mor,
         :ems_ref_obj      => mor,
         :name             => hostname,
@@ -728,6 +729,7 @@ module EmsRefresh::Parsers::Vc
       uid = hardware[:bios]
 
       new_result = {
+        :type             => template ? "TemplateVmware" : "VmVmware",
         :ems_ref          => mor,
         :ems_ref_obj      => mor,
         :uid_ems          => uid,

--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -85,9 +85,6 @@ module EmsRefresh::SaveInventory
           disconnects.delete(found)
         end
 
-        # Make sure to set the type as VMs use Single-Table Inheritance (STI)
-        found.type ||= found.detect_type || (found.template? ? ems.class.default_template_type : ems.class.default_vm_type)
-
         # Set the power state
         found.state = key_backup[:power_state] unless key_backup[:power_state].nil?
 

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -173,10 +173,6 @@ module EmsRefresh::SaveInventoryInfra
           found.update_attributes(h)
         end
 
-        # Make sure to set the type as Hosts use Single-Table Inheritance (STI)
-        # TODO: Verify if this is needed anymore since :type is now supported with the NewWithTypeStiMixin
-        found.type ||= found.detect_type || ems.class.default_host_type
-
         # Handle duplicate names coming in because of duplicate hostnames.
         begin
           found.save!

--- a/vmdb/app/models/ems_vmware.rb
+++ b/vmdb/app/models/ems_vmware.rb
@@ -4,18 +4,6 @@ class EmsVmware < EmsInfra
   before_save :stop_event_monitor_queue_on_change
   before_destroy :stop_event_monitor
 
-  def self.default_host_type
-    @default_host_type ||= "HostVmwareEsx".freeze
-  end
-
-  def self.default_vm_type
-    @default_vm_type ||= "VmVmware".freeze
-  end
-
-  def self.default_template_type
-    @default_template_type ||= "TemplateVmware".freeze
-  end
-
   def self.ems_type
     @ems_type ||= "vmwarews".freeze
   end

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -139,12 +139,6 @@ class ExtManagementSystem < ActiveRecord::Base
     end
   end
 
-  def detect_type
-    model_name = self.class.model_name_from_emstype(self.emstype)
-    return nil if model_name == "ExtManagementSystem"
-    return model_name
-  end
-
   def self.model_name_from_emstype(emstype)
     leaf_subclasses.each do |k|
       return k.name if k.ems_type == emstype.downcase

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -245,11 +245,6 @@ class VmOrTemplate < ActiveRecord::Base
     virtual_column m, :type => :string, :uses => :all_relationships
   end
 
-  def detect_type
-    prefix = self.template? ? "Template" : "Vm"
-    "#{prefix}#{self.read_attribute(:vendor).downcase.classify}"
-  end
-
   def v_annotation
     return nil if self.hardware.nil?
     self.hardware.annotation

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
@@ -72,8 +72,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_flavor
-    @flavor = Flavor.where(:name => "t1.micro").first
-    @flavor.should be_kind_of(FlavorAmazon)
+    @flavor = FlavorAmazon.where(:name => "t1.micro").first
     @flavor.should have_attributes(
       :name                 => "t1.micro",
       :description          => "T1 Micro",
@@ -91,16 +90,14 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_az
-    @az = AvailabilityZone.where(:name => "us-west-1a").first
-    @az.should be_kind_of(AvailabilityZoneAmazon)
+    @az = AvailabilityZoneAmazon.where(:name => "us-west-1a").first
     @az.should have_attributes(
       :name => "us-west-1a",
     )
   end
 
   def assert_specific_floating_ip
-    ip = FloatingIp.where(:address => "54.215.0.230").first
-    ip.should be_kind_of(FloatingIpAmazon)
+    ip = FloatingIpAmazon.where(:address => "54.215.0.230").first
     ip.should have_attributes(
       :address            => "54.215.0.230",
       :ems_ref            => "54.215.0.230",
@@ -109,7 +106,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_key_pair
-    @kp = AuthPrivateKey.where(:name => "EmsRefreshSpec-KeyPair-OtherRegion").first
+    @kp = AuthKeyPairAmazon.where(:name => "EmsRefreshSpec-KeyPair-OtherRegion").first
     @kp.should have_attributes(
       :name        => "EmsRefreshSpec-KeyPair-OtherRegion",
       :fingerprint => "fc:53:30:aa:d2:23:c7:8d:e2:e8:05:95:a0:d2:90:fb:15:30:a2:51"
@@ -117,7 +114,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_security_group
-    @sg = SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-OtherRegion").first
+    @sg = SecurityGroupAmazon.where(:name => "EmsRefreshSpec-SecurityGroup-OtherRegion").first
     @sg.should have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup-OtherRegion",
       :description => "EmsRefreshSpec-SecurityGroup-OtherRegion",
@@ -136,7 +133,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_template
-    @template = MiqTemplate.where(:name => "EmsRefreshSpec-Image-OtherRegion").first
+    @template = TemplateAmazon.where(:name => "EmsRefreshSpec-Image-OtherRegion").first
     @template.should have_attributes(
       :template              => true,
       :ems_ref               => "ami-183e175d",
@@ -185,7 +182,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_vm_powered_on
-    v = Vm.where(:name => "EmsRefreshSpec-PoweredOn-OtherRegion", :power_state => "on").first
+    v = VmAmazon.where(:name => "EmsRefreshSpec-PoweredOn-OtherRegion", :power_state => "on").first
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "i-dc1ee486",
@@ -258,7 +255,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_vm_in_other_region
-    v = Vm.where(:name => "EmsRefreshSpec-PoweredOn-Basic").first
+    v = VmAmazon.where(:name => "EmsRefreshSpec-PoweredOn-Basic").first
     v.should be_nil
   end
 

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -81,8 +81,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_flavor
-    @flavor = Flavor.where(:name => "t1.micro").first
-    @flavor.should be_kind_of(FlavorAmazon)
+    @flavor = FlavorAmazon.where(:name => "t1.micro").first
     @flavor.should have_attributes(
       :name                     => "t1.micro",
       :description              => "T1 Micro",
@@ -101,16 +100,14 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_az
-    @az = AvailabilityZone.where(:name => "us-east-1b").first
-    @az.should be_kind_of(AvailabilityZoneAmazon)
+    @az = AvailabilityZoneAmazon.where(:name => "us-east-1b").first
     @az.should have_attributes(
       :name => "us-east-1b",
     )
   end
 
   def assert_specific_floating_ip
-    @ip = FloatingIp.where(:address => "54.221.202.53").first
-    @ip.should be_kind_of(FloatingIpAmazon)
+    @ip = FloatingIpAmazon.where(:address => "54.221.202.53").first
     @ip.should have_attributes(
       :address            => "54.221.202.53",
       :ems_ref            => "54.221.202.53",
@@ -119,8 +116,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_floating_ip_for_cloud_network
-    ip = FloatingIp.where(:address => "54.208.119.197").first
-    ip.should be_kind_of(FloatingIpAmazon)
+    ip = FloatingIpAmazon.where(:address => "54.208.119.197").first
     ip.should have_attributes(
       :address            => "54.208.119.197",
       :ems_ref            => "54.208.119.197",
@@ -129,7 +125,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_key_pair
-    @kp = AuthPrivateKey.where(:name => "EmsRefreshSpec-KeyPair").first
+    @kp = AuthKeyPairAmazon.where(:name => "EmsRefreshSpec-KeyPair").first
     @kp.should have_attributes(
       :name        => "EmsRefreshSpec-KeyPair",
       :fingerprint => "49:9f:3f:a4:26:48:39:94:26:06:dd:25:73:e5:da:9b:4b:1b:6c:93"
@@ -165,7 +161,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_security_group
-    @sg = SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup").first
+    @sg = SecurityGroupAmazon.where(:name => "EmsRefreshSpec-SecurityGroup").first
     @sg.should have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup",
       :description => "EmsRefreshSpec-SecurityGroup",
@@ -197,7 +193,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_security_group_on_cloud_network
-    @sg_on_cn = SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-VPC").first
+    @sg_on_cn = SecurityGroupAmazon.where(:name => "EmsRefreshSpec-SecurityGroup-VPC").first
     @sg_on_cn.should have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup-VPC",
       :description => "EmsRefreshSpec-SecurityGroup-VPC",
@@ -208,7 +204,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_template
-    @template = MiqTemplate.where(:name => "EmsRefreshSpec-Image").first
+    @template = TemplateAmazon.where(:name => "EmsRefreshSpec-Image").first
     @template.should have_attributes(
       :template              => true,
       :ems_ref               => "ami-5769193e",
@@ -259,12 +255,12 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_shared_template
-    t = MiqTemplate.where(:ems_ref => "ami-5e094837").first # TODO: Share an EmsRefreshSpec specific template
+    t = TemplateAmazon.where(:ems_ref => "ami-5e094837").first # TODO: Share an EmsRefreshSpec specific template
     t.should_not be_nil
   end
 
   def assert_specific_vm_powered_on
-    v = Vm.where(:name => "EmsRefreshSpec-PoweredOn-Basic", :power_state => "on").first
+    v = VmAmazon.where(:name => "EmsRefreshSpec-PoweredOn-Basic", :power_state => "on").first
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "i-7ab3c301",
@@ -297,7 +293,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     v.key_pairs.should              == [@kp]
     v.cloud_network.should          be_nil
     v.cloud_subnet.should           be_nil
-    v.security_groups.should        match_array [@sg, SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
+    v.security_groups.should        match_array [@sg, SecurityGroupAmazon.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
 
     v.operating_system.should       be_nil # TODO: This should probably not be nil
     v.custom_attributes.size.should == 0
@@ -339,7 +335,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_vm_powered_off
-    v = Vm.where(:name => "EmsRefreshSpec-PoweredOff", :power_state => "off").first
+    v = VmAmazon.where(:name => "EmsRefreshSpec-PoweredOff", :power_state => "off").first
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "i-79188d11",
@@ -366,7 +362,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     )
 
     v.ext_management_system.should  == @ems
-    v.availability_zone.should      == AvailabilityZone.find_by_name("us-east-1d")
+    v.availability_zone.should      == AvailabilityZoneAmazon.find_by_name("us-east-1d")
     v.floating_ip.should            be_nil
     v.key_pairs.should              == [@kp]
     v.cloud_network.should          be_nil
@@ -398,7 +394,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_vm_on_cloud_network
-    v = Vm.where(:name => "EmsRefreshSpec-PoweredOn-VPC").first
+    v = VmAmazon.where(:name => "EmsRefreshSpec-PoweredOn-VPC").first
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "i-8b5739f2",
@@ -430,7 +426,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_vm_in_other_region
-    v = Vm.where(:name => "EmsRefreshSpec-PoweredOn-OtherRegion").first
+    v = VmAmazon.where(:name => "EmsRefreshSpec-PoweredOn-OtherRegion").first
     v.should be_nil
   end
 

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_grizzly_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_grizzly_spec.rb
@@ -123,8 +123,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   # end
 
   def assert_specific_flavor
-    @flavor = Flavor.where(:name => "m1.ems_refresh_spec").first
-    @flavor.should be_kind_of(FlavorOpenstack)
+    @flavor = FlavorOpenstack.where(:name => "m1.ems_refresh_spec").first
     @flavor.should have_attributes(
       :name        => "m1.ems_refresh_spec",
       :description => nil,
@@ -154,8 +153,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_floating_ip
-    @ip = FloatingIp.where(:address => "10.3.4.1").first
-    @ip.should be_kind_of(FloatingIpOpenstack)
+    @ip = FloatingIpOpenstack.where(:address => "10.3.4.1").first
     @ip.should have_attributes(
       :address => "10.3.4.1",
       :ems_ref => "1"
@@ -163,7 +161,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_key_pair
-    @kp = AuthPrivateKey.where(:name => "EmsRefreshSpec-KeyPair").first
+    @kp = AuthKeyPairOpenstack.where(:name => "EmsRefreshSpec-KeyPair").first
     @kp.should have_attributes(
       :name        => "EmsRefreshSpec-KeyPair",
       :fingerprint => "5e:51:73:2d:71:14:94:34:97:4c:e8:e5:92:49:9e:9e"
@@ -171,7 +169,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_security_group
-    @sg = SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup").first
+    @sg = SecurityGroupOpenstack.where(:name => "EmsRefreshSpec-SecurityGroup").first
     @sg.should have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup",
       :description => "EmsRefreshSpec-SecurityGroup",
@@ -200,7 +198,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_template
-    @template = MiqTemplate.where(:name => "EmsRefreshSpec-Image").first
+    @template = TemplateOpenstack.where(:name => "EmsRefreshSpec-Image").first
     @template.should have_attributes(
       :template              => true,
       :ems_ref               => "a11384ef-a7d1-4c99-b063-dd60a357d3ff",
@@ -236,7 +234,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_vm_powered_on
-    @vm = Vm.where(:name => "EmsRefreshSpec-PoweredOn").first
+    @vm = VmOpenstack.where(:name => "EmsRefreshSpec-PoweredOn").first
     @vm.should have_attributes(
       :template              => false,
       :ems_ref               => "4bb8d624-a3a5-421c-9e14-8a6eaa16aed8",
@@ -267,7 +265,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
     @vm.floating_ip.should            == @ip
     @vm.flavor.should                 == @flavor
     @vm.key_pairs.should              == [@kp]
-    @vm.security_groups.should        match_array [@sg, SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
+    @vm.security_groups.should        match_array [@sg, SecurityGroupOpenstack.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
 
     @vm.operating_system.should       be_nil # TODO: This should probably not be nil
     @vm.custom_attributes.size.should == 0
@@ -317,18 +315,18 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_template_created_from_vm
-    @snap = MiqTemplate.where(:name => "EmsRefreshSpec-Snapshot").first
+    @snap = TemplateOpenstack.where(:name => "EmsRefreshSpec-Snapshot").first
     @snap.should_not be_nil
     #FIXME: @snap.parent.should == @vm
   end
 
   def assert_specific_vm_created_from_snapshot_template
-    t = Vm.where(:name => "EmsRefreshSpec-PoweredOn-FromSnapshot").first
+    t = VmOpenstack.where(:name => "EmsRefreshSpec-PoweredOn-FromSnapshot").first
     t.parent.should == @snap
   end
 
   def assert_specific_vm_paused
-    v = Vm.where(:name => "EmsRefreshSpec-Paused").first
+    v = VmOpenstack.where(:name => "EmsRefreshSpec-Paused").first
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "83de8005-7138-4005-b4a9-980d0df622ff",
@@ -404,7 +402,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_vm_suspended
-    v = Vm.where(:name => "EmsRefreshSpec-Suspended").first
+    v = VmOpenstack.where(:name => "EmsRefreshSpec-Suspended").first
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "ed1056c3-53b1-4cec-af88-a6e6a6be1d44",

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
@@ -125,8 +125,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   # end
 
   def assert_specific_flavor
-    @flavor = Flavor.where(:name => "m1.ems_refresh_spec").first
-    @flavor.should be_kind_of(FlavorOpenstack)
+    @flavor = FlavorOpenstack.where(:name => "m1.ems_refresh_spec").first
     @flavor.should have_attributes(
       :name        => "m1.ems_refresh_spec",
       :description => nil,
@@ -165,8 +164,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_floating_ip
-    @ip = FloatingIp.where(:address => "10.8.97.2").first
-    @ip.should be_kind_of(FloatingIpOpenstack)
+    @ip = FloatingIpOpenstack.where(:address => "10.8.97.2").first
     @ip.should have_attributes(
       :address => "10.8.97.2",
     )
@@ -174,7 +172,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_key_pair
-    @kp = AuthPrivateKey.where(:name => "EmsRefreshSpec-KeyPair").first
+    @kp = AuthKeyPairOpenstack.where(:name => "EmsRefreshSpec-KeyPair").first
     @kp.should have_attributes(
       :name        => "EmsRefreshSpec-KeyPair",
       :fingerprint => "1d:e2:f2:f4:05:0c:d5:00:95:c5:78:22:9f:89:61:a5"
@@ -182,7 +180,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_security_group
-    @sg = SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup").first
+    @sg = SecurityGroupOpenstack.where(:name => "EmsRefreshSpec-SecurityGroup").first
     @sg.should have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup",
       :description => "EmsRefreshSpec-SecurityGroup description",
@@ -248,7 +246,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_template
-    @template = MiqTemplate.where(:name => "EmsRefreshSpec-Image").first
+    @template = TemplateOpenstack.where(:name => "EmsRefreshSpec-Image").first
     @template.should have_attributes(
       :template              => true,
       :ems_ref_obj           => nil,
@@ -284,7 +282,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_vm_powered_on
-    @vm = Vm.where(:name => "EmsRefreshSpec-PoweredOn").first
+    @vm = VmOpenstack.where(:name => "EmsRefreshSpec-PoweredOn").first
     @vm.should have_attributes(
       :template              => false,
       :ems_ref_obj           => nil,
@@ -366,18 +364,18 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_template_created_from_vm
-    @snap = MiqTemplate.where(:name => "EmsRefreshSpec-Snapshot").first
+    @snap = TemplateOpenstack.where(:name => "EmsRefreshSpec-Snapshot").first
     @snap.should_not be_nil
     #FIXME: @snap.parent.should == @vm
   end
 
   def assert_specific_vm_created_from_snapshot_template
-    t = Vm.where(:name => "EmsRefreshSpec-PoweredOn-FromSnapshot").first
+    t = VmOpenstack.where(:name => "EmsRefreshSpec-PoweredOn-FromSnapshot").first
     t.parent.should == @snap
   end
 
   def assert_specific_vm_paused
-    v = Vm.where(:name => "EmsRefreshSpec-Paused").first
+    v = VmOpenstack.where(:name => "EmsRefreshSpec-Paused").first
     v.should have_attributes(
       :template              => false,
       :ems_ref_obj           => nil,
@@ -453,7 +451,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
   end
 
   def assert_specific_vm_suspended
-    v = Vm.where(:name => "EmsRefreshSpec-Suspended").first
+    v = VmOpenstack.where(:name => "EmsRefreshSpec-Suspended").first
     v.should have_attributes(
       :template              => false,
       :ems_ref_obj           => nil,

--- a/vmdb/spec/models/ems_refresh/refreshers/rhevm_refresher_3_0_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/rhevm_refresher_3_0_spec.rb
@@ -127,7 +127,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_host
-    @host = Host.find_by_name("rhelvirt.manageiq.com")
+    @host = HostRedhat.find_by_name("rhelvirt.manageiq.com")
     @host.should have_attributes(
       :ems_ref          => "/api/hosts/ca389dbc-2054-11e1-9241-005056af0085",
       :ems_ref_obj      => "/api/hosts/ca389dbc-2054-11e1-9241-005056af0085",
@@ -228,7 +228,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_vm_powered_on
-    v = Vm.find_by_name("EmsRefreshSpec-PoweredOn")
+    v = VmRedhat.find_by_name("EmsRefreshSpec-PoweredOn")
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
@@ -366,7 +366,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_vm_powered_off
-    v = Vm.find_by_name("EmsRefreshSpec-PoweredOff")
+    v = VmRedhat.find_by_name("EmsRefreshSpec-PoweredOff")
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
@@ -520,7 +520,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_template
-    v = MiqTemplate.find_by_name("EmsRefreshSpec")
+    v = TemplateRedhat.find_by_name("EmsRefreshSpec")
     v.should have_attributes(
       :template              => true,
       :ems_ref               => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",

--- a/vmdb/spec/models/ems_refresh/refreshers/rhevm_refresher_3_1_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/rhevm_refresher_3_1_spec.rb
@@ -127,7 +127,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_host
-    @host = Host.find_by_name("per410-rh1")
+    @host = HostRedhat.find_by_name("per410-rh1")
     @host.should have_attributes(
       :ems_ref          => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
       :ems_ref_obj      => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
@@ -228,7 +228,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_vm_powered_on
-    v = Vm.find_by_name("EmsRefreshSpec-PoweredOn")
+    v = VmRedhat.find_by_name("EmsRefreshSpec-PoweredOn")
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
@@ -379,7 +379,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_vm_powered_off
-    v = Vm.find_by_name("EmsRefreshSpec-PoweredOff")
+    v = VmRedhat.find_by_name("EmsRefreshSpec-PoweredOff")
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
@@ -524,7 +524,7 @@ describe EmsRefresh::Refreshers::RhevmRefresher do
   end
 
   def assert_specific_template
-    v = MiqTemplate.find_by_name("EmsRefreshSpec-Template")
+    v = TemplateRedhat.find_by_name("EmsRefreshSpec-Template")
     v.should have_attributes(
       :template              => true,
       :ems_ref               => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",

--- a/vmdb/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
@@ -103,7 +103,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
   end
 
   def assert_specific_host
-    @host = Host.find_by_name("hyperv-h01.manageiq.com")
+    @host = HostMicrosoft.find_by_name("hyperv-h01.manageiq.com")
     @host.should have_attributes(
       :ems_ref          => "60e92646-b9f8-432a-a71a-5bc169ceeca2",
       :name             => "hyperv-h01.manageiq.com",
@@ -155,7 +155,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
   end
 
   def assert_specific_vm
-    v = Vm.find_by_name("Salesforce_A")
+    v = VmMicrosoft.find_by_name("Salesforce_A")
 
     v.should have_attributes(
       :template         => false,

--- a/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_spec.rb
@@ -161,7 +161,7 @@ describe EmsRefresh::Refreshers::VcRefresher do
   end
 
   def assert_specific_host
-    @host = Host.find_by_name("VI4ESXM1.manageiq.com")
+    @host = HostVmware.find_by_name("VI4ESXM1.manageiq.com")
     @host.should have_attributes(
       :ems_ref          => "host-9",
       :ems_ref_obj      => VimString.new("host-9", :HostSystem, :ManagedObjectReference),
@@ -317,7 +317,7 @@ describe EmsRefresh::Refreshers::VcRefresher do
   end
 
   def assert_specific_vm
-    v = Vm.find_by_name("JoeF 4.0.1")
+    v = VmVmware.find_by_name("JoeF 4.0.1")
     v.should have_attributes(
       :template              => false,
       :ems_ref               => "vm-11342",

--- a/vmdb/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/vmdb/spec/models/ems_refresh/save_inventory_spec.rb
@@ -258,7 +258,7 @@ describe EmsRefresh::SaveInventory do
 
   private
 
-  RAW_DATA_ATTRS = [:name, :ems_ref_obj, :ems_ref, :vendor, :location, :uid_ems]
+  RAW_DATA_ATTRS = [:name, :ems_ref_obj, :ems_ref, :vendor, :location, :uid_ems, :type]
 
   def raw_data_process(*args)
     args.collect do |v|

--- a/vmdb/spec/models/host_spec.rb
+++ b/vmdb/spec/models/host_spec.rb
@@ -213,24 +213,6 @@ describe Host do
     end
   end
 
-  context "#detect_type" do
-    it "with known vendor and product" do
-      expect(Host.new(:vmm_vendor => "vmware", :vmm_product => "esx").detect_type).to eq("HostVmwareEsx")
-    end
-
-    it "with known vendor" do
-      expect(Host.new(:vmm_vendor => "vmware").detect_type).to eq("HostVmware")
-    end
-
-    it "with unknown vendor" do
-      expect(Host.new(:vmm_vendor => "unknown").detect_type).to eq("Host")
-    end
-
-    it "with nil vendor" do
-      expect(Host.new.detect_type).to eq("Host")
-    end
-  end
-
   context "#vmm_vendor" do
     it "with known host type" do
       expect(FactoryGirl.create(:host_vmware_esx).vmm_vendor).to eq("VMware")

--- a/vmdb/spec/models/hyperv_data/hyperv_ems_refresh.yaml
+++ b/vmdb/spec/models/hyperv_data/hyperv_ems_refresh.yaml
@@ -975,13 +975,14 @@
     :storages:
     - *51796560
     :storage: *51796560
-    :operating_system: 
+    :operating_system:
     :host: *51538920
     :vendor: microsoft
     :name: Win7Test
     :uid_ems: 3c75233f-bd78-4090-8a98-9dd476eb75b7
     :power_state: 'off'
     :location: hyper-v/Win7Test/Virtual%20Machines/3C75233F-BD78-4090-8A98-9DD476EB75B7.xml
+    :type: "VmMicrosoft"
   - &57531080
     :snapshots: []
     :hardware:
@@ -993,27 +994,28 @@
     :storages:
     - *51796560
     :storage: *51796560
-    :operating_system: 
+    :operating_system:
     :host: *51538920
     :vendor: microsoft
     :name: Windows_2012_Server
     :uid_ems: 385f6280-07a7-4f8a-9fe3-d3020d553b6c
     :power_state: 'off'
     :location: hyper-v/Windows_2012_Server/Virtual%20Machines/385F6280-07A7-4F8A-9FE3-D3020D553B6C.xml
+    :type: "VmMicrosoft"
   - &57523820
     :snapshots: []
     :hardware:
       :bios: 2CE1916B-68BF-4BFA-9134-D16FCF13FC90
       :memory_cpu: 2024
-      :guest_os_full_name: 
+      :guest_os_full_name:
       :annotation: ''
       :numvcpus: 3
-      :guest_os: 
+      :guest_os:
       :guest_devices: []
     :storages:
     - *51796560
     :storage: *51796560
-    :operating_system: 
+    :operating_system:
     :host: *51538920
     :tools_status: No Contact
     :vendor: microsoft
@@ -1022,6 +1024,7 @@
     :boot_time: 2013-09-12 15:27:27.000000000 Z
     :power_state: 'on'
     :location: hyper-v/Ubuntu12.04/Virtual%20Machines/8A7628A6-C02A-420D-8C5D-AB2B1DA3C47E.xml
+    :type: "VmMicrosoft"
   :ipaddress: 192.168.253.110
   :vmm_buildnumber: '17514'
 :vms: *55313860


### PR DESCRIPTION
The `detect_type` method is no longer necessary with new_with_type_sti_mixin.

However, removing `detect_type` requires that _all_ EMS Refreshers set the type
attribute for all STI objects.
- removes `detect_type`
- removes `default_type` for all models
- ensures that all refreshers set :type
- removes all references to `detect_type`
- removes all references to `default_type`

EDIT by @Fryguy: Needed to avoid the hackery in #481 .
