### PR TITLE
Language selection in webui

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -42,6 +42,7 @@ gem 'secure_headers'
 # Needed by the REST API
 gem "jbuilder",                       "~>2.0.7"
 gem "gettext_i18n_rails"
+gem "rails-i18n",                     "~> 3.0.0"
 
 # Not vendored and not required
 gem "ancestry",                       "~>1.2.4",      :require => false

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -2712,10 +2712,22 @@ class ApplicationController < ActionController::Base
   end
 
   def set_gettext_locale
-    user_locale = request.env['HTTP_ACCEPT_LANGUAGE'].to_s.split(',')
-      .collect { |l| l.sub(/;.*/, '') }
-      .detect { |locale| FastGettext.available_locales.include?(locale) }
-    session[:locale] = I18n.locale = FastGettext.set_locale(user_locale)
+    user_settings =  User.find_by_userid(session[:userid]).try(:settings)
+    locale = user_settings[:display][:locale] if user_settings &&
+                                                 user_settings.key?(:display) &&
+                                                 user_settings[:display].key?(:locale)
+    if locale.nil? || locale == 'default'
+      unless MiqServer.my_server.nil?
+        locale = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :locale)
+      end
+      if locale.nil? || locale == 'default'
+        locale = request.env['HTTP_ACCEPT_LANGUAGE'].to_s.split(',')
+          .collect { |l| l.sub(/;.*/, '') }
+          .detect  { |l| FastGettext.available_locales.include?(l) }
+      end
+    end
+
+    session[:locale] = I18n.locale = FastGettext.set_locale(locale)
     super
   end
 end

--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -832,6 +832,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:display][:timezone] = params[:display_timezone] if params[:display_timezone] != nil
       @edit[:new][:display][:startpage] = params[:start_page] if params[:start_page] != nil
       @edit[:new][:display][:quad_truncate] = params[:quad_truncate] if params[:quad_truncate] != nil
+      @edit[:new][:display][:locale] = params[:display_locale] if params[:display_locale]
     when "ui_2"                                               # Visual Settings tab
       @edit[:new][:display][:compare] = params[:display][:compare] if params[:display] != nil && params[:display][:compare] != nil
       @edit[:new][:display][:drift] = params[:display][:drift] if params[:display] != nil && params[:display][:drift] != nil

--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -647,6 +647,7 @@ module OpsController::Settings::Common
         @sb[:new_to] = nil
       end
       new[:smtp][:authentication] = params[:smtp_authentication] if params[:smtp_authentication]
+      new[:server][:locale] = params[:locale] if params[:locale]
       @smtp_auth_none = (new[:smtp][:authentication] == "none")
       if !new[:smtp][:host].blank? && !new[:smtp][:port].blank? && !new[:smtp][:domain].blank? &&
           (!new[:smtp][:user_name].blank? || new[:smtp][:authentication] == "none") &&
@@ -904,6 +905,7 @@ module OpsController::Settings::Common
       end
       @edit[:current].config[:server][:role] = @edit[:current].config[:server][:role] ? @edit[:current].config[:server][:role].split(",").sort.join(",") : ""
       @edit[:current].config[:server][:timezone] = "UTC" if @edit[:current].config[:server][:timezone].blank?
+      @edit[:current].config[:server][:locale] = "default" if @edit[:current].config[:server][:locale].blank?
       @edit[:current].config[:server][:remote_console_type] ||= "MKS"
       @edit[:current].config[:server][:vnc_proxy_address] ||= nil
       @edit[:current].config[:server][:vnc_proxy_port] ||= nil

--- a/vmdb/app/views/configuration/_ui_1.html.haml
+++ b/vmdb/app/views/configuration/_ui_1.html.haml
@@ -84,7 +84,9 @@
                                      "height: 32px;" +                                                     |
                                      "float: left;"}                                                       |
             - [[_("Chart Theme"), "display_reporttheme", Charting.chart_themes_for_select, :reporttheme],
-               [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES,         :timezone]].each do |display_settings|
+               [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES,                    :timezone],
+               [_("Locale"), "display_locale",      [[_("Global Default"), "default"]] + FastGettext.human_available_locales,
+                :locale]].each do |display_settings|
               %tr
                 %td.key
                   = display_settings[0]

--- a/vmdb/app/views/ops/_settings_server_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_server_tab.html.erb
@@ -75,6 +75,15 @@
                                   "data-miq_observe"=>{:url=>url}.to_json) %>
               </td>
             </tr>
