### PR TITLE
Reset flash_array when viewing screen off off vm summary screen.

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -258,6 +258,7 @@ module VmCommon
   end
 
   def show(id = nil)
+    @flash_array = [] if params[:display]
     @sb[:action] = params[:display]
 
     return if perfmenu_click?


### PR DESCRIPTION
Reset flash_array so flash message is not displayed when clicking on links such as Snapshots/Genealogy/Container/Operating System etc from summary screen after perfomring some actions like "Edit Tags".

https://bugzilla.redhat.com/show_bug.cgi?id=1146249
https://bugzilla.redhat.com/show_bug.cgi?id=1102658

@dclarizio please review/test.
