### PR TITLE
Corrected misspellings for form button definitions

### DIFF
--- a/vmdb/app/views/layouts/_x_edit_buttons.html.erb
+++ b/vmdb/app/views/layouts/_x_edit_buttons.html.erb
@@ -4,7 +4,7 @@
 <% default_button ||= nil   %>  <%# Default button for menus editor %>
 <% no_cancel ||= nil        %>  <%# don't need cancel button in OPS %>
 <% no_reset ||= nil         %>  <%# don't need reset button %>
-<% multi_record ||= nil     %>  <%# need to show save/cancel button, for screens edititng multiple records or when @record is not set %>
+<% multi_record ||= nil     %>  <%# need to show save/cancel button, for screens editing multiple records or when @record is not set %>
 <% submit_button ||= nil    %>  <%# need to show submit button instead of save button %>
 <% submit_text ||= nil      %>  <%# need to show title on submit button on database config screen %>
 <% apply_button ||= nil     %>  <%# need to show apply button instead of save button %>

--- a/vmdb/spec/controllers/application_controller/buttons_spec.rb
+++ b/vmdb/spec/controllers/application_controller/buttons_spec.rb
@@ -88,7 +88,7 @@ describe ApplicationController do
   end
 
   context "#button_set_form_vars" do
-    it "check button_set_form_vars sets correct applies_to_class when edititng a button" do
+    it "check button_set_form_vars sets correct applies_to_class when editing a button" do
       # button_set_form_vars expects that the simulation screen will be built,
       #   which, in turn, needs *something* to come back from automate
       MiqAeClass.stub(:find_distinct_instances_across_domains => [double(:name => "foo")])


### PR DESCRIPTION
Corrections made to spell "editing" in both the form message and spec code
