### PR TITLE
Zone collecting only one server logs n times

### DIFF
--- a/vmdb/app/models/miq_server/log_management.rb
+++ b/vmdb/app/models/miq_server/log_management.rb
@@ -105,7 +105,9 @@ module MiqServer::LogManagement
   end
 
   def synchronize_logs(*args)
-    LogFile.logs_from_server(*args)
+    options = args.extract_options!
+    args << self unless args.last.kind_of?(self.class)
+    LogFile.logs_from_server(*args, options)
   end
 
   def last_log_sync_on

--- a/vmdb/spec/models/miq_server/log_management_spec.rb
+++ b/vmdb/spec/models/miq_server/log_management_spec.rb
@@ -2,21 +2,21 @@ require "spec_helper"
 
 describe MiqServer do
   context "LogManagement" do
-    let(:depot)          { FactoryGirl.build(:file_depot, :uri => uri) { |d| d.save(:validate => false) } }
-    let(:new_depot_hash) { {:uri => "nfs://server.example.com", :username => "new_user", :password => "new_pass"} }
-    let(:uri)            { "smb://server/share" }
-
-    before do
-      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      depot.update_authentication(:default => {:userid => "user", :password => "pass"})
-    end
-
     context "#get_log_depot_settings" do
       let(:depot_hash) do
         {:uri      => uri,
          :username => "user",
          :password => "pass",
          :name     => "File Depot"}
+      end
+
+      let(:depot)          { FactoryGirl.build(:file_depot, :uri => uri) { |d| d.save(:validate => false) } }
+      let(:new_depot_hash) { {:uri => "nfs://server.example.com", :username => "new_user", :password => "new_pass"} }
+      let(:uri)            { "smb://server/share" }
+
+      before do
+        _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+        depot.update_authentication(:default => {:userid => "user", :password => "pass"})
       end
 
       it "set on miq_server" do

--- a/vmdb/spec/models/miq_server/log_management_spec.rb
+++ b/vmdb/spec/models/miq_server/log_management_spec.rb
@@ -2,6 +2,25 @@ require "spec_helper"
 
 describe MiqServer do
   context "LogManagement" do
+    before do
+      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server2          = FactoryGirl.create(:miq_server, :zone => @zone)
+    end
+
+    context "#synchronize_logs" do
+      it "passes along server override" do
+        @miq_server.synchronize_logs("system", @miq_server2)
+        expect(MiqTask.first.miq_server_id).to eql @miq_server2.id
+        expect(MiqQueue.first.args.first[:id]).to eql @miq_server2.id
+      end
+
+      it "passes 'self' server if no server arg" do
+        @miq_server2.synchronize_logs("system")
+        expect(MiqTask.first.miq_server_id).to eql @miq_server2.id
+        expect(MiqQueue.first.args.first[:id]).to eql @miq_server2.id
+      end
+    end
+
     context "#get_log_depot_settings" do
       let(:depot_hash) do
         {:uri      => uri,
@@ -15,7 +34,6 @@ describe MiqServer do
       let(:uri)            { "smb://server/share" }
 
       before do
-        _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
         depot.update_authentication(:default => {:userid => "user", :password => "pass"})
       end
 

--- a/vmdb/spec/models/shared_examples/log_collection.rb
+++ b/vmdb/spec/models/shared_examples/log_collection.rb
@@ -2,19 +2,19 @@ shared_examples_for "Log Collection #synchronize_logs" do |type|
   let(:instance) { instance_variable_get("@#{type}") }
 
   it "#{type.camelize} no args" do
-    LogFile.should_receive(:logs_from_server).with()
+    LogFile.should_receive(:logs_from_server).with(MiqServer.my_server, {})
 
     instance.synchronize_logs
   end
 
   it "#{type.camelize} with options" do
-    LogFile.should_receive(:logs_from_server).with(:only_current => true)
+    LogFile.should_receive(:logs_from_server).with(MiqServer.my_server, :only_current => true)
 
     instance.synchronize_logs(:only_current => true)
   end
 
   it "#{type.camelize} user with options" do
-    LogFile.should_receive(:logs_from_server).with("test", :only_current => false)
+    LogFile.should_receive(:logs_from_server).with("test", MiqServer.my_server, :only_current => false)
 
     instance.synchronize_logs("test", :only_current => false)
   end


### PR DESCRIPTION
Pass the server receiving the synchronize_logs message. …
https://bugzilla.redhat.com/show_bug.cgi?id=1174855

If initiated from a zone, we want to create one miq_queue and miq_tasks row for each server in the Zone.

Without this change, it will create N number of rows for the server receiving the web request, MiqServer.my_server, where N is the number of active servers in the zone.  It will never request logs for the other servers in the zone.

This is fairly easy to recreate:
1) Setup a Zone with 2 or more "active" appliances (miq_servers)
2) Request log collection for the Zone
3) Look at the log depot and find only the logs from the server receiving the web request.