### PR TITLE
Fixed parameter being passed to assert_privilege call.

### DIFF
--- a/vmdb/app/controllers/application_controller/automate.rb
+++ b/vmdb/app/controllers/application_controller/automate.rb
@@ -4,7 +4,8 @@ module ApplicationController::Automate
   # Perform AE resolution
   #Moving it here, this method is called when "Paste" button is pressed in customization explorer
   def resolve
-    assert_privileges("ab_button_simulate")
+    custom_button_redirect = params[:button] == 'simulate' || params[:simulate] == 'simulate'
+    assert_privileges(custom_button_redirect ? 'ab_button_simulate' : 'miq_ae_class_simulation')
     @explorer = true
     @collapse_c_cell = true
     @breadcrumbs = Array.new


### PR DESCRIPTION
Added code to pass in different parameter to assert_privilege call depending upon where user is coming from as 'resolve' method is a common method. This method is called when user presses 'Simulation' subtab under Automate maintab and also when user presses 'Simulate' button for a custom button from Customization explorer.

https://bugzilla.redhat.com/show_bug.cgi?id=1146885
https://bugzilla.redhat.com/show_bug.cgi?id=1147081

@dclarizio please review/test.
