### PR TITLE
SCVMM - DB error VM with multiple VHDs on volume

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -395,7 +395,7 @@ module EmsRefresh::Parsers
     def process_vm_storages(properties)
       properties[:VirtualHardDisks].collect do |vhd|
         @data_index.fetch_path(:storages, vhd[:Props][:HostVolumeId])
-      end.compact
+      end.compact.uniq
     end
 
     def process_vm_storage(vmcpath, host)


### PR DESCRIPTION
This PR ensures the VM storages hash does not contain duplicate host volumes. Otherwise a  [ActiveRecord::RecordNotUnique] error will be thrown for the storages_vms_and_templates table.

https://bugzilla.redhat.com/show_bug.cgi?id=1173251
