### PR TITLE
Fix openstack C&U collection with irregular intervals

### DIFF
--- a/vmdb/app/models/metric/ci_mixin/capture/openstack.rb
+++ b/vmdb/app/models/metric/ci_mixin/capture/openstack.rb
@@ -36,26 +36,35 @@ module Metric::CiMixin::Capture::Openstack
     @perf_ems = nil
   end
 
+  def list_meters(field_name = "resource_id", capture_method = :capture_counters)
+    instance_filter = {"field" => field_name, "value" => self.ems_ref}
+    counters, _ = Benchmark.realtime_block(capture_method) do
+      @perf_ems.list_meters([instance_filter]).body
+    end
+    counters.each { |c| c[:instance_filter] = instance_filter }
+    counters
+  end
+
+  def list_metadata_meters
+    list_meters("metadata.instance_id", :capture_meta_counters)
+  end
+
+  def meter_names
+    @meter_names ||= Metric::Capture::Openstack::COUNTER_NAMES
+  end
+
+  def find_meter_counters
+    counters = list_meters + list_metadata_meters
+    counters.select { |c| meter_names.include? c["name"] }
+  end
+
   def perf_capture_data_openstack(start_time, end_time)
     # some meters can get gathered by directly querying for the "resource_id",
     #   but other meters can only be gathered by examining the
     #   "metadata.instance_id"
     log_header = "MIQ(#{self.class.name}.perf_collect_data_openstack) [#{start_time} - #{end_time}]"
-    counter_instance_filters = {}
-    instance_filter = {"field" => "resource_id", "value" => self.ems_ref}
-    counters, _ = Benchmark.realtime_block(:capture_counters) do
-      @perf_ems.list_meters([instance_filter]).body
-    end
-    counters.each {|m| m[:instance_filter] = instance_filter}
 
-    instance_filter = {"field" => "metadata.instance_id", "value" => self.ems_ref}
-    meta_counters, _ = Benchmark.realtime_block(:capture_meta_counters) do
-      @perf_ems.list_meters([instance_filter]).body
-    end
-    meta_counters.each {|m| m[:instance_filter] = instance_filter}
-    counters += meta_counters
-
-    counters.select! {|c| Metric::Capture::Openstack::COUNTER_NAMES.include? c["name"]}
+    counters = find_meter_counters
 
     # We will have to account for the fact that each counter can be configured
     # for individual capture intervals ... the out-of-box default is 10min
@@ -63,92 +72,114 @@ module Metric::CiMixin::Capture::Openstack
 
     metrics_by_counter_name = {}
     counters.each do |c|
-      metrics = metrics_by_counter_name[c["name"]] = {}
-
-      # For now, this logic just mirrors how we capture Amazon CloudWatch data
-      # (see amazon.rb)
-      (start_time..end_time).step_value(1.day).each_cons(2) do |st, et|
-        filter = [{"field" => "timestamp", "op" => "lt", "value" => et.iso8601},
-                  {"field" => "timestamp", "op" => "gt", "value" => st.iso8601},
-                  c[:instance_filter]]
-        statistics, _ = Benchmark.realtime_block(:capture_counter_values) do
-          # try to capture for every 20s over the timeframe ... however, the
-          # server can be configured for any arbitrary capture interval
-          # we'll deal with that below
-          @perf_ems.get_statistics(c["name"], options={'period'=>20, 'q'=>filter}).body
-        end
-
-        # This is a pretty bad hack to work around a problem with the timestamp
-        #   values that come back from ceilometer.  The timestamps come back
-        #   without a timezone specifier, e.g.: "2013-08-23T20:06:09".
-        #   The time value is actually in UTC, but there's nothing about the
-        #   string which indicates that.
-        # This hack looks at the length of the string and tries to determine if
-        #   the timezone information is missing.  If so, it appends "Z" (zulu
-        #   time) to the string to indicate UTC before it is parsed.  This will
-        #   force a UTC timezone in order to keep the value consistent with what
-        #   was intended--but not indicated--by ceilometer.
-        # http://lists.openstack.org/pipermail/openstack-dev/2012-November/002235.html
-        statistics.each do |s|
-          duration_end = s["duration_end"]
-          duration_end << "Z" if duration_end.size == 19
-          timestamp = Time.parse(duration_end)
-          metrics[timestamp] = s["avg"]
-        end
-      end
+      metrics_by_counter_name[c["name"]] = collect_metrics_by_counter(c, start_time, end_time)
     end
 
