### PR TITLE
Use AR relations to save fields/inputs and values

### DIFF
--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -3,9 +3,12 @@ class MiqAeClass < ActiveRecord::Base
   include MiqAeYamlImportExportMixin
 
   belongs_to :ae_namespace, :class_name => "MiqAeNamespace", :foreign_key => :namespace_id
-  has_many   :ae_fields,    :class_name => "MiqAeField",     :foreign_key => :class_id, :dependent => :destroy, :order => :priority
-  has_many   :ae_instances, :class_name => "MiqAeInstance",  :foreign_key => :class_id, :dependent => :destroy, :include => :ae_values
-  has_many   :ae_methods,   :class_name => "MiqAeMethod",    :foreign_key => :class_id, :dependent => :destroy
+  has_many   :ae_fields,    :class_name => "MiqAeField",     :foreign_key => :class_id,
+                            :dependent => :destroy, :order => :priority, :autosave => true
+  has_many   :ae_instances, :class_name => "MiqAeInstance",  :foreign_key => :class_id,
+                            :dependent => :destroy, :include => :ae_values
+  has_many   :ae_methods,   :class_name => "MiqAeMethod",    :foreign_key => :class_id,
+                            :dependent => :destroy
 
   validates_presence_of   :name, :namespace_id
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id

--- a/vmdb/app/models/miq_ae_instance.rb
+++ b/vmdb/app/models/miq_ae_instance.rb
@@ -2,8 +2,10 @@ class MiqAeInstance < ActiveRecord::Base
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 
-  belongs_to :ae_class,  :class_name => "MiqAeClass", :foreign_key => :class_id,    :include => :ae_fields
-  has_many   :ae_values, :class_name => "MiqAeValue", :foreign_key => :instance_id, :include => :ae_field, :dependent => :destroy
+  belongs_to :ae_class,  :class_name => "MiqAeClass", :foreign_key => :class_id,
+                         :include => :ae_fields
+  has_many   :ae_values, :class_name => "MiqAeValue", :foreign_key => :instance_id,
+                         :include => :ae_field, :dependent => :destroy, :autosave => true
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
   validates_presence_of   :name

--- a/vmdb/app/models/miq_ae_method.rb
+++ b/vmdb/app/models/miq_ae_method.rb
@@ -4,8 +4,9 @@ class MiqAeMethod < ActiveRecord::Base
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 
-  belongs_to :ae_class,     :class_name => "MiqAeClass", :foreign_key => :class_id
-  has_many   :inputs,       :class_name => "MiqAeField", :foreign_key => :method_id, :dependent => :destroy, :order => :priority
+  belongs_to :ae_class, :class_name => "MiqAeClass", :foreign_key => :class_id
+  has_many   :inputs,   :class_name => "MiqAeField", :foreign_key => :method_id,
+                        :dependent => :destroy, :order => :priority, :autosave => true
 
   validates_presence_of   :name, :scope
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]

--- a/vmdb/app/presenters/tree_builder_ae_class.rb
+++ b/vmdb/app/presenters/tree_builder_ae_class.rb
@@ -15,7 +15,7 @@ class TreeBuilderAeClass  < TreeBuilder
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(options)
     objects = if MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-                MiqAeDomain.where(:id => @sb[:domain_id])
+                [MiqAeDomain.find_by_id(@sb[:domain_id])] # GIT support can't use where
               else
                 MiqAeDomain.all
               end
@@ -34,7 +34,7 @@ class TreeBuilderAeClass  < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, options)
-    objects = MiqAeNamespace.all(:conditions => {:parent_id => object.id.to_i})
+    objects = object.ae_namespaces
     unless MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       ns_classes = object.ae_classes
       objects += ns_classes.flatten unless ns_classes.blank?

--- a/vmdb/app/views/miq_ae_class/_class_fields.html.erb
+++ b/vmdb/app/views/miq_ae_class/_class_fields.html.erb
@@ -67,7 +67,7 @@
                     <%= link_to(image_tag("/images/icons/16/notequal-red.png",
                                           :alt     => "Click to delete this field from schema"),
                                 {:action => "field_delete", 
-                                 :id     => field['id'].to_i,
+                                 :id     => field['id'].to_s,
                                  :arr_id => i },
                                 "data-miq_sparkle_on"  => true,
                                 "data-miq_sparkle_off" => true,

--- a/vmdb/app/views/miq_ae_class/_method_form.html.erb
+++ b/vmdb/app/views/miq_ae_class/_method_form.html.erb
@@ -107,7 +107,7 @@
                 <%= link_to(image_tag("/images/icons/16/notequal-red.png",
                                       :alt     => "Click to delete this input field from method"),
                             {:action => "field_method_delete",
-                             :id     => flds["id"].to_i,
+                             :id     => flds["id"].to_s,
                              :arr_id => i},
                             "data-miq_sparkle_on"  => true,
                             "data-miq_sparkle_off" => true,


### PR DESCRIPTION
Instead of saving/destroying fields/inputs and values one at time
Use the Active Record relations to save these with a single save
call on the parent. This is done by adding the :autosave to the has_many
relations

It also includes the removal of to_i calls on the id fields. This will
help us when we switch to GIT and have strings as id's and the to_i
calls would fail
