### PR TITLE
split aggregation methods in to modules.

### DIFF
--- a/vmdb/app/models/metric/aggregation.rb
+++ b/vmdb/app/models/metric/aggregation.rb
@@ -1,98 +1,109 @@
 module Metric::Aggregation
+  module Aggregate
+    def self.average(col, obj, result, counts, value)
+      return if value.nil?
+      result[col] += value
+      counts[col] += 1
+    end
+
+    def self.summation(col, obj, result, counts, value)
+      return if value.nil?
+      result[col] += value
+      counts[col] += 1
+    end
+
+    class << self
+      alias derived_vm_numvcpus summation
+    end
+
+    def self.latest(col, obj, result, counts, value)
+      return if value.nil?
+      result[col] = value
+    end
+
+    def self.cpu_usage_rate_average(col, state, result, counts, value)
+      return if value.nil?
+      if state && state.total_cpu
+        pct = ( value / 100 )
+        total = state.total_cpu
+        value = ( total * pct )
+        result[col] += value
+      else
+        self.average(col, state, result, counts, value)
+      end
+    end
+
+    def self.mem_usage_absolute_average(col, state, result, counts, value)
+      return if value.nil?
+      if state && state.total_mem
+        pct = ( value / 100 )
+        total = state.total_mem
+        value = ( total * pct )
+        result[col] += value
+      else
+        self.average(col, state, result, counts, value)
+      end
+    end
+  end
+
+  module Process
+    def self.average(col, dummy, result, counts, aggregate_only = false)
+      return if aggregate_only || result[col].nil?
+      result[col] = ( result[col] / counts[col] ) unless counts[col] == 0
+    end
+
+    def self.summation(*args)
+      # noop
+    end
+
+    class << self
+      alias derived_vm_numvcpus   summation
+    end
+
+    def self.latest(*args)
+      # noop
+    end
+
+    def self.cpu_usage_rate_average(col, state, result, counts, aggregate_only = false)
+      return if result[col].nil?
+      if state && state.total_cpu
+        total = state.total_cpu
+        result[col] = ( result[col] / total * 100 ) unless total == 0
+      else
+        self.average(col, state, result, counts) unless aggregate_only
+      end
+    end
+
+    def self.mem_usage_absolute_average(col, state, result, counts, aggregate_only = false)
+      return if result[col].nil?
+      if state && state.total_mem
+        total = state.total_mem
+        result[col] = ( result[col] / total * 100 ) unless total == 0
+      else
+        self.average(col, state, result, counts) unless aggregate_only
+      end
+    end
+  end
+
   def self.aggregate_for_column(*args)
-    self.execute_for_column(:aggregate, *args)
+    self.execute_for_column(Aggregate, *args)
   end
 
   def self.process_for_column(*args)
-    self.execute_for_column(:process, *args)
+    self.execute_for_column(Process, *args)
   end
 
   def self.execute_for_column(mode, col, *args) # args => obj, result, counts, value, default_operation = nil
     default_operation = args[4]
     args = args[0..3]
 
-    meth = "#{mode}_#{col}"
-    meth = "#{mode}_#{col.to_s.split("_").last}" unless self.respond_to?(meth)
-    meth = "#{mode}_#{default_operation}"        unless self.respond_to?(meth) || default_operation.nil?
-    self.send(meth, col, *args) if self.respond_to?(meth)
+    meth = col
+    meth = col.to_s.split("_").last unless supports?(mode, meth)
+    meth = default_operation        unless supports?(mode, meth) || default_operation.nil?
+    mode.send(meth, col, *args) if supports?(mode, meth)
   end
 
-  def self.aggregate_average(col, obj, result, counts, value)
-    return if value.nil?
-    result[col] += value
-    counts[col] += 1
-  end
-
-  def self.process_average(col, dummy, result, counts, aggregate_only = false)
-    return if aggregate_only || result[col].nil?
-    result[col] = ( result[col] / counts[col] ) unless counts[col] == 0
-  end
-
-  def self.aggregate_summation(col, obj, result, counts, value)
-    return if value.nil?
-    result[col] += value
-    counts[col] += 1
-  end
-
-  def self.process_summation(*args)
-    # noop
-  end
-
-  class << self
-    alias aggregate_derived_vm_numvcpus aggregate_summation
-    alias process_derived_vm_numvcpus   process_summation
-  end
-
-  def self.aggregate_latest(col, obj, result, counts, value)
-    return if value.nil?
-    result[col] = value
-  end
-
-  def self.process_latest(*args)
-    # noop
-  end
-
-  def self.aggregate_cpu_usage_rate_average(col, state, result, counts, value)
-    return if value.nil?
-    if state && state.total_cpu
-      pct = ( value / 100 )
-      total = state.total_cpu
-      value = ( total * pct )
-      result[col] += value
-    else
-      self.aggregate_average(col, state, result, counts, value)
-    end
-  end
-
-  def self.process_cpu_usage_rate_average(col, state, result, counts, aggregate_only = false)
-    return if result[col].nil?
-    if state && state.total_cpu
-      total = state.total_cpu
-      result[col] = ( result[col] / total * 100 ) unless total == 0
-    else
-      self.process_average(col, state, result, counts) unless aggregate_only
-    end
-  end
-
-  def self.aggregate_mem_usage_absolute_average(col, state, result, counts, value)
-    return if value.nil?
-    if state && state.total_mem
-      pct = ( value / 100 )
-      total = state.total_mem
-      value = ( total * pct )
-      result[col] += value
-    else
-      self.aggregate_average(col, state, result, counts, value)
-    end
-  end
-
-  def self.process_mem_usage_absolute_average(col, state, result, counts, aggregate_only = false)
-    return if result[col].nil?
-    if state && state.total_mem
-      total = state.total_mem
-      result[col] = ( result[col] / total * 100 ) unless total == 0
-    else
-      self.process_average(col, state, result, counts) unless aggregate_only
-    end
+  def self.supports?(mode, meth)
+    mode.singleton_methods(false).include?(meth.to_sym)
   end
 end

