### PR TITLE
Remove ruby 2.0 deprecated StringIO#lines by using #each_line.

### DIFF
--- a/vmdb/spec/lib/vmdb/logging/mirrored_logger_spec.rb
+++ b/vmdb/spec/lib/vmdb/logging/mirrored_logger_spec.rb
@@ -28,14 +28,14 @@ describe Vmdb::Logging::MirroredLogger do
           @log.send(level, "Testing!")
 
           @log_stream.rewind
-          lines = @log_stream.lines.to_a
+          lines = @log_stream.each_line.to_a
           lines.length.should == 1
           line = lines.first.chomp
           line[7, 1].should == level.to_s[0, 1].upcase
           line[-13..-1].should == "-- : Testing!"
 
           @mirror_stream.rewind
-          lines = @mirror_stream.lines.to_a
+          lines = @mirror_stream.each_line.to_a
           if mirrored
             lines.length.should == 1
             line = lines.first.chomp


### PR DESCRIPTION
StringIO#each_line without a block returning an Enumerator exists on ruby 1.9.3 so we can start enjoying this now and remove the 2.0 deprecation.

See: http://www.ruby-doc.org/stdlib-1.9.3/libdoc/stringio/rdoc/StringIO.html#method-i-each_line

Seen in travis output:

```
vmdb/spec/lib/vmdb/logging/mirrored_logger_spec.rb:38: warning: StringIO#lines is deprecated; use #each_line instead
vmdb/spec/lib/vmdb/logging/mirrored_logger_spec.rb:31: warning: StringIO#lines is deprecated; use #each_line instead
```
