### PR TITLE
Pass :type => :bigint to t.belongs_to to retain 64 bit columns.

### DIFF
--- a/vmdb/db/migrate/20110210224809_create_vim_performance_operating_ranges.rb
+++ b/vmdb/db/migrate/20110210224809_create_vim_performance_operating_ranges.rb
@@ -1,7 +1,7 @@
 class CreateVimPerformanceOperatingRanges < ActiveRecord::Migration
   def self.up
     create_table :vim_performance_operating_ranges do |t|
-      t.belongs_to  :resource, :polymorphic => true
+      t.belongs_to  :resource, :polymorphic => true, :type => :bigint
       t.bigint      :time_profile_id
       t.float       :cpu_usagemhz_rate_average_avg_over_time_period
       t.float       :cpu_usagemhz_rate_average_high_over_time_period

--- a/vmdb/db/migrate/20110701100258_create_miq_request_tasks.rb
+++ b/vmdb/db/migrate/20110701100258_create_miq_request_tasks.rb
@@ -35,9 +35,9 @@ class CreateMiqRequestTasks < ActiveRecord::Migration
     change_table :miq_provisions do |t|
       t.string      :type
       t.rename      :provision_type, :request_type
-      t.belongs_to  :miq_request
-      t.belongs_to  :source,         :polymorphic => true
-      t.belongs_to  :destination,    :polymorphic => true
+      t.belongs_to  :miq_request,                          :type => :bigint
+      t.belongs_to  :source,         :polymorphic => true, :type => :bigint
+      t.belongs_to  :destination,    :polymorphic => true, :type => :bigint
     end
 
     # Adjust data in columns to match the new model
@@ -57,8 +57,8 @@ class CreateMiqRequestTasks < ActiveRecord::Migration
     change_table :miq_request_tasks do |t|
       t.rename             :request_type,   :provision_type
       t.integer            :src_vm_id,      :limit => 8
-      t.belongs_to         :vm
-      t.belongs_to         :miq_provision_request
+      t.belongs_to         :vm,                            :type => :bigint
+      t.belongs_to         :miq_provision_request,         :type => :bigint
       t.remove             :type
       t.remove_belongs_to  :miq_request
       t.remove_belongs_to  :source,         :polymorphic => true

--- a/vmdb/db/migrate/20110701142013_add_miq_provisions_to_miq_requests.rb
+++ b/vmdb/db/migrate/20110701142013_add_miq_provisions_to_miq_requests.rb
@@ -37,8 +37,8 @@ class AddMiqProvisionsToMiqRequests < ActiveRecord::Migration
       t.string      :status
       t.text        :options
       t.string      :userid
-      t.belongs_to  :source,         :polymorphic => true
-      t.belongs_to  :destination,    :polymorphic => true
+      t.belongs_to  :source,         :polymorphic => true, :type => :bigint
+      t.belongs_to  :destination,    :polymorphic => true, :type => :bigint
       t.rename      :state,          :approval_state
     end
 
@@ -77,7 +77,7 @@ class AddMiqProvisionsToMiqRequests < ActiveRecord::Migration
       t.datetime      :created_on
       t.datetime      :updated_on
       t.string        :message
-      t.belongs_to    :src_vm
+      t.belongs_to    :src_vm, :type => :bigint
       t.string        :status
     end
 

--- a/vmdb/db/migrate/20110822140627_add_settings_to_miq_group.rb
+++ b/vmdb/db/migrate/20110822140627_add_settings_to_miq_group.rb
@@ -33,8 +33,8 @@ class AddSettingsToMiqGroup < ActiveRecord::Migration
     end
 
     change_table :miq_reports do |t|
-      t.belongs_to  :miq_group
-      t.belongs_to  :user
+      t.belongs_to  :miq_group, :type => :bigint
+      t.belongs_to  :user,      :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20110830191326_add_miq_report_results_to_miq_group.rb
+++ b/vmdb/db/migrate/20110830191326_add_miq_report_results_to_miq_group.rb
@@ -4,7 +4,7 @@ class AddMiqReportResultsToMiqGroup < ActiveRecord::Migration
 
   def self.up
     change_table :miq_report_results do |t|
-      t.belongs_to  :miq_group
+      t.belongs_to  :miq_group, :type => :bigint
     end
 
     say_with_time("Setting MiqReportResult miq_group_id to User's group") do

