### PR TITLE
Raise error when attaching item without dialog to a catalog

### DIFF
--- a/vmdb/app/models/service_template.rb
+++ b/vmdb/app/models/service_template.rb
@@ -22,6 +22,8 @@ class ServiceTemplate < ActiveRecord::Base
 
   default_value_for :service_type,  'unknown'
 
+  validate :dialog_when_catalog
+
   def custom_buttons
     CustomButton.buttons_for(self).select { |b| b.parent.nil? }
   end
@@ -163,4 +165,12 @@ class ServiceTemplate < ActiveRecord::Base
     service.save
   end
 
+  private
+
+  # validate presence of a dialog when attached to a catalog
+  def dialog_when_catalog
+    if display && resource_actions.collect { |a| a.dialog.nil? }.reduce(:&)
+      errors.add(:dialog, "has to be set if Display in Catalog is chosen")
+    end
+  end
 end

--- a/vmdb/app/views/catalog/_svccat_tree_show.html.haml
+++ b/vmdb/app/views/catalog/_svccat_tree_show.html.haml
@@ -15,19 +15,13 @@
           %br
           #buttons
             - res_acts = @record.resource_actions.find_all { |ra| ra.action.downcase.eql? "provision" }
-            - if res_acts.detect { |ra| Dialog.find_by_id(ra.dialog_id.to_i) }.nil?
-              = button_tag("Order",
-                           :class => "btn btn-default btn-disabled",
-                           :alt   => t = "No Ordering Dialog is available",
-                           :title => t)
-            - else
-              = button_tag("Order",
-                           :class   => "btn btn-default",
-                           :alt     => t = "Order this Service",
-                           :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:action => "svc_catalog_provision",
-                                                                 :id     => @record.id,
-                                                                 :button => "order")}');")
+            = button_tag("Order",
+                         :class   => "btn btn-default",
+                         :alt     => t = "Order this Service",
+                         :title   => t,
+                         :onclick => "miqAjaxButton('#{url_for(:action => "svc_catalog_provision",
+                                                               :id     => @record.id,
+                                                               :button => "order")}');")
         %td{:valign => "top"}
           %table.style1
             %tr


### PR DESCRIPTION
I've added a validation function into the ServiceTemplate model, it fixes the bug when editing a catalog item.
When attaching items to a ServiceTemplateCatalog, an exception is raised, and it's rescued in the controller.
The obsolete disabled order button for dialog-less items was also removed.

https://bugzilla.redhat.com/show_bug.cgi?id=1145266
