### PR TITLE
simplify copy_hash / copy_array

### DIFF
--- a/vmdb/app/controllers/application_controller/filter.rb
+++ b/vmdb/app/controllers/application_controller/filter.rb
@@ -51,7 +51,9 @@ module ApplicationController::Filter
       end
     else
       if ["commit", "not", "remove"].include?(params[:pressed])
-        @edit[:new][@expkey] = copy_hash(@edit[@expkey][:expression], :token)
+        copy = copy_hash(@edit[@expkey][:expression])
+        copy.deep_delete :token
+        @edit[:new][@expkey] = copy
         exp_array(:push, @edit[:new][@expkey])
       end
       unless ["and", "or"].include?(params[:pressed]) # Unless adding an AND or OR token

--- a/vmdb/lib/vmdb/global_methods.rb
+++ b/vmdb/lib/vmdb/global_methods.rb
@@ -22,17 +22,13 @@ module Vmdb
     end
 
     # Copy a hash, duplicating any embedded hashes/arrays contained within
-    def copy_hash(hashin, skip_key = nil)
-      h = hashin.deep_clone
-      h.deep_delete(skip_key) unless skip_key.nil?
-      h
+    def copy_hash(hashin)
+      hashin.deep_clone
     end
 
     # Copy an array, duplicating any embedded hashes/arrays contained within
-    def copy_array(arrayin, skip_key = nil)
-      a = arrayin.deep_clone
-      a.deep_delete(skip_key) unless skip_key.nil?
-      a
+    def copy_array(arrayin)
+      arrayin.deep_clone
     end
 
     def column_type(model, column)


### PR DESCRIPTION
the second parameter for copy_hash was only used in one place, so
isolate it there.  The second parameter for copy_array was never used,
so delete it.
