### PR TITLE
Moved hidden features for Report download buttons under View section.

### DIFF
--- a/vmdb/db/fixtures/miq_product_features.yml
+++ b/vmdb/db/fixtures/miq_product_features.yml
@@ -1494,6 +1494,22 @@
       :description: View Reports
       :feature_type: view
       :identifier: miq_report_view
+      :children:
+      - :name: Download CSV Format
+        :description: Download Report in CSV Format
+        :feature_type: admin
+        :hidden: true
+        :identifier: render_report_csv
+      - :name: Download PDF Format
+        :description: Download Report in PDF Format
+        :feature_type: admin
+        :hidden: true
+        :identifier: render_report_pdf
+      - :name: Download Text Format
+        :description: Download Report in Text Format
+        :feature_type: admin
+        :hidden: true
+        :identifier: render_report_txt
     - :name: Operate
       :description: Perform Operations on Reports
       :feature_type: control
@@ -1524,21 +1540,6 @@
         :description: Edit a Report
         :feature_type: admin
         :identifier: miq_report_edit
-      - :name: Download CSV Fromat
-        :description: Download Report in CSV Format
-        :feature_type: admin
-        :hidden: true
-        :identifier: render_report_csv
-      - :name: Download PDF Fromat
-        :description: Download Report in PDF Format
-        :feature_type: admin
-        :hidden: true
-        :identifier: render_report_pdf
-      - :name: Download Text Fromat
-        :description: Download Report in Text Format
-        :feature_type: admin
-        :hidden: true
-        :identifier: render_report_txt
   - :name: Schedules
     :description: Schedules Accordion
     :feature_type: node


### PR DESCRIPTION
If a user can view a report they should be able to download a report. Hidden report download features were under Modify section, if user didn't have access to modify/add reports they were getting User not authorized for this task message when trying to download a report.

https://bugzilla.redhat.com/show_bug.cgi?id=1126363
https://bugzilla.redhat.com/show_bug.cgi?id=1144602

@dclarizio please review/test.
