### PR TITLE
Avoid checking if "services" tenant is accessible

### DIFF
--- a/lib/openstack/openstack_handle/handle.rb
+++ b/lib/openstack/openstack_handle/handle.rb
@@ -221,6 +221,10 @@ module OpenstackHandle
 
     def accessible_tenants
       @accessible_tenants ||= tenants.select do |t|
+        # avoid 401 Unauth errors when checking for accessible tenants
+        # the "services" tenant is a special tenant in openstack reserved
+        # specifically for the various services
+        next if t.name == "services"
         begin
           compute_service(t.name)
           true


### PR DESCRIPTION
Attempting to handle the Openstack 401 errors by not checking whether the "services" tenant is an accessible tenant.

We already know that the "services" tenant is a special tenant created specifically for the various openstack services.  The openstack services' users are the only users that should be members of the services tenant.

And, despite the fact that we don't actually throw the 401 error after receiving it, it appears that the underlying libraries nicely log it for us.