--- a/vmdb/db/migrate/20111228214919_rename_vim_performance_id_to_metric.rb
+++ b/vmdb/db/migrate/20111228214919_rename_vim_performance_id_to_metric.rb
@@ -1,7 +1,7 @@
 class RenameVimPerformanceIdToMetric < ActiveRecord::Migration
   def up
     change_table :vim_performance_tag_values do |t|
-      t.belongs_to :metric, :polymorphic => true
+      t.belongs_to :metric, :polymorphic => true, :type => :bigint
     end
 
     say_with_time("Migrating data from vim_performance_id column to metric_* columns for realtime") do
@@ -22,7 +22,7 @@ class RenameVimPerformanceIdToMetric < ActiveRecord::Migration
 
   def down
     change_table :vim_performance_tag_values do |t|
-      t.belongs_to :vim_performance
+      t.belongs_to :vim_performance,              :type => :bigint
     end
 
     say_with_time("Migrating data from metric_* columns to vim_performance_id column") do

--- a/vmdb/db/migrate/20120221192819_create_services_and_templates.rb
+++ b/vmdb/db/migrate/20120221192819_create_services_and_templates.rb
@@ -8,14 +8,14 @@ class CreateServicesAndTemplates < ActiveRecord::Migration
       t.string     :description
       t.string     :guid
       t.string     :type
-      t.belongs_to :service_or_template
+      t.belongs_to :service_or_template,               :type => :bigint
       t.text       :options
       t.timestamps
     end
 
     create_table :service_resources do |t|
-      t.belongs_to :service_or_template
-      t.belongs_to :resource,    :polymorphic => true
+      t.belongs_to :service_or_template,               :type => :bigint
+      t.belongs_to :resource,    :polymorphic => true, :type => :bigint
       t.integer    :group_idx,   :default => 0
       t.integer    :scaling_min, :default => 1
       t.integer    :scaling_max, :default => -1

--- a/vmdb/db/migrate/20120329205436_create_services.rb
+++ b/vmdb/db/migrate/20120329205436_create_services.rb
@@ -4,8 +4,8 @@ class CreateServices < ActiveRecord::Migration
 
     change_table :service_resources do |t|
       t.string      :name
-      t.belongs_to  :service
-      t.belongs_to  :source,  :polymorphic => true
+      t.belongs_to  :service,                       :type => :bigint
+      t.belongs_to  :source,  :polymorphic => true, :type => :bigint
       t.rename      :service_or_template_id, :service_template_id
     end
 
@@ -21,7 +21,7 @@ class CreateServices < ActiveRecord::Migration
       t.string      :description
       t.string      :guid
       t.string      :type
-      t.belongs_to  :service_template
+      t.belongs_to  :service_template,              :type => :bigint
       t.text        :options
       t.boolean     :display
       t.timestamps

--- a/vmdb/db/migrate/20120410153053_create_tables_for_vmdb_database.rb
+++ b/vmdb/db/migrate/20120410153053_create_tables_for_vmdb_database.rb
@@ -10,7 +10,7 @@ class CreateTablesForVmdbDatabase < ActiveRecord::Migration
     end
 
     create_table :vmdb_database_metrics do |t|
-      t.belongs_to :vmdb_database
+      t.belongs_to :vmdb_database,                  :type => :bigint
       t.float      :disk_size
       t.float      :allocated_size
       t.float      :used_size
@@ -20,19 +20,19 @@ class CreateTablesForVmdbDatabase < ActiveRecord::Migration
     end
 
     create_table :vmdb_tables do |t|
-      t.belongs_to :vmdb_database
+      t.belongs_to :vmdb_database,                  :type => :bigint
       t.string     :name
       t.string     :table_type
       t.bigint     :parent_id
     end
 
     create_table :vmdb_indexes do |t|
-      t.belongs_to :vmdb_table
+      t.belongs_to :vmdb_table,                     :type => :bigint
       t.string     :name
     end
 
     create_table :vmdb_metrics do |t|
-      t.belongs_to :resource, :polymorphic => true
+      t.belongs_to :resource, :polymorphic => true, :type => :bigint
       t.float      :size
       t.bigint     :rows
       t.bigint     :pages

--- a/vmdb/db/migrate/20120514132616_create_dialogs.rb
+++ b/vmdb/db/migrate/20120514132616_create_dialogs.rb
@@ -43,8 +43,8 @@ class CreateDialogs < ActiveRecord::Migration
     end
 
     create_table :dialog_resources do |t|
