### PR TITLE
EvmDatabase.destroy isn't called anywhere.

### DIFF
--- a/vmdb/lib/evm_database.rb
+++ b/vmdb/lib/evm_database.rb
@@ -72,12 +72,4 @@ class EvmDatabase
     query = "SELECT 1"
     Benchmark.realtime { 10.times { connection.select_value(query) } } / 10 * 1000
   end
-
-  # Legacy method for destroying database content:
-  # Instead use rake evm:db:destroy which drops and recreates the database.
-  def self.destroy
-    ActiveRecord::Base.connection.views.each  {|v| ActiveRecord::Schema.define { drop_view  v.to_sym, :force => true } rescue nil}
-    ActiveRecord::Base.connection.tables.each {|t| ActiveRecord::Schema.define { drop_table t.to_sym, :force => true } rescue nil}
-    ActiveRecord::Base.connection_handler.clear_all_connections!
-  end
 end


### PR DESCRIPTION
This was last touched in 2010.

It references views which we haven't used since this migration killed them:
20110325161234_remove_vim_performance_views
