### PR TITLE
Ensured that dynatree cookies get deleted after a session reset.

### DIFF
--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -636,6 +636,7 @@ class DashboardController < ApplicationController
     # Rebuild the session
     session_reset(db_user)
     session_init(db_user)
+    session[:group_changed] = true
     url = start_url_for_user(nil) || url_for(:controller => params[:controller], :action => 'show')
     render :update do |page|
       page.redirect_to(url)

--- a/vmdb/app/views/layouts/_dynatree.html.erb
+++ b/vmdb/app/views/layouts/_dynatree.html.erb
@@ -52,6 +52,10 @@
     click_url = "<%= click_url %>";
   <% end %>
   cfme_changes_check = <%= cfme_changes_check %>
+  <% if session[:group_changed] %>
+    cfme_delete_dynatree_cookies();
+    <% session[:group_changed] = false %>
+  <% end %>
   <%# Create the Dynatree object from the passed in options %>
   $j("#<%= tree_id %>").dynatree({
     title: "<%= tree_name %>",


### PR DESCRIPTION
The session reset that happens after a LDAP user switches groups, clears out all the dynatree sandboxes. However, the cookies are left intact which cause an issue with the dynatrees, making them lose
some functionality. For e.g. the trees expand the nodes, but nothing happens when the user clicks on them.

https://bugzilla.redhat.com/show_bug.cgi?id=1102250
https://bugzilla.redhat.com/show_bug.cgi?id=1086468
