### PR TITLE
Remove unreachable code from several years ago.

### DIFF
--- a/lib/Verbs/implementations/VmdbOps.rb
+++ b/lib/Verbs/implementations/VmdbOps.rb
@@ -98,8 +98,7 @@ class VmdbOps
 	# context of this class.
 	
 	def getVmFile(ost)
-	    return VMWareOps.getVmFile(ost) #if VMWareOps.isVmwareFile?(ost)
-	    return ost.args[0]
+	    VMWareOps.getVmFile(ost)
 	end
 	
 	def getVmMdFile(vmName, sfx)


### PR DESCRIPTION
rubocop --only Lint/UnreachableCode -d

lib/Verbs/implementations/VmdbOps.rb:102:6: W: Lint/UnreachableCode: Unreachable code detected.
      return ost.args[0]
     ^^^^^^^^^^^^^^^^^^
