### PR TITLE
extract preloader usage to a new method

### DIFF
--- a/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
@@ -30,7 +30,7 @@ module EmsRefresh::Refreshers
 
     def group_targets_by_ems(targets)
       non_ems_targets = targets.select { |t| !t.kind_of?(ExtManagementSystem) }
-      ActiveRecord::Associations::Preloader.new(non_ems_targets, :ext_management_system).run
+      MiqPreloader.preload(non_ems_targets, :ext_management_system)
 
       self.ems_by_ems_id     = {}
       self.targets_by_ems_id = Hash.new { |h, k| h[k] = Array.new }

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1694,7 +1694,7 @@ class Host < ActiveRecord::Base
     $log.debug "Checking for VMs that are scheduled to be scanned"
 
     hosts = MiqServer.my_server.zone.hosts
-    ActiveRecord::Associations::Preloader.new(hosts, :vms).run
+    MiqPreloader.preload(hosts, :vms)
     hosts.each do |h|
       next if h.scan_frequency.to_i == 0
 

--- a/vmdb/app/models/metric/rollup.rb
+++ b/vmdb/app/models/metric/rollup.rb
@@ -204,7 +204,7 @@ module Metric::Rollup
     #   the current hour too because the capture in vim_performance_state_for_ts,
     #   if not found for the perf timestamp, will return a state for the current
     #   hour only.
-    ActiveRecord::Associations::Preloader.new(recs, :vim_performance_states, :conditions => {'vim_performance_states.timestamp' => [ts, Metric::Helper.nearest_hourly_timestamp(Time.now.utc)]}).run unless recs.empty?
+    MiqPreloader.preload(recs, :vim_performance_states, :conditions => {'vim_performance_states.timestamp' => [ts, Metric::Helper.nearest_hourly_timestamp(Time.now.utc)]}) unless recs.empty?
 
     recs.each do |rec|
       perf = perf_recs.fetch_path(rec.class.base_class.name, rec.id, interval_name, ts)

--- a/vmdb/app/models/metric/targets.rb
+++ b/vmdb/app/models/metric/targets.rb
@@ -13,7 +13,7 @@ module Metric::Targets
     # TODO: Include hosts under clusters
     includes = {:ext_management_systems => {:hosts => {:tags => {}}, :ems_clusters => :tags}}
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
-    ActiveRecord::Associations::Preloader.new(zone, includes).run
+    MiqPreloader.preload(zone, includes)
 
     targets = zone.ems_clusters + zone.non_clustered_hosts
     targets += zone.storages.select { |s| Storage::SUPPORTED_STORAGE_TYPES.include?(s.store_type) } unless options[:exclude_storages]
@@ -34,7 +34,7 @@ module Metric::Targets
     targets = []
 
     includes = {:availability_zones => {:tags => {}}}
-    ActiveRecord::Associations::Preloader.new(zone.ems_clouds, includes).run
+    MiqPreloader.preload(zone.ems_clouds, includes)
 
     targets += capture_vm_targets(zone.availability_zones, AvailabilityZone, options)
 
@@ -56,7 +56,7 @@ module Metric::Targets
           t.perf_capture_enabled? &&
           t.respond_to?(:vms)
       end
-      ActiveRecord::Associations::Preloader.new(enabled_parents, :vms).run
+      MiqPreloader.preload(enabled_parents, :vms)
       vms = targets.collect { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }.flatten.compact
     end
     vms

--- a/vmdb/app/models/miq_provision_workflow.rb
+++ b/vmdb/app/models/miq_provision_workflow.rb
@@ -526,7 +526,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
       unless @vlan_options[:vlans] == false
         rails_logger('allowed_vlans', 0)
         hosts = get_selected_hosts(src)
-        ActiveRecord::Associations::Preloader.new(hosts, :switches => :lans).run
+        MiqPreloader.preload(hosts, :switches => :lans)
         hosts.each {|h| h.lans.each {|l| vlans[l.name] = l.name}}
 
         # Remove certain networks
@@ -718,7 +718,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
       allowed_templates_list.each { |vm| $log.info "#{log_header} Allowed Template <#{vm.id}:#{vm.name}>  GUID: <#{vm.guid}>  UID_EMS: <#{vm.uid_ems}>"}
     end
 
