### PR TITLE
Refactoring refreshers' core logic into mixin

### DIFF
--- a/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
@@ -46,5 +46,10 @@ module EmsRefresh::Refreshers
         self.targets_by_ems_id[ems.id] << t
       end
     end
+
+    def refresher_type
+      # "EmsRefresh::Refreshers::Ec2Refresher" => "Ec2Refresher" => "Ec2"
+      self.class.name.demodulize.sub(/Refresher$/, '')
+    end
   end
 end

--- a/vmdb/app/models/ems_refresh/refreshers/ec2_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/ec2_refresher.rb
@@ -1,35 +1,13 @@
 module EmsRefresh::Refreshers
   class Ec2Refresher < BaseRefresher
-    def refresh
-      $log.info "MIQ(Ec2Refresher.refresh) Refreshing all targets..."
+    include EmsRefresherMixin
 
-      @targets_by_ems_id.each do |ems_id, targets|
-        # Get the ems object
-        ems = @ems_by_ems_id[ems_id]
+    def parse_inventory(ems, _targets)
+      EmsRefresh::Parsers::Ec2.ems_inv_to_hashes(ems, refresher_options)
+    end
 
-        log_header = "MIQ(Ec2Refresher.refresh) EMS: [#{ems.name}], id: [#{ems.id}]"
-        $log.info "#{log_header} Refreshing targets for EMS: [#{ems.name}], id: [#{ems.id}]..."
-        targets.each { |t| $log.info "#{log_header}   #{t.class} [#{t.name}] id [#{t.id}]" }
-
-        start_time = Time.now
-
-        $log.debug "#{log_header} Parsing EC2 inventory..."
-        hashes = EmsRefresh::Parsers::Ec2.ems_inv_to_hashes(ems, refresher_options)
-        $log.debug "#{log_header} Parsing EC2 inventory...Completed in #{Time.now - start_time} seconds"
-        $log.debug "#{log_header} inv hashes:\n#{hashes.pretty_inspect}" if DEBUG_TRACE
-        EmsRefresh.save_ems_inventory(ems, hashes)
-
-        # Do any post-operations for this EMS
-        [Vm].each do |klass|
-          if klass.respond_to?(:post_refresh_ems)
-            $log.info "#{log_header} Performing post-refresh operations for #{klass} instances..."
-            klass.post_refresh_ems(ems_id, start_time)
-            $log.info "#{log_header} Performing post-refresh operations for #{klass} instances...Complete"
-          end
-        end
-      end
-
-      $log.info "MIQ(Ec2Refresher.refresh) Refreshing all targets...Complete"
+    def post_process_refresh_classes
+      [Vm]
     end
   end
 end

