### PR TITLE
Hashes do not need this monkey patch on ruby 1.9.3, 2.0.0, 2.1.3.

### DIFF
--- a/lib/util/extensions/miq-hash.rb
+++ b/lib/util/extensions/miq-hash.rb
@@ -1,20 +1,6 @@
 require 'more_core_extensions/core_ext/hash'
 
 class Hash #:nodoc:
-
-  # The following fixes a bug in Ruby where if subclasses of String are
-  #   used as keys, and those subclasses have instance variables, then later
-  #   calls to access the keys return the subclass type but the instance
-  #   variables are missing.
-  # TODO: Wrap this in a ruby version conditional depending on where this
-  #       bug is present
-  def bracket_equals_with_subclassed_string(key, value)
-    key = key.dup.freeze if key.kind_of?(String) && !key.instance_of?(String)
-    bracket_equals_without_subclassed_string(key, value)
-  end
-  alias bracket_equals_without_subclassed_string []=
-  alias []= bracket_equals_with_subclassed_string
-
   unless method_defined?(:sort!)
     def sort!(*args, &block)
       sorted = sort(*args, &block)


### PR DESCRIPTION
Subclasses of String with instance variables can be used as keys and do not lose
their instance variables.

The spec passes without the patch.
