### PR TITLE
Fix database diagnostics tab

### DIFF
--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -293,9 +293,6 @@ module OpsController::Diagnostics
     @edit[:selected_backup_schedule] = params[:backup_schedule] if params[:backup_schedule]
     schedule = MiqSchedule.find_by_id(@edit[:selected_backup_schedule]) if @edit[:selected_backup_schedule] && @edit[:selected_backup_schedule] != ""
     settings = schedule ? schedule.depot_hash : nil
-    @prev_uri_prefix = @edit[:new][:uri_prefix]
-    @edit[:protocol] = params[:log_protocol] if params[:log_protocol]
-    @edit[:new][:uri_prefix] = @edit[:protocols_hash].invert[params[:log_protocol]] if params[:log_protocol]
     if settings && !settings.blank? && @prev_backup_schedule != @edit[:selected_backup_schedule]
       log_depot_get_form_vars_from_settings(settings)
       @edit[:protocol] = @edit[:new][:uri_prefix]
@@ -578,7 +575,7 @@ module OpsController::Diagnostics
   end
 
   def log_depot_get_form_vars
-    unless @schedule
+    unless @schedule || (@sb["active_tree"] == :diagnostics_tree && @sb["active_tab"] == "diagnostics_database")
       @record = @sb[:selected_typ].classify.constantize.find_by_id(@sb[:selected_server_id])
     end
     @prev_uri_prefix = @edit[:new][:uri_prefix]

--- a/vmdb/app/views/layouts/_edit_log_depot_settings.html.erb
+++ b/vmdb/app/views/layouts/_edit_log_depot_settings.html.erb
@@ -11,7 +11,7 @@
   <fieldset>
     <p class="legend">
       <%# Used for editing both database backup and log collection depot settings %>
-      <% if @sb[:active_tree] != :diagnostics_tree %>
+      <% if (@sb[:active_tree] == :diagnostics_tree && @sb[:active_tab] == "diagnostics_database") || (@sb[:active_tree] == :settings_tree) %>
         Database Backup Settings
       <% else %>
         Editing Log Depot Settings for <%= "#{Dictionary::gettext(record.class.name, :type => :model, :notfound => :titleize)}: #{@record.display_name}" %>


### PR DESCRIPTION
This is to fix the following two problems:
1. Traceback when accessing the diagnostics -> database tab:

Error caught: [NoMethodError] undefined method `display_name' for nil:NilClass
vmdb/app/views/layouts/_edit_log_depot_settings.html.erb:17
1. DB depot selection not working. This was caused by @prev_uri_prefix
   being erroneously overwritten by log_depot_get_form_vars() method.

https://bugzilla.redhat.com/show_bug.cgi?id=1145800
