### PR TITLE
Remove at_exit exception handling monkey patch

### DIFF
--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -99,20 +99,3 @@ VCR.configure do |c|
   #c.debug_logger = File.open(Rails.root.join("log", "vcr_debug.log"), "w")
   #c.debug_logger = File.open(File.join(ENV['CC_BUILD_ARTIFACTS'], "vcr_debug.log"), "w") if ENV['CC_BUILD_ARTIFACTS']
 end
-
-# TODO: Remove this once 1.9.3 has this fixed
-# ruby 1.9.2+ (1.9.3-p194) doesn't propagate exit codes properly when exceptions occur in an at_exit.
-# The vmdb project reported 'green' despite test failures raising exceptions which set non-zero exit codes.
-# http://bugs.ruby-lang.org/issues/5218
-if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
-  module Kernel
-    alias :__at_exit :at_exit
-    def at_exit(&block)
-      __at_exit do
-        exit_status = $!.status if $!.is_a?(SystemExit)
-        block.call
-        exit exit_status if exit_status
-      end
-    end
-  end
-end


### PR DESCRIPTION
This is not an issue with newer versions of ruby 1.9.3 and 2.0.0+ as the exit
code does NOT get reset to 0.

Fixes #846

Example code from: https://bugs.ruby-lang.org/issues/5218

``` ruby
at_exit do
  raise "X" rescue nil
end

at_exit do
  nil
end

at_exit do
  exit 1
end

at_exit do
  exit 2
end
```

```
$ ruby -v
ruby 2.0.0p576 (2014-09-19) [x86_64-darwin13.4.0]
$ ruby at_exit.rb; echo $?
1
```

```
$ ruby -v
ruby 1.9.3p547 (2014-05-14) [x86_64-darwin13.4.0]
$ ruby at_exit.rb; echo $?
1
```
