### PR TITLE
remove with_connection delegate

### DIFF
--- a/vmdb/lib/extensions/ar_with_connection.rb
+++ b/vmdb/lib/extensions/ar_with_connection.rb
@@ -1,7 +1,0 @@
-module ActiveRecord
-  class Base
-    class << self
-      delegate :with_connection, :to => :connection_pool
-    end
-  end
-end


### PR DESCRIPTION
I don't see us using this method anywhere, so I think we can remove it.
