### PR TITLE
Fixed rendering issues after the upload of Sysprep Answer File

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -47,6 +47,13 @@ function miqOnLoad() {
   }
 }
 
+function miqPrepRightCellForm(tree) {
+  if ($j('#adv_searchbox_div')) $j('#adv_searchbox_div').hide();
+  dhxLayoutB.cells("a").collapse();
+  $j('#' + tree).dynatree('disable');
+  miqDimDiv(tree + '_div', true);
+}
+
 // Things to be done on page resize
 function miqOnResize() {
 //  if ($('miq_timeline')) miqResizeTL();

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -37,6 +37,7 @@ class ApplicationController < ActionController::Base
   include_concern 'Tags'
   include_concern 'Timelines'
   include_concern 'TreeSupport'
+  include_concern 'SysprepAnswerFile'
 
   before_filter :get_global_session_data, :except => [:window_sizes, :authenticate]
   before_filter :set_user_time_zone

--- a/vmdb/app/controllers/application_controller/miq_request_methods.rb
+++ b/vmdb/app/controllers/application_controller/miq_request_methods.rb
@@ -202,9 +202,8 @@ module ApplicationController::MiqRequestMethods
       else
         @layout = "miq_request_vm"
       end
-      if params[:no_refresh]
-        @edit = session[:edit]
-        @edit[:new][:current_tab_key] = :customize
+      if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
+        upload_sysprep_file
         @tabactive = "customize_div"
       else
         if params[:req_id]

--- a/vmdb/app/controllers/application_controller/sysprep_answer_file.rb
+++ b/vmdb/app/controllers/application_controller/sysprep_answer_file.rb
@@ -1,0 +1,27 @@
+class ApplicationController
+  module SysprepAnswerFile
+    def upload_sysprep_file
+      @_params.delete :commit
+      @upload_sysprep_file = true
+      @edit = session[:edit]
+      build_grid
+      if params.fetch_path(:upload, :file).respond_to?(:read)
+        @edit[:new][:sysprep_upload_file] = params[:upload][:file].original_filename
+        begin
+          @edit[:new][:sysprep_upload_text] = MiqProvisionWorkflow.validate_sysprep_file(params[:upload][:file])
+          msg = _('Sysprep "%s" upload was successful') % params[:upload][:file].original_filename
+          add_flash(msg)
+        rescue StandardError => bang
+          @edit[:new][:sysprep_upload_text] = nil
+          msg = _("Error during Sysprep \"%s\" file upload: ") % params[:upload][:file].original_filename <<
+            bang.message
+          add_flash(msg, :error)
+        end
+      else
+        @edit[:new][:sysprep_upload_text] = nil
+        msg = _("Use the Browse button to locate an Upload file")
+        add_flash(msg, :error)
+      end
+    end
+  end
+end

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -186,6 +186,9 @@ class CatalogController < ApplicationController
     @built_trees = []
     @accords     = []
 
+    x_last_active_tree = x_active_tree if x_active_tree
+    x_last_active_accord = x_active_accord if x_active_accord
+
     if role_allows(:feature => "catalog_items_view")
       self.x_active_tree   = 'sandt_tree'
       self.x_active_accord = 'sandt'
@@ -205,6 +208,9 @@ class CatalogController < ApplicationController
       @accords.push(:name => "svccat", :title => "Service Catalogs", :container => "svccat_tree_div")
     end
 
+    self.x_active_tree = x_last_active_tree if x_last_active_tree
+    self.x_active_accord = x_last_active_accord.to_s if x_last_active_accord
+
     if params[:id]  # If a tree node id came in, show in one of the trees
       @nodetype, id = params[:id].split("_").last.split("-")
       self.x_active_tree   = 'sandt_tree'
@@ -222,7 +228,20 @@ class CatalogController < ApplicationController
       @in_a_form = false
     end
 
+    if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
+      upload_sysprep_file
+      set_form_locals_for_sysprep
+    end
+
     render :layout => "explorer"
+  end
+
+  def set_form_locals_for_sysprep
+    @pages = false
+    @edit[:explorer] = true
+    @sb[:st_form_active_tab] = "request"
+    @right_cell_text = _("Adding a new %s") % ui_lookup(:model => "ServiceTemplate")
+    @temp[:x_edit_buttons_locals] = {:action_url => "servicetemplate_edit"}
   end
 
   def identify_catalog(id = nil)

--- a/vmdb/app/controllers/miq_request_controller.rb
+++ b/vmdb/app/controllers/miq_request_controller.rb
@@ -350,26 +350,6 @@ class MiqRequestController < ApplicationController
     end
   end
 
-  def upload
-    @edit = session[:edit]
-    if params.fetch_path(:upload, :file).respond_to?(:read)
-      @edit[:new][:sysprep_upload_file] = params[:upload][:file].original_filename
-      begin
-        @edit[:new][:sysprep_upload_text] = MiqProvisionWorkflow.validate_sysprep_file(params[:upload][:file])
-        msg = _("Sysprep \"%s\" upload was successful") % params[:upload][:file].original_filename
-        redirect_to :action => 'prov_edit', :flash_msg=>msg, :no_refresh=>true, :id=>params[:id]
-      rescue StandardError => bang
-        @edit[:new][:sysprep_upload_text] = nil
-        msg = _("Error during Sysprep \"%s\" file upload: ") % params[:upload][:file].original_filename << bang.message
-        redirect_to :action => 'prov_edit', :flash_msg=>msg, :flash_error=>true, :no_refresh=>true, :id=>params[:id]
-      end
-    else
-      @edit[:new][:sysprep_upload_text] = nil
-      msg = _("Use the Browse button to locate an Upload file")
-      redirect_to :action => 'prov_edit', :flash_msg=>msg, :flash_error=>true, :no_refresh=>true, :id=>params[:id]
-    end
-  end
-
   # Gather any changed options
   def prov_change_options
     resource_type = get_request_tab_type.to_sym

--- a/vmdb/app/controllers/mixins/vm_show_mixin.rb
+++ b/vmdb/app/controllers/mixins/vm_show_mixin.rb
@@ -31,15 +31,28 @@ module VmShowMixin
     params.merge!(session[:exp_parms]) if session[:exp_parms]  # Grab any explorer parm overrides
     session.delete(:exp_parms)
 
+    if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
+      upload_sysprep_file
+      set_form_locals_for_sysprep
+    end
     if params[:id]
       # if you click on a link to VM on a dashboard widget that will redirect you
       # to explorer with params[:id] and you get into the true branch
       redirected = set_elements_and_redirect_unauthorized_user
     else
-      set_active_elements
+      set_active_elements unless @upload_sysprep_file
     end
 
     render :layout => "explorer" unless redirected
+  end
+
+  def set_form_locals_for_sysprep
+    _partial, action, @right_cell_text = set_right_cell_vars
+    locals = {:submit_button => true,
+              :no_reset      => true,
+              :action_url    => action
+             }
+    @temp[:x_edit_buttons_locals] = locals
   end
 
   # VM or Template show selected, redirect to proper controller, to get links on tasks screen working

--- a/vmdb/app/views/catalog/explorer.html.haml
+++ b/vmdb/app/views/catalog/explorer.html.haml
@@ -26,6 +26,12 @@
   #main_div.main_div
     - if @sb[:buttons_node]
       = render :partial => "shared/buttons/ab_list"
+    - elsif @upload_sysprep_file
+      = render :partial => "layouts/flash_msg"
+      = render :partial => "catalog/form"
+      - @upload_sysprep_file = false
+      :javascript
+        var miq_after_onload = "miqPrepRightCellForm('#{x_active_tree}');"
     - else
       = render :partial => "layouts/x_gtl"
 

--- a/vmdb/app/views/miq_request/_prov_field.html.erb
+++ b/vmdb/app/views/miq_request/_prov_field.html.erb
@@ -480,9 +480,17 @@ pfx = "miq_request/"
         </td>
       <% elsif [:sysprep_upload_file].include?(field) %>
         <td>
-          <%= form_tag({:action=>"upload", :id=>"#{@edit[:req_id] || "new"}"}, :multipart => true) do %>
+          <% path = Rails.application.routes.recognize_path request.referrer %>
+          <% if path[:controller] == "miq_request" %>
+            <%= form_tag({:action => "prov_edit", :req_id => "#{@edit[:req_id]}"}, :multipart => true) do %>
               <%= file_field("upload", "file") %>
               <%= submit_tag("Upload", :class => "upload") %>
+            <% end %>
+          <% else %>
+            <%= form_tag({:controller => path[:controller], :action => "explorer"}, :multipart => true) do %>
+              <%= file_field("upload", "file") %>
+              <%= submit_tag("Upload", :class => "upload") %>
+            <% end %>
           <% end %>
           </td>
       <% end %>

--- a/vmdb/app/views/vm_infra/explorer.html.haml
+++ b/vmdb/app/views/vm_infra/explorer.html.haml
@@ -31,7 +31,12 @@
         var miq_after_onload = "miqAsyncAjax('#{url_for(:action=>@ajax_action, :id=>@record)}');"
     - else
       = render(:partial => 'vm_common/main', :locals=>{:controller=>"vm"})
-
+- elsif @upload_sysprep_file
+  #main_div.main_div
+    = render(:partial => 'miq_request/prov_edit')
+    - @upload_sysprep_file = false
+    :javascript
+      var miq_after_onload = "miqPrepRightCellForm('#{x_active_tree}');"
 - else
   - # Showing a list of VMs
   #main_div.main_div

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -101,6 +101,7 @@ Vmdb::Application.routes.draw do
         sort_host_grid
         sort_iso_img_grid
         sort_pxe_img_grid
+        sort_vc_grid
         sort_vm_grid
         st_catalog_edit
         st_catalog_form_field_changed
@@ -1754,6 +1755,7 @@ Vmdb::Application.routes.draw do
         sort_ds_grid
         sort_host_grid
         sort_iso_img_grid
+        sort_vc_grid
         sort_vm_grid
         squash_toggle
         tagging_edit

--- a/vmdb/spec/routing/catalog_routing_spec.rb
+++ b/vmdb/spec/routing/catalog_routing_spec.rb
@@ -50,6 +50,7 @@ describe 'routes for CatalogController' do
     sort_host_grid
     sort_iso_img_grid
     sort_pxe_img_grid
+    sort_vc_grid
     sort_vm_grid
     st_catalog_edit
     st_catalog_form_field_changed

--- a/vmdb/spec/routing/vm_infra_routing_spec.rb
+++ b/vmdb/spec/routing/vm_infra_routing_spec.rb
@@ -121,6 +121,12 @@ describe 'routes for VmInfra' do
     end
   end
 
+  describe '#sort_vc_grid' do
+    it 'routes with POST' do
+      expect(post("/#{controller_name}/sort_vc_grid")).to route_to("#{controller_name}#sort_vc_grid")
+    end
+  end
+
   describe '#sort_vm_grid' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/sort_vm_grid")).to route_to("#{controller_name}#sort_vm_grid")


### PR DESCRIPTION
Clicking on Upload resulted in many Provisioning dialog rendering issues such as -
1. Form buttons (submit/cancel) were not showing up effectively inhibiting provisioning
2. Layout abruptly switched from explorer to non-explorer

Other than the above rendering issues, also fixed a routing error and a crash that was originally reported in the BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=1154054
