### PR TITLE
Corrected text literals in Catalog edit items form

### DIFF
--- a/vmdb/app/views/catalog/_column_lists.html.haml
+++ b/vmdb/app/views/catalog/_column_lists.html.haml
@@ -1,7 +1,7 @@
 #column_lists
   %table.form#formtest{:width => "100%"}
     %tr
-      %td.widthed{:align => "left"} UnAssigned:
+      %td.widthed{:align => "left"} Unassigned:
       %td
       %td{:align => "left"} Selected:
     %tr

--- a/vmdb/app/views/catalog/_stcat_form.html.haml
+++ b/vmdb/app/views/catalog/_stcat_form.html.haml
@@ -25,5 +25,5 @@
                          "data-miq_observe" => {:interval => ".5",
                                                 :url      => url}.to_json)
   %hr
-  %p.legend Assign Items
+  %p.legend Assign Catalog Items
   = render :partial => "column_lists"

--- a/vmdb/app/views/shared/buttons/_column_lists.html.erb
+++ b/vmdb/app/views/shared/buttons/_column_lists.html.erb
@@ -2,7 +2,7 @@
   <table width="100%" class="form" id="formtest">
     <tr>
       <% if x_active_tree == :ab_tree %>
-        <td align="left" class="widthed">   UnAssigned:</td>
+        <td align="left" class="widthed">   Unassigned:</td>
         <td></td>
       <% end %>
       <td align="left">Selected:</td>


### PR DESCRIPTION
Fixed "Unassigned" text display for consistency throughout application
Fixed Assign Catalog Items to be more data subject specific

https://bugzilla.redhat.com/show_bug.cgi?id=1095470
