### PR TITLE
warn if v2_key exists with meaningful error

### DIFF
--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -84,8 +84,9 @@ module ApplianceConsole
         opt :username, "Database Username",  :type => :string,  :short => 'U', :default => "root"
         opt :password, "Database Password",  :type => :string,  :short => "p"
         opt :dbname,   "Database Name",      :type => :string,  :short => "d", :default => "vmdb_production"
-        opt :key,      "Create encryption key (forcefully)",  :type => :boolean, :short => "k"
-        opt :fetch_key, "SSH host with encryption key", :type => :string
+        opt :key,      "Create encryption key",  :type => :boolean, :short => "k"
+        opt :fetch_key, "SSH host with encryption key", :type => :string, :short => "K"
+        opt :force_key, "Forcefully create encryption key", :type => :boolean, :short => "f"
         opt :sshlogin,  "SSH login",         :type => :string,                 :default => "root"
         opt :sshpassword, "SSH password",    :type => :string
         opt :verbose,  "Verbose",            :type => :boolean, :short => "v"
@@ -171,7 +172,7 @@ module ApplianceConsole
     def key_configuration
       @key_configuration ||= KeyConfiguration.new(
         :action   => options[:fetch_key] ? :fetch : :create,
-        :force    => options[:fetch_key] ? true : options[:key],
+        :force    => options[:fetch_key] ? true : options[:force_key],
         :host     => options[:fetch_key],
         :login    => options[:sshlogin],
         :password => options[:sshpassword],
@@ -180,7 +181,9 @@ module ApplianceConsole
 
     def create_key
       say "#{key_configuration.action} encryption key"
-      key_configuration.activate
+      unless key_configuration.activate
+        raise "Could not create encryption key (v2_key)"
+      end
     end
 
     def install_certs

--- a/lib/appliance_console/key_configuration.rb
+++ b/lib/appliance_console/key_configuration.rb
@@ -47,12 +47,21 @@ module ApplianceConsole
     end
 
     def activate
-      return true unless remove_key(force)
-
-      if fetch_key?
-        fetch_key
+      if remove_key(force)
+        if fetch_key?
+          fetch_key
+        else
+          create_key
+        end
       else
-        create_key
+        # probably only got here via the cli
+        $stderr.puts
+        $stderr.puts "Only generate one v2_key per installation."
+        $stderr.puts "Chances are you did not want to overwrite this file."
+        $stderr.puts "If you do this all encrypted secrets in the database will not be readable."
+        $stderr.puts "Please backup your key and run this command again with --force-key."
+        $stderr.puts
+        false
       end
     end
 

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -261,7 +261,7 @@ describe ApplianceConsole::Cli do
         end
 
         context "remote database" do
-          it "doesnt auto generate a key" do
+          it "does not generate an encryption key" do
             subject.parse(%w(--hostname xyc.com))
             expect_v2_key(false)
             expect(subject).not_to be_key
@@ -270,15 +270,24 @@ describe ApplianceConsole::Cli do
       end
       context "key exists" do
         context "local database" do
-          it "doesnt generate key" do
+          it "does not generate an encryption key" do
             subject.parse(%w(--internal --region 1))
             expect_v2_key(true)
             expect(subject).not_to be_key
+            expect(key_configuration.force).to eq(false)
           end
         end
 
-        it "should setup a key if passing --key" do
+        it "fails to generate an encryption key" do
           subject.parse(%w(--internal --region 1 --key))
+          expect_v2_key(true)
+          expect(subject).to be_key
+          expect(key_configuration.force).to eq(false)
+          expect(key_configuration.activate).to eq(false)
+        end
+
+        it "forecefully removes existing encryption keys" do
+          subject.parse(%w(--internal --region 1 --key --force-key))
           expect_v2_key(true)
           expect(subject).to be_key
           expect(key_configuration.force).to eq(true)

--- a/lib/spec/appliance_console/key_configuration_spec.rb
+++ b/lib/spec/appliance_console/key_configuration_spec.rb
@@ -88,12 +88,12 @@ describe ApplianceConsole::KeyConfiguration do
           expect(subject.activate).to be_true
         end
 
-        it "skips if key exists (no force)" do
+        it "fails if key exists (no force)" do
           subject.force = false
           v2_exists(true)
           expect(FileUtils).not_to receive(:rm)
           expect(Net::SCP).not_to receive(:start)
-          expect(subject.activate).to be_true
+          expect(subject.activate).to be_false
         end
       end
     end

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -40,6 +40,14 @@ module FixAuth
 
     def generate_password
       MiqPassword.generate_symmetric("#{cert_dir}/v2_key")
+    rescue Errno::EEXIST => e
+      $stderr.puts
+      $stderr.puts "Only generate one v2_key per installation."
+      $stderr.puts "Chances are you did not want to overwrite this file."
+      $stderr.puts "If you do this all encrypted secrets in the database will not be readable."
+      $stderr.puts "Please backup your key and run again."
+      $stderr.puts
+      raise Errno::EEXIST, e.message
     end
 
     def fix_database_passwords


### PR DESCRIPTION
warn if v2_key exists with meaningful error

fix_auth (the most common place to generate a key) tries to provide
a user context that they should not just remove the file.

The cli is more powerful, so a --force-key option is provided
- cli only replaces v2_key if --force-key
- cli does replace v2_key if fetching from remote
- fix_auth displays warning. User must backup key first
- cli displays warning. offers --force-key option
- change raise so the stack trace points to our code

https://bugzilla.redhat.com/show_bug.cgi?id=1153777

/cc @Fryguy @jrafanie 
