### PR TITLE
[Openstack][provisioning] use Security Group ems_ref instead of name during provisioning

### DIFF
--- a/vmdb/app/models/miq_provision_openstack/cloning.rb
+++ b/vmdb/app/models/miq_provision_openstack/cloning.rb
@@ -16,7 +16,7 @@ module MiqProvisionOpenstack::Cloning
     clone_options[:image_ref]         = self.source.ems_ref
     clone_options[:flavor_ref]        = instance_type.ems_ref
     clone_options[:availability_zone] = nil if dest_availability_zone.kind_of?(AvailabilityZoneOpenstackNull)
-    clone_options[:security_groups]   = security_groups.collect(&:name)
+    clone_options[:security_groups]   = security_groups.collect(&:ems_ref)
     clone_options[:nics]              = configure_network_adapters unless configure_network_adapters.blank?
 
     clone_options

--- a/vmdb/spec/models/miq_provision_openstack_spec.rb
+++ b/vmdb/spec/models/miq_provision_openstack_spec.rb
@@ -67,8 +67,8 @@ describe MiqProvisionOpenstack do
     end
 
     context "security_groups" do
-      let(:security_group_1) { FactoryGirl.create(:security_group_openstack, :name => "group_1") }
-      let(:security_group_2) { FactoryGirl.create(:security_group_openstack, :name => "group_2") }
+      let(:security_group_1) { FactoryGirl.create(:security_group_openstack, :ems_ref => "340c315c-6c30-11e4-a103-56847afe9799") }
+      let(:security_group_2) { FactoryGirl.create(:security_group_openstack, :ems_ref => "41a73064-6c30-11e4-a103-56847afe9799") }
 
       it "with no security groups" do
         expect(subject.prepare_for_clone_task[:security_groups]).to eq([])
@@ -76,17 +76,17 @@ describe MiqProvisionOpenstack do
 
       it "with one security group" do
         subject.options[:security_groups] = [security_group_1.id]
-        expect(subject.prepare_for_clone_task[:security_groups]).to eq([security_group_1.name])
+        expect(subject.prepare_for_clone_task[:security_groups]).to eq([security_group_1.ems_ref])
       end
 
       it "with two security group" do
         subject.options[:security_groups] = [security_group_1.id, security_group_2.id]
-        expect(subject.prepare_for_clone_task[:security_groups]).to eq([security_group_1.name, security_group_2.name])
+        expect(subject.prepare_for_clone_task[:security_groups]).to eq([security_group_1.ems_ref, security_group_2.ems_ref])
       end
 
       it "with a missing security group" do
         subject.options[:security_groups] = [security_group_1.id, (security_group_1.id + 1)]
-        expect(subject.prepare_for_clone_task[:security_groups]).to eq([security_group_1.name])
+        expect(subject.prepare_for_clone_task[:security_groups]).to eq([security_group_1.ems_ref])
       end
     end
   end


### PR DESCRIPTION
Openstack allows you to create multiple security groups with the same name
If you attempt provisioning by name and there are multiple matches,
you will will receive an API error (HTTP 409 or 500).  Using the ems_ref
is guaranteed unique.  We display the name and description in the dialog,
so no further changes are required

https://bugzilla.redhat.com/show_bug.cgi?id=1161322
