### PR TITLE
add an initializer that listens for instantiation

### DIFF
--- a/vmdb/config/initializers/instantiation_listener.rb
+++ b/vmdb/config/initializers/instantiation_listener.rb
@@ -1,0 +1,8 @@
+ActiveSupport::Notifications.subscribe('instantiation.active_record') do |name, start, finish, id, payload|
+  elapsed = finish - start
+  name = payload[:class_name]
+  count = payload[:record_count]
+  logger = ActiveRecord::Base.logger
+
+  logger.debug('  %s Inst Including Associations (%.1fms - %drows)' % [name || 'SQL', (elapsed * 1000), count])
+end


### PR DESCRIPTION
this adds a listener for AR instantiation, then outputs the
instantiation time and record count to the logger set on AR::Base.logger

This should only be merged after ManageIQ/rails#6
