### PR TITLE
Add EMS provider_region column; Undo hack for EmsAmazon to use hostname.

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -564,6 +564,7 @@ module EmsCommon
     @edit[:current] = Hash.new
 
     @edit[:new][:name] = @ems.name
+    @edit[:new][:provider_region] = @ems.provider_region
     @edit[:new][:hostname] = @ems.hostname
     @edit[:new][:ipaddress] = @ems.ipaddress
     @edit[:new][:emstype] = @ems.emstype
@@ -620,6 +621,7 @@ module EmsCommon
 
     @edit[:new][:name] = params[:name] if params[:name]
     @edit[:new][:ipaddress] = @edit[:new][:hostname] = "" if params[:server_emstype]
+    @edit[:new][:provider_region] = params[:provider_region] if params[:provider_region]
     @edit[:new][:hostname] = params[:hostname] if params[:hostname]
     @edit[:new][:ipaddress] = params[:ipaddress] if params[:ipaddress]
     if params[:server_emstype]
@@ -654,6 +656,7 @@ module EmsCommon
   # Set record variables to new values
   def set_record_vars(ems, mode = nil)
     ems.name = @edit[:new][:name]
+    ems.provider_region = @edit[:new][:provider_region]
     ems.hostname = @edit[:new][:hostname]
     ems.ipaddress = @edit[:new][:ipaddress]
     ems.port = @edit[:new][:port] if ["openstack", "rhevm"].include?(ems.emstype)

--- a/vmdb/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module EmsCloudHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w{hostname ipaddress type port guid}
+    items = %w{provider_region hostname ipaddress type port guid}
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -26,10 +26,14 @@ module EmsCloudHelper::TextualSummary
   #
   # Items
   #
+  def textual_provider_region
+    return nil if @ems.provider_region.nil?
+    {:label => "Region", :value => @ems.description }
+  end
+
   def textual_hostname
-    label = @ems.kind_of?(EmsAmazon) ? "Region" : "Hostname"
-    value = @ems.kind_of?(EmsAmazon) ? @ems.description : @ems.hostname
-    {:label => label, :value => value }
+    return nil if @ems.hostname.blank?
+    {:label => "Hostname", :value => @ems.hostname }
   end
 
   def textual_ipaddress

--- a/vmdb/app/views/ems_cloud/_form_fields.html.haml
+++ b/vmdb/app/views/ems_cloud/_form_fields.html.haml
@@ -1,14 +1,14 @@
 - if @edit[:new][:emstype] == "ec2"
   %tr
-    %td.key Amazon Region
+    %td.key Region
     %td.wide
-      = select_tag("hostname",
+      = select_tag("provider_region",
                    options_for_select([["<Choose>", nil]] + Array(@edit[:amazon_regions].invert).sort { |a, b| a[0] <=> b[0] },
-                                      @edit[:new][:hostname]),
+                                      @edit[:new][:provider_region]),
                    "data-miq_observe" => {:url => url}.to_json)
 - elsif @edit[:new][:emstype].present?
   %tr
