### PR TITLE
We're leaving miq_ae_namespaces rows around by using :all.

### DIFF
--- a/vmdb/spec/migrations/20140424173120_migrate_automate_to_customer_domain_spec.rb
+++ b/vmdb/spec/migrations/20140424173120_migrate_automate_to_customer_domain_spec.rb
@@ -6,7 +6,7 @@ describe MigrateAutomateToCustomerDomain do
   let(:miq_ae_class_stub)     { migration_stub(:MiqAeClass) }
 
   migration_context :up do
-    before(:all) do
+    before do
       migration_stub(:MiqAeNamespace).create!(:name => '$')
     end
 
@@ -76,7 +76,7 @@ describe MigrateAutomateToCustomerDomain do
   end
 
   migration_context :down do
-    before(:all) do
+    before do
       migration_stub(:MiqAeNamespace).create!(:name => '$')
     end
 


### PR DESCRIPTION
We shouldn't use before(:all) unless we cleanup after ourselves and even then, it's not worth it most of the times.
