### PR TITLE
Fixed the Right cell text in the Import/Export Accordion in Reports

### DIFF
--- a/vmdb/app/controllers/report_controller.rb
+++ b/vmdb/app/controllers/report_controller.rb
@@ -87,7 +87,9 @@ class ReportController < ApplicationController
         redirect_to :action => 'explorer'
       end
     else
-      redirect_to :action => 'explorer', :flash_msg=>_("Use the Browse button to locate an Import file"), :flash_error=>true
+      redirect_to :action        => 'explorer',
+                  :flash_msg     => _("Use the Browse button to locate an Import file"),
+                  :flash_warning => true
     end
   end
 
@@ -434,15 +436,14 @@ class ReportController < ApplicationController
   end
 
   def export_get_node_info
+    @right_cell_text = "Import / Export"
     if x_node.split('-').last == "exportcustomreports"
       get_export_reports
       @right_cell_div = "export_custom_reports"
-      @right_cell_text = "Custom Reports"
     else
       @in_a_form = true
       @widget_exports = MiqWidget.all.reject(&:read_only).collect { |widget| [widget.title, widget.id] }
       @right_cell_div = "export_widgets"
-      @right_cell_text = "Widgets"
     end
   end
 

--- a/vmdb/app/views/report/_export_custom_reports.haml
+++ b/vmdb/app/views/report/_export_custom_reports.haml
@@ -1,8 +1,8 @@
 - url = url_for(:action=>'export_field_changed')
 
-%h2 Custom Reports
-
 = render :partial=>"layouts/flash_msg"
+
+%h2 Custom Reports
 
 %p.legend Import
 


### PR DESCRIPTION
Clicking on the Upload button causes the form to refresh and display the "Custom Reports" caption twice. This was fixed by setting the correct value in @right_cell_text
(This is yet another case of a non-AJAX Upload button, where the entire form refreshes after a file upload)

https://bugzilla.redhat.com/show_bug.cgi?id=1163661
