### PR TITLE
Fix typos in javascript_focus() calls

### DIFF
--- a/vmdb/app/views/miq_ae_class/_class_form.html.erb
+++ b/vmdb/app/views/miq_ae_class/_class_form.html.erb
@@ -21,7 +21,7 @@
               "data-miq_observe" => {:interval => '.5',
                                      :url      => url}.to_json)
           %>
-          <%= javascript_tag(javascript_focus('#name')) %>
+          <%= javascript_tag(javascript_focus('name')) %>
         </td>
       </tr>
       <tr>

--- a/vmdb/app/views/miq_ae_class/_ns_list.html.erb
+++ b/vmdb/app/views/miq_ae_class/_ns_list.html.erb
@@ -53,7 +53,7 @@
                                 "data-miq_observe" => {:interval => '.5',
                                                        :url      => url}.to_json)
             %>
-            <%= javascript_tag(javascript_focus('#ns_name')) %>
+            <%= javascript_tag(javascript_focus('ns_name')) %>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
The forms for adding a new Automate namespace or adding a new class to an existing namespace are rendering as expected again.

@h-kataria please review.
