### PR TITLE
[WIP] Phase 1 of multiple provider connection feature

### DIFF
--- a/vmdb/app/models/authentication.rb
+++ b/vmdb/app/models/authentication.rb
@@ -95,6 +95,7 @@ class Authentication < ActiveRecord::Base
     return  case self.resource_type
     when "Host"                then "host"
     when "ExtManagementSystem" then "ems"
+    when "ProviderConnection"  then "provider connection"
     end
   end
 end

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -451,8 +451,18 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def authentications_by_class(class_name)
-    return provider_connection.authentications if class_name.nil? || class_name == AUTH_BASE_CLASS
+    return authentications if class_name.nil? || class_name == AUTH_BASE_CLASS
     klass = class_name.constantize
-    provider_connection.authentications.select { |a| a.kind_of?(klass) }
+    authentications.select { |a| a.kind_of?(klass) }
   end
+
+  def authentications
+    provider_connection.authentications <<
+      Authentication.where(resource_id: self.id, resource_type: self.class.base_class.name)
+  end
+
+  def authentications=(auths)
+    provider_connection.authentications = auths
+  end
+
 end

--- a/vmdb/app/models/provider_connection.rb
+++ b/vmdb/app/models/provider_connection.rb
@@ -33,4 +33,8 @@ class ProviderConnection < ActiveRecord::Base
   def hostname_ipaddress_required?
     true
   end
+
+  def authentication_check_role
+    'ems_operations'
+  end
 end

--- a/vmdb/app/models/provider_connection.rb
+++ b/vmdb/app/models/provider_connection.rb
@@ -1,0 +1,36 @@
+class ProviderConnection < ActiveRecord::Base
+  attr_accessible :ipaddress, :port, :provider_component, :hostname
+  belongs_to      :ext_management_system, :foreign_key => "ems_id", :polymorphic => true
+  validates       :hostname, :ipaddress, :presence => true, :uniqueness => {:case_sensitive => false},
+    :if => :hostname_ipaddress_required?
+
+  include AuthenticationMixin
+
+  def verify_credentials(auth_type = nil, _options = {})
+    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?
+    ems = ExtManagementSystem.find_by_id(ems_id)
+
+    ems.verify_credentials(auth_type, make_options_hash(auth_type))
+  end
+
+  def make_options_hash(_auth_type = nil)
+    {
+      :user      => username,
+      :password  => password,
+      :ipaddress => ipaddress,
+      :port      => port
+    }
+  end
+
+  def username
+    authentications.first.userid
+  end
+
+  def password
+    authentications.first.password
+  end
+
+  def hostname_ipaddress_required?
+    true
+  end
+end

--- a/vmdb/db/migrate/20141006200403_create_provider_connections.rb
+++ b/vmdb/db/migrate/20141006200403_create_provider_connections.rb
@@ -1,0 +1,14 @@
+class CreateProviderConnections < ActiveRecord::Migration
+  def change
+    create_table :provider_connections do |t|
+      t.string :port
+      t.bigint :ems_id
+      t.string :ipaddress
+      t.string :hostname
+      t.string :name
+      t.string :provider_component
+
+      t.timestamps
+    end
+  end
+end

--- a/vmdb/db/migrate/20141121200153_move_data_from_ext_mgmt_to_provider_connections.rb
+++ b/vmdb/db/migrate/20141121200153_move_data_from_ext_mgmt_to_provider_connections.rb
@@ -1,0 +1,38 @@
+class MoveDataFromExtMgmtToProviderConnections < ActiveRecord::Migration
+  def up
+    ExtManagementSystem.find_each do |ext|
+      conn = ext.provider_connections.create(
+        :ems_id    => ext[:id],
+        :port      => ext[:port],
+        :hostname  => ext[:hostname],
+        :ipaddress => ext[:ipaddress]
+      )
+      Authentication.where(:resource_id => ext.id).find_each do |auth|
+        auth.update_attributes(
+          :resource_type => conn.class.name,
+          :name          => "#{conn.class.name}/#{conn.id}",
+          :resource_id   => conn.id
+        )
+      end
+    end
+  end
+
+  def down
+    ProviderConnection.find_each do |conn|
+      ems = ExtManagementSystem.where(:id => conn.ems_id).first
+
+      execute "update ext_management_systems set port ='#{conn.port}',
+        ipaddress='#{conn.ipaddress}', hostname ='#{conn.hostname}' where id=#{conn.ems_id}"
+
+      Authentication.where(:resource_id => conn.id).find_each do |auth|
+        auth.update_attributes(
+          :resource_type => 'ExtManagementSystem',
+          :name          => ems.name,
+          :resource_id   => ems.id
+        )
+      end
+
+      conn.destroy
+    end
+  end
+end

--- a/vmdb/db/migrate/20141121200523_remove_provider_conn_data_from_ext_mgmt.rb
+++ b/vmdb/db/migrate/20141121200523_remove_provider_conn_data_from_ext_mgmt.rb
@@ -1,0 +1,13 @@
+class RemoveProviderConnDataFromExtMgmt < ActiveRecord::Migration
+  def up
+    remove_column :ext_management_systems, :port
+    remove_column :ext_management_systems, :ipaddress
+    remove_column :ext_management_systems, :hostname
+  end
+
+  def down
+    add_column    :ext_management_systems, :port, :string
+    add_column    :ext_management_systems, :ipaddress, :string
+    add_column    :ext_management_systems, :hostname, :string
+  end
+end

--- a/vmdb/spec/factories/provider_connection.rb
+++ b/vmdb/spec/factories/provider_connection.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :provider_connection do
+    sequence(:name)      { |n| "p_conn_#{seq_padded_for_sorting(n)}" }
+    sequence(:hostname)  { |n| "p_conn_#{seq_padded_for_sorting(n)}" }
+    sequence(:ipaddress) { |n| "192.168.123.12"}
+  end
+
+  factory :provider_connection_with_authentication, :parent => :provider_connection do
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication)
+      # x.authentications = [FactoryGirl.build(:authentication, :resource => x)]
+    end
+  end
+end


### PR DESCRIPTION
Still to do:

1. spec tests
2. test with Openstack events, RHEV and Amazon to make sure they are all still working.
3. there is something not quite right with one of the rollback migrations.

note i needed a postgresSQL statement in one of the migrations. This is because setting the port, hostname and ipaddress would call the ext_management_system accessor methods which would in turn set these properties on the provider_connections records which were rolled back.  

Replaces part of #1037 