### PR TITLE
Changed to save a Dialog that has at least one dialog field.

### DIFF
--- a/vmdb/app/controllers/miq_ae_customization_controller.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller.rb
@@ -237,7 +237,7 @@ class MiqAeCustomizationController < ApplicationController
           }
       ] if tree
     end
-    presenter[:osf_node] = x_node
+    presenter[:osf_node] = x_node unless @in_a_form
 
     if ['dialog_edit', 'dialog_copy'].include?(params[:pressed])
       presenter[:clear_tree_cookies] = "edit_treeOpenStatex"

--- a/vmdb/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/vmdb/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -43,5 +43,79 @@ describe MiqAeCustomizationController do
         expect(controller.instance_variable_get(:@idx)).to eq(1)
       end
     end
+
+    context "#dialog_edit" do
+      before do
+        seed_specific_product_features("dialog_edit")
+        @dialog = FactoryGirl.create(:dialog,
+                                     :label       => "Test Label",
+                                     :description => "Test Description"
+        )
+        tree_hash = {
+          :active_tree => :dialog_edit_tree,
+          :trees       => {
+            :dialog_edit_tree => {
+              :active_node => "root"
+            }
+          }
+        }
+        controller.instance_variable_set(:@_params, :button => "add")
+        controller.instance_variable_set(:@sb, tree_hash)
+        new = {:label => "a1", :description => "a1", :buttons => ["submit"], :tabs => []}
+        edit = {
+          :dialog         => @dialog,
+          :key            => 'dialog_edit__new',
+          :new            => new,
+          :dialog_buttons => ['submit, cancel']
+        }
+
+        controller.instance_variable_set(:@edit, edit)
+        session[:edit] = edit
+      end
+
+      it "Dialog with out Dialog fields should not be saved" do
+        controller.stub(:render_flash)
+        controller.send(:dialog_edit)
+        assigns(:flash_array).first[:message].should include("Dialog must have at least one Element")
+      end
+
+      it "Adds a Dialog with Tab/Groups/Field" do
+        new_hash = {
+          :label       => "Dialog 1",
+          :description => "Dialog 1",
+          :buttons     => ["submit"],
+          :tabs        => [
+            {
+              :label       => "Tab 1",
+              :description => "Tab 1",
+              :groups      => [
+                {
+                  :label       => "Box 1",
+                  :description => "Box 1",
+                  :fields      => [
+                    {
+                      :label         => "Field 1",
+                      :description   => "Field 1",
+                      :typ           => "DialogFieldCheckBox",
+                      :name          => "Field1",
+                      :default_value => false
+                    }
+                  ]
+                },
+                {
+                  :label => "Box 2", :description => "Box 2"
+                }
+              ]
+            }
+          ]
+        }
+        assigns(:edit)[:new] = new_hash
+        controller.stub(:get_node_info)
+        controller.stub(:replace_right_cell)
+        controller.send(:dialog_edit)
+        assigns(:flash_array).first[:message].should include("Dialog \"Dialog 1\" was added")
+        @dialog.dialog_fields.count.should eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Fixed code to not allow user to save a dialog that does not have at least one dialog field.
- Fixed infinite spinner after an existing resource was removed from a dialog.
- Added controller spec tests for dialog_edit method to verify that dialog is not saved without fields, and another one to verify save of dialog with 1 tab, 2 groups and 1 field.

https://bugzilla.redhat.com/show_bug.cgi?id=1156634
https://bugzilla.redhat.com/show_bug.cgi?id=1157796

@dclarizio please review/test.
