### PR TITLE
Add models for cloud orchestration

### DIFF
--- a/vmdb/app/models/cloud_network.rb
+++ b/vmdb/app/models/cloud_network.rb
@@ -1,6 +1,7 @@
 class CloudNetwork < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "EmsCloud"
   belongs_to :cloud_tenant
+  belongs_to :orchestration_stack
   has_many   :cloud_subnets, :dependent => :destroy
   has_many   :security_groups
   has_many   :vms

--- a/vmdb/app/models/ems_cloud.rb
+++ b/vmdb/app/models/ems_cloud.rb
@@ -27,6 +27,7 @@ class EmsCloud < ExtManagementSystem
   has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
+  has_many :orchestration_stacks,          :foreign_key => :ems_id, :dependent => :destroy
   has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
 
   # Development helper method for Rails console for opening a browser to the EMS.

--- a/vmdb/app/models/orchestration_stack.rb
+++ b/vmdb/app/models/orchestration_stack.rb
@@ -1,0 +1,33 @@
+require 'ancestry'
+class OrchestrationStack < ActiveRecord::Base
+  include NewWithTypeStiMixin
+
+  has_ancestry
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "EmsCloud"
+  belongs_to :orchestration_template
+
+  has_many   :vms, :class_name => "VmCloud"
+  has_many   :security_groups
+  has_many   :cloud_networks
+  has_many   :parameters, :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackParameter"
+  has_many   :outputs,    :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackOutput"
+  has_many   :resources,  :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackResource"
+
+  # @param options [Hash] what to update for the stack. Option keys and values are:
+  #   :template (String, URI, S3::S3Object, Object) - A new stack template.
+  #     This may be provided in a number of formats including:
+  #       a String, containing the template in CFN or HOT format.
+  #       a URL String pointing to the document in S3.
+  #       a URI object pointing to the document in S3.
+  #       an S3::S3Object which contains the template.
+  #       an Object which responds to #to_json and returns the template.
+  #   :parameters (Hash) - A hash that specifies the input parameters of the new stack.
+  def raw_update_stack(_options)
+    raise NotImplementedError, "raw_update_stack must be implemented in a subclass"
+  end
+
+  def raw_delete_stack
+    raise NotImplementedError, "raw_delete_stack must be implemented in a subclass"
+  end
+end

--- a/vmdb/app/models/orchestration_stack_output.rb
+++ b/vmdb/app/models/orchestration_stack_output.rb
@@ -1,0 +1,3 @@
+class OrchestrationStackOutput < ActiveRecord::Base
+  belongs_to :stack, :class_name => "OrchestrationStack"
+end

--- a/vmdb/app/models/orchestration_stack_parameter.rb
+++ b/vmdb/app/models/orchestration_stack_parameter.rb
@@ -1,0 +1,3 @@
+class OrchestrationStackParameter < ActiveRecord::Base
+  belongs_to :stack, :class_name => "OrchestrationStack"
+end

--- a/vmdb/app/models/orchestration_stack_resource.rb
+++ b/vmdb/app/models/orchestration_stack_resource.rb
@@ -1,0 +1,3 @@
+class OrchestrationStackResource < ActiveRecord::Base
+  belongs_to :stack, :class_name => "OrchestrationStack"
+end

