### PR TITLE
add fix_auth --v2 to fix bad/changed v2_keys

### DIFF
--- a/vmdb/spec/tools/fix_auth/auth_model_spec.rb
+++ b/vmdb/spec/tools/fix_auth/auth_model_spec.rb
@@ -52,9 +52,14 @@ describe FixAuth::AuthModel do
     end
 
     it "should build selection criteria (non selects)" do
-      # using [^O] means no more 'OR's
       expect(subject.selection_criteria).to match(/OR/)
       expect(subject.selection_criteria).to match(/password.*!~ 'v2.*OR.*auth_key.*!~ 'v2/)
+    end
+
+    it "should build selection criteria (non selects)" do
+      expect(subject.selection_criteria(true)).to match(/OR/)
+      expect(subject.selection_criteria(true)).not_to match(/password.*!~ 'v2.*OR.*auth_key.*!~ 'v2/)
+      expect(subject.selection_criteria(true)).to match(/password.*<>.*''.*OR.*auth_key.*<>.*''/)
     end
 
     it "should not find empty records" do
@@ -66,6 +71,11 @@ describe FixAuth::AuthModel do
       [v1, v2, leg, nls].each(&:save!)
       expect(contenders).to include(v1.name, leg.name)
       expect(contenders).not_to include(v2.name, nls.name)
+    end
+
+    it "finds records already encryped when requested" do
+      [v1, v2].each(&:save!)
+      expect(subject.contenders(true).collect(&:name)).to include(v2.name)
     end
 
     it "should find viable records among mixed mode records" do

--- a/vmdb/tools/fix_auth/auth_model.rb
+++ b/vmdb/tools/fix_auth/auth_model.rb
@@ -11,18 +11,17 @@ module FixAuth
         column_names & password_columns
       end
 
-      def contenders
-        with_non_v2_values
-      end
-
-      def with_non_v2_values
-        where(selection_criteria)
+      def contenders(include_v2 = false)
+        where(selection_criteria(include_v2))
       end
 
       # bring back anything with a password column that is not nil, blank, or v2:{.*}
-      def selection_criteria
-        available_columns.map do |column|
-          "(COALESCE(#{column},'') <> '' AND #{column} !~ 'v2:\{[^\}]*\}')"
+      # include_v2 states that v2 encrypted passwords should come back too
+      def selection_criteria(include_v2 = false)
+        available_columns.collect do |column|
+          col = ["COALESCE(#{column},'') <> ''"]
+          col << "#{column} !~ 'v2:\{[^\}]*\}'" unless include_v2
+          "(#{col.join(" AND ")})"
         end.join(" OR ")
       end
 
@@ -72,7 +71,7 @@ module FixAuth
       end
 
       def run(options = {})
-        contenders.each do |r|
+        contenders(options[:v2]).each do |r|
           fix_passwords(r, options)
           if options[:verbose]
             display_record(r)

--- a/vmdb/tools/fix_auth/cli.rb
+++ b/vmdb/tools/fix_auth/cli.rb
@@ -18,6 +18,7 @@ module FixAuth
         opt :hardcode, "Password to use for all passwords",     :type => :string, :short => "P"
         opt :invalid,  "Password to use for invalid passwords", :type => :string, :short => "i"
         opt :key,      "Generate key",      :type => :boolean, :short => "k"
+        opt :v2,       "Fix V2 passwords also", :type => :boolean, :short => "f", :default => false
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
       end

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -26,7 +26,7 @@ module FixAuth
     end
 
     def run_options
-      options.slice(:verbose, :dry_run, :hardcode, :invalid)
+      options.slice(:verbose, :dry_run, :hardcode, :invalid, :v2)
     end
 
     def databases


### PR DESCRIPTION
If a user wants to secure a manageiq appliance with a preshipped v2_key, they will need to fix any data already in the database. Even a blank database has a token in there.

Currently, `fix_auth.rb` will not clear out passwords encrypted with a lost `v2_key`. This code allows the admin to clear out those values and access the 
- don’t hardcode session token (pick a random one instead)

https://bugzilla.redhat.com/show_bug.cgi?id=1148590
