### PR TITLE
ManageIQ domain - Fix infrastructure retirement method issue.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_unregistered_from_provider.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_unregistered_from_provider.rb
@@ -5,7 +5,7 @@
 vm = $evm.root['vm']
 
 unless vm.nil?
-  if !vm.registered?
+  if vm.archived || vm.orphaned
     # Bump State
     $evm.log('info', "VM:<#{vm.name}> has been unregistered from EMS")
     $evm.root['ae_result'] = 'ok'

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/delete_from_provider_check.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/delete_from_provider_check.rb
@@ -15,9 +15,8 @@ else
 end
 
 if vm && (vm_was_provisioned || vm.miq_provision || vm.tagged_with?(category, tag))
-  host = vm.host
-  $evm.log('info', "VM <#{vm.name}> parent Host ID is <#{host}>")
-  if host.nil?
+  $evm.log('info', "Checking if VM: <#{vm.name}> has been deleted from the provider. ")
+  if vm.archived || vm.orphaned
     # Bump State
     $evm.root['ae_result'] = 'ok'
   else


### PR DESCRIPTION
Change automate methods to use archived or orphaned as the criteria to
progress the retirement state machine.

https://bugzilla.redhat.com/show_bug.cgi?id=1074532