-    %td.key Host name
+    %td.key Host Name
     %td.wide
       = text_field_tag("hostname",
                        @edit[:new][:hostname],

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -604,8 +604,8 @@ en:
 
   activerecord:
     attributes:
-      ems_amazon:
-        hostname: "Region"
+      ems_cloud:
+        provider_region: "Region"
       ext_management_system:
         hostname: "Host Name"
         ipaddress: "IP Address"

--- a/vmdb/db/migrate/20140918154013_add_provider_region_to_ext_management_systems.rb
+++ b/vmdb/db/migrate/20140918154013_add_provider_region_to_ext_management_systems.rb
@@ -1,0 +1,22 @@
+class AddProviderRegionToExtManagementSystems < ActiveRecord::Migration
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    add_column :ext_management_systems, :provider_region, :string
+
+    say_with_time("Moving EmsAmazon regions from hostname to provider_region") do
+      ExtManagementSystem.where(:type => "EmsAmazon").update_all("provider_region = hostname")
+      ExtManagementSystem.where(:type => "EmsAmazon").update_all(:hostname => nil)
+    end
+  end
+
+  def down
+    say_with_time("Moving EmsAmazon regions from provider_region to hostname") do
+      ExtManagementSystem.where(:type => "EmsAmazon").update_all("hostname = provider_region")
+    end
+
+    remove_column :ext_management_systems, :provider_region
+  end
+end

--- a/vmdb/spec/controllers/ems_common_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_common_controller_spec.rb
@@ -37,7 +37,7 @@ describe EmsCloudController do
     end
 
     context "#create" do
-      it "displays correct attribute name in error message when adding Amazon EMS" do
+      it "displays correct attribute name in error message when adding cloud EMS" do
         set_user_privileges
         controller.instance_variable_set(:@model, EmsCloud)
         controller.instance_variable_set(:@edit, {:new => {:name => "EMS 1", :emstype => "ec2"},
@@ -50,7 +50,7 @@ describe EmsCloudController do
         flash_messages.first[:level].should == :error
       end
 
-      it "displays correct attribute name in error message when adding non-Amazon EMS" do
+      it "displays correct attribute name in error message when adding infra EMS" do
         set_user_privileges
         controller.instance_variable_set(:@model, EmsCloud)
         controller.instance_variable_set(:@edit, {:new => {:name => "EMS 2", :emstype => "rhevm"},

--- a/vmdb/spec/factories/ext_management_system.rb
+++ b/vmdb/spec/factories/ext_management_system.rb
@@ -37,7 +37,7 @@ FactoryGirl.define do
   end
 
   factory :ems_amazon, :class => "EmsAmazon", :parent => :ext_management_system do
-    hostname "us-east-1"
+    provider_region "us-east-1"
   end
 
   factory :ems_amazon_with_authentication, :parent => :ems_amazon do

--- a/vmdb/spec/migrations/20140918154013_add_provider_region_to_ext_management_systems_spec.rb
+++ b/vmdb/spec/migrations/20140918154013_add_provider_region_to_ext_management_systems_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20140918154013_add_provider_region_to_ext_management_systems")
+
+describe AddProviderRegionToExtManagementSystems do
+  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it "Updates the provider_region and hostname columns" do
+      e1 = ems_stub.create!(:type => "EmsAmazon", :hostname => "us-east-1")
+      e2 = ems_stub.create!(:type => "EmsAmazon", :hostname => "us-west-1")
+      e3 = ems_stub.create!(:type => "EmsOther",  :hostname => "my.org")
+
+      migrate
+
+      e1.reload
+      e2.reload
+      e3.reload
+
+      expect(e1.provider_region).to eq("us-east-1")
+      expect(e1.hostname).to        be_nil
+      expect(e2.provider_region).to eq("us-west-1")
+      expect(e2.hostname).to        be_nil
+      expect(e3.provider_region).to be_nil
+      expect(e3.hostname).to        eq("my.org")
+    end
+  end
+
+  migration_context :down do
+    it "Updates the hostname columns" do
+      e1 = ems_stub.create!(:type => "EmsAmazon", :provider_region => "us-east-1", :hostname => nil)
+      e2 = ems_stub.create!(:type => "EmsAmazon", :provider_region => "us-west-1", :hostname => nil)
+      e3 = ems_stub.create!(:type => "EmsOther",  :provider_region => nil,         :hostname => "my.org")
+
+      migrate
+
+      e1.reload
+      e2.reload
+      e3.reload
+
+      expect(e1.hostname).to eq("us-east-1")
+      expect(e2.hostname).to eq("us-west-1")
+      expect(e3.hostname).to eq("my.org")
+    end
+  end
+end

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -26,15 +26,15 @@ describe EmsAmazon do
     end
 
     def assert_region(ems, name)
-      ems.name.should          == name
-      ems.hostname.should      == name.split(" ").first
-      ems.auth_user_pwd.should == [@ec2_user, @ec2_pass]
+      ems.name.should            == name
+      ems.provider_region.should == name.split(" ").first
+      ems.auth_user_pwd.should   == [@ec2_user, @ec2_pass]
     end
 
     def assert_region_on_another_account(ems, name)
-      ems.name.should          == name
-      ems.hostname.should      == name.split(" ").first
-      ems.auth_user_pwd.should == [@ec2_user2, @ec2_pass2]
+      ems.name.should            == name
+      ems.provider_region.should == name.split(" ").first
+      ems.auth_user_pwd.should   == [@ec2_user2, @ec2_pass2]
     end
 
 
@@ -58,7 +58,7 @@ describe EmsAmazon do
     end
 
     it "with some existing records" do
-      FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :hostname => "us-west-1")
+      FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :provider_region => "us-west-1")
 
       found = recorded_discover(example)
       found.count.should == 1
@@ -70,8 +70,8 @@ describe EmsAmazon do
     end
 
     it "with all existing records" do
-      FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-east-1", :hostname => "us-east-1")
-      FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :hostname => "us-west-1")
+      FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-east-1", :provider_region => "us-east-1")
+      FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :provider_region => "us-west-1")
 
       found = recorded_discover(example)
       found.count.should == 0
@@ -84,7 +84,7 @@ describe EmsAmazon do
 
     context "with records from a different account" do
       it "with the same name" do
-        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :hostname => "us-west-1")
+        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :provider_region => "us-west-1")
 
         found = recorded_discover(example)
         found.count.should == 2
