### PR TITLE
add the original exception's backtrace when raising

### DIFF
--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -293,7 +293,7 @@ class MiqQueue < ActiveRecord::Base
       rescue ActiveRecord::StaleObjectError
         $log.debug("#{log_prefix} #{MiqQueue.format_short_log_msg(msg)} stale, retrying...")
       rescue => err
-        raise "#{log_prefix} \"#{err}\" attempting merge next message"
+        raise RuntimeError, "#{log_prefix} \"#{err}\" attempting merge next message", err.backtrace
       end
     end
     return msg


### PR DESCRIPTION
just raising an exception with the string will lose the backtrace of the
original exception.  This patch adds the backtrace from the original
exception so we can tell where the real error originates.
