### PR TITLE
Add Version 5 XFS Filesystem Support

### DIFF
--- a/lib/fs/xfs/allocation_group.rb
+++ b/lib/fs/xfs/allocation_group.rb
@@ -87,19 +87,17 @@ module XFS
   ])
   AG_FL_STRUCT_SIZE = AG_FREELIST.size
 
-  AG_FREESPACE_SIZE = 512
-  AG_INODEINFO_SIZE = 512
-  AG_FREELIST_SIZE  = 512
-
   # ////////////////////////////////////////////////////////////////////////////
   # // Class.
 
   class AllocationGroup
+    AG_FREESPACE_SIZE = 512
+    AG_INODEINFO_SIZE = 512
+    AG_FREELIST_SIZE  = 512
+
     XFS_AGF_MAGIC                          = 0x58414746
     XFS_AGI_MAGIC                          = 0x58414749
     XFS_AGFL_MAGIC                         = 0x5841464c
-    XFS_AGF_VERSION                        = 1
-    XFS_AGI_VERSION                        = 1
 
     # /////////////////////////////////////////////////////////////////////////
     # // initialize

--- a/lib/fs/xfs/bmap_btree_block.rb
+++ b/lib/fs/xfs/bmap_btree_block.rb
@@ -72,36 +72,26 @@ module XFS
   ])
   SIZEOF_BTREE_BLOCK_LONG = BTREE_BLOCK_LONG.size
 
-  XFS_LOOKUP_EQ = 0
-  XFS_LOOKUP_LE = 1
-  XFS_LOOKUP_GE = 2
-
-  XFS_BTNUM_BNO  = 0
-  XFS_BTNUM_CNT  = 1
-  XFS_BTNUM_BMAP = 2
-  XFS_BTNUM_INO  = 3
-  XFS_BTNUM_FINO = 4
-  XFS_BTNUM_MAX  = 5
-
   # ////////////////////////////////////////////////////////////////////////////
   # // Class.
 
   class BmapBTreeBlock
     XFS_BTREE_LONG_PTRS = 1
     XFS_BMAP_MAGIC      = 0x424d4150
+    XFS_BMAP_CRC_MAGIC  = 0x424d4133
     # // initialize
     attr_reader :level, :number_records, :header_size, :buffer, :left_sibling, :right_sibling
 
     def initialize(buffer, sb)
       @sb = sb
       if defined? XFS_BTREE_LONG_PTRS
-        if @sb.sb_version_hascrc
+        if @sb.version_has_crc?
           @btree_block = BTREE_BLOCK_LONG.decode(buffer)
         else
           @btree_block = BTREE_BLOCK_LONG_NOCRC.decode(buffer)
         end
       else
-        if sb.sb_version_hascrc
+        if sb.version_has_crc?
           @btree_block = BTREE_BLOCK_SHORT.decode(buffer)
         else
           @btree_block = BTREE_BLOCK_SHORT_NOCRC.decode(buffer)
@@ -110,7 +100,8 @@ module XFS
       @header_size   = btree_block_length
       @number_records = @btree_block['num_recs']
       @level         = @btree_block['level']
-      raise "Invalid BTreeBlock"       unless @btree_block['magic_num'] == XFS_BMAP_MAGIC
+      raise "Invalid BTreeBlock" unless (@btree_block['magic_num'] == XFS_BMAP_MAGIC) ||
+                                        (@btree_block['magic_num'] == XFS_BMAP_CRC_MAGIC)
       @left_sibling  = @btree_block['left_sibling']
       @right_sibling = @btree_block['right_sibling']
       @buffer        = buffer
@@ -118,13 +109,13 @@ module XFS
 
     def btree_block_length
       if defined? XFS_BTREE_LONG_PTRS
-        if @sb.sb_version_hascrc
+        if @sb.version_has_crc?
           len = SIZEOF_BTREE_BLOCK_LONG
         else
           len = SIZEOF_BTREE_BLOCK_LONG_NOCRC
         end
       else
