### PR TITLE
Fix session store on metric_fu environment

### DIFF
--- a/vmdb/config/initializers/session_store.rb
+++ b/vmdb/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-if Rails.env.test?
+if !Rails.env.development? && !Rails.env.production?
   Vmdb::Application.config.session_store :memory_store
 elsif MiqEnvironment::Process.is_web_server_worker?
   session_options = {}


### PR DESCRIPTION
This is why metric_fu keeps failing.  The session_store setting was set for test only, but metric_fu runs in its own environment type.  I've changed it to "not production nor development" to account for both test environments.

@brandondunne @abellotti @jrafanie 
