### PR TITLE
Fully qualified name for automate was missing leading /

### DIFF
--- a/vmdb/app/models/miq_ae_namespace.rb
+++ b/vmdb/app/models/miq_ae_namespace.rb
@@ -14,7 +14,7 @@ class MiqAeNamespace < ActiveRecord::Base
   def self.find_by_fqname(fqname, include_classes = true)
     return nil if fqname.blank?
 
-    fqname   = fqname[1..-1] if fqname[0] == '/'
+    fqname   = fqname[0] == '/' ? fqname : "/#{fqname}"
     fqname   = fqname.downcase
     last     = fqname.split('/').last
     low_name = arel_table[:name].lower
@@ -69,7 +69,7 @@ class MiqAeNamespace < ActiveRecord::Base
   end
 
   def fqname
-    @fqname ||= ancestors.collect(&:name).reverse.push(name).join('/')
+    @fqname ||= "/#{ancestors.collect(&:name).reverse.push(name).join('/')}"
   end
 
   def editable?
@@ -84,7 +84,7 @@ class MiqAeNamespace < ActiveRecord::Base
   end
 
   def fqname_sans_domain
-    fqname.split('/')[1..-1].join("/")
+    fqname.split('/')[2..-1].join("/")
   end
 
   def domain_name

--- a/vmdb/app/models/miq_ae_yaml_export.rb
+++ b/vmdb/app/models/miq_ae_yaml_export.rb
@@ -93,7 +93,7 @@ class MiqAeYamlExport
   def write_namespace_file(ns_obj)
     $log.info("#{self.class} Exporting namespace: <#{ns_obj.fqname}>")
     envelope_hash = setup_envelope(ns_obj, NAMESPACE_OBJ_TYPE).to_yaml
