### PR TITLE
backup v2_key before creating a new one

### DIFF
--- a/lib/appliance_console/key_configuration.rb
+++ b/lib/appliance_console/key_configuration.rb
@@ -47,7 +47,7 @@ module ApplianceConsole
     end
 
     def activate
-      return true unless remove_key(force)
+      MiqPassword.backup_symetric(KEY_FILE)
 
       if fetch_key?
         fetch_key
@@ -84,12 +84,6 @@ module ApplianceConsole
     def ask_for_action(default_action)
       options = {'Create key' => :create, 'Fetch key from remote machine' => :fetch}
       ask_with_menu("Encryption Key", options, default_action, false)
-    end
-
-    # return true if key is gone, otherwise false (and we should probably abort)
-    # throws an exception if rm fails e.g.: Errno::EACCES
-    def remove_key(force)
-      !key_exist? || (force && FileUtils.rm(KEY_FILE))
     end
   end
 end

--- a/lib/spec/appliance_console/key_configuration_spec.rb
+++ b/lib/spec/appliance_console/key_configuration_spec.rb
@@ -77,22 +77,14 @@ describe ApplianceConsole::KeyConfiguration do
       end
 
       context "with existing key" do
-        it "removes existing key" do
+        it "moves existing key" do
           subject.force = true
           v2_exists(true) # before downloaded
           v2_exists(true) # after downloaded
-          expect(FileUtils).to receive(:rm).with(/v2_key/).and_return(["v2_key"])
+          expect(FileUtils).to receive(:mv).with(/v2_key/, /v2_key\.20/).and_return(["v2_key"])
           scp = double('scp')
           expect(scp).to receive(:download!).with(subject.key_path, /v2_key/).and_return(:result)
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password).and_yield(scp).and_return(true)
-          expect(subject.activate).to be_true
-        end
-
-        it "skips if key exists (no force)" do
-          subject.force = false
-          v2_exists(true)
-          expect(FileUtils).not_to receive(:rm)
-          expect(Net::SCP).not_to receive(:start)
           expect(subject.activate).to be_true
         end
       end

--- a/lib/util/miq-password.rb
+++ b/lib/util/miq-password.rb
@@ -5,6 +5,7 @@ require 'ezcrypto'
 require 'CryptString'
 require 'base64'
 require 'yaml'
+require 'fileutils'
 
 class MiqPassword
   CURRENT_VERSION = "2"
@@ -148,6 +149,11 @@ class MiqPassword
             EzCrypto::Key.generate(:algorithm => "aes-256-cbc")
           end
     key.store(filename)
+  end
+
+  def self.backup_symetric(filename)
+    ext=Time.now.strftime("%Y%m%d-%H%M%S")
+    FileUtils.mv(filename, "#{filename}.#{ext}") if File.exist?(filename)
   end
 
   protected

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -39,6 +39,7 @@ module FixAuth
     end
 
     def generate_password
+      MiqPassword.backup_symetric("#{cert_dir}/v2_key")
       MiqPassword.generate_symmetric("#{cert_dir}/v2_key")
     end
 


### PR DESCRIPTION
Xav and the community seem very concerned about loosing the encryption key (`v2_key`). And if you don't know what you are doing, it is pretty easy to blow it away.

The goal here is to backup the previous encryption key so mistakes are not so costly.

IT also makes the tools more consistent. `auth_tool` blows up if a key exists while `appliance_console_cli` happily overwrites it. The `appliance_console` nicely prompts you with a "are you sure".

Since nothing is lost, adding a force option or "are you sure" is not necessary. Did decide to leave it in the `appliance_console`. That tool is expected to have more hand holding.

https://bugzilla.redhat.com/show_bug.cgi?id=1148606
