### PR TITLE
Use placeholder to display default/new value in grey/black in the form.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -725,22 +725,6 @@ function miqCheckMaxLength(obj){
     else $(counter).innerText = obj.value.length;
 }
 
-// Handle showing/hiding default values as grey in automate instance editor if field value is blank
-function miqSetInputValues(fld, evt){
-  if (evt == 'blur' && fld.value == '' && typeof fld.attributes['data-miq_default_value'] != 'undefined') {
-    self.setTimeout(function(el, default_value) {
-      $j(el).off();
-      $j(el).addClass('input_def_val');
-      el.setValue(default_value);
-    }, 700, fld, fld.attributes['data-miq_default_value'].value);
-  }
-  if (evt == 'focus' && $j(fld).hasClass('input_def_val')) {
-    fld.setValue('');
-    $j(fld).removeClass('input_def_val');
-  }
-  return true;
-}
-
 function miqSetInputClass(fld,cname,typ){
   if (typ == "remove"){
     $j(fld).removeClass(cname)

--- a/vmdb/app/assets/javascripts/miq_ujs_bindings.js
+++ b/vmdb/app/assets/javascripts/miq_ujs_bindings.js
@@ -49,10 +49,7 @@ $j(document).ready(function(){
 		} else {
       $j(this).off(); // Use jQuery to turn off observe_field, prevents multi ajax transactions
 
-      // If the field has a default value, call function to remove the greyed out default before turning on the observer
-      if (typeof this.attributes['data-miq_default_value'] != 'undefined') miqSetInputValues(this, 'focus');
-
-			$j(this).observe_field(interval, function(){
+      $j(this).observe_field(interval, function(){
 				var oneTrans = this.getAttribute('data-miq_send_one_trans');	// Grab one trans URL, if present
 				if (typeof submit != "undefined"){										// If submit element passed in
 					new Ajax.Request(encodeURI(url),										//  serialize the element
@@ -64,14 +61,12 @@ $j(document).ready(function(){
 				} else if (oneTrans) {
 					miqSendOneTrans(url);
 				} else {
-          if (!$j(this).hasClass('input_def_val')) { // Do not send up transaction if showing the default value
-            urlstring = url + "?" + this.id + "=" + encodeURIComponent(this.value);	//  tack on the id and value to the URL
-            new Ajax.Request(urlstring,
-                            {
-                              asynchronous:true, evalScripts:true
-                            }
-            );
-          }
+          urlstring = url + "?" + this.id + "=" + encodeURIComponent(this.value);	//  tack on the id and value to the URL
+          new Ajax.Request(urlstring,
+                          {
+                            asynchronous:true, evalScripts:true
+                          }
+          );
         }
 			});
 		}

--- a/vmdb/app/assets/stylesheets/template.css.erb
+++ b/vmdb/app/assets/stylesheets/template.css.erb
@@ -328,7 +328,6 @@ ul#searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px; bac
 .tab3 li a { display: block;margin: 2px 2px 0 0; padding: 1px 10px 1px 10px; height: 20px; background: none; vertical-align: middle; font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif; }
 
 /* Automate Specific */
-.input_def_val { color: #a8a8a8;}
 .checkall { padding: 0 0 7px 7px;} /*styling for automate (Check All) */
 #automate_tree_div { position: absolute; z-index: 49; left:100px; padding: 10px; overflow-y: none; background: #fff;}
 #automate_tree_box { width: 550px; height:300px; top: 43px; padding: 15px 5px 5px 0;color:#000;overflow-Y:scroll}

--- a/vmdb/app/views/miq_ae_class/_instance_form.html.erb
+++ b/vmdb/app/views/miq_ae_class/_instance_form.html.erb
@@ -74,78 +74,55 @@
           </td>
           <td>
             <% default_value = @edit[:new][:ae_fields][i]["default_value"] %>
-            <% cls = flds["value"].blank? && !default_value.blank? ? "input_def_val" : "" %>
             <% if @edit[:new][:ae_fields][i]["datatype"] == "password" %>
               <%= password_field_tag("#{prefix}inst_password_value_#{i}",
-                                     flds["value"].blank? ? default_value : flds["value"],
-                                     :class  => cls,
-                                     :onBlur =>"miqSetInputValues(this, 'blur')",
-                                     #:onFocus =>"miqSetInputValues(this, 'focus')",  # UJS binding will call this
-                                     "data-miq_default_value" => default_value,
-                                     "data-miq_observe"       => {:interval => '.5',
+                                     flds["value"].blank? ? '' : flds["value"],
+                                     :placeholder       => default_value,
+                                     "data-miq_observe" => {:interval => '.5',
                                                                   :url      => url}.to_json)
               %>
             <% else %>
               <%= text_field_tag("#{prefix}inst_value_#{i}",
-                                 flds["value"].blank? ? default_value : flds["value"],
-                                 :class  => cls,
-                                 :onBlur => "miqSetInputValues(this, 'blur')",
-                                 #:onFocus =>"miqSetInputValues(this, 'focus')",  # UJS binding will call this
-                                 "data-miq_default_value" => default_value,
-                                 "data-miq_observe"       => {:interval => '.5',
+                                 flds["value"].blank? ? '' : flds["value"],
+                                 :placeholder       => default_value,
+                                 "data-miq_observe" => {:interval => '.5',
                                                               :url      => url}.to_json)
               %>
             <% end %>
           </td>
           <td>
             <% default_value = @edit[:new][:ae_fields][i]["on_entry"] %>
-            <% cls = flds["on_entry"].blank? && !default_value.blank? ? "input_def_val" : "" %>
             <%= text_field_tag("#{prefix}inst_on_entry_#{i}",
-                               flds["on_entry"].blank? ? default_value : flds["on_entry"],
-                               :class => cls,
-                               :onBlur => "miqSetInputValues(this, 'blur')",
-                               #:onFocus =>"miqSetInputValues(this, 'focus')",  # UJS binding will call this
-                               "data-miq_default_value" => default_value,
+                               flds["on_entry"].blank? ? '' : flds["on_entry"],
+                               :placeholder       => default_value,
                                "data-miq_observe" => {:interval => '.5',
-                                                      :url      => url}.to_json)
+                                                            :url      => url}.to_json)
             %>
           </td>
           <td>
             <% default_value = @edit[:new][:ae_fields][i]["on_exit"] %>
-            <% cls = flds["on_exit"].blank? && !default_value.blank? ? "input_def_val" : "" %>
             <%= text_field_tag("#{prefix}inst_on_exit_#{i}",
-                               flds["on_exit"].blank? ? default_value : flds["on_exit"],
-                               :class  => cls,
-                               :onBlur =>"miqSetInputValues(this, 'blur')",
-                               #:onFocus =>"miqSetInputValues(this, 'focus')",  # UJS binding will call this
-                               "data-miq_default_value" => default_value,
+                               flds["on_exit"].blank? ? '' : flds["on_exit"],
+                               :placeholder       => default_value,
                                "data-miq_observe" => {:interval => '.5',
-                                                      :url      => url}.to_json)
+                                                            :url      => url}.to_json)
             %>
           </td>
           <td>
             <% default_value = @edit[:new][:ae_fields][i]["on_error"] %>
-            <% cls = flds["on_error"].blank? && !default_value.blank? ? "input_def_val" : "" %>
             <%= text_field_tag("#{prefix}inst_on_error_#{i}",
-                               flds["on_error"].blank? ? default_value : flds["on_error"],
-                               :class  => cls,
-                               :onBlur => "miqSetInputValues(this, 'blur')",
-                               #:onFocus =>"miqSetInputValues(this, 'focus')",  # UJS binding will call this
-                               "data-miq_default_value" => default_value,
-                               "data-miq_observe"       => {:interval => '.5',
+                               flds["on_error"].blank? ? '' : flds["on_error"],
+                               :placeholder       => default_value,
+                               "data-miq_observe" => {:interval => '.5',
                                                             :url      => url}.to_json)
             %>
           </td>
           <td>
             <% default_value = @edit[:new][:ae_fields][i]["collect"] %>
-            <% cls = flds["collect"].blank? && !default_value.blank? ? "input_def_val" : "" %>
             <%= text_field_tag("#{prefix}inst_collect_#{i}",
-                               flds["collect"].blank? ? default_value : flds["collect"],
-                               :class  => cls,
-                               :onBlur => "miqSetInputValues(this, 'blur')",
-                               #:onFocus =>"miqSetInputValues(this, 'focus')",  # UJS binding will call this
-                               "data-miq_default_value" => default_value,
-                               "data-miq_observe"       => {:interval => '.5',
+                               flds["collect"].blank? ? '' : flds["collect"],
+                               :placeholder       => default_value,
+                               "data-miq_observe" => {:interval => '.5',
                                                             :url      => url}.to_json)
             %>
           </td>


### PR DESCRIPTION
Removed JS code that used to show default value of class fields in grey on value Instance edit form and used to change it to black text when user changed the value. Replaced that functionality by using :placeholder attribute of text_field_tag. Deleted any related CSS and JS methods.

@dclarizio please review/test.
