### PR TITLE
Added missing 'forest_delete' route

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1110,6 +1110,7 @@ Vmdb::Application.routes.draw do
         explorer
         fetch_build
         forest_accept
+        forest_delete
         forest_form_field_changed
         forest_select
         log_depot_edit

--- a/vmdb/spec/routing/ops_routing_spec.rb
+++ b/vmdb/spec/routing/ops_routing_spec.rb
@@ -53,6 +53,7 @@ describe "routing for OpsController" do
     explorer
     fetch_build
     forest_accept
+    forest_delete
     forest_form_field_changed
     forest_select
     log_depot_edit


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1163382
https://bugzilla.redhat.com/show_bug.cgi?id=1163384

@dclarizio please review/test.
Steps to Reproduce:
1. Go to Configuration/Configure
2. Select Current server in Settings Accordion
3. Go to Authentication tab
4. change mode to LDAP
5. Check the checkbox for "Get User Groups from LDAP"
6. In "Trusted Forest Settings" box, click on + sign to Add a new forest
7. Enter new Forest details and then press "Add this entry" button.
