### PR TITLE
Remove reference to no longer needed host version

### DIFF
--- a/build/Rakefile
+++ b/build/Rakefile
@@ -5,7 +5,6 @@ namespace :build do
   module FilePaths
     BUILD        = Pathname.new(File.dirname(__FILE__)).join("../vmdb/BUILD")
     VERSION      = Pathname.new(File.dirname(__FILE__)).join("../vmdb/VERSION")
-    HOST_VERSION = Pathname.new(File.dirname(__FILE__)).join("../host/miqhost/VERSION")
   end
 
   class ConfigOptions
@@ -33,7 +32,6 @@ namespace :build do
 
   task :version_files do
     File.write(FilePaths::VERSION, "#{ConfigOptions.version}\n")
-    File.write(FilePaths::HOST_VERSION, "#{ConfigOptions.version}\n")
   end
 
   task :precompile_assets do


### PR DESCRIPTION
Seemed to fix and allow build creation to proceed.

Original error:

```
rake build:tar
rake aborted!
No such file or directory - /home/jprause/tagging/manageiq/host/miqhost/VERSION
/home/jprause/tagging/manageiq/build/Rakefile:36:in `write'
/home/jprause/tagging/manageiq/build/Rakefile:36:in `block (2 levels) in <top (required)>'
/home/jprause/.rvm/gems/ruby-1.9.3-p551/bin/ruby_executable_hooks:15:in `eval'
/home/jprause/.rvm/gems/ruby-1.9.3-p551/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => build:tar => build:version_files
(See full trace by running task with --trace)
```
