### PR TITLE
Remove year old pending blank tests

### DIFF
--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
@@ -71,18 +71,5 @@ module MiqAeServiceMiqHostProvisionRequestSpec
       @ae_method.update_attributes(:data => method)
       invoke_ae.root(@ae_result_key).should == 'host'
     end
-
-    pending "Not yet implemented: 10 specs" do
-      it "#options"
-      it "#get_option"
-      it "#set_option"
-      it "#set_message"
-      it "#get_tag"
-      it "#get_tags"
-      it "#clear_tag"
-      it "#add_tag"
-      it "#get_classification"
-      it "#get_classifications"
-    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
@@ -243,45 +243,5 @@ module MiqAeServiceMiqProvisionSpec
         @miq_provision.reload.options[:placement_rp_name].should == [@rsc.id, @rsc.name]
       end
     end
-
-    pending "Not yet implemented: 39 specs" do
-      it "#options"
-      it "#get_option"
-      it "#get_option_last"
-      it "#set_option"
-      it "#get_tag"
-      it "#get_tags"
-      it "#get_classification"
-      it "#get_classifications"
-      it "#set_vm_notes"
-      it "#set_customization_spec"
-      it "#set_dvs"
-      it "#set_vlan"
-      it "#set_network_address_mode"
-      it "#get_network_scope"
-      it "#get_domain_name"
-      it "#get_network_details"
-      it "#get_domain_details"
-      it "#set_vm_notes"
-      it "#set_folder"
-      it "#get_folder_paths"
-      it "#clear_tag"
-      it "#add_tag"
-      it "#check_quota"
-      it "#eligible_resources"
-      it "#eligible_hosts"
-      it "#eligible_storages"
-      it "#eligible_folders"
-      it "#eligible_clusters"
-      it "#set_resource"
-      it "#set_host"
-      it "#set_storage"
-      it "#set_cluster"
-      it "#message="
-      it "#finished"
-      it "#status"
-      it "#set_nic_settings"
-      it "#set_network_adapter"
-    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
@@ -124,10 +124,5 @@ EOF
         Service.find_by_name(service_name).should_not be_nil
       end
     end
-
-    pending "Not yet implemented: specs" do
-      it "#retires_on="
-      it "#retirement_warn="
-    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
@@ -101,51 +101,5 @@ module MiqAeServiceVmSpec
         end
       end
     end
-
-
-    pending "Not yet implemented: 43 specs" do
-      it "#ext_management_system"
-      it "#storage"
-      it "#host"
-      it "#hardware"
-      it "#operating_system"
-      it "#guest_applications"
-      it "#miq_provision"
-      it "#ems_cluster"
-      it "#ems_folder"
-      it "#ems_blue_folder"
-      it "#resource_pool"
-      it "#datacenter"
-      it "#remove_from_disk"
-      it "#registered?"
-      it "#to_s"
-      it "#event_threshold?"
-      it "#event_log_threshold?"
-      it "#performances_maintains_value_for_duration?"
-      it "#reconfigured_hardware_value?"
-      it "#changed_vm_value?"
-      it "#retire_now"
-      it "#files"
-      it "#directories"
-      it "#refresh"
-      it "#start"
-      it "#stop"
-      it "#suspend"
-      it "#unregister"
-      it "#collect_running_processes"
-      it "#shutdown_guest"
-      it "#standby_guest"
-      it "#reboot_guest"
-      it "#migrate"
-      it "#owner"
-      it "#scan"
-      it "#unlink_storage"
-      it "#ems_custom_set"
-      it "#custom_keys"
-      it "#custom_get"
-      it "#custom_set"
-      it "#retires_on="
-      it "#retirement_warn="
-    end
   end
 end

--- a/vmdb/spec/models/ems_refresh_spec.rb
+++ b/vmdb/spec/models/ems_refresh_spec.rb
@@ -53,11 +53,6 @@ describe EmsRefresh do
   end
 
   context ".get_ar_objects" do
-    it "instance"
-    it "array of instances"
-    it "class/id pair"
-    it "class_name/id pair"
-
     it "array of class/ids pairs" do
       ems1 = FactoryGirl.create(:ems_vmware,     :name => "ems_vmware1")
       ems2 = FactoryGirl.create(:ems_redhat, :name => "ems_redhat1")
@@ -68,8 +63,5 @@ describe EmsRefresh do
 
       described_class.get_ar_objects(pairs).should have_same_elements([ems1, ems2])
     end
-
-    it "array of class_name/id pairs"
-
   end
 end

--- a/vmdb/spec/presenters/tree_node_builder_spec.rb
+++ b/vmdb/spec/presenters/tree_node_builder_spec.rb
@@ -20,9 +20,6 @@ describe TreeNodeBuilderDynatree do
       node.should_not be_nil
     end
 
-    pending 'Condition node' do
-    end
-
     it 'CustomButton node' do
       button = FactoryGirl.build(:custom_button,
         :applies_to_class => 'bleugh',
@@ -105,12 +102,6 @@ describe TreeNodeBuilderDynatree do
       node.should_not be_nil
     end
 
-    pending 'LdapDomain node' do
-    end
-
-    pending 'LdapRegion node' do
-    end
-
     it 'MiqAeClass node' do
       namespace = FactoryGirl.build(:miq_ae_namespace)
       aclass = FactoryGirl.build(:miq_ae_class, :namespace_id => namespace.id)
@@ -122,9 +113,6 @@ describe TreeNodeBuilderDynatree do
       instance = FactoryGirl.build(:miq_ae_instance)
       node = TreeNodeBuilderDynatree.build(instance, nil, {})
       node.should_not be_nil
-    end
-
-    pending 'MiqAeMethod node' do
     end
 
     it 'MiqAeNamespace node' do
@@ -239,9 +227,6 @@ describe TreeNodeBuilderDynatree do
       node.should_not be_nil
     end
 
-    pending 'ScanItemSet node' do
-    end
-
     it 'Service node' do
       service = FactoryGirl.create(:service)
       node = TreeNodeBuilderDynatree.build(service, nil, {})
@@ -276,9 +261,6 @@ describe TreeNodeBuilderDynatree do
       user = FactoryGirl.build(:user)
       node = TreeNodeBuilderDynatree.build(user, nil, {})
       node.should_not be_nil
-    end
-
-    pending 'MiqSearch node' do
     end
 
     pending 'MiqDialog node' do
@@ -321,9 +303,6 @@ describe TreeNodeBuilderDynatree do
       zone = FactoryGirl.build(:zone)
       node = TreeNodeBuilderDynatree.build(zone, nil, {})
       node.should_not be_nil
-    end
-
-    pending 'Hash node' do
     end
   end
 end


### PR DESCRIPTION
The nightly tests show over 2 pages of "pending" test.

It has been over a year since these TODOs were written. Do we think we going will circle back and implement these?

If so, I can add yours back - if not, I just want to remove them.

/cc @Fryguy @chessbyte @tinaafitz @martinpovolny ok to remove your blank tests?
