### PR TITLE
[WIP] Ensure queries are returned in expected order

### DIFF
--- a/vmdb/app/models/metric/finders.rb
+++ b/vmdb/app/models/metric/finders.rb
@@ -47,7 +47,7 @@ module Metric::Finders
     cond.nil? ? cond = [res_cond] : cond[0] << " AND #{res_cond}"
     cond += res_params
 
-    return klass.all(:conditions => cond)
+    return klass.all(:conditions => cond).order(:id)
   end
 
   #

--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -592,7 +592,7 @@ describe Metric do
 
         it "should find the correct rows" do
           Metric::Finders.day_to_range("2010-04-14T00:00:00Z", @time_profile).should == ["2010-04-14T00:00:00Z", "2010-04-14T23:59:59Z"]
-          Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:timestamp)[1..5]
+          Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:id)[1..5]
         end
 
         it "should find multiple resource types" do


### PR DESCRIPTION
While researching the travis failure [here](https://travis-ci.org/ManageIQ/manageiq/jobs/38194331), I realized the reason it was failing sporadically was because the spec is ordering by timestamp and the finder was providing no order.

Attached, I changed it to order by id on both... Is this right?  I don't know but the attached test no longer fails under stress and the test shows that we were expecting things in a specific order, an order we can't guarantee.

In order to recreate this, I added the code below which caused the failure to occur at least once... increase it from 1_000 if it's not working for you.

Using this code, I confirmed that order(:id) on both sides fixes it, while order(:timestamp) does NOT, maybe because of timestamp precision?

``` diff
diff --git a/vmdb/spec/models/metric_spec.rb b/vmdb/spec/models/metric_spec.rb
index bd7aa29..fb963e8 100644
--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -590,9 +590,11 @@ describe Metric do
           end
         end

-        it "should find the correct rows" do
-          Metric::Finders.day_to_range("2010-04-14T00:00:00Z", @time_profile).should == ["2010-04-14T00:00:00Z", "2010-04-14T23:59:59Z"]
-          Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:id)[1..5]
+        1_000.times do |i|
+          it "should find the correct rows #{i}" do
+            Metric::Finders.day_to_range("2010-04-14T00:00:00Z", @time_profile).should == ["2010-04-14T00:00:00Z", "2010-04-14T23:59:59Z"]
+            Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:id)[1..5]
+          end
         end
```

Or this:

``` diff
diff --git a/vmdb/spec/models/metric_spec.rb b/vmdb/spec/models/metric_spec.rb
index 219a49f..cf07482 100644
--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -590,9 +590,11 @@ describe Metric do
           end
         end

-        it "should find the correct rows" do
-          Metric::Finders.day_to_range("2010-04-14T00:00:00Z", @time_profile).should == ["2010-04-14T00:00:00Z", "2010-04-14T23:59:59Z"]
-          Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:timestamp)[1..5]
+        1_000.times do |i|
+          it "should find the correct rows #{i}" do
+            Metric::Finders.day_to_range("2010-04-14T00:00:00Z", @time_profile).should == ["2010-04-14T00:00:00Z", "2010-04-14T23:59:59Z"]
+            Metric::Finders.find_all_by_day(@vm1, "2010-04-14T00:00:00Z", 'hourly', @time_profile).should == @vm1.metric_rollups.sort_by(&:timestamp)[1..5]
+          end
         end
```

cc @Fryguy @kbrock 
