### PR TITLE
Fixed to reload toolbar using active node in the tree

### DIFF
--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -18,7 +18,7 @@ class MiqAeClassController < ApplicationController
     #resetting flash array so messages don't get displayed when tab is changed
     @flash_array = Array.new
     @explorer = true
-    @record = @ae_class = MiqAeClass.find_by_id(from_cid(@temp[:ae_class_id]))
+    @record = @ae_class = MiqAeClass.find_by_id(from_cid(x_node.split('-').last))
     @sb[:active_tab] = params[:tab_id]
     c_buttons, c_xml = build_toolbar_buttons_and_xml(center_toolbar_filename)
     case params[:tab_id]


### PR DESCRIPTION
Fixed to use x_node to reload toolbars when tab is changed on the class node, @temp variable does not exist when change_tab transaction comes in.  This was causing automate to load incorrect toolbar buttons when change tab transaction came in.

https://bugzilla.redhat.com/show_bug.cgi?id=1149791
https://bugzilla.redhat.com/show_bug.cgi?id=1153780

@dclarizio please review/test.
You can recreate this issue by changing tabs on a class that is in a Locked domain.
