### PR TITLE
SCVMM - Set the active snapshot for a VM

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -293,7 +293,7 @@ module EmsRefresh::Parsers
           :name        => s[:Name],
           :description => s[:description],
           :create_time => s[:AddedTime],
-          :current     => s == last_restored_snapshot,
+          :current     => s[:CheckpointID] == last_restored_snapshot[:Props][:CheckpointID],
         }
         result << new_result
       end


### PR DESCRIPTION
No active snapshot was visible from the UI for a VM, the reason was because the 'current' property of the snapshot was not being correctly set.

https://bugzilla.redhat.com/show_bug.cgi?id=1141180
