### PR TITLE
Refactor VM post_create_actions into separate sub-classes

### DIFF
--- a/vmdb/app/models/template_cloud.rb
+++ b/vmdb/app/models/template_cloud.rb
@@ -5,6 +5,12 @@ class TemplateCloud < MiqTemplate
   }
 
   default_value_for :cloud, true
+
+  private
+
+  def raise_created_event
+    MiqEvent.raise_evm_event(self, "vm_template", :vm => self)
+  end
 end
 
 # Preload any subclasses of this class, so that they will be part of the

--- a/vmdb/app/models/template_infra.rb
+++ b/vmdb/app/models/template_infra.rb
@@ -12,6 +12,12 @@ class TemplateInfra < MiqTemplate
   def self.eligible_for_provisioning
     super.where(:type => %w(TemplateRedhat TemplateVmware))
   end
+
+  private
+
+  def raise_created_event
+    MiqEvent.raise_evm_event(self, "vm_template", :vm => self, :host => host)
+  end
 end
 
 # Preload any subclasses of this class, so that they will be part of the

--- a/vmdb/app/models/vm_cloud.rb
+++ b/vmdb/app/models/vm_cloud.rb
@@ -32,6 +32,11 @@ class VmCloud < Vm
     true
   end
 
+  private
+
+  def raise_created_event
+    MiqEvent.raise_evm_event(self, "vm_create", :vm => self)
+  end
 end
 
 # Preload any subclasses of this class, so that they will be part of the

--- a/vmdb/app/models/vm_infra.rb
+++ b/vmdb/app/models/vm_infra.rb
@@ -13,6 +13,7 @@ class VmInfra < Vm
   def cpu_mhz_available?
     true
   end
+
   def memory_mb_available?
     true
   end
@@ -22,6 +23,38 @@ class VmInfra < Vm
     super
   end
 
+  def post_create_actions
+    inherit_host_mgt_tags
+    super
+    post_create_autoscan
+  end
+
+  private
+
+  def inherit_host_mgt_tags
+    return unless host.try(:inherit_mgt_tags)
+
+    log_header = "MIQ(#{self.class.name}#inherit_host_mgt_tags)"
+    $log.info("#{log_header} Applying tags from [(#{host.class.name}) #{host.name}] to [(#{self.class.name}) #{name}]")
+    tags = host.tag_list(:ns => "/managed").split
+    tags.delete_if { |t| t =~ /^power_state/ } # omit power state since this is assigned by the system
+
+    tag_add(tags, :ns => "/managed")
+  rescue => err
+    $log.log_backtrace(err)
+  end
+
+  def post_create_autoscan
+    return unless host.try(:autoscan)
+
+    log_header = "MIQ(#{self.class.name}#post_create_autoscan)"
+    $log.info("#{log_header} Creating scan job on [(#{self.class.name}) #{name}]")
+    scan
+  end
+
+  def raise_created_event
+    MiqEvent.raise_evm_event(self, "vm_create", :vm => self, :host => host)
+  end
 end
 
 # Preload any subclasses of this class, so that they will be part of the

--- a/vmdb/spec/models/template_cloud_spec.rb
+++ b/vmdb/spec/models/template_cloud_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe TemplateCloud do
+  it "#post_create_actions" do
+    expect(subject).to receive(:reconnect_events)
+    expect(subject).to receive(:classify_with_parent_folder_path)
+    expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_template", :vm => subject)
+
+    subject.post_create_actions
+  end
+end

--- a/vmdb/spec/models/template_infra_spec.rb
+++ b/vmdb/spec/models/template_infra_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe TemplateInfra do
+  context "#post_create_actions" do
+    it "without a host relationship" do
+      expect(subject).to receive(:reconnect_events)
+      expect(subject).to receive(:classify_with_parent_folder_path)
+      expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_template", :vm => subject, :host => nil)
+
+      subject.post_create_actions
+    end
+
+    it "with a host relationship" do
+      subject.host = FactoryGirl.build(:host)
+
+      expect(subject).to receive(:reconnect_events)
+      expect(subject).to receive(:classify_with_parent_folder_path)
+      expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_template", :vm => subject, :host => subject.host)
+
+      subject.post_create_actions
+    end
+  end
+end

--- a/vmdb/spec/models/vm_cloud_spec.rb
+++ b/vmdb/spec/models/vm_cloud_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe VmCloud do
+  it "#post_create_actions" do
+    expect(subject).to receive(:reconnect_events)
+    expect(subject).to receive(:classify_with_parent_folder_path)
+    expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_create", :vm => subject)
+
+    subject.post_create_actions
+  end
+end

--- a/vmdb/spec/models/vm_infra_spec.rb
+++ b/vmdb/spec/models/vm_infra_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+
+describe VmInfra do
+
+  context "#post_create_actions" do
+    it "without a host relationship" do
+      expect(subject).to receive(:reconnect_events)
+      expect(subject).to receive(:classify_with_parent_folder_path)
+      expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_create", :vm => subject, :host => nil)
+
+      subject.post_create_actions
+    end
+
+    it "with a host relationship" do
+      subject.host = FactoryGirl.build(:host)
+
+      expect(subject).to receive(:reconnect_events)
+      expect(subject).to receive(:classify_with_parent_folder_path)
+      expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_create", :vm => subject, :host => subject.host)
+      expect(subject).to receive(:inherit_host_mgt_tags)
+      expect(subject).to receive(:post_create_autoscan)
+
+      subject.post_create_actions
+    end
+  end
+
+  context "#inherit_host_mgt_tags" do
+    it "without a host" do
+      expect(subject).to_not receive(:add_tag)
+
+      subject.send(:inherit_host_mgt_tags)
+    end
+
+    context "with a host" do
+      let(:host) { subject.host = FactoryGirl.build(:host, :settings => {:inherit_mgt_tags => false}) }
+
+      it "inherit_mgt_tags is false" do
+        subject.host = host
+
+        expect(subject).to_not receive(:add_tag)
+
+        subject.send(:inherit_host_mgt_tags)
+      end
+
+      it "inherit_mgt_tags is true" do
+        subject.host = host
+        subject.host.inherit_mgt_tags = true
+
+        expect(subject).to receive(:tag_add)
+
+        subject.send(:inherit_host_mgt_tags)
+      end
+    end
+  end
+
+  context "#post_create_autoscan" do
+    it "without a host" do
+      expect(subject).to_not receive(:scan)
+
+      subject.send(:post_create_autoscan)
+    end
+
+    context "with a host" do
+      let(:host) { FactoryGirl.create(:host, :settings => {:autoscan => false}) }
+
+      it "autoscan is false" do
+        subject.host = host
+
+        expect(subject).to_not receive(:scan)
+
+        subject.send(:post_create_autoscan)
+      end
+
+      it "autoscan is true" do
+        subject.host = host
+        subject.host.autoscan = true
+
+        expect(subject).to receive(:scan)
+
+        subject.send(:post_create_autoscan)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moved logic to raise created_event into sub-classes
Moved infra logic for inherit of tags and scanning based on host into Infra sub-class

https://bugzilla.redhat.com/show_bug.cgi?id=1044597