--- a/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -1,0 +1,77 @@
+module EmsRefresh
+  module Refreshers
+    module EmsRefresherMixin
+      def refresh
+        log_header = "MIQ(#{self.class.name}.refresh)"
+        $log.info "#{log_header} Refreshing all targets..."
+
+        @targets_by_ems_id.each do |ems_id, targets|
+          # Get the ems object
+          ems = @ems_by_ems_id[ems_id]
+
+          log_ems_target = "#{log_header} EMS: [#{ems.name}], id: [#{ems.id}]"
+          $log.info "#{log_ems_target} Refreshing targets for EMS: [#{ems.name}], id: [#{ems.id}]..."
+          targets.each { |t| $log.info "#{log_ems_target}   #{t.class} [#{t.name}] id [#{t.id}]" }
+
+          ems_refresh_start_time = Time.now
+
+          begin
+            $log.debug "#{log_ems_target} Parsing #{refresher_type} inventory..."
+            hashes = parse_inventory(ems, targets)
+            $log.debug "#{log_ems_target} Parsing #{refresher_type} inventory..." \
+                       "Completed in #{Time.now - ems_refresh_start_time} seconds"
+            $log.debug "#{log_ems_target} inv hashes:\n#{hashes.pretty_inspect}" if self.class::DEBUG_TRACE
+
+            if hashes.blank?
+              # TODO: determine if this is "success" or "failed"
+              $log.warn "#{log_header} No inventory data returned for EMS: [#{@ems.name}], id: [#{@ems.id}]..."
+              next
+            end
+            save_inventory(ems, targets, hashes)
+          rescue => e
+            $log.error("#{log_ems_target} Refresh failed")
+            $log.log_backtrace(e)
+            $log.error("#{log_ems_target} Unable to perform refresh for the following targets:")
+            targets.each do |target|
+              target = target.first if target.is_a?(Array)
+              $log.error(" --- #{target.class} [#{target.name}] id [#{target.id}]")
+            end
+            # skip post processing below
+            next
+          ensure
+            post_refresh_ems_cleanup(ems, targets)
+          end
+
+          post_refresh(ems, ems_refresh_start_time)
+        end
+
+        $log.info "#{log_header} Refreshing all targets...Complete"
+      end
+
+      def save_inventory(ems, _targets, hashes)
+        EmsRefresh.save_ems_inventory(ems, hashes)
+      end
+
+      def post_refresh_ems_cleanup(_ems, _targets)
+        # Clean up any resources opened during inventory collection
+      end
+
+      def post_process_refresh_classes
+        # Return the list of classes that need post processing
+        []
+      end
+
+      def post_refresh(ems, ems_refresh_start_time)
+        log_header = "MIQ(#{self.class.name}.#{__method__})"
+        log_ems_target = "#{log_header} EMS: [#{ems.name}], id: [#{ems.id}]"
+        # Do any post-operations for this EMS
+        post_process_refresh_classes.each do |klass|
+          next unless klass.respond_to? :post_refresh_ems
+          $log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances..."
+          klass.post_refresh_ems(ems.id, ems_refresh_start_time)
+          $log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances...Complete"
+        end
+      end
+    end
+  end
+end

--- a/vmdb/app/models/ems_refresh/refreshers/kvm_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/kvm_refresher.rb
@@ -4,42 +4,19 @@ require 'MiqKvmInventory'
 module EmsRefresh::Refreshers
   class KvmRefresher < BaseRefresher
     include RefresherRelatsMixin
+    include EmsRefrehserMixin
 
-    def refresh
-      $log.info "MIQ(KvmRefresher.refresh) Refreshing all targets..."
+    def parse_inventory(ems, _targets)
+      @kvm = MiqKvmInventory.new(ems.ipaddress, *ems.auth_user_pwd)
+      @kvm.refresh
+    end
 
-      @targets_by_ems_id.each do |ems_id, targets|
-        # Get the ems object
-        @ems = @ems_by_ems_id[ems_id]
+    def save_inventory(ems, targets, hashes)
+      EmsRefresh.save_inventory(ems, hashes, targets[0])
+    end
 
-        log_header = "MIQ(KvmRefresher.refresh) EMS: [#{@ems.name}], id: [#{@ems.id}]"
-        $log.info "#{log_header} Refreshing targets for EMS: [#{@ems.name}], id: [#{@ems.id}]..."
-        targets.each { |t| $log.info "#{log_header}   #{t.class} [#{t.name}] id [#{t.id}]" }
-
-        begin
-          kvm = nil
-          kvm = MiqKvmInventory.new(@ems.ipaddress, *@ems.auth_user_pwd())
-          hashes = kvm.refresh()
-          if hashes.blank?
-            $log.warn "#{log_header} No inventory data returned for EMS: [#{@ems.name}], id: [#{@ems.id}]..."
-            next
-          end
-
-          EmsRefresh.save_ems_inventory(@ems, hashes, targets[0])
-        rescue => err
-          $log.log_backtrace(err)
-          $log.error("Unable to perform refresh for the following targets:" )
-          targets.each do |target|
-            target, filtered_data = *target if target.kind_of?(Array)
-            $log.error("  #{target.class} [#{target.name}] id [#{target.id}]")
-          end
-          next
-        ensure
-          kvm.disconnect if kvm
-        end
-      end
-
-      $log.info "MIQ(KvmRefresher.refresh) Refreshing all targets...Complete"
+    def post_refresh_ems_cleanup(_ems, _targets)
+      @kvm.disconnect if @kvm
     end
   end
 end

--- a/vmdb/app/models/ems_refresh/refreshers/openstack_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/openstack_refresher.rb
@@ -1,36 +1,13 @@
 module EmsRefresh::Refreshers
   class OpenstackRefresher < BaseRefresher
