### PR TITLE
Dynamic radio service dialogs

### DIFF
--- a/vmdb/app/assets/stylesheets/main.sass
+++ b/vmdb/app/assets/stylesheets/main.sass
@@ -7,5 +7,6 @@
 @import partials/header
 @import partials/jqplot
 @import partials/dialog_import_export
+@import partials/dialog_fields
 
 // Third-party

--- a/vmdb/app/assets/stylesheets/partials/_dialog_fields.sass
+++ b/vmdb/app/assets/stylesheets/partials/_dialog_fields.sass
@@ -1,0 +1,2 @@
+.dynamic-radio-label
+  padding: 0 3px

--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -163,13 +163,17 @@ module ApplicationController::DialogRunner
   end
 
   def dynamic_radio_button_refresh
-    field = DialogField.find(params[:id])
-    field.refresh_button_pressed
+    @edit = session[:edit]
+
+    dialog = @edit[:wf].dialog
+
+    field = dialog.field(params[:name])
+    values = field.refresh_button_pressed
 
     json = {
       :default_value => field.default_value,
       :field_name    => field.name,
-      :values        => field.values
+      :values        => values
     }
 
     respond_to do |format|

--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -170,8 +170,13 @@ module ApplicationController::DialogRunner
     field = dialog.field(params[:name])
     values = field.refresh_button_pressed
 
+    checked_value = values.collect { |value_pair| value_pair[0] }.include?(params[:checked_value]) ?
+      params[:checked_value] : field.default_value
+
+    field.value = checked_value
+
     json = {
-      :default_value => field.default_value,
+      :checked_value => checked_value,
       :field_name    => field.name,
       :values        => values
     }

--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -170,7 +170,7 @@ module ApplicationController::DialogRunner
     field = dialog.field(params[:name])
     values = field.refresh_button_pressed
 
-    checked_value = values.collect { |value_pair| value_pair[0] }.include?(params[:checked_value]) ?
+    checked_value = values.collect { |value_pair| value_pair[0].to_s }.include?(params[:checked_value]) ?
       params[:checked_value] : field.default_value
 
     field.value = checked_value

--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -162,6 +162,21 @@ module ApplicationController::DialogRunner
     end
   end
 
+  def dynamic_radio_button_refresh
+    field = DialogField.find(params[:id])
+    field.refresh_button_pressed
+
+    json = {
+      :default_value => field.default_value,
+      :field_name    => field.name,
+      :values        => field.values
+    }
+
+    respond_to do |format|
+      format.json { render :json => json, :status => 200 }
+    end
+  end
+
   private     #######################
 
   def dialog_reset_form

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -55,7 +55,7 @@ module MiqAeCustomizationController::Dialogs
 
         unless @edit[:field_typ] && @edit[:field_typ].include?("TagControl")
           page.replace("field_values_div", :partial=>"field_values", :locals=>{ :entry=>nil}) if params[:field_data_typ] ||
-            params[:field_sort_by] || params[:field_sort_order] || params[:field_dynamic] #need to refresh values table if sortby or data_type changed
+            params[:field_sort_by] || params[:field_sort_order] || params[:field_dynamic]
         end
         page << "miqInitDashboardCols();"
       end
@@ -1044,7 +1044,7 @@ module MiqAeCustomizationController::Dialogs
         @edit[:field_category]     = field[:category]
       end
 
-      if 'DialogFieldDynamicList' == field[:typ] || field[:dynamic] == true
+      if dynamic_field?(field)
         @edit.update(
           :field_load_on_init        => field[:load_on_init],
           :field_show_refresh_button => field[:show_refresh_button],
@@ -1142,7 +1142,7 @@ module MiqAeCustomizationController::Dialogs
               :dynamic        => f.dynamic
             }
 
-            if f.type == 'DialogFieldDynamicList' || f.dynamic == true
+            if dynamic_field?(f)
               fld.update(
                 :load_on_init        => f.load_values_on_init,
                 :show_refresh_button => f.show_refresh_button,
@@ -1252,7 +1252,7 @@ module MiqAeCustomizationController::Dialogs
                     )
                   end
 
-                  if field[:typ] == 'DialogFieldDynamicList' || field[:dynamic] == true
+                  if dynamic_field?(field)
                     fld[:load_values_on_init] = field[:load_on_init]
                     fld[:show_refresh_button] = field[:show_refresh_button]
 
@@ -1284,7 +1284,7 @@ module MiqAeCustomizationController::Dialogs
                   end
 
                   df = field[:typ].constantize.new(fld)
-                  df.resource_action.fqname = field[:entry_point] if field[:typ] == 'DialogFieldDynamicList' || field[:dynamic] == true
+                  df.resource_action.fqname = field[:entry_point] if dynamic_field?(field)
                   dg.add_resource(df, {:order => k})
                 end
               end
@@ -1355,5 +1355,31 @@ module MiqAeCustomizationController::Dialogs
         @right_cell_text = _("%{model} \"%{name}\"") % {:model=>ui_lookup(:model=>"Dialog"), :name=>@record.label}
       end
     end
+  end
+
+  def build_sample_tree
+    temp = {
+      'id'      => 'tag_1',
+      'tooltip' => 'Tag 1',
+      'style'   => 'cursor:default',
+      'text'    => 'Tag 1',
+    }
+    temp['im0'] = temp['im1'] = temp['im2'] = "tag.png"
+
+    parent_node = { # Build the ci node
+      'id'         => 'Tags',
+      'text'       => 'Tags',
+      'tooltip'    => 'Tags',
+      'style'      => 'cursor:default;font-weight:bold;', # Show node as different
+      'nocheckbox' => true,
+      'radio'      => '1',
+      'item'       => [temp],
+    }
+
+    @temp[:sample_tree] = {"id"=>0, "item"=>[parent_node]}.to_json
+  end
+
+  def dynamic_field?(field)
+    field[:typ] == 'DialogFieldDynamicList' || field[:dynamic]
   end
 end

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -870,7 +870,7 @@ module MiqAeCustomizationController::Dialogs
     end
 
     if @edit[:field_typ] == "DialogFieldRadioButton" && params[:field_dynamic] != true
-      @edit[:field_values] = key[:values] = []
+      @edit[:field_values] ||= key[:values] = []
     end
 
     copy_field_param.call(:entry_point)

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -897,6 +897,8 @@ module MiqAeCustomizationController::Dialogs
       end
 
       if @edit[:field_typ] != params[:field_typ]
