### PR TITLE
Add missing post route for dashboard widget move

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1111,6 +1111,7 @@ Vmdb::Application.routes.draw do
         db_edit
         db_form_field_changed
         db_seq_edit
+        db_widget_dd_done
         db_widget_remove
         discard_changes
         explorer

--- a/vmdb/spec/routing/report_routing_spec.rb
+++ b/vmdb/spec/routing/report_routing_spec.rb
@@ -5,6 +5,10 @@ describe "routes for ReportController" do
     it "routes with GET" do
       expect(get("/report/db_widget_dd_done")).to route_to("report#db_widget_dd_done")
     end
+
+    it "routes with POST" do
+      expect(post("/report/db_widget_dd_done")).to route_to("report#db_widget_dd_done")
+    end
   end
 
   describe "#download_report" do


### PR DESCRIPTION
This is to fix the following error:

ActionController::RoutingError (No route matches [POST]
"/report/db_widget_dd_done")
...

https://bugzilla.redhat.com/show_bug.cgi?id=1167308
