### PR TITLE
Fix NTP server configuration

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -419,9 +419,7 @@ module OpsController::Settings::Common
       @update.config.each_key do |category|
         @update.config[category] = @edit[:new][category].dup
       end
-      if @edit[:new][:ntp]
-        @update.config[:ntp] = @edit[:new][:ntp].dup
-      end
+      @update.config[:ntp][:server].reject!(&:blank?) if @update.config[:ntp]
       if @update.validate                                           # Have VMDB class validate the settings
         if ["settings_server","settings_authentication"].include?(@sb[:active_tab])
           server = MiqServer.find(@sb[:selected_server_id])
@@ -672,12 +670,6 @@ module OpsController::Settings::Common
       @edit[:new][:ntp][:server][0] = params[:ntp_server_1] if params[:ntp_server_1]
       @edit[:new][:ntp][:server][1] = params[:ntp_server_2] if params[:ntp_server_2]
       @edit[:new][:ntp][:server][2] = params[:ntp_server_3] if params[:ntp_server_3]
-
-      @edit[:new][:ntp][:server].each_with_index do |ntp,i|
-        if @edit[:new][:ntp][:server][i].nil? || @edit[:new][:ntp][:server][i] == ""
-          @edit[:new][:ntp][:server].delete_at(i)
-        end
-      end
 
       @edit[:new][:server][:custom_support_url] = params[:custom_support_url].strip if params[:custom_support_url]
       @edit[:new][:server][:custom_support_url_description] = params[:custom_support_url_description] if params[:custom_support_url_description]


### PR DESCRIPTION
This fix is to make sure the list of NTP servers stored in session
reflects the reality of webui, i.e. order of servers entered + blank
fields. The "empty" servers are then removed from the list just
before the configuration is to be saved (commited into DB).

https://bugzilla.redhat.com/show_bug.cgi?id=1153633
