### PR TITLE
Harden security for requests

### DIFF
--- a/vmdb/lib/vmdb/configuration_encoder.rb
+++ b/vmdb/lib/vmdb/configuration_encoder.rb
@@ -35,9 +35,14 @@ module Vmdb
       end
     end
 
-    def self.dump(hash, fd = nil)
-      hash = encrypt_password_fields(hash)
-      hash = stringify(hash)
+    def self.dump(hash, fd = nil, stringify_keys = true, &block)
+      if block_given?
+        hash = hash.deep_clone
+        walk_nested_hashes(hash, &block)
+      else
+        hash = encrypt_password_fields(hash)
+      end
+      hash = stringify(hash) if stringify_keys
       YAML.dump(hash, fd)
     end
 

--- a/vmdb/spec/tools/fix_auth/auth_model_spec.rb
+++ b/vmdb/spec/tools/fix_auth/auth_model_spec.rb
@@ -174,4 +174,68 @@ describe FixAuth::AuthModel do
       expect(new_settings['production']['password']).to be_encrypted("replacement")
     end
   end
+
+  context "#requests" do
+    subject { FixAuth::FixMiqRequest }
+    let(:request) do
+      subject.create(
+        :type    => 'MiqProvisionRequest',
+        :options => YAML.dump(
+          :dialog                  => {
+            :'password::special' => enc_v1,
+          },
+          :root_password           => enc_v1,
+          :sysprep_password        => enc_v1,
+          :sysprep_domain_password => enc_v1
+        )
+      )
+    end
+
+    it "upgrades request (find with prefix, dont stringify keys)" do
+      subject.fix_passwords(request)
+      expect(request).to be_changed
+      new_options = YAML.load(request.options)
+      expect(new_options[:dialog]['password::special'.to_sym]).to be_encrypted(pass)
+      expect(new_options[:dialog]['password::special'.to_sym]).to be_encrypted_version(2)
+
+      expect(new_options[:root_password]).to be_encrypted(pass)
+      expect(new_options[:root_password]).to be_encrypted_version(2)
+      expect(new_options[:sysprep_password]).to be_encrypted(pass)
+      expect(new_options[:sysprep_password]).to be_encrypted_version(2)
+      expect(new_options[:sysprep_domain_password]).to be_encrypted(pass)
+      expect(new_options[:sysprep_domain_password]).to be_encrypted_version(2)
+    end
+  end
+
+  context "#requests" do
+    subject { FixAuth::FixMiqRequestTask }
+    let(:request) do
+      subject.create(
+        :type    => 'MiqProvisionRequest',
+        :options => YAML.dump(
+          :dialog                  => {
+            :'password::special' => enc_v1,
+          },
+          :root_password           => enc_v1,
+          :sysprep_password        => enc_v1,
+          :sysprep_domain_password => enc_v1
+        )
+      )
+    end
+
+    it "upgrades request (find with prefix, dont stringify keys)" do
+      subject.fix_passwords(request)
+      expect(request).to be_changed
+      new_options = YAML.load(request.options)
+      expect(new_options[:dialog]['password::special'.to_sym]).to be_encrypted(pass)
+      expect(new_options[:dialog]['password::special'.to_sym]).to be_encrypted_version(2)
+
+      expect(new_options[:root_password]).to be_encrypted(pass)
+      expect(new_options[:root_password]).to be_encrypted_version(2)
+      expect(new_options[:sysprep_password]).to be_encrypted(pass)
+      expect(new_options[:sysprep_password]).to be_encrypted_version(2)
+      expect(new_options[:sysprep_domain_password]).to be_encrypted(pass)
+      expect(new_options[:sysprep_domain_password]).to be_encrypted_version(2)
+    end
+  end
 end

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -34,7 +34,8 @@ module FixAuth
     end
 
     def models
-      [FixAuthentication, FixMiqDatabase, FixMiqAeValue, FixMiqAeField, FixConfiguration]
+      [FixAuthentication, FixMiqDatabase, FixMiqAeValue, FixMiqAeField, FixConfiguration,
+       FixMiqRequest, FixMiqRequestTask]
     end
 
     def generate_password

--- a/vmdb/tools/fix_auth/models.rb
+++ b/vmdb/tools/fix_auth/models.rb
@@ -57,4 +57,44 @@ module FixAuth
       "typ = 'vmdb'"
     end
   end
+
+  class FixMiqRequest < ActiveRecord::Base
+    include FixAuth::AuthConfigModel
+    # don't want to leverage STI
+    self.inheritance_column = :_type_disabled
+    self.password_columns = %w(options)
+    self.password_fields = %w(root_password sysprep_password sysprep_domain_password)
+    self.password_prefix = "password::"
+    self.symbol_keys = true
+    self.table_name = "miq_requests"
+
+    def self.display_record(r)
+      puts "  #{r.id}:"
+    end
+
+    # bring back everything
+    def self.selection_criteria
+      "options like '%password%'"
+    end
+  end
+
+  class FixMiqRequestTask < ActiveRecord::Base
+    include FixAuth::AuthConfigModel
+    # don't want to leverage STI
+    self.inheritance_column = :_type_disabled
+    self.password_columns = %w(options)
+    self.password_fields = %w(root_password sysprep_password sysprep_domain_password)
+    self.password_prefix = "password::"
+    self.symbol_keys = true
+    self.table_name = "miq_request_tasks"
+
+    def self.display_record(r)
+      puts "  #{r.id}:"
+    end
+
+    # bring back everything
+    def self.selection_criteria
+      "options like '%password%'"
+    end
+  end
 end


### PR DESCRIPTION
We also need to harden security for options parameters stored in `MiqRequest` and `MiqRequestTask`.

They are encoded a little differently from Configurations (stored `vmdb.yml`) - so need to make sure those parameters are covered.

Tried to keep this change to as few files as possible. May need to backport. Couldn't bring myself to rewrite the `ConfigurationEncoder` serialization routines that may not be used in `MiqRequest`, but are very close.

https://bugzilla.redhat.com/show_bug.cgi?id=1151241

/cc @jdeubel @gmcculloug 
