### PR TITLE
Fixed misspelled method name (capitalize)

### DIFF
--- a/vmdb/app/controllers/chargeback_controller.rb
+++ b/vmdb/app/controllers/chargeback_controller.rb
@@ -165,10 +165,10 @@ class ChargebackController < ApplicationController
           replace_right_cell([:cb_rates])
         else
           @sb[:rate].errors.each do |field,msg|
-            add_flash("#{field.to_s.capitlize} #{msg}", :error)
+            add_flash("#{field.to_s.capitalize} #{msg}", :error)
           end
           @sb[:rate_details].each do |detail|
-            detail.errors.each {|field,msg| add_flash("'#{detail.description}' #{field.to_s.capitlize} #{msg}", :error)}
+            detail.errors.each { |field, msg| add_flash("'#{detail.description}' #{field.to_s.capitalize} #{msg}", :error) }
           end
           @changed = session[:changed] = (@edit[:new] != @edit[:current])
           render :update do |page|

--- a/vmdb/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/vmdb/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,4 +1,5 @@
 - url = url_for(:action=>'cb_rate_form_field_changed', :id=>"#{@sb[:rate].id || "new"}")
+= render :partial => "layouts/flash_msg", :locals => {:top_pad => 10}
 #form_div
   %fieldset
     %p.legend=_('Basic Info')


### PR DESCRIPTION
Fixed misspelled "capitalize" when creating error message for adding duplicate Compute Chargeback Rate

https://bugzilla.redhat.com/show_bug.cgi?id=1073366
