### PR TITLE
SCVMM - Use the exception's own 'message' in the verify_credentials method.

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -45,8 +45,9 @@ class EmsMicrosoft < EmsInfra
 
     begin
       run_dos_command("hostname")
-    rescue WinRM::WinRMHTTPTransportError # Error 401
-      raise MiqException::MiqHostError, "Login failed due to a bad username or password."
+    rescue WinRM::WinRMHTTPTransportError => e # Error 401
+      raise MiqException::MiqHostError, "Check credentials and WinRM configuration settings. " \
+      "Remote error message: #{e.message}"
     end
 
     true


### PR DESCRIPTION
 A 401 exception can be returned by the WinRM service on the SCVMM box for reasons other than a user has entered invalid credentials. For example, if we set the winrm/config/service/AllowUnencrypted value to 'false' we get the same 401 error, probably because it is still a denial of access..
I think it is safer just to stick with the message built into the exception. That said, I am open to appending some clues to the message such as "Check credentials and WinRM configuration settings"… or something like that.

https://bugzilla.redhat.com/show_bug.cgi?id=1131236
