### PR TITLE
Add modeling for template many-to-many tenant

### DIFF
--- a/vmdb/app/models/cloud_tenant.rb
+++ b/vmdb/app/models/cloud_tenant.rb
@@ -1,5 +1,6 @@
 class CloudTenant < ActiveRecord::Base
   include ReportableMixin
+  include NewWithTypeStiMixin
 
   attr_accessible :description, :ems_ref, :enabled, :name
 

--- a/vmdb/app/models/cloud_tenant_openstack.rb
+++ b/vmdb/app/models/cloud_tenant_openstack.rb
@@ -1,0 +1,7 @@
+class CloudTenantOpenstack < CloudTenant
+  has_and_belongs_to_many :miq_templates,
+                          :foreign_key             => "cloud_tenant_id",
+                          :join_table              => "cloud_tenants_vms",
+                          :association_foreign_key => "vm_id",
+                          :class_name              => "TemplateOpenstack"
+end

--- a/vmdb/app/models/template_openstack.rb
+++ b/vmdb/app/models/template_openstack.rb
@@ -1,6 +1,12 @@
 class TemplateOpenstack < TemplateCloud
   belongs_to :cloud_tenant
 
+  has_and_belongs_to_many :cloud_tenants,
+                          :foreign_key             => "vm_id",
+                          :join_table              => "cloud_tenants_vms",
+                          :association_foreign_key => "cloud_tenant_id",
+                          :class_name              => "CloudTenantOpenstack"
+
   def provider_object(connection = nil)
     connection ||= self.ext_management_system.connect
     connection.images.get(self.ems_ref)

--- a/vmdb/db/migrate/20140918131740_add_template_multi_tenant_relationship.rb
+++ b/vmdb/db/migrate/20140918131740_add_template_multi_tenant_relationship.rb
@@ -1,0 +1,12 @@
+class AddTemplateMultiTenantRelationship < ActiveRecord::Migration
+  def up
+    create_table 'cloud_tenants_vms', :id => false do |t|
+      t.column :cloud_tenant_id, :bigint
+      t.column :vm_id, :bigint
+    end
+  end
+
+  def down
+    drop_table 'cloud_tenants_vms'
+  end
+end

--- a/vmdb/db/migrate/20140918140859_add_cloud_tenant_sti_column.rb
+++ b/vmdb/db/migrate/20140918140859_add_cloud_tenant_sti_column.rb
@@ -1,0 +1,17 @@
+class AddCloudTenantStiColumn < ActiveRecord::Migration
+  class CloudTenant < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    add_column :cloud_tenants, :type, :string
+
+    say_with_time("Default cloud tenant type value to CloudTenantOpenstack") do
+      CloudTenant.update_all(:type => "CloudTenantOpenstack")
+    end
+  end
+
+  def down
+    remove_column :cloud_tenants, :type
+  end
+end

--- a/vmdb/spec/migrations/20140918140859_add_cloud_tenant_sti_column_spec.rb
+++ b/vmdb/spec/migrations/20140918140859_add_cloud_tenant_sti_column_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20140918140859_add_cloud_tenant_sti_column")
+
+describe AddCloudTenantStiColumn do
+  let(:cloud_tenant_stub) { migration_stub(:CloudTenant) }
+
+  migration_context :up do
+    it "Sets the default type for Cloud Tenant records to 'CloudTenantOpenstack'" do
+      cloud_tenant_stub.create!(:name => "tenant 1")
+      cloud_tenant_stub.create!(:name => "tenant 2")
+
+      migrate
+
+      cloud_tenant_stub.all.each { |tenant| tenant.type.should be == "CloudTenantOpenstack" }
+    end
+  end
+end


### PR DESCRIPTION
In OpenStack, an image (TemplateOpenstack) can exist in more than one project
(CloudTenantOpenstack).  These migration and model changes allow an OpenStack
template to list the tenants it can be used in, and allows a Cloud Tenant to
list the templates associated with it.

The table is named "cloud_tenants_vms" to reflect the physical tables used in
for the join.

Despite the table name referring to the generic objects, the relationship is
purposefully restricted to Openstack templates and Openstack cloud tenants in
the association defined in the models.  This keeps the notion of the
many-to-many relationship restricted to the most specific level.

The relationship methods are named:
- TemplateOpenstack#cloud_tenants
- CloudTenantOpenstack#opentack_templates

Additionally, to facilitate keeping the relationship as specific as possible,
CloudTenant is now sublassed to CloudTenantOpenstack.  Since all of the existing
cloud tenants are only openstack tenants, the migration initializes all of the
CloudTenant records to have a type of CloudTenantOpenstack.
