### PR TITLE
drop support for passing VirtualColumn and Reflection objects

### DIFF
--- a/vmdb/lib/extensions/ar_virtual.rb
+++ b/vmdb/lib/extensions/ar_virtual.rb
@@ -203,7 +203,7 @@ module VirtualFields
 
   def add_virtual_column(name, options)
     reset_virtual_column_information
-    _virtual_columns_hash[name.to_s] = options.kind_of?(VirtualColumn) ? options : VirtualColumn.new(name, options)
+    _virtual_columns_hash[name.to_s] = VirtualColumn.new(name, options)
   end
 
   def reset_virtual_column_information
@@ -213,7 +213,7 @@ module VirtualFields
   def add_virtual_reflection(macro, name, options)
     raise ArgumentError, "macro must be specified" if macro.nil?
     reset_virtual_reflection_information
-    _virtual_reflections[name.to_sym] = options.kind_of?(VirtualReflection) ? options : VirtualReflection.new(macro.to_sym, name.to_sym, options, self)
+    _virtual_reflections[name.to_sym] = VirtualReflection.new(macro.to_sym, name.to_sym, options, self)
   end
 
   def reset_virtual_reflection_information

--- a/vmdb/spec/lib/extensions/ar_virtual_spec.rb
+++ b/vmdb/spec/lib/extensions/ar_virtual_spec.rb
@@ -198,17 +198,6 @@ describe VirtualFields do
         TestClass.virtual_columns_hash.values.all? { |c| c.kind_of?(VirtualColumn) }.should be_true
       end
 
-      it "with a VirtualColumn" do
-        TestClass.virtual_columns = {
-          :vcol1  => VirtualColumn.new(:vcol1,  :type => :string),
-          "vcol2" => VirtualColumn.new("vcol2", :type => :string)
-        }
-
-        TestClass.virtual_columns_hash.length.should == 2
-        TestClass.virtual_columns_hash.keys.should match_array(["vcol1", "vcol2"])
-        TestClass.virtual_columns_hash.values.all? { |c| c.kind_of?(VirtualColumn) }.should be_true
-      end
-
       it "with existing virtual columns" do
         TestClass.virtual_column :existing_vcol, :type => :string
 
@@ -460,17 +449,6 @@ describe VirtualFields do
         TestClass.virtual_reflections = {
           :vref1  => {:macro => :has_one},
           "vref2" => {:macro => :has_many},
-        }
-
-        TestClass.virtual_reflections.length.should == 2
-        TestClass.virtual_reflections.keys.should match_array([:vref1, :vref2])
-        TestClass.virtual_reflections.values.all? { |c| c.kind_of?(VirtualReflection) }.should be_true
-      end
-
-      it "with a VirtualReflection" do
-        TestClass.virtual_reflections = {
-          :vref1  => VirtualReflection.new(:has_one, :vref1, {}, TestClass),
-          "vref2" => VirtualReflection.new(:has_one, "vref2", {}, TestClass)
         }
 
         TestClass.virtual_reflections.length.should == 2


### PR DESCRIPTION
no app code ever passes virtual column or reflection objects to the
add_\* methods, so we don't need to support that case.
