### PR TITLE
Force a binary string literal as binary for ruby 2.0+.

### DIFF
--- a/lib/ec2Extract/Ec2Payload.rb
+++ b/lib/ec2Extract/Ec2Payload.rb
@@ -10,7 +10,7 @@ module Ec2Payload
 	PAIRAPD = 2
 	PAIRBPD = 3
 	
-	GLOBAL_KEY = "\222dL\256\177\311X)\177\332\214*3\367\252\002\023\034\305\243\274\252\312X\276\b\273\261\331(\216\310"
+	GLOBAL_KEY = "\222dL\256\177\311X)\177\332\214*3\367\252\002\023\034\305\243\274\252\312X\276\b\273\261\331(\216\310".force_encoding("ASCII-8BIT")
 	
 	def self.userData
 		ud = `curl http://169.254.169.254/latest/user-data 2> /dev/null`

--- a/lib/spec/ec2Extract/Ec2Payload_spec.rb
+++ b/lib/spec/ec2Extract/Ec2Payload_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'ec2Extract/Ec2Payload'
+
+describe Ec2Payload do
+  it "GLOBAL_KEY treated as binary" do
+    binary_key = "\222dL\256\177\311X)\177\332\214*3\367\252\002\023\034\305\243\274\252\312X\276\b\273\261\331(\216\310".force_encoding("ASCII-8BIT")
+    expect(described_class::GLOBAL_KEY).to eq binary_key
+  end
+end


### PR DESCRIPTION
See #218 #465 #589

Ruby 2.0 reads Strings in ruby scripts by default as UTF-8 unless you specify a magic comment #coding or force the encoding.

Binary string literals, if they can't be converted to UTF-8, will not be equivalent to their binary string counterparts:

```
"\222dL\256".force_encoding("ASCII-8BIT") == "\222dL\256".force_encoding("UTF-8")
=> false
```

Whereas, compatible conversions will be equivalent:

```
"\001\002".force_encoding("ASCII-8BIT") == "\001\002".force_encoding("UTF-8")
=> true
```
