### PR TITLE
Service requests page: allow to save table column widths

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -837,6 +837,7 @@ Vmdb::Application.routes.draw do
         request_copy
         request_edit
         retrieve_email
+        save_col_widths
         show_list
         sort_ds_grid
         sort_host_grid

--- a/vmdb/spec/routing/miq_request_routing_spec.rb
+++ b/vmdb/spec/routing/miq_request_routing_spec.rb
@@ -5,6 +5,7 @@ describe 'routes for MiqRequestController' do
   let(:controller_name) { 'miq_request' }
 
   it_behaves_like 'A controller that has show list routes'
+  it_behaves_like 'A controller that has column width routes'
 
   describe '#index' do
     it 'routes with GET' do


### PR DESCRIPTION
This is to address the following error:

ActionController::RoutingError
(No route matches [POST] "/miq_request/save_col_widths")
