### PR TITLE
Changes to set priority for params & show focus on input name in form..

### DIFF
--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -2506,6 +2506,7 @@ private
         new_field = MiqAeField.new
         if @ae_method
           new_field.method_id = @ae_method.id
+          new_field.priority  = i + 1
         else
           new_field.class_id = @ae_class.id
         end

--- a/vmdb/app/views/layouts/_my_code_mirror.html.erb
+++ b/vmdb/app/views/layouts/_my_code_mirror.html.erb
@@ -8,6 +8,7 @@
 <% width ||= "auto"							%><%# Edit box width in pixels %>
 <% read_only ||= false					%><%# Edit box height in pixels %>
 <% multi_mode ||= false         %><%# to load/switch between multiple modes, for customization template editor %>
+<% no_focus ||= false           %><%# don't focus on code mirror textbox if there are other fields on screen %>
 
 <% if multi_mode %>
   <% modes.each do |mode| %>
@@ -40,6 +41,8 @@
     miqEditor.on("blur", function(cm) {miqEditor.save()}),
 		$j('.CodeMirror-scroll')[0].style.height = '<%= height %>px';
 		$j('.CodeMirror-scroll')[0].style.width = '<%= width %>px';
-		miqEditor.focus();
+    <% unless no_focus %>
+      miqEditor.focus();
+    <% end %>
 	}
 </script>

--- a/vmdb/app/views/miq_ae_class/_method_data.html.erb
+++ b/vmdb/app/views/miq_ae_class/_method_data.html.erb
@@ -45,6 +45,7 @@
             :locals => {:text_area_id => "#{field_name}_data",
                         :mode         => "ruby",
                         :line_numbers => true,
+                        :no_focus     => true,
                         :url          => url_one_trans}
 %>
 <% end %>


### PR DESCRIPTION
- Changed code to not focus on method data code mirror textbox. Code mirror partial was set to always put focus on code mirror text box. When adding a new input parameter for a method, controller sends down JS command to focus on parameter name text field which was not working as when replacing the whole screen code mirror field focus was taking over.
- Added code to set a priority as last for newly added input parameters so they are displayed in same order as they were added on screen.

@dclarizio please review/test
