### PR TITLE
Loosen time precision for assertions to decrease sporadic failures.

### DIFF
--- a/lib/spec/util/extensions/miq-benchmark_spec.rb
+++ b/lib/spec/util/extensions/miq-benchmark_spec.rb
@@ -21,9 +21,9 @@ describe Benchmark do
       "test"
     end
     result.should == "test"
-    timings[:test1].should be_within(0.01).of(1500)
-    timings[:test2].should be_within(0.01).of(1000)
-    timings[:test3].should be_within(0.01).of(500)
+    timings[:test1].should be_within(0.5).of(1500)
+    timings[:test2].should be_within(0.5).of(1000)
+    timings[:test3].should be_within(0.5).of(500)
   end
 
   it '.realtime_store with an Exception' do
@@ -34,7 +34,7 @@ describe Benchmark do
         raise Exception
       end
     rescue Exception
-      timings[:test1].should be_within(0.01).of(500)
+      timings[:test1].should be_within(0.5).of(500)
     end
   end
 
@@ -50,9 +50,9 @@ describe Benchmark do
       "test"
     end
     result.should == "test"
-    timings[:test1].should be_within(0.01).of(1500)
-    timings[:test2].should be_within(0.01).of(1000)
-    timings[:test3].should be_within(0.01).of(500)
+    timings[:test1].should be_within(0.5).of(1500)
+    timings[:test2].should be_within(0.5).of(1000)
+    timings[:test3].should be_within(0.5).of(500)
   end
 
   it '.in_realtime_block?' do


### PR DESCRIPTION
Testing the overhead of benchmarking doesn't need such granular precision.

This is to lessen the frequency of test failures such as [this](https://travis-ci.org/ManageIQ/manageiq/jobs/38942808)
cc @Fryguy 