-    def refresh
-      log_header = "MIQ(#{self.class.name}.refresh)"
-      $log.info "#{log_header} Refreshing all targets..."
+    include EmsRefresherMixin
 
-      @targets_by_ems_id.each do |ems_id, targets|
-        # Get the ems object
-        ems = @ems_by_ems_id[ems_id]
+    def parse_inventory(ems, _targets)
+      EmsRefresh::Parsers::Openstack.ems_inv_to_hashes(ems, refresher_options)
+    end
 
-        log_ems_target = "#{log_header} EMS: [#{ems.name}], id: [#{ems.id}]"
-        $log.info "#{log_ems_target} Refreshing targets for EMS: [#{ems.name}], id: [#{ems.id}]..."
-        targets.each { |t| $log.info "#{log_ems_target}   #{t.class} [#{t.name}] id [#{t.id}]" }
-
-        start_time = Time.now
-
-        $log.debug "#{log_ems_target} Parsing Openstack inventory..."
-        hashes = EmsRefresh::Parsers::Openstack.ems_inv_to_hashes(ems, refresher_options)
-        $log.debug "#{log_ems_target} Parsing Openstack inventory...Completed in #{Time.now - start_time} seconds"
-        $log.debug "#{log_ems_target} inv hashes:\n#{hashes.pretty_inspect}" if DEBUG_TRACE
-        EmsRefresh.save_ems_inventory(ems, hashes)
-
-        # Do any post-operations for this EMS
-        [Vm].each do |klass|
-          if klass.respond_to?(:post_refresh_ems)
-            $log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances..."
-            klass.post_refresh_ems(ems_id, start_time)
-            $log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances...Complete"
-          end
-        end
-      end
-
-      $log.info "#{log_header} Refreshing all targets...Complete"
+    def post_process_refresh_classes
+      [Vm]
     end
   end
 end

--- a/vmdb/app/models/ems_refresh/refreshers/rhevm_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/rhevm_refresher.rb
@@ -1,61 +1,27 @@
 module EmsRefresh::Refreshers
   class RhevmRefresher < BaseRefresher
     include RefresherRelatsMixin
+    include EmsRefresherMixin
 
-    def refresh
-      $log.info "MIQ(RhevmRefresher.refresh) Refreshing all targets..."
+    def parse_inventory(ems, _targets)
+      rhevm = ems.rhevm_inventory
+      raise "Invalid RHEV server ip address." if rhevm.api.nil?
 
-      @targets_by_ems_id.each do |ems_id, targets|
-        # Get the ems object
-        @ems = @ems_by_ems_id[ems_id]
+      raw_ems_data = rhevm.refresh
+      return [] if raw_ems_data.blank?
 
-        log_header = "MIQ(RhevmRefresher.refresh) EMS: [#{@ems.name}], id: [#{@ems.id}]"
-        $log.info "#{log_header} Refreshing targets for EMS: [#{@ems.name}], id: [#{@ems.id}]..."
-        targets.each { |t| $log.info "#{log_header}   #{t.class} [#{t.name}] id [#{t.id}]" }
+      ems.api_version = rhevm.service.version_string
+      ems.save
 
-        begin
-          rhevm = @ems.rhevm_inventory
-          raise "Invalid RHEV server ip address." if rhevm.api.nil?
-
-          raw_ems_data = rhevm.refresh()
-          if raw_ems_data.blank?
-            $log.warn "#{log_header} No inventory data returned for EMS: [#{@ems.name}], id: [#{@ems.id}]..."
-            next
-          end
-
-          @ems.api_version = rhevm.service.version_string
-
-          refresh_complete = Time.now
-
-          @ems.save
-
-          hashes = EmsRefresh::Parsers::Rhevm.ems_inv_to_hashes(raw_ems_data)
-          EmsRefresh.save_ems_inventory(@ems, hashes, targets[0])
-        rescue => err
-          $log.log_backtrace(err)
-          $log.error("Unable to perform refresh for the following targets:" )
-          targets.each do |target|
-            target, filtered_data = *target if target.kind_of?(Array)
-            $log.error("  #{target.class} [#{target.name}] id [#{target.id}]")
-          end
-          next
-        end
-
-        self.post_refresh_ems(refresh_complete)
-      end
-
-      $log.info "MIQ(RhevmRefresher.refresh) Refreshing all targets...Complete"
+      EmsRefresh::Parsers::Rhevm.ems_inv_to_hashes(raw_ems_data)
     end
 
