### PR TITLE
Don't clone so many hashes in ConfigurationEncoder

### DIFF
--- a/vmdb/lib/vmdb/configuration_encoder.rb
+++ b/vmdb/lib/vmdb/configuration_encoder.rb
@@ -10,16 +10,13 @@ module Vmdb
       h.each_key { |k| h[k].stringify_keys! }.stringify_keys!
     end
 
+    # TODO: Stringify, why does MiqDbConfig have to call stringify directly?
     def self.stringify(h)
       stringify!(h.deep_clone)
     end
 
     def self.symbolize!(h)
       h.each_key { |k| h[k].symbolize_keys! }.symbolize_keys!
-    end
-
-    def self.symbolize(h)
-      symbolize!(h.deep_clone)
     end
 
     def self.load(data, symbolize_keys = true, &block)

--- a/vmdb/spec/lib/vmdb/configuration_encoder_spec.rb
+++ b/vmdb/spec/lib/vmdb/configuration_encoder_spec.rb
@@ -172,15 +172,8 @@ describe Vmdb::ConfigurationEncoder do
     end
   end
 
-  context ".symbolize" do
-    subject { described_class.symbolize(@config) }
-
-    it "should not change original hash" do
-      @config = {"one"=> {"two"=> "three"}}
-
-      subject.should == {:one => {:two => "three"}}
-      @config.should == {"one"=> {"two"=> "three"}}
-    end
+  context ".symbolize!" do
+    subject { described_class.symbolize!(@config) }
 
     it "should handle two layers deep hash" do
       @config = {"one"=> {"two"=> {"three" => "four"}}}


### PR DESCRIPTION
Using [stackprof](https://github.com/tmm1/stackprof), ruby 2.1.3, and a simple script that does VMDB::Config.new("vmdb"), the attached PR drops object allocations by nearly 6%, **16% in ConfigurationEncoder.load**.

The second and third commit show why we're adding the first commit.

**Example 1: VMDB::Config.new("vmdb")**

``` ruby
require 'stackprof'
StackProf.run(mode: :object, out: 'tmp/stackprof-object-vmdb-config-new-after.dump') do
  VMDB::Config.new("vmdb")
end
```

**Before**

```
# stackprof tmp/stackprof-object-vmdb-config-new-before.dump --text --limit 500 |grep -Ei "Samples|ConfigurationEncoder"
  Samples: 80497 (0.00% miss rate)
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1568   (1.9%)        1566   (1.9%)     block in Vmdb::ConfigurationEncoder.decrypt_password_fields
      5982   (7.4%)         206   (0.3%)     Vmdb::ConfigurationEncoder.walk_nested_hashes
     29765  (37.0%)           7   (0.0%)     Vmdb::ConfigurationEncoder.load
      3114   (3.9%)           4   (0.0%)     Vmdb::ConfigurationEncoder.decrypt_password_fields
```

**After**

```
# stackprof tmp/stackprof-object-vmdb-config-new-after.dump --text --limit 500 |grep -Ei "Samples|ConfigurationEncoder"
  Samples: 75824 (0.00% miss rate)
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1568   (2.1%)        1566   (2.1%)     block in Vmdb::ConfigurationEncoder.decrypt_password_fields!
      5982   (7.9%)         206   (0.3%)     Vmdb::ConfigurationEncoder.walk_nested_hashes
     25105  (33.1%)           7   (0.0%)     Vmdb::ConfigurationEncoder.load
      1778   (2.3%)           4   (0.0%)     Vmdb::ConfigurationEncoder.decrypt_password_fields!
```

**Example 2: VMDB::Config.new("vmdb").save**

``` ruby
require 'stackprof'
StackProf.run(mode: :object, out: 'tmp/stackprof-object-vmdb-config-new-save-before.dump') do
  VMDB::Config.new("vmdb").save
end

```

Here's the results of profiling VMDB::Config.new("vmdb").save
**~16% drop in objects from ConfigurationEncoder.load**
**~43% drop in objects from ConfigurationEncoder.decrypt_password_fields**

**Before**

```
# stackprof tmp/stackprof-object-vmdb-config-new-save-before.dump --text --limit 500 |grep -Ei "Samples|ConfigurationEncoder"
  Samples: 283706 (0.00% miss rate)
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3138   (1.1%)        3134   (1.1%)     block in Vmdb::ConfigurationEncoder.decrypt_password_fields
      1570   (0.6%)        1568   (0.6%)     block in Vmdb::ConfigurationEncoder.encrypt_password_fields
     17962   (6.3%)         618   (0.2%)     Vmdb::ConfigurationEncoder.walk_nested_hashes
     59520  (21.0%)          13   (0.0%)     Vmdb::ConfigurationEncoder.load
      6232   (2.2%)           8   (0.0%)     Vmdb::ConfigurationEncoder.decrypt_password_fields
```

**After**

```
# stackprof tmp/stackprof-object-vmdb-config-new-save-after.dump --text --limit 500 |grep -Ei "Samples|ConfigurationEncoder"
  Samples: 273052 (0.00% miss rate)
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3138   (1.1%)        3134   (1.1%)     block in Vmdb::ConfigurationEncoder.decrypt_password_fields!
      1570   (0.6%)        1568   (0.6%)     block in Vmdb::ConfigurationEncoder.encrypt_password_fields!
     17962   (6.6%)         618   (0.2%)     Vmdb::ConfigurationEncoder.walk_nested_hashes
     50186  (18.4%)          13   (0.0%)     Vmdb::ConfigurationEncoder.load
      3558   (1.3%)           8   (0.0%)     Vmdb::ConfigurationEncoder.decrypt_password_fields!
```