-      t.belongs_to  :parent,      :polymorphic => true
-      t.belongs_to  :resource,    :polymorphic => true
+      t.belongs_to  :parent,      :polymorphic => true, :type => :bigint
+      t.belongs_to  :resource,    :polymorphic => true, :type => :bigint
       t.integer     :order
     end
   end

--- a/vmdb/db/migrate/20120605132213_create_resource_actions.rb
+++ b/vmdb/db/migrate/20120605132213_create_resource_actions.rb
@@ -2,8 +2,8 @@ class CreateResourceActions < ActiveRecord::Migration
   def change
     create_table :resource_actions do |t|
       t.string      :action
-      t.belongs_to  :dialog
-      t.belongs_to  :resource,    :polymorphic => true
+      t.belongs_to  :dialog,                         :type => :bigint
+      t.belongs_to  :resource, :polymorphic => true, :type => :bigint
       t.timestamps
     end
   end

--- a/vmdb/db/migrate/20120802030449_create_pxe_menus_table.rb
+++ b/vmdb/db/migrate/20120802030449_create_pxe_menus_table.rb
@@ -3,7 +3,7 @@ class CreatePxeMenusTable < ActiveRecord::Migration
     create_table :pxe_menus do |t|
       t.string      :file_name
       t.text        :contents
-      t.belongs_to  :pxe_server
+      t.belongs_to  :pxe_server, :type => :bigint
       t.timestamps
     end
   end

--- a/vmdb/db/migrate/20120802154022_add_pxe_menu_id_to_pxe_images.rb
+++ b/vmdb/db/migrate/20120802154022_add_pxe_menu_id_to_pxe_images.rb
@@ -1,7 +1,7 @@
 class AddPxeMenuIdToPxeImages < ActiveRecord::Migration
   def up
     change_table :pxe_images do |t|
-      t.belongs_to :pxe_menu
+      t.belongs_to :pxe_menu, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20120803170449_create_pxe_image_types.rb
+++ b/vmdb/db/migrate/20120803170449_create_pxe_image_types.rb
@@ -6,12 +6,12 @@ class CreatePxeImageTypes < ActiveRecord::Migration
     end
 
     change_table :pxe_images do |t|
-      t.belongs_to :pxe_image_type
+      t.belongs_to :pxe_image_type, :type => :bigint
       t.remove     :image_type
     end
 
     change_table :customization_templates do |t|
-      t.belongs_to :pxe_image_type
+      t.belongs_to :pxe_image_type, :type => :bigint
       t.remove     :image_type
     end
 

--- a/vmdb/db/migrate/20120820180244_create_pictures.rb
+++ b/vmdb/db/migrate/20120820180244_create_pictures.rb
@@ -1,7 +1,7 @@
 class CreatePictures < ActiveRecord::Migration
   def up
     create_table :pictures do |t|
-      t.belongs_to  :resource, :polymorphic => true
+      t.belongs_to  :resource, :polymorphic => true, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20120827162810_add_ems_cluster_id_to_hosts_and_vms.rb
+++ b/vmdb/db/migrate/20120827162810_add_ems_cluster_id_to_hosts_and_vms.rb
@@ -7,8 +7,8 @@ class AddEmsClusterIdToHostsAndVms < ActiveRecord::Migration
   end
 
   def up
-    change_table(:vms)   { |t| t.belongs_to :ems_cluster }
-    change_table(:hosts) { |t| t.belongs_to :ems_cluster }
+    change_table(:vms)   { |t| t.belongs_to :ems_cluster, :type => :bigint }
+    change_table(:hosts) { |t| t.belongs_to :ems_cluster, :type => :bigint }
 
     say_with_time("Migrate Host-Cluster relationships to new column") do
       cluster_rels    = Relationship.where(:resource_type => "EmsCluster").index_by(&:id)

--- a/vmdb/db/migrate/20120904183349_create_windows_images.rb
+++ b/vmdb/db/migrate/20120904183349_create_windows_images.rb
@@ -5,7 +5,7 @@ class CreateWindowsImages < ActiveRecord::Migration
       t.string     :description
       t.string     :path
       t.integer    :index
-      t.belongs_to :pxe_server
+      t.belongs_to :pxe_server, :type => :bigint
     end
 
     add_column :pxe_servers, :windows_images_directory, :string

