### PR TITLE
Fixed crash when validations fail while creating a catalog item

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -643,7 +643,7 @@ class CatalogController < ApplicationController
     if @edit[:wf] && @edit[:new][:st_prov_type] != "generic"
       request = @edit[:req_id] ? @edit[:wf].update_request(@edit[:req_id], @edit[:new], session[:userid]) :
                                   @edit[:wf].create_request(@edit[:new], session[:userid])
-      if request.errors.present?
+      if request && request.errors.present?
         request.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end


### PR DESCRIPTION
`create_request` returns `false` if validations fail or it returns the `request` object itself.
An additional check was added to check for the existence of the `request` object.

https://bugzilla.redhat.com/show_bug.cgi?id=1095457
https://bugzilla.redhat.com/show_bug.cgi?id=1138397
