### PR TITLE
Remove 'Non-VM File Space' chart from datastore C&U

### DIFF
--- a/vmdb/product/charts/layouts/daily_perf_charts/Storage.yaml
+++ b/vmdb/product/charts/layouts/daily_perf_charts/Storage.yaml
@@ -55,13 +55,6 @@
   - derived_storage_vm_count_unregistered
   - derived_storage_vm_count_unmanaged
 
-- :title: Non-VM Files Space
-  :type: Line
-  :columns:
-  - derived_storage_other_managed
-  :decimals: 2
-  :units: GB
-
 - :title: Used Disk Space
   :type: Line
   :columns:

--- a/vmdb/product/charts/layouts/hourly_perf_charts/Storage.yaml
+++ b/vmdb/product/charts/layouts/hourly_perf_charts/Storage.yaml
@@ -16,9 +16,6 @@
 - :title: Number of VMs by Type
   :type: None
 
-- :title: Non-VM Files Space
-  :type: None
-
 - :title: Used Disk Space
   :type: StackedArea
   :columns:

--- a/vmdb/product/charts/miq_reports/vim_perf_daily.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_daily.yaml
@@ -71,7 +71,6 @@ cols:
 - derived_storage_mem_registered
 - derived_storage_mem_unregistered
 - derived_storage_mem_unmanaged
-- derived_storage_other_managed
 - assoc_ids
 
 # Included tables (joined, has_one, has_many) and columns
@@ -138,7 +137,6 @@ col_order:
 - derived_storage_mem_registered
 - derived_storage_mem_unregistered
 - derived_storage_mem_unmanaged
-- derived_storage_other_managed
 - resource.cpu_usagemhz_rate_average_high_over_time_period
 - resource.cpu_usagemhz_rate_average_low_over_time_period
 - resource.cpu_usage_rate_average_high_over_time_period

--- a/vmdb/product/charts/miq_reports/vim_perf_daily_cloud.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_daily_cloud.yaml
@@ -71,7 +71,6 @@ cols:
 - derived_storage_mem_registered
 - derived_storage_mem_unregistered
 - derived_storage_mem_unmanaged
-- derived_storage_other_managed
 - assoc_ids
 
 # Included tables (joined, has_one, has_many) and columns
@@ -138,7 +137,6 @@ col_order:
 - derived_storage_mem_registered
 - derived_storage_mem_unregistered
 - derived_storage_mem_unmanaged
-- derived_storage_other_managed
 - resource.cpu_usagemhz_rate_average_high_over_time_period
 - resource.cpu_usagemhz_rate_average_low_over_time_period
 - resource.cpu_usage_rate_average_high_over_time_period


### PR DESCRIPTION
Removed the chart from charts YAML config files.

The chart's displayed blank and causing a crash of the Flash Player because attribute/column 'derived_storage_other_managed' doesn't exist for Metrics model/table.

https://bugzilla.redhat.com/show_bug.cgi?id=1123516
