### PR TITLE
Rest API: fix "limit" and "offset" functionality

### DIFF
--- a/vmdb/app/models/rbac.rb
+++ b/vmdb/app/models/rbac.rb
@@ -418,8 +418,8 @@ module Rbac
 
     if options[:limit] && !attrs[:apply_limit_in_sql]
       attrs[:target_ids_for_paging] = targets.collect(&:id) # Save ids of targets, since we have then all, to avoid going back to SQL for the next page
-      offset = options[:offset] || 0
-      targets = targets[offset..(offset + options[:limit] - 1)]
+      offset = options[:offset].to_i
+      targets = targets[offset..(offset + options[:limit].to_i - 1)]
     end
 
     # Preserve sort order of incoming target_ids


### PR DESCRIPTION
This is to fix the followig errors:
1. When using 'limit' argument:

```
String can't be coerced into Fixnum, klass:TypeError
```
1. When using 'limit' with the 'offset' argument:
   
   undefined method `-' for ...:String, klass:NoMethodError

Both problems are only reproducible with a user belonging to a group, which has non-empty
hosts & clusters access filters assigned (i.e. you explicitly limit the access to hosts and clusters
for this group).
