### PR TITLE
Add :publicly_available to Templates

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack.rb
@@ -483,13 +483,14 @@ module EmsRefresh::Parsers
       parent_server_uid = parse_image_parent_id(image)
 
       new_result = {
-        :type        => "TemplateOpenstack",
-        :uid_ems     => uid,
-        :ems_ref     => uid,
-        :name        => image.name,
-        :vendor      => "openstack",
-        :power_state => "never",
-        :template    => true,
+        :type               => "TemplateOpenstack",
+        :uid_ems            => uid,
+        :ems_ref            => uid,
+        :name               => image.name,
+        :vendor             => "openstack",
+        :power_state        => "never",
+        :template           => true,
+        :publicly_available => image.is_public,
       }
       new_result[:parent_vm_uid] = parent_server_uid unless parent_server_uid.nil?
       new_result[:cloud_tenant]  = @data_index.fetch_path(:cloud_tenants, image.owner) if image.owner

--- a/vmdb/db/migrate/20140917145331_add_vm_publicly_available.rb
+++ b/vmdb/db/migrate/20140917145331_add_vm_publicly_available.rb
@@ -1,0 +1,9 @@
+class AddVmPubliclyAvailable < ActiveRecord::Migration
+  def up
+    add_column :vms, :publicly_available, :boolean
+  end
+
+  def down
+    remove_column :vms, :publicly_available
+  end
+end

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_grizzly_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_grizzly_spec.rb
@@ -32,7 +32,8 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
       assert_specific_floating_ip
       assert_specific_key_pair
       assert_specific_security_group
-      assert_specific_template
+      assert_specific_private_template
+      assert_specific_public_template
       assert_specific_vm_powered_on
       assert_specific_template_created_from_vm
       assert_specific_vm_created_from_snapshot_template
@@ -197,13 +198,22 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
     end
   end
 
-  def assert_specific_template
-    @template = TemplateOpenstack.where(:name => "EmsRefreshSpec-Image").first
-    @template.should have_attributes(
+  def assert_specific_private_template
+    assert_specific_template("cirros-0.3.0-x86_64", "d3a7f7fd-4642-405a-983c-d84008cf3e8b", true)
+  end
+
+  def assert_specific_public_template
+    @template = assert_specific_template("EmsRefreshSpec-Image", "a11384ef-a7d1-4c99-b063-dd60a357d3ff")
+  end
+
+  def assert_specific_template(name, uid, is_public = false)
+    template = TemplateOpenstack.where(:name => name).first
+    template.should have_attributes(
       :template              => true,
-      :ems_ref               => "a11384ef-a7d1-4c99-b063-dd60a357d3ff",
+      :publicly_available    => is_public,
+      :ems_ref               => uid,
       :ems_ref_obj           => nil,
-      :uid_ems               => "a11384ef-a7d1-4c99-b063-dd60a357d3ff",
+      :uid_ems               => uid,
       :vendor                => "OpenStack",
       :power_state           => "never",
       :location              => "unknown",
@@ -224,13 +234,14 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
       :cpu_shares_level      => nil
     )
 
-    @template.ext_management_system.should  == @ems
-    @template.operating_system.should       be_nil # TODO: This should probably not be nil
-    @template.custom_attributes.size.should == 0
-    @template.snapshots.size.should         == 0
-    @template.hardware.should               be_nil
+    template.ext_management_system.should  == @ems
+    template.operating_system.should       be_nil # TODO: This should probably not be nil
+    template.custom_attributes.size.should == 0
+    template.snapshots.size.should         == 0
+    template.hardware.should               be_nil
 
-    @template.parent.should                 be_nil
+    template.parent.should                 be_nil
+    template
   end
 
   def assert_specific_vm_powered_on

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
@@ -34,7 +34,8 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
       assert_specific_key_pair
       assert_specific_security_group
       assert_specific_network
-      assert_specific_template
+      assert_specific_private_template
+      assert_specific_public_template
       assert_specific_vm_powered_on
       assert_specific_template_created_from_vm
       assert_specific_vm_created_from_snapshot_template
@@ -245,12 +246,21 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
     end
   end
 
-  def assert_specific_template
-    @template = TemplateOpenstack.where(:name => "EmsRefreshSpec-Image").first
-    @template.should have_attributes(
+  def assert_specific_private_template
+    @template = assert_specific_template("EmsRefreshSpec-Image", "f163ac1a-57f9-4a2a-beca-12bc28e3ff78")
+  end
+
+  def assert_specific_public_template
+    assert_specific_template("cirros", "20fa4213-0c13-4d0c-8a73-c80479ca1b21", true)
+  end
+
+  def assert_specific_template(name, uid, is_public = false)
+    template = TemplateOpenstack.where(:name => name).first
+    template.should have_attributes(
       :template              => true,
+      :publicly_available    => is_public,
       :ems_ref_obj           => nil,
-      :uid_ems               => "f163ac1a-57f9-4a2a-beca-12bc28e3ff78",
+      :uid_ems               => uid,
       :vendor                => "OpenStack",
       :power_state           => "never",
       :location              => "unknown",
@@ -270,15 +280,16 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
       :cpu_shares            => nil,
       :cpu_shares_level      => nil
     )
-    @template.ems_ref.should be_guid
+    template.ems_ref.should be_guid
 
-    @template.ext_management_system.should  == @ems
-    @template.operating_system.should       be_nil # TODO: This should probably not be nil
-    @template.custom_attributes.size.should == 0
-    @template.snapshots.size.should         == 0
-    @template.hardware.should               be_nil
+    template.ext_management_system.should  == @ems
+    template.operating_system.should       be_nil # TODO: This should probably not be nil
+    template.custom_attributes.size.should == 0
+    template.snapshots.size.should         == 0
+    template.hardware.should               be_nil
 
-    @template.parent.should                 be_nil
+    template.parent.should                 be_nil
+    template
   end
 
   def assert_specific_vm_powered_on


### PR DESCRIPTION
Now Templates can be public or non-public.  This exposes the public flag on
images from cloud providers.

For Openstack, this information is available on the detailed image information
retrieved from the Openstack Glance API.

For Amazon, to avoid making an additional EC2 API call per image, the
:publicly_available information is derived from how the images are gathered by
the EC2 Parser.  For instance, get_private_images sets :publicly_available =
false, and get_public_images sets :publicly_available = true.
