### PR TITLE
Changed key name to check for provider_region instead of hostname

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -450,7 +450,7 @@ module EmsCommon
 
   def set_verify_status
     if @edit[:new][:emstype] == "ec2"
-      if @edit[:new][:default_userid].blank? || @edit[:new][:hostname].blank?
+      if @edit[:new][:default_userid].blank? || @edit[:new][:provider_region].blank?
         @edit[:default_verify_status] = false
       else
         @edit[:default_verify_status] = (@edit[:new][:default_password] == @edit[:new][:default_verify])


### PR DESCRIPTION
Changed key name to check for provider_region instead of hostname, EC2 specific code was changed to use provider_region column instead of hostname. Wrong key name in the check was causing validate button to not be enabled when adding EC2 provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1146776
https://bugzilla.redhat.com/show_bug.cgi?id=1147075

@dclarizio please review/test. This broke with changes for https://bugzilla.redhat.com/show_bug.cgi?id=1144523
