### PR TITLE
define delegate methods for virtual column info

### DIFF
--- a/vmdb/app/models/cim_base_storage_extent.rb
+++ b/vmdb/app/models/cim_base_storage_extent.rb
@@ -1,8 +1,14 @@
 class CimBaseStorageExtent < ActsAsArModel
 
   set_columns_hash(CimStorageExtent.columns_hash.keys.each_with_object({}) { |c, h| h[c.to_sym] = CimStorageExtent.columns_hash[c].type })
-  self.virtual_columns     = CimStorageExtent.virtual_columns_hash
-  self.virtual_reflections = CimStorageExtent.virtual_reflections
+
+  def self._virtual_colums_hash
+    CimStorageExtent._virtual_columns_hash
+  end
+
+  def self._virtual_reflections
+    CimStorageExtent._virtual_reflections
+  end
 
   def self.find(*args)
     options = args.extract_options!


### PR DESCRIPTION
this ensures that the virtual column info is consistent between the two
models and also eliminates the need for the setter method.