+        @edit[:field_dynamic] = key[:dynamic] = false
+
         if params[:field_typ].include?("TextBox")
           @edit[:field_protected]      = key[:protected] = false
           @edit[:field_validator_type] = key[:validator_type] = nil

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -1149,7 +1149,7 @@ module MiqAeCustomizationController::Dialogs
               :dynamic        => f.dynamic
             }
 
-            if dynamic_field?(f)
+            if dynamic_field?(fld)
               fld.update(
                 :load_on_init        => f.load_values_on_init,
                 :show_refresh_button => f.show_refresh_button,

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -1266,8 +1266,9 @@ module MiqAeCustomizationController::Dialogs
                     fld[:values]              = []
                     fld[:load_values_on_init] = field[:load_on_init]
                     fld[:show_refresh_button] = field[:show_refresh_button]
+                  end
 
-                  elsif field[:typ] == "DialogFieldCheckBox"
+                  if field[:typ] == "DialogFieldCheckBox"
                     fld[:default_value] = field[:default_value]
                     fld[:required] = field[:required]
 

--- a/vmdb/app/helpers/automate_tree_helper.rb
+++ b/vmdb/app/helpers/automate_tree_helper.rb
@@ -9,7 +9,7 @@ module AutomateTreeHelper
                                                     @edit[:new][:namespace].nil?
         page << javascript_hide("ae_tree_select_div")
         page << javascript_hide("blocker_div")
-        page << javascript_for_miq_button_visibility(@changed, 'automate')
+        page << javascript_for_miq_button_visibility(@changed)
         page << "miqSparkle(false);"
       end
 

--- a/vmdb/app/models/dialog_field_radio_button.rb
+++ b/vmdb/app/models/dialog_field_radio_button.rb
@@ -53,7 +53,11 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   end
 
   def raw_values
-    @raw_values ||= values_from_automate
+    if dynamic
+      @raw_values ||= values_from_automate
+    else
+      @raw_values = super
+    end
   end
 
   def values_from_automate

--- a/vmdb/app/models/dialog_field_radio_button.rb
+++ b/vmdb/app/models/dialog_field_radio_button.rb
@@ -54,7 +54,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
 
   def raw_values
     if dynamic
-      @raw_values ||= values_from_automate
+      @raw_values = values_from_automate
     else
       @raw_values = super
     end

--- a/vmdb/app/models/dialog_field_radio_button.rb
+++ b/vmdb/app/models/dialog_field_radio_button.rb
@@ -18,19 +18,19 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   end
 
   def show_refresh_button
-    self.options[:show_refresh_button] || false
+    options[:show_refresh_button] || false
   end
 
   def show_refresh_button=(value)
-    self.options[:show_refresh_button] = value
+    options[:show_refresh_button] = value
   end
 
   def load_values_on_init
-    self.options[:load_values_on_init] || false
+    options[:load_values_on_init] || false
   end
 
   def load_values_on_init=(value)
-    self.options[:load_values_on_init] = value
+    options[:load_values_on_init] = value
   end
 
   def show_refresh_button?
@@ -40,8 +40,8 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   private
 
   def load_values_on_init?
-    return true if self.options[:show_refresh_button] == false
-    !!self.options[:load_values_on_init]
+    return true if options[:show_refresh_button] == false
+    !!options[:load_values_on_init]
   end
 
   def default_resource_action
@@ -66,10 +66,10 @@ class DialogFieldRadioButton < DialogFieldSortedItem
 
   def process_automate_values(workspace_attributes)
     %w(sort_by sort_order data_type default_value).each do |key|
-      self.send("#{key}=", workspace_attributes[key]) if workspace_attributes.has_key?(key)
+      send("#{key}=", workspace_attributes[key]) if workspace_attributes.key?(key)
     end
 
-    @required = (workspace_attributes["required"].to_s.downcase == "true") if workspace_attributes.has_key?("required")
+    @required = (workspace_attributes["required"].to_s.downcase == "true") if workspace_attributes.key?("required")
     normalize_automate_values(workspace_attributes["values"])
   end
 

--- a/vmdb/app/models/dialog_field_radio_button.rb
+++ b/vmdb/app/models/dialog_field_radio_button.rb
@@ -1,2 +1,80 @@
 class DialogFieldRadioButton < DialogFieldSortedItem
+  has_one :resource_action, :as => :resource, :dependent => :destroy
+
+  after_initialize :default_resource_action
+
+  def refresh_button_pressed
+    @raw_values = @default_value = nil
+    values
+  end
+
+  def initialize_with_values(dialog_values)
+    if load_values_on_init?
+      raw_values
+      @value = value_from_dialog_fields(dialog_values) || @default_value
+    else
+      @raw_values = initial_values
+    end
+  end
+
+  def show_refresh_button
+    self.options[:show_refresh_button] || false
+  end
+
+  def show_refresh_button=(value)
+    self.options[:show_refresh_button] = value
+  end
+
+  def load_values_on_init
+    self.options[:load_values_on_init] || false
+  end
+
+  def load_values_on_init=(value)
+    self.options[:load_values_on_init] = value
+  end
+
+  def show_refresh_button?
+    !!show_refresh_button
+  end
+
+  private
+
+  def load_values_on_init?
+    return true if self.options[:show_refresh_button] == false
+    !!self.options[:load_values_on_init]
+  end
+
+  def default_resource_action
+    build_resource_action if resource_action.nil?
+  end
+
+  def initial_values
+    [["", "<None>"]]
+  end
+
+  def raw_values
+    @raw_values ||= values_from_automate
+  end
+
+  def values_from_automate
+    dialog_values = {:dialog => @dialog.try(:automate_values_hash)}
+    workspace = resource_action.deliver_to_automate_from_dialog_field(dialog_values, @dialog.try(:target_resource))
+    process_automate_values(workspace.root.attributes)
+  rescue
+    [[nil, "<Script error>"]]
+  end
+
+  def process_automate_values(workspace_attributes)
+    %w(sort_by sort_order data_type default_value).each do |key|
+      self.send("#{key}=", workspace_attributes[key]) if workspace_attributes.has_key?(key)
+    end
+
+    @required = (workspace_attributes["required"].to_s.downcase == "true") if workspace_attributes.has_key?("required")
+    normalize_automate_values(workspace_attributes["values"])
+  end
+
+  def normalize_automate_values(ae_values)
+    result = ae_values.to_a
+    result.blank? ? initial_values : result
+  end
 end

--- a/vmdb/app/models/dialog_field_radio_button.rb
+++ b/vmdb/app/models/dialog_field_radio_button.rb
@@ -11,7 +11,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   def initialize_with_values(dialog_values)
     if load_values_on_init?
       raw_values
-      @value = value_from_dialog_fields(dialog_values) || @default_value
+      @value = value_from_dialog_fields(dialog_values) || default_value
     else
       @raw_values = initial_values
     end

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -20,7 +20,7 @@
             :maxlength         => MAX_NAME_LEN,
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       %tr
-        %td.key_=('Description')
+        %td.key=_('Description')
         %td.wide
           = text_field_tag("field_description",
             @edit[:field_description],

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -116,7 +116,7 @@
             %td.wide
               = text_field_tag('field_entry_point',
                 @edit[:field_entry_point],
-                :onFocus => 'miqShowAE_Tree("field_entry_point"); miqButtons("hide");')
+                :onFocus => 'miqShowAE_Tree("field_entry_point");')
           %tr
             %td.key=_('Show Refresh Button')
             %td

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -11,6 +11,7 @@
             :maxlength         => MAX_NAME_LEN,
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           = javascript_tag(javascript_focus('field_label'))
+
       %tr
         %td.key=_('Name')
         %td.wide
@@ -34,6 +35,13 @@
           - if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
             &nbsp;
             =_('Only 1 Date or Date/Time element can be present in a Dialog')
+
+      - if @edit[:field_typ] == "DialogFieldRadioButton"
+        %tr
+          %td.key=_('Dynamic')
+          %td
+            = check_box_tag('field_dynamic', '1', @edit[:field_dynamic], "data-miq_observe" => {:url => url}.to_json)
+
   - unless @edit[:field_typ].nil?
     %fieldset
       %p.legend=_('Options')
@@ -93,6 +101,7 @@
                   :disabled          => @edit[:field_validator_type].blank?,
                   :maxlength         => 250)
                 \/