-    counter_values_by_ts = {}
-    Metric::Capture::Openstack::COUNTER_INFO.each do |i|
-      timestamps = i[:openstack_counters].collect { |c| metrics_by_counter_name[c].try(:keys) }.flatten.compact.uniq.sort
-
-      aggregate = []
-      agg_start = nil
-      timestamps.each_cons(2) do |last_ts, ts|
-        agg_start ||= last_ts
-
-        interval     = ts - last_ts
-        metrics      = i[:openstack_counters].collect { |c| metrics_by_counter_name.fetch_path(c, ts) }
-        value        = i[:calculation].call(*metrics, interval)
-
-        # break down values from cumulative meters into discrete values
-        if Metric::Capture::Openstack.is_diff_meter? i[:openstack_counters]
-          last_metrics = i[:openstack_counters].collect { |c| metrics_by_counter_name.fetch_path(c, last_ts) }
-          last_value   = i[:calculation].call(*last_metrics, interval)
-          value = value - last_value
-        end
-
-        # if the interval is not divisible by 20, keep an aggregate interval
-        # the two main risks here are:
-        #   1. the openstack admin configured a crazy interval like 17sec
-        #   2. one of the configured intervals contains an outlier that is
-        #      "sanded down" by the surrounding aggregated values
-        if interval % 20 != 0
-          aggregate << value
-          interval = ts - agg_start
-          # if the aggregate interval is divisible by 20,
-          #   average over the aggregate
-          #   reset the last_ts for the VIM API symmetry below
-          #   reset the agg_start
-          if interval % 20 == 0
-            value = aggregate.inject(0.0){|sum, el| sum + el} / aggregate.size
-            last_ts = agg_start
-            agg_start = ts
-          else
-            # the aggregate is still not divisible by 20, grab the next stat
-            next
-          end
-        end
-
-        # For (temporary) symmetry with VIM API we create 20-second intervals.
-        (last_ts + 20.seconds..ts).step_value(20.seconds).each do |ts|
-          counter_values_by_ts.store_path(ts.iso8601, i[:vim_style_counter_key], value)
-        end
-      end
-    end
+    ## process the openstack statistics to make them look like vmware statistics
+    counter_values_by_ts = process_statistics(metrics_by_counter_name)
 
     counters_by_id              = {self.ems_ref => Metric::Capture::Openstack::VIM_STYLE_COUNTERS}
     counter_values_by_id_and_ts = {self.ems_ref => counter_values_by_ts}
     return counters_by_id, counter_values_by_id_and_ts
