### PR TITLE
Adding Amazon AWS Config event catcher

### DIFF
--- a/lib/Amazon/amazon_connection.rb
+++ b/lib/Amazon/amazon_connection.rb
@@ -15,6 +15,14 @@ class AmazonConnection
     AWS.const_get(service).new(params)
   end
 
+  def self.sqs(access_key_id, secret_access_key, region = nil, proxy_uri = nil)
+    raw_connect(access_key_id, secret_access_key, "SQS", region, proxy_uri)
+  end
+
+  def self.sns(access_key_id, secret_access_key, region = nil, proxy_uri = nil)
+    raw_connect(access_key_id, secret_access_key, "SNS", region, proxy_uri)
+  end
+
   def self.verify_credentials(access_key_id, secret_access_key)
     begin
       self.raw_connect(access_key_id, secret_access_key).regions.map(&:name)

--- a/lib/Amazon/events/amazon_event_monitor.rb
+++ b/lib/Amazon/events/amazon_event_monitor.rb
@@ -1,0 +1,164 @@
+require 'Amazon/amazon_connection'
+
+#
+# Uses the AWS Config service to monitor for events.
+#
+# AWS Config events are collected in an SNS Topic.  Each appliance uses a unique
+# SQS queue subscribed to the AWS Config topic.  If the appliance-specific queue
+# doesn't exist, this event monitor will create the queue and subscribe the
+# queue to the AWS Config topic.
+#
+class AmazonEventMonitor
+  #
+  # Creates an AmazonEventMonitor
+  #
+  def initialize(aws_access_key_id, aws_secret_access_key, aws_region, queue_id, sns_aws_config_topic_name = "AWSConfig_topic")
+    @aws_access_key_id     = aws_access_key_id
+    @aws_secret_access_key = aws_secret_access_key
+    @aws_region            = aws_region
+    @queue_id              = queue_id
+    @topic_name            = sns_aws_config_topic_name
+    @collecting_events     = false
+    @queue                 = nil
+  end
+
+  #
+  # Start capturing events
+  #
+  def start
+    @collecting_events = true
+  end
+
+  #
+  # Stop capturing events
+  #
+  def stop
+    @collecting_events = false
+  end
+
+  #
+  # Collect events off the appliance-specific queue and return the events as a
+  # batch to the caller.
+  #
+  # :yield: array of Amazon events as hashes
+  #
+  def each_batch
+    while @collecting_events
+      # allow the queue to be lazy created
+      # if the amazon account doesn't have AWS Config enabled yet, this will pick
+      # up if AWS Config is enabled later
+      @queue ||= find_or_create_queue
+      yield collect_events(@queue) if @queue
+    end
+  end
+
+  #
+  # Similar to #each_batch, but yields each event individually.
+  #
+  # :yield: an Amazon event as a hash
+  #
+  def each
+    each_batch do |events|
+      events.each { |e| yield e }
+    end
+  end
+
+  private
+
+  #
+  # Find the appliance-specific queue, or create the appliance-specific queue
+  # and subscribe it to the AWS Config topic.
+  #
+  def find_or_create_queue
+    log_header = "MIQ(#{self.class.name}##{__method__})"
+
+    # manageiq-awsconfig-queue-queue_id
+    queue_name = "manageiq-awsconfig-queue-#{@queue_id}"
+
+    begin
+      $aws_log.debug("#{log_header} Looking for Amazon SQS Queue #{queue_name} ...")
+      queue = sqs.queues.named(queue_name)
+      $aws_log.debug("#{log_header} ... found Amazon SQS Queue")
+    rescue AWS::SQS::Errors::NonExistentQueue
+      aws_config_topic = find_aws_config_topic
+      if aws_config_topic
+        $aws_log.info("#{log_header} Amazone SQS Queue #{queue_name} does not exist; creating queue")
+        queue = sqs.queues.create(queue_name)
+
+        $aws_log.info("#{log_header} Subscribing Queue #{queue_name} to AWSConfig_topic")
+        aws_config_topic.subscribe(queue)
+        $aws_log.info("#{log_header} Created Amazon SQS Queue #{queue_name} and subscribed to AWSConfig_topic")
+      else
+        $aws_log.warn("#{log_header} Unable to find the AWS Config Topic. " \
+                      "Cannot collect Amazon events for AWS Access Key ID #{@aws_access_key_id}")
+        $aws_log.warn("#{log_header} Contact Amazon to create the AWS Config service and topic for Amazon events.")
+        queue = nil
+        # no need to raise an error
+      end
+    end
+    queue
+  end
+
+  def find_aws_config_topic
+    sns.topics.detect { |t| t.name == @topic_name }
+  end
+
+  def collect_events(queue)
+    events = []
+    # http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/SQS/Queue.html
+    # :batch_size   - maximum number of messages to retrieve per request
+    # :idle_timeout - maximum number of seconds to poll while no messages are returned
+    queue.poll(:idle_timeout => 5) do |amazon_message|
+      sns_message = amazon_message.as_sns_message
+
+      event = parse_event(sns_message)
+      events << event if event
+    end
+    events
+  end
+
+  def parse_event(sns_message)
+    log_header = "MIQ(#{self.class.name}##{__method__})"
+    event = sns_message.body_message_as_h.dup
+    message_type = event["messageType"]
+    $log.info("#{log_header} Found SNS Message with message type #{message_type}")
+    return unless message_type == "ConfigurationItemChangeNotification"
+
+    log_header = "MIQ(#{self.class.name}##{__method__})"
+    event["messageId"] = sns_message.message_id
+    event["eventType"] = parse_event_type(event)
+    $log.info("#{log_header} Parsed event from SNS Message #{event["eventType"]}")
+    event
+  end
+
+  def parse_event_type(event)
+    event_type_prefix = event.fetch_path("configurationItem", "resourceType")
+    change_type       = event.fetch_path("configurationItemDiff", "changeType")
+
+    if event_type_prefix.end_with?("::Instance")
+      suffix   = change_type if change_type == "CREATE"
+      suffix ||= parse_instance_state_change(event)
+    else
+      suffix = change_type
+    end
+
+    # e.g., AWS_EC2_Instance_STARTED
+    "#{event_type_prefix}_#{suffix}".gsub("::", "_")
+  end
+
+  def parse_instance_state_change(event)
+    change_type = event["configurationItemDiff"]["changeType"]
+    return change_type if change_type == "CREATE"
+
+    state_changed = event.fetch_path("configurationItemDiff", "changedProperties", "Configuration.State.Name")
+    return state_changed ? state_changed["updatedValue"] : change_type
+  end
+
+  def sns
+    @sns ||= AmazonConnection.sns(@aws_access_key_id, @aws_secret_access_key, @aws_region)
+  end
+
+  def sqs
+    @sqs ||= AmazonConnection.sqs(@aws_access_key_id, @aws_secret_access_key, @aws_region)
+  end
+end

