### PR TITLE
Delegate the purging of 6 month+ old metrics to the purger.

### DIFF
--- a/vmdb/app/models/vmdb_index.rb
+++ b/vmdb/app/models/vmdb_index.rb
@@ -1,7 +1,7 @@
 class VmdbIndex < ActiveRecord::Base
   belongs_to :vmdb_table
 
-  has_many :vmdb_metrics,          :as => :resource, :dependent => :destroy
+  has_many :vmdb_metrics,          :as => :resource  # Destroy will be handled by purger
   has_one  :latest_hourly_metric,  :as => :resource, :class_name => 'VmdbMetric', :conditions => {:capture_interval_name => 'hourly'}, :order => "timestamp DESC"
 
   include ReportableMixin

--- a/vmdb/app/models/vmdb_table.rb
+++ b/vmdb/app/models/vmdb_table.rb
@@ -2,7 +2,7 @@ class VmdbTable < ActiveRecord::Base
   belongs_to :vmdb_database
 
   has_many :vmdb_indexes,                            :dependent => :destroy
-  has_many :vmdb_metrics,          :as => :resource, :dependent => :destroy
+  has_many :vmdb_metrics,          :as => :resource  # Destroy will be handled by purger
   has_one  :latest_hourly_metric,  :as => :resource, :class_name => 'VmdbMetric', :conditions => {:capture_interval_name => 'hourly'}, :order => "timestamp DESC"
 
   include ReportableMixin


### PR DESCRIPTION
Fixes timeouts during server startup.

The existing purging works in rails console using an old migrated database:

VmdbMetric.count => 4696666
require 'workers/schedule_worker'
ScheduleWorker::Jobs.new.metric_purge_all_timer
simulate_queue_worker
VmdbMetric.count => 0

Fixes #1029
