### PR TITLE
Reset value of index if chart is not available.

### DIFF
--- a/vmdb/app/controllers/application_controller/performance.rb
+++ b/vmdb/app/controllers/application_controller/performance.rb
@@ -550,6 +550,7 @@ module ApplicationController::Performance
         @perf_record.respond_to?(c[:applies_to_method]) &&
         !@perf_record.send(c[:applies_to_method].to_sym)
     end
+    @perf_options[:index] = nil unless @perf_options[:index].nil? || charts[@perf_options[:index].to_i]
     return charts
   end
 
@@ -832,8 +833,8 @@ module ApplicationController::Performance
       to_dt = create_time_in_utc("#{@perf_options[:daily_date]} 23", @perf_options[:tz])    # Get tz 11pm in UTC
       rpt = perf_get_chart_rpt("vim_perf_tag_daily")
       rpt.time_profile_id = @perf_options[:time_profile]
+      chart_layout = perf_get_chart_layout("daily_tag_charts", @perf_options[:model]) if @perf_options[:index]
       if @perf_options[:index]                    # If only looking at 1 chart, trim report columns for less daily rollups
-        chart_layout = perf_get_chart_layout("daily_tag_charts", @perf_options[:model])
         chart = chart_layout[@perf_options[:index].to_i]
         perf_trim_report_cols(rpt, chart)
       end


### PR DESCRIPTION
Added line of code to reset value of index in @perf_options to fix an issue([] for nil:NilClass error), if user has zoomed in on one of the charts and then changed options such as group by from the options box on the screen and the returning result didn't include the chart user was zoomed in on. With this change user will be presented with all the zoomed out available charts.

https://bugzilla.redhat.com/show_bug.cgi?id=1144622
https://bugzilla.redhat.com/show_bug.cgi?id=1145741

@dclarizio please review/test
