### PR TITLE
Use detect instead of select + first to avoid an intermediate array.

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -56,7 +56,7 @@ module ApplicationHelper
                              User.current_user.role_allows?(:identifier => options[:feature])
       $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{session[:userid]}], role id [#{role_id}], feature identifier [#{options[:feature]}]")
     elsif options[:main_tab]
-      tab = MAIN_TAB_FEATURES.select{|t| t.first == options[:main_tab]}.first
+      tab = MAIN_TAB_FEATURES.detect { |t| t.first == options[:main_tab] }
       auth = User.current_user.role_allows_any?(:identifiers => tab.last)
       $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{session[:userid]}], role id [#{role_id}], main tab [#{options[:main_tab]}]")
     else

--- a/vmdb/app/models/miq_ae_instance.rb
+++ b/vmdb/app/models/miq_ae_instance.rb
@@ -102,7 +102,7 @@ class MiqAeInstance < ActiveRecord::Base
 
   def ae_values_sorted
     ae_class.ae_fields.sort_by(&:priority).collect { |field|
-      ae_values.select { |value| value.field_id == field.id }.first
+      ae_values.detect { |value| value.field_id == field.id }
     }.compact
   end
 

--- a/vmdb/app/models/miq_region.rb
+++ b/vmdb/app/models/miq_region.rb
@@ -54,7 +54,7 @@ class MiqRegion < ActiveRecord::Base
   end
 
   def find_master_server
-    self.active_miq_servers.select { |s| s.is_master? }.first
+    active_miq_servers.detect(&:is_master?)
   end
 
   def self.my_region

--- a/vmdb/app/models/zone.rb
+++ b/vmdb/app/models/zone.rb
@@ -36,7 +36,7 @@ class Zone < ActiveRecord::Base
   override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, :vms_and_templates)
 
   def find_master_server
-    self.active_miq_servers.select { |s| s.is_master? }.first
+    active_miq_servers.detect(&:is_master?)
   end
 
   def self.seed


### PR DESCRIPTION
Additionally, the intent is more obvious by removing the extra block.

Other examples of more concise use of enumerable are listed here:
https://github.com/tcopeland/pippi