+
         - elsif %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
           %tr
             %td.key=_('Show Past Dates')
@@ -100,6 +109,28 @@
               = check_box_tag("field_past_dates", "1",
                 @edit[:field_past_dates],
                 "data-miq_observe_checkbox" => {:url => url}.to_json)
+
+        - elsif 'DialogFieldDynamicList' == @edit[:field_typ] || @edit[:field_dynamic] == true
+          %tr
+            %td.key=_('Entry Point (NS/Cls/Inst)')
+            %td.wide
+              = text_field_tag('field_entry_point',
+                @edit[:field_entry_point],
+                :onFocus => 'miqShowAE_Tree("field_entry_point"); miqButtons("hide");')
+          %tr
+            %td.key=_('Show Refresh Button')
+            %td
+              = check_box_tag('field_show_refresh_button', '1',
+                @edit[:field_show_refresh_button],
+                'data-miq_observe_checkbox' => {:url => url}.to_json)
+          - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
+            %tr
+              %td.key=_('Load Values on Init')
+              %td
+                = check_box_tag('field_load_on_init', '1',
+                  @edit[:field_load_on_init],
+                  'data-miq_observe_checkbox' => {:url => url}.to_json)
+
         - elsif %w(DialogFieldDropDownList DialogFieldRadioButton).include?(@edit[:field_typ])
           %tr
             %td.key=_('Required')
@@ -137,6 +168,7 @@
                 = select_tag('field_sort_order',
                   options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
                   "data-miq_observe" => {:url => url}.to_json)
+
         - elsif @edit[:field_typ].include?("TagControl")
           %tr
             %td.key=_('Category')
@@ -177,29 +209,9 @@
               = check_box_tag('field_required', 'true',
                 @edit[:field_required],
                 "data-miq_observe_checkbox" => {:url => url}.to_json)
-        - elsif 'DialogFieldDynamicList' == @edit[:field_typ]
-          %tr
-            %td.key=_('Entry Point (NS/Cls/Inst)')
-            %td.wide
-              = text_field_tag('field_entry_point',
-                @edit[:field_entry_point],
-                :onFocus => 'miqShowAE_Tree("field_entry_point"); miqButtons("hide");')
-          %tr
-            %td.key=_('Show Refresh Button')
-            %td
-              = check_box_tag('field_show_refresh_button', '1',
-                @edit[:field_show_refresh_button],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
-          - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
-            %tr
-              %td.key=_('Load Values on Init')
-              %td
-                = check_box_tag('field_load_on_init', '1',
-                  @edit[:field_load_on_init],
-                  'data-miq_observe_checkbox' => {:url => url}.to_json)
 
-  - if @edit[:field_typ] =~ /Drop|Radio/
-    = render :partial => 'field_values', :locals => {:entry => nil}
+  - if @edit[:field_typ] =~ /Drop|Radio/ && !@edit[:field_dynamic]
+    = render :partial => 'field_values', :locals=>{:entry=>nil}
   - elsif @edit[:field_typ] && @edit[:field_typ].include?("TagControl") && @edit[:field_category]
     = render :partial => 'tag_field_values', :locals => {:entry => nil}
 

--- a/vmdb/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -102,7 +102,9 @@
                                   - unless field.required || i != 0
                                     %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
                                       :id => "None", :value => "nil", :name => "None"}
-                                  %input{:type => "radio", :disabled => true, :checked => (field.default_vaule == rb[0]),
+                                    &nbsp; None &nbsp;
+
+                                  %input{:type => "radio", :disabled => true, :checked => (field.default_value == rb[0]),
                                     :id => rb[0], :value => rb[1], :name => rb[0]}
                                   &nbsp;
                                   = rb[1]

--- a/vmdb/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -62,43 +62,54 @@
                           - if field.show_refresh_button?
                             = button_tag('Refresh', :disabled => true)
                         - when "DialogFieldDropDownList", "DialogFieldRadioButton"
-                          - if field.values.length > 1
-                            - if field.sort_by.to_s != "none"
-                              - if field.data_type == "integer"
-                                - val = field.values.sort_by { |d| field.sort_by == :value ? d.first.to_i : d.last.to_i }
-                                - val = val.reverse if field.sort_order == :descending
-                              - else
-                                - val = field.values.sort_by { |d| field.sort_by == :value ? d.first : d.last }
-                                - val = val.reverse if field.sort_order == :descending
-                            - else
-                              - val = copy_array(field.values)
+                          - if field.dynamic
+                            %input#dialog_field_radio_sample_1(type="radio" name="dialog_field_radio")
+                            %label(for="dialog_field_radio_sample_1") Option 1
+                            %input#dialog_field_radio_sample_2(type="radio" name="dialog_field_radio")
+                            %label(for="dialog_field_radio_sample_2") Option 2
 
-                            - if field.type == "DialogFieldDropDownList"
-                              - if field.required
-                                - if field.default_value.nil?
-                                  = select_tag('field.id',
-                                    options_for_select(val.collect(&:reverse), field.default_value))
-                                - else
-                                  = select_tag('field.id',
-                                    options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse), field.default_value))
+                            - if field.show_refresh_button?
+                              = button_tag('Refresh', :disabled => true)
 
