### PR TITLE
just call the method rather than sending

### DIFF
--- a/vmdb/app/models/vim_performance_daily.rb
+++ b/vmdb/app/models/vim_performance_daily.rb
@@ -40,7 +40,7 @@ class VimPerformanceDaily < MetricRollup
       end
     end
 
-    tp && tp.rollup_daily_metrics ? self.send(:find_by_time_profile, *args) : []
+    tp && tp.rollup_daily_metrics ? find_by_time_profile(*args) : []
   end
 
   def self.find_by_time_profile(*args)


### PR DESCRIPTION
We don't need to call send.  We can just call the method directly.
