### PR TITLE
Added applies_to_method to parent Host & Cluster charts.

### DIFF
--- a/vmdb/product/charts/layouts/daily_perf_charts/Parent-EmsCluster.yaml
+++ b/vmdb/product/charts/layouts/daily_perf_charts/Parent-EmsCluster.yaml
@@ -26,6 +26,24 @@
     :columns:
     - derived_vm_count_on
     - derived_host_count_on
+  :applies_to_method: cpu_mhz_available?
+
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+  - min_cpu_usage_rate_average
+  - max_cpu_usage_rate_average
+  - trend_max_cpu_usage_rate_average
+  - resource.cpu_usage_rate_average_high_over_time_period
+  - resource.cpu_usage_rate_average_low_over_time_period
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Timeline-Current-Daily:Daily events on this Cluster
+  - Timeline-Current-Hourly:Hourly events on this Cluster
+  :max_value: 100.4
+  :decimals: 1
+  :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
   :type: StackedArea
@@ -49,6 +67,7 @@
     :columns:
     - derived_vm_count_on
     - derived_host_count_on
+  :applies_to_method: cpu_ready_available?
 
 - :title: Memory (MB)
   :type: Line
@@ -76,6 +95,7 @@
     :columns:
     - derived_vm_count_on
     - derived_host_count_on
+  :applies_to_method: memory_mb_available?
 
 - :title: Disk I/O (KBps)
   :type: Line

--- a/vmdb/product/charts/layouts/daily_perf_charts/Parent-Host.yaml
+++ b/vmdb/product/charts/layouts/daily_perf_charts/Parent-Host.yaml
@@ -23,6 +23,24 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: cpu_mhz_available?
+
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+  - min_cpu_usage_rate_average
+  - max_cpu_usage_rate_average
+  - trend_max_cpu_usage_rate_average
+  - resource.cpu_usage_rate_average_high_over_time_period
+  - resource.cpu_usage_rate_average_low_over_time_period
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  :max_value: 100.4
+  :decimals: 1
+  :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
   :type: StackedArea
@@ -43,6 +61,7 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: cpu_ready_available?
 
 - :title: Memory (MB)
   :type: Line
@@ -67,6 +86,7 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: memory_mb_available?
 
 - :title: Disk I/O (KBps)
   :type: Line


### PR DESCRIPTION
Need to sort charts by title so when viewing comparison charts side-by-side they line up and show same type of charts in front of each other. This also fixes an issue where different types were being shown when trying to zoom in a chart in side-by-side comparison.

https://bugzilla.redhat.com/show_bug.cgi?id=1138449

@dclarizio please review/test.

screenshots attached for before/after fix:

Before:
side-by-side comaprison of VM and Parent Host
![non-sorted_comparison_charts](https://cloud.githubusercontent.com/assets/3450808/4498563/a6174616-4a79-11e4-85ff-1f8a5695e6ea.png)

zoomed in chart of VM and Parent Host 
![non_sorted_zoomed_in_comparison_charts](https://cloud.githubusercontent.com/assets/3450808/4498566/adc8207e-4a79-11e4-8ff5-6e9bc30c90ef.png)

After:
side-by-side comaprison of VM and Parent Host
![sorted_comparison_charts](https://cloud.githubusercontent.com/assets/3450808/4498571/b59ec898-4a79-11e4-93f2-e7831d077477.png)

zoomed in chart of VM and Parent Host 
![sorted_zoomed_in_comparison_charts](https://cloud.githubusercontent.com/assets/3450808/4498573/ba5a44d4-4a79-11e4-83be-29ba783fd9ba.png)
