### PR TITLE
Set raw power state in pxe/iso provision

### DIFF
--- a/vmdb/app/models/miq_provision_redhat_via_iso/state_machine.rb
+++ b/vmdb/app/models/miq_provision_redhat_via_iso/state_machine.rb
@@ -21,8 +21,8 @@ module MiqProvisionRedhatViaIso::StateMachine
       $log.info("MIQ(#{self.class.name}#boot_from_cdrom) #{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else
-      # Temporarily set the database power_state in case the refresh has not come along yet.
-      self.destination.update_attributes(:power_state => "wait_for_launch")
+      # Temporarily set the database raw_power_state in case the refresh has not come along yet.
+      self.destination.update_attributes(:raw_power_state => "wait_for_launch")
 
       signal :poll_destination_powered_off_in_vmdb
     end

--- a/vmdb/app/models/miq_provision_redhat_via_pxe/state_machine.rb
+++ b/vmdb/app/models/miq_provision_redhat_via_pxe/state_machine.rb
@@ -28,8 +28,8 @@ module MiqProvisionRedhatViaPxe::StateMachine
       $log.info("MIQ(#{self.class.name}#boot_from_network) #{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else
-      # Temporarily set the database power_state in case the refresh has not come along yet.
-      self.destination.update_attributes(:power_state => "wait_for_launch")
+      # Temporarily set the database raw_power_state in case the refresh has not come along yet.
+      self.destination.update_attributes(:raw_power_state => "wait_for_launch")
 
       signal :poll_destination_powered_off_in_vmdb
     end

--- a/vmdb/app/models/miq_provision_vmware_via_pxe/state_machine.rb
+++ b/vmdb/app/models/miq_provision_vmware_via_pxe/state_machine.rb
@@ -30,8 +30,8 @@ module MiqProvisionVmwareViaPxe::StateMachine
       $log.info("MIQ(#{self.class.name}#boot_from_network) #{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else
-      # Temporarily set the database power_state in case the refresh has not come along yet.
-      self.destination.update_attributes(:power_state => "wait_for_launch")
+      # Temporarily set the database raw_power_state in case the refresh has not come along yet.
+      self.destination.update_attributes(:raw_power_state => "wait_for_launch")
 
       signal :poll_destination_powered_off_in_vmdb
     end

--- a/vmdb/app/models/vm_infra.rb
+++ b/vmdb/app/models/vm_infra.rb
@@ -17,6 +17,11 @@ class VmInfra < Vm
     true
   end
 
+  def self.calculate_power_state(raw_power_state)
+    return raw_power_state if raw_power_state == "wait_for_launch"
+    super
+  end
+
 end
 
 # Preload any subclasses of this class, so that they will be part of the


### PR DESCRIPTION
Set raw power state in pxe/iso provision

The power_state attribute on the VM was recently changed to read-only.  However, pxe and iso provisioning in RHEV and VMware still set the power_state after launch.

This is now changed to set the raw_power_state.  However, there's a bit of a smell here because we're setting the "raw_power_state" to a non-raw value.

Can't think of a better way right now.

https://bugzilla.redhat.com/show_bug.cgi?id=1149195
