### PR TITLE
Adding miq_dialogs to the replication excludes list.

### DIFF
--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -422,6 +422,7 @@ workers:
         - miq_alert_statuses
         - miq_alerts
         - miq_databases
+        - miq_dialogs
         - miq_enterprises
         - miq_events
         - miq_globals


### PR DESCRIPTION
Duplicate dialogs showing up in Global Region UI.
They are coming from the remote regions.

https://bugzilla.redhat.com/show_bug.cgi?id=1151110
