### PR TITLE
If zone is available for a resource connected to button use it

### DIFF
--- a/vmdb/app/models/custom_button.rb
+++ b/vmdb/app/models/custom_button.rb
@@ -53,12 +53,13 @@ class CustomButton < ActiveRecord::Base
   def invoke(target)
     args = self.resource_action.automate_queue_hash({:object_type => target.class.base_class.name, :object_id => target.id})
     args[:user_id] ||= User.current_user.try(:id)
+    zone = target.respond_to?(:my_zone) ? target.my_zone : nil
     MiqQueue.put(
       :class_name  => 'MiqAeEngine',
       :method_name => 'deliver',
       :args        => [args],
       :role        => 'automate',
-      :zone        => nil,
+      :zone        => zone,
       :priority    => MiqQueue::HIGH_PRIORITY,
     )
   end

--- a/vmdb/app/models/resource_action.rb
+++ b/vmdb/app/models/resource_action.rb
@@ -44,12 +44,11 @@ class ResourceAction < ActiveRecord::Base
   def deliver_to_automate_from_dialog(dialog_hash_values, target)
     log_header = "MIQ(#{self.class.name}.deliver_to_automate_from_dialog)"
     $log.info("#{log_header} Queuing <#{self.class.name}:#{self.id}> for <#{self.resource_type}:#{self.resource_id}>")
-
-    MiqAeEngine.deliver_queue(prepare_automate_args(dialog_hash_values, target), {
-      :zone     => nil,
-      :priority => MiqQueue::HIGH_PRIORITY,
-      :task_id  => "#{self.class.name.underscore}_#{self.id}"
-      })
+    zone = target.respond_to?(:my_zone) ? target.my_zone : nil
+    MiqAeEngine.deliver_queue(prepare_automate_args(dialog_hash_values, target),
+                              :zone     => zone,
+                              :priority => MiqQueue::HIGH_PRIORITY,
+                              :task_id  => "#{self.class.name.underscore}_#{id}")
   end
 
   def deliver_to_automate_from_dialog_field(dialog_hash_values, target)

--- a/vmdb/spec/models/custom_button_spec.rb
+++ b/vmdb/spec/models/custom_button_spec.rb
@@ -65,7 +65,7 @@ describe CustomButton do
           q.class_name.should  == "MiqAeEngine"
           q.method_name.should == "deliver"
           q.role.should        == "automate"
-          q.zone.should        == nil
+          q.zone.should eq("default")
           q.priority.should    == MiqQueue::HIGH_PRIORITY
           a = q.args
           a.should be_kind_of(Array)

--- a/vmdb/spec/models/resource_action_spec.rb
+++ b/vmdb/spec/models/resource_action_spec.rb
@@ -20,7 +20,7 @@ describe ResourceAction do
         :method_name => 'deliver',
         :args        => [q_args],
         :role        => 'automate',
-        :zone        => nil,
+        :zone        => zone_name,
         :priority    => MiqQueue::HIGH_PRIORITY,
         :task_id     => "#{ra.class.name.underscore}_#{ra.id}",
         :msg_timeout => 3600
@@ -32,6 +32,8 @@ describe ResourceAction do
     end
 
     context 'with no target' do
+      let(:zone_name) { nil }
+
       it "validates queue entry" do
         target             = nil
         MiqQueue.should_receive(:put).with(q_options).once


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1149003

Most of the resources like host, vm, cluster, datastore etc.
have a zone, so when submitting a task into the queue specify
the zone if the target supports has one.