--- a/vmdb/db/migrate/20120906193426_add_pxe_image_type_reference_to_windows_image.rb
+++ b/vmdb/db/migrate/20120906193426_add_pxe_image_type_reference_to_windows_image.rb
@@ -1,7 +1,7 @@
 class AddPxeImageTypeReferenceToWindowsImage < ActiveRecord::Migration
   def up
     change_table :windows_images do |t|
-      t.belongs_to :pxe_image_type
+      t.belongs_to :pxe_image_type, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20120925162220_create_service_template_catalog.rb
+++ b/vmdb/db/migrate/20120925162220_create_service_template_catalog.rb
@@ -6,7 +6,7 @@ class CreateServiceTemplateCatalog < ActiveRecord::Migration
     end
 
     change_table :service_templates do |t|
-      t.belongs_to :service_template_catalog
+      t.belongs_to :service_template_catalog, :type => :bigint
     end
 
     remove_column :custom_buttons, :button_id

--- a/vmdb/db/migrate/20121002183249_create_miq_shortcuts.rb
+++ b/vmdb/db/migrate/20121002183249_create_miq_shortcuts.rb
@@ -10,8 +10,8 @@ class CreateMiqShortcuts < ActiveRecord::Migration
 
     create_table :miq_widget_shortcuts do |t|
       t.string     :description
-      t.belongs_to :miq_shortcut
-      t.belongs_to :miq_widget
+      t.belongs_to :miq_shortcut, :type => :bigint
+      t.belongs_to :miq_widget,   :type => :bigint
     end
   end
 end

--- a/vmdb/db/migrate/20121205035058_create_iso_datastores_and_iso_images.rb
+++ b/vmdb/db/migrate/20121205035058_create_iso_datastores_and_iso_images.rb
@@ -1,14 +1,14 @@
 class CreateIsoDatastoresAndIsoImages < ActiveRecord::Migration
   def up
     create_table :iso_datastores do |t|
-      t.belongs_to :ems
+      t.belongs_to :ems,             :type => :bigint
       t.datetime   :last_refresh_on
     end
 
     create_table :iso_images do |t|
       t.string     :name
-      t.belongs_to :iso_datastore
-      t.belongs_to :pxe_image_type
+      t.belongs_to :iso_datastore,   :type => :bigint
+      t.belongs_to :pxe_image_type,  :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20121207100520_create_ldap_servers.rb
+++ b/vmdb/db/migrate/20121207100520_create_ldap_servers.rb
@@ -15,7 +15,7 @@ class CreateLdapServers < ActiveRecord::Migration
       t.integer    :group_membership_max_depth
       t.boolean    :get_direct_groups
       t.boolean    :follow_referrals
-      t.belongs_to :ldap_server
+      t.belongs_to :ldap_server, :type => :bigint
       t.timestamps
     end
   end

--- a/vmdb/db/migrate/20121208094220_create_ldap_users_and_ldap_groups.rb
+++ b/vmdb/db/migrate/20121208094220_create_ldap_users_and_ldap_groups.rb
@@ -6,7 +6,7 @@ class CreateLdapUsersAndLdapGroups < ActiveRecord::Migration
       t.string     :whencreated
       t.string     :whenchanged
       t.string     :mail
-      t.belongs_to :ldap_server
+      t.belongs_to :ldap_server, :type => :bigint
       t.timestamps
     end
 
@@ -33,7 +33,7 @@ class CreateLdapUsersAndLdapGroups < ActiveRecord::Migration
       t.string     :whenchanged
       t.string     :sid
 
-      t.belongs_to :ldap_server
+      t.belongs_to :ldap_server, :type => :bigint
       t.timestamps
     end
 

--- a/vmdb/db/migrate/20130115114420_add_vdi_user_reltionship_to_ldap_users.rb
+++ b/vmdb/db/migrate/20130115114420_add_vdi_user_reltionship_to_ldap_users.rb
@@ -1,7 +1,7 @@
 class AddVdiUserReltionshipToLdapUsers < ActiveRecord::Migration
   def up
     change_table :ldap_users do |t|
-       t.belongs_to   :vdi_user
+       t.belongs_to   :vdi_user, :type => :bigint
        t.string       :sam_account_name
        t.string       :upn
      end

--- a/vmdb/db/migrate/20130115171747_create_ldap_region_and_ldap_domain_and_refactor_ldap_server.rb
+++ b/vmdb/db/migrate/20130115171747_create_ldap_region_and_ldap_domain_and_refactor_ldap_server.rb
@@ -23,7 +23,7 @@ class CreateLdapRegionAndLdapDomainAndRefactorLdapServer < ActiveRecord::Migrati
       t.string    :mode
       t.integer   :port
 
