### PR TITLE
Specs use case insensitive fqname for comparison

### DIFF
--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
@@ -110,7 +110,8 @@ module MiqAeServiceSpec
             result_hash.should be_kind_of(Hash)
             result_hash.length.should == 1
             key = "/#{@domain}/EVM/AUTOMATE/test1"
-            result_hash.keys.should == [key]
+            [key].should match_string_array_ignorecase(result_hash.keys)
+            key = result_hash.keys.first
             result_hash[key].should be_kind_of(Hash)
             result_hash[key].length.should == 3
           end

--- a/vmdb/spec/models/miq_ae_domain_spec.rb
+++ b/vmdb/spec/models/miq_ae_domain_spec.rb
@@ -90,7 +90,7 @@ describe MiqAeDomain do
       create_multiple_domains
       expected = %w(/DOM2/A/b/C/cLaSS1 /DOM1/A/B/C/CLASS1 /DOM3/a/B/c/CLASs1)
       result = MiqAeClass.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1', true)
-      expected.should match_array(result.each.collect(&:fqname))
+      expected.should match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
 
@@ -113,7 +113,7 @@ describe MiqAeDomain do
         /DOM3/a/B/c/CLASs1/instance1
       )
       result = MiqAeInstance.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/instance1')
-      expected.should match_array(result.each.collect(&:fqname))
+      expected.should match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
 
@@ -131,7 +131,7 @@ describe MiqAeDomain do
       create_multiple_domains_with_methods
       expected = %w(/DOM2/A/b/C/cLaSS1/method1 /DOM1/A/B/C/CLASS1/method1 /DOM3/a/B/c/CLASs1/method1)
       result = MiqAeMethod.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/method1', true)
-      expected.should match_array(result.each.collect(&:fqname))
+      expected.should match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
 

--- a/vmdb/spec/support/custom_matchers/match_string_array_ignorecase.rb
+++ b/vmdb/spec/support/custom_matchers/match_string_array_ignorecase.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :match_string_array_ignorecase do |expected|
+  match do |actual|
+    expect(expected.map(&:downcase)).to match_array(actual.map(&:downcase))
+  end
+
+  description do
+    "a case insensitive string array matcher"
+  end
+end


### PR DESCRIPTION
Automation engine uses lowercase names for domains, namespaces
class, instances and methods. It can be refered to in mix case in
the models. The fqname is critcal to locating files in the new
git based automated model, by having mixed case the search takes
longer so we are planning on using all lowercase name when storing
files in git and the fqname becomes all lowercase.
