### PR TITLE
Account for empty files encountered during fleecing.

### DIFF
--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -229,7 +229,7 @@ class MD5deep
 
   def getFileContents(fh, xml_node)
     fh.seek(0, IO::SEEK_SET)
-    buf = fh.read(1024000)
+    buf = fh.read(1024000) || "" # read will return nil when at EOF.
     xml_node.add_element("contents", "compressed"=>"true", "encoded"=>"true").text = (MIQEncode.encode(buf))
   end
 


### PR DESCRIPTION
When an attempting to read at EOF, the "read" method returns nil, not an empty string.
When an empty file is encountered during fleecing, this causes an unlogged exception,
resulting in all glob file info not being saved.

https://bugzilla.redhat.com/show_bug.cgi?id=1160855
https://bugzilla.redhat.com/show_bug.cgi?id=1161267
https://bugzilla.redhat.com/show_bug.cgi?id=1160859
https://bugzilla.redhat.com/show_bug.cgi?id=1161266
