### PR TITLE
Fixed bad reference to @display variable

### DIFF
--- a/vmdb/app/controllers/mixins/vm_show_mixin.rb
+++ b/vmdb/app/controllers/mixins/vm_show_mixin.rb
@@ -142,7 +142,7 @@ module VmShowMixin
     session[:vm_filters]      = @filters
     session[:vm_catinfo]      = @catinfo
     session[:vm_cats]         = @cats
-    session[:vm_display]      = @display unless display.nil?
+    session[:vm_display]      = @display unless @display.nil?
     session[:polArr]          = @polArr unless @polArr.nil?
     session[:policy_options]  = @policy_options unless @policy_options.nil?
   end


### PR DESCRIPTION
This was causing test output contamination where the controller
was being inspected in the output

For example, with spec/controllers/vm_common_spec.rb:32
Before:

```
VmOrTemplateController
  #snap_pressed
#<VmOrTemplateController:0x007f949fa96a10>    when snapshot is selected center toolbars are replaced
```

After

```
VmOrTemplateController
  #snap_pressed
    when snapshot is selected center toolbars are replaced
```

@dclarizio Please review. I don't know why this never presented problems with the UI before.
