### PR TITLE
Treat date "from" filters as dates, not times

### DIFF
--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -501,10 +501,17 @@ class MiqExpression
       col_type = self.get_col_type(col_name)
 
       start_val, end_val = exp[operator]["value"]
-      start_val = self.quote(self.normalize_date_time(start_val, tz, "beginning").utc, :datetime)
-      end_val   = self.quote(self.normalize_date_time(end_val, tz, "end").utc, :datetime)
+      if col_type == :date
+        start_val = self.quote(self.normalize_date_time(start_val, "UTC", "beginning").to_date, :date)
+        end_val   = self.quote(self.normalize_date_time(end_val, "UTC", "end").to_date, :date)
 
-      clause = "val=#{col_ruby}; !val.nil? && val.to_time >= #{start_val} && val.to_time <= #{end_val}"
+        clause = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
+      else
+        start_val = self.quote(self.normalize_date_time(start_val, tz, "beginning").utc, :datetime)
+        end_val   = self.quote(self.normalize_date_time(end_val, tz, "end").utc, :datetime)
+
+        clause = "val=#{col_ruby}; !val.nil? && val.to_time >= #{start_val} && val.to_time <= #{end_val}"
+      end
     when "date_time_with_logical_operator"
       exp = exp[operator]
       operator = exp.keys.first
@@ -518,9 +525,16 @@ class MiqExpression
       when ">", "<="  then "end"        # (>  <date> 23::59:59), (<= <date> 23::59:59)
       when "<", ">="  then "beginning"  # (<  <date> 00::00:00), (>= <date> 00::00:00)
       end
-      val = self.normalize_date_time(exp[operator]["value"], tz, mode)
 
-      clause = "val=#{col_ruby}; !val.nil? && val.to_time #{normalized_operator} #{self.quote(val.utc, :datetime)}"
+      if col_type == :date
+        val = self.normalize_date_time(exp[operator]["value"], "UTC", mode)
+
+        clause = "val=#{col_ruby}; !val.nil? && val.to_date #{normalized_operator} #{self.quote(val.to_date, :date)}"
+      else
+        val = self.normalize_date_time(exp[operator]["value"], tz, mode)
+
+        clause = "val=#{col_ruby}; !val.nil? && val.to_time #{normalized_operator} #{self.quote(val.utc, :datetime)}"
+      end
     else
       raise "operator '#{operator}' is not supported"
     end
@@ -695,10 +709,17 @@ class MiqExpression
       col_type = self.class.get_col_type(col_name)
 
       start_val, end_val = exp[operator]["value"]
-      start_val = self.class.quote(self.class.normalize_date_time(start_val, tz, "beginning").utc, :datetime, :sql)
-      end_val   = self.class.quote(self.class.normalize_date_time(end_val, tz, "end").utc, :datetime, :sql)
+      if col_type == :date
+        start_val = self.class.quote(self.class.normalize_date_time(start_val, "UTC", "beginning").to_date, :date, :sql)
+        end_val   = self.class.quote(self.class.normalize_date_time(end_val, "UTC", "end").to_date, :date, :sql)
 
-      clause = "#{col_sql} BETWEEN #{start_val} AND #{end_val}"
+        clause = "#{col_sql} BETWEEN #{start_val} AND #{end_val}"
+      else
+        start_val = self.class.quote(self.class.normalize_date_time(start_val, tz, "beginning").utc, :datetime, :sql)
+        end_val   = self.class.quote(self.class.normalize_date_time(end_val, tz, "end").utc, :datetime, :sql)
+
+        clause = "#{col_sql} BETWEEN #{start_val} AND #{end_val}"
+      end
     when "date_time_with_logical_operator"
       exp = exp[operator]
       operator = exp.keys.first
@@ -712,9 +733,16 @@ class MiqExpression
       when ">", "<="  then "end"        # (>  <date> 23::59:59), (<= <date> 23::59:59)
       when "<", ">="  then "beginning"  # (<  <date> 00::00:00), (>= <date> 00::00:00)
       end
-      val = self.class.normalize_date_time(exp[operator]["value"], tz, mode)
 
-      clause = "#{col_sql} #{normalized_operator} #{self.class.quote(val.utc, :datetime, :sql)}"
+      if col_type == :date
+        val = self.class.normalize_date_time(exp[operator]["value"], "UTC", mode)
+
+        clause = "#{col_sql} #{normalized_operator} #{self.class.quote(val.to_date, :date, :sql)}"
+      else
+        val = self.class.normalize_date_time(exp[operator]["value"], tz, mode)
+
+        clause = "#{col_sql} #{normalized_operator} #{self.class.quote(val.utc, :datetime, :sql)}"
+      end
     else
       raise "operator '#{operator}' is not supported"
     end

