### PR TITLE
Speed up application_controller/buttons_spec #button_set_form_vars

### DIFF
--- a/vmdb/spec/controllers/application_controller/buttons_spec.rb
+++ b/vmdb/spec/controllers/application_controller/buttons_spec.rb
@@ -89,8 +89,10 @@ describe ApplicationController do
 
   context "#button_set_form_vars" do
     it "check button_set_form_vars sets correct applies_to_class when edititng a button" do
-      MiqRegion.seed
-      MiqAeDatastore.seed
+      # button_set_form_vars expects that the simulation screen will be built,
+      #   which, in turn, needs *something* to come back from automate
+      MiqAeClass.stub(:find_distinct_instances_across_domains => [double(:name => "foo")])
+
       custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm")
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")
       custom_button.uri_attributes["request"] = "req"


### PR DESCRIPTION
Prefer targeted stubbing over seeding the world in specs.

Locally, example went from 6.82 seconds to 0.23 seconds. WAT

@jrafanie Please review.
