### PR TITLE
Add ability to encrypt database.yml from fix_auth

### DIFF
--- a/vmdb/tools/fix_auth/auth_config_model.rb
+++ b/vmdb/tools/fix_auth/auth_config_model.rb
@@ -10,6 +10,10 @@ module FixAuth
       # true if we want to output the keys as symbols (default: false - output as string keys)
       attr_accessor :symbol_keys
 
+      def display_record(r)
+        puts "  #{r.id}:"
+      end
+
       def display_column(r, column)
         puts "    #{column}:"
         traverse_column([], YAML.load(r.send(column)))
@@ -34,7 +38,7 @@ module FixAuth
           h[k] = new_value if password_field?(k) && v.present?
         end
         Vmdb::ConfigurationEncoder.dump(hash, nil, !symbol_keys) do |k, v, h|
-          h[k] = MiqPassword.try_encrypt(new_value) if password_field?(k) && v.present?
+          h[k] = MiqPassword.try_encrypt(v) if password_field?(k) && v.present?
         end
       end
 

--- a/vmdb/tools/fix_auth/auth_model.rb
+++ b/vmdb/tools/fix_auth/auth_model.rb
@@ -87,9 +87,5 @@ module FixAuth
         clear_active_connections!
       end
     end
-
-    def fix_passwords
-      self.class.fix_passwords(self)
-    end
   end
 end

--- a/vmdb/tools/fix_auth/cli.rb
+++ b/vmdb/tools/fix_auth/cli.rb
@@ -21,6 +21,7 @@ module FixAuth
         opt :v2,       "Fix V2 passwords also", :type => :boolean, :short => "f", :default => false
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
+        opt :databaseyml, "rewrite databaseyml", :type => :boolean, :short => "y", :default => false
       end
 
       options[:databases] = args.presence || %w(vmdb_production)

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -63,10 +63,17 @@ module FixAuth
       end
     end
 
+    def fix_database_yml
+      FixDatabaseYml.file_name = "#{options[:root]}/config/database.yml"
+      FixDatabaseYml.run(run_options.merge(:hardcode => options[:password]))
+    end
+
     def run
       MiqPassword.key_root = cert_dir if cert_dir
+
       generate_password if options[:key]
-      fix_database_passwords
+      fix_database_yml if options[:databaseyml]
+      fix_database_passwords if !options[:key] && !options[:databaseyml]
     end
   end
 end

--- a/vmdb/tools/fix_auth/models.rb
+++ b/vmdb/tools/fix_auth/models.rb
@@ -73,10 +73,6 @@ module FixAuth
     self.symbol_keys = true
     self.table_name = "miq_requests"
 
-    def self.display_record(r)
-      puts "  #{r.id}:"
-    end
-
     def self.contenders(_ = nil)
       where("options like '%password%'")
     end
@@ -92,12 +88,39 @@ module FixAuth
     self.symbol_keys = true
     self.table_name = "miq_request_tasks"
 
-    def self.display_record(r)
-      puts "  #{r.id}:"
-    end
-
     def self.contenders(_ = nil)
       where("options like '%password%'")
+    end
+  end
+
+  class FixDatabaseYml
+    attr_accessor :id
+    attr_accessor :yaml
+    include FixAuth::AuthConfigModel
+
+    class << self
+      attr_accessor :available_columns
+      attr_accessor :file_name
+    end
+
+    def initialize(options = {})
+      options.each { |n, v| public_send("#{n}=", v) }
+    end
+
+    def load
+      @yaml = File.read(id)
+      self
+    end
+
+    def save!
+      File.write(id, @yaml)
+    end
+
+    self.password_fields = %w(password)
+    self.available_columns = %w(yaml)
+
+    def self.contenders(_options = {})
+      [new(:id => file_name).load]
     end
   end
 end


### PR DESCRIPTION
There is an issue when a customer upgraded to 5.3 but hadn't hardened the databse yet.

We need a way to re-encrypt `database.yml`. It is tricky since we can't use `rails runner` when there is an invalid `database.yml` - chicken and egg.

https://bugzilla.redhat.com/show_bug.cgi?id=1141299