-      t.belongs_to :ldap_domain
+      t.belongs_to :ldap_domain, :type => :bigint
       t.timestamps
     end
     add_index     :ldap_servers, :ldap_domain_id
@@ -32,7 +32,7 @@ class CreateLdapRegionAndLdapDomainAndRefactorLdapServer < ActiveRecord::Migrati
       t.string    :name
       t.string    :description
 
-      t.belongs_to :zone
+      t.belongs_to :zone,        :type => :bigint
       t.timestamps
     end
     add_index     :ldap_regions, :zone_id

--- a/vmdb/db/migrate/20130608025610_create_availability_zones.rb
+++ b/vmdb/db/migrate/20130608025610_create_availability_zones.rb
@@ -1,7 +1,7 @@
 class CreateAvailabilityZones < ActiveRecord::Migration
   def up
     create_table :availability_zones do |t|
-      t.belongs_to :ems
+      t.belongs_to :ems, :type => :bigint
       t.string     :name
     end
 

--- a/vmdb/db/migrate/20130608030909_create_flavors.rb
+++ b/vmdb/db/migrate/20130608030909_create_flavors.rb
@@ -1,7 +1,7 @@
 class CreateFlavors < ActiveRecord::Migration
   def up
     create_table :flavors do |t|
-      t.belongs_to :ems
+      t.belongs_to :ems, :type => :bigint
       t.string     :name
       t.string     :description
       t.integer    :cpus

--- a/vmdb/db/migrate/20130715221820_add_order_to_dialog_resources.rb
+++ b/vmdb/db/migrate/20130715221820_add_order_to_dialog_resources.rb
@@ -48,8 +48,8 @@ class AddOrderToDialogResources < ActiveRecord::Migration
 
   def down
     create_table :dialog_resources do |t|
-      t.belongs_to  :parent,      :polymorphic => true
-      t.belongs_to  :resource,    :polymorphic => true
+      t.belongs_to  :parent,      :polymorphic => true, :type => :bigint
+      t.belongs_to  :resource,    :polymorphic => true, :type => :bigint
       t.integer     :order
     end
 

--- a/vmdb/db/migrate/20130725223459_create_security_groups.rb
+++ b/vmdb/db/migrate/20130725223459_create_security_groups.rb
@@ -4,7 +4,7 @@ class CreateSecurityGroups < ActiveRecord::Migration
       t.string     :name
       t.string     :description
       t.string     :type
-      t.belongs_to :ems
+      t.belongs_to :ems, :type => :bigint
       t.string     :ems_ref
     end
   end

--- a/vmdb/db/migrate/20130725224004_change_firewall_rules_to_polymorphic.rb
+++ b/vmdb/db/migrate/20130725224004_change_firewall_rules_to_polymorphic.rb
@@ -5,7 +5,7 @@ class ChangeFirewallRulesToPolymorphic < ActiveRecord::Migration
 
   def up
     change_table :firewall_rules do |t|
-      t.belongs_to :resource, :polymorphic => true
+      t.belongs_to :resource, :polymorphic => true, :type => :bigint
       t.index      [:resource_id, :resource_type]
     end
 
@@ -21,7 +21,7 @@ class ChangeFirewallRulesToPolymorphic < ActiveRecord::Migration
 
   def down
     change_table :firewall_rules do |t|
-      t.belongs_to :operating_system
+      t.belongs_to :operating_system,               :type => :bigint
       t.index      :operating_system_id
     end
 

--- a/vmdb/db/migrate/20130912141816_create_cloud_volume_and_cloud_volume_snapshot.rb
+++ b/vmdb/db/migrate/20130912141816_create_cloud_volume_and_cloud_volume_snapshot.rb
@@ -5,17 +5,17 @@ class CreateCloudVolumeAndCloudVolumeSnapshot < ActiveRecord::Migration
       t.string     :ems_ref
       t.string     :device_name
       t.bigint     :size
-      t.belongs_to :ems
-      t.belongs_to :availability_zone
-      t.belongs_to :cloud_volume_snapshot
-      t.belongs_to :vm
+      t.belongs_to :ems,                   :type => :bigint
+      t.belongs_to :availability_zone,     :type => :bigint
+      t.belongs_to :cloud_volume_snapshot, :type => :bigint
+      t.belongs_to :vm,                    :type => :bigint
     end
 
     create_table :cloud_volume_snapshots do |t|
       t.string     :type
       t.string     :ems_ref
