### PR TITLE
return empty list for resource pool without host or parent cluster

### DIFF
--- a/vmdb/app/models/resource_pool.rb
+++ b/vmdb/app/models/resource_pool.rb
@@ -157,6 +157,7 @@ class ResourcePool < ActiveRecord::Base
   # Overridden from AggregationMixin to provide hosts related to this RP
   def all_hosts
     p = self.parent_cluster_or_host
+    return [] unless p
     p.is_a?(Host) ? [p] : p.all_hosts
   end
 


### PR DESCRIPTION
This is to address the following error:

Error caught: [NoMethodError] undefined method `collect' for nil:NilClass
vmdb/app/models/resource_pool.rb:165:in`all_host_ids'
vmdb/app/models/mixins/aggregation_mixin.rb:95:in `aggregate_hardware'
vmdb/app/models/mixins/aggregation_mixin.rb:28:in`aggregate_cpu_speed'
...

showing for resource pools, which -- for whatever reason -- do not
have a host or a parent cluster.

https://bugzilla.redhat.com/show_bug.cgi?id=1133569
