### PR TITLE
Add the miq_shortcuts table to the replication excludes list

### DIFF
--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -441,6 +441,7 @@ workers:
         - miq_servers_product_updates
         - miq_sets
         - miq_schedules
+        - miq_shortcuts
         - miq_tasks
         - miq_user_roles
         - miq_widgets


### PR DESCRIPTION
The miq_shortcuts table in the master region database was ending up with duplicate records that were replicated up from the slave regions, causing the UI to show multiple entries for each start page.

https://bugzilla.redhat.com/show_bug.cgi?id=1146719
