### PR TITLE
Fixed tab id when clicking on timelines links on C&U charts.

### DIFF
--- a/vmdb/app/controllers/application_controller/performance.rb
+++ b/vmdb/app/controllers/application_controller/performance.rb
@@ -301,7 +301,7 @@ module ApplicationController::Performance
       if f.nil?
         msg = "No events available for this #{new_opts[:model] == "EmsCluster" ? "Cluster" : new_opts[:model]}"
       elsif @record.kind_of?(MiqServer) # For server charts in OPS
-        change_tab("a6")                # Switch to the Timelines tab
+        change_tab("diagnostics_timelines")                # Switch to the Timelines tab
         return
       else
         if @explorer
@@ -340,7 +340,7 @@ module ApplicationController::Performance
       if f.nil?
         msg = "No events available for this #{model == "EmsCluster" ? "Cluster" : model}"
       elsif @record.kind_of?(MiqServer) # For server charts in OPS
-        change_tab("a6")                # Switch to the Timelines tab
+        change_tab("diagnostics_timelines")                # Switch to the Timelines tab
         return
       else
         if @explorer

--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -682,8 +682,8 @@ class OpsController < ApplicationController
         when :diagnostics_tree
           #need to refresh all_tabs for server by roles and roles by servers screen
           #to show correct buttons on screen when tree node is selected
-          if ["accordion_select","change_tab","tree_select"].include?(params[:action]) ||
-                  ["diagnostics_roles_servers","diagnostics_servers_roles"].include?(@sb[:active_tab])
+          if %w(accordion_select change_tab explorer tree_select).include?(params[:action]) ||
+             %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab])
             page.replace("ops_tabs", :partial=>"all_tabs")
           elsif nodetype == "log_depot_edit"
             @right_cell_text = "Editing Log Depot settings"


### PR DESCRIPTION
Fixed tab id when clicking on timelines links on C&U charts.  Changed to replace all_tabs partial when loading Timelines tab after a link was clicked on C&U chart.

https://bugzilla.redhat.com/show_bug.cgi?id=1154867
https://bugzilla.redhat.com/show_bug.cgi?id=1135656

@AparnaKarve can you please test this fix.
@gmcculloug please review/merge.
