### PR TITLE
Charting: implement autoresize for charts

### DIFF
--- a/vmdb/app/assets/javascripts/miq_jqplot.js
+++ b/vmdb/app/assets/javascripts/miq_jqplot.js
@@ -25,11 +25,9 @@ function jqplot_process_options(data) {
 }
 
 function load_jqplot_charts() {
-  for (var set in miq_chart_data) {
-    for (var i = 0; i < miq_chart_data[set].length; i = i + 1) {
+  for (var set in miq_chart_data)
+    for (var i = 0; i < miq_chart_data[set].length; i++)
       load_jqplot_chart(set, i);
-    }
-  }
 }
 
 function load_jqplot_chart(chart_set, index) {
@@ -49,4 +47,30 @@ function load_jqplot_chart(chart_set, index) {
     }
   }
 }
+
+function jqplot_register_chart(chart_id, chart) {
+  if (typeof(ManageIQ) === 'undefined') ManageIQ = {};
+  if (ManageIQ.charts === undefined) ManageIQ.charts = {};
+
+  ManageIQ.charts[chart_id] = chart;
+}
+
+function jqplot_redraw_charts() {
+  if (typeof(ManageIQ) === 'undefined') return;
+
+  for (var chart in ManageIQ.charts)
+    if (ManageIQ.charts.hasOwnProperty(chart)) {
+	    // We are passing in the foobar option to fool jqplot into doing full reInitialize()
+	    // instead of quickInit() to properly recalculate the bar charts.
+      try {
+        ManageIQ.charts[chart].replot({resetAxes: true, foobar: true});
+      } catch (e) {};
+    }
+}
+
+$(document).ready(function(){
+  $(window).resize(function() {
+    setTimeout(jqplot_redraw_charts, 500);
+  });
+});
 

--- a/vmdb/app/assets/stylesheets/jqplot.css
+++ b/vmdb/app/assets/stylesheets/jqplot.css
@@ -1,6 +1,8 @@
 .jqplot-target {
   font-family: $base-font-family;
   font-size: $base-font-size;
+  position: relative !important;
+  width: auto !important;
 }
 
 
@@ -35,10 +37,11 @@ div.jqplot-table-legend-swatch-outline {
   position: absolute;
   bottom: -8px;
   left: 50%;
-  margin-top: -15px;  /*adjust position, arrow has a height of 30px.*/ 
+  margin-top: -15px;  /*adjust position, arrow has a height of 30px.*/
   margin-left: -8px;
   border: solid 15px transparent;
   border-width: 10px 10px 0;
   border-top-color: #434343;
   z-index: 1;
 }
+

--- a/vmdb/app/helpers/jqplot_helper.rb
+++ b/vmdb/app/helpers/jqplot_helper.rb
@@ -9,7 +9,8 @@ jQuery(document).ready(function($) {
       dataType: "json",
       complete: function(request) { miqSparkle(false); },
       success:  function(chart) {
-        $.jqplot('#{chart_id}', chart.data, jqplot_process_options(chart.options));
+        var a_chart = $.jqplot('#{chart_id}', chart.data, jqplot_process_options(chart.options));
+        jqplot_register_chart('#{chart_id}', a_chart);
       }
     });
 });
@@ -31,7 +32,8 @@ jQuery(document).ready(function($) {
   var data    = #{data};
   var options = #{options};
 
-  $.jqplot('#{chart_id}', data, jqplot_process_options(options));
+  var chart = $.jqplot('#{chart_id}', data, jqplot_process_options(options));
+  jqplot_register_chart('#{chart_id}', chart);
 });
 EOJ
     content_tag_for_jqplot(chart_id, opts[:width], opts[:height], javascript)


### PR DESCRIPTION
When browser window resizes, charts are recalculated.

Implements #1101 

More testing is needed especially for situation when chart is drawn and then removed from the screen while browser is still on the page.

@epwinchell, please, take a look if this fits your idea about #1101