### PR TITLE
do not load rspec task if no rspec available

### DIFF
--- a/vmdb/lib/tasks/spec_evm.rake
+++ b/vmdb/lib/tasks/spec_evm.rake
@@ -1,3 +1,5 @@
+# these are only useful in development
+if defined?(RSpec)
 namespace :spec do
   namespace :evm do
     def initialize_task(t, rspec_opts = [])
@@ -47,3 +49,4 @@ namespace :spec do
     end
   end
 end
+end # ifdef


### PR DESCRIPTION
On production appliances, rspec gem is not installed
This was causing an error like:

```
rake aborted!
NameError: uninitialized constant RSpec
/var/www/miq/vmdb/lib/tasks/spec_evm.rake:10:in block (2 levels) in <top (required)>'
/var/www/miq/vmdb/lib/tasks/spec_evm.rake:2:inblock in '
/var/www/miq/vmdb/lib/tasks/spec_evm.rake:1:in <top (required)>'
/var/www/miq/vmdb/Rakefile:8:in'
/var/www/miq/vmdb/script/rake:15:in <top (required)>'
/var/www/miq/vmdb/script/rails:6:inrequire'
/var/www/miq/vmdb/script/rails:6:in `'
(See full trace by running task with --trace)
```
