### PR TITLE
Don't generate the v2 key, use the one in source control.

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -249,5 +249,5 @@ export LC_ALL=en_US.UTF-8
 sysctl -p "/etc/sysctl.conf"
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
-appliance_console_cli --region 0 --internal --key --password smartvm
+appliance_console_cli --region 0 --internal --password smartvm
 %end


### PR DESCRIPTION
Fixes #944
Fallout from #936 

[skip ci]

cc @kbrock 
