### PR TITLE
Fixed error on workers tab.

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -625,7 +625,7 @@ module OpsController::Settings::Common
 
     params = self.params
     new = @edit[:new]
-    auth = new[:authentication]
+    auth = new[:authentication] unless @sb[:active_tab] == "settings_workers"
 
     # WTF? here we can have a Zone or a MiqServer, what about Region? --> rescue from exception
     @temp[:selected_server] = (cls.find(from_cid(nodes.last)) rescue nil)


### PR DESCRIPTION
Fixed undefined method `[]' for #VMDB::Config:0x00000006f06a80 when editing any field on workers tab. We cannot set auth from new[:authentication], @edit[:new] is a config object on the Workers tab. This broke with changes for https://github.com/ManageIQ/manageiq/pull/954

@dclarizio please review/test.