+            <tr>
+              <td class="key">Default Locale</td>
+              <td class="wide">
+                <%= select_tag('locale',
+                               options_for_select([['Client Browser Setting', 'default']] + FastGettext.human_available_locales,
+                                                  @edit[:new][:server][:locale]),
+                               "data-miq_observe" => {:url => url}.to_json) %>
+              </td>
+            </tr>
         </table>
         <div class="note">* Changing the Zone will reset all of this Server's priorities to secondary.</div>
       </fieldset>

--- a/vmdb/config/initializers/fast_gettext.rb
+++ b/vmdb/config/initializers/fast_gettext.rb
@@ -1,6 +1,27 @@
+def register_human_localenames
+  original_locale = FastGettext.locale
+  FastGettext.class.class_eval { attr_accessor :human_available_locales }
+  FastGettext.human_available_locales = []
+  FastGettext.default_available_locales.each do |locale|
+    FastGettext.locale = locale
+    # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
+    human_locale = _("locale_name")
+    human_locale = locale if human_locale == "locale_name"
+    FastGettext.human_available_locales << [human_locale, locale]
+  end
+  FastGettext.human_available_locales.sort! { |a, b| a[0] <=> b[0] }
+ensure
+  FastGettext.locale = original_locale
+end
+
+locale_path = Rails.root.join("config/locales")
+
 FastGettext.add_text_domain('manageiq',
-                            :path           => Rails.root.join("config/locales"),
+                            :path           => locale_path,
                             :type           => :po,
                             :report_warning => false)
-FastGettext.default_available_locales = %w(en hu it nl sk)
+FastGettext.default_available_locales = Dir.entries(locale_path)
+  .select { |entry| (File.directory? File.join(locale_path, entry)) && entry != '.' && entry != '..' }
+  .sort
 FastGettext.default_text_domain = 'manageiq'
+register_human_localenames

--- a/vmdb/config/locales/en/manageiq.po
+++ b/vmdb/config/locales/en/manageiq.po
@@ -1243,3 +1243,7 @@ msgstr ""
 
 msgid "write_ios_per_sec"
 msgstr ""
+
+#. Provide locale name in native language (e.g. English, Deutsch or Português)
+msgid "locale_name"
+msgstr "English"

--- a/vmdb/config/locales/hu/manageiq.po
+++ b/vmdb/config/locales/hu/manageiq.po
@@ -1307,3 +1307,7 @@ msgstr ""
 
 msgid "write_ios_per_sec"
 msgstr ""
+
+#. Provide locale name in native language (e.g. English, Deutsch or Português)
+msgid "locale_name"
+msgstr "Magyar"

--- a/vmdb/config/locales/it/manageiq.po
+++ b/vmdb/config/locales/it/manageiq.po
@@ -1307,3 +1307,7 @@ msgstr ""
 
 msgid "write_ios_per_sec"
 msgstr ""
+
+#. Provide locale name in native language (e.g. English, Deutsch or Português)
+msgid "locale_name"
+msgstr "Italiano"

--- a/vmdb/config/locales/nl/manageiq.po
+++ b/vmdb/config/locales/nl/manageiq.po
@@ -1307,3 +1307,7 @@ msgstr ""
 
 msgid "write_ios_per_sec"
 msgstr ""
+
+#. Provide locale name in native language (e.g. English, Deutsch or Português)
+msgid "locale_name"
+msgstr "Nederlands"

--- a/vmdb/config/locales/sk/manageiq.po
+++ b/vmdb/config/locales/sk/manageiq.po
@@ -1307,3 +1307,7 @@ msgstr ""
 
 msgid "write_ios_per_sec"
 msgstr ""
+
+#. Provide locale name in native language (e.g. English, Deutsch or Português)
+msgid "locale_name"
+msgstr "Slovensky"


### PR DESCRIPTION
This change allows for selection of webui language on a user
and a server level. Should the user settings be set to default,
server settings will apply. Should the server settings be set
to default, webui will set the language based on browser
preferences.

This change also introduces a new translation string 'locale_name',
which is meant to be translated into a locale name in every
supported native language.

Additionaly, this change also adds a new gem rails-i18n which
contains translations for some of the strings we use in our webui.
Having the translations available effectively fixes tracebacks occuring
in the UI once the UI language is switch from english to something else.

Fixes #1008