### PR TITLE
access rhevm with TLSv1 and above

### DIFF
--- a/lib/RedHatEnterpriseVirtualizationManagerAPI/rhevm_service.rb
+++ b/lib/RedHatEnterpriseVirtualizationManagerAPI/rhevm_service.rb
@@ -252,7 +252,7 @@ class RhevmService
 
   def resource_options
     headers = merge_headers({ 'Prefer' => 'persistent-auth' })
-    options = { :ssl_version => :SSLv3 }
+    options = {:ssl_version => 'TLSv1'}
 
     if self.session_id
       headers[:cookie]     = "#{SESSION_ID_KEY}=#{self.session_id}"


### PR DESCRIPTION
Upgrading ssl protocol to access RHEVM

@blomquisg I modified RHEVM - does this affect you?

https://bugzilla.redhat.com/show_bug.cgi?id=1159114