-      t.belongs_to :ems
-      t.belongs_to :cloud_volume
+      t.belongs_to :ems,                   :type => :bigint
+      t.belongs_to :cloud_volume,          :type => :bigint
     end
   end
 end

--- a/vmdb/db/migrate/20130923182042_create_cloud_networks_and_subnets.rb
+++ b/vmdb/db/migrate/20130923182042_create_cloud_networks_and_subnets.rb
@@ -3,16 +3,16 @@ class CreateCloudNetworksAndSubnets < ActiveRecord::Migration
     create_table :cloud_networks do |t|
       t.string     :name
       t.string     :ems_ref
-      t.belongs_to :ems
+      t.belongs_to :ems,               :type => :bigint
       t.string     :cidr
     end
 
     create_table :cloud_subnets do |t|
       t.string     :name
       t.string     :ems_ref
-      t.belongs_to :ems
-      t.belongs_to :availability_zone
-      t.belongs_to :cloud_network
+      t.belongs_to :ems,               :type => :bigint
+      t.belongs_to :availability_zone, :type => :bigint
+      t.belongs_to :cloud_network,     :type => :bigint
       t.string     :cidr
       t.string     :status
     end

--- a/vmdb/db/migrate/20140228153536_create_cloud_tenants.rb
+++ b/vmdb/db/migrate/20140228153536_create_cloud_tenants.rb
@@ -6,7 +6,7 @@ class CreateCloudTenants < ActiveRecord::Migration
       t.boolean :enabled
       t.string  :ems_ref
 
-      t.belongs_to :ems
+      t.belongs_to :ems, :type => :bigint
 
       t.timestamps
     end

--- a/vmdb/db/migrate/20140306150006_add_cloud_tenant_ref_to_security_groups.rb
+++ b/vmdb/db/migrate/20140306150006_add_cloud_tenant_ref_to_security_groups.rb
@@ -1,7 +1,7 @@
 class AddCloudTenantRefToSecurityGroups < ActiveRecord::Migration
   def self.up
     change_table :security_groups do |t|
-      t.belongs_to  :cloud_tenant
+      t.belongs_to  :cloud_tenant, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20140306153718_add_cloud_tenant_ref_to_cloud_networks.rb
+++ b/vmdb/db/migrate/20140306153718_add_cloud_tenant_ref_to_cloud_networks.rb
@@ -1,7 +1,7 @@
 class AddCloudTenantRefToCloudNetworks < ActiveRecord::Migration
   def self.up
     change_table :cloud_networks do |t|
-      t.belongs_to  :cloud_tenant
+      t.belongs_to  :cloud_tenant, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20140306154541_add_cloud_tenant_ref_to_vms.rb
+++ b/vmdb/db/migrate/20140306154541_add_cloud_tenant_ref_to_vms.rb
@@ -1,7 +1,7 @@
 class AddCloudTenantRefToVms < ActiveRecord::Migration
   def self.up
     change_table :vms do |t|
-      t.belongs_to  :cloud_tenant
+      t.belongs_to  :cloud_tenant, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20140306154747_add_cloud_tenant_ref_to_floating_ips.rb
+++ b/vmdb/db/migrate/20140306154747_add_cloud_tenant_ref_to_floating_ips.rb
@@ -1,7 +1,7 @@
 class AddCloudTenantRefToFloatingIps < ActiveRecord::Migration
   def self.up
     change_table :floating_ips do |t|
-      t.belongs_to  :cloud_tenant
+      t.belongs_to  :cloud_tenant, :type => :bigint
     end
   end
 

--- a/vmdb/db/migrate/20140612181021_update_cloud_volume_and_cloud_volume_snapshot.rb
+++ b/vmdb/db/migrate/20140612181021_update_cloud_volume_and_cloud_volume_snapshot.rb
@@ -10,7 +10,7 @@ class UpdateCloudVolumeAndCloudVolumeSnapshot < ActiveRecord::Migration
       t.boolean    :bootable
       t.datetime   :creation_time
 
-      t.belongs_to :cloud_tenant
+      t.belongs_to :cloud_tenant, :type => :bigint
     end
 
     change_table :cloud_volume_snapshots do |t|
