### PR TITLE
Ignore RHEVM user login failed events

### DIFF
--- a/vmdb/config/event_handling.tmpl.yml
+++ b/vmdb/config/event_handling.tmpl.yml
@@ -1350,6 +1350,7 @@ filtered_events:
   USER_REMOVE_VG_FAILED:
   USER_VDC_LOGIN:
   USER_VDC_LOGOUT:
+  USER_VDC_LOGIN_FAILED:
   UserLoginSessionEvent:
   UserLogoutSessionEvent:
   scheduler.run_instance.start:             # OpenStack filtered events


### PR DESCRIPTION
This doesn't fix bug 1114656, but it does address part of the problem of
grabbing way too many RHEVM events for historical processing.

https://bugzilla.redhat.com/show_bug.cgi?id=1114656
