### PR TITLE
Fixed broken vm reference in snapshot service model.

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_snapshot.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_snapshot.rb
@@ -1,15 +1,15 @@
 module MiqAeMethodService
   class MiqAeServiceSnapshot < MiqAeServiceModelBase
-    expose :vm, :association => true
+    expose :vm_or_template, :association => true
     expose :current?
     expose :get_current_snapshot
 
     def revert_to
-      self.vm.revert_to_snapshot(self.id)
+      vm_or_template.revert_to_snapshot(id)
     end
 
     def remove
-      self.vm.remove_snapshot(self.id)
+      vm_or_template.remove_snapshot(id)
     end
   end
 end


### PR DESCRIPTION
This has been broken since the vm/template split.

https://bugzilla.redhat.com/show_bug.cgi?id=1169930
