### PR TITLE
Merge hidden_span_if and hidden_div_if

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -26,23 +26,21 @@ module ApplicationHelper
 
   # Create a hidden div area based on a condition (using for hiding nav panes)
   def hidden_div_if(condition, options = {}, &block)
-    options[:style] = "display: none" if condition
-    if block_given?
-      content_tag(:div, options, &block)
-    else
-      # TODO: Remove this old open-tag-only way in favor of block style
-      tag(:div, options, true)
-    end
+    hidden_tag_if(:div, condition, options, &block)
   end
 
   # Create a hidden span tag based on a condition (using for hiding nav panes)
   def hidden_span_if(condition, options = {}, &block)
+    hidden_tag_if(:span, condition, options, &block)
+  end
+
+  def hidden_tag_if(tag, condition, options = {}, &block)
     options[:style] = "display: none" if condition
     if block_given?
-      content_tag(:span, options, &block)
+      content_tag(tag, options, &block)
     else
       # TODO: Remove this old open-tag-only way in favor of block style
-      tag(:span, options, true)
+      tag(tag, options, true)
     end
   end
 


### PR DESCRIPTION
Merged `hidden_span_if` with `hidden_div_if`. They both call `hidden_tag_if` for purposes of good and evil.

Net net, it is only -2 lines. But it opens up any tag being able to use the hidden logic.

While it would be nice if we could go towards the block version, there are currently 58 that use blocks and 110 that do not.
Apparently, there are only 12 instances of the `hidden_span_if`, most of which have a block.

@dclarizio 
