### PR TITLE
Remove <Unknown> entry from Authentication Status box.

### DIFF
--- a/vmdb/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -124,6 +124,7 @@ module EmsCloudHelper::TextualSummary
     return [{:label => "Default Authentication", :title => "None", :value => "None"}] if authentications.blank?
 
     authentications.collect do |auth|
+      next if auth.kind_of?(AuthPrivateKey)
       label =
         case auth.authtype
         when "default"; "Default"


### PR DESCRIPTION
Remove <Unknown> entry from Authentication Status box, these entries were for keypairs(AuthKeyPairAmazon), and had null in authtype field in the table.

https://bugzilla.redhat.com/show_bug.cgi?id=1158180
https://bugzilla.redhat.com/show_bug.cgi?id=1158179

@fryguy @dclarizio please review.