--- a/vmdb/app/models/ems_event.rb
+++ b/vmdb/app/models/ems_event.rb
@@ -98,6 +98,10 @@ class EmsEvent < ActiveRecord::Base
     self.add(ems_id, EmsEvent::Parsers::Openstack.event_to_hash(event, ems_id))
   end
 
+  def self.add_amazon(ems_id, event)
+    self.add(ems_id, EmsEvent::Parsers::Amazon.event_to_hash(event, ems_id))
+  end
+
   def self.add(ems_id, event_hash)
     event_type = event_hash[:event_type]
     raise MiqException::Error, "event_type must be set in event" if event_type.nil?

--- a/vmdb/app/models/ems_event/parsers/amazon.rb
+++ b/vmdb/app/models/ems_event/parsers/amazon.rb
@@ -1,0 +1,32 @@
+module EmsEvent::Parsers::Amazon
+  def self.event_to_hash(event, ems_id)
+    log_header = "MIQ(#{self.name}.event_to_hash)"
+    log_header << " ems_id: [#{ems_id}]" unless ems_id.nil?
+
+    $log.debug("#{log_header} event: [#{event["configurationItem"]["resourceType"]} - " \
+               "#{event["configurationItem"]["resourceId"]}]") if $log.debug?
+
+    event_hash = {
+      :event_type => event["eventType"],
+      :source     => "AMAZON",
+      :message    => event["configurationItemDiff"],
+      :timestamp  => event["notificationCreationTime"],
+      :full_data  => event,
+      :ems_id     => ems_id
+    }
+
+    event_hash[:vm_ems_ref]                = parse_vm_ref(event)
+    event_hash[:availability_zone_ems_ref] = parse_availability_zone_ref(event)
+    event_hash
+  end
+
+  def self.parse_vm_ref(event)
+    resource_type = event["configurationItem"]["resourceType"]
+    # other ways to find the VM?
+    event.fetch_path("configurationItem", "resourceId") if resource_type == "AWS::EC2::Instance"
+  end
+
+  def self.parse_availability_zone_ref(event)
+    event.fetch_path("configurationItem", "availabilityZone")
+  end
+end

--- a/vmdb/app/models/miq_event_catcher_amazon.rb
+++ b/vmdb/app/models/miq_event_catcher_amazon.rb
@@ -1,0 +1,5 @@
+class MiqEventCatcherAmazon < MiqEventCatcher
+  def self.ems_class
+    EmsAmazon
+  end
+end

--- a/vmdb/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/vmdb/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -14,6 +14,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqEmsRefreshWorkerRedhat
     MiqEmsRefreshWorkerOpenstack
     MiqEmsRefreshWorkerVmware
+    MiqEventCatcherAmazon
     MiqEventCatcherRedhat
     MiqEventCatcherOpenstack
     MiqEventCatcherVmware
@@ -62,6 +63,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqEventCatcherVmware
     MiqEventCatcherRedhat
     MiqEventCatcherOpenstack
+    MiqEventCatcherAmazon
     MiqUiWorker
   }.freeze
 

--- a/vmdb/config/event_handling.tmpl.yml
+++ b/vmdb/config/event_handling.tmpl.yml
@@ -1287,6 +1287,36 @@ event_handling:
   network.floating_ip.disassociate:
   - refresh:
     - ems
