### PR TITLE
JS helper calls in views appended with .html_safe() method

### DIFF
--- a/vmdb/app/helpers/js_helper.rb
+++ b/vmdb/app/helpers/js_helper.rb
@@ -1,6 +1,6 @@
 module JsHelper
   def set_element_visible(element, status)
-    status ? javascript_show_if_exists(j_str(element)) : javascript_hide_if_exists(j_str(element))
+    status ? javascript_show_if_exists(element) : javascript_hide_if_exists(element)
   end
 
   # replacement for app/views/shared/ajax/_spinner_control.js.erb
@@ -14,9 +14,9 @@ module JsHelper
     bool_str = (!!lock).to_s
     element = "#{tree_var}_div"
     "
-      $j('##{tree_var}box').dynatree('#{lock ? 'disable' : 'enable'}');
+      $j('##{j_str(tree_var)}box').dynatree('#{lock ? 'disable' : 'enable'}');
       #{javascript_dim(element, bool_str)}
-    "
+    ".html_safe
   end
 
   # options:
@@ -38,42 +38,42 @@ module JsHelper
   end
 
   def javascript_focus(element)
-    "$j('##{element}').focus();"
+    "$j('##{j_str(element)}').focus();".html_safe
   end
 
   def javascript_focus_if_exists(element)
-    "if ($j('##{element}').length) #{javascript_focus(element)}"
+    "if ($j('##{j_str(element)}').length) #{javascript_focus(element)}".html_safe
   end
 
   def javascript_highlight(element, status)
-    "miqHighlight('##{element}', #{status});"
+    "miqHighlight('##{j_str(element)}', #{j_str(status)});".html_safe
   end
 
   def javascript_dim(element, status)
-    "miqDimDiv('##{element}', #{status});"
+    "miqDimDiv('##{j_str(element)}', #{j_str(status)});".html_safe
   end
 
   def javascript_add_class(element, cls)
-    "$j('##{element}').addClass('#{cls}');"
+    "$j('##{j_str(element)}').addClass('#{j_str(cls)}');".html_safe
   end
 
   def javascript_del_class(element, cls)
-    "$j('##{element}').removeClass('#{cls}');"
+    "$j('##{j_str(element)}').removeClass('#{j_str(cls)}');".html_safe
   end
 
   def javascript_show(element)
-    "$j('\##{element}').show();"
+    "$j('##{j_str(element)}').show();".html_safe
   end
 
   def javascript_hide(element)
-    "$j('\##{element}').hide();"
+    "$j('##{j_str(element)}').hide();".html_safe
   end
 
   def javascript_show_if_exists(element)
-    "if ($j('\##{element}').length) #{javascript_show(element)}"
+    "if ($j('##{j_str(element)}').length) #{javascript_show(element)}".html_safe
   end
 
   def javascript_hide_if_exists(element)
-    "if ($j('\##{element}').length) #{javascript_hide(element)}"
+    "if ($j('##{j_str(element)}').length) #{javascript_hide(element)}".html_safe
   end
 end

--- a/vmdb/app/views/layouts/_dhtmlxlayout_explorer.html.erb
+++ b/vmdb/app/views/layouts/_dhtmlxlayout_explorer.html.erb
@@ -120,7 +120,7 @@
 
       <%# Show search box for VMX tree list nodes or when in control explorer%>
       <% if x_tree && (([:filter, :images, :instances, :vandt].include?(x_tree[:type]) && !@record) || @show_adv_search) %>
-        <%= javascript_show_if_exists("#adv_searchbox_div") %>
+        <%= javascript_show_if_exists("adv_searchbox_div") %>
       <% end %>
 
     <% else %>  <%# Not using new explorer right cell layout %>

--- a/vmdb/app/views/layouts/_flash_msg.html.erb
+++ b/vmdb/app/views/layouts/_flash_msg.html.erb
@@ -20,7 +20,7 @@
 
 		<div id="flash_text_div<%= div_num %>"
 			<% if click_remove == true %>
-				onclick="<%= javascript_hide("flash_msg_div#{div_num}"); %>" title="Click to remove messages"
+				onclick="<%= javascript_hide("flash_msg_div#{div_num}") %>" title="Click to remove messages"
 			<% end %>
 		>
 			<% @flash_array.each do |fl| %>


### PR DESCRIPTION
When calling a JS helper from a view the JS will be escaped without appending .html_safe() to the end
