### PR TITLE
Fixed issue - buttons do not light up after a selection is made in the dialog

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -258,7 +258,7 @@ function miqNewTagPrompt() {
 } }
 
 // Hide/show form buttons
-function miqButtons(h_or_s) {
+function miqButtons(h_or_s, prefix) {
   if ($j('#flash_msg_div').length) $j('#flash_msg_div').hide();
   if (h_or_s == "show") {
     // checking if more than one buttons exist on screen turn them all on/off
@@ -268,6 +268,14 @@ function miqButtons(h_or_s) {
     $j('#buttons_off').each(function(b) {
       $j(this).hide();
     })
+    if (prefix != 'undefined') {
+      $j('#' + prefix + '_buttons_on').each(function(b) {
+        $j(this).show();
+      })
+      $j('#' + prefix + '_buttons_off').each(function(b) {
+        $j(this).hide();
+      })
+    }
   } else {
     $j('#buttons_off').each(function(b) {
       $j(this).show();
@@ -275,6 +283,14 @@ function miqButtons(h_or_s) {
     $j('#buttons_on').each(function(b) {
       $j(this).hide();
     })
+    if (prefix != 'undefined') {
+      $j('#' + prefix + 'buttons_off').each(function(b) {
+        $j(this).show();
+      })
+      $j('#' + prefix + 'buttons_on').each(function(b) {
+        $j(this).hide();
+      })
+    }
   }
 }
 

--- a/vmdb/app/controllers/application_controller/filter.rb
+++ b/vmdb/app/controllers/application_controller/filter.rb
@@ -971,7 +971,7 @@ module ApplicationController::Filter
     else
       any_empty = @edit[:qs_tokens].values.any? { |v| v[:value].to_s.empty? }
       render :update do |page|
-        page << javascript_for_miq_button_visibility(!any_empty)
+        page << javascript_for_miq_button_visibility(!any_empty, 'quick_search')
       end
     end
   end

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1636,8 +1636,12 @@ module ApplicationHelper
   end
 
   # Show/hide the Save and Reset buttons based on whether changes have been made
-  def javascript_for_miq_button_visibility(display)
-    "miqButtons('#{display ? 'show' : 'hide'}');".html_safe
+  def javascript_for_miq_button_visibility(display, prefix = nil)
+    if prefix
+      "miqButtons('#{display ? 'show' : 'hide'}', '#{prefix}');".html_safe
+    else
+      "miqButtons('#{display ? 'show' : 'hide'}');".html_safe
+    end
   end
 
   def javascript_for_miq_button_visibility_changed(changed)

--- a/vmdb/app/views/layouts/_quick_search.html.erb
+++ b/vmdb/app/views/layouts/_quick_search.html.erb
@@ -80,10 +80,10 @@
       <tr>
         <td align="right">
           <div id="buttons">
-            <span id="buttons_off">
+            <span id="quick_search_buttons_off">
               <%= button_tag("Apply",	:class => "btn btn-primary btn-disabled") %>
             </span>
-            <span id="buttons_on" style="display:none;">
+            <span id="quick_search_buttons_on" style="display:none;">
               <%= link_to(button_tag('Apply',
                                     :class => "btn btn-primary",
                                     :alt   => 'Apply the current filter (Enter)'),


### PR DESCRIPTION
This issue was seen in the Provisioning dialog page where despite a template selection, the Continue button would not light up.

Recent prototype -> jQuery changes exposed this issue (which is an issue for jQuery, but not for prototype) where if there are multiple elements in a html page with the same id , for e.g. -

```
<span id='buttons_on'>
<div id='buttons_on'>
```

then a jQuery call - `$j('#buttons_on')` would pick only the first element, thus introducing a bug where the second element with the same id would not be handled at all.

On the Provisioning dialog page, the `quick_search` bar had its own set of buttons that were causing the above issue with the Provisioning dialog buttons. The quick_search bar buttons have now been renamed to
`quick_search_buttons_on/off` to avoid the id clash.
