### PR TITLE
Don't show full backtrace for rspec failures

### DIFF
--- a/lib/.rspec
+++ b/lib/.rspec
@@ -1,4 +1,3 @@
---backtrace
 --color
 --order random
 --format documentation

--- a/lib/.rspec_ci
+++ b/lib/.rspec_ci
@@ -1,4 +1,3 @@
---backtrace
 --color
 --order random
 --profile

--- a/lib/spec/spec_helper.rb
+++ b/lib/spec/spec_helper.rb
@@ -17,4 +17,7 @@ rescue LoadError
 end
 
 RSpec.configure do |config|
+  config.backtrace_exclusion_patterns -= [%r{/lib\d*/ruby/}, %r{/gems/}]
+  config.backtrace_exclusion_patterns << %r{/lib\d*/ruby/[0-9]}
+  config.backtrace_exclusion_patterns << %r{/gems/[0-9][^/]+/gems/}
 end

--- a/vmdb/.rspec
+++ b/vmdb/.rspec
@@ -1,4 +1,3 @@
---backtrace
 --color
 --order random
 --format documentation

--- a/vmdb/.rspec_ci
+++ b/vmdb/.rspec_ci
@@ -1,4 +1,3 @@
---backtrace
 --color
 --order random
 --profile

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -76,6 +76,10 @@ RSpec.configure do |config|
   config.after(:each) do
     EvmSpecHelper.clear_caches
   end
+
+  config.backtrace_exclusion_patterns -= [%r{/lib\d*/ruby/}, %r{/gems/}]
+  config.backtrace_exclusion_patterns << %r{/lib\d*/ruby/[0-9]}
+  config.backtrace_exclusion_patterns << %r{/gems/[0-9][^/]+/gems/}
 end
 
 # PATCH: Temporary monkey patch until a new version of webmock is released


### PR DESCRIPTION
This was making me sad, because I had to scroll past all the lines that implement the rspec example groups and matchers... none of which is at all interesting.

@jrafanie added the option so we don't miss out on lines from our customized rails.

So instead, I'll just remove any filter that would affect `ActiveRecord::Base.connection`, as a simple proxy for "any of rails".
