### PR TITLE
Fixed a few known issues in Chargeback Explorer

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -237,6 +237,7 @@ Vmdb::Application.routes.draw do
         tree_autoload_dynatree
         tree_select
         x_button
+        x_show
       )
     },
 

--- a/vmdb/spec/routing/chargeback_routing_spec.rb
+++ b/vmdb/spec/routing/chargeback_routing_spec.rb
@@ -94,4 +94,10 @@ describe 'routes for ChargebackController' do
       expect(get("/#{controller_name}/report_only")).to route_to("#{controller_name}#report_only")
     end
   end
+
+  describe '#x_show' do
+    it 'routes with POST' do
+      expect(post("/#{controller_name}/x_show")).to route_to("#{controller_name}#x_show")
+    end
+  end
 end


### PR DESCRIPTION
1. Fixed sorting and paging in Rates list
2. Fixed "Abandon Changes" prompt appearing even for no changes in the form