--- a/vmdb/spec/models/miq_expression/miq_expression_spec.rb
+++ b/vmdb/spec/models/miq_expression/miq_expression_spec.rb
@@ -465,22 +465,22 @@ describe MiqExpression do
     context "Testing expression conversion ruby, sql and human with static dates and times" do
       it "should generate the correct ruby expression with an expression having static dates and times with no time zone" do
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-10T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
 
         exp = MiqExpression.new({">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-10T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T00:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T00:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
 
         exp = MiqExpression.new({">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time <= '2011-01-10T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time"
@@ -495,10 +495,10 @@ describe MiqExpression do
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time && val.to_time <= '2011-01-10T23:59:59Z'.to_time"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-09T00:00:00Z'.to_time && val.to_time <= '2011-01-10T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-09T00:00:00Z'.to_time && val.to_time <= '2011-01-10T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]}})
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T08:00:00Z'.to_time && val.to_time <= '2011-01-10T17:00:00Z'.to_time"
@@ -511,22 +511,22 @@ describe MiqExpression do
         tz = "Eastern Time (US & Canada)"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-11T04:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
 
         exp = MiqExpression.new({">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-11T04:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T05:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T05:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
 
         exp = MiqExpression.new({">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time <= '2011-01-11T04:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
         exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time"
@@ -538,7 +538,7 @@ describe MiqExpression do
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-09T05:00:00Z'.to_time && val.to_time <= '2011-01-11T04:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]}})
         exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T13:00:00Z'.to_time && val.to_time <= '2011-01-10T22:00:00Z'.to_time"
@@ -552,27 +552,27 @@ describe MiqExpression do
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on > #{'N' if sqlserver}'2011-01-10T23:59:59Z'"
+        sql.should == "vms.retires_on > #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on > #{'N' if sqlserver}'2011-01-10T23:59:59Z'"
+        sql.should == "vms.retires_on > #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on < #{'N' if sqlserver}'2011-01-10T00:00:00Z'"
+        sql.should == "vms.retires_on < #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({"<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on < #{'N' if sqlserver}'2011-01-10T00:00:00Z'"
+        sql.should == "vms.retires_on < #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on >= #{'N' if sqlserver}'2011-01-10T00:00:00Z'"
+        sql.should == "vms.retires_on >= #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({"<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on <= #{'N' if sqlserver}'2011-01-10T23:59:59Z'"
+        sql.should == "vms.retires_on <= #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
         sql, includes, attrs = exp.to_sql
@@ -588,11 +588,11 @@ describe MiqExpression do
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN #{'N' if sqlserver}'2011-01-09T00:00:00Z' AND #{'N' if sqlserver}'2011-01-10T23:59:59Z'"
+        sql.should == "vms.retires_on BETWEEN #{'N' if sqlserver}'2011-01-09' AND #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN #{'N' if sqlserver}'2011-01-09T00:00:00Z' AND #{'N' if sqlserver}'2011-01-10T23:59:59Z'"
+        sql.should == "vms.retires_on BETWEEN #{'N' if sqlserver}'2011-01-09' AND #{'N' if sqlserver}'2011-01-10'"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]}})
         sql, includes, attrs = exp.to_sql
@@ -729,13 +729,13 @@ describe MiqExpression do
 
       it "should generate the correct ruby expression running to_ruby with an expression having relative dates with no time zone" do
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"}})
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"}})
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time"
@@ -744,7 +744,7 @@ describe MiqExpression do
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time && val.to_time <= '2011-01-11T17:59:59Z'.to_time"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time && val.to_time <= '2011-01-09T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]}})
         exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time && val.to_time <= '2011-01-09T23:59:59Z'.to_time"
@@ -775,7 +775,7 @@ describe MiqExpression do
         exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time && val.to_time <= '2011-01-11T17:59:59Z'.to_time"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time && val.to_time <= '2011-01-10T09:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]}})
         exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time && val.to_time <= '2011-01-10T09:59:59Z'.to_time"
@@ -804,7 +804,7 @@ describe MiqExpression do
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on > #{'N' if sqlserver}'2011-01-09T23:59:59Z'"
+        sql.should == "vms.retires_on > #{'N' if sqlserver}'2011-01-09'"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"}})
         sql, includes, attrs = exp.to_sql
@@ -812,7 +812,7 @@ describe MiqExpression do
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on < #{'N' if sqlserver}'2011-01-09T00:00:00Z'"
+        sql.should == "vms.retires_on < #{'N' if sqlserver}'2011-01-09'"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"}})
         sql, includes, attrs = exp.to_sql
@@ -824,7 +824,7 @@ describe MiqExpression do
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]}})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN #{'N' if sqlserver}'2011-01-03T00:00:00Z' AND #{'N' if sqlserver}'2011-01-09T23:59:59Z'"
+        sql.should == "vms.retires_on BETWEEN #{'N' if sqlserver}'2011-01-03' AND #{'N' if sqlserver}'2011-01-09'"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]}})
         sql, includes, attrs = exp.to_sql


### PR DESCRIPTION
Without this, the existing tests fail when run on a system that's east of Greenwich.

(Namely, `rspec ./spec/models/rbac_spec.rb:719`.)

EDIT by @Fryguy: https://github.com/ManageIQ/manageiq/blob/27758d437b9a722136ad84aa5d962ec88eea8c94/vmdb/spec/models/rbac_spec.rb#L719