-                              - else
-                                - # NOT REQUIRED
-                                = select_tag('field.id',
-                                  options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse), field.default_value))
-
-                            - else
-                              - val.each_with_index do |rb, i|
-                                - unless field.required || i != 0
-                                  %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
-                                    :id => "None", :value => "nil", :name => "None"}
-                                %input{:type => "radio", :disabled => true, :checked => (field.default_vaule == rb[0]),
-                                  :id => rb[0], :value => rb[1], :name => rb[0]}
-                                &nbsp;
-                                = rb[1]
-                                &nbsp;
                           - else
-                            = h(field.values[0].last) unless field.values.empty?
+                            - if field.values.length > 1
+                              - if field.sort_by.to_s != "none"
+                                - if field.data_type == "integer"
+                                  - val = field.values.sort_by { |d| field.sort_by == :value ? d.first.to_i : d.last.to_i }
+                                  - val = val.reverse if field.sort_order == :descending
+                                - else
+                                  - val = field.values.sort_by { |d| field.sort_by == :value ? d.first : d.last }
+                                  - val = val.reverse if field.sort_order == :descending
+                              - else
+                                - val = copy_array(field.values)
+
+                              - if field.type == "DialogFieldDropDownList"
+                                - if field.required
+                                  - if field.default_value.nil?
+                                    = select_tag('field.id',
+                                      options_for_select(val.collect(&:reverse), field.default_value))
+                                  - else
+                                    = select_tag('field.id',
+                                      options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse), field.default_value))
+
+                                - else
+                                  - # NOT REQUIRED
+                                  = select_tag('field.id',
+                                    options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse), field.default_value))
+
+                              - else
+                                - val.each_with_index do |rb, i|
+                                  - unless field.required || i != 0
+                                    %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
+                                      :id => "None", :value => "nil", :name => "None"}
+                                  %input{:type => "radio", :disabled => true, :checked => (field.default_vaule == rb[0]),
+                                    :id => rb[0], :value => rb[1], :name => rb[0]}
+                                  &nbsp;
+                                  = rb[1]
+                                  &nbsp;
+                            - else
+                              = h(field.values[0].last) unless field.values.empty?
+
                         - when "DialogFieldButton"
                           = button_tag(_('Save'), :disabled => true)
                         - when "DialogFieldTagControl"

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -98,22 +98,22 @@
                            "data-miq_sparkle_off" => true,
                            "data-miq_observe"     => {:url => url}.to_json)
             - else
