### PR TITLE
Replace flash message div when there is an error while saving record.

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/zones.rb
+++ b/vmdb/app/controllers/ops_controller/settings/zones.rb
@@ -21,8 +21,10 @@ module OpsController::Settings::Zones
       if @edit[:new][:description] == ""
         add_flash(_("%s is required") % "Description", :error)
       end
-      if @flash_array != nil
-        replace_right_cell("ze")
+      if @flash_array
+        render :update do |page|
+          page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
+        end
         return
       end
       #zone = @zone.id.blank? ? Zone.new : Zone.find(@zone.id)  # Get new or existing record


### PR DESCRIPTION
Don't need to replace_right_cell when there is an error while saving zone record.

https://bugzilla.redhat.com/show_bug.cgi?id=1179446
https://bugzilla.redhat.com/show_bug.cgi?id=1178078

@dclarizio please review/test.