### PR TITLE
Added option to hide warnings for fuzzy messages

### DIFF
--- a/vmdb/config/initializers/fast_gettext.rb
+++ b/vmdb/config/initializers/fast_gettext.rb
@@ -1,3 +1,6 @@
-FastGettext.add_text_domain('manageiq', :path => Rails.root.join("config/locales"), :type => :po)
+FastGettext.add_text_domain('manageiq',
+                            :path           => Rails.root.join("config/locales"),
+                            :type           => :po,
+                            :report_warning => false)
 FastGettext.default_available_locales = %w(en hu it nl sk)
 FastGettext.default_text_domain = 'manageiq'


### PR DESCRIPTION
The option is also hidding obsolete translations.

As proposal from https://github.com/ManageIQ/manageiq/pull/1062, we could use an option :ignore_fuzzy => true, but that one's still showing a warning message in rails log.

```
 Warning: fuzzy message was ignored.
```
