### PR TITLE
convert Rails 2 finders to Rails 3 and 4 finders

### DIFF
--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -2182,16 +2182,15 @@ class Host < ActiveRecord::Base
     else             HostPerformance
     end
 
-    perfs = klass.all(
-      :conditions => [
+    perfs = klass.where(
+      [
         "resource_id = ? AND capture_interval_name = ? AND timestamp >= ? AND timestamp <= ?",
         self.id,
         capture_interval.to_s,
         time_range[0],
         time_range[1]
-      ],
-      :order => "timestamp"
-    )
+      ]
+    ).order "timestamp"
 
     if capture_interval.to_sym == :realtime && metric.to_s.starts_with?("v_pct_cpu_")
       vm_vals_by_ts = self.get_pct_cpu_metric_from_child_vm_performances(metric, capture_interval, time_range)

--- a/vmdb/app/models/job_proxy_dispatcher.rb
+++ b/vmdb/app/models/job_proxy_dispatcher.rb
@@ -215,8 +215,7 @@ class JobProxyDispatcher
         .where(:agent_class      => "MiqServer")
         .where(:target_class     => "VmOrTemplate")
         .where("state != ?", "finished")
-        .uniq
-        .pluck("DISTINCT target_id")
+        .select("target_id").collect { |ji| ji.target_id }.compact.uniq
     return @busy_resources_for_embedded_scanning_hash if vms_in_embedded_scanning.blank?
 
     embedded_scans_by_resource = Hash.new {|h,k| h[k]=0}

--- a/vmdb/app/models/job_proxy_dispatcher.rb
+++ b/vmdb/app/models/job_proxy_dispatcher.rb
@@ -25,8 +25,11 @@ class JobProxyDispatcher
         Benchmark.realtime_block(:busy_resources_for_embedded_scanning) { self.busy_resources_for_embedded_scanning }
 
         vms_for_jobs = jobs_to_dispatch.collect {|j| j.target_id}
-        @vms_for_dispatch_jobs, = Benchmark.realtime_block(:vm_find) { VmOrTemplate.find_all_by_id(vms_for_jobs, :include => {:ext_management_system => :zone, :storage => {:hosts => :miq_proxy} }, :order => :id) }
-
+        @vms_for_dispatch_jobs, = Benchmark.realtime_block(:vm_find) do
+          VmOrTemplate.where(:id => vms_for_jobs)
+            .includes(:ext_management_system => :zone, :storage => {:hosts => :miq_proxy})
+            .order(:id)
+        end
         zone = Zone.find_by_name(@zone)
         concurrent_vm_scans_limit = zone.settings.blank? ? 0 : zone.settings[:concurrent_vm_scans].to_i
 
@@ -142,20 +145,17 @@ class JobProxyDispatcher
 
   def pending_jobs
     @zone = MiqServer.my_zone