-              - values = field.values
-              - values = [['', '<None>']] + values if !field.required
-              - values.each_with_index do |rb, i|
-                %input{:type     => 'radio',
-                       :id       => field.id,
-                       :value    => rb[0],
-                       :name     => field.name,
-                       :checked  => field.default_value == rb[0].to_s ? '' : nil,
-                       :onclick  => remote_function(:with     => 'Form.Element.serialize(this)',
-                                                    :url      => { :action => 'dialog_field_changed',
-                                                                   :id     => "#{(@edit && @edit[:rec_id]) || "new"}"},
-                                                    :loading  => "miqSparkle(true);",
-                                                    :complete => "miqSparkle(false);")}
-                  &nbsp;
-                  = rb[1]
-                  &nbsp;
+              %span(class="dynamic-radio-#{field.id}")
+                - values = field.values
+                - values = [['', '<None>']] + values if !field.required && !field.dynamic
+                - values.each_with_index do |rb, i|
+                  %input{:type     => 'radio',
+                         :id       => field.id,
+                         :value    => rb[0],
+                         :name     => field.name,
+                         :checked  => field.default_value == rb[0].to_s ? '' : nil,
+                         :onclick  => remote_function(:with     => 'Form.Element.serialize(this)',
+                                                      :url      => { :action => 'dialog_field_changed',
+                                                                     :id     => "#{(@edit && @edit[:rec_id]) || "new"}"},
+                                                      :loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);")}
+                  %label.dynamic-radio-label= rb[1]
+
           - else
             = h(field.values[0].last) if !field.values.empty?
 
@@ -121,11 +121,35 @@
           = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
 
         - if field.dynamic && field.show_refresh_button?
-          = button_tag('Refresh',
-                       :onclick  => remote_function(:url      => { :action => 'dynamic_list_refresh',
-                                                                   :id     => field.name },
-                                                    :loading  => "miqSparkle(true);",
-                                                    :complete => "miqSparkle(false);"))
+          = button_tag('Refresh', :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
+
+          :javascript
+            $j('#refresh-dynamic-field-#{field.id}').click(function() {
+              miqSparkleOn();
+
+              var fieldId = "#{field.id}";
+
+              $j.post('dynamic_radio_button_refresh', {id: fieldId}, function(data) {
+                var radioButtons = [];
+
+                $j.each(data.values, function(index, value) {
+                  var radio = '<input type="radio" ';
+                  radio += 'id="' + fieldId + '" ';
+                  radio += 'value="' + value[0] + '" ';
+                  radio += 'name="' + data.field_name + '" ';
+                  if (data.default_value === value[0]) {
+                    radio += 'checked="" ';
+                  }
+                  radio += '/>';
+                  radio += '<label class="dynamic-radio-label"> ' + value[1] + ' </label>';
+                  radioButtons.push(radio);
+                });
+
+                $j('.dynamic-radio-' + fieldId).html(radioButtons);
+
+                miqSparkleOff();
+              });
+            });
 
       - when 'DialogFieldButton'
         = button_tag("Save",

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -106,7 +106,7 @@
                          :id       => field.id,
                          :value    => rb[0],
                          :name     => field.name,
-                         :checked  => field.default_value == rb[0].to_s ? '' : nil,
+                         :checked  => field.default_value.to_s == rb[0].to_s ? '' : nil,
                          :onclick  => remote_function(:with     => 'Form.Element.serialize(this)',
                                                       :url      => { :action => 'dialog_field_changed',
                                                                      :id     => "#{(@edit && @edit[:rec_id]) || "new"}"},
@@ -139,7 +139,7 @@
                   radio += 'id="' + fieldId + '" ';
                   radio += 'value="' + value[0] + '" ';
                   radio += 'name="' + data.field_name + '" ';
-                  if (data.checked_value === value[0]) {
+                  if (data.checked_value === value[0].toString()) {
                     radio += 'checked="" ';
                   }
                   radio += 'onclick="' + "#{remote_function(
@@ -148,8 +148,9 @@
                     :loading  => 'miqSparkle(true);',
                     :complete => 'miqSparkle(false);'
                   )}" + '"';
-                  radio += '/>';
-                  radio += '<label class="dynamic-radio-label"> ' + value[1] + ' </label>';
+                  radio += '/> ';
+                  radio += $j('<label></label>').addClass('dynamic-radio-label').text(value[1]).prop('outerHTML');
+                  radio += ' ';
                   radioButtons.push(radio);
                 });
 

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -100,12 +100,12 @@
             - else
               - values = field.values
               - values = [['', '<None>']] + values if !field.required
-              - field.values.each_with_index do |rb, i|
+              - values.each_with_index do |rb, i|
                 %input{:type     => 'radio',
                        :id       => field.id,
                        :value    => rb[0],
                        :name     => field.name,
-                       :checked  => wf.value(field.name) == rb[0] ? '' : nil,
+                       :checked  => field.default_value == rb[0].to_s ? '' : nil,
                        :onclick  => remote_function(:with     => 'Form.Element.serialize(this)',
                                                     :url      => { :action => 'dialog_field_changed',
                                                                    :id     => "#{(@edit && @edit[:rec_id]) || "new"}"},
@@ -114,19 +114,18 @@
                   &nbsp;
                   = rb[1]
                   &nbsp;
-
-              - if field.dynamic && field.show_refresh_button?
-                = button_tag('Refresh',
-                             :onclick  => remote_function(:url      => { :action => 'dynamic_list_refresh',
-                                                                         :id     => field.name },
-                                                          :loading  => "miqSparkle(true);",
-                                                          :complete => "miqSparkle(false);"))
-
           - else
             = h(field.values[0].last) if !field.values.empty?
+
         - else
           = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
 
+        - if field.dynamic && field.show_refresh_button?
+          = button_tag('Refresh',
+                       :onclick  => remote_function(:url      => { :action => 'dynamic_list_refresh',
+                                                                   :id     => field.name },
+                                                    :loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);"))
 
       - when 'DialogFieldButton'
         = button_tag("Save",

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -129,8 +129,9 @@
 
               var fieldId = "#{field.id}";
               var fieldName = "#{field.name}";
+              var checkedValue = $j('input:radio[name="#{field.name}"]:checked').val();
 
-              $j.post('dynamic_radio_button_refresh', {name: fieldName}, function(data) {
+              $j.post('dynamic_radio_button_refresh', {name: fieldName, checked_value: checkedValue}, function(data) {
                 var radioButtons = [];
 
                 $j.each(data.values, function(index, value) {
@@ -138,9 +139,15 @@
                   radio += 'id="' + fieldId + '" ';
                   radio += 'value="' + value[0] + '" ';
                   radio += 'name="' + data.field_name + '" ';
-                  if (data.default_value === value[0]) {
+                  if (data.checked_value === value[0]) {
                     radio += 'checked="" ';
                   }
+                  radio += 'onclick="' + "#{remote_function(
+                    :with     => 'Form.Element.serialize(this)',
+                    :url      => {:action => 'dialog_field_changed', :id => (@edit && @edit[:rec_id]) || 'new'},
+                    :loading  => 'miqSparkle(true);',
+                    :complete => 'miqSparkle(false);'
+                  )}" + '"';
                   radio += '/>';
                   radio += '<label class="dynamic-radio-label"> ' + value[1] + ' </label>';
                   radioButtons.push(radio);

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -128,8 +128,9 @@
               miqSparkleOn();
 
               var fieldId = "#{field.id}";
+              var fieldName = "#{field.name}";
 
-              $j.post('dynamic_radio_button_refresh', {id: fieldId}, function(data) {
+              $j.post('dynamic_radio_button_refresh', {name: fieldName}, function(data) {
                 var radioButtons = [];
 
                 $j.each(data.values, function(index, value) {

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -114,10 +114,19 @@
                   &nbsp;
                   = rb[1]
                   &nbsp;
+
+              - if field.dynamic && field.show_refresh_button?
+                = button_tag('Refresh',
+                             :onclick  => remote_function(:url      => { :action => 'dynamic_list_refresh',
+                                                                         :id     => field.name },
+                                                          :loading  => "miqSparkle(true);",
+                                                          :complete => "miqSparkle(false);"))
+
           - else
             = h(field.values[0].last) if !field.values.empty?
         - else
           = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
+
 
       - when 'DialogFieldButton'
         = button_tag("Save",

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -346,6 +346,7 @@ Vmdb::Application.routes.draw do
         button
         create
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         form_field_changed
         listnav_search_selected
         panel_control
@@ -385,6 +386,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         listnav_search_selected
         panel_control
         protect
@@ -514,6 +516,7 @@ Vmdb::Application.routes.draw do
         drift_mode
         drift_same
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         filesystems
         firewall_rules
         firewallrules
@@ -793,6 +796,7 @@ Vmdb::Application.routes.draw do
         button
         dialog_field_changed
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         post_install_callback
         pre_prov
         prov_button
@@ -1250,6 +1254,7 @@ Vmdb::Application.routes.draw do
         dialog_field_changed
         dialog_form_button_pressed
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         explorer
         ownership_field_changed
         ownership_update
@@ -1295,6 +1300,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         files
         listnav_search_selected
         panel_control
@@ -1396,6 +1402,7 @@ Vmdb::Application.routes.draw do
         dialog_form_button_pressed
         dialog_field_changed
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         edit_vm
         event_logs
         explorer
@@ -1468,6 +1475,7 @@ Vmdb::Application.routes.draw do
         dialog_field_changed
         dialog_form_button_pressed
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         edit_vm
         event_logs
         explorer
@@ -1560,6 +1568,7 @@ Vmdb::Application.routes.draw do
         drift_mode
         drift_same
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         edit_vm
         event_logs
         explorer

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -177,6 +177,7 @@ Vmdb::Application.routes.draw do
         dialog_field_changed
         dialog_form_button_pressed
         dynamic_list_refresh
+        dynamic_radio_button_refresh
         explorer
         get_ae_tree_edit_key
         group_create

--- a/vmdb/db/migrate/20141117082419_add_dynamic_field_to_dialog_fields.rb
+++ b/vmdb/db/migrate/20141117082419_add_dynamic_field_to_dialog_fields.rb
@@ -1,0 +1,9 @@
+class AddDynamicFieldToDialogFields < ActiveRecord::Migration
+  def up
+    add_column :dialog_fields, :dynamic, :boolean
+  end
+
+  def down
+    remove_column :dialog_fields, :dynamic
+  end
+end

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -110,6 +110,7 @@ describe DialogFieldRadioButton do
         context "when the dialog field is dynamic" do
           before do
             dialog_field_radio_button.dynamic = true
+            dialog_field_radio_button.default_value = [["test", 321]]
             dialog_field_radio_button.initialize_with_values("lolvalues")
           end
 
@@ -118,6 +119,10 @@ describe DialogFieldRadioButton do
             # ok to let this one fail through and expect the rescued values
 
             expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+          end
+
+          it "sets value from default value attribute" do
+            expect(dialog_field_radio_button.instance_variable_get(:@value)).to eq([["test", 321]])
           end
         end
 
@@ -128,7 +133,7 @@ describe DialogFieldRadioButton do
             dialog_field_radio_button.initialize_with_values("lolvalues")
           end
 
-          it "gets values from values attribute" do
+          it "sets raw values from values attribute" do
             expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
           end
         end

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -12,32 +12,6 @@ describe DialogFieldRadioButton do
   let(:resource_action) { ResourceAction.new }
 
   describe "#refresh_button_pressed" do
-    let(:dialog_values) { {:dialog => "automate_values_hash"} }
-    let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspaceRuntime") }
-    let(:workspace_attributes) do
-      double(
-        :attributes => {
-          "sort_by"       => "none",
-          "sort_order"    => "descending",
-          "data_type"     => "datatype",
-          "default_value" => "default",
-          "values"        => workspace_attribute_values
-        }
-      )
-    end
-
-    before do
-      dialog.stub(:automate_values_hash).and_return("automate_values_hash")
-      dialog.stub(:target_resource).and_return("target_resource")
-
-      resource_action.stub(:deliver_to_automate_from_dialog_field).with(
-        dialog_values,
-        "target_resource"
-      ).and_return(workspace)
-
-      workspace.stub(:root).and_return(workspace_attributes)
-    end
-
     shared_examples_for "DialogFieldRadioButton#refresh_button_pressed" do
       it "sets the sort by" do
         dialog_field_radio_button.refresh_button_pressed
@@ -60,23 +34,64 @@ describe DialogFieldRadioButton do
       end
     end
 
-    context "when the workspace attribute values exist" do
-      let(:workspace_attribute_values) { [[123, "456"]] }
+    context "when the dialog field is dynamic" do
+      let(:dialog_values) { {:dialog => "automate_values_hash"} }
+      let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspaceRuntime") }
+      let(:workspace_attributes) do
+        double(
+          :attributes => {
+            "sort_by"       => "none",
+            "sort_order"    => "descending",
+            "data_type"     => "datatype",
+            "default_value" => "default",
+            "values"        => workspace_attribute_values
+          }
+        )
+      end
 
-      it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
+      before do
+        dialog_field_radio_button.dynamic = true
 
-      it "returns the dialog values" do
-        expect(dialog_field_radio_button.refresh_button_pressed).to eq([[123, "456"]])
+        dialog.stub(:automate_values_hash).and_return("automate_values_hash")
+        dialog.stub(:target_resource).and_return("target_resource")
+
+        resource_action.stub(:deliver_to_automate_from_dialog_field).with(
+          dialog_values,
+          "target_resource"
+        ).and_return(workspace)
+
+        workspace.stub(:root).and_return(workspace_attributes)
+      end
+
+      context "when the workspace attribute values exist" do
+        let(:workspace_attribute_values) { [[123, "456"]] }
+
+        it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
+
+        it "returns the dialog values" do
+          expect(dialog_field_radio_button.refresh_button_pressed).to eq([[123, "456"]])
+        end
+      end
+
+      context "when the workspace attributes values do not exist" do
+        let(:workspace_attribute_values) { nil }
+
+        it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
+
+        it "returns the initial values" do
+          expect(dialog_field_radio_button.refresh_button_pressed).to eq([["", "<None>"]])
+        end
       end
     end
 
-    context "when the workspace attributes values do not exist" do
-      let(:workspace_attribute_values) { nil }
+    context "when the dialog field is not dynamic" do
+      before do
+        dialog_field_radio_button.dynamic = false
+        dialog_field_radio_button.values = [["testing", 123]]
+      end
 
-      it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
-
-      it "returns the initial values" do
-        expect(dialog_field_radio_button.refresh_button_pressed).to eq([["", "<None>"]])
+      it "returns the dialog values from the values attribute" do
+        expect(dialog_field_radio_button.refresh_button_pressed).to eq([["testing", 123]])
       end
     end
   end
@@ -90,14 +105,32 @@ describe DialogFieldRadioButton do
       context "when load values on init is true" do
         before do
           dialog_field_radio_button.load_values_on_init = true
-          dialog_field_radio_button.initialize_with_values("lolvalues")
         end
 
-        it "gets values from automate" do
-          # Since we are testing the values from automate piece in the above #refresh_button pressed, I think it is
-          # ok to let this one fail through and expect the rescued values
+        context "when the dialog field is dynamic" do
+          before do
+            dialog_field_radio_button.dynamic = true
+            dialog_field_radio_button.initialize_with_values("lolvalues")
+          end
 
-          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+          it "gets values from automate" do
+            # Since we are testing the values from automate piece in the above #refresh_button pressed, I think it is
+            # ok to let this one fail through and expect the rescued values
+
+            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+          end
+        end
+
+        context "when the dialog field is not dynamic" do
+          before do
+            dialog_field_radio_button.dynamic = false
+            dialog_field_radio_button.values = [["testing", 123]]
+            dialog_field_radio_button.initialize_with_values("lolvalues")
+          end
+
+          it "gets values from values attribute" do
+            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
+          end
         end
       end
 
@@ -116,11 +149,29 @@ describe DialogFieldRadioButton do
     context "when show refresh button is false" do
       before do
         dialog_field_radio_button.show_refresh_button = false
-        dialog_field_radio_button.initialize_with_values("lolvalues")
       end
 
-      it "gets values from automate" do
-        expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+      context "when the dialog field is dynamic" do
+        before do
+          dialog_field_radio_button.dynamic = true
+          dialog_field_radio_button.initialize_with_values("lolvalues")
+        end
+
+        it "gets values from automate" do
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+        end
+      end
+
+      context "when the dialog field is not dynamic" do
+        before do
+          dialog_field_radio_button.dynamic = false
+          dialog_field_radio_button.values = [["testing", 123]]
+          dialog_field_radio_button.initialize_with_values("lolvalues")
+        end
+
+        it "gets values from values attribute" do
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
+        end
       end
     end
   end

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "debugger"
 
 describe DialogFieldRadioButton do
   let(:dialog_field_radio_button) do
@@ -16,20 +15,25 @@ describe DialogFieldRadioButton do
     let(:dialog_values) { {:dialog => "automate_values_hash"} }
     let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspaceRuntime") }
     let(:workspace_attributes) do
-      double(:attributes => {
-        "sort_by"       => "none",
-        "sort_order"    => "descending",
-        "data_type"     => "datatype",
-        "default_value" => "default",
-        "values"        => workspace_attribute_values
-      })
+      double(
+        :attributes => {
+          "sort_by"       => "none",
+          "sort_order"    => "descending",
+          "data_type"     => "datatype",
+          "default_value" => "default",
+          "values"        => workspace_attribute_values
+        }
+      )
     end
 
     before do
       dialog.stub(:automate_values_hash).and_return("automate_values_hash")
       dialog.stub(:target_resource).and_return("target_resource")
 
-      resource_action.stub(:deliver_to_automate_from_dialog_field).with(dialog_values, "target_resource").and_return(workspace)
+      resource_action.stub(:deliver_to_automate_from_dialog_field).with(
+        dialog_values,
+        "target_resource"
+      ).and_return(workspace)
 
       workspace.stub(:root).and_return(workspace_attributes)
     end
@@ -57,12 +61,12 @@ describe DialogFieldRadioButton do
     end
 
     context "when the workspace attribute values exist" do
-      let(:workspace_attribute_values) { [["123", "456"]] }
+      let(:workspace_attribute_values) { [[123, "456"]] }
 
       it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
 
       it "returns the dialog values" do
-        expect(dialog_field_radio_button.refresh_button_pressed).to eq([["123", "456"]])
+        expect(dialog_field_radio_button.refresh_button_pressed).to eq([[123, "456"]])
       end
     end
 
@@ -114,7 +118,6 @@ describe DialogFieldRadioButton do
         dialog_field_radio_button.show_refresh_button = false
         dialog_field_radio_button.initialize_with_values("lolvalues")
       end
-
 
       it "gets values from automate" do
         expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -1,0 +1,156 @@
+require "spec_helper"
+require "debugger"
+
+describe DialogFieldRadioButton do
+  let(:dialog_field_radio_button) do
+    DialogFieldRadioButton.new(
+      :dialog          => dialog,
+      :resource_action => resource_action
+    )
+  end
+
+  let(:dialog) { Dialog.new }
+  let(:resource_action) { ResourceAction.new }
+
+  describe "#refresh_button_pressed" do
+    let(:dialog_values) { {:dialog => "automate_values_hash"} }
+    let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspaceRuntime") }
+    let(:workspace_attributes) do
+      double(:attributes => {
+        "sort_by"       => "none",
+        "sort_order"    => "descending",
+        "data_type"     => "datatype",
+        "default_value" => "default",
+        "values"        => workspace_attribute_values
+      })
+    end
+
+    before do
+      dialog.stub(:automate_values_hash).and_return("automate_values_hash")
+      dialog.stub(:target_resource).and_return("target_resource")
+
+      resource_action.stub(:deliver_to_automate_from_dialog_field).with(dialog_values, "target_resource").and_return(workspace)
+
+      workspace.stub(:root).and_return(workspace_attributes)
+    end
+
+    shared_examples_for "DialogFieldRadioButton#refresh_button_pressed" do
+      it "sets the sort by" do
+        dialog_field_radio_button.refresh_button_pressed
+        expect(dialog_field_radio_button.sort_by).to eq(:none)
+      end
+
+      it "sets the sort order" do
+        dialog_field_radio_button.refresh_button_pressed
+        expect(dialog_field_radio_button.sort_order).to eq(:descending)
+      end
+
+      it "sets the data type" do
+        dialog_field_radio_button.refresh_button_pressed
+        expect(dialog_field_radio_button.data_type).to eq("datatype")
+      end
+
+      it "sets the default value" do
+        dialog_field_radio_button.refresh_button_pressed
+        expect(dialog_field_radio_button.default_value).to eq("default")
+      end
+    end
+
+    context "when the workspace attribute values exist" do
+      let(:workspace_attribute_values) { [["123", "456"]] }
+
+      it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
+
+      it "returns the dialog values" do
+        expect(dialog_field_radio_button.refresh_button_pressed).to eq([["123", "456"]])
+      end
+    end
+
+    context "when the workspace attributes values do not exist" do
+      let(:workspace_attribute_values) { nil }
+
+      it_behaves_like "DialogFieldRadioButton#refresh_button_pressed"
+
+      it "returns the initial values" do
+        expect(dialog_field_radio_button.refresh_button_pressed).to eq([["", "<None>"]])
+      end
+    end
+  end
+
+  describe "#initialize_with_values" do
+    context "when show refresh button is true" do
+      before do
+        dialog_field_radio_button.show_refresh_button = true
+      end
+
+      context "when load values on init is true" do
+        before do
+          dialog_field_radio_button.load_values_on_init = true
+          dialog_field_radio_button.initialize_with_values("lolvalues")
+        end
+
+        it "gets values from automate" do
+          # Since we are testing the values from automate piece in the above #refresh_button pressed, I think it is
+          # ok to let this one fail through and expect the rescued values
+
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+        end
+      end
+
+      context "when load values on init is false" do
+        before do
+          dialog_field_radio_button.load_values_on_init = false
+          dialog_field_radio_button.initialize_with_values("lolvalues")
+        end
+
+        it "sets raw_values to initial values" do
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["", "<None>"]])
+        end
+      end
+    end
+
+    context "when show refresh button is false" do
+      before do
+        dialog_field_radio_button.show_refresh_button = false
+        dialog_field_radio_button.initialize_with_values("lolvalues")
+      end
+
+
+      it "gets values from automate" do
+        expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<Script error>"]])
+      end
+    end
+  end
+
+  describe "#show_refresh_button?" do
+    context "when show refresh button is true" do
+      before do
+        dialog_field_radio_button.show_refresh_button = true
+      end
+
+      it "returns true" do
+        expect(dialog_field_radio_button.show_refresh_button?).to be(true)
+      end
+    end
+
+    context "when show refresh button is false" do
+      before do
+        dialog_field_radio_button.show_refresh_button = false
+      end
+
+      it "returns false" do
+        expect(dialog_field_radio_button.show_refresh_button?).to be(false)
+      end
+    end
+
+    context "when show refresh button is nil" do
+      before do
+        dialog_field_radio_button.show_refresh_button = nil
+      end
+
+      it "returns false" do
+        expect(dialog_field_radio_button.show_refresh_button?).to be(false)
+      end
+    end
+  end
+end

--- a/vmdb/spec/models/dialog_field_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_field_serializer_spec.rb
@@ -15,6 +15,7 @@ describe DialogFieldSerializer do
       "display"                 => "display",
       "display_method"          => "display method",
       "display_method_options"  => "display method options",
+      "dynamic"                 => false,
       "required"                => false,
       "required_method"         => "required method",
       "required_method_options" => "required method options",

--- a/vmdb/spec/routing/catalog_routing_spec.rb
+++ b/vmdb/spec/routing/catalog_routing_spec.rb
@@ -33,6 +33,7 @@ describe 'routes for CatalogController' do
     dialog_field_changed
     dialog_form_button_pressed
     dynamic_list_refresh
+    dynamic_radio_button_refresh
     explorer
     get_ae_tree_edit_key
     group_create

--- a/vmdb/spec/routing/ems_cloud_routing_spec.rb
+++ b/vmdb/spec/routing/ems_cloud_routing_spec.rb
@@ -32,6 +32,7 @@ describe EmsCloudController do
     button
     create
     dynamic_list_refresh
+    dynamic_radio_button_refresh
     form_field_changed
     listnav_search_selected
     save_default_search

--- a/vmdb/spec/routing/ems_cluster_routing_spec.rb
+++ b/vmdb/spec/routing/ems_cluster_routing_spec.rb
@@ -64,6 +64,12 @@ describe EmsClusterController do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/ems_cluster/dynamic_radio_button_refresh")).to route_to("ems_cluster#dynamic_radio_button_refresh")
+    end
+  end
+
   describe "#listnav_search_selected" do
     it "routes with POST" do
       expect(post("/ems_cluster/listnav_search_selected/123")).to route_to(

--- a/vmdb/spec/routing/host_routing_spec.rb
+++ b/vmdb/spec/routing/host_routing_spec.rb
@@ -115,6 +115,12 @@ describe "routes for HostController" do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/host/dynamic_radio_button_refresh")).to route_to("host#dynamic_radio_button_refresh")
+    end
+  end
+
   describe "#filesystems" do
     it "routes with GET" do
       expect(get("/host/filesystems")).to route_to("host#filesystems")

--- a/vmdb/spec/routing/service_routing_spec.rb
+++ b/vmdb/spec/routing/service_routing_spec.rb
@@ -34,6 +34,12 @@ describe 'routes for ServiceController' do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/service/dynamic_radio_button_refresh")).to route_to("service#dynamic_radio_button_refresh")
+    end
+  end
+
   describe '#explorer' do
     it 'routes with GET' do
       expect(get("/service/explorer")).to route_to("service#explorer")

--- a/vmdb/spec/routing/storage_routing_spec.rb
+++ b/vmdb/spec/routing/storage_routing_spec.rb
@@ -41,6 +41,13 @@ describe "routes for StorageController" do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/dynamic_radio_button_refresh"))
+        .to route_to("#{controller_name}#dynamic_radio_button_refresh")
+    end
+  end
+
   describe "#files" do
     it "routes with GET" do
       expect(get("/#{controller_name}/files")).to route_to("#{controller_name}#files")

--- a/vmdb/spec/routing/vm_cloud_routing_spec.rb
+++ b/vmdb/spec/routing/vm_cloud_routing_spec.rb
@@ -35,6 +35,13 @@ describe 'routes for VmCloud' do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/dynamic_radio_button_refresh"))
+        .to route_to("#{controller_name}#dynamic_radio_button_refresh")
+    end
+  end
+
   describe '#pre_prov' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/pre_prov")).to route_to("#{controller_name}#pre_prov")

--- a/vmdb/spec/routing/vm_infra_routing_spec.rb
+++ b/vmdb/spec/routing/vm_infra_routing_spec.rb
@@ -35,6 +35,13 @@ describe 'routes for VmInfra' do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/dynamic_radio_button_refresh"))
+        .to route_to("#{controller_name}#dynamic_radio_button_refresh")
+    end
+  end
+
   describe '#launch_vmware_console' do
     it 'routes with GET' do
       expect(get("/#{controller_name}/launch_vmware_console")).to route_to("#{controller_name}#launch_vmware_console")

--- a/vmdb/spec/routing/vm_or_template_routing_spec.rb
+++ b/vmdb/spec/routing/vm_or_template_routing_spec.rb
@@ -19,6 +19,13 @@ describe VmOrTemplateController do
     end
   end
 
+  describe "#dynamic_radio_button_refresh" do
+    it "routes with POST" do
+      expect(post("/vm_or_template/dynamic_radio_button_refresh"))
+        .to route_to("vm_or_template#dynamic_radio_button_refresh")
+    end
+  end
+
   describe "#explorer" do
     it "routes with GET" do
       expect(get("/vm_or_template/explorer")).to route_to("vm_or_template#explorer")


### PR DESCRIPTION
This PR allows radio button dialog fields to be populated by automate values in the same way a drop-down list can be.

Trello card: https://trello.com/c/aHoR5dxB

cc @gmcculloug