+  ConfigurationItemChangeNotification:
+  - refresh:
+    - ems
+  AWS_EC2_Instance_CREATE:
+  - policy:
+    - src_vm
+    - vm_create
+  - refresh:
+    - ems
+  AWS_EC2_Instance_UPDATE:
+  - refresh:
+    - ems
+  AWS_EC2_Instance_running:
+  - policy:
+    - src_vm
+    - vm_start
+  - refresh:
+    - ems
+  AWS_EC2_Instance_stopped:
+  - policy:
+    - src_vm
+    - vm_power_off
+  - refresh:
+    - ems
+  AWS_EC2_Instance_shutting-down:
+  - policy:
+    - src_vm
+    - vm_power_off
+  - refresh:
+    - ems
 
 #
 # The filtered_events section defines which events should not be added to the
@@ -1296,7 +1326,7 @@ event_handling:
 #   table.
 #
 filtered_events:
-  AlarmActionTriggeredEvent:
+  AlarmActionTriggeredEvent:                # Vmware filtered events
   AlarmCreatedEvent:
   AlarmEmailCompletedEvent:
   AlarmEmailFailedEvent:
@@ -1308,16 +1338,19 @@ filtered_events:
   AlarmSnmpFailedEvent:
   AlarmStatusChangedEvent:
   AlreadyAuthenticatedSessionEvent:
-  UNASSIGNED:
+  UNASSIGNED:                               # RHEV filtered events
   USER_REMOVE_VG:
   USER_REMOVE_VG_FAILED:
   USER_VDC_LOGIN:
   USER_VDC_LOGOUT:
   UserLoginSessionEvent:
   UserLogoutSessionEvent:
-  scheduler.run_instance.start:
+  scheduler.run_instance.start:             # OpenStack filtered events
   scheduler.run_instance.scheduled:
   scheduler.run_instance.end:
+  ConfigurationSnapshotDeliveryCompleted:   # Amazon filtered events
+  ConfigurationSnapshotDeliveryStarted:
+  ConfigurationSnapshotDeliveryFailed:
 
 #
 # The task_final_events section defines which events could be the final event

--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -284,6 +284,8 @@ workers:
         :duration: 10.seconds
         :capacity: 50
         :amqp_port: 5672
+      :event_catcher_amazon:
+        :poll: 15.seconds
     :queue_worker_base:
       :defaults:
         :cpu_usage_threshold: 100.percent

--- a/vmdb/lib/workers/event_catcher_amazon.rb
+++ b/vmdb/lib/workers/event_catcher_amazon.rb
@@ -1,0 +1,50 @@
+require 'workers/event_catcher'
+require 'json'
+
+class EventCatcherAmazon < EventCatcher
+  def event_monitor_handle
+    require 'Amazon/events/amazon_event_monitor'
+    unless @event_monitor_handle
+      aws_access_key_id     = @ems.authentication_userid
+      aws_secret_access_key = @ems.authentication_password
+      aws_region            = @ems.provider_region
+      queue_id              = @ems.guid
+      @event_monitor_handle = AmazonEventMonitor.new(aws_access_key_id, aws_secret_access_key, aws_region, queue_id)
+    end
+    @event_monitor_handle
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.try(:stop)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.each_batch do |events|
+      $log.debug("#{log_prefix} Received events #{events.collect(&:message)}") if $log.debug?
+      @queue.enq events
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def process_event(event)
+    if filtered?(event)
+      $log.info "#{log_prefix} Skipping filtered Amazon event [#{event["messageId"]}]"
+    else
+      $log.info "#{log_prefix} Caught event [#{event["messageId"]}]"
+      EmsEvent.add_queue('add_amazon', @cfg[:ems_id], event)
+    end
+  end
+
+  def filtered?(event)
+    filtered_events.include?(event["messageType"])
+  end
+end


### PR DESCRIPTION
Amazon has launched the new AWS Config service that emits configuration diffs on
a scheduled basis.  The new AWS Config event catcher listens to an SQS Queue and
discovers configuration changes.  These configurations changes are parsed and
treated as an event stream from AWS.

Each appliance that attempts to receive events for a single AWS account will
create a unique SQS queue, allowing multiple appliances to listen for the same
events.

Captured events are parsed to determine the type of object changed and the
manner in which it was changed.  For instance, when a stopped instance is
started, the configuration diff will indicate that the item changed was an
instance, and that the state changed from stopped to starting.  When this
configuration diff is recevied, the Amazon Event Monitor enqueues a event called
"AWS_EC2_Instance_STARTED".

There are still other events that need to be detemined from the event stream,
but an initial set has been added to the event handling file to illustrate the
types of events ManageIQ will process.

The only requirement for now imposed on the AWS account configuration is that
the SNS Topic configured for AWS Config needs to be called "AWSConfig_topic".
With that in place, ManageIQ's Amazon Event Monitor can create the appropriate
SQS queue and begin receiving events.

https://trello.com/c/qdeChZPC