--- a/vmdb/app/models/orchestration_template.rb
+++ b/vmdb/app/models/orchestration_template.rb
@@ -1,0 +1,50 @@
+require 'digest/md5'
+class OrchestrationTemplate < ActiveRecord::Base
+  has_many :stacks, :class_name => "OrchestrationStack"
+
+  # Find only by template content. Here we only compare md5 considering the table is expected
+  # to be small and the chance of md5 collision is minimal.
+  #
+  def self.find_or_create_by_contents(hashes)
+    hashes = [hashes] unless hashes.kind_of?(Array)
+    md5s = hashes.collect { |hash| Digest::MD5.hexdigest(hash[:content]) }
+    existing_templates = find_all_by_ems_ref(md5s).index_by(&:ems_ref)
+
+    hashes.collect do |hash|
+      template = existing_templates[hash[:ems_ref]]
+      unless template
+        hash.delete(:ems_ref)     # field :ems_ref is read only from outside
+        template = create(hash)
+        existing_templates[hash[:ems_ref]] = template
+      end
+      template
+    end
+  end
+
+  def content=(c)
+    super
+    self.ems_ref = Digest::MD5.hexdigest(c)
+  end
+
+  # Check whether a template has been referenced by any stack. A template that is in use should be
+  # considered read only
+  def in_use?
+    !stacks.empty?
+  end
+
+  # Find all in use and read-only templates
+  def self.in_use
+    joins(:stacks).uniq
+  end
+
+  # Find all not in use thus editable templates
+  def self.not_in_use
+    includes(:stacks).where(OrchestrationStack.arel_table[:orchestration_template_id].eq(nil))
+  end
+
+  private
+
+  def ems_ref=(_md5)
+    super
+  end
+end

--- a/vmdb/app/models/security_group.rb
+++ b/vmdb/app/models/security_group.rb
@@ -7,6 +7,7 @@ class SecurityGroup < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "EmsCloud"
   belongs_to :cloud_network
   belongs_to :cloud_tenant
+  belongs_to :orchestration_stack
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy
   has_and_belongs_to_many :vms
 

--- a/vmdb/app/models/vm_cloud.rb
+++ b/vmdb/app/models/vm_cloud.rb
@@ -8,6 +8,7 @@ class VmCloud < Vm
   belongs_to :flavor
   belongs_to :cloud_network
   belongs_to :cloud_subnet
+  belongs_to :orchestration_stack
   has_one    :floating_ip, :foreign_key => :vm_id
   has_and_belongs_to_many :security_groups, :join_table => :security_groups_vms, :foreign_key => :vm_id
   has_and_belongs_to_many :key_pairs,       :join_table => :key_pairs_vms,       :foreign_key => :vm_id, :association_foreign_key => :authentication_id, :class_name => "AuthKeyPairCloud"

--- a/vmdb/db/migrate/20141020195642_create_orchestration_stacks.rb
+++ b/vmdb/db/migrate/20141020195642_create_orchestration_stacks.rb
@@ -1,0 +1,70 @@
+class CreateOrchestrationStacks < ActiveRecord::Migration
+  def change
+    create_table :orchestration_templates do |t|
+      t.string   :name
+      t.string   :type
+      t.text     :description
+      t.text     :content
+      t.string   :ems_ref
+
+      t.timestamps
+    end
+
+    add_index :orchestration_templates, :ems_ref, :unique => true
+
+    create_table :orchestration_stacks do |t|
+      t.string  :name
+      t.string  :type
+      t.text    :description
+      t.string  :status
+      t.string  :ems_ref
+      t.string  :ancestry
+
+      t.belongs_to :ems
+      t.belongs_to :orchestration_template
+
+      t.timestamps
+    end
+
+    add_index :orchestration_stacks, :orchestration_template_id
+    add_index :orchestration_stacks, :ancestry
+
+    add_column :vms,             :orchestration_stack_id, :bigint
+    add_column :security_groups, :orchestration_stack_id, :bigint
+    add_column :cloud_networks,  :orchestration_stack_id, :bigint
+
+    create_table :orchestration_stack_parameters do |t|
+      t.string :name
+      t.text   :value
+
+      t.belongs_to :stack
+    end
+
+    add_index :orchestration_stack_parameters, :stack_id
+
+    create_table :orchestration_stack_outputs do |t|
+      t.string :key
+      t.text   :value
+      t.text   :description
+
+      t.belongs_to :stack
+    end
+
+    add_index :orchestration_stack_outputs, :stack_id
+
+    create_table :orchestration_stack_resources do |t|
+      t.string :name
+      t.text   :description
+      t.text   :logical_resource
+      t.text   :physical_resource
+      t.string :resource_category
+      t.string :resource_status
+      t.text   :resource_status_reason
+      t.timestamp :last_updated
+
+      t.belongs_to :stack
+    end
+
+    add_index :orchestration_stack_resources, :stack_id
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_template.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_template.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceOrchestrationTemplate < MiqAeServiceModelBase
+    def deploy(provider_id, stack_name, options)
+      object_send(:deploy, provider_id, stack_name, options)
+    end
+  end
+end