-    Job.find(:all, :order => "id" ,:conditions => [
-        "state = ? and dispatch_status = ? and
-     (zone is null or zone = ?) and
-     (sync_key is NULL or
-       sync_key not in (
-         select sync_key from jobs where
-           dispatch_status = 'active' and
-           state != 'finished' and
-           (zone is null or zone = ?) and
-           sync_key is not NULL
-       )
-    )",
-        "waiting_to_start", "pending", @zone, @zone
-      ])
+    Job.order(:id)
+      .where(:state           => "waiting_to_start")
+      .where(:dispatch_status => "pending")
+      .where("zone is null or zone = ?", @zone)
+      .where("sync_key is NULL or
+        sync_key not in (
+           select sync_key from jobs where
+             dispatch_status = 'active' and
+             state != 'finished' and
+             (zone is null or zone = ?) and
+             sync_key is not NULL)", @zone)
   end
 
   def busy_proxy?(proxy, job)
@@ -186,11 +186,13 @@ class JobProxyDispatcher
 
   def busy_proxies
     @busy_proxies_hash ||= begin
-      Job.find(:all, :conditions => ["dispatch_status = ? AND state != ?", "active", "finished"], :select => "agent_id, agent_class").inject({}) do |busy_hsh, j|
-        busy_hsh["#{j.agent_class}_#{j.agent_id}"] ||= 0
-        busy_hsh["#{j.agent_class}_#{j.agent_id}"] += 1
-        busy_hsh
-      end
+      Job.where(:dispatch_status => "active")
+        .where("state != ?", "finished")
+        .select(:agent_id, :agent_class)
+        .each_with_object({}) do |j, busy_hsh|
+          busy_hsh["#{j.agent_class}_#{j.agent_id}"] ||= 0
+          busy_hsh["#{j.agent_class}_#{j.agent_id}"] += 1
+        end
     end
   end
 
@@ -208,11 +210,17 @@ class JobProxyDispatcher
     $log.debug("MIQ(JobProxyDispatcher.busy_resources_for_embedded_scanning) Initializing busy_resources_for_embedding_scanning hash")
     @busy_resources_for_embedded_scanning_hash ||= {}
 
-    vms_in_embedded_scanning = Job.find(:all, :conditions => ["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"], :select => "target_id").collect {|ji| ji.target_id}.compact.uniq
+    vms_in_embedded_scanning =
+      Job.where(:dispatch_status => "active")
+        .where(:agent_class      => "MiqServer")
+        .where(:target_class     => "VmOrTemplate")
+        .where("state != ?", "finished")
+        .uniq
+        .pluck("DISTINCT target_id")
     return @busy_resources_for_embedded_scanning_hash if vms_in_embedded_scanning.blank?
 
     embedded_scans_by_resource = Hash.new {|h,k| h[k]=0}
-    VmOrTemplate.find_all_by_id(vms_in_embedded_scanning).each do |v|
+    VmOrTemplate.where(:id => vms_in_embedded_scanning).each do |v|
       key = self.embedded_scan_resource(v)
       embedded_scans_by_resource[key] += 1 if key
     end

--- a/vmdb/app/models/job_proxy_dispatcher.rb
+++ b/vmdb/app/models/job_proxy_dispatcher.rb
@@ -188,7 +188,7 @@ class JobProxyDispatcher
     @busy_proxies_hash ||= begin
       Job.where(:dispatch_status => "active")
         .where("state != ?", "finished")
-        .select(:agent_id, :agent_class)
+        .select([:agent_id, :agent_class])
         .each_with_object({}) do |j, busy_hsh|
           busy_hsh["#{j.agent_class}_#{j.agent_id}"] ||= 0
           busy_hsh["#{j.agent_class}_#{j.agent_id}"] += 1

--- a/vmdb/app/models/metric/capture.rb
+++ b/vmdb/app/models/metric/capture.rb
@@ -78,7 +78,7 @@ module Metric::Capture
     # Create a new task for each rollup parent
     tasks_by_rollup_parent = targets_by_rollup_parent.keys.inject({}) do |h, pkey|
       name = "Performance rollup for #{pkey}"
-      prev_task = MiqTask.first(:conditions => {:identifier => pkey}, :order => "id DESC")
+      prev_task = MiqTask.where(:identifier => pkey).order("id DESC").first
       task_start_time = prev_task ? prev_task.context_data[:end] : default_task_start_time
 
       task = MiqTask.create(

--- a/vmdb/app/models/metric/ci_mixin.rb
+++ b/vmdb/app/models/metric/ci_mixin.rb
@@ -92,7 +92,7 @@ module Metric::CiMixin
     #
 
     pkey = "#{self.class}:#{self.id}"
-    last_task = MiqTask.first(:conditions => {:identifier => pkey}, :order => "id DESC")
+    last_task = MiqTask.where(:identifier => pkey).order("id DESC").first
 
     default_how_long = (interval_name == "realtime" ? 70.minutes : 28.hours)
     starting_on ||= if last_task
@@ -107,12 +107,14 @@ module Metric::CiMixin
     window_starting_on = starting_on - duration
     $log.info("#{log_header} Reading performance records from: #{window_starting_on} to: #{now}")
 
-    select = "capture_interval_name, capture_interval, timestamp, #{column}" if Metric.column_names.include?(column.to_s)
-    total_records = self.send(meth).all(
-      :select     => select,
-      :conditions => ["capture_interval_name = ? and timestamp >= ? and timestamp < ?", interval_name, window_starting_on, now],
-      :order      => "timestamp DESC"
-    )
+    scope = send(meth)
+    if Metric.column_names.include?(column.to_s)
+      scope = scope.select "capture_interval_name, capture_interval, timestamp, #{column}"
+    end
+
+    total_records = scope.
+      where(["capture_interval_name = ? and timestamp >= ? and timestamp < ?", interval_name, window_starting_on, now]).
+      order("timestamp DESC").to_a
 
     return false if total_records.empty?
 

--- a/vmdb/app/models/metric/ci_mixin.rb
+++ b/vmdb/app/models/metric/ci_mixin.rb
@@ -112,9 +112,10 @@ module Metric::CiMixin
       scope = scope.select "capture_interval_name, capture_interval, timestamp, #{column}"
     end
 
-    total_records = scope.
-      where(["capture_interval_name = ? and timestamp >= ? and timestamp < ?", interval_name, window_starting_on, now]).
-      order("timestamp DESC").to_a
+    total_records = scope
+                    .where(:capture_interval_name => interval_name)
+                    .where(["timestamp >= ? and timestamp < ?", window_starting_on, now])
+                    .order("timestamp DESC")
 
     return false if total_records.empty?
 

--- a/vmdb/app/models/metric/ci_mixin/rollup.rb
+++ b/vmdb/app/models/metric/ci_mixin/rollup.rb
@@ -80,7 +80,7 @@ module Metric::CiMixin::Rollup
 
       perf = nil
       Benchmark.realtime_block(:db_find_prev_perf) do
-        perf = self.send(meth).first(:conditions => new_perf)
+        perf = self.send(meth).where(new_perf).first
         perf ||= self.send(meth).build(:resource_name => self.name)
       end
 

--- a/vmdb/app/models/metric/finders.rb
+++ b/vmdb/app/models/metric/finders.rb
@@ -31,7 +31,7 @@ module Metric::Finders
 
     klass, meth = Metric::Helper.class_and_association_for_interval_name(interval_name)
 
-    return resource.send(meth).where(cond).to_a unless resource.kind_of?(Array)
+    return resource.send(meth).where(cond) unless resource.kind_of?(Array)
 
     # Group the resources by type to find the ids on which to query
     res_cond = []
@@ -47,7 +47,7 @@ module Metric::Finders
     cond.nil? ? cond = [res_cond] : cond[0] << " AND #{res_cond}"
     cond += res_params
 
-    return klass.where(cond).to_a
+    return klass.where(cond)
   end
 
   #

--- a/vmdb/app/models/metric/finders.rb
+++ b/vmdb/app/models/metric/finders.rb
@@ -31,7 +31,7 @@ module Metric::Finders
 
     klass, meth = Metric::Helper.class_and_association_for_interval_name(interval_name)
 
-    return resource.send(meth).all(:conditions => cond) unless resource.kind_of?(Array)
+    return resource.send(meth).where(cond).to_a unless resource.kind_of?(Array)
 
     # Group the resources by type to find the ids on which to query
     res_cond = []
@@ -47,7 +47,7 @@ module Metric::Finders
     cond.nil? ? cond = [res_cond] : cond[0] << " AND #{res_cond}"
     cond += res_params
 
-    return klass.all(:conditions => cond)
+    return klass.where(cond).to_a
   end
 
   #

--- a/vmdb/app/models/metric/rollup.rb
+++ b/vmdb/app/models/metric/rollup.rb
@@ -305,8 +305,8 @@ module Metric::Rollup
   end
 
   def self.find_distinct_resources
-    metrics = Metric.in_my_region.all(:select => "DISTINCT resource_type, resource_id")
-    metric_rollups = MetricRollup.in_my_region.all(:select => "DISTINCT resource_type, resource_id")
+    metrics = Metric.in_my_region.select("DISTINCT resource_type, resource_id")
+    metric_rollups = MetricRollup.in_my_region.select("DISTINCT resource_type, resource_id")
 
     recs = (metrics + metric_rollups).group_by { |m| m.resource_type }
     recs.keys.each { |k| recs[k] = recs[k].collect { |r| r.resource_id }.uniq }

--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -28,11 +28,11 @@ class MiqAeClass < ActiveRecord::Base
   end
 
   def self.find_by_namespace_id_and_name(ns_id, name)
-    self.find(:first, :conditions => ["namespace_id = ? AND lower(name) = ?", ns_id, name.downcase] )
+    self.where(["namespace_id = ? AND lower(name) = ?", ns_id, name.downcase]).first
   end
 
   def self.find_by_name(name)
-    self.find(:first, :conditions => ["lower(name) = ?", name.downcase], :include => [:ae_methods, :ae_fields] )
+    self.where(["lower(name) = ?", name.downcase]).includes([:ae_methods, :ae_fields] ).first
   end
 
   def self.fqname(ns, name)

--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -28,7 +28,7 @@ class MiqAeClass < ActiveRecord::Base
   end
 
   def self.find_by_namespace_id_and_name(ns_id, name)
-    self.where(["namespace_id = ? AND lower(name) = ?", ns_id, name.downcase]).first
+    self.where(:namespace_id => ns_id).where(["lower(name) = ?", name.downcase]).first
   end
 
   def self.find_by_name(name)

--- a/vmdb/app/models/miq_ae_namespace.rb
+++ b/vmdb/app/models/miq_ae_namespace.rb
@@ -18,7 +18,7 @@ class MiqAeNamespace < ActiveRecord::Base
     fqname   = fqname.downcase
     last     = fqname.split('/').last
     low_name = arel_table[:name].lower
-    query = include_classes ? includes(:parent, :ae_classes) : scoped
+    query = include_classes ? includes(:parent, :ae_classes) : self
     query.where(low_name.eq(last)).detect { |namespace| namespace.fqname.downcase == fqname }
   end
 

--- a/vmdb/app/models/miq_task.rb
+++ b/vmdb/app/models/miq_task.rb
@@ -251,7 +251,7 @@ class MiqTask < ActiveRecord::Base
     cond[1] << ts.utc
 
     $log.info("#{log_prefix} cond.flatten: #{cond.flatten.inspect}")
-    ids = self.find(:all, :conditions => cond.flatten, :select => "id").collect {|j| j.id}
+    ids = where(cond.flatten).select("id").collect {|j| j.id}
 
     self.delete_by_id(ids)
   end

--- a/vmdb/app/models/mixins/aggregation_mixin.rb
+++ b/vmdb/app/models/mixins/aggregation_mixin.rb
@@ -93,7 +93,7 @@ module AggregationMixin
     select    = field == :aggregate_cpu_speed ? "logical_cpus, cpu_speed" : field
     targets ||= self.send("all_#{from}_ids")
     targets   = targets.collect(&:id) unless targets.first.kind_of?(Integer)
-    hdws      = Hardware.all(:conditions => {"#{from}_id" => targets}, :select => select)
+    hdws      = Hardware.where("#{from}_id" => targets).select(select)
 
     hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
   end

--- a/vmdb/app/models/relationship.rb
+++ b/vmdb/app/models/relationship.rb
@@ -5,7 +5,7 @@ class Relationship < ActiveRecord::Base
 
   belongs_to :resource, :polymorphic => true
 
-  scope :in_relationship, lambda { |rel| {:conditions => {:relationship => rel}} }
+  scope :in_relationship, lambda { |rel| where({:relationship => rel}) }
 
   #
   # Filtering methods

--- a/vmdb/app/models/server_role.rb
+++ b/vmdb/app/models/server_role.rb
@@ -64,7 +64,7 @@ class ServerRole < ActiveRecord::Base
   end
 
   def self.region_scoped_roles
-    @region_scoped_roles ||= self.find_all_by_role_scope('region').sort { |a,b| a.name <=> b.name }
+    @region_scoped_roles ||= self.where(:role_scope => 'region').sort { |a,b| a.name <=> b.name }
   end
 
   def self.zone_scoped_roles

--- a/vmdb/app/models/storage.rb
+++ b/vmdb/app/models/storage.rb
@@ -75,7 +75,7 @@ class Storage < ActiveRecord::Base
   end
 
   def ext_management_systems
-    @ext_management_systems ||= Host.includes(:storages).to_a.select { |h| h.storages.include?(self) }.collect { |h| h.ext_management_system }.compact.uniq
+    @ext_management_systems ||= Host.includes(:storages).select { |h| h.storages.include?(self) }.collect { |h| h.ext_management_system }.compact.uniq
   end
 
   def ext_management_systems_in_zone(zone_name)

--- a/vmdb/app/models/storage.rb
+++ b/vmdb/app/models/storage.rb
@@ -75,7 +75,7 @@ class Storage < ActiveRecord::Base
   end
 
   def ext_management_systems
-    @ext_management_systems ||= Host.find(:all, :include => :storages).select { |h| h.storages.include?(self) }.collect { |h| h.ext_management_system }.compact.uniq
+    @ext_management_systems ||= Host.includes(:storages).to_a.select { |h| h.storages.include?(self) }.collect { |h| h.ext_management_system }.compact.uniq
   end
 
   def ext_management_systems_in_zone(zone_name)

--- a/vmdb/app/models/user.rb
+++ b/vmdb/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_userid(userid)
-    self.in_region.find(:first, :conditions => {:userid => userid})
+    self.in_region.where(:userid => userid).first
   end
 
   def self.find_by_email(email)

--- a/vmdb/app/models/vim_performance_state.rb
+++ b/vmdb/app/models/vim_performance_state.rb
@@ -82,27 +82,27 @@ class VimPerformanceState < ActiveRecord::Base
 
   def storages
     ids = get_assoc(:storages, :on)
-    return ids.empty? ? [] : Storage.where(:id => ids).order(:id).to_a
+    return ids.empty? ? [] : Storage.where(:id => ids).order(:id)
   end
 
   def ext_management_systems
     ids = get_assoc(:ext_management_systems, :on)
-    return ids.empty? ? [] : ExtManagementSystem.where(:id => ids).order(:id).to_a
+    return ids.empty? ? [] : ExtManagementSystem.where(:id => ids).order(:id)
   end
 
   def ems_clusters
     ids = get_assoc(:ems_clusters, :on)
-    return ids.empty? ? [] : EmsCluster.where(:id => ids).order(:id).to_a
+    return ids.empty? ? [] : EmsCluster.where(:id => ids).order(:id)
   end
 
   def hosts
     ids = get_assoc(:hosts)
-    return ids.empty? ? [] : Host.where(:id => ids).order(:id).to_a
+    return ids.empty? ? [] : Host.where(:id => ids).order(:id)
   end
 
   def vms
     ids = get_assoc(:vms)
-    return ids.empty? ? [] : VmOrTemplate.where(:id => ids).order(:id).to_a
+    return ids.empty? ? [] : VmOrTemplate.where(:id => ids).order(:id)
   end
 
   def get_assoc(relat, mode = nil)

--- a/vmdb/app/models/vim_performance_state.rb
+++ b/vmdb/app/models/vim_performance_state.rb
@@ -82,27 +82,27 @@ class VimPerformanceState < ActiveRecord::Base
 
   def storages
     ids = get_assoc(:storages, :on)
-    return ids.empty? ? [] : Storage.find_all_by_id(ids, :order => :id)
+    return ids.empty? ? [] : Storage.where(:id => ids).order(:id).to_a
   end
 
   def ext_management_systems
     ids = get_assoc(:ext_management_systems, :on)
-    return ids.empty? ? [] : ExtManagementSystem.find_all_by_id(ids, :order => :id)
+    return ids.empty? ? [] : ExtManagementSystem.where(:id => ids).order(:id).to_a
   end
 
   def ems_clusters
     ids = get_assoc(:ems_clusters, :on)
-    return ids.empty? ? [] : EmsCluster.find_all_by_id(ids, :order => :id)
+    return ids.empty? ? [] : EmsCluster.where(:id => ids).order(:id).to_a
   end
 
   def hosts
     ids = get_assoc(:hosts)
-    return ids.empty? ? [] : Host.find_all_by_id(ids, :order => :id)
+    return ids.empty? ? [] : Host.where(:id => ids).order(:id).to_a
   end
 
   def vms
     ids = get_assoc(:vms)
-    return ids.empty? ? [] : VmOrTemplate.find_all_by_id(ids, :order => :id)
+    return ids.empty? ? [] : VmOrTemplate.where(:id => ids).order(:id).to_a
   end
 
   def get_assoc(relat, mode = nil)

--- a/vmdb/app/models/vim_performance_state.rb
+++ b/vmdb/app/models/vim_performance_state.rb
@@ -82,27 +82,27 @@ class VimPerformanceState < ActiveRecord::Base
 
   def storages
     ids = get_assoc(:storages, :on)
-    return ids.empty? ? [] : Storage.where(:id => ids).order(:id)
+    return ids.empty? ? [] : Storage.where(:id => ids).order(:id).to_a
   end
 
   def ext_management_systems
     ids = get_assoc(:ext_management_systems, :on)
-    return ids.empty? ? [] : ExtManagementSystem.where(:id => ids).order(:id)
+    return ids.empty? ? [] : ExtManagementSystem.where(:id => ids).order(:id).to_a
   end
 
   def ems_clusters
     ids = get_assoc(:ems_clusters, :on)
-    return ids.empty? ? [] : EmsCluster.where(:id => ids).order(:id)
+    return ids.empty? ? [] : EmsCluster.where(:id => ids).order(:id).to_a
   end
 
   def hosts
     ids = get_assoc(:hosts)
-    return ids.empty? ? [] : Host.where(:id => ids).order(:id)
+    return ids.empty? ? [] : Host.where(:id => ids).order(:id).to_a
   end
 
   def vms
     ids = get_assoc(:vms)
-    return ids.empty? ? [] : VmOrTemplate.where(:id => ids).order(:id)
+    return ids.empty? ? [] : VmOrTemplate.where(:id => ids).order(:id).to_a
   end
 
   def get_assoc(relat, mode = nil)

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1102,7 +1102,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   # Cache the servers because the JobProxyDispatch calls this for each Vm scan job in a loop
   cache_with_timeout(:miq_servers_for_scan, 30.seconds) do
-    MiqServer.find(:all, :conditions => {:status => "started"}, :include => [:zone, :server_roles])
+    MiqServer.where(:status => "started").includes([:zone, :server_roles]).to_a
   end
 
   def miq_server_proxies

--- a/vmdb/app/models/vm_or_template/scanning.rb
+++ b/vmdb/app/models/vm_or_template/scanning.rb
@@ -117,7 +117,9 @@ module VmOrTemplate::Scanning
   # Call the VmScan Job and raise a "request" event
   def scan(userid = "system", options={})
     # Check if there are any current scan jobs already waiting to run
-    j = VmScan.find(:all, :conditions => ["state = 'waiting_to_start' AND sync_key = ?", self.guid], :select => "id").collect {|ji| ji.id}.compact.uniq
+    j = VmScan.where(:state => 'waiting_to_start')
+          .where(:sync_key => guid)
+          .pluck(:id)
     unless j.blank?
       $log.info "(Vm-scan) VM scan job will not be added due to existing scan job waiting to be processed.  VM ID:[#{self.id}] Name:[#{self.name}] Guid:[#{self.guid}]  Existing Job IDs [#{j.join(", ")}]"
       return nil

--- a/vmdb/db/migrate/20101028195038_remove_custom_fields_from_vms_hosts.rb
+++ b/vmdb/db/migrate/20101028195038_remove_custom_fields_from_vms_hosts.rb
@@ -29,7 +29,7 @@ class RemoveCustomFieldsFromVmsHosts < ActiveRecord::Migration
     end
 
     say_with_time("Remove non-VC CustomAttributes") do
-      deletes = CustomAttribute.find(:all, :select=>'id',:conditions=>"source != 'VC'")
+      deletes = CustomAttribute.select('id').where("source != 'VC'")
       CustomAttribute.delete(deletes.collect{|ca| ca.id})
     end
     remove_column :custom_attributes, :source

--- a/vmdb/db/migrate/20111227190505_convert_rubyrep_data_for_vim_performances_to_metrics_subtables_on_postgres.rb
+++ b/vmdb/db/migrate/20111227190505_convert_rubyrep_data_for_vim_performances_to_metrics_subtables_on_postgres.rb
@@ -61,12 +61,12 @@ class ConvertRubyrepDataForVimPerformancesToMetricsSubtablesOnPostgres < ActiveR
       rrpc_table  = connection.quote_table_name(RrPendingChange.table_name)
 
       loop do
-        batch = RrPendingChange.all(:conditions => {:change_table => "vim_performances"}, :limit => 10000)
+        batch = RrPendingChange.where(:change_table => "vim_performances").limit(10000)
         break if batch.empty?
 
         vp_ids_to_rrpcs = batch.group_by { |rrpc| rrpc.change_key.split("|").last.to_i }
         vp_ids = vp_ids_to_rrpcs.keys
-        vps    = VimPerformance.find_all_by_id(vp_ids)
+        vps    = VimPerformance.where(:id => vp_ids)
 
         # For any pending changes that have deleted vim_performances, delete
         # the remote vim_performances, then delete the local pending changes

--- a/vmdb/db/migrate/20121022185550_add_resource_to_miq_widget_contents.rb
+++ b/vmdb/db/migrate/20121022185550_add_resource_to_miq_widget_contents.rb
@@ -55,7 +55,7 @@ class AddResourceToMiqWidgetContents < ActiveRecord::Migration
     add_column :miq_widget_contents, :owner_type, :string
     add_column :miq_widget_contents, :timezone,   :string
 
-    contents = MiqWidgetContent.all(:select => [:id, :owner_type, :owner_id, :user_id], :include => :user)
+    contents = MiqWidgetContent.select([:id, :owner_type, :owner_id, :user_id]).includes(:user)
 
     contents.each do |c|
       user = c.user
@@ -79,7 +79,7 @@ class AddResourceToMiqWidgetContents < ActiveRecord::Migration
   def down
     add_column :miq_widget_contents, :user_id, :bigint
 
-    contents = MiqWidgetContent.all(:select => [:id, :owner_type, :owner_id, :user_id])
+    contents = MiqWidgetContent.select([:id, :owner_type, :owner_id, :user_id])
     contents.each do |content|
       if content.owner_type == 'User'
         content.update_attributes(:owner_id => nil, :owner_type => nil, :user_id => content.owner_id)

--- a/vmdb/lib/extensions/ar_extract_objects.rb
+++ b/vmdb/lib/extensions/ar_extract_objects.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     def self.extract_objects(*objects)
       is_array = objects.length > 1 || objects.first.kind_of?(Array)
       objects = objects.flatten
-      ret = objects.first.kind_of?(Integer) ? self.find_all_by_id(objects) : objects
+      ret = objects.first.kind_of?(Integer) ? where(:id => objects) : objects
       return is_array ? ret : ret.first
     end
 

--- a/vmdb/lib/extensions/ar_taggable.rb
+++ b/vmdb/lib/extensions/ar_taggable.rb
@@ -97,7 +97,7 @@ module ActsAsTaggable
     Tag.transaction do
       # Remove existing tags
       tag = Tag.arel_table
-      Tagging.includes(:tag).
+      Tagging.joins(:tag).
                 where(:taggable_id    => self.id).
                 where(:taggable_type  => self.class.base_class.name).
                 where(:tag_id         => tag[:id]).

--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -99,7 +99,7 @@ describe Metric do
               task.context_data[:targets].sort.should == cluster.hosts.collect {|h| "Host:#{h.id}"}.sort
 
               expected_hosts.each do |host|
-                messages = MiqQueue.where(:class_name => "Host", :instance_id => host.id).to_a.select {|m| m.args.first == "realtime"}
+                messages = MiqQueue.where(:class_name => "Host", :instance_id => host.id).select {|m| m.args.first == "realtime"}
                 messages.each do |m|
                   m.miq_callback.should_not be_nil
                   m.miq_callback[:method_name].should == :perf_capture_callback
@@ -133,7 +133,7 @@ describe Metric do
               task_ids = tasks.collect(&:id)
 
               expected_hosts.each do |host|
-                messages = MiqQueue.where(:class_name => "Host", :instance_id => host.id).to_a.select {|m| m.args.first == "realtime"}
+                messages = MiqQueue.where(:class_name => "Host", :instance_id => host.id).select {|m| m.args.first == "realtime"}
                 host.update_attribute(:last_perf_capture_on, 1.minute.from_now.utc)
                 messages.each do |m|
                   next if m.miq_callback[:args].blank?
@@ -155,12 +155,12 @@ describe Metric do
           end
 
           it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
-            messages = MiqQueue.where(:class_name => "Host").to_a.select {|m| m.args.first == "realtime"}
+            messages = MiqQueue.where(:class_name => "Host").select {|m| m.args.first == "realtime"}
             messages.each {|m| m.update_attribute(:state, "dequeue")}
 
             Metric::Capture.perf_capture_timer
 
-            messages = MiqQueue.where(:class_name => "Host").to_a.select {|m| m.args.first == "realtime"}
+            messages = MiqQueue.where(:class_name => "Host").select {|m| m.args.first == "realtime"}
             messages.each {|m| m.lock_version.should == 1}
           end
 

--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -77,7 +77,7 @@ describe Metric do
             t.is_a?(Storage) ? [t, "hourly"] : [[t, "realtime"], [t, "historical"] * 8]
           end.flatten
 
-          selected = MiqQueue.all(:conditions => {:method_name => "perf_capture"}, :order => :id).collect do |q|
+          selected = MiqQueue.where(:method_name => "perf_capture").order(:id).collect do |q|
             [Object.const_get(q.class_name).find(q.instance_id), q.args.first]
           end.flatten
 
@@ -99,7 +99,7 @@ describe Metric do
               task.context_data[:targets].sort.should == cluster.hosts.collect {|h| "Host:#{h.id}"}.sort
 
               expected_hosts.each do |host|
-                messages = MiqQueue.all(:conditions => {:class_name => "Host", :instance_id => host.id}).select {|m| m.args.first == "realtime"}
+                messages = MiqQueue.where(:class_name => "Host", :instance_id => host.id).to_a.select {|m| m.args.first == "realtime"}
                 messages.each do |m|
                   m.miq_callback.should_not be_nil
                   m.miq_callback[:method_name].should == :perf_capture_callback
@@ -124,7 +124,7 @@ describe Metric do
               expected_hosts = cluster.hosts.select {|h| @expected_targets.include?(h)}
               next if expected_hosts.empty?
 
-              tasks = MiqTask.all(:conditions => {:name => "Performance rollup for EmsCluster:#{cluster.id}"}, :order => "id DESC")
+              tasks = MiqTask.where(:name => "Performance rollup for EmsCluster:#{cluster.id}").order("id DESC")
               tasks.length.should == 2
               tasks.each do |task|
                 task.context_data[:targets].sort.should == cluster.hosts.collect {|h| "Host:#{h.id}"}.sort
@@ -133,7 +133,7 @@ describe Metric do
               task_ids = tasks.collect(&:id)
 
               expected_hosts.each do |host|
-                messages = MiqQueue.all(:conditions => {:class_name => "Host", :instance_id => host.id}).select {|m| m.args.first == "realtime"}
+                messages = MiqQueue.where(:class_name => "Host", :instance_id => host.id).to_a.select {|m| m.args.first == "realtime"}
                 host.update_attribute(:last_perf_capture_on, 1.minute.from_now.utc)
                 messages.each do |m|
                   next if m.miq_callback[:args].blank?
@@ -155,12 +155,12 @@ describe Metric do
           end
 
           it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
-            messages = MiqQueue.all(:conditions => {:class_name => "Host"}).select {|m| m.args.first == "realtime"}
+            messages = MiqQueue.where(:class_name => "Host").to_a.select {|m| m.args.first == "realtime"}
             messages.each {|m| m.update_attribute(:state, "dequeue")}
 
             Metric::Capture.perf_capture_timer
 
-            messages = MiqQueue.all(:conditions => {:class_name => "Host"}).select {|m| m.args.first == "realtime"}
+            messages = MiqQueue.where(:class_name => "Host").to_a.select {|m| m.args.first == "realtime"}
             messages.each {|m| m.lock_version.should == 1}
           end
 
@@ -171,7 +171,7 @@ describe Metric do
               expected_hosts = cluster.hosts.select {|h| @expected_targets.include?(h)}
               next if expected_hosts.empty?
 
-              tasks = MiqTask.all(:conditions => {:name => "Performance rollup for EmsCluster:#{cluster.id}"}, :order => "id")
+              tasks = MiqTask.where(:name => "Performance rollup for EmsCluster:#{cluster.id}").order("id")
               tasks.length.should == 2
 
               t1, t2 = tasks
@@ -193,7 +193,7 @@ describe Metric do
           expected_targets = Metric::Targets.capture_targets(nil, :exclude_storages => true)
           expected = expected_targets.collect { |t| [t, "historical"] * 2 }.flatten # Vm, Host, Host, Vm, Host
 
-          selected = MiqQueue.all(:order => :id).collect do |q|
+          selected = MiqQueue.order(:id).collect do |q|
             [Object.const_get(q.class_name).find(q.instance_id), q.args.first]
           end.flatten
 
@@ -343,7 +343,7 @@ describe Metric do
             # Check every timestamp is present; performance realtime timestamps
             #   are to the nearest 20 second interval
             ts = "2011-08-12T20:33:20Z"
-            Metric.all(:order => :timestamp).each do |p|
+            Metric.order(:timestamp).each do |p|
               p_ts = p.timestamp.utc
               p_ts.iso8601.should == ts
               ts = (p_ts + 20.seconds).iso8601
@@ -458,7 +458,7 @@ describe Metric do
         end
 
         it "should have queued rollups for vm hourly" do
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id)
           q_all.length.should == 2
           assert_queue_items_are_hourly_rollups(q_all, "2010-04-14T21:00:00Z", @vm.id, "VmVmware")
         end
@@ -469,7 +469,7 @@ describe Metric do
           end
 
           it "should have one set of queued rollups" do
-            q_all = MiqQueue.all(:order => :id)
+            q_all = MiqQueue.order(:id)
             q_all.length.should == 2
             assert_queue_items_are_hourly_rollups(q_all, "2010-04-14T21:00:00Z", @vm.id, "VmVmware")
           end
@@ -826,7 +826,7 @@ describe Metric do
             end
 
             it "should queue up perf_rollup_gap" do
-              q_all = MiqQueue.all(:order => :class_name)
+              q_all = MiqQueue.order(:class_name)
               q_all.length.should == 1
 
               expected = {
@@ -888,14 +888,14 @@ describe Metric do
       context "calling perf_rollup_to_parent" do
         it "should queue up from Vm realtime to Vm hourly" do
           @vm.perf_rollup_to_parent('realtime', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 1
           assert_queue_item_rollup_chain(q_all[0], @vm, 'hourly')
         end
 
         it "should queue up from Host realtime to Host hourly" do
           @host.perf_rollup_to_parent('realtime', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 1
           # assert_queue_item_rollup_chain(q_all[0], @ems_cluster, 'realtime')
           # assert_queue_item_rollup_chain(q_all[1], @host, 'hourly')
@@ -904,7 +904,7 @@ describe Metric do
 
         it "should queue up from Vm hourly to Host hourly and Vm daily" do
           @vm.perf_rollup_to_parent('hourly', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 2
           assert_queue_item_rollup_chain(q_all[0], @host, 'hourly')
           assert_queue_item_rollup_chain(q_all[1], @vm,   'daily', @time_profile)
@@ -912,7 +912,7 @@ describe Metric do
 
         it "should queue up from Host hourly to EmsCluster hourly and Host daily" do
           @host.perf_rollup_to_parent('hourly', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 2
           assert_queue_item_rollup_chain(q_all[0], @ems_cluster, 'hourly')
           assert_queue_item_rollup_chain(q_all[1], @host,        'daily', @time_profile)
@@ -920,7 +920,7 @@ describe Metric do
 
         it "should queue up from EmsCluster hourly to EMS hourly and EmsCluster daily" do
           @ems_cluster.perf_rollup_to_parent('hourly', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 2
           assert_queue_item_rollup_chain(q_all[0], @ems_vmware,         'hourly')
           assert_queue_item_rollup_chain(q_all[1], @ems_cluster, 'daily', @time_profile)
@@ -1222,7 +1222,7 @@ describe Metric do
             t.is_a?(Storage) ? [t, "hourly"] : [[t, "realtime"], [t, "historical"] * 8]
           end.flatten
 
-          selected = MiqQueue.all(:conditions => {:method_name => "perf_capture"}, :order => :id).collect do |q|
+          selected = MiqQueue.where(:method_name => "perf_capture").order(:id).collect do |q|
             [Object.const_get(q.class_name).find(q.instance_id), q.args.first]
           end.flatten
 
@@ -1243,7 +1243,7 @@ describe Metric do
         end
 
         it "should have queued rollups for vm hourly" do
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 2
           assert_queue_items_are_hourly_rollups(q_all, "2010-04-14T21:00:00Z", @vm.id, "VmOpenstack")
         end
@@ -1254,7 +1254,7 @@ describe Metric do
           end
 
           it "should have one set of queued rollups" do
-            q_all = MiqQueue.all(:order => :id)
+            q_all = MiqQueue.order(:id).all
             q_all.length.should == 2
             assert_queue_items_are_hourly_rollups(q_all, "2010-04-14T21:00:00Z", @vm.id, "VmOpenstack")
           end
@@ -1275,21 +1275,21 @@ describe Metric do
       context "calling perf_rollup_to_parent" do
         it "should queue up from Vm realtime to Vm hourly" do
           @vm.perf_rollup_to_parent('realtime', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 1
           assert_queue_item_rollup_chain(q_all[0], @vm, 'hourly')
         end
 
         it "should queue up from AvailabilityZone realtime to AvailabilityZone hourly" do
           @availability_zone.perf_rollup_to_parent('realtime', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 1
           assert_queue_item_rollup_chain(q_all[0], @availability_zone, 'hourly')
         end
 
         it "should queue up from Vm hourly to AvailabilityZone hourly and Vm daily" do
           @vm.perf_rollup_to_parent('hourly', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 2
           assert_queue_item_rollup_chain(q_all[0], @availability_zone, 'hourly')
           assert_queue_item_rollup_chain(q_all[1], @vm,   'daily', @time_profile)
@@ -1297,7 +1297,7 @@ describe Metric do
 
         it "should queue up from AvailabilityZone hourly to EMS hourly and AvailabilityZone daily" do
           @availability_zone.perf_rollup_to_parent('hourly', ROLLUP_CHAIN_TIMESTAMP)
-          q_all = MiqQueue.all(:order => :id)
+          q_all = MiqQueue.order(:id).all
           q_all.length.should == 2
           assert_queue_item_rollup_chain(q_all[0], @ems_openstack,  'hourly')
           assert_queue_item_rollup_chain(q_all[1], @availability_zone, 'daily', @time_profile)

--- a/vmdb/spec/models/miq_schedule_spec.rb
+++ b/vmdb/spec/models/miq_schedule_spec.rb
@@ -498,14 +498,14 @@ describe MiqSchedule do
     context "valid db_gc unsaved schedule, run_adhoc_db_gc" do
       before(:each) do
         @task_id = MiqSchedule.run_adhoc_db_gc(:userid => "admin", :aggressive => true)
-        @gc_message = MiqQueue.find(:first, :conditions => {:class_name => "DatabaseBackup", :method_name => "gc", :role => "database_operations"} )
+        @gc_message = MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "gc", :role => "database_operations").first
 
         @region = FactoryGirl.create(:miq_region)
         MiqRegion.stub(:my_region).and_return(@region)
       end
 
       it "should create 1 miq task" do
-        tasks = MiqTask.find(:all, :conditions => {:name => "Database GC", :userid => "admin" } )
+        tasks = MiqTask.where(:name => "Database GC", :userid => "admin").all
         tasks.length.should == 1
         tasks.first.id.should == @task_id
       end
@@ -597,7 +597,7 @@ describe MiqSchedule do
       context "calling run adhoc_db_backup" do
         before(:each) do
           @task_id = @schedule.run_adhoc_db_backup
-          @backup_message = MiqQueue.find(:first, :conditions => {:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations"} )
+          @backup_message = MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations").first
 
           @region = FactoryGirl.create(:miq_region)
           MiqRegion.stub(:my_region).and_return(@region)
@@ -609,13 +609,13 @@ describe MiqSchedule do
         end
 
         it "should create 1 miq task" do
-          tasks = MiqTask.find(:all, :conditions => {:name => "Database backup", :userid => @schedule.userid } )
+          tasks = MiqTask.where({:name => "Database backup", :userid => @schedule.userid })
           tasks.length.should == 1
           tasks.first.id.should == @task_id
         end
 
         it "should create one backup queue message for our db backup instance for the database role" do
-          MiqQueue.count(:conditions => {:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations"} ).should == 1
+          MiqQueue.where({:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations"} ).count.should == 1
         end
       end
 
@@ -623,7 +623,7 @@ describe MiqSchedule do
         before(:each) do
 
           MiqSchedule.queue_scheduled_work(@schedule.id, nil, Time.now.utc.to_i, nil)
-          @invoke_actions_message = MiqQueue.find(:first, :conditions => {:class_name => "MiqSchedule", :instance_id => @schedule.id, :method_name => "invoke_actions" } )
+          @invoke_actions_message = MiqQueue.where({:class_name => "MiqSchedule", :instance_id => @schedule.id, :method_name => "invoke_actions" }).first
         end
 
         it "should create an invoke_actions queue message" do
@@ -638,7 +638,7 @@ describe MiqSchedule do
           before(:each) do
             status, message, result = @invoke_actions_message.deliver
             @invoke_actions_message.delivered(status, message, result)
-            @backup_message = MiqQueue.find(:first, :conditions => {:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations"} )
+            @backup_message = MiqQueue.where({:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations"} ).first
 
             @region = FactoryGirl.create(:miq_region)
             MiqRegion.stub(:my_region).and_return(@region)


### PR DESCRIPTION
These will work on Rails 4, so it should make the switch to Rails 4
easier.  The general strategy is to change :conditions to `where`,
:order to `order` etc.  Then we need to maintain method return value
compatibility.  IOW, methods that returned arrays should continue to
return arrays