### PR TITLE
ignore order of smart proxy affinity tree

### DIFF
--- a/vmdb/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/vmdb/spec/controllers/ops_controller/settings/common_spec.rb
@@ -45,7 +45,7 @@ describe OpsController do
       context "#build_smartproxy_affinity_tree" do
         it "should build a SmartProxy Affinity tree" do
           tree = controller.send(:build_smartproxy_affinity_tree, @zone)
-          tree.should be == [
+          expect(tree).to match_array([
             {
               :key      => @svr1.id.to_s,
               :icon     => "evm_server.png",
@@ -138,7 +138,7 @@ describe OpsController do
                 }
               ]
             }
-          ]
+          ])
         end
       end
 


### PR DESCRIPTION
this was causing a spec to sporadically fail

/cc @jrafanie this fixes the false failure we got after merging the ruby 2.0 changes yesterday
