### PR TITLE
Remove virtual assignment methods

### DIFF
--- a/vmdb/lib/extensions/ar_virtual.rb
+++ b/vmdb/lib/extensions/ar_virtual.rb
@@ -129,12 +129,6 @@ module VirtualFields
     add_virtual_reflection(:belongs_to, name, options)
   end
 
-  def virtual_reflections=(reflection_hash)
-    reflection_hash.each do |name, options|
-      add_virtual_reflection(options.kind_of?(VirtualReflection) ? options.macro : options[:macro], name, options)
-    end
-  end
-
   def virtual_reflection?(name)
     virtual_reflections.has_key?(name.to_sym)
   end

--- a/vmdb/spec/lib/extensions/ar_virtual_spec.rb
+++ b/vmdb/spec/lib/extensions/ar_virtual_spec.rb
@@ -440,16 +440,14 @@ describe VirtualFields do
       end
     end
 
-    context ".virtual_reflections=" do
-      it "with invalid parameters" do
-        lambda { TestClass.virtual_reflections = {:vref1 => {}} }.should raise_error(ArgumentError)
-      end
-
+    context "virtual_reflection assignment" do
       it "" do
-        TestClass.virtual_reflections = {
+        {
           :vref1  => {:macro => :has_one},
           "vref2" => {:macro => :has_many},
-        }
+        }.each do |name, options|
+          TestClass.send "virtual_#{options[:macro]}", name
+        end
 
         TestClass.virtual_reflections.length.should == 2
         TestClass.virtual_reflections.keys.should match_array([:vref1, :vref2])
@@ -459,10 +457,12 @@ describe VirtualFields do
       it "with existing virtual reflections" do
         TestClass.virtual_has_one :existing_vref
 
-        TestClass.virtual_reflections = {
+        {
           :vref1  => {:macro => :has_one},
           "vref2" => {:macro => :has_many},
-        }
+        }.each do |name, options|
+          TestClass.send "virtual_#{options[:macro]}", name
+        end
 
         TestClass.virtual_reflections.length.should == 3
         TestClass.virtual_reflections.keys.should match_array([:existing_vref, :vref1, :vref2])


### PR DESCRIPTION
This pull request removes `virtual_columns=` and `virtual_reflections=`.  We aren't using these methods anymore in the application, and removing them should help simplify porting virtual columns to Rails 4.
