### PR TITLE
SCVMM - Printing the exception's own message in verify_credentials

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -45,8 +45,9 @@ class EmsMicrosoft < EmsInfra
 
     begin
       run_dos_command("hostname")
-    rescue WinRM::WinRMHTTPTransportError # Error 401
-      raise MiqException::MiqHostError, "Login failed due to a bad username or password."
+    rescue WinRM::WinRMHTTPTransportError => e # Error 401
+      raise MiqException::MiqHostError, "Check credentials and WinRM configuration settings. " \
+      "Remote error message: #{e.message}"
     end
 
     true


### PR DESCRIPTION
 A 401 exception can be returned by the WinRM service on the SCVMM box for reasons other than a user has entered invalid credentials. For example, if we set the winrm/config/service/AllowUnencrypted setting on the Windows server to 'FALSE' we get the same 401 error.
It is more accurate and descriptive to display the exception's own message with the string "Check credentials and WinRM configuration settings" appended.

https://bugzilla.redhat.com/show_bug.cgi?id=1131236