-        if @sb.sb_version_hascrc
+        if @sb.version_has_crc?
           len = SIZEOF_BTREE_BLOCK_SHORT
         else
           len = SIZEOF_BTREE_BLOCK_SHORT_NOCRC

--- a/lib/fs/xfs/bmap_btree_record.rb
+++ b/lib/fs/xfs/bmap_btree_record.rb
@@ -5,17 +5,15 @@ module XFS
   ])
 
   SIZEOF_BMAP_BTREE_REC   = 16
-  BMBT_EXNTFLAG_BITLEN    = 1
-  BMBT_STARTOFF_BITLEN    = 54
-  BMBT_STARTBLOCK_BITLEN  = 52
-  BMBT_BLOCKCOUNT_BITLEN  = 21
-
-  XFS_EXT_NORM            = 0
-  XFS_EXT_UNWRITTEN       = 1
-  XFS_EXT_DMAPI_OFFLINE   = 2
-  XFS_EXT_INVALID         = 3
 
   class BmapBTreeRecord
+    BMBT_EXNTFLAG_BITLEN    = 1
+    BMBT_STARTOFF_BITLEN    = 54
+    BMBT_STARTBLOCK_BITLEN  = 52
+    BMBT_BLOCKCOUNT_BITLEN  = 21
+
+    XFS_EXT_NORM            = 0
+    XFS_EXT_UNWRITTEN       = 1
     attr_accessor   :key_ptr, :start_offset, :start_block, :big_start_block, :block_count, :flag
 
     def xfs_mask64lo(shift)

--- a/lib/fs/xfs/directory2_data_header.rb
+++ b/lib/fs/xfs/directory2_data_header.rb
@@ -1,0 +1,27 @@
+require 'directory'
+require 'superblock'
+
+module XFS
+  #
+  # xfs_dir2_data_hdr consists of the magic number
+  # followed by 3 copies of the xfs_dir2_data_free structure
+  #
+  DIRECTORY2_DATA_HEADER = BinaryStruct.new([
+    'I>', 'magic',               # magic number
+  ])
+  SIZEOF_DIRECTORY2_DATA_HEADER = DIRECTORY2_DATA_HEADER.size
+
+  class Directory2DataHeader
+    XFS_DIR2_BLOCK_MAGIC        = 0x58443242 # XD2B: single block dirs
+    XFS_DIR2_DATA_MAGIC         = 0x58443244 # XD2D: multiblock dirs
+
+    attr_reader :template, :magic_numbers, :pad, :version_3
+
+    def initialize
+      @template      = DIRECTORY2_DATA_HEADER
+      @magic_numbers = [XFS_DIR2_BLOCK_MAGIC, XFS_DIR2_DATA_MAGIC]
+      @pad           = 0
+      @version_3     = false
+    end
+  end # class Directory3DataHeader
+end   # module XFS

--- a/lib/fs/xfs/directory3_data_header.rb
+++ b/lib/fs/xfs/directory3_data_header.rb
@@ -1,0 +1,34 @@
+require 'directory'
+require 'superblock'
+
+module XFS
+  DIRECTORY3_DATA_HEADER = BinaryStruct.new([
+    'I>',  'magic',               # magic number
+    'I>',  'crc',                 # CRC of block
+    'Q>',  'block_number',        # first block of the buffer
+    'Q>',  'last_write_sequence', # sequence number of last write
+    'a16', 'uuid',                # filesystem we belong to
+    'Q>',  'owner',               # inode that owns the block
+  ])
+  SIZEOF_DIRECTORY3_DATA_HEADER = DIRECTORY3_DATA_HEADER.size
+
+  DIRECTORY3_DATA_PAD = BinaryStruct.new([
+    'I>',  'padding',             # padding
+  ])
+  SIZEOF_DIRECTORY3_DATA_PAD = DIRECTORY3_DATA_PAD.size
+
+  class Directory3DataHeader
+    XFS_DIR3_BLOCK_MAGIC        = 0x58444233 # XDB3: single block dirs
+    XFS_DIR3_DATA_MAGIC         = 0x58444433 # XDD3: multiblock dirs
+
+    attr_reader :template, :magic_numbers, :pad, :version_3
+
+    def initialize
+      @template      = DIRECTORY3_DATA_HEADER
+      @magic_numbers = [XFS_DIR3_BLOCK_MAGIC, XFS_DIR3_DATA_MAGIC]
+      @pad           = SIZEOF_DIRECTORY3_DATA_PAD
+      @version_3     = true
+      super
+    end
+  end # class Directory3DataHeader
+end   # module XFS

