### PR TITLE
Fix specs that reference the wrong fields in ops_controller/common

### DIFF
--- a/vmdb/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/vmdb/spec/controllers/ops_controller/settings/common_spec.rb
@@ -162,13 +162,13 @@ describe OpsController do
         it "should select a datastore when checked" do
           controller.params = {:id => "#{@svr1.id}__storage_#{@storage2.id}", :check => '1'}
           controller.smartproxy_affinity_field_changed
-          @edit[:new][:servers][@svr1.id][:hosts].to_a.should_not include(@storage2.id)
+          @edit[:new][:servers][@svr1.id][:storages].to_a.should include(@storage2.id)
         end
 
         it "should deselect a datastore when unchecked" do
-          controller.params = {:id => "#{@svr1.id}__host_#{@storage1.id}", :check => '0'}
+          controller.params = {:id => "#{@svr1.id}__storage_#{@storage1.id}", :check => '0'}
           controller.smartproxy_affinity_field_changed
-          @edit[:new][:servers][@svr1.id][:hosts].to_a.should_not include(@storage1.id)
+          @edit[:new][:servers][@svr1.id][:storages].to_a.should_not include(@storage1.id)
         end
 
         it "should select all child hosts when checked" do


### PR DESCRIPTION
@dclarizio Please review...I think this fixes the sporadic failures we are seeing, notably in #745 and #725 .

The tests in question are supposed to be testing what happens when one checks a "storage" checkbox in the UI and how it is expected to affect `@edit`.  However, it seems like there was a few typos and it is checking the wrong thing.  The first spec checks the `__storage` box, but then it verifies the `:hosts` key in `@edit`, which is wrong.  The second spec is supposed to uncheck the `__storage` box, but instead unchecks a `__host` box...in addition it verifies against the `:hosts` key in `@edit` instead of `:storage`, which is wrong.

I believe the test is sporadically failing because it is comparing storage ids to host ids, and depending on luck and/or test ordering those id numbers will happen to line up.  (Thanks @blomquisg for the insight on that last point)

cc @kbrock @jrafanie 
