### PR TITLE
upgrading acts_as_tree

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -28,7 +28,7 @@ gem "ziya",                           "=2.3.0",       :require => false, :git =>
 
 # Not vendored, but required
 gem "acts_as_list",                   "~>0.1.4"
-gem "acts_as_tree",                   "~>0.1.1"  # acts_as_tree needs to be required so that it loads before ancestry
+gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be required so that it loads before ancestry
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
 # american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.
 # See miq_expression_spec Date/Time Support examples.


### PR DESCRIPTION
the older version was not compatible with Rails 4, so it was blocking
the upgrade.

The model specs passed for me, but when I ran the whole suite, something was messed up.  Let's see if Travis likes this.
