### PR TITLE
SCVMM: Virtual DVD drive support fixes

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -31,6 +31,8 @@ function get_images{
   $i_hash = @{}
   $id = $_.ID
   $i_hash["Properties"] = $_
+  $dvds = Get-SCVirtualDVDDrive -VMTemplate $_ | Select-Object -ExpandProperty "ISO"
+  $i_hash["DVDs"] = $dvds
   $results[$id]= $i_hash
  }
  return $results

--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -341,7 +341,10 @@ module EmsRefresh::Parsers
     end
 
     def process_vm_guest_devices(vm)
-      dvdprops   = vm[:Properties][:Props][:VirtualDVDDrives][0][:Props]
+      dvds = vm[:Properties][:Props][:VirtualDVDDrives]
+      return [] if dvds.empty?
+
+      dvdprops   = dvds[0][:Props]
       connection = dvdprops[:Connection]
       devices    = []
 


### PR DESCRIPTION
This PR includes the following:
1) Support for virtual dvd drives for templates
2) Graceful handling of VMs without a virtual DVD mounted. VMM server version 3.1.6 returns an empty hash which caused the parser to blow up. More recent versions of VMM server return a hash containing values that indicate no DVD has been configured.

https://bugzilla.redhat.com/show_bug.cgi?id=1166861
