### PR TITLE
SCVMM - Host children missing in the relationships tree

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -449,7 +449,8 @@ module EmsRefresh::Parsers
         :is_datacenter => false,
         :uid_ems       => "host_folder",
         :ems_ref       => "host_folder",
-        :ems_children  => {:clusters => @data[:clusters]}
+        :ems_children  => set_host_folder_children
+
       }
       vm_folder = {
         :name          => 'vm',
@@ -474,6 +475,14 @@ module EmsRefresh::Parsers
       }
       @data[:folders]  = [dc_folder, scvmm_folder, host_folder, vm_folder]
       @data[:ems_root] = dc_folder
+    end
+
+    def set_host_folder_children
+      if @data[:clusters].empty?
+        {:hosts => @data[:hosts]}
+      else
+        {:clusters => @data[:clusters]}
+      end
     end
 
     def identify_primary_ip(nics)


### PR DESCRIPTION
The relationship tree (aka the accordion view) works fine when a cluster node has been configured in SCVMM. However, when no cluster nodes exist no relationship is created between the hosts and the 'host folder'.  This commit addresses this by setting the ems_children property of the 'host folder' to the clusters when they exist and to the hosts when they don't.

https://bugzilla.redhat.com/show_bug.cgi?id=1141208
