### PR TITLE
set date_from for calendar during initial load of dialog.

### DIFF
--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -111,19 +111,6 @@ module ApplicationController::DialogRunner
                   elsif field.type.include?("TagControl") && field.single_value? && field.required
                     category_tags = DialogFieldTagControl.category_tags(field.category).map {|cat| [cat[:description], cat[:id]]}
                     page.replace("#{field.name}", :text => "#{select_tag(field.name, options_for_select(category_tags, p[1]), 'data-miq_sparkle_on' => true, 'data-miq_sparkle_off'=> true, 'data-miq_observe'=>{:url=>url}.to_json)}")
-
-                  else
-                    if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
-
-                      if field.show_past_dates
-                        page << "miq_cal_dateFrom = undefined ;"
-                      else
-                        date_tz = Time.now.in_time_zone(session[:user_tz]).strftime("%Y,%m,%d")
-                        page << "miq_cal_dateFrom = new Date('#{date_tz}');"
-                      end
-
-                      page << "miqBuildCalendar();"
-                    end
                   end
                 end
               end

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -1398,7 +1398,13 @@ class CatalogController < ApplicationController
         presenter[:expand_collapse_cells][:c] = 'expand'  # incase it was collapsed for summary screen, and incase there were no records on show_list
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
-        presenter[:build_calendar] = true
+        @record.dialog_fields.each do |field|
+          if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
+            presenter[:build_calendar]  = {
+              :date_from => field.show_past_dates ? nil : Time.now.in_time_zone(session[:user_tz]).to_i * 1000
+            }
+          end
+        end
         presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_dialog_buttons", :locals => {:action_url =>"dialog_form_button_pressed", :record_id => @edit[:rec_id]}]
       else
         # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record


### PR DESCRIPTION
Changed code to set date_from for calendar during initial load of dialog. Removed setting of miq_cal_dateFrom JS variables from dialog_runner that was being done after a field is changed in the form no need to do it there as value of show past dates cannot be changed once dialog is loaded.

https://bugzilla.redhat.com/show_bug.cgi?id=1052795

@dclarizio please review/test.
