### PR TITLE
Properly ask for realm in appliance_console

### DIFF
--- a/lib/appliance_console/external_httpd_authentication.rb
+++ b/lib/appliance_console/external_httpd_authentication.rb
@@ -21,8 +21,8 @@ module ApplianceConsole
       say("\nIPA Server Parameters:\n\n")
       @ipaserver = ask_for_hostname("IPA Server Hostname", @ipaserver)
       @domain    = ask_for_domain("IPA Server Domain", @domain)
-      @realm     = ask_for_realm("IPA Server Realm", realm)
-      @principal = just_ask("IPA Server Principal", @principal)
+      @realm     = ask_for_string("IPA Server Realm", realm)
+      @principal = ask_for_string("IPA Server Principal", @principal)
       @password  = ask_for_password("IPA Server Principal Password", @password)
 
       @ipaserver = fqdn(@ipaserver, @domain)


### PR DESCRIPTION
A search/replace had gone wrong before with "realm". fixed it

https://bugzilla.redhat.com/show_bug.cgi?id=1144493

/cc @abellotti 
