### PR TITLE
Remove the Hash patch that's not used in lib/test/xml/tc_xmlhash_methods.rb

### DIFF
--- a/lib/test/xml/tc_xmlhash_methods.rb
+++ b/lib/test/xml/tc_xmlhash_methods.rb
@@ -5,12 +5,6 @@ require 'test/unit'
 require 'miq-xml'
 require 'xmlsimple'
 
-class Hash
-  def to_h
-    self
-  end
-end
-
 class TestXmlHashMethods < Test::Unit::TestCase
   require 'xml_base_parser_tests'
   include XmlBaseParserTests


### PR DESCRIPTION
Fix #842
