### PR TITLE
Show 'default' cursor on certain list views.

### DIFF
--- a/vmdb/app/views/layouts/gtl/_list.html.erb
+++ b/vmdb/app/views/layouts/gtl/_list.html.erb
@@ -154,7 +154,8 @@
           <% @id = to_cid(row['id']) %>
           <% cls = view.db == "MiqWorker" && @sb[:selected_worker_id].to_i == row['id'].to_i ? "row3" : cycle('row0', 'row1') %>
           <tr class="<%= cls %>">
-            <% cursor = ["MiqEvent", "MiqTask", "VmdbDatabaseConnection", "VmdbDatabaseSetting"].include?(view.db) ? "default" : "pointer" %>
+            <% cursor = %w(MiqEvent MiqTask VmdbDatabaseConnection VmdbDatabaseSetting).include?(view.db) ||
+                        @embedded ? "default" : "pointer" %>
             <% unless @embedded || @no_checkboxes %>
               <td class="checkbox" style="cursor:<%=cursor%>;">
                 <%= check_box_tag("check_#{@id}", 


### PR DESCRIPTION
Showing a hand cursor on screens that dont have links to other screen was confusing, changed to show 'default' cursor on screens when @embedded is set.

https://bugzilla.redhat.com/show_bug.cgi?id=1178697

@dclarizio please review/test.