### PR TITLE
Saved reports view: fix missing icon error

### DIFF
--- a/vmdb/product/toolbars/report_view_tb.yaml
+++ b/vmdb/product/toolbars/report_view_tb.yaml
@@ -16,7 +16,7 @@
     :url: 'explorer'
     :url_parms: '?type=hybrid'
   - :buttonTwoState: view_tabular
-    :image: view_textual
+    :image: view_list
     :title: "Tabular View"
     :url: 'explorer'
     :url_parms: '?type=tabular'


### PR DESCRIPTION
PR #841 removed view_textual.png from sources, although this
icon was still being referenced from saved reports view, causing
the following error:

Started GET "/images/toolbars/view_textual.png"
No route matches [GET] "/images/toolbars/view_textual.png"
...

view_list.png is identical to view_textual.png, so let's
use that icon instead.
