### PR TITLE
Filter: whitelist suffixes

### DIFF
--- a/vmdb/app/controllers/application_controller/filter.rb
+++ b/vmdb/app/controllers/application_controller/filter.rb
@@ -403,8 +403,10 @@ module ApplicationController::Filter
     end
 
     # Check for suffixes changed
-    @edit[:suffix] = params[:chosen_suffix].to_sym if params[:chosen_suffix]
-    @edit[:suffix2] = params[:chosen_suffix2].to_sym if params[:chosen_suffix2]
+    %w(suffix suffix2).each do |key|
+      params_key = "chosen_#{key}"
+      @edit[key.to_sym] = MiqExpression::BYTE_FORMAT_WHITELIST[params[params_key]] if params[params_key]
+    end
 
     # See if only a text value changed
     if params[:chosen_value] || params[:chosen_regkey] || params[:chosen_regval] ||

--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -321,6 +321,7 @@ class MiqExpression
   FORMAT_SUB_TYPES[:mhz_avg] = FORMAT_SUB_TYPES[:mhz]
   FORMAT_SUB_TYPES[:text] = FORMAT_SUB_TYPES[:string]
   FORMAT_BYTE_SUFFIXES = FORMAT_SUB_TYPES[:bytes][:units].inject({}) {|h, (v,k)| h[k] = v; h}
+  BYTE_FORMAT_WHITELIST = Hash[FORMAT_BYTE_SUFFIXES.keys.collect(&:to_s).zip(FORMAT_BYTE_SUFFIXES.keys)]
 
   def initialize(exp, ctype = nil)
     @exp = exp


### PR DESCRIPTION
Whitelist byte suffixes removing a `.to_sym` call.
