### PR TITLE
Use more descriptive assertions

### DIFF
--- a/vmdb/spec/models/miq_expression/miq_expression_spec.rb
+++ b/vmdb/spec/models/miq_expression/miq_expression_spec.rb
@@ -454,10 +454,10 @@ describe MiqExpression do
       relats  = MiqExpression.get_relats(Vm)
       details = MiqExpression._model_details(relats, {})
       cluster_sorted = details.select { |d| d.first.starts_with?("Cluster") }.sort
-      cluster_sorted.select { |d| d.first == "Cluster : Total Number of Physical CPUs" }.should_not be_empty
-      cluster_sorted.select { |d| d.first == "Cluster : Total Number of Logical CPUs" }.should_not be_empty
+      cluster_sorted.map(&:first).should include("Cluster : Total Number of Physical CPUs")
+      cluster_sorted.map(&:first).should include("Cluster : Total Number of Logical CPUs")
       hardware_sorted = details.select { |d| d.first.starts_with?("Hardware") }.sort
-      hardware_sorted.select { |d| d.first == "Hardware : Logical Cpus" }.should be_empty
+      hardware_sorted.map(&:first).should_not include("Hardware : Logical Cpus")
     end
   end
 

--- a/vmdb/spec/models/miq_expression/model_details_spec.rb
+++ b/vmdb/spec/models/miq_expression/model_details_spec.rb
@@ -23,13 +23,13 @@ describe MiqExpression do
     context "with :typ=>tag" do
       it "VmInfra" do
         result = described_class.model_details("VmInfra", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "Virtual Machine.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("Virtual Machine.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "VmCloud" do
         result = described_class.model_details("VmCloud", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "Instance.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
-        result.select { |r| r.first == "Instance.VM and Instance.My Company Tags : Auto Approve - Max CPU" }.should be_empty
+        result.map(&:first).should include("Instance.My Company Tags : Auto Approve - Max CPU")
+        result.map(&:first).should_not include("Instance.VM and Instance.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "VmOrTemplate" do
@@ -39,32 +39,32 @@ describe MiqExpression do
                                                :include_my_tags => true,
                                                :userid          => "admin"
         )
-        result.select { |r| r.first == "VM or Template.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("VM or Template.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "TemplateInfra" do
         result = described_class.model_details("TemplateInfra", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "Template.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("Template.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "TemplateCloud" do
         result = described_class.model_details("TemplateCloud", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "Image.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("Image.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "MiqTemplate" do
         result = described_class.model_details("MiqTemplate", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "VM Template and Image.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("VM Template and Image.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "EmsInfra" do
         result = described_class.model_details("EmsInfra", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "Infrastructure Provider.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("Infrastructure Provider.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "EmsCloud" do
         result = described_class.model_details("EmsCloud", :typ=>"tag", :include_model=>true, :include_my_tags=>true, :userid=>"admin")
-        result.select { |r| r.first == "Cloud Provider.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("Cloud Provider.My Company Tags : Auto Approve - Max CPU")
       end
     end
 
@@ -74,12 +74,12 @@ describe MiqExpression do
                                                :typ           => "all",
                                                :include_model => false,
                                                :include_tags  => true)
-        result.select { |r| r.first == "My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("My Company Tags : Auto Approve - Max CPU")
       end
 
       it "Service" do
         result = described_class.model_details("Service", :typ => "all", :include_model => false, :include_tags => true)
-        result.select { |r| r.first == "My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
+        result.map(&:first).should include("My Company Tags : Auto Approve - Max CPU")
       end
     end
   end


### PR DESCRIPTION
The previous spelling:

```
xs.select { ..something.. }.should_not be_empty
```

can only fail when the filtered collection _is_ empty. Which means the failure message is... less than helpful.

By using `.should include(..)`, when it fails, we're shown what _was_ in there. This makes it much easier to work out why the particular expected value is absent.

The same issue doesn't apply to `.should be_empty`, but I've changed the two instances of that for symmetry.

---

Before:

```
  1) MiqExpression.model_details with :typ=>tag VmCloud
     Failure/Error: result.select { |r| r.first == "Instance.My Company Tags : Auto Approve - Max CPU" }.should_not be_empty
       expected empty? to return false, got true
     # ./spec/models/miq_expression/model_details_spec.rb:31:in `block (4 levels) in <top (required)>'
```

After:

```
  1) MiqExpression.model_details with :typ=>tag VmCloud
     Failure/Error: result.map(&:first).should include("Instance.My Company Tags : Auto Approve - Max CPU")
       expected ["Vm Cloud.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Cloud/Infrastructure Provider.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Cluster.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Datastore.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Host.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Miq Group.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Repository.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Resource Pool.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.Service.My Company Tags : Auto Approve - Max CPU", "Vm Cloud.User.My Company Tags : Auto Approve - Max CPU"] to include "Instance.My Company Tags : Auto Approve - Max CPU"
     # ./spec/models/miq_expression/model_details_spec.rb:31:in `block (4 levels) in <top (required)>'
```
