### PR TITLE
Add test for autoloading of missing constants during yaml load.

### DIFF
--- a/vmdb/spec/intializers/yaml_autoloader_spec.rb
+++ b/vmdb/spec/intializers/yaml_autoloader_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe Psych::Visitors::ToRuby do
+  let(:missing_model) { Rails.root.join("app/models/zzz_model.rb") }
+
+  before do
+    File.write(missing_model, "class ZzzModel\nend\n")
+  end
+
+  after do
+    require 'fileutils'
+    FileUtils.rm_f(missing_model)
+  end
+
+  it "missing constants during yaml load are autoloaded" do
+    dump = "--- !ruby/object:ZzzModel {}\n"
+    expect(YAML.load(dump).class.name).to eql "ZzzModel"
+  end
+end


### PR DESCRIPTION
Verified this works on ruby 1.9.3 and 2.0.0.

Part of #535

I feel dirty writing the file to disk and then deleting it... Not sure how else to test this.

To verify this, with the [initializer removed](https://github.com/ManageIQ/manageiq/blob/897e5ade1952756a57d6c16538cdaa6528424431/vmdb/config/initializers/yaml_autoloader.rb#L6), this spec fails on ruby 1.9.3 and 2.0.0:

```
  1) Psych::Visitors::ToRuby missing constants during yaml load are autoloaded
     Failure/Error: expect(YAML.load(dump).class.name).to eql "ZzzModel"
     ArgumentError:
       undefined class/module ZzzModel
```