-    ActiveRecord::Associations::Preloader.new(allowed_templates_list, [:operating_system, :ext_management_system, {:hardware => :disks}]).run
+    MiqPreloader.preload(allowed_templates_list, [:operating_system, :ext_management_system, {:hardware => :disks}])
     @allowed_templates_cache = allowed_templates_list.collect do |v|
       nh = MiqHashStruct.new(
         :id       => v.id,

--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -1083,7 +1083,7 @@ class MiqRequestWorkflow
 
     rails_logger('allowed_storages', 0)
     st = Time.now
-    ActiveRecord::Associations::Preloader.new(hosts, :storages).run
+    MiqPreloader.preload(hosts, :storages)
 
     storage_ids = []
     storages = hosts.inject([]) do |a, h|

--- a/vmdb/app/models/miq_widget.rb
+++ b/vmdb/app/models/miq_widget.rb
@@ -250,7 +250,7 @@ class MiqWidget < ActiveRecord::Base
       return
     end
 
-    ActiveRecord::Associations::Preloader.new(group_hash_visibility_agnostic.keys, [:miq_user_role]).run
+    MiqPreloader.preload(group_hash_visibility_agnostic.keys, [:miq_user_role])
 
     group_hash = group_hash_visibility_agnostic.select { |k, v| available_for_group?(k) }      # Process users grouped by LDAP group membership of whether they have RBAC
 

--- a/vmdb/app/models/mixins/aggregation_mixin.rb
+++ b/vmdb/app/models/mixins/aggregation_mixin.rb
@@ -84,7 +84,7 @@ module AggregationMixin
 
   def all_storages
     hosts = self.all_hosts
-    ActiveRecord::Associations::Preloader.new(hosts, :storages).run
+    MiqPreloader.preload(hosts, :storages)
     hosts.collect { |h| h.storages }.flatten.compact.uniq
   end
 

--- a/vmdb/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/vmdb/app/models/mixins/miq_provision_quota_mixin.rb
@@ -106,7 +106,7 @@ module MiqProvisionQuotaMixin
     prov_owner = self.get_owner
     unless prov_owner.nil?
       vms = Vm.user_or_group_owned(prov_owner)
-      ActiveRecord::Associations::Preloader.new(vms, :hardware => :disks).run
+      MiqPreloader.preload(vms, :hardware => :disks)
       vms.reject! do |vm|
         result = vm.template? || vm.host_id.nil?
         # if result is already true we can skip the following checks

--- a/vmdb/app/models/rbac.rb
+++ b/vmdb/app/models/rbac.rb
@@ -477,7 +477,7 @@ module Rbac
     clusters = subtree.select { |obj| obj.kind_of?(EmsCluster)}
     hosts    = subtree.select { |obj| obj.kind_of?(Host) }
 
-    ActiveRecord::Associations::Preloader.new(clusters, :hosts).run
+    MiqPreloader.preload(clusters, :hosts)
     clusters.collect(&:hosts).flatten + hosts
   end
 

--- a/vmdb/app/models/relationship.rb
+++ b/vmdb/app/models/relationship.rb
@@ -32,7 +32,7 @@ class Relationship < ActiveRecord::Base
   end
 
   def self.resources(relationships)
-    ActiveRecord::Associations::Preloader.new(relationships, :resource).run
+    MiqPreloader.preload(relationships, :resource)
     relationships.collect { |r| r.resource }
   end
 
@@ -72,7 +72,7 @@ class Relationship < ActiveRecord::Base
   end
 
   def self.arranged_rels_to_resources(relationships, initial = true)
-    ActiveRecord::Associations::Preloader.new(self.flatten_arranged_rels(relationships), :resource).run if initial
+    MiqPreloader.preload(self.flatten_arranged_rels(relationships), :resource) if initial
 
     relationships.each_with_object({}) do |(rel, children), h|
       h[rel.resource] = self.arranged_rels_to_resources(children, false)

--- a/vmdb/app/models/storage.rb
+++ b/vmdb/app/models/storage.rb
@@ -744,7 +744,7 @@ class Storage < ActiveRecord::Base
       end
 
       Benchmark.realtime_block(:db_find_storage_files) do
-        ActiveRecord::Associations::Preloader.new(self, :vms => :storage_files_files).run
+        MiqPreloader.preload(self, :vms => :storage_files_files)
       end
 
       state, = Benchmark.realtime_block(:capture_state) { self.perf_capture_state }

--- a/vmdb/app/models/vim_performance_analysis.rb
+++ b/vmdb/app/models/vim_performance_analysis.rb
@@ -71,7 +71,7 @@ module VimPerformanceAnalysis
           @compute, attrs = Rbac.search(:class => topts[:compute_type].to_s ,:results_format => :objects, :include_for_find => includes, :userid => @options[:userid], :miq_group_id => @options[:miq_group_id])
         end
 
-        ActiveRecord::Associations::Preloader.new(@compute, :storages).run
+        MiqPreloader.preload(@compute, :storages)
         stores = @compute.collect {|c| storages_for_compute_target(c)}.flatten.uniq
 
         if topts[:storage_filter]
@@ -108,13 +108,13 @@ module VimPerformanceAnalysis
         # For clusters, to allow for fragmentation in calculations, calculate using child hosts and aggregate at the end.
         @hosts_to_cluster = {}
 
-        ActiveRecord::Associations::Preloader.new(@compute, :hosts => [:hardware, {:vms => :hardware}]).run
+        MiqPreloader.preload(@compute, :hosts => [:hardware, {:vms => :hardware}])
         compute_hosts = @compute.collect do |c|
           c.hosts.each {|h| @hosts_to_cluster[h.id] = c}
           c.hosts
         end.flatten
       else
-        ActiveRecord::Associations::Preloader.new(@compute, [:hardware, {:vms => :hardware}]).run
+        MiqPreloader.preload(@compute, [:hardware, {:vms => :hardware}])
         compute_hosts = @compute
       end
 

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1066,7 +1066,7 @@ class VmOrTemplate < ActiveRecord::Base
   def storage2proxies
     return @storage_proxies unless @storage_proxies.nil?
 
-    ActiveRecord::Associations::Preloader.new(self, :storage => {:hosts => :miq_proxy}).run
+    MiqPreloader.preload(self, :storage => {:hosts => :miq_proxy})
     proxies = self.storage2hosts.select { |h| h && h.is_a_proxy? }
 
     # Support vixDisk scanning of VMware VMs from the vmdb server
@@ -1223,7 +1223,7 @@ class VmOrTemplate < ActiveRecord::Base
 
     # Collect the updated folder relationships to determine which vms need updated path information
     ems_folders = ems.ems_folders
-    ActiveRecord::Associations::Preloader.new(ems_folders, :all_relationships).run
+    MiqPreloader.preload(ems_folders, :all_relationships)
 
     updated_folders = ems_folders.select do |f|
       f.created_on >= update_start_time || f.updated_on >= update_start_time ||      # Has the folder itself changed (e.g. renamed)?

--- a/vmdb/app/models/zone.rb
+++ b/vmdb/app/models/zone.rb
@@ -129,22 +129,22 @@ class Zone < ActiveRecord::Base
   end
 
   def hosts
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :hosts).run
+    MiqPreloader.preload(self, :ext_management_systems => :hosts)
     self.ext_management_systems.collect { |e| e.hosts }.flatten
   end
 
   def non_clustered_hosts
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :hosts).run
+    MiqPreloader.preload(self, :ext_management_systems => :hosts)
     self.ext_management_systems.collect { |e| e.non_clustered_hosts }.flatten
   end
 
   def clustered_hosts
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :hosts).run
+    MiqPreloader.preload(self, :ext_management_systems => :hosts)
     self.ext_management_systems.collect { |e| e.clustered_hosts }.flatten
   end
 
   def ems_clusters
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :ems_clusters).run
+    MiqPreloader.preload(self, :ext_management_systems => :ems_clusters)
     self.ext_management_systems.collect { |e| e.ems_clusters }.flatten
   end
 
