### PR TITLE
Fix inheriting tags from resource pool

### DIFF
--- a/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
@@ -276,7 +276,7 @@ module MiqPolicyController::MiqActions
                                   [ui_lookup(:table=>"ems_cluster"), "ems_cluster"],
                                   ["Host","host"],
                                   [ui_lookup(:table=>"storage"),"storage"],
-                                  ["Resource Pool","resource_pool"]
+                                  ["Resource Pool","parent_resource_pool"]
                                 ].sort{|a,b| a.first.downcase<=>b.first.downcase}
     @edit[:cats] = MiqAction.inheritable_cats.sort{|a,b| a.description.downcase <=> b.description.downcase}.collect{|c| [c.name, c.description]}
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1164386

"Resource Pool" needs to point to a valid method in `VmOrTemplate`. `VmOrTemplate#parent_resource_pool` is the existing method while `VmOrTemplate#resource_pool` does not exist. 

Another way to fix the problem is to add an alias `resource_pool` for the existing `parent_resource_pool` method in `VmOrTemplate`. This way any user already defined policies will start to work. The down side of the way is exposing a new (alias) method only for this bug. 