--- a/vmdb/app/models/metric/long_term_averages.rb
+++ b/vmdb/app/models/metric/long_term_averages.rb
@@ -53,12 +53,12 @@ module Metric::LongTermAverages
 
         val =  p.send(c) || 0
         vals[c] << val
-        Metric::Aggregation.aggregate_average(c, self, results[:avg], counts, val)
+        Metric::Aggregation::Aggregate.average(c, self, results[:avg], counts, val)
       end
     end
 
     results[:avg].each_key do |c|
-      Metric::Aggregation.process_average(c, nil, results[:avg], counts)
+      Metric::Aggregation::Process.average(c, nil, results[:avg], counts)
 
       begin
         results[:dev][c]  = vals[c].deviation

--- a/vmdb/app/models/vim_performance_daily.rb
+++ b/vmdb/app/models/vim_performance_daily.rb
@@ -153,7 +153,7 @@ class VimPerformanceDaily < MetricRollup
         # Average all values, regardless of rollup type, when going from hourly
         # to daily, since these are already rolled up and this is an average
         # over the day.
-        Metric::Aggregation.aggregate_average(c, nil, result[key], counts[key], value)
+        Metric::Aggregation::Aggregate.average(c, nil, result[key], counts[key], value)
 
         Metric::Rollup.rollup_min(c, result[key], perf.send(c))
         Metric::Rollup.rollup_max(c, result[key], perf.send(c))
@@ -194,7 +194,7 @@ class VimPerformanceDaily < MetricRollup
 
       if rollup_day
         (Metric::Rollup::ROLLUP_COLS & (options[:only_cols] || Metric::Rollup::ROLLUP_COLS)).each { |c|
-          Metric::Aggregation.process_average(c, nil, result[key], counts[key])
+          Metric::Aggregation::Process.average(c, nil, result[key], counts[key])
           result[key][c] = result[key][c].round if self.columns_hash[c.to_s].type == :integer && !result[key][c].nil?
         }
       else

--- a/vmdb/app/models/vim_performance_tag_value.rb
+++ b/vmdb/app/models/vim_performance_tag_value.rb
@@ -101,7 +101,7 @@ class VimPerformanceTagValue < ActiveRecord::Base
               result[c] ||= 0
               counts[c] ||= 0
               value = value * 1.0 unless value.nil?
-              Metric::Aggregation.aggregate_average(c, nil, result, counts, value)
+              Metric::Aggregation::Aggregate.average(c, nil, result, counts, value)
             else
               assoc = perf.resource.class.table_name.to_sym
               result[c] ||= {assoc => {:on => []}}
@@ -121,7 +121,7 @@ class VimPerformanceTagValue < ActiveRecord::Base
       col, tag = key.to_s.split(TAG_SEP)
       category = tag.split("/").first
       tag_name = tag.split("/").last
-      Metric::Aggregation.process_average(key, nil, result, counts) unless col.to_s.starts_with?("assoc_ids") || col.to_s.starts_with?("derived_storage_vm_count")
+      Metric::Aggregation::Process.average(key, nil, result, counts) unless col.to_s.starts_with?("assoc_ids") || col.to_s.starts_with?("derived_storage_vm_count")
       new_rec = {
         :association_type => association_type,
         :category         => category,


### PR DESCRIPTION
this helps to simplify `execute_for_column` because we don't have to
prepend a "mode" variable to the beginning of the method.  It puts
us in a good place to refactor the "Aggregate" and "Process" modules in
to objects, and helps expose some duplicate code in `summation` and
`average`.

This diff looks a bit messy, but I'm just moving methods around.  Also, I'm not sure if `Aggregate` and `Process` are appropriate names for these modules because I don't fully understand how they're used yet.  If anyone has better names, please tell me!