### PR TITLE
Fixed utilization trend data (Max Used/Avg Used) for datastore

### DIFF
--- a/vmdb/app/models/metric/common.rb
+++ b/vmdb/app/models/metric/common.rb
@@ -19,7 +19,6 @@ module Metric::Common
     serialize :assoc_ids
     serialize :min_max   # TODO: Move this to MetricRollup
 
-    attr_accessor :v_derived_storage_used, :min_v_derived_storage_used, :max_v_derived_storage_used
     virtual_column :v_derived_storage_used, :type => :float
 
     [


### PR DESCRIPTION
The following methods -

```
:v_derived_storage_used
:min_v_derived_storage_used
:max_v_derived_storage_used
```

that populate the trending data for datastore were not being called earlier due to `attr_accessor` being specified.

https://bugzilla.redhat.com/show_bug.cgi?id=1089625
