### PR TITLE
remove Symbol monkey patch

### DIFF
--- a/lib/util/extensions/miq-symbol.rb
+++ b/lib/util/extensions/miq-symbol.rb
@@ -1,10 +1,4 @@
 class Symbol
-  unless method_defined?(:<=>)
-    def <=>(rhs)
-      return self.to_s <=> rhs.to_s
-    end
-  end
-
   unless method_defined?(:to_i)
     def to_i
       to_s.to_i


### PR DESCRIPTION
[:one, :two].sort works in 1.9.3 and up, so we can remove this patch
