### PR TITLE
Upgrade aws gem to latest

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -44,7 +44,7 @@ gem "jbuilder",                       "~>2.0.7"
 
 # Not vendored and not required
 gem "ancestry",                       "~>1.2.4",      :require => false
-gem "aws-sdk",                        "~>1.11",       :require => false
+gem "aws-sdk",                        "~>1.56.0",     :require => false
 gem 'dalli',                          "~>2.2.1",      :require => false
 gem "elif",                           "=0.1.0",       :require => false
 gem "haml",                           "~>4.0.5",      :require => false

--- a/vmdb/lockfiles/RHEL6.4/Gemfile.lock
+++ b/vmdb/lockfiles/RHEL6.4/Gemfile.lock
@@ -44,10 +44,11 @@ GEM
     arel (3.0.2)
       bigdecimal
     awesome_spawn (1.2.1)
-    aws-sdk (1.11.3)
+    aws-sdk (1.56.0)
+      aws-sdk-v1 (= 1.56.0)
+    aws-sdk-v1 (1.56.0)
       json (~> 1.4)
-      nokogiri (< 1.6.0)
-      uuidtools (~> 2.1)
+      nokogiri (>= 1.4.4)
     bcrypt-ruby (3.0.1)
     bigdecimal (1.1.0)
     binary_struct (1.0.1)
@@ -254,7 +255,7 @@ DEPENDENCIES
   american_date
   ancestry (~> 1.2.4)
   awesome_spawn (~> 1.2)
-  aws-sdk (~> 1.11.3)
+  aws-sdk (~> 1.11)
   bcrypt-ruby (~> 3.0.1)
   binary_struct (~> 1.0.1)
   bundler (~> 1.3.5)


### PR DESCRIPTION
We currently use aws gem 1.11.3 from June 18, 2013. Lets upgrade to something recent.
The old version pegs nokogiri to a version from the end of 2013.

To be honest, I care about keeping nokogiri up to date more than the aws-sdk.

This is strictly maintenance, I am not suggesting this for particular features.

Can we upgrade it?

/cc @blomquisg just like fog, the affects you more than me.
/cc @jrafanie @tenderlove is this necessary for ruby 2.x or rails 4.x?
