### PR TITLE
REST API fail to authenticate with Ldap

### DIFF
--- a/vmdb/app/models/miq_task.rb
+++ b/vmdb/app/models/miq_task.rb
@@ -227,7 +227,9 @@ class MiqTask < ActiveRecord::Base
       Timeout.timeout(options[:timeout]) do
         while task.state != STATE_FINISHED
           sleep(options[:sleep_time])
-          task.reload
+          # Code running with Rails QueryCache enabled,
+          # need to disable caching for the reload to see updates.
+          task.class.uncached { task.reload }
         end
       end
     rescue Timeout::Error


### PR DESCRIPTION
With AD enabled, always getting a 401 in REST API
for non admin even though user credentials properly bind
with AD.

https://bugzilla.redhat.com/show_bug.cgi?id=1146110
