### PR TITLE
For MiqAeField and MiqAeValue use build+save instead of create!

### DIFF
--- a/vmdb/app/models/miq_ae_datastore.rb
+++ b/vmdb/app/models/miq_ae_datastore.rb
@@ -159,10 +159,11 @@ module MiqAeDatastore
     object_class.ae_methods.create!(default_method_options.merge(:name => 'log_workspace'))
 
     email_method = object_class.ae_methods.create!(default_method_options.merge(:name => 'send_email'))
-    email_method.inputs.create!([{:name => 'to',      :priority => 1, :datatype => 'string'},
-                                 {:name => 'from',    :priority => 2, :datatype => 'string'},
-                                 {:name => 'subject', :priority => 3, :datatype => 'string'},
-                                 {:name => 'body',    :priority => 4, :datatype => 'string'}])
+    email_method.inputs.build([{:name => 'to',      :priority => 1, :datatype => 'string'},
+                               {:name => 'from',    :priority => 2, :datatype => 'string'},
+                               {:name => 'subject', :priority => 3, :datatype => 'string'},
+                               {:name => 'body',    :priority => 4, :datatype => 'string'}])
+    email_method.save!
   end
 
   def self.reset_to_defaults

--- a/vmdb/spec/factories/miq_ae_class.rb
+++ b/vmdb/spec/factories/miq_ae_class.rb
@@ -12,9 +12,8 @@ FactoryGirl.define do
 
       after :create do |aeclass, evaluator|
 
-        evaluator.ae_fields.each do |name, f|
-          FactoryGirl.create(:miq_ae_field, {:class_id => aeclass.id,
-                                             :name     => name}.merge(f))
+        aeclass.ae_fields << evaluator.ae_fields.collect do |name, f|
+          FactoryGirl.build(:miq_ae_field, {:name => name}.merge(f))
         end
 
         evaluator.ae_instances.each do |name, values|

--- a/vmdb/spec/factories/miq_ae_instance.rb
+++ b/vmdb/spec/factories/miq_ae_instance.rb
@@ -8,10 +8,9 @@ FactoryGirl.define do
       end
 
       after :create do |aeinstance, evaluator|
-        aeinstance.ae_class.ae_fields.each do |field|
+        aeinstance.ae_values << aeinstance.ae_class.ae_fields.collect do |field|
           next unless evaluator.values.key?(field.name)
-          FactoryGirl.create(:miq_ae_value, {:instance_id => aeinstance.id,
-                                             :field_id    => field.id}.merge(evaluator.values[field.name]))
+          FactoryGirl.build(:miq_ae_value, {:field_id => field.id}.merge(evaluator.values[field.name]))
         end
       end
 

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
@@ -18,9 +18,11 @@ module MiqAeMethodSpec
       params = [{:name => 'num1', :priority => 1, :datatype => 'integer'},
                 {:name => 'num2', :priority => 2, :datatype => 'integer', :default_value => 0}]
       foo_c = FactoryGirl.create(:miq_ae_method, method_options.merge(:name => 'foo', :scope => 'class'))
-      foo_c.inputs.create!(params)
+      foo_c.inputs.build(params)
+      foo_c.save!
       foo_i = FactoryGirl.create(:miq_ae_method, method_options.merge(:name => 'foo', :scope => 'instance'))
-      foo_i.inputs.create!(params)
+      foo_i.inputs.build(params)
+      foo_i.save!
       method_options = {:language => 'ruby', :name => 'non_existent',
                         :scope => 'instance', :location => 'builtin',
                         :class_id => object_class.id}


### PR DESCRIPTION
This PR is based on the Active Record/Postgres.

For Git based Automate model the MiqAeField and MiqAeValue are saved
in the class and instance yaml files and are not separate tables like
in ActiveRecord. Build followed by a save allows us to write just once
into the file as opposed to writing the file several times once a value
or field is saved.