@@ -157,29 +157,29 @@ class Zone < ActiveRecord::Base
   end
 
   def availability_zones
-    ActiveRecord::Associations::Preloader.new(self.ems_clouds, :availability_zones).run
+    MiqPreloader.preload(self.ems_clouds, :availability_zones)
     self.ems_clouds.collect { |e| e.availability_zones }.flatten
   end
 
   def vms_without_availability_zone
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :vms).run
+    MiqPreloader.preload(self, :ext_management_systems => :vms)
     self.ext_management_systems.collect do |e|
       e.kind_of?(EmsCloud) ? e.vms.select { |vm| vm.availability_zone.nil? } : []
     end.flatten
   end
 
   def vms_and_templates
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :vms_and_templates).run
+    MiqPreloader.preload(self, :ext_management_systems => :vms_and_templates)
     self.ext_management_systems.collect { |e| e.vms_and_templates }.flatten
   end
 
   def vms
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :vms).run
+    MiqPreloader.preload(self, :ext_management_systems => :vms)
     self.ext_management_systems.collect { |e| e.vms }.flatten
   end
 
   def miq_templates
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => :miq_templates).run
+    MiqPreloader.preload(self, :ext_management_systems => :miq_templates)
     self.ext_management_systems.collect { |e| e.miq_templates }.flatten
   end
 
