### PR TITLE
Avoid creating unneeded hashes by using Hash#merge! instead of #merge.

### DIFF
--- a/vmdb/app/controllers/application_controller/compare.rb
+++ b/vmdb/app/controllers/application_controller/compare.rb
@@ -1275,11 +1275,10 @@ module ApplicationController::Compare
 
   # Build a field row under a record row
   def drift_add_record_field(view, section, record, field)
-    row = {}
     if @compressed  # Compressed
-      row.merge!(drift_record_field_compressed(view, section, record, field))
+      row = drift_record_field_compressed(view, section, record, field)
     else  # Expanded
-      row.merge!(drift_record_field_expanded(view, section, record, field))
+      row = drift_record_field_expanded(view, section, record, field)
     end
     row.merge!(:id           => "id_#{@temp[:rows].length}",
                     :indent       => 2,


### PR DESCRIPTION
The "row" hash created within each of these methods is modified and returned.
The intermediate hashes are unneeded since no one else can accidentally modify them.

EDIT:  Note, in some of these methods, we were creating 2, 3, 4, etc. extra hashes.