+  end
+
+  def collect_metrics_by_counter(counter, start_time, end_time)
+    metrics = {}
+
+    # For now, this logic just mirrors how we capture Amazon CloudWatch data
+    # (see amazon.rb)
+    (start_time..end_time).step_value(1.day).each_cons(2) do |st, et|
+      filter = [{"field" => "timestamp", "op" => "lt", "value" => et.iso8601},
+                {"field" => "timestamp", "op" => "gt", "value" => st.iso8601},
+                counter[:instance_filter]]
+      statistics, _ = Benchmark.realtime_block(:capture_counter_values) do
+        # try to capture for every 20s over the timeframe ... however, the
+        # server can be configured for any arbitrary capture interval
+        # we'll deal with that below
+        @perf_ems.get_statistics(counter["name"], 'period' => 20, 'q' => filter).body
+      end
+
+      # This is a pretty bad hack to work around a problem with the timestamp
+      #   values that come back from ceilometer.  The timestamps come back
+      #   without a timezone specifier, e.g.: "2013-08-23T20:06:09".
+      #   The time value is actually in UTC, but there's nothing about the
+      #   string which indicates that.
+      # This hack looks at the length of the string and tries to determine if
+      #   the timezone information is missing.  If so, it appends "Z" (zulu
+      #   time) to the string to indicate UTC before it is parsed.  This will
+      #   force a UTC timezone in order to keep the value consistent with what
+      #   was intended--but not indicated--by ceilometer.
+      # http://lists.openstack.org/pipermail/openstack-dev/2012-November/002235.html
+      statistics.each do |s|
+        duration_end = s["duration_end"]
+        duration_end << "Z" if duration_end.size == 19
+        timestamp = Time.parse(duration_end)
+        metrics[timestamp] = s["avg"]
+      end
+    end
+    metrics
+  end
+
+  def process_statistics(metrics_by_counter_name)
+    log_header = "MIQ(#{self.class.name}.#{__method__})"
+    counter_values_by_ts = {}
+
+    # Sometimes the metric capture intervals slightly exceed the configured
+    # value when openstack is under heavy load.
+    # Capture the extra seconds in the remainder values
+    remainder_seconds    = 0
+    remainder_value      = 0
+
+    Metric::Capture::Openstack::COUNTER_INFO.each do |i|
+      timestamps = i[:openstack_counters].collect { |c| metrics_by_counter_name[c].try(:keys) }.flatten.compact.uniq.sort
+
+      # loop through each interval and break it down into 20sec chunks
+      # this is purely to match vmware C&U logic
+      timestamps.each_cons(2) do |ts, next_ts|
+        interval = next_ts - ts
+        # skip any intervals that are fewer than 20sec
+        if interval < 20.seconds
+          $log.warn("#{log_header} [#{self.name}] Capture interval invalid--fewer than 20sec.  #{ts} - #{next_ts}")
+          next
+        end
+        metrics  = i[:openstack_counters].collect { |c| metrics_by_counter_name.fetch_path(c, ts) }
+        value    = i[:calculation].call(*metrics, interval)
+
+        # Some meters store the cumulative values instead of snapshots of usage
+        # (e.g., disk reads).
+        # break down cumulative meter values into discrete values
+        # e.g., 10, 20, 25, 35, 40 => 10, 10, 5, 10, 5
+        if Metric::Capture::Openstack.is_diff_meter? i[:openstack_counters]
+          next_metrics = i[:openstack_counters].collect { |c| metrics_by_counter_name.fetch_path(c, next_ts) }
+          next_value   = i[:calculation].call(*next_metrics, interval)
+          value        = next_value - value
+        end
+
+        # add in the remainder and previous value from the previous interval
+        # and create a single 20 second time slot with a value that's the
+        # average of the previous interval's value and this interval's value
+        if remainder_seconds > 0
+          # steal from the current interval in order to create a "catchup" value
+          interval -= (20 - remainder_seconds)
+          ts       += (20 - remainder_seconds)
+
+          # store the catchup value in the hash
+          catchup_value = (value + remainder_value) / 2
+          counter_values_by_ts.store_path((ts - 20.seconds).iso8601, i[:vim_style_counter_key], catchup_value)
+        end
+
+        # determine if there's a remainder for the next iteration
+        remainder_seconds = interval % 20
+        remainder_value   = value
+
+        # divide the interval into 20s segments ... each segment gets the value
+        # for the entire interval
+        range = (remainder_seconds == 0) ? (ts..next_ts) : (ts...(next_ts - 20.seconds))
+        range.step_value(20.seconds).each do |timestamp|
+          counter_values_by_ts.store_path(timestamp.iso8601, i[:vim_style_counter_key], value)
+        end
+      end
+    end
+    counter_values_by_ts
   end
 end

