### PR TITLE
Automate endpoint miqButtons fix

### DIFF
--- a/vmdb/app/helpers/automate_tree_helper.rb
+++ b/vmdb/app/helpers/automate_tree_helper.rb
@@ -9,7 +9,7 @@ module AutomateTreeHelper
                                                     @edit[:new][:namespace].nil?
         page << javascript_hide("ae_tree_select_div")
         page << javascript_hide("blocker_div")
-        page << javascript_for_miq_button_visibility(@changed)
+        page << javascript_for_miq_button_visibility(@changed, 'automate')
         page << "miqSparkle(false);"
       end
 
@@ -58,7 +58,7 @@ module AutomateTreeHelper
       @changed = @edit[:new][edit_key] != @edit[:automate_tree_selected_path]
     end
     render :update do |page|
-      page << javascript_for_miq_button_visibility(@changed)
+      page << javascript_for_miq_button_visibility(@changed, 'automate')
     end
   end
 end

--- a/vmdb/app/views/layouts/_ae_tree_select.html.erb
+++ b/vmdb/app/views/layouts/_ae_tree_select.html.erb
@@ -22,33 +22,33 @@
       <table width="100%">
         <tr>
           <td align="right">
-            <div id="buttons_on" style="display:<%= @changed ? "display" : "none" %>;">
+            <div id="automate_buttons_on" style="display:<%= @changed ? "display" : "none" %>;">
               <%= link_to(button_tag('Apply',
-                                     :class => "btn btn-primary", 
+                                     :class => "btn btn-primary",
                                      :alt   => 'Apply'),
-                          {:action => "ae_tree_select_toggle", 
+                          {:action => "ae_tree_select_toggle",
                            :button => "submit"},
                           :remote => true,
-                          :title  => "Apply") 
+                          :title  => "Apply")
               %>
               <%= link_to(button_tag('Cancel',
-                                     :class => "btn btn-default", 
+                                     :class => "btn btn-default",
                                      :alt   => 'Cancel'),
-                          {:action => "ae_tree_select_toggle", 
+                          {:action => "ae_tree_select_toggle",
                            :button => "cancel"},
                           :remote => true,
-                          :title  => "Cancel") 
+                          :title  => "Cancel")
               %>
             </div>
-            <div id="buttons_off" style="display:<%= @changed ? "none" : "display" %>;">
+            <div id="automate_buttons_off" style="display:<%= @changed ? "none" : "display" %>;">
               <%= button_tag("Apply",	:class => "btn btn-primary btn-disabled") %>
-              <%= link_to(button_tag('Cancel', 
-                                     :class => "btn btn-disabled", 
+              <%= link_to(button_tag('Cancel',
+                                     :class => "btn btn-disabled",
                                      :alt   => 'Cancel'),
-                          {:action => "ae_tree_select_toggle", 
+                          {:action => "ae_tree_select_toggle",
                            :button => "cancel"},
                           :remote => true,
-                          :title  => "Cancel") 
+                          :title  => "Cancel")
               %>
             </div>
           </td>


### PR DESCRIPTION
Avoid DOM id conflict by prefixing AE endpoint selection buttons.

@h-kataria, please, review

Original report: When editing a new dialog in the dialog editor, add a new dialog, add tab, then box then try to add a field. Add button is NOT enabled for you.

The reason for this was a duplicit DOM id, so it may work for someone in some browser, sometime, but will not work for someone else depending on which of the conflicting DOM elements gets updated.