--- a/lib/fs/xfs/inode.rb
+++ b/lib/fs/xfs/inode.rb
@@ -91,54 +91,12 @@ module XFS
   SIZEOF_INODE = INODE.size
   SIZEOF_EXTENDED_INODE = EXTENDED_INODE.size
 
-  SYM_LNK_SIZE          = 60
-  MAX_READ              = 4_294_967_296
-  DEFAULT_BLOCK_SIZE    = 1024
-
   # ////////////////////////////////////////////////////////////////////////////
   # // Class.
 
   class Inode
+    MAX_READ              = 4_294_967_296
     XFS_DINODE_MAGIC             = 0x494e
-    # Values for Inode flags field
-    XFS_DIFLAG_REALTIME_BIT      = 0	# file's blocks come from rt area
-    XFS_DIFLAG_PREALLOC_BIT      = 1	# file space has been preallocated
-    XFS_DIFLAG_NEWRTBM_BIT       = 2	# for rtbitmap inode, new format
-    XFS_DIFLAG_IMMUTABLE_BIT     = 3	# inode is immutable
-    XFS_DIFLAG_APPEND_BIT        = 4	# inode is append-only
-    XFS_DIFLAG_SYNC_BIT          = 5	# inode is written synchronously
-    XFS_DIFLAG_NOATIME_BIT       = 6	# do not update atime
-    XFS_DIFLAG_NODUMP_BIT        = 7	# do not dump
-    XFS_DIFLAG_RTINHERIT_BIT     = 8	# create with realtime bit set
-    XFS_DIFLAG_PROJINHERIT_BIT   = 9	# create with parents projid
-    XFS_DIFLAG_NOSYMLINKS_BIT    = 10	# disallow symlink creation
-    XFS_DIFLAG_EXTSIZE_BIT       = 11	# inode extent size allocator hint
-    XFS_DIFLAG_EXTSZINHERIT_BIT  = 12	# inherit inode extent size
-    XFS_DIFLAG_NODEFRAG_BIT      = 13	# do not reorganize/defragment
-    XFS_DIFLAG_FILESTREAM_BIT    = 14  # use filestream allocator
-    XFS_DIFLAG_REALTIME          = 1 << XFS_DIFLAG_REALTIME_BIT
-    XFS_DIFLAG_PREALLOC          = 1 << XFS_DIFLAG_PREALLOC_BIT
-    XFS_DIFLAG_NEWRTBM           = 1 << XFS_DIFLAG_NEWRTBM_BIT
-    XFS_DIFLAG_IMMUTABLE         = 1 << XFS_DIFLAG_IMMUTABLE_BIT
-    XFS_DIFLAG_APPEND            = 1 << XFS_DIFLAG_APPEND_BIT
-    XFS_DIFLAG_SYNC              = 1 << XFS_DIFLAG_SYNC_BIT
-    XFS_DIFLAG_NOATIME           = 1 << XFS_DIFLAG_NOATIME_BIT
-    XFS_DIFLAG_NODUMP            = 1 << XFS_DIFLAG_NODUMP_BIT
-    XFS_DIFLAG_RTINHERIT         = 1 << XFS_DIFLAG_RTINHERIT_BIT
-    XFS_DIFLAG_PROJINHERIT       = 1 << XFS_DIFLAG_PROJINHERIT_BIT
-    XFS_DIFLAG_NOSYMLINKS        = 1 << XFS_DIFLAG_NOSYMLINKS_BIT
-    XFS_DIFLAG_EXTSIZE           = 1 << XFS_DIFLAG_EXTSIZE_BIT
-    XFS_DIFLAG_EXTSZINHERIT      = 1 << XFS_DIFLAG_EXTSZINHERIT_BIT
-    XFS_DIFLAG_NODEFRAG          = 1 << XFS_DIFLAG_NODEFRAG_BIT
-    XFS_DIFLAG_FILESTREAM        = 1 << XFS_DIFLAG_FILESTREAM_BIT
-
-    XFS_DIFLAG_ANY = (XFS_DIFLAG_REALTIME | XFS_DIFLAG_PREALLOC | XFS_DIFLAG_NEWRTBM |
-                      XFS_DIFLAG_IMMUTABLE | XFS_DIFLAG_APPEND | XFS_DIFLAG_SYNC |
-                      XFS_DIFLAG_NOATIME | XFS_DIFLAG_NODUMP | XFS_DIFLAG_RTINHERIT |
-                      XFS_DIFLAG_PROJINHERIT | XFS_DIFLAG_NOSYMLINKS | XFS_DIFLAG_EXTSIZE |
-                      XFS_DIFLAG_EXTSZINHERIT | XFS_DIFLAG_NODEFRAG | XFS_DIFLAG_FILESTREAM)
-
-    XFS_DI_MAX_FLUSH = 0xffff
 
     # Bits 0 to 8 of file mode.
     PF_O_EXECUTE  = 0x0001  # owner execute
