### PR TITLE
Allow removing keys from :clone_options by setting value to nil

### DIFF
--- a/vmdb/app/models/miq_provision/state_machine.rb
+++ b/vmdb/app/models/miq_provision/state_machine.rb
@@ -12,7 +12,7 @@ module MiqProvision::StateMachine
     update_and_notify_parent(:message => "Preparing to Clone #{clone_direction}")
     phase_context[:clone_options] = prepare_for_clone_task
     dumpObj(phase_context[:clone_options], "MIQ(#{self.class.name}##{__method__}) Default Clone Options: ", $log, :info)
-    phase_context[:clone_options].merge!(get_option(:clone_options) || {})
+    phase_context[:clone_options].merge!(get_option(:clone_options) || {}).delete_nils
 
     signal :start_clone_task
   end

--- a/vmdb/spec/models/miq_provision/state_machine_spec.rb
+++ b/vmdb/spec/models/miq_provision/state_machine_spec.rb
@@ -47,6 +47,23 @@ describe MiqProvision do
           :test_key        => "test_value"
         )
       end
+
+      it "handles deleting nils when merging :clone_options from automate" do
+        options[:clone_options] = {:image_ref => nil, :test_key => "test_value"}
+        task.update_attributes(:options => options)
+
+        task.should_receive(:signal).with(:prepare_provision).and_call_original
+        task.should_receive(:signal).with(:start_clone_task)
+
+        task.signal(:prepare_provision)
+
+        expect(task.phase_context[:clone_options]).to eq(
+          :flavor_ref      => flavor.ems_ref,
+          :name            => options[:vm_target_name],
+          :security_groups => [],
+          :test_key        => "test_value"
+        )
+      end
     end
 
     context "#post_create_destination" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1160342
