### PR TITLE
Automate methods should not be able to modify readonly domains

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -256,6 +256,8 @@ module MiqAeMethodService
     def instance_create(path, values_hash = {})
       $log.info "MiqAeService#instance_create << path=#{path.inspect}, values_hash=#{values_hash.inspect}"
 
+      return false unless editable_instance?(path)
+
       ns, klass, instance = MiqAeEngine::MiqAePath.split(path)
       $log.info("Instance Create for ns: #{ns} class #{klass} instance: #{instance}")
 
@@ -288,6 +290,8 @@ module MiqAeMethodService
 
     def instance_update(path, values_hash)
       $log.info "MiqAeService#instance_update << path=#{path.inspect}, values_hash=#{values_hash.inspect}"
+      return false unless editable_instance?(path)
+
       aei = __find_instance_from_path(path)
       return false if aei.nil?
 
@@ -332,6 +336,8 @@ module MiqAeMethodService
 
     def instance_delete(path)
       $log.info "MiqAeService#instance_delete << path=#{path.inspect}"
+      return false unless editable_instance?(path)
+
       aei = __find_instance_from_path(path)
       return false if aei.nil?
 
@@ -346,6 +352,15 @@ module MiqAeMethodService
       return nil if aec.nil?
 
       aec.ae_instances.detect { |i| instance.casecmp(i.name) == 0 }
+    end
+
+    private
+
+    def editable_instance?(path)
+      dom, _, _, _ = MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(path)
+      domain = MiqAeDomain.find_by_fqname(dom, false)
+      return false unless domain
+      domain.editable?
     end
   end
 

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
@@ -22,6 +22,15 @@ module MiqAeServiceSpec
       MiqAeEngine.instantiate("/EVM/AUTOMATE/test1")
     end
 
+    def assert_readonly_instance(automate_method_script)
+      dom_obj = MiqAeDomain.find_by_name(@domain)
+      dom_obj.update_attributes!(:system => true)
+      @ae_method.update_attributes(:data => automate_method_script)
+      result = invoke_ae.root(@ae_result_key)
+      dom_obj.update_attributes!(:system => false)
+      result.should be_false
+    end
+
     context "$evm.instance_exists?" do
       it "nonexistant instance " do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('/bogus/evenworse/fred')"
@@ -44,6 +53,11 @@ module MiqAeServiceSpec
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
         result.should == false
+      end
+
+      it "readonly domain" do
+        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/freddy', 'method1' => 'a', 'var1' => 'b')"
+        assert_readonly_instance(method)
       end
 
       it "instance does not exist, create it, check that it exists, then get the instance values" do
@@ -230,6 +244,11 @@ module MiqAeServiceSpec
         result.should == false
       end
 
+      it "readonly domain" do
+        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/test1', 'method1' => 'a', 'var1' => 'b')"
+        assert_readonly_instance(method)
+      end
+
       it "instance does not exist, create it, then update it" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue', 'var1' => 'variablevalue1'})"
         @ae_method.update_attributes(:data => method)
@@ -249,6 +268,11 @@ module MiqAeServiceSpec
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
         result.should == false
+      end
+
+      it "readonly domain " do
+        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/EVM/AUTOMATE/test1')"
+        assert_readonly_instance(method)
       end
 
       it "make sure instance does not exist, create new instance, make sure it exists, delete it, then check if it exists" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1142317

The $evm.instance_create, $evm.instance_delete and
$evm.instance_update methods now check if the domain
is editable before creating/updating/deleting
