### PR TITLE
Add new AWS Region EU Frankfurt

### DIFF
--- a/lib/Amazon/ec2/regions.rb
+++ b/lib/Amazon/ec2/regions.rb
@@ -26,6 +26,11 @@ module Amazon
           :hostname    => "ec2.eu-west-1.amazonaws.com",
           :description => "EU (Ireland)",
         },
+        "eu-central-1" => {
+          :name        => "eu-central-1",
+          :hostname    => "ec2.eu-central-1.amazonaws.com",
+          :description => "EU (Frankfurt)",
+        },
         "ap-southeast-1" => {
           :name        => "ap-southeast-1",
           :hostname    => "ec2.ap-southeast-1.amazonaws.com",


### PR DESCRIPTION
Adds new AWS region:
  EU (Frankfurt)
  ec2.eu-central-1.amazonaws.com

https://bugzilla.redhat.com/show_bug.cgi?id=1164033
