### PR TITLE
Refresh button toolbar after timezone deletion

### DIFF
--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -65,9 +65,16 @@ class ConfigurationController < ApplicationController
         page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
       end
     else
+      c_buttons, c_xml = build_toolbar_buttons_and_xml(center_toolbar_filename)
       render :update do |page|                    # Use RJS to update the display
-        page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
-        page.replace_html("main_div", :partial=>"ui_4")                                                 # Replace the main div area contents
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page.replace_html("main_div", :partial => "ui_4") # Replace the main div area contents
+        if c_buttons && c_xml
+          page << javascript_for_toolbar_reload('center_tb', c_buttons, c_xml)
+          page << "$('center_buttons_div').show();"
+        else
+          page << "$('center_buttons_div').hide();"
+        end
       end
     end
   end


### PR DESCRIPTION
We need to refresh the button toolbar after timezone deletion
so that the button items are enabled / disabled correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1155579