@@ -196,7 +196,7 @@ class Zone < ActiveRecord::Base
   end
 
   def storages
-    ActiveRecord::Associations::Preloader.new(self, :ext_management_systems => {:hosts => :storages}).run
+    MiqPreloader.preload(self, :ext_management_systems => {:hosts => :storages})
     self.ext_management_systems.collect { |e| e.storages }.flatten.uniq
   end
 

--- a/vmdb/app/presenters/tree_builder_vms_and_templates.rb
+++ b/vmdb/app/presenters/tree_builder_vms_and_templates.rb
@@ -103,6 +103,6 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
 
   def preload_ems_for_vms(tree)
     vms = extract_vms(tree)
-    ActiveRecord::Associations::Preloader.new(vms, :ext_management_system).run
+    MiqPreloader.preload(vms, :ext_management_system)
   end
 end

--- a/vmdb/db/migrate/20110328153536_add_perf_by_tag_to_classifications.rb
+++ b/vmdb/db/migrate/20110328153536_add_perf_by_tag_to_classifications.rb
@@ -27,7 +27,7 @@ class AddPerfByTagToClassifications < ActiveRecord::Migration
 
     say_with_time("Migrate data from reserved table") do
       cats = Classification.categories
-      ActiveRecord::Associations::Preloader.new(cats, :reserved_rec).run
+      MiqPreloader.preload(cats, :reserved_rec)
       cats.each do |cat|
         cat.reserved_hash_migrate(:perf_by_tag)
       end

--- a/vmdb/lib/extensions/ar_to_model_hash.rb
+++ b/vmdb/lib/extensions/ar_to_model_hash.rb
@@ -44,7 +44,7 @@ module ToModelHash
 
   def to_model_hash(options = nil)
     options ||= self.class.to_model_hash_options
-    ActiveRecord::Associations::Preloader.new(self, to_model_hash_build_preload(options)).run
+    MiqPreloader.preload(self, to_model_hash_build_preload(options))
     to_model_hash_recursive(options)
   end
 

--- a/vmdb/lib/extensions/ar_virtual.rb
+++ b/vmdb/lib/extensions/ar_virtual.rb
@@ -284,7 +284,7 @@ module ActiveRecord
             next unless field.kind_of?(VirtualReflection)
 
             parents = records.map {|record| record.send(field.name)}.flatten.compact
-            Preloader.new(parents, child).run unless parents.empty?
+            MiqPreloader.preload(parents, child) unless parents.empty?
           end
         when String, Symbol
           field = records_model.virtual_field(association)
@@ -305,7 +305,7 @@ module ActiveRecord
 
       if original
         self.includes_values = original
-        ActiveRecord::Associations::Preloader.new(recs, preload_values + includes_values).run
+        MiqPreloader.preload(recs, preload_values + includes_values)
       end
       return recs
     end

--- a/vmdb/lib/miq_preloader.rb
+++ b/vmdb/lib/miq_preloader.rb
@@ -1,0 +1,5 @@
+module MiqPreloader
+  def self.preload(records, associations, options = {})
+    ActiveRecord::Associations::Preloader.new(records, associations, options).run
+  end
+end

--- a/vmdb/lib/workers/ems_refresh_core_worker.rb
+++ b/vmdb/lib/workers/ems_refresh_core_worker.rb
@@ -149,7 +149,7 @@ class EmsRefreshCoreWorker < WorkerBase
     inv = inv.to_miq_a
     return if inv.none? { |i| i['connected'] }
 
-    ActiveRecord::Associations::Preloader.new(vm, :hardware => {:nics => :network}).run
+    MiqPreloader.preload(vm, :hardware => {:nics => :network})
 
     nics = vm.try(:hardware).try(:nics).to_miq_a.select(&:network)
     return if nics.blank?

--- a/vmdb/lib/workers/vim_broker_worker.rb
+++ b/vmdb/lib/workers/vim_broker_worker.rb
@@ -24,7 +24,7 @@ class VimBrokerWorker < WorkerBase
 
   def self.emses_and_hosts_to_monitor
     emses = MiqVimBrokerWorker.emses_to_monitor
-    ActiveRecord::Associations::Preloader.new(emses, :hosts => :authentications).run
+    MiqPreloader.preload(emses, :hosts => :authentications)
     hosts = emses.collect { |e| e.hosts }.flatten.uniq.select { |h| h.authentication_valid? }
     return emses + hosts
   end


### PR DESCRIPTION
the preloader API in Rails has changed.  This commit extracts our usage
to a new method so that when we upgrade, we only need to change one
place.
