### PR TITLE
Fixed typo in the method 'perpage_key', dbbame changed to dbname

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1962,7 +1962,7 @@ class ApplicationController < ActionController::Base
   end
   private :get_view_process_search_text
 
-  def perpage_key(dbbame)
+  def perpage_key(dbname)
    ["job", "miqtask"].include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
   end
   private :perpage_key


### PR DESCRIPTION
This typo was introduced by https://github.com/ManageIQ/manageiq/pull/562 and was causing a crash while
changing the per-page setting on a view with paging.
