### PR TITLE
Verify the rollups for the day match, regardless of order.

### DIFF
--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -532,7 +532,7 @@ describe Metric do
 
         it "should find the correct rows" do
           Metric::Finders.hour_to_range("2010-04-14T21:00:00Z").should == ["2010-04-14T21:00:00Z", "2010-04-14T21:59:59Z"]
-          Metric::Finders.find_all_by_hour(@vm1, "2010-04-14T21:00:00Z", 'realtime').should == @vm1.metrics.sort_by(&:timestamp)[1..5]
+          Metric::Finders.find_all_by_hour(@vm1, "2010-04-14T21:00:00Z", 'realtime').should match_array @vm1.metrics.sort_by(&:timestamp)[1..5]
         end
 
         context "calling perf_rollup to hourly on the Vm" do


### PR DESCRIPTION
Similar solution as #891 

I noticed a recent travis failed with this sporadic failure: https://travis-ci.org/ManageIQ/manageiq/jobs/41621952
