### PR TITLE
fix appliance_console requires

### DIFF
--- a/lib/appliance_console/env.rb
+++ b/lib/appliance_console/env.rb
@@ -1,4 +1,4 @@
-# NOTE: relies upon RAILS_ROOT being set
+RAILS_ROOT ||= Pathname.new(File.dirname(__FILE__)).join("../../vmdb")
 
 module ApplianceConsole
   class Env

--- a/lib/appliance_console/key_configuration.rb
+++ b/lib/appliance_console/key_configuration.rb
@@ -1,6 +1,7 @@
 require 'pathname'
 require 'fileutils'
 require 'net/scp'
+require 'active_support/all'
 
 RAILS_ROOT ||= Pathname.new(File.dirname(__FILE__)).join("../../vmdb")
 require 'util/miq-password'

--- a/lib/appliance_console/logging.rb
+++ b/lib/appliance_console/logging.rb
@@ -1,3 +1,5 @@
+require 'awesome_spawn'
+require 'active_support/all'
 
 RAILS_ROOT ||= Pathname.new(File.dirname(__FILE__)).join("../../vmdb")
 module ApplianceConsole

--- a/lib/spec/appliance_console/certificate_spec.rb
+++ b/lib/spec/appliance_console/certificate_spec.rb
@@ -2,8 +2,6 @@ require "spec_helper"
 require "fileutils"
 require "appliance_console/certificate"
 
-RAILS_ROOT ||= File.expand_path("../../../vmdb", Pathname.new(__FILE__).realpath)
-
 describe ApplianceConsole::Certificate do
   before { Open3.should_not_receive(:capture) }
   let(:host)  { "client.network.com" }

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -2,8 +2,6 @@ require "spec_helper"
 require 'appliance_console/env'
 require "appliance_console/cli"
 
-RAILS_ROOT ||= File.expand_path("../../../vmdb", Pathname.new(__FILE__).realpath)
-
 describe ApplianceConsole::Cli do
   subject { described_class.new }
 

--- a/lib/spec/appliance_console/database_configuration_spec.rb
+++ b/lib/spec/appliance_console/database_configuration_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "appliance_console/prompts"
 require "appliance_console/database_configuration"
 require "appliance_console/external_database_configuration"
+require "appliance_console/internal_database_configuration"
 require "appliance_console/logging"
 
 describe ApplianceConsole::DatabaseConfiguration do

--- a/lib/spec/appliance_console/env_spec.rb
+++ b/lib/spec/appliance_console/env_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 require "appliance_console/env"
 
-RAILS_ROOT ||= File.expand_path("../../../vmdb", Pathname.new(__FILE__).realpath)
-
 describe ApplianceConsole::Env do
   before do
     described_class.stub(:`).and_raise("Spawning is not permitted in specs.  Please add stubs to your spec")

--- a/lib/spec/appliance_console/principal_spec.rb
+++ b/lib/spec/appliance_console/principal_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 require "appliance_console/principal"
 
-RAILS_ROOT ||= File.expand_path("../../../vmdb", Pathname.new(__FILE__).realpath)
-
 describe ApplianceConsole::Principal do
   before { Open3.should_not_receive(:capture3) }
   let(:hostname) { "machine.network.com" }


### PR DESCRIPTION
set RAILS_ROOT where it is needed
add all requirements of the specs to the specs

while running #701 found these missing requires.
They shouldn't effect the running of the actual console, just the specs

/cc @Fryguy 
