### PR TITLE
Replace call to removed ie8_safe_redirect

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1454,7 +1454,9 @@ class ApplicationController < ActionController::Base
     pass = check_generic_rbac
     unless pass
       if request.xml_http_request?
-        ie8_safe_redirect(url_for(:controller => 'dashboard', :action => 'auth_error'))
+        render :update do |page|
+          page.redirect_to(:controller => 'dashboard', :action => 'auth_error')
+        end
       else
         redirect_to(:controller => 'dashboard', :action => 'auth_error')
       end


### PR DESCRIPTION
replaces `ie8_safe_redirect` with `page.redirect_to`.
`ie8_safe_redirect` was removed in #451
