### PR TITLE
SCVMM - Only gather IP addresses from running VMs

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -10,7 +10,7 @@ function get_vms{
   $id = $_.ID
   
   $vm_hash["Properties"] = $_
-  if ($_.StatusString -ne "Host Not Responding"){
+  if ($_.StatusString -eq "Running"){
    $networks = Read-SCGuestInfo -VM $_ -Key "NetworkAddressIPv4"
    if ($networks -ne $null){
     $vm_hash["Networks"] = $networks.KvpMap["NetworkAddressIPv4"]


### PR DESCRIPTION
The IP addresses of the VMs in SCVMM are exposed by the Hyperv server. To enable this:
1) The VM must be running
2) The Data Exchange Service must be running on the VM.

If either of the above are false an error is thrown by Powershell and logged in the evm.log file making for a messy and unreadable file.
This PR will significantly reduce the volume of these errors by checking if the VM is in a running state before we try to get the IP addresses.
We will still print out the same error for VMs that do not have 2) above enabled but only for a limited number of VMs since Integration Services are installed by default.

Note -
We can turn off this error completely but i think customers will find the logging helpful.

https://bugzilla.redhat.com/show_bug.cgi?id=1141203
