### PR TITLE
Remove Numeric.format and Numberic#format monkey patch.

### DIFF
--- a/lib/fs/ntfs/NtUtil.rb
+++ b/lib/fs/ntfs/NtUtil.rb
@@ -51,17 +51,3 @@ module NtUtil
 
 end
 
-# Format numeric data (thousands grouping).
-class Numeric
-  
-  def format(separator = ',', decimal_point = '.')
-    num_parts = self.to_s.split('.')
-    x = num_parts[0].reverse.scan(/\d{1,3}-?/).join(separator).reverse
-    x << decimal_point + num_parts[1] if num_parts.length == 2
-    x
-  end
-  
-  def Numeric.format(number, *args)
-    number.format(*args)
-  end
-end


### PR DESCRIPTION
Git grep cannot help me find where this is used.

Let's remove this if it's not used.

It was added before I started at MIQ and has only been moved from one file to another.

```
commit 7987c43e93c5207eb76d70f8ae58d280fa5649c1
Date:   Wed Apr 18 13:55:29 2007 +0000

    Bring ntfs up to date.
```
