### PR TITLE
Appliance console no login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ bin/*
 config/apache
 config/database.yml*
 config/vmdb.yml.db
-config/miq_pass
 
 # db/
 db/*.sqlite3

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -25,7 +25,6 @@ class MiqServer < ActiveRecord::Base
 
   cattr_accessor          :my_guid_cache
 
-  after_create            :sync_admin_password_queue
   before_destroy          :validate_is_deleteable
 
   default_value_for       :rhn_mirror, false
@@ -279,16 +278,6 @@ class MiqServer < ActiveRecord::Base
       _log.error("#{msg}")
       raise msg
     end
-  end
-
-  def sync_admin_password_queue
-    MiqQueue.put_unless_exists(
-      :class_name  => "User",
-      :method_name => "sync_admin_password",
-      :server_guid => self.guid,
-      :zone        => self.zone.name,
-      :priority    => MiqQueue::HIGH_PRIORITY
-    )
   end
 
   def heartbeat

--- a/db/migrate/20130528153700_migrate_to_bcrypt_password.rb
+++ b/db/migrate/20130528153700_migrate_to_bcrypt_password.rb
@@ -14,10 +14,6 @@ class MigrateToBcryptPassword < ActiveRecord::Migration
 
       password = BCrypt::Password.create(decrypted_password)
       user.update_attribute(:password_digest, password)
-      # sync admin password
-      if user.userid == "admin"
-        sync_admin_password(user)
-      end
     end
     remove_column :users, :password
   end
@@ -25,12 +21,5 @@ class MigrateToBcryptPassword < ActiveRecord::Migration
   def down
     remove_column :users, :password_digest
     add_column    :users, :password, :string
-  end
-
-  def sync_admin_password(user)
-    fd = File.open(File.join(Rails.root, "config/miq_pass"), 'w')
-    fd.puts user.read_attribute(:password_digest)
-  ensure
-    fd.close unless fd.nil?
   end
 end

--- a/gems/pending/appliance_console/locales/en.yml
+++ b/gems/pending/appliance_console/locales/en.yml
@@ -17,7 +17,7 @@ en:
     - restart
     - shutdown
     - summary
-    - logoff
+    - quit
     dhcp: Set DHCP Network Configuration
     static: Set Static Network Configuration
     testnet: Test Network Configuration
@@ -31,4 +31,4 @@ en:
     restart: Restart Appliance
     shutdown: Shut Down Appliance
     summary: Summary Information
-    logoff: Log Off
+    quit: Quit

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -6,14 +6,6 @@ FactoryGirl.define do
     started_on      { Time.now.utc }
     stopped_on      ""
     version         '9.9.9.9'
-
-    after(:create) do |s|
-      MiqQueue.destroy_all(
-        :class_name  => "User",
-        :method_name => "sync_admin_password",
-        :server_guid => s.guid
-      )
-    end
   end
 
   factory :miq_server_master, :parent => :miq_server do

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -2,46 +2,18 @@ require "spec_helper"
 require 'bcrypt'
 
 describe "User Password" do
-  def read_miq_pass
-    filename = File.exist?("config/miq_pass") ? "config/miq_pass" : "config/miq_pass_default"
-    File.open(File.join(Rails.root, filename), 'r') {|f| f.read.chomp }
-  end
-
-  def save_old_miq_pass
-    @has_miq_pass = File.exist?("config/miq_pass")
-    @old_miq_pass = read_miq_pass
-  end
-
-  def restore_old_miq_pass
-    if @has_miq_pass
-      File.open(File.join(Rails.root, "config/miq_pass"), 'w') {|f| f.write(@old_miq_pass) }
-    else
-      File.delete("config/miq_pass") if File.exist?("config/miq_pass")
-    end
-  end
-
   context "With admin user" do
     before(:each) do
       MiqRegion.seed
       guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
-
-      save_old_miq_pass
       @old = 'smartvm'
       @admin = FactoryGirl.create(:user, :userid => 'admin',
                                   :password_digest => BCrypt::Password.create(@old))
     end
 
-    after(:each) do
-      restore_old_miq_pass
-    end
-
     it "should have set password" do
       @admin.authenticate_bcrypt(@old).should == @admin
-    end
-
-    it "should have miq_pass match current password" do
-      BCrypt::Password.new(self.read_miq_pass).should == @old
     end
 
     context "call change_password" do
@@ -54,10 +26,6 @@ describe "User Password" do
         @admin.authenticate_bcrypt(@new).should == @admin
       end
 
-      it "should write miq_pass file with new password" do
-        BCrypt::Password.new(self.read_miq_pass).should == @new
-        BCrypt::Password.new(self.read_miq_pass).should_not == @old
-      end
     end
 
     context "call password=" do
@@ -69,59 +37,6 @@ describe "User Password" do
 
       it "should change password" do
         @admin.authenticate_bcrypt(@new).should == @admin
-      end
-
-      it "should write miq_pass file with new password" do
-        BCrypt::Password.new(self.read_miq_pass).should == @new
-        BCrypt::Password.new(self.read_miq_pass).should_not == @old
-      end
-    end
-
-    context "#sync_admin_password" do
-      before(:each) do
-        @new = 'Zug-drep5s'
-        @admin.password = @new
-      end
-
-      it "normal case" do
-        @admin.sync_admin_password
-        BCrypt::Password.new(self.read_miq_pass).should == @new
-      end
-
-      it "writes new password to the provided IO object" do
-        str = StringIO.new
-        @admin.sync_admin_password(str)
-        str.rewind
-        BCrypt::Password.new(str.read.chomp).should == @new
-      end
-    end
-
-    context "#on_changed_admin_password" do
-      before(:each) do
-        @server2 = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone)
-        @new = 'Zug-drep5s'
-      end
-
-      it "calls sync_admin_password" do
-        @admin.should_receive(:sync_admin_password).once
-        @admin.password = @new
-        @admin.save!
-      end
-
-      it "queues sync_admin_password for other servers in the region" do
-        @admin.password = @new
-        @admin.save!
-        MiqQueue.count.should == 1
-        message = MiqQueue.first
-        message.class_name.should  == "User"
-        message.method_name.should == "sync_admin_password"
-        message.server_guid.should == @server2.guid
-        message.priority.should    == MiqQueue::HIGH_PRIORITY
-      end
-
-      it "doesn't call sync_admin_password when password unchanged" do
-        @admin.should_receive(:sync_admin_password).never
-        @admin.save!
       end
     end
   end


### PR DESCRIPTION
Instead of us replacing the virtual console's tty with the appliance_console, go back to using a tty.

Just type `appliance_console` from the command prompt.

# Accessing via Console

![miq-20140919 2014-10-11 12-24-03](https://cloud.githubusercontent.com/assets/1930/4603285/2bbde686-5163-11e4-8c33-bbb5fdecb997.png)

![miq-20140919 2014-10-11 12-32-02](https://cloud.githubusercontent.com/assets/1930/4603313/2f509d42-5164-11e4-814f-b6798659bf08.png)

# Accessing via SSH

![kbrock root master3 ssh 99x52 2014-10-11 12-30-29](https://cloud.githubusercontent.com/assets/1930/4603305/fb591ffa-5163-11e4-8af5-532cc3004eb7.png)

Same summary screen
![vmdb ssh 99x52 2014-10-10 14-31-38](https://cloud.githubusercontent.com/assets/1930/4597231/ba3eb83a-50ab-11e4-8a2f-7befdb829b79.png)

Logout has been renamed to quit. And there is no confirmation
![vmdb ssh 99x52 2014-10-10 14-32-54](https://cloud.githubusercontent.com/assets/1930/4597249/df14262c-50ab-11e4-97c2-b4074b34da51.png)