-    write_export_file('fqname'          => swap_domain_name(ns_obj.fqname),
+    write_export_file('fqname'          => swap_domain_path(ns_obj.fqname),
                       'output_filename' => NAMESPACE_YAML_FILENAME,
                       'export_data'     => envelope_hash,
                       'created_on'      => ns_obj.created_on,
@@ -132,7 +132,7 @@ class MiqAeYamlExport
   def write_class_schema(ns_fqname, class_obj)
     envelope_hash = setup_envelope(class_obj, CLASS_OBJ_TYPE)
     envelope_hash['object']['schema'] = class_obj.export_schema
-    write_export_file('fqname'          => swap_domain_name(ns_fqname),
+    write_export_file('fqname'          => swap_domain_path(ns_fqname),
                       'class_name'      => "#{class_obj.name}#{CLASS_DIR_SUFFIX}",
                       'output_filename' => CLASS_YAML_FILENAME,
                       'export_data'     => envelope_hash.to_yaml,
@@ -142,7 +142,7 @@ class MiqAeYamlExport
   end
 
   def write_all_instances(ns_fqname, class_obj)
-    export_file_hash = {'fqname'     => swap_domain_name(ns_fqname),
+    export_file_hash = {'fqname'     => swap_domain_path(ns_fqname),
                         'class_name' => "#{class_obj.name}#{CLASS_DIR_SUFFIX}"}
     class_obj.ae_instances.sort_by(&:fqname).each do |inst|
       file_name = inst.name.gsub('.', '_')
@@ -158,7 +158,7 @@ class MiqAeYamlExport
   end
 
   def write_all_methods(ns_fqname, class_obj)
-    export_file_hash = {'fqname' => swap_domain_name(ns_fqname)}
+    export_file_hash = {'fqname' => swap_domain_path(ns_fqname)}
     export_file_hash['class_name'] = "#{class_obj.name}#{CLASS_DIR_SUFFIX}/#{METHOD_FOLDER_NAME}"
     class_obj.ae_methods.sort_by(&:fqname).each do |meth_obj|
       export_file_hash['created_on'] = meth_obj.created_on
@@ -252,8 +252,13 @@ class MiqAeYamlExport
     end
   end
 
-  def swap_domain_name(fqname)
+  def swap_domain_name(name)
+    return name if @options['export_as'].blank?
+    name.gsub(/^#{@domain}/, @options['export_as'])
+  end
+
+  def swap_domain_path(fqname)
     return fqname if @options['export_as'].blank?
-    fqname.gsub(/^#{@domain}/, @options['export_as'])
+    fqname.gsub(/^\/#{@domain}/, @options['export_as'])
   end
 end

--- a/vmdb/app/models/miq_ae_yaml_export_consolidated.rb
+++ b/vmdb/app/models/miq_ae_yaml_export_consolidated.rb
@@ -15,6 +15,7 @@ class MiqAeYamlExportConsolidated < MiqAeYamlExport
 
   def write_data(base_path, export_hash)
     path = File.join(base_path, export_hash['output_filename']).split('/')
+    path.shift  if base_path[0, 1]  == '/'
     data = export_hash['export_data']
     data = YAML.load(data) if export_hash['output_filename'].ends_with?('.yaml')
     path << data

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -313,9 +313,7 @@ module MiqAeMethodService
 
         aec.ae_instances.select { |i| instance_re =~ i.name }.each do |aei|
           iname = if options[:path]
-                    MiqAeEngine::MiqAePath.new(:ae_namespace => aec.namespace,
-                                               :ae_class     => aec.name,
-                                               :ae_instance  => aei.name).to_s
+                    aei.fqname
                   else
                     aei.name
                   end

--- a/vmdb/spec/models/miq_ae_class_spec.rb
+++ b/vmdb/spec/models/miq_ae_class_spec.rb
@@ -76,11 +76,11 @@ describe MiqAeClass do
       set_priority('domain1', 10)
       set_priority('domain2', 20)
       set_priority('domain3', 50)
-      @inst4_list =  %w(DOMAIN3/SYSTEM/PROCESS/inst4  DOMAIN1/SYSTEM/PROCESS/inst4)
-      @sorted_inst_list =  ['DOMAIN3/SYSTEM/PROCESS/inst1', 'DOMAIN3/SYSTEM/PROCESS/inst2',
-                            'DOMAIN3/SYSTEM/PROCESS/inst32', 'DOMAIN3/SYSTEM/PROCESS/inst4',
-                            'DOMAIN2/SYSTEM/PROCESS/inst31', 'DOMAIN2/SYSTEM/PROCESS/inst41',
-                            'DOMAIN1/SYSTEM/PROCESS/inst3']
+      @inst4_list =  %w(/DOMAIN3/SYSTEM/PROCESS/inst4  /DOMAIN1/SYSTEM/PROCESS/inst4)
+      @sorted_inst_list =  ['/DOMAIN3/SYSTEM/PROCESS/inst1', '/DOMAIN3/SYSTEM/PROCESS/inst2',
+                            '/DOMAIN3/SYSTEM/PROCESS/inst32', '/DOMAIN3/SYSTEM/PROCESS/inst4',
+                            '/DOMAIN2/SYSTEM/PROCESS/inst31', '/DOMAIN2/SYSTEM/PROCESS/inst41',
+                            '/DOMAIN1/SYSTEM/PROCESS/inst3']
     end
 
     it 'invalid path should return an empty array' do

--- a/vmdb/spec/models/miq_ae_domain_spec.rb
+++ b/vmdb/spec/models/miq_ae_domain_spec.rb
@@ -88,7 +88,7 @@ describe MiqAeDomain do
 
     it "get same named classes" do
       create_multiple_domains
-      expected = %w(DOM2/A/b/C/cLaSS1 DOM1/A/B/C/CLASS1 DOM3/a/B/c/CLASs1)
+      expected = %w(/DOM2/A/b/C/cLaSS1 /DOM1/A/B/C/CLASS1 /DOM3/a/B/c/CLASs1)
       result = MiqAeClass.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1', true)
       expected.should match_array(result.each.collect(&:fqname))
     end
@@ -107,10 +107,10 @@ describe MiqAeDomain do
     it "get same named instances" do
       create_multiple_domains
       expected = %w(
-        DOM5/A/B/C/CLASS1/instance1
-        DOM2/A/b/C/cLaSS1/instance1
-        DOM1/A/B/C/CLASS1/instance1
-        DOM3/a/B/c/CLASs1/instance1
+        /DOM5/A/B/C/CLASS1/instance1
+        /DOM2/A/b/C/cLaSS1/instance1
+        /DOM1/A/B/C/CLASS1/instance1
+        /DOM3/a/B/c/CLASs1/instance1
       )
       result = MiqAeInstance.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/instance1')
       expected.should match_array(result.each.collect(&:fqname))
@@ -129,7 +129,7 @@ describe MiqAeDomain do
 
     it "get same named methods" do
       create_multiple_domains_with_methods
-      expected = %w(DOM2/A/b/C/cLaSS1/method1 DOM1/A/B/C/CLASS1/method1 DOM3/a/B/c/CLASs1/method1)
+      expected = %w(/DOM2/A/b/C/cLaSS1/method1 /DOM1/A/B/C/CLASS1/method1 /DOM3/a/B/c/CLASs1/method1)
       result = MiqAeMethod.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/method1', true)
       expected.should match_array(result.each.collect(&:fqname))
     end


### PR DESCRIPTION
Fixes to the 2 spec and model code to put a leading / for fqnames
