### PR TITLE
Fixed 'Hourly' charts for VMs that are grouped using tags

### DIFF
--- a/vmdb/app/models/vim_performance_tag.rb
+++ b/vmdb/app/models/vim_performance_tag.rb
@@ -14,7 +14,11 @@ class VimPerformanceTag < MetricRollup
     tp = options.fetch_path(:ext_options, :time_profile)
     results = recs.inject({:res => [], :tags => [], :tcols => []}) do |h,rec|
       if rec.class.name == "VimPerformanceTag"
-        tvrecs = rec.vim_performance_tag_values.find_all_by_category_and_association_type(options[:category], options[:cat_model].to_s)
+        tvrecs = rec.vim_performance_tag_values.build_for_association(rec,
+                                                                      options[:cat_model].pluralize.underscore,
+                                                                      :save     => false,
+                                                                      :category => options[:category])
+        tvrecs = tvrecs.select { |r| r.category == options[:category] }
         rec.inside_time_profile = tp ? tp.ts_in_profile?(rec.timestamp) : true
       else
         #TODO - Should use table name instead of options[:cat_model].pluralize.underscore

--- a/vmdb/spec/models/vim_performance_tag_spec.rb
+++ b/vmdb/spec/models/vim_performance_tag_spec.rb
@@ -133,7 +133,10 @@ describe VimPerformanceTag do
 
       it "#find_and_group_by_tags" do
         where_clause = [ "resource_type = ? and resource_id = ?", @host.class.base_class.name, @host.id ]
-        results, group_by_tag_cols, group_by_tags = VimPerformanceTag.find_and_group_by_tags(:cat_model => "VmOrTemplate", :category => "environment", :where_clause => where_clause)
+        results, group_by_tag_cols, group_by_tags =
+          VimPerformanceTag.find_and_group_by_tags(:cat_model    => "Vm",
+                                                   :category     => "environment",
+                                                   :where_clause => where_clause)
 
         classification_entries_with_none = @classification_entries + ["_none_"]
 


### PR DESCRIPTION
Previously, the hourly charts always showed 'None' as in no records
found when the 'Group by' option was selected to retrieve VMs
associated with a particular tag, even though the records did exist.
This was due to the fact that the model name for 'association_type'
that was being used to retrieve the records was 'Vm' instead of 'VmOrTemplate'

https://bugzilla.redhat.com/show_bug.cgi?id=1009951