@@ -97,8 +97,8 @@ describe EmsAmazon do
       end
 
       it "with the same name and backup name" do
-        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :hostname => "us-west-1")
-        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 #{@ec2_user}", :hostname => "us-west-1")
+        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :provider_region => "us-west-1")
+        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 #{@ec2_user}", :provider_region => "us-west-1")
 
         found = recorded_discover(example)
         found.count.should == 2
@@ -112,9 +112,9 @@ describe EmsAmazon do
       end
 
       it "with the same name, backup name, and secondary backup name" do
-        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :hostname => "us-west-1")
-        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 #{@ec2_user}", :hostname => "us-west-1")
-        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 1", :hostname => "us-west-1")
+        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :provider_region => "us-west-1")
+        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 #{@ec2_user}", :provider_region => "us-west-1")
+        FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 1", :provider_region => "us-west-1")
 
         found = recorded_discover(example)
         found.count.should == 2
@@ -132,30 +132,30 @@ describe EmsAmazon do
   end
 
   it "#description" do
-    ems = FactoryGirl.build(:ems_amazon, :hostname => "us-east-1")
+    ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
     ems.description.should == "US East (Northern Virginia)"
 
-    ems = FactoryGirl.build(:ems_amazon, :hostname => "us-west-1")
+    ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-west-1")
     ems.description.should == "US West (Northern California)"
   end
 
   context "validates_uniqueness_of" do
     it "name" do
-      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :hostname => "us-east-1") }.to_not raise_error
-      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :hostname => "us-east-1") }.to     raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name has already been taken")
+      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :provider_region => "us-east-1") }.to_not raise_error
+      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :provider_region => "us-east-1") }.to     raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "blank region" do
-      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :hostname => "") }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Region is not included in the list")
+      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :provider_region => "") }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "nil region" do
-      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :hostname => nil) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Region is not included in the list")
+      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :provider_region => nil) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
-    it "duplicate hostname" do
-      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :hostname => "us-east-1") }.to_not raise_error
-      expect { FactoryGirl.create(:ems_amazon, :name => "ems_2", :hostname => "us-east-1") }.to_not raise_error
+    it "duplicate provider_region" do
+      expect { FactoryGirl.create(:ems_amazon, :name => "ems_1", :provider_region => "us-east-1") }.to_not raise_error
+      expect { FactoryGirl.create(:ems_amazon, :name => "ems_2", :provider_region => "us-east-1") }.to_not raise_error
     end
   end
 end

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe EmsRefresh::Refreshers::Ec2Refresher do
   before(:each) do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_amazon, :hostname => "us-west-1", :zone => zone)
+    @ems = FactoryGirl.create(:ems_amazon, :provider_region => "us-west-1", :zone => zone)
     @ems.update_authentication(:default => {:userid => "0123456789ABCDEFGHIJ", :password => "ABCDEFGHIJKLMNO1234567890abcdefghijklmno"})
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1144523

In addition, this will enable us to support OpenStack regions in an analogous way to how we support Amazon regions.

@blomquisg @gmcculloug Please review
@dclarizio There is a small UI change here, so please review that one
