### PR TITLE
Use memoist gem instead of carrying a patch in our rails fork.

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -24,6 +24,7 @@ gem "httpclient",           "~>2.2.4",   :require => false
 gem "io-extra",             "=1.2.6",    :require => false
 gem "linux_admin",          "~>0.9",     :require => false
 gem "log4r",                "=1.1.8",    :require => false
+gem "memoist",              "~>0.11.0",  :require => false
 gem "more_core_extensions", "~>1.2.0",   :require => false
 gem "nokogiri",             "~>1.5.0",   :require => false
 gem "ovirt",                "~>0.2.1",   :require => false

--- a/vmdb/app/models/mixins/relationship_mixin.rb
+++ b/vmdb/app/models/mixins/relationship_mixin.rb
@@ -1,3 +1,5 @@
+require 'memoist'
+
 module RelationshipMixin
   extend ActiveSupport::Concern
 
@@ -20,7 +22,7 @@ module RelationshipMixin
   ]
 
   included do
-    ActiveSupport::Deprecation.silence { extend ActiveSupport::Memoizable }
+    extend Memoist
 
     cattr_accessor :default_relationship_type
 


### PR DESCRIPTION
We upstreamed our patch to memoist here:
https://github.com/matthewrudy/memoist/pull/2

It has been available in memoist since:
v0.11.0 v0.10.0 v0.9.3 v0.9.2 0.9.0 0.2.0

We can now drop our rails fork patch:
https://github.com/ManageIQ/rails/commit/76ba73412f6de3abe775464bba6a8ec9434fdc98

Fixes #538
