### PR TITLE
Remove `kind_of?(EMS)`

### DIFF
--- a/vmdb/app/models/ems_refresh.rb
+++ b/vmdb/app/models/ems_refresh.rb
@@ -56,9 +56,9 @@ module EmsRefresh
     # Split the targets into refresher groups
     groups = targets.group_by do |t|
       # Determine the group
-      if t.kind_of?(ExtManagementSystem) || t.respond_to?(:ext_management_system)
-        ems = t.kind_of?(ExtManagementSystem) ? t : t.ext_management_system
-        ems.kind_of?(EmsVmware) ? :vc : ems.emstype.to_sym unless ems.nil?
+      ems = t.respond_to?(:ext_management_system) ? t.ext_management_system : t
+      if t.respond_to?(:emstype)
+        ems.kind_of?(EmsVmware) ? :vc : ems.emstype.to_sym
       end
     end
 

--- a/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
@@ -29,14 +29,14 @@ module EmsRefresh::Refreshers
     end
 
     def group_targets_by_ems(targets)
-      non_ems_targets = targets.select { |t| !t.kind_of?(ExtManagementSystem) }
+      non_ems_targets = targets.select { |t| t.respond_to?(:ext_management_system) }
       MiqPreloader.preload(non_ems_targets, :ext_management_system)
 
       self.ems_by_ems_id     = {}
       self.targets_by_ems_id = Hash.new { |h, k| h[k] = Array.new }
 
       targets.each do |t|
-        ems = t.kind_of?(ExtManagementSystem) ? t : t.ext_management_system
+        ems = t.respond_to?(:ext_management_system) ? t.ext_management_system : t
         if ems.nil?
           $log.warn "MIQ(#{self.class.name}.group_targets_by_ems) Unable to perform refresh for #{t.class} [#{t.name}] id [#{t.id}], since it is not on an EMS."
           next

--- a/vmdb/app/presenters/tree_builder_vms_and_templates.rb
+++ b/vmdb/app/presenters/tree_builder_vms_and_templates.rb
@@ -2,7 +2,7 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
   attr_accessor :root_ems
 
   def initialize(root, *args)
-    @root_ems = root.kind_of?(ExtManagementSystem) ? root : root.ext_management_system
+    @root_ems = root.respond_to?(:ext_management_system) ? root.ext_management_system : root
     super
   end
 


### PR DESCRIPTION
Many places are comparing the ems to `ExtManagementSystem`.

Now that we are going towards `Providers`, it makes sense to remove some of these compares.

In general, `kind_of?` is nice to remove.

/cc @gmcculloug @brandondunne @Fryguy 
/cc @jrafanie :scissors: :scissors: :scissors:

**UPDATE:**
all of these places have very common code around loading the deletes/associations if it is refreshing the whole ems. Moved that into `save_inventory_ext`