### PR TITLE
Fix to not encode user input in forms before sending up to server.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -1015,7 +1015,11 @@ function miqObserveCheckboxes() {
     new Form.Element.EventObserver(this.id, function(element, value) {
       var sparkleOn = this.element.getAttribute('data-miq_sparkle_on'); // Grab miq_sparkle settings
       var sparkleOff = this.element.getAttribute('data-miq_sparkle_off');
-      miqJqueryRequest(url, {beforeSend: true, complete: true, data:element.id + '=' + encodeURIComponent(value)});
+      miqJqueryRequest(url, {beforeSend: true,
+        complete: true,
+        data:element.id + '=' + encodeURIComponent(value),
+        no_encoding: true
+      });
     })
   })
 }
@@ -1247,5 +1251,5 @@ function miqJqueryRequest(url, options) {
 
   if (options['complete']) ajax_options['complete'] = function(request) { miqSparkle(false); };
 
-  new $j.ajax(encodeURI(url), ajax_options);
+  new $j.ajax(options['no_encoding'] ? url : encodeURI(url), ajax_options);
 }

--- a/vmdb/app/assets/javascripts/cfme_dynatree.js
+++ b/vmdb/app/assets/javascripts/cfme_dynatree.js
@@ -55,7 +55,10 @@ function miqMenuEditor(id) {
     nid = id.split('__');
     if(nid[0]!='r') {
       var url = click_url + '?node_id=' + encodeURIComponent(id) + '&node_clicked=1'
-      miqJqueryRequest(url, {beforeSend: true, complete: true});
+      miqJqueryRequest(url, {beforeSend: true,
+        complete: true,
+        no_encoding: true
+      });
     }
 }
 
@@ -442,7 +445,7 @@ function miqMenuChangeRow(grid,action,click_url) {
     case "add":
       folder_list_grid.addRow("folder" + count,"New Folder",count+1)
       folder_list_grid.selectRowById("folder" + count,true,true,true);
-      miqJqueryRequest('/report/menu_folder_message_display?typ=add');
+      miqJqueryRequest('/report/menu_folder_message_display?typ=add', {no_encoding: true});
       break;
     case "delete":
       var selected_id = id.split('|-|')
@@ -454,7 +457,7 @@ function miqMenuChangeRow(grid,action,click_url) {
       break;
     case "serialize":
       var url = click_url + '?tree=' + encodeURIComponent(miqDhtmlxgridSerialize(folder_list_grid));
-      miqJqueryRequest(url, {beforeSend: true, complete: true});
+      miqJqueryRequest(url, {beforeSend: true, complete: true, no_encoding: true});
       ret = true;
       break;
     default:

--- a/vmdb/app/assets/javascripts/miq_ujs_bindings.js
+++ b/vmdb/app/assets/javascripts/miq_ujs_bindings.js
@@ -37,7 +37,11 @@ $j(document).ready(function(){
 			new Form.Element.EventObserver(this.id, function(element, value) {
 				var sparkleOn = this.element.getAttribute('data-miq_sparkle_on');	// Grab miq_sparkle settings
 				var sparkleOff = this.element.getAttribute('data-miq_sparkle_off');
-        miqJqueryRequest(url, {beforeSend: true, complete: true, data: element.id + '=' + encodeURIComponent(value)});
+        miqJqueryRequest(url, {beforeSend: true,
+          complete: true,
+          data: element.id + '=' + encodeURIComponent(value),
+          no_encoding: true
+        });
 			})
 		} else {
       $j(this).off(); // Use jQuery to turn off observe_field, prevents multi ajax transactions
@@ -50,7 +54,7 @@ $j(document).ready(function(){
 					miqSendOneTrans(url);
 				} else {
           var urlstring = url + "?" + this.id + "=" + encodeURIComponent(this.value);	//  tack on the id and value to the URL
-          miqJqueryRequest(urlstring);
+          miqJqueryRequest(urlstring, {no_encoding: true});
         }
 			});
 		}


### PR DESCRIPTION
Fixed an issue introduced in https://github.com/ManageIQ/manageiq/issues/1150 PR, encoding of URL for forms was causing an issue if user entered empty space or other characters in the form fields. Added a setting to be passed in to miqJqueryRequest method when url does not need to be encoded.

@dclarizio please review/test.
