### PR TITLE
Fix for gettext rake tasks

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -90,6 +90,10 @@ unless ENV['APPLIANCE']
     gem "win32console",                 :require => false if RUBY_PLATFORM =~ /mingw/
 
     gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
+    # used for finding translations
+    gem "gettext",                      :require => false
+    # used for finding translations inside HAML
+    gem 'ruby_parser',                  :require => false
   end
 
   group :test do

--- a/vmdb/config/application.rb
+++ b/vmdb/config/application.rb
@@ -75,19 +75,16 @@ module Vmdb
     # ActiveSupport::Dependencies.autoload_paths empty, thus breaking autoloading.  Thus, in
     # order to prevent eager loading, but still populate autoload_paths, we copy them.
     config.autoload_paths += config.eager_load_paths
-    config.autoload_paths << Rails.root.join("app", "models", "mixins")
-    config.autoload_paths << Rails.root.join("app", "controllers", "mixins")
-    config.autoload_paths << Rails.root.join("lib")
-    config.autoload_paths << Rails.root.join('app', 'presenters')
+    config.autoload_paths << Rails.root.join("app", "models", "mixins").to_s
+    config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
+    config.autoload_paths << Rails.root.join("lib").to_s
+    config.autoload_paths << Rails.root.join('app', 'presenters').to_s
 
     # config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled.
     # Defaults to every folder in the app directory of the application.
     config.eager_load_paths = []
 
     require_relative 'environments/patches/database_configuration'
-
-    # Rails3 TODO: check if anything in lib cannot be autoloaded
-    $:.push Rails.root.join("lib")
 
     console do
       Rails::ConsoleMethods.class_eval do


### PR DESCRIPTION
These commits are fixing issues with gettext rake tasks, especially
* rake gettext:find
* rake gettext:add_language[XX]
*(where XX is the ISO 639-1 2-letter code for the language)*

To run those rake tasks, you need to define in your Gemfile.dev.rb:
```ruby
  gem "gettext",  "~>2.0",  :require => false
  gem "locale",   "=2.0.9"
  gem 'ruby_parser',        :require => false
```
Still not working
* rake gettext:store_model_attributes (broken off into #1153)
