### PR TITLE
Hide the paging controls in Chargeback -> Assignments -> Storage

### DIFF
--- a/vmdb/app/controllers/chargeback_controller.rb
+++ b/vmdb/app/controllers/chargeback_controller.rb
@@ -67,7 +67,6 @@ class ChargebackController < ApplicationController
 
     @sb[:open_tree_nodes] ||= []
 
-    cb_rates_list
     @right_cell_text = case x_active_tree
     when :cb_rates_tree       then _("All %s") % ui_lookup(:models=>"ChargebackRate")
     when :cb_assignments_tree then _("All %s") % "Assignments"


### PR DESCRIPTION
The call to the 'cb_rates_list' method applies to the Rates accordion only and should not be called in explorer since that fetches the chargeback rates list and displays a paging control at the bottom of the 'Assignments' page where the paging controls are not applicable.

https://bugzilla.redhat.com/show_bug.cgi?id=1166187
