### PR TITLE
UI Tasks view: fix per page settings

### DIFF
--- a/vmdb/app/controllers/miq_proxy_controller.rb
+++ b/vmdb/app/controllers/miq_proxy_controller.rb
@@ -15,7 +15,7 @@ class MiqProxyController < ApplicationController
       @tabform ||= "tasks_3" if role_allows(:feature=>"job_all_smartproxy") && role_allows(:feature=>"job_all_smartproxy")
       @tabform ||= "tasks_4" if role_allows(:feature=>"miq_task_all_ui") && role_allows(:feature=>"miq_task_all_ui")
       jobs
-      render :action=>"jobs"
+      render :action => "jobs" unless request.xml_http_request?
     end
   end
 
@@ -23,7 +23,7 @@ class MiqProxyController < ApplicationController
   def change_tab
     @tabform = "tasks_" + params[:tab]
     jobs
-    render :action=>"jobs"
+    render :action => "jobs" unless request.xml_http_request?
   end
 
   def build_jobs_tab
@@ -71,21 +71,16 @@ class MiqProxyController < ApplicationController
   def jobs
     build_jobs_tab
     @title = "Tasks for #{session[:username]}"
-    @breadcrumbs = Array.new
+    @breadcrumbs = []
     @lastaction = "jobs"
+    @edit = {:opts => copy_hash(@tasks_options[@tabform])} # Backup current settings
 
-    @edit = Hash.new
-    @edit[:opts] = Hash.new
-    @edit[:opts] = copy_hash(@tasks_options[@tabform])   # Backup current settings
-
+    get_jobs(tasks_condition(@tasks_options[@tabform]))
     if params[:action] != "button" && (params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice] || params[:user_choice])
-      get_jobs(tasks_condition(@tasks_options[@tabform]))
       render :update do |page|
-        page.replace_html("gtl_div", :partial=>"layouts/gtl", :locals=>{:action_url=>@lastaction})
+        page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
-    else                      # Came in from non-ajax, just get the jobs
-      get_jobs(tasks_condition(@tasks_options[@tabform]))
     end
   end
 

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -758,10 +758,12 @@ Vmdb::Application.routes.draw do
         compare_get,
       :post => %w(
         button
+        change_tab
         create
         credential_field_changed
         form_field_changed
         get_log
+        index
         install_007
         jobs
         panel_control

--- a/vmdb/spec/routing/miq_proxy_routing_spec.rb
+++ b/vmdb/spec/routing/miq_proxy_routing_spec.rb
@@ -19,6 +19,9 @@ describe "routes for MiqProxyController" do
     it 'routes with GET' do
       expect(get("/miq_proxy/change_tab")).to route_to("miq_proxy#change_tab")
     end
+    it 'routes with POST' do
+      expect(post("/miq_proxy/change_tab")).to route_to("miq_proxy#change_tab")
+    end
   end
 
   describe "#create" do
@@ -64,6 +67,9 @@ describe "routes for MiqProxyController" do
   describe "#index" do
     it 'routes with GET' do
       expect(get("miq_proxy/index")).to route_to("miq_proxy#index")
+    end
+    it 'routes with POST' do
+      expect(post("miq_proxy/index")).to route_to("miq_proxy#index")
     end
   end
 


### PR DESCRIPTION
Configuration -> Tasks -> per page settings and page navigation
wouldn't work correctly:
- the view would always default to 50 items per page
- incorrect numbers shown next to the navigation icons

Fixes #818

https://bugzilla.redhat.com/show_bug.cgi?id=1171150
