### PR TITLE
Fixes validation of ampq credentials for OpenStack

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -325,11 +325,15 @@ module EmsCommon
     @in_a_form = true
     @changed = session[:changed]
     begin
-      verify_ems.verify_credentials(params[:type])
-    rescue StandardError=>bang
+      result = verify_ems.verify_credentials(params[:type])
+    rescue StandardError => bang
       add_flash("#{bang}", :error)
     else
-      add_flash(_("Credential validation was successful"))
+      if result
+        add_flash(_("Credential validation was successful"))
+      else
+        add_flash(_("Credential validation was not successful"))
+      end
     end
     render_flash
   end

--- a/vmdb/spec/controllers/ems_common_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_common_controller_spec.rb
@@ -63,5 +63,41 @@ describe EmsCloudController do
         flash_messages.first[:level].should == :error
       end
     end
+
+    context "#update_button_validate" do
+      context "when verify_credentials" do
+        let(:mocked_ems_cloud) { mock_model(EmsCloud) }
+        before(:each) do
+          controller.instance_variable_set(:@_params, :id => "42", :type => "amqp")
+          controller.instance_variable_set(:@model, EmsCloud)
+          controller.should_receive(:find_by_id_filtered).with(EmsCloud, "42").and_return(mocked_ems_cloud)
+          controller.should_receive(:set_record_vars).with(mocked_ems_cloud, :validate).and_return(mocked_ems_cloud)
+        end
+        context "returns true" do
+          it "renders successful flash message" do
+            mocked_ems_cloud.should_receive(:verify_credentials).with("amqp").and_return(true)
+            controller.should_receive(:add_flash).with(_("Credential validation was successful"))
+            controller.should_receive(:render_flash)
+            controller.send(:update_button_validate)
+          end
+        end
+        context "returns false" do
+          it "renders unsuccessful flash message" do
+            mocked_ems_cloud.should_receive(:verify_credentials).with("amqp").and_return(false)
+            controller.should_receive(:add_flash).with(_("Credential validation was not successful"))
+            controller.should_receive(:render_flash)
+            controller.send(:update_button_validate)
+          end
+        end
+        context "raises StandardError" do
+          it "renders error flash message with StandardError" do
+            mocked_ems_cloud.should_receive(:verify_credentials).with("amqp").and_raise(StandardError)
+            controller.should_receive(:add_flash).with(_("StandardError"), :error)
+            controller.should_receive(:render_flash)
+            controller.send(:update_button_validate)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Original problem was when verify_credentials method returned false
code in controller went into else branch of begin rescue block and
rendered "successful" flash message.

This patch adds if-else to test result of verify_credentials method call
and renders "unsuccessful" flash message if the result is false.

Also adds tests for this behavior.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1136289