--- a/vmdb/spec/factories/orchestration_stack.rb
+++ b/vmdb/spec/factories/orchestration_stack.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :orchestration_stack do
+  end
+end

--- a/vmdb/spec/factories/orchestration_template.rb
+++ b/vmdb/spec/factories/orchestration_template.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :orchestration_template do
+    sequence(:name)        { |n| "template name #{seq_padded_for_sorting(n)}" }
+    sequence(:content)     { |n| "any template text #{seq_padded_for_sorting(n)}" }
+    sequence(:description) { |n| "some description #{seq_padded_for_sorting(n)}" }
+  end
+
+  factory :orchestration_template_with_stacks, :parent => :orchestration_template do
+    stacks { [FactoryGirl.create(:orchestration_stack)] }
+  end
+end

--- a/vmdb/spec/models/orchestration_template_spec.rb
+++ b/vmdb/spec/models/orchestration_template_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+describe OrchestrationTemplate do
+
+  describe ".find_or_create_by_contents" do
+    context "when the template does not exist" do
+      let(:query_hash) { FactoryGirl.build(:orchestration_template).as_json.symbolize_keys }
+
+      it "creates a new template" do
+        OrchestrationTemplate.count.should == 0
+        record = OrchestrationTemplate.find_or_create_by_contents(query_hash)[0]
+        OrchestrationTemplate.count.should == 1
+        record.name.should        == query_hash[:name]
+        record.content.should     == query_hash[:content]
+        record.description.should == query_hash[:description]
+        record.ems_ref.should_not be_nil
+      end
+    end
+
+    context "when the template already exists" do
+      before do
+        @existing_record = FactoryGirl.create(:orchestration_template)
+        # prepare the query with different name and description; it is considered the same template
+        # because the body (:template and :ems_ref) does not change
+        @query_hash = @existing_record.as_json.symbolize_keys
+        @query_hash[:name]        = "renamed"
+        @query_hash[:description] = "modified description"
+      end
+
+      it "finds the existing template regardless the new name or description" do
+        OrchestrationTemplate.count.should == 1
+        @existing_record.should == OrchestrationTemplate.find_or_create_by_contents(@query_hash)[0]
+        OrchestrationTemplate.count.should == 1
+      end
+    end
+  end
+
+  context "when both types of templates, either alone or with deployed stacks, are present" do
+    before do
+      # prepare a mini environment with an orphan template and a template with deployed stacks
+      @template_alone      = FactoryGirl.create(:orchestration_template)
+      @template_with_stack = FactoryGirl.create(:orchestration_template_with_stacks)
+    end
+
+    describe "#in_use?" do
+      it "knows whether a template is in use" do
+        @template_alone.in_use?.should      be_false
+        @template_with_stack.in_use?.should be_true
+      end
+    end
+
+    describe ".in_use" do
+      it "finds all templates that are in use" do
+        inused_templates = OrchestrationTemplate.in_use
+        inused_templates.size.should == 1
+        inused_templates[0].should == @template_with_stack
+      end
+    end
+
+    describe ".not_in_use" do
+      it "finds all templates that are never deployed" do
+        alone_templates = OrchestrationTemplate.not_in_use
+        alone_templates.size.should == 1
+        alone_templates[0].should == @template_alone
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is split from original PR #333  (to be discarded). It focus only on the models for orchestrations. 
The master PR #523 covers the design and progress of the support for orchestration including AWS CloudFormation and OpenStack Heat.
![orchestration](https://cloud.githubusercontent.com/assets/7047579/4719534/6144c4e0-592a-11e4-9dc1-7d882f00f947.png)
