### PR TITLE
restore appliance_console database config logging

### DIFF
--- a/lib/spec/appliance_console/database_configuration_spec.rb
+++ b/lib/spec/appliance_console/database_configuration_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "appliance_console/prompts"
 require "appliance_console/database_configuration"
 require "appliance_console/external_database_configuration"
+require "appliance_console/internal_database_configuration"
 require "appliance_console/logging"
 
 describe ApplianceConsole::DatabaseConfiguration do
@@ -230,10 +231,15 @@ describe ApplianceConsole::DatabaseConfiguration do
 
   context "#log_and_feedback" do
     before do
-      @config.logger = nil
+      @old_logger = @config.logger
+    end
+
+    after do
+      @config.logger = @old_logger
     end
 
     it "raises ArgumentError with no block_given" do
+      @config.logger = nil
       lambda {@config.log_and_feedback(:some_method)}.should raise_error(ArgumentError)
     end
 


### PR DESCRIPTION
getting random failures when logger is set to nil

/cc @Fryguy this fixes random appliance_console failure on master