@@ -18,13 +18,13 @@ class UpdateCloudVolumeAndCloudVolumeSnapshot < ActiveRecord::Migration
       t.datetime :creation_time
       t.integer  :size, :limit => 8
 
-      t.belongs_to :cloud_tenant
+      t.belongs_to :cloud_tenant, :type => :bigint
     end
   end
 
   def down
     change_table :cloud_volumes do |t|
-      t.belongs_to :vm
+      t.belongs_to :vm,           :type => :bigint
       t.string     :device_name
 
       t.remove     :status

--- a/vmdb/db/migrate/20140612212226_create_cloud_object_store_containers_and_cloud_object_store_objects.rb
+++ b/vmdb/db/migrate/20140612212226_create_cloud_object_store_containers_and_cloud_object_store_objects.rb
@@ -5,8 +5,8 @@ class CreateCloudObjectStoreContainersAndCloudObjectStoreObjects < ActiveRecord:
       t.string     :key
       t.integer    :object_count
       t.bigint     :bytes
-      t.belongs_to :ems
-      t.belongs_to :cloud_tenant
+      t.belongs_to :ems,                          :type => :bigint
+      t.belongs_to :cloud_tenant,                 :type => :bigint
     end
 
     create_table :cloud_object_store_objects do |t|
@@ -16,9 +16,9 @@ class CreateCloudObjectStoreContainersAndCloudObjectStoreObjects < ActiveRecord:
       t.string     :content_type
       t.bigint     :content_length
       t.datetime   :last_modified
-      t.belongs_to :ems
-      t.belongs_to :cloud_tenant
-      t.belongs_to :cloud_object_store_container
+      t.belongs_to :ems,                          :type => :bigint
+      t.belongs_to :cloud_tenant,                 :type => :bigint
+      t.belongs_to :cloud_object_store_container, :type => :bigint
     end
   end
 end

--- a/vmdb/db/migrate/20140620201430_create_cloud_resource_quotas.rb
+++ b/vmdb/db/migrate/20140620201430_create_cloud_resource_quotas.rb
@@ -7,8 +7,8 @@ class CreateCloudResourceQuotas < ActiveRecord::Migration
       t.integer :value
       t.string  :type
 
-      t.belongs_to :ems
-      t.belongs_to :cloud_tenant
+      t.belongs_to :ems,          :type => :bigint
+      t.belongs_to :cloud_tenant, :type => :bigint
 
       t.timestamps
     end

--- a/vmdb/db/migrate/20141020195642_create_orchestration_stacks.rb
+++ b/vmdb/db/migrate/20141020195642_create_orchestration_stacks.rb
@@ -20,8 +20,8 @@ class CreateOrchestrationStacks < ActiveRecord::Migration
       t.string  :ems_ref
       t.string  :ancestry
 
-      t.belongs_to :ems
-      t.belongs_to :orchestration_template
+      t.belongs_to :ems,                    :type => :bigint
+      t.belongs_to :orchestration_template, :type => :bigint
 
       t.timestamps
     end
@@ -37,7 +37,7 @@ class CreateOrchestrationStacks < ActiveRecord::Migration
       t.string :name
       t.text   :value
 
-      t.belongs_to :stack
+      t.belongs_to :stack,                  :type => :bigint
     end
 
     add_index :orchestration_stack_parameters, :stack_id
@@ -47,7 +47,7 @@ class CreateOrchestrationStacks < ActiveRecord::Migration
       t.text   :value
       t.text   :description
 
-      t.belongs_to :stack
+      t.belongs_to :stack,                  :type => :bigint
     end
 
     add_index :orchestration_stack_outputs, :stack_id
@@ -62,7 +62,7 @@ class CreateOrchestrationStacks < ActiveRecord::Migration
       t.text   :resource_status_reason
       t.timestamp :last_updated
 
-      t.belongs_to :stack
+      t.belongs_to :stack,                  :type => :bigint
     end
 
     add_index :orchestration_stack_resources, :stack_id


### PR DESCRIPTION
When we merged [1] via [2]:

[1] https://github.com/ManageIQ/manageiq/pull/895/
[2] https://github.com/ManageIQ/rails/pull/10

We inherited new behavior: we now are required to specify the :type => :bigint when specifying t.belongs_to and t.references whereas these were always bigint using our prior version of our rails fork.

The t.references was fixed in:
https://github.com/ManageIQ/manageiq/pull/895

This commit fixes t.belongs_to.

This PR replaces #1170
