### PR TITLE
MiqAeExpression isn't referenced anywhere, so rm

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_expression.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_expression.rb
@@ -1,7 +1,0 @@
-module MiqAeEngine
-  class MiqAeExpression
-    def self.evaluate(expr)
-      eval expr
-    end
-  end
-end


### PR DESCRIPTION
I think we can delete this.  Is this constant referenced anywhere that I might not know about?
