### PR TITLE
Don't send up all_checked checkbox IDs upto server on onselect event.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_dynatree.js
+++ b/vmdb/app/assets/javascripts/cfme_dynatree.js
@@ -454,7 +454,7 @@ function miqCheck_CU_All(cb, treename) {
     return node.data.key;
   });
   new Ajax.Request(encodeURI(check_url + "?check_all=" + cb.checked +
-        "&all_checked=" + selectedKeys + "&tree_name=" + treename
+        "&tree_name=" + treename
     ),
     {asynchronous:true, evalScripts:true}
   );
@@ -462,8 +462,8 @@ function miqCheck_CU_All(cb, treename) {
 }
 
 // OnCheck handler for the C&U collection trees
-function miqOnCheck_CU_Filters(tree_name, key, checked, all_checked) {
-  new Ajax.Request(encodeURI(check_url + "?id=" + key +"&check=" + checked + "&all_checked=" + all_checked + "&tree_name=" + tree_name),
+function miqOnCheck_CU_Filters(tree_name, key, checked) {
+  new Ajax.Request(encodeURI(check_url + "?id=" + key +"&check=" + checked + "&tree_name=" + tree_name),
     {asynchronous:true, evalScripts:true}
   );
   return true;

--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -923,7 +923,6 @@ class ConfigurationController < ApplicationController
     @config_tab   = session[:config_tab]        if session[:config_tab]
     @tabform      = session[:config_tabform]    if session[:config_tabform]
     @schema_ver   = session[:config_schema_ver] if session[:config_schema_ver]
-    @all_checked  = session[:all_checked]       if session[:all_checked]
     @zone_options = session[:zone_options]      if session[:zone_options]
   end
 
@@ -934,7 +933,6 @@ class ConfigurationController < ApplicationController
     session[:vm_filters]        = @filters
     session[:vm_catinfo]        = @catinfo
     session[:vm_cats]           = @cats
-    session[:all_checked]       = @all_checked if @all_checked
     session[:zone_options]      = @zone_options
   end
 end

--- a/vmdb/app/models/ems_cluster.rb
+++ b/vmdb/app/models/ems_cluster.rb
@@ -340,8 +340,9 @@ class EmsCluster < ActiveRecord::Base
     self.perf_capture_enabled? ? [self] + hosts : hosts
   end
 
-  def set_perf_collection_object_list(list)
-    ([self] + self.hosts).each { |obj| obj.perf_capture_enabled = list.include?(obj) }
+  def perf_capture_enabled_host_ids=(ids)
+    self.perf_capture_enabled = ids.any?
+    hosts.each { |h| h.perf_capture_enabled = ids.include?(h.id) }
   end
 
   def hosts_enabled_for_perf_capture

--- a/vmdb/app/models/metric/targets.rb
+++ b/vmdb/app/models/metric/targets.rb
@@ -65,7 +65,6 @@ module Metric::Targets
   # If a Cluster, standalone Host, or Storage is not enabled, skip it.
   # If a Cluster is enabled, capture all of its Hosts.
   # If a Host is enabled, capture all of its Vms.
-  # We assume that if a Host is tagged enabled, it's Cluster will also be tagged enabled.  TODO: code this directly?
   def self.capture_targets(zone = nil, options = {})
     zone = MiqServer.my_server.zone(true) if zone.nil?
     zone = Zone.find(zone) if zone.kind_of?(Integer)

--- a/vmdb/spec/models/ems_cluster_spec.rb
+++ b/vmdb/spec/models/ems_cluster_spec.rb
@@ -134,4 +134,42 @@ describe EmsCluster do
       :hosts                   => [],
     }
   end
+
+  context("#perf_capture_enabled_host_ids=") do
+    before do
+      @miq_region = FactoryGirl.create(:miq_region, :region => 1)
+      MiqRegion.stub(:my_region).and_return(@miq_region)
+      @cluster = FactoryGirl.create(:ems_cluster)
+      @host1 = FactoryGirl.create(:host, :ems_cluster => @cluster)
+      @host2 = FactoryGirl.create(:host, :ems_cluster => @cluster)
+    end
+
+    it "Initially Performance capture for cluster and its hosts should not be set" do
+      @cluster.perf_capture_enabled.should eq(false)
+      @host1.perf_capture_enabled.should eq(false)
+      @host2.perf_capture_enabled.should eq(false)
+    end
+
+    it "Performance capture for cluster and its hosts should be set" do
+      @cluster.perf_capture_enabled_host_ids = [@host1.id, @host2.id]
+      @cluster.perf_capture_enabled.should eq(true)
+      @host1.perf_capture_enabled.should eq(true)
+      @host2.perf_capture_enabled.should eq(true)
+    end
+
+    it "Performance capture for cluster and only 1 hosts should be set" do
+      @cluster.perf_capture_enabled_host_ids = [@host2.id]
+      @cluster.perf_capture_enabled.should eq(true)
+      @host1.perf_capture_enabled.should eq(false)
+      @host2.perf_capture_enabled.should eq(true)
+    end
+
+    it "Performance capture for cluster and its hosts should get unset" do
+      @cluster.perf_capture_enabled_host_ids = [@host2.id]
+      @cluster.perf_capture_enabled_host_ids = []
+      @cluster.perf_capture_enabled.should eq(false)
+      @host1.perf_capture_enabled.should eq(false)
+      @host2.perf_capture_enabled.should eq(false)
+    end
+  end
 end


### PR DESCRIPTION
- Made changes to JS method to not send up all_checked checkboxes on onselect event, this was causing JS error when there were lots of nodes in the tree, as a result of that transaction was not being sent upto server. Made changes to set/save C&U collection based upon checkbox that was changed and sent up. Removed code that was expecting all_checked checkboxes to come in with JS transaction.
- Changed code to only call Metric::Targets.perf_capture_always if any of the "Collect for All XXX" checkboxes values were changed and only for the one that's value was changed.

https://bugzilla.redhat.com/show_bug.cgi?id=1153047
https://bugzilla.redhat.com/show_bug.cgi?id=1145799

@dclarizio please review/test. Let me know If you need db with lots of nodes to recreate the issue.
