### PR TITLE
yes no prompt with a default

### DIFF
--- a/lib/appliance_console/prompts.rb
+++ b/lib/appliance_console/prompts.rb
@@ -50,6 +50,14 @@ module ApplianceConsole
       agree("Are you sure#{clarifier}? (Y/N): ")
     end
 
+    def ask_yn?(prompt, default = nil)
+      ask("#{prompt}? (Y/N): ") do |q|
+        q.default = default if default
+        q.validate = ->(p) { (p.blank? && default) || %w(y n).include?(p.downcase[0]) }
+        q.responses[:not_valid] = "Please provide yes or no."
+      end.downcase[0] == 'y'
+    end
+
     def ask_for_domain(prompt, default = nil, validate = DOMAIN_REGEXP, error_text = "a valid Domain.", &block)
       just_ask(prompt, default, validate, error_text, &block)
     end

--- a/lib/spec/appliance_console/prompts_spec.rb
+++ b/lib/spec/appliance_console/prompts_spec.rb
@@ -417,6 +417,45 @@ describe ApplianceConsole::Prompts do
     end
   end
 
+  context "#ask_yn?" do
+    it "should respond to yes (and enforce y/n)" do
+      error = "Please provide yes or no."
+      say %w(x z yes)
+      expect(subject.ask_yn?("prompt")).to be_true
+      expect_heard ["prompt? (Y/N): ", error, prompt + error, prompt]
+    end
+
+    it "should respond to no" do
+      say %w(n)
+      expect(subject.ask_yn?("prompt")).not_to be_true
+      expect_heard "prompt? (Y/N): "
+    end
+
+    it "should support the default true" do
+      say ""
+      expect(subject.ask_yn?("prompt", "Y")).to be_true
+      expect_heard "prompt? (Y/N): |Y| "
+    end
+
+    it "should support the default false" do
+      say ""
+      expect(subject.ask_yn?("prompt", "N")).not_to be_true
+      expect_heard "prompt? (Y/N): |N| "
+    end
+
+    it "should support overriding the default true" do
+      say %w(no)
+      expect(subject.ask_yn?("prompt", "Y")).not_to be_true
+      expect_heard "prompt? (Y/N): |Y| "
+    end
+
+    it "should support overriding the default false" do
+      say %w(yes)
+      expect(subject.ask_yn?("prompt", "N")).to be_true
+      expect_heard "prompt? (Y/N): |N| "
+    end
+  end
+
   context "#just_ask (private method)" do
     it "should work without a default" do
       say "x"


### PR DESCRIPTION
It is like the `agree` method, but follows our naming conventions and more importantly, it allows for a default.

```
prompt? # old way using agree()

new:
prompt? (Y/N): |Y| # using ask_yn
```

While I'm not thrilled with the new format, it is the way highline works. So it is the simplest in terms of code and consistency.
