### PR TITLE
Patternfly chart styling updates 

### DIFF
--- a/vmdb/app/assets/stylesheets/partials/_jqplot.sass
+++ b/vmdb/app/assets/stylesheets/partials/_jqplot.sass
@@ -1,10 +1,12 @@
 .jqplot-target
   font-family: $base-font-family
   font-size: $base-font-size
-  font-weight: bold
 
-.jqplot-data-label
+
+.jqplot-data-label  //pie and donut charts
   color: #fff
+
+.jqplot-point-label //line and bar charts 
 
 table.jqplot-table-legend
   border: 0 !important
@@ -13,3 +15,23 @@ table.jqplot-table-legend
 div.jqplot-table-legend-swatch-outline
   border: none
 
+.jqplot-highlighter-tooltip
+  background: #4c4c4c
+  border: 0px solid #1d1d1d
+  font-size: $base-font-size*.9
+  font-weight: normal
+  padding: 8px
+  color: #fff
+  z-index: 10
+
+.jqplot-highlighter-tooltip:before
+  content: ""
+  position: absolute
+  bottom: -8px
+  left: 50%
+  margin-top: -15px              // adjust position, arrow has a height of 30px. 
+  margin-left: -8px
+  border: solid 15px transparent
+  border-width: 10px 10px 0
+  border-top-color: #434343
+  z-index: 1

--- a/vmdb/lib/charting/jqplot_themes.rb
+++ b/vmdb/lib/charting/jqplot_themes.rb
@@ -7,14 +7,18 @@ class JqplotThemes
     'MIQ' => {
       :seriesColors   => ['#0099d3', '#00618a', '#0b3a54', '#979a9c', '#686b6e', '#505459', '#393f44', '#bde0ed'],
       :seriesDefaults => {
-        :shadow => false
+        :shadow          => false,
+        :rendererOptions => {
+          :dataLabelPositionFactor => 0.7,
+          :sliceMargin             => 4
+        }
       },
       :grid           => {
         :drawGridlines => true,     # mind the lowecase 'l'
         :gridLineColor => '#e1e1e1',
         :borderWidth => 0,
         :background => 'transparent',
-        :shadow => false
+        :shadow => false,
       },
       # use EnhancedLegendRenderer by default
       # http://www.jqplot.com/docs/files/plugins/jqplot-enhancedLegendRenderer-js.html

--- a/vmdb/lib/report_formatter/jqplot.rb
+++ b/vmdb/lib/report_formatter/jqplot.rb
@@ -107,6 +107,7 @@ module ReportFormatter
                      plot.options.series[seriesIndex].label + ': ' +
                      str;
           }",
+          :tooltipLocation      => 'n'
         }
       )
     end
@@ -131,6 +132,7 @@ module ReportFormatter
               return plot.series[seriesIndex].data[pointIndex][0] + ': ' +
                      plot.series[seriesIndex].data[pointIndex][1];
           }",
+          :tooltipLocation      => 'n'
         }
       ) if @is_pie
     end


### PR DESCRIPTION
- updated pie/donut chart styling with slice margins
- updated pie chart label location
- updated highlighter styling

Issue #976
https://trello.com/c/2733Yjls

Before:
![screen shot 2014-12-01 at 3 35 31 pm](https://cloud.githubusercontent.com/assets/1287144/5252852/ee711b6a-796f-11e4-855b-39072d9a62a5.png)

After:
![screen shot 2014-12-01 at 3 34 14 pm](https://cloud.githubusercontent.com/assets/1287144/5252861/fc6f6e88-796f-11e4-8257-7c9f628a3473.png)

Patternfly examples:
![screen shot 2014-12-01 at 3 37 56 pm](https://cloud.githubusercontent.com/assets/1287144/5252872/1631e49a-7970-11e4-9c28-2d76c192283c.png)