@@ -155,11 +113,6 @@ module XFS
     MSK_PERM_OWNER = (PF_O_EXECUTE | PF_O_WRITE | PF_O_READ)
     MSK_PERM_GROUP = (PF_G_EXECUTE | PF_G_WRITE | PF_G_READ)
     MSK_PERM_USER  = (PF_U_EXECUTE | PF_U_WRITE | PF_U_READ)
-
-    # Bits 9 to 11 of file mode.
-    DF_STICKY     = 0x0200
-    DF_SET_GID    = 0x0400
-    DF_SET_UID    = 0x0800
 
     # Bits 12 to 15 of file mode.
     FM_FIFO       = 0x1000  # fifo device (pipe)

--- a/lib/fs/xfs/short_form_header.rb
+++ b/lib/fs/xfs/short_form_header.rb
@@ -10,14 +10,14 @@ module XFS
   #
   DIRECTORY_SHORTERFORM_HEADER = BinaryStruct.new([
     'C',  'entry_count',         # count of entries
-    'S',  'i8byte_count',        # count of 8-byte inode #s
+    'C',  'i8byte_count',        # count of 8-byte inode #s
     'I>', 'parent_ino_4byte',    # parent dir inode # stored as 4 8-bit values
   ])
   SIZEOF_DIRECTORY_SHORTERFORM_HEADER = DIRECTORY_SHORTERFORM_HEADER.size
 
   DIRECTORY_SHORTFORM_HEADER = BinaryStruct.new([
     'C',  'entry_count',         # count of entries
-    'S',  'i8byte_count',        # count of 8-byte inode #s
+    'C',  'i8byte_count',        # count of 8-byte inode #s
     'Q>', 'parent_ino_8byte',    # parent dir inode # stored as 8 8-bit values
   ])
   SIZEOF_DIRECTORY_SHORTFORM_HEADER = DIRECTORY_SHORTFORM_HEADER.size


### PR DESCRIPTION
Add support for Version 5 XFS filesystems.

This includes adding CRC fields to several on-disk
data structures including directory headers, as
well as allowing for a filetype field in the directory
entries.

A few Rubocop warnings in the code were fixed as well as
some style issues pointed out by @jrafanie and @Fryguy.

@Fryguy, @jrafanie, @roliveri, & @chessbyte please review
as appropriate.
