### PR TITLE
Fixed spec/requests/ authentication specs

### DIFF
--- a/vmdb/app/services/request_referer_service.rb
+++ b/vmdb/app/services/request_referer_service.rb
@@ -160,7 +160,7 @@ class RequestRefererService
   end
 
   def ie8_referer_exception?(headers, controller_name, action_name)
-    return false unless headers['HTTP_USER_AGENT'].downcase.include?("msie 8")
+    return false unless headers['HTTP_USER_AGENT'].to_s.downcase.include?("msie 8")
     controller_sym = controller_name.to_sym
     true if IE8_EXCEPTIONS.key?(controller_sym) && IE8_EXCEPTIONS[controller_sym].include?(action_name)
   end

--- a/vmdb/config/initializers/session_store.rb
+++ b/vmdb/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
-if !MiqEnvironment::Process.is_web_server_worker?
-  Vmdb::Application.config.session_store :memory_store if Rails.env.test?
-else
+if Rails.env.test?
+  Vmdb::Application.config.session_store :memory_store
+elsif MiqEnvironment::Process.is_web_server_worker?
   session_options = {}
   if MiqEnvironment::Command.is_appliance?
     session_options[:secure]   = true

--- a/vmdb/spec/requests/auth_spec.rb
+++ b/vmdb/spec/requests/auth_spec.rb
@@ -39,13 +39,13 @@ describe "Login process" do
   context 'w/ a valid session' do
     it "allows access w/ a valid referer" do
       post '/dashboard/authenticate', :user_name => 'admin', :user_password => 'smartvm'
-      get '/ems_cloud/show_list', nil, 'HTTP_USER_AGENT' => "chrome", 'HTTP_REFERER' => "http://www.example.com/"
+      get '/ems_cloud/show_list', nil, 'HTTP_REFERER' => "http://www.example.com/"
       expect(response.status).to eq(200)
     end
 
     it "does not allow access w/o a valid referer" do
       post '/dashboard/authenticate', :user_name => 'admin', :user_password => 'smartvm'
-      get '/ems_cloud/show_list', nil, 'HTTP_USER_AGENT' => "chrome", 'HTTP_REFERER' => "http://foo.bar.com/"
+      get '/ems_cloud/show_list', nil, 'HTTP_REFERER' => "http://foo.bar.com"
       expect(response.status).to eq(403)
     end
 


### PR DESCRIPTION
- Update session_store to use :memory instead of default cookie_store for tests, eliminating the 4K limit that was giving us the 500's.
- Needed to specify HTTP_USER_AGENT for a couple of tests in auth_spec.rb

This fix is needed before enabling spec:requests as part of test:vmdb for the REST API.

@martinpovolny @Fryguy please review.