--- a/vmdb/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
+++ b/vmdb/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
@@ -1,0 +1,673 @@
+# Think twice before editing this file!
+# spec/models/metric/ci_mixin/capture/openstack_spec.rb uses the values in this
+# file and is highly dependent on specific values.
+# It's in your best interest to read that spec before editing this file.
+# NB: some of the values here don't make sense.  That's on purpose.  Well, it's
+# actually laziness.  The only values used by the spec of any importance are
+# "duration_end" and "avg".
+---
+  cpu_util:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 59.732767253505116
+    max: 59.732767253505116
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:04"
+    avg: 50
+    sum: 59.732767253505116
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 93.22194385928294
+    max: 93.22194385928294
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:04"
+    avg: 100
+    sum: 93.22194385928294
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:15"
+    min: 69.18954688449031
+    max: 69.18954688449031
+    duration_end: "2013-08-28T11:03:15"
+    period: 20
+    period_end: "2013-08-28T11:03:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:04"
+    avg: 25
+    sum: 69.18954688449031
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:18"
+    min: 90.25964906693075
+    max: 90.25964906693075
+    duration_end: "2013-08-28T11:04:18"
+    period: 20
+    period_end: "2013-08-28T11:04:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:04"
+    avg: 50
+    sum: 90.25964906693075
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:21"
+    min: 58.68941796269206
+    max: 58.68941796269206
+    duration_end: "2013-08-28T11:05:21"
+    period: 20
+    period_end: "2013-08-28T11:05:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:04"
+    avg: 25
+    sum: 58.68941796269206
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:23"
+    min: 89.69734809669511
+    max: 89.69734809669511
+    duration_end: "2013-08-28T11:06:23"
+    period: 20
+    period_end: "2013-08-28T11:06:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:04"
+    avg: 100
+    sum: 89.69734809669511
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:25"
+    min: 58.72447525285487
+    max: 58.72447525285487
+    duration_end: "2013-08-28T11:07:25"
+    period: 20
+    period_end: "2013-08-28T11:07:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:04"
+    avg: 0
+    sum: 58.72447525285487
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:27"
+    min: 89.81626981074749
+    max: 89.81626981074749
+    duration_end: "2013-08-28T11:08:27"
+    period: 20
+    period_end: "2013-08-28T11:08:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:04"
+    avg: 100
+    sum: 89.81626981074749
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:28"
+    min: 58.51123473402716
+    max: 58.51123473402716
+    duration_end: "2013-08-28T11:09:28"
+    period: 20
+    period_end: "2013-08-28T11:09:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:04"
+    avg: 25
+    sum: 58.51123473402716
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:29"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T11:10:29"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 50
+    sum: 89.74293759622134
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T11:10:39"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 50
+    sum: 89.74293759622134
+  disk.read.bytes:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:15"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:03:15"
+    period: 20
+    period_end: "2013-08-28T11:03:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:18"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:04:18"
+    period: 20
+    period_end: "2013-08-28T11:04:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:21"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:05:21"
+    period: 20
+    period_end: "2013-08-28T11:05:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:23"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:06:23"
+    period: 20
+    period_end: "2013-08-28T11:06:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:25"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:07:25"
+    period: 20
+    period_end: "2013-08-28T11:07:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:27"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:08:27"
+    period: 20
+    period_end: "2013-08-28T11:08:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:28"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:09:28"
+    period: 20
+    period_end: "2013-08-28T11:09:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:29"
+    min: 507942400.0
+    max: 507942400.0
+    duration_end: "2013-08-28T11:10:29"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 507942400.0
+    sum: 507942400.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T11:10:39"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 50
+    sum: 89.74293759622134
+  disk.write.bytes:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 58125377536.0
+    max: 58125377536.0
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:04"
+    avg: 58125377536.0
+    sum: 58125377536.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 58149425152.0
+    max: 58149425152.0
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:04"
+    avg: 58149425152.0
+    sum: 58149425152.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:15"
+    min: 58192719872.0
+    max: 58192719872.0
+    duration_end: "2013-08-28T11:03:15"
+    period: 20
+    period_end: "2013-08-28T11:03:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:04"
+    avg: 58192719872.0
+    sum: 58192719872.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:18"
+    min: 58204168192.0
+    max: 58204168192.0
+    duration_end: "2013-08-28T11:04:18"
+    period: 20
+    period_end: "2013-08-28T11:04:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:04"
+    avg: 58204168192.0
+    sum: 58204168192.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:21"
+    min: 58212818944.0
+    max: 58212818944.0
+    duration_end: "2013-08-28T11:05:21"
+    period: 20
+    period_end: "2013-08-28T11:05:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:04"
+    avg: 58212818944.0
+    sum: 58212818944.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:23"
+    min: 58218557440.0
+    max: 58218557440.0
+    duration_end: "2013-08-28T11:06:23"
+    period: 20
+    period_end: "2013-08-28T11:06:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:04"
+    avg: 58218557440.0
+    sum: 58218557440.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:25"
+    min: 58223599616.0
+    max: 58223599616.0
+    duration_end: "2013-08-28T11:07:25"
+    period: 20
+    period_end: "2013-08-28T11:07:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:04"
+    avg: 58223599616.0
+    sum: 58223599616.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:27"
+    min: 58229735424.0
+    max: 58229735424.0
+    duration_end: "2013-08-28T11:08:27"
+    period: 20
+    period_end: "2013-08-28T11:08:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:04"
+    avg: 58229735424.0
+    sum: 58229735424.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:28"
+    min: 58234626048.0
+    max: 58234626048.0
+    duration_end: "2013-08-28T11:09:28"
+    period: 20
+    period_end: "2013-08-28T11:09:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:04"
+    avg: 58234626048.0
+    sum: 58234626048.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:29"
+    min: 58240987136.0
+    max: 58240987136.0
+    duration_end: "2013-08-28T11:10:29"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 58240987136.0
+    sum: 58240987136.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T11:10:39"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 50
+    sum: 89.74293759622134
+  network.incoming.bytes:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 134681418.0
+    max: 134681418.0
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:04"
+    avg: 134681418.0
+    sum: 134681418.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 134682753.0
+    max: 134682753.0
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:04"
+    avg: 134682753.0
+    sum: 134682753.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:15"
+    min: 134732080.0
+    max: 134732080.0
+    duration_end: "2013-08-28T11:03:15"
+    period: 20
+    period_end: "2013-08-28T11:03:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:04"
+    avg: 134732080.0
+    sum: 134732080.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:18"
+    min: 134733457.0
+    max: 134733457.0
+    duration_end: "2013-08-28T11:04:18"
+    period: 20
+    period_end: "2013-08-28T11:04:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:04"
+    avg: 134733457.0
+    sum: 134733457.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:21"
+    min: 134734792.0
+    max: 134734792.0
+    duration_end: "2013-08-28T11:05:21"
+    period: 20
+    period_end: "2013-08-28T11:05:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:04"
+    avg: 134734792.0
+    sum: 134734792.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:23"
+    min: 134736127.0
+    max: 134736127.0
+    duration_end: "2013-08-28T11:06:23"
+    period: 20
+    period_end: "2013-08-28T11:06:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:04"
+    avg: 134736127.0
+    sum: 134736127.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:25"
+    min: 134739000.0
+    max: 134739000.0
+    duration_end: "2013-08-28T11:07:25"
+    period: 20
+    period_end: "2013-08-28T11:07:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:04"
+    avg: 134739000.0
+    sum: 134739000.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:27"
+    min: 134740467.0
+    max: 134740467.0
+    duration_end: "2013-08-28T11:08:27"
+    period: 20
+    period_end: "2013-08-28T11:08:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:04"
+    avg: 134740467.0
+    sum: 134740467.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:28"
+    min: 134741802.0
+    max: 134741802.0
+    duration_end: "2013-08-28T11:09:28"
+    period: 20
+    period_end: "2013-08-28T11:09:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:04"
+    avg: 134741802.0
+    sum: 134741802.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:29"
+    min: 134743538.0
+    max: 134743538.0
+    duration_end: "2013-08-28T11:10:29"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 134743538.0
+    sum: 134743538.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T11:10:39"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 50
+    sum: 89.74293759622134
+  network.outgoing.bytes:
+  -
+    count: 1
+    duration_start: "2013-08-28T11:01:09"
+    min: 196678550.0
+    max: 196678550.0
+    duration_end: "2013-08-28T11:01:09"
+    period: 20
+    period_end: "2013-08-28T11:01:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:01:04"
+    avg: 196678550.0
+    sum: 196678550.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:02:12"
+    min: 196679966.0
+    max: 196679966.0
+    duration_end: "2013-08-28T11:02:12"
+    period: 20
+    period_end: "2013-08-28T11:02:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:02:04"
+    avg: 196679966.0
+    sum: 196679966.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:03:15"
+    min: 196691325.0
+    max: 196691325.0
+    duration_end: "2013-08-28T11:03:15"
+    period: 20
+    period_end: "2013-08-28T11:03:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:03:04"
+    avg: 196691325.0
+    sum: 196691325.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:04:18"
+    min: 196692783.0
+    max: 196692783.0
+    duration_end: "2013-08-28T11:04:18"
+    period: 20
+    period_end: "2013-08-28T11:04:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:04:04"
+    avg: 196692783.0
+    sum: 196692783.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:05:21"
+    min: 196694199.0
+    max: 196694199.0
+    duration_end: "2013-08-28T11:05:21"
+    period: 20
+    period_end: "2013-08-28T11:05:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:05:04"
+    avg: 196694199.0
+    sum: 196694199.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:06:23"
+    min: 196695615.0
+    max: 196695615.0
+    duration_end: "2013-08-28T11:06:23"
+    period: 20
+    period_end: "2013-08-28T11:06:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:06:04"
+    avg: 196695615.0
+    sum: 196695615.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:07:25"
+    min: 196706601.0
+    max: 196706601.0
+    duration_end: "2013-08-28T11:07:25"
+    period: 20
+    period_end: "2013-08-28T11:07:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:07:04"
+    avg: 196706601.0
+    sum: 196706601.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:08:27"
+    min: 196708017.0
+    max: 196708017.0
+    duration_end: "2013-08-28T11:08:27"
+    period: 20
+    period_end: "2013-08-28T11:08:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:08:04"
+    avg: 196708017.0
+    sum: 196708017.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:09:28"
+    min: 196709433.0
+    max: 196709433.0
+    duration_end: "2013-08-28T11:09:28"
+    period: 20
+    period_end: "2013-08-28T11:09:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:09:04"
+    avg: 196709433.0
+    sum: 196709433.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:29"
+    min: 196711321.0
+    max: 196711321.0
+    duration_end: "2013-08-28T11:10:29"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 196711321.0
+    sum: 196711321.0
+  -
+    count: 1
+    duration_start: "2013-08-28T11:10:39"
+    min: 89.74293759622134
+    max: 89.74293759622134
+    duration_end: "2013-08-28T11:10:39"
+    period: 20
+    period_end: "2013-08-28T11:10:24"
+    duration: 0.0
+    period_start: "2013-08-28T11:10:04"
+    avg: 50
+    sum: 89.74293759622134


