### PR TITLE
Changes to show tag category only once for each base class.

### DIFF
--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -191,25 +191,25 @@ class MiqExpression
     guid
   }
 
-  TAG_CLASSES = %w(
-    EmsCloud ext_management_system
-    EmsCluster ems_cluster
-    EmsInfra ext_management_system
-    Host host
-    MiqGroup miq_group
-    MiqTemplate miq_template
-    Repository repository
-    ResourcePool resource_pool
-    Service service
-    Storage storage
-    TemplateCloud miq_template
-    TemplateInfra miq_template
-    User user
-    Vm vm
-    VmOrTemplate vm
-    VmCloud vm
-    VmInfra vm
-  )
+  TAG_CLASSES = {
+    'EmsCloud'      => 'ext_management_system',
+    'EmsCluster'    => 'ems_cluster',
+    'EmsInfra'      => 'ext_management_system',
+    'Host'          => 'host',
+    'MiqGroup'      => 'miq_group',
+    'MiqTemplate'   => 'miq_template',
+    'Repository'    => 'repository',
+    'ResourcePool'  => 'resource_pool',
+    'Service'       => 'service',
+    'Storage'       => 'storage',
+    'TemplateCloud' => 'miq_template',
+    'TemplateInfra' => 'miq_template',
+    'User'          => 'user',
+    'Vm'            => 'vm',
+    'VmOrTemplate'  => 'vm',
+    'VmCloud'       => 'vm',
+    'VmInfra'       => 'vm',
+  }
   EXCLUDE_FROM_RELATS = {
     "EmsCloud" => ["hosts", "ems_clusters", "resource_pools"]
   }
@@ -1362,12 +1362,11 @@ class MiqExpression
     if opts[:typ] == "tag"
       tags_for_model = self.tag_details(model, model, opts)
       result = []
-
-      TAG_CLASSES.each_slice(2) {|tc, name|
+      TAG_CLASSES.invert.each do |name, tc|
         next if tc.constantize.base_class == model.constantize.base_class
         path = [model, name].join(".")
         result.concat(self.tag_details(tc, path, opts))
-      }
+      end
       @classifications = nil
       return tags_for_model.concat(result.sort!{|a,b|a.to_s<=>b.to_s})
     end

--- a/vmdb/spec/models/miq_expression/miq_expression_spec.rb
+++ b/vmdb/spec/models/miq_expression/miq_expression_spec.rb
@@ -461,6 +461,19 @@ describe MiqExpression do
     end
   end
 
+  context ".model_details" do
+    it "should not contain duplicate tag fields" do
+      category = FactoryGirl.create(:classification, :name => 'environment', :description => 'Environment')
+      FactoryGirl.create(:classification, :parent_id => category.id, :name => 'prod', :description => 'Production')
+      tags = MiqExpression.model_details('Host',
+                                         :typ             => 'tag',
+                                         :include_model   => true,
+                                         :include_my_tags => false,
+                                         :userid          => 'admin')
+      tags.uniq.length.should eq(tags.length)
+    end
+  end
+
   context "Date/Time Support" do
     context "Testing expression conversion ruby, sql and human with static dates and times" do
       it "should generate the correct ruby expression with an expression having static dates and times with no time zone" do


### PR DESCRIPTION
Added changes to store value of TAG_CLASSES array into a hash and then use invert on it in order to use each model only once to add tag categories for them, having base class more than once in that array was causing duplicate entries in the pull down.

https://bugzilla.redhat.com/show_bug.cgi?id=1160209

@dclarizio please review & test.