-    #TODO: move this and other common methods to a mixin
-    def post_refresh_ems(start_time)
-      log_header = "MIQ(VcRefresher.refresh) EMS: [#{@ems.name}], id: [#{@ems.id}]"
-      [VmOrTemplate, Host].each do |klass|
-        next unless klass.respond_to?(:post_refresh_ems)
-        $log.info "#{log_header} Performing post-refresh operations for #{klass} instances..."
-        klass.post_refresh_ems(@ems.id, start_time)
-        $log.info "#{log_header} Performing post-refresh operations for #{klass} instances...Complete"
-      end
+    def save_inventory(ems, targets, hashes)
+      EmsRefresh.save_ems_inventory(ems, hashes, targets[0])
+    end
+
+    def post_process_refresh_classes
+      [VmOrTemplate, Host]
     end
   end
 end

--- a/vmdb/app/models/ems_refresh/refreshers/scvmm_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/scvmm_refresher.rb
@@ -1,41 +1,19 @@
-
+#TODO: is this required?  never seemed to be used anywhere
 $:.push("#{File.dirname(__FILE__)}/../../../../../lib/Scvmm")
 require 'MiqScvmmInventory'
 
-
 module EmsRefresh::Refreshers
   class ScvmmRefresher < BaseRefresher
-    def refresh
-      log_header = "MIQ(#{self.class.name}.refresh)"
-      $log.info "#{log_header} Refreshing Scvmm..."
+    include EmsRefresherMixin
 
-      @targets_by_ems_id.each do |ems_id, targets|
-        # Get the ems object
-        ems = @ems_by_ems_id[ems_id]
+    def parse_inventory(ems, _targets)
+      EmsRefresh::Parsers::Scvmm.ems_inv_to_hashes(ems, refresher_options)
+    end
 
-        log_ems_target = "#{log_header} EMS: [#{ems.name}], id: [#{ems.id}]"
-        $log.info "#{log_ems_target} Refreshing targets for EMS: [#{ems.name}], id: [#{ems.id}]..."
-        targets.each { |t| $log.info "#{log_ems_target}   #{t.class} [#{t.name}] id [#{t.id}]" }
-
-        start_time = Time.now
-
-        $log.debug "#{log_ems_target} Parsing Scvmm inventory..."
-        hashes = EmsRefresh::Parsers::Scvmm.ems_inv_to_hashes(ems, refresher_options)
-        $log.debug "#{log_ems_target} Parsing Scvmm inventory...Completed in #{Time.now - start_time} seconds"
-        $log.debug "#{log_ems_target} inv hashes:\n#{hashes.pretty_inspect}" if DEBUG_TRACE
-        EmsRefresh.save_ems_inventory(ems, hashes)
-
-        # Do any post-operations for this EMS
-        [Vm].each do |klass|
-          if klass.respond_to?(:post_refresh_ems)
-            $log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances..."
-            klass.post_refresh_ems(ems_id, start_time)
-            $log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances...Complete"
-          end
-        end
-      end
-
-      $log.info "#{log_header} Refreshing Scvmm...Complete"
+    def post_process_refresh_classes
+      # TODO: previously this only looped over VM classes, but, since SCVMM is
+      # infra, it should probably include Host, too
+      [Vm]
     end
   end
 end


### PR DESCRIPTION
Supplants #777 for now.  That PR will be remade later based on this code.

The main purpose here is to introduce a common way to set the refresh status and
handle some common logging for the EMS Refresh process.

Two caveats:
1. The status/logging was copied/pasted for VC Refresher since the logic there
   is quite a bit different from the other refreshers.
2. The NonEmsRefresher wasn't touched, since it's not an EMS refresher

Why not just put this logic into the base_refresher?  Because not all refreshers are EMS Refreshers.  The mixin approach allows only the EMS Refreshers to adapt to this logic flow.

@Fryguy, please review
