### PR TITLE
Set passed in zone when calling create_request_task

### DIFF
--- a/vmdb/app/models/miq_provision_request.rb
+++ b/vmdb/app/models/miq_provision_request.rb
@@ -73,7 +73,7 @@ class MiqProvisionRequest < MiqRequest
   end
 
   def my_zone
-    self.source.ext_management_system.zone.name
+    source.my_zone
   end
 
   def my_role

--- a/vmdb/app/models/miq_request.rb
+++ b/vmdb/app/models/miq_request.rb
@@ -140,7 +140,7 @@ class MiqRequest < ActiveRecord::Base
       :instance_id => self.id,
       :method_name => "call_automate_event",
       :args        => [event_name],
-      :zone        => options.fetch(:miq_zone, MiqServer.my_zone),
+      :zone        => options.fetch(:miq_zone, my_zone),
       :msg_timeout => 3600
     )
   end
@@ -386,7 +386,7 @@ class MiqRequest < ActiveRecord::Base
   end
 
   def my_zone
-    nil
+    MiqServer.my_zone
   end
 
   def my_role
@@ -412,7 +412,7 @@ class MiqRequest < ActiveRecord::Base
       :class_name  => self.class.name,
       :instance_id => self.id,
       :method_name => "create_request_tasks",
-      :zone        => self.my_zone,
+      :zone        => options.fetch(:miq_zone, my_zone),
       :role        => self.my_role,
       :task_id     => "#{self.class.name.underscore}_#{self.id}",
       :msg_timeout => 3600,

--- a/vmdb/app/models/miq_request_task.rb
+++ b/vmdb/app/models/miq_request_task.rb
@@ -138,7 +138,7 @@ class MiqRequestTask < ActiveRecord::Base
         :method_name => 'deliver',
         :args        => [args],
         :role        => 'automate',
-        :zone        => zone,
+        :zone        => options.fetch(:miq_zone, zone),
         :task_id     => my_task_id,
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
@@ -158,13 +158,13 @@ class MiqRequestTask < ActiveRecord::Base
       deliver_on = self.get_option(:schedule_time).utc rescue nil
     end
 
-    zone = self.source.my_zone rescue nil
+    zone = source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
 
     queue_options.reverse_merge!(
       :class_name  => self.class.name,
       :instance_id => self.id,
       :method_name => "execute",
-      :zone        => zone,
+      :zone        => options.fetch(:miq_zone, zone),
       :role        => self.miq_request.my_role,
       :task_id     => my_task_id,
       :deliver_on  => deliver_on,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1162832

When a create_automation_request is called it triggers creation
of 4 queue entries with method names call_automate_event/
call_automate_event/create_request_tasks/execute. Only the first
entry had the zone set, the other 3 did not set the zone. This PR
addresses setting of zones for all 4 queue entries
