### PR TITLE
Remove "initialize" method from StorageManager model.

### DIFF
--- a/vmdb/app/models/storage_manager.rb
+++ b/vmdb/app/models/storage_manager.rb
@@ -31,10 +31,6 @@ class StorageManager < ActiveRecord::Base
     :MiqCimVirtualMachine
   ]
 
-  def initialize(options={})
-    super()
-  end
-
   def self.new_of_type(typ, options={})
     klass = typ.constantize
     options.symbolize_keys!


### PR DESCRIPTION
The initialize method of the StorageManager model class was calling super()
and in so doing, not passing the proper args to the subclass. Given
this was all the method did, the entire method has been removed.

https://bugzilla.redhat.com/show_bug.cgi?id=1171286
https://bugzilla.redhat.com/show_bug.cgi?id=1171899
