### PR TITLE
appliance_console#fetch_key fix "try again"

### DIFF
--- a/lib/appliance_console/key_configuration.rb
+++ b/lib/appliance_console/key_configuration.rb
@@ -41,7 +41,7 @@ module ApplianceConsole
       loop do
         return false unless ask_questions
         return true if activate
-        return false unless agree("Try again?")
+        return false unless agree("Try again? (Y/N) ")
       end
     end
 
@@ -53,7 +53,6 @@ module ApplianceConsole
       else
         create_key
       end
-      true
     end
 
     def key_exist?


### PR DESCRIPTION
When the appliance fails to download a key, ask try again.

Old code did not properly detect the failure
(also fixed prompting message to be more clear)

https://bugzilla.redhat.com/show_bug.cgi?id=1145365