### PR DESCRIPTION
When OpenStack compute nodes are under heavy load, the ceilometer agent might
fall behind in metrics collection.  This will show up as adding an extra 2 or 3
seconds to the collection intervals.

E.g., whereas the out-of-the-box configuration for Ceilometer is to process data
every 10min.  When compute nodes are under load, the agent may miss that mark by
2 or 3 seconds, and end up processing data every 10:02 or 10:03.

This impact on the original metrics collection code was rather catastrophic.
The original collection logic attempted to bucket the intervals into 20
second chunks (to adhere to internal reporting and rollup requirements).  But,
when the collection intervals were not readily divisible by 20 seconds, the
collection logic would attempt to group that interval with the next interval and
average out the data points.

The problem with this approach is that if it cannot ever find a consecutive
grouping of intervals that is in totality divisible by 20 seconds, it fails to
register that *any* metrics were collected.

The new logic still attempts to break the intervals into 20 second buckets.
However, it handles irregular intervals by carrying forward remainder values.
For instance, take the following timestamps, intervals and average metric values
for cpu utilization.

10:00:00 - 10:10:01 601s,  5%
10:10:01 - 10:20:04 603s, 25%
10:20:04 - 10:30:06 602s, 10%
10:30:06 - 10:40:06 600s, 30%

In this case the new logic will create 20 second buckets like the following
(repeated values omitted for brevity):

10:00:20  5%
10:00:40  5%
10:01:00  5%
 :
 :
10:20:00  5%
10:20:20 15%  # average of 5% and 25%
10:20:40 25%
10:21:00 25%
 :
 :
10:30:00 25%
10:30:20 17.5% # average of 25% and 10%
10:30:40 10%
10:31:00 10%

At the end of this process, a 6sec chunk will fall on the floor because the
overall difference between 10:00:00 and 10:40:06 is 6 seconds.

However, we have two restrictions:  1) we must have 20 second buckets, and 2)
we are not guaranteed to get collection intervals that are divisible by 20.

@Fryguy, please review

https://bugzilla.redhat.com/show_bug.cgi?id=1148608