### PR TITLE
Don't test the implementation of the yaml patch.

### DIFF
--- a/lib/spec/util/extensions/miq-yaml_spec.rb
+++ b/lib/spec/util/extensions/miq-yaml_spec.rb
@@ -20,7 +20,6 @@ describe YAML do
     h.merge!(:a => 1, :b => 2)
 
     y = YAML.dump(h)
-    y.include?("__iv__").should be_false
 
     h2 = YAML.load(y)
     h2.should be_instance_of Hash
@@ -33,7 +32,6 @@ describe YAML do
     h.val = 3
 
     y = YAML.dump(h)
-    y.include?("__iv__@val: 3").should be_true
 
     h2 = YAML.load(y)
     h2.should be_instance_of SubHash


### PR DESCRIPTION
Checking for `__iv__` is testing the implementation...
This might get fixed upstream differently.

Part of #535
