### PR TITLE
remove error text in lib rspecs

### DIFF
--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -279,6 +279,7 @@ describe ApplianceConsole::Cli do
         end
 
         it "fails to generate an encryption key" do
+          expect($stderr).to receive(:puts).at_least(2).times
           subject.parse(%w(--internal --region 1 --key))
           expect_v2_key(true)
           expect(subject).to be_key

--- a/lib/spec/appliance_console/key_configuration_spec.rb
+++ b/lib/spec/appliance_console/key_configuration_spec.rb
@@ -89,6 +89,7 @@ describe ApplianceConsole::KeyConfiguration do
         end
 
         it "fails if key exists (no force)" do
+          expect($stderr).to receive(:puts).at_least(2).times
           subject.force = false
           v2_exists(true)
           expect(FileUtils).not_to receive(:rm)

--- a/lib/spec/openstack/openstack_handle/handle_spec.rb
+++ b/lib/spec/openstack/openstack_handle/handle_spec.rb
@@ -49,7 +49,7 @@ describe OpenstackHandle::Handle do
 
       # setup the socket error for the initial non-ssl failure
       socket_error = double('socket_error')
-      socket_error.should_receive(:message).any_number_of_times.and_return("end of file reached (EOFError)")
+      allow(socket_error).to receive(:message).and_return("end of file reached (EOFError)")
       socket_error.should_receive(:class).and_return(Object)
       socket_error.should_receive(:backtrace)
 


### PR DESCRIPTION
there is stderr from the key configuration complaining about key files existing
there are deprecation warning around `any_number_of_times`
