### PR TITLE
Changed model in TAG_CLASSES array to VmOrTemplate instead of Vm

### DIFF
--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -218,28 +218,27 @@ class MiqExpression
     guid
   }
 
+  TAG_CLASSES = %w(
+    EmsCloud ext_management_system
+    EmsCluster ems_cluster
+    EmsInfra ext_management_system
+    Host host
+    MiqGroup miq_group
+    MiqTemplate miq_template
+    Repository repository
+    ResourcePool resource_pool
+    Service service
+    Storage storage
+    TemplateCloud miq_template
+    TemplateInfra miq_template
+    User user
+    VmOrTemplate vm
+    VmCloud vm
+    VmInfra vm
+  )
   EXCLUDE_FROM_RELATS = {
     "EmsCloud" => ["hosts", "ems_clusters", "resource_pools"]
   }
-
-  TAG_CLASSES = [
-    "EmsCloud", "ext_management_system",
-    "EmsCluster", "ems_cluster",
-    "EmsInfra", "ext_management_system",
-    "Host", "host",
-    "MiqGroup", "miq_group",
-    "MiqTemplate", "miq_template",
-    "Repository", "repository",
-    "ResourcePool", "resource_pool",
-    "Service", "service",
-    "Storage", "storage",
-    "TemplateCloud", "miq_template",
-    "TemplateInfra", "miq_template",
-    "User", "user",
-    "VmOrTemplate", "vm",
-    "VmCloud", "vm",
-    "VmInfra", "vm"
-  ]
 
   FORMAT_SUB_TYPES = {
     :boolean => {

--- a/vmdb/spec/models/miq_expression/model_details_spec.rb
+++ b/vmdb/spec/models/miq_expression/model_details_spec.rb
@@ -32,9 +32,14 @@ describe MiqExpression do
         result.select { |r| r.first == "Instance.VM and Instance.My Company Tags : Auto Approve - Max CPU" }.should be_empty
       end
 
-      it "Vm" do
-        result = described_class.model_details("Vm", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "VM and Instance.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+      it "VmOrTemplate" do
+        result = described_class.model_details("VmOrTemplate",
+                                               :typ             => "tag",
+                                               :include_model   => true,
+                                               :include_my_tags => true,
+                                               :userid          => "admin"
+        )
+        result.select { |r| r.first == "VM or Template.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
       end
 
       it "TemplateInfra" do
@@ -64,8 +69,11 @@ describe MiqExpression do
     end
 
     context "with :typ=>all" do
-      it "Vm" do
-        result = described_class.model_details("Vm", :typ => "all", :include_model => false, :include_tags => true)
+      it "VmOrTemplate" do
+        result = described_class.model_details("VmOrTemplate",
+                                               :typ           => "all",
+                                               :include_model => false,
+                                               :include_tags  => true)
         result.select { |r| r.first == "My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
       end
 


### PR DESCRIPTION
 "VM and Instance.My Company Tags: XXX" fields for Performance VM reports were not getting displayed in UI due to the model being incorrect in TAG_CLASSES array.

https://bugzilla.redhat.com/show_bug.cgi?id=1129228

@dclarizio please review/test
