### PR TITLE
Use gem version of rest-client

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -33,7 +33,7 @@ gem "rufus-lru",            "~>1.0.3",   :require => false
 gem "uuidtools",            "~>2.1.3",   :require => false
 gem "sass",                 "3.1.20",    :require => false
 gem "trollop",              "~>1.16.2",  :require => false
-
+gem "rest-client",          "~>1.7.2",   :require => false
 # qpid group is needed to gate the inclusion of qpid_messaging gem on platforms
 # where the qpid-cpp-client-devel package is not available.  This includes
 # OSX, Windows, and CruiseControl machines.
@@ -55,7 +55,6 @@ end
 
 # Locally modified but not required
 gem "handsoap",    "~>0.2.5",   :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-2"
-gem "rest-client", "~>1.6.7",   :require => false, :git => "git://github.com/ManageIQ/rest-client.git", :tag => "v1.6.7-5"
 gem "rubywbem",    "=0.1.0",    :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :tag => "v0.1.0-2"
 
 ### Start of gems excluded from the appliances.


### PR DESCRIPTION
The patch that we forked for has been merged.

Unfortunately ssl v3 needs to be disabled, so we need to find an alternative here.

@gmcculloug @blomquisg do we have plans for ssl on RHEVM?
