### PR TITLE
I18N - Remove orphaned translate keys

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -580,18 +580,23 @@ class ApplicationController < ActionController::Base
     flds = direction == "right" ? "available_fields" : "selected_fields"
     edit_fields = direction == "right" ? "available_fields" : "fields"
     sort_fields = direction == "right" ? "fields" : "available_fields"
-    if !params["#{flds}".to_sym] || params["#{flds}".to_sym].length == 0 || params["#{flds}".to_sym][0] == ""
-      add_flash(I18n.t("flash.edit.no_fields_to_move.#{direction}", :field=>"fields"), :error)
+    if !params[flds.to_sym] || params[flds.to_sym].length == 0 || params[flds.to_sym][0] == ""
+      lr_messages = {
+        "left"  => _("No %s were selected to move left"),
+        "right" => _("No %s were selected to move right")
+      }
+      add_flash(lr_messages[direction] % "fields", :error)
     else
-      @edit[:new]["#{edit_fields}".to_sym].each do |af|                 # Go thru all available columns
-        if params["#{flds}".to_sym].include?(af[1].to_s)        # See if this column was selected to move
-          unless @edit[:new]["#{sort_fields}".to_sym].include?(af)                # Only move if it's not there already
-            @edit[:new]["#{sort_fields}".to_sym].push(af)                     # Add it to the new fields list
+      @edit[:new][edit_fields.to_sym].each do |af|                 # Go thru all available columns
+        if params[flds.to_sym].include?(af[1].to_s)        # See if this column was selected to move
+          unless @edit[:new][sort_fields.to_sym].include?(af)                # Only move if it's not there already
+            @edit[:new][sort_fields.to_sym].push(af)                     # Add it to the new fields list
           end
         end
       end
-      @edit[:new]["#{edit_fields}".to_sym].delete_if{|af| params["#{flds}".to_sym].include?(af[1].to_s)} # Remove selected fields
-      @edit[:new]["#{sort_fields}".to_sym].sort!                  # Sort the selected fields array
+      # Remove selected fields
+      @edit[:new][edit_fields.to_sym].delete_if { |af| params[flds.to_sym].include?(af[1].to_s) }
+      @edit[:new][sort_fields.to_sym].sort!                  # Sort the selected fields array
       @refresh_div = "column_lists"
       @refresh_partial = "column_lists"
     end

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -351,9 +351,8 @@ class CatalogController < ApplicationController
       st_set_record_vars(@st)
       if @add_rsc
         if @st.save
-          add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                          :model=>"Catalog Bundle",
-                          :name=>@edit[:new][:name]))
+          flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+          add_flash(flash_key % {:model => "Catalog Bundle", :name => @edit[:new][:name]})
           @changed = session[:changed] = false
           @in_a_form = false
           @edit = session[:edit] = @record = nil
@@ -702,9 +701,8 @@ class CatalogController < ApplicationController
       st.add_resource(request) if @edit[:new][:st_prov_type] != "generic"
     end
     if st.save
-      add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                       :model=>"#{ui_lookup(:model=>"ServiceTemplate")}",
-                       :name=>@edit[:new][:name]))
+      flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+      add_flash(flash_key % {:model => ui_lookup(:model => "ServiceTemplate"), :name => @edit[:new][:name]})
       @changed = session[:changed] = false
       @in_a_form = false
       @edit = session[:edit] = @record = nil

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -351,7 +351,8 @@ class CatalogController < ApplicationController
       st_set_record_vars(@st)
       if @add_rsc
         if @st.save
-          flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+          flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                  _("%{model} \"%{name}\" was added")
           add_flash(flash_key % {:model => "Catalog Bundle", :name => @edit[:new][:name]})
           @changed = session[:changed] = false
           @in_a_form = false

--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -2709,9 +2709,9 @@ private
 
   def ns_right_cell_text
     model = ui_lookup(:model => @edit[:typ])
-    name_for_msg = @edit[:rec_id].nil? ? "cell_header.adding_model_record" : "cell_header.editing_model_record"
+    name_for_msg = @edit[:rec_id].nil? ? _("Adding a new %s") : _("Editing %{model} \"%{name}\"")
     options = @edit[:rec_id].nil? ? {:model => model} : {:model => model, :name => @ae_ns.name}
-    I18n.t(name_for_msg, options)
+    name_for_msg % options
   end
 
   def priority_edit_screen

--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -2133,7 +2133,7 @@ private
     end
 
     process_aeinstances(aeinstances, "destroy") unless aeinstances.empty?
-    add_flash(I18n.t(flash.selected_records_deleted,:model=>ui_lookup(:models=>"MiqAeInstances"))) if @flash_array == nil
+    add_flash(_("The selected %s were deleted") % ui_lookup(:models => "MiqAeInstances")) if @flash_array.nil?
     replace_right_cell([:ae])
   end
 
@@ -2160,7 +2160,7 @@ private
     end
 
     process_aemethods(aemethods, "destroy") unless aemethods.empty?
-    add_flash(I18n.t(flash.selected_records_deleted,:model=>ui_lookup(:models=>"MiqAeMethod"))) if @flash_array == nil
+    add_flash(_("The selected %s were deleted") % ui_lookup(:models => "MiqAeMethod")) if @flash_array.nil?
     replace_right_cell([:ae])
   end
 

--- a/vmdb/app/controllers/miq_policy_controller.rb
+++ b/vmdb/app/controllers/miq_policy_controller.rb
@@ -89,7 +89,7 @@ class MiqPolicyController < ApplicationController
     end
 
     if ! @refresh_partial # if no button handler ran, show not implemented msg
-      add_flash(I18n.t("flash.button.not_implemented)"), :error)
+      add_flash(_("Button not yet implemented"), :error)
       @refresh_partial = "layouts/flash_msg"
       @refresh_div = "flash_msg_div"
     end

--- a/vmdb/app/controllers/miq_policy_controller.rb
+++ b/vmdb/app/controllers/miq_policy_controller.rb
@@ -694,12 +694,23 @@ class MiqPolicyController < ApplicationController
       end
     when 'ev'
       presenter[:update_partials][:main_div] = r[:partial => 'event_details', :locals=>{:read_only=>true}]
-      right_cell_text = I18n.t("cell_header.#{edit_str}model_record", :name=>@event.description.gsub(/'/,"\\\\'"), :model=>ui_lookup(:table=>'miq_event'))
+      options = {:name => @event.description.gsub(/'/, "\\\\'"), :model => ui_lookup(:table => 'miq_event')}
+      right_cell_text = @edit ? _("Editing %{model} \"%{name}\"") % options : _("%{model} \"%{name}\"") % options
     when 'a', 'ta', 'fa'
       presenter[:update_partials][:main_div] = r[:partial => 'action_details', :locals=>{:read_only=>true}]
-      right_cell_text = @action.id.blank? ?
-        _("Adding a new %s") % ui_lookup(:model=>'MiqAction') :
-        I18n.t("cell_header.#{edit_str}model_record", :name=>@action.description.gsub(/'/,"\\\\'"), :model=>ui_lookup(:model=>'MiqAction'))
+      right_cell_text = if @action.id.blank?
+                          _("Adding a new %s") % ui_lookup(:model => 'MiqAction')
+                        else
+                          if @edit
+                            _("Editing %{model} \"%{name}\"") %
+                              {:name  => @action.description.gsub(/'/, "\\\\'"),
+                               :model => ui_lookup(:model => 'MiqAction')}
+                          else
+                            _("%{model} \"%{name}\"") %
+                              {:name  => @action.description.gsub(/'/, "\\\\'"),
+                               :model => ui_lookup(:model => 'MiqAction')}
+                          end
+                        end
     when 'ap'
       presenter[:update_partials][:main_div] = r[:partial => 'alert_profile_details', :locals=>{:read_only=>true}]
       right_cell_text = if @alert_profile.id.blank?
@@ -714,7 +725,8 @@ class MiqPolicyController < ApplicationController
         _("Adding a new %s") % ui_lookup(:model=>'MiqAlert')
       else
         pfx = @assign ? ' assignments for ' : ''
-        I18n.t("#{@edit ? 'cell_header.editing_model_record' : 'cell_header.model_record'}", :name=>@alert.description.gsub(/'/,"\\\\'"), :model=>"#{pfx} #{ui_lookup(:model=>"MiqAlert")}")
+        msg = @edit ? _("Editing %{model} \"%{name}\"") : _("%{model} \"%{name}\"")
+        msg % {:name => @alert.description.gsub(/'/, "\\\\'"), :model => "#{pfx} #{ui_lookup(:model => "MiqAlert")}"}
       end
     end
     presenter[:right_cell_text] = right_cell_text

--- a/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -50,7 +50,8 @@ module MiqPolicyController::AlertProfiles
           add_flash(_("Error during '%s': ") % "Alert Profile #{params[:button]}" << bang.message, :error)
         end
         AuditEvent.success(build_saved_audit(alert_profile, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "MiqAlertSet"), :name => @edit[:new][:description]})
         alert_profile_get_info(MiqAlertSet.find(alert_profile.id))
         @edit = nil

--- a/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -50,9 +50,8 @@ module MiqPolicyController::AlertProfiles
           add_flash(_("Error during '%s': ") % "Alert Profile #{params[:button]}" << bang.message, :error)
         end
         AuditEvent.success(build_saved_audit(alert_profile, params[:button] == "add"))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"MiqAlertSet"),
-                        :name=>@edit[:new][:description]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "MiqAlertSet"), :name => @edit[:new][:description]})
         alert_profile_get_info(MiqAlertSet.find(alert_profile.id))
         @edit = nil
         self.x_node = @new_alert_profile_node = "xx-#{alert_profile.mode}_ap-#{to_cid(alert_profile.id)}"

--- a/vmdb/app/controllers/miq_policy_controller/alerts.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alerts.rb
@@ -22,7 +22,8 @@ module MiqPolicyController::Alerts
       alert_set_record_vars(alert)
       if alert_valid_record?(alert) && alert.valid? && !@flash_array && alert.save
         AuditEvent.success(build_saved_audit(alert, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "MiqAlert"), :name => @edit[:new][:description]})
         alert_get_info(MiqAlert.find(alert.id))
         @edit = nil

--- a/vmdb/app/controllers/miq_policy_controller/alerts.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alerts.rb
@@ -22,9 +22,8 @@ module MiqPolicyController::Alerts
       alert_set_record_vars(alert)
       if alert_valid_record?(alert) && alert.valid? && !@flash_array && alert.save
         AuditEvent.success(build_saved_audit(alert, params[:button] == "add"))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"MiqAlert"),
-                        :name=>@edit[:new][:description]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "MiqAlert"), :name => @edit[:new][:description]})
         alert_get_info(MiqAlert.find(alert.id))
         @edit = nil
         @nodetype = "al"

--- a/vmdb/app/controllers/miq_policy_controller/conditions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/conditions.rb
@@ -55,7 +55,8 @@ module MiqPolicyController::Conditions
           policy.save
         end
         AuditEvent.success(build_saved_audit(condition, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "Condition"), :name => @edit[:new][:description]})
         @edit = nil
         @nodetype = "co"

--- a/vmdb/app/controllers/miq_policy_controller/conditions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/conditions.rb
@@ -55,9 +55,8 @@ module MiqPolicyController::Conditions
           policy.save
         end
         AuditEvent.success(build_saved_audit(condition, params[:button] == "add"))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"Condition"),
-                        :name=>@edit[:new][:description]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "Condition"), :name => @edit[:new][:description]})
         @edit = nil
         @nodetype = "co"
         if adding # If add

--- a/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
@@ -41,7 +41,8 @@ module MiqPolicyController::MiqActions
       action_set_record_vars(action)
       if action_valid_record?(action) && !@flash_array && action.save
         AuditEvent.success(build_saved_audit(action, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "MiqAction"), :name => @edit[:new][:description]})
         action_get_info(MiqAction.find(action.id))
         @edit = nil

--- a/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
@@ -41,9 +41,8 @@ module MiqPolicyController::MiqActions
       action_set_record_vars(action)
       if action_valid_record?(action) && !@flash_array && action.save
         AuditEvent.success(build_saved_audit(action, params[:button] == "add"))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"MiqAction"),
-                        :name=>@edit[:new][:description]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "MiqAction"), :name => @edit[:new][:description]})
         action_get_info(MiqAction.find(action.id))
         @edit = nil
         @nodetype = "a"

--- a/vmdb/app/controllers/miq_policy_controller/policies.rb
+++ b/vmdb/app/controllers/miq_policy_controller/policies.rb
@@ -59,7 +59,8 @@ module MiqPolicyController::Policies
         end
         policy.sync_events(@edit[:new][:events].collect{|e| MiqEvent.find(e)}) if @edit[:typ] == "events"
         AuditEvent.success(build_saved_audit(policy, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "MiqPolicy"), :name => @edit[:new][:description]})
         policy_get_info(MiqPolicy.find(policy.id))
         @edit = nil

--- a/vmdb/app/controllers/miq_policy_controller/policies.rb
+++ b/vmdb/app/controllers/miq_policy_controller/policies.rb
@@ -59,9 +59,8 @@ module MiqPolicyController::Policies
         end
         policy.sync_events(@edit[:new][:events].collect{|e| MiqEvent.find(e)}) if @edit[:typ] == "events"
         AuditEvent.success(build_saved_audit(policy, params[:button] == "add"))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"MiqPolicy"),
-                        :name=>@edit[:new][:description]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "MiqPolicy"), :name => @edit[:new][:description]})
         policy_get_info(MiqPolicy.find(policy.id))
         @edit = nil
         @nodetype = "p"

--- a/vmdb/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/vmdb/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -48,9 +48,8 @@ module MiqPolicyController::PolicyProfiles
           add_flash(_("Error during '%s': ") % "Policy Profile #{params[:button]}" << bang.message, :error)
         end
         AuditEvent.success(build_saved_audit(profile, params[:button] == "add"))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"MiqPolicySet"),
-                        :name=>@edit[:new][:description]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @edit[:new][:description]})
         profile_get_info(MiqPolicySet.find(profile.id))
         @edit = nil
         @nodetype = "pp"

--- a/vmdb/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/vmdb/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -48,7 +48,8 @@ module MiqPolicyController::PolicyProfiles
           add_flash(_("Error during '%s': ") % "Policy Profile #{params[:button]}" << bang.message, :error)
         end
         AuditEvent.success(build_saved_audit(profile, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @edit[:new][:description]})
         profile_get_info(MiqPolicySet.find(profile.id))
         @edit = nil

--- a/vmdb/app/controllers/ops_controller/analytics.rb
+++ b/vmdb/app/controllers/ops_controller/analytics.rb
@@ -30,27 +30,15 @@ module OpsController::Analytics
     if x_node.split('-').first == "z"
       zone = Zone.find_by_id(from_cid(x_node.split('-').last))
       @sb[:rpt_title] = "Analytics Report for '#{zone.description}'"
-      @right_cell_text = @sb[:my_zone] == zone.name ?
-        I18n.t("cell_header.type_of_model_record_current)",
-                                  :typ=>"Diagnostics",
-                                  :model=>ui_lookup(:model=>zone.class.to_s),
-                                  :name=>zone.description) :
-        I18n.t("cell_header.type_of_model_record)",
-                                  :typ=>"Diagnostics",
-                                  :model=>ui_lookup(:model=>zone.class.to_s),
-                                  :name=>zone.description)
+      msg = zone.name ? _("%{typ} %{model} \"%{name}\" (current)") : _("%{typ} %{model} \"%{name}\"")
+      @right_cell_text = @sb[:my_zone] == msg %
+        {:typ => "Diagnostics", :model => ui_lookup(:model => zone.class.to_s), :name => zone.description}
     elsif x_node.split('-').first == "svr"
       svr = MiqServer.find(from_cid(nodetype.downcase.split("-").last))
       @sb[:rpt_title] = "Analytics Report for '#{svr.name} [#{svr.id}]'"
-      @right_cell_text = @sb[:my_server_id] == svr.id ?
-        I18n.t("cell_header.type_of_model_record_current)",
-                                  :typ=>"Diagnostics",
-                                  :model=>ui_lookup(:model=>svr.class.to_s),
-                                  :name=>"#{svr.name} [#{svr.id}]") :
-        I18n.t("cell_header.type_of_model_record)",
-                                  :typ=>"Diagnostics",
-                                  :model=>ui_lookup(:model=>svr.class.to_s),
-                                  :name=>"#{svr.name} [#{svr.id}]")
+      msg = svr.id ? _("%{typ} %{model} \"%{name}\" (current)") : _("%{typ} %{model} \"%{name}\"")
+      @right_cell_text = @sb[:my_server_id] == msg %
+        {:typ => "Diagnostics", :model => ui_lookup(:model => svr.class.to_s), :name => "#{svr.name} [#{svr.id}]"}
     else
       @right_cell_text = _("%{model} \"%{name}\"") % {:name=>"Enterprise", :model=>"Analytics"}
       @sb[:rpt_title] = "Analytics Report for Enterprise"

--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -1253,25 +1253,6 @@ module OpsController::Settings::Common
     @edit[:default_verify_status] = (w[:password] == w[:verify])
   end
 
-  def move_cols_left_right(direction)
-    flds = direction == "right" ? "available_fields" : "selected_fields"
-    hosts = direction == "right" ? "available_hosts" : "selected_hosts"
-    sort_hosts = direction == "right" ? "selected_hosts" : "available_hosts"
-    if !params["#{flds}".to_sym] || params["#{flds}".to_sym].length == 0 || params["#{flds}".to_sym][0] == ""
-      add_flash(I18n.t("flash.edit.no_fields_to_move.#{direction}", :field=>"fields"), :error)
-    else
-      @edit[:new][@edit[:new][:selected_server][0]]["#{hosts}".to_sym].each do |af|                 # Go thru all available columns
-        if params["#{flds}".to_sym].include?(af)        # See if this column was selected to move
-          @edit[:new][@edit[:new][:selected_server][0]]["#{sort_hosts}".to_sym].push(af)                      # Add it to the new fields list
-        end
-      end
-      @edit[:new][@edit[:new][:selected_server][0]]["#{hosts}".to_sym].delete_if{|af| params["#{flds}".to_sym].include?(af)} # Remove selected fields
-      @edit[:new][@edit[:new][:selected_server][0]]["#{sort_hosts}".to_sym].sort!                 # Sort the selected fields array
-      @refresh_div = "hosts_lists"
-      @refresh_partial = "hosts_lists"
-    end
-  end
-
   def build_smartproxy_affinity_node(zone, server, node_type)
     affinities = server.send("vm_scan_#{node_type}_affinity").collect(&:id)
     {

--- a/vmdb/app/controllers/ops_controller/settings/schedules.rb
+++ b/vmdb/app/controllers/ops_controller/settings/schedules.rb
@@ -200,22 +200,21 @@ module OpsController::Settings::Schedules
   end
 
   def schedule_toggle(enable)
-    present_action = enable ? 'enable' : 'disable'
-    past_action = present_action + 'd'
+    present_action, msg = if enable
+                            ['enable', _("No %s were selected to be enabled")]
+                          else
+                            ['disable', _("No %s were selected to be disabled")]
+                          end
 
     schedules = find_checked_items
     if schedules.empty?
-      add_flash(I18n.t("flash.no_records_selected_to_be_#{past_action}",
-                    :model=>ui_lookup(:models=>"MiqSchedule")),
-              :error)
+      add_flash(msg % ui_lookup(:models => "MiqSchedule"), :error)
       render :update do |page|
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
       end
     end
     schedule_enable_disable(schedules, present_action)  unless schedules.empty?
-    add_flash(I18n.t("flash.selected_records_were_#{past_action}",
-                    :model=>ui_lookup(:models=>"MiqSchedule")),
-              :info, true) if ! flash_errors?
+    add_flash(msg % ui_lookup(:models => "MiqSchedule"), :info, true) unless flash_errors?
     schedule_build_list
     settings_get_info("st")
     replace_right_cell("root")

--- a/vmdb/app/controllers/ops_controller/settings/upload.rb
+++ b/vmdb/app/controllers/ops_controller/settings/upload.rb
@@ -18,12 +18,19 @@ module OpsController::Settings::Upload
     if params["#{fld}".to_sym] && params["#{fld}".to_sym][:logo] &&
         params["#{fld}".to_sym][:logo].respond_to?(:read)
       if params["#{fld}".to_sym][:logo].original_filename.split(".").last.downcase != "png"
-        msg = I18n.t(typ == "custom" ? "flash.ops.settings.custom_logo_type" : "flash.ops.settings.custom_login_type")
+        msg = if typ == "custom"
+                _("Custom logo image must be a .png file")
+              else
+                _("Custom login image must be a .png file")
+              end
         err = true
       else
         File.open(typ == "custom" ? @@logo_file : @@login_logo_file, "wb") { |f| f.write(params["#{fld}".to_sym][:logo].read) }
-        msg = I18n.t(typ == "custom" ? "flash.ops.settings.custom_logo_uploaded" : "flash.ops.settings.custom_login_uploaded",
-          :filename=>params["#{fld}".to_sym][:logo].original_filename)
+        msg = if typ == "custom"
+                _('Custom Logo file "%s" uploaded') % params[fld.to_sym][:logo].original_filename
+              else
+                _('Custom login file "%s" uploaded') % params[fld.to_sym][:logo].original_filename
+              end
         err = false
       end
     else

--- a/vmdb/app/controllers/ops_controller/settings/zones.rb
+++ b/vmdb/app/controllers/ops_controller/settings/zones.rb
@@ -31,7 +31,8 @@ module OpsController::Settings::Zones
       zone_set_record_vars(@zone)
       if valid_record?(@zone) && @zone.save
         AuditEvent.success(build_created_audit(@zone, @edit))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
+                                                _("%{model} \"%{name}\" was added")
         add_flash(flash_key % {:model => ui_lookup(:model => "Zone"), :name => @edit[:new][:name]})
         @edit = nil
         self.x_node = params[:button] == "save" ?

--- a/vmdb/app/controllers/ops_controller/settings/zones.rb
+++ b/vmdb/app/controllers/ops_controller/settings/zones.rb
@@ -31,9 +31,8 @@ module OpsController::Settings::Zones
       zone_set_record_vars(@zone)
       if valid_record?(@zone) && @zone.save
         AuditEvent.success(build_created_audit(@zone, @edit))
-        add_flash(I18n.t("#{params[:button] == "save" ? "flash.edit.saved" : "flash.add.added"}",
-                        :model=>ui_lookup(:model=>"Zone"),
-                        :name=>@edit[:new][:name]))
+        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "Zone"), :name => @edit[:new][:name]})
         @edit = nil
         self.x_node = params[:button] == "save" ?
               "z-#{@zone.id}" : "xx-z"

--- a/vmdb/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/vmdb/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -123,10 +123,8 @@ module PxeController::PxeCustomizationTemplates
       template_set_record_vars(ct)
 
       if !flash_errors? && ct.valid? && ct.save
-        flash_key = ct.id ? "flash.edit.saved" : "flash.add.added"
-        add_flash(I18n.t(flash_key,
-                         :model => ui_lookup(:model => "PxeCustomizationTemplate"),
-                         :name  => ct.name))
+        flash_key = ct_id ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+        add_flash(flash_key % {:model => ui_lookup(:model => "PxeCustomizationTemplate"), :name  => ct.name})
           AuditEvent.success(build_created_audit(ct, @edit))
           @edit = session[:edit] = nil # clean out the saved info
           self.x_node = "xx-xx-#{to_cid(ct.pxe_image_type.id)}"

--- a/vmdb/app/controllers/pxe_controller/pxe_servers.rb
+++ b/vmdb/app/controllers/pxe_controller/pxe_servers.rb
@@ -65,9 +65,8 @@ module PxeController::PxeServers
         pxe_server_set_record_vars(pxe)
       end
 
-      add_flash(I18n.t(pxe.id ? "flash.edit.saved" : "flash.add.added",
-                         :model=>ui_lookup(:model=>"PxeServer"),
-                         :name=>@edit[:new][:name]))
+      flash_key = pxe.id ? _("%{model} \"%{name}\" was saved") : _("%{model} \"%{name}\" was added")
+      add_flash(flash_key % {:model => ui_lookup(:model => "PxeServer"), :name => @edit[:new][:name]})
 
       if pxe.valid? && !flash_errors? && pxe_server_set_record_vars(pxe) && pxe.save!
         AuditEvent.success(build_created_audit(pxe, @edit))

--- a/vmdb/app/controllers/report_controller.rb
+++ b/vmdb/app/controllers/report_controller.rb
@@ -455,11 +455,10 @@ class ReportController < ApplicationController
     nodes = x_node.split('-')
     show_saved_report
     @record = MiqReportResult.find_by_id(from_cid(nodes.last))
-    @right_cell_text = I18n.t(
-      "cell_header.model_record",
+    @right_cell_text = _("%{model} \"%{name}\"") % {
       :name  => "#{@record.name} - #{format_timezone(@record.created_on, Time.zone, "gt")}",
       :model => "Saved Report"
-    )
+    }
     @right_cell_div  = "savedreports_list"
   end
 

--- a/vmdb/app/controllers/report_controller/reports.rb
+++ b/vmdb/app/controllers/report_controller/reports.rb
@@ -346,8 +346,15 @@ module ReportController::Reports
               if e = MiqExpression.atom_error(rpt.col_to_expression_col(col.split("__").first), # See if the value is in error
                                               s[:operator],
                                               s[:value])
-                order = case s_idx + 1 when 1;"first" when 2;"second" when 3;"third" end
-                add_flash(I18n.t("flash.edit.field_styling_error.#{order}", :field=>f.first) + e.message, :error)
+                msg = case s_idx + 1
+                      when 1
+                        _("Styling for '%s', first value is in error: ")
+                      when 2
+                        _("Styling for '%s', second value is in error: ")
+                      when 3
+                        _("Styling for '%s', third value is in error: ")
+                      end
+                add_flash((msg % f.first) + e.message, :error)
                 @sb[:miq_tab] = "new_9"
               end
             end

--- a/vmdb/app/controllers/report_controller/schedules.rb
+++ b/vmdb/app/controllers/report_controller/schedules.rb
@@ -85,9 +85,8 @@ module ReportController::Schedules
     end
     process_schedules(scheds, "destroy")  unless scheds.empty?
     unless flash_errors?
-      msg_str = scheds.length > 1 ? "selected_records_deleted" : "selected_record_deleted"
-      add_flash(I18n.t("flash.#{msg_str}",
-                       :model => "#{ui_lookup(:model => "MiqReport")} #{ui_lookup(:models => "MiqSchedule")}"),
+      msg_str = scheds.length > 1 ? _("The selected %s were deleted") : _("The selected %s was deleted")
+      add_flash(msg_str % "#{ui_lookup(:model => "MiqReport")} #{ui_lookup(:models => "MiqSchedule")}",
                 :info, true)
     end
     self.x_node = "root"

--- a/vmdb/app/services/user_validation_service.rb
+++ b/vmdb/app/services/user_validation_service.rb
@@ -37,7 +37,8 @@ class UserValidationService
     db_user = User.find_by_userid(user[:name])
     return ValidateResult.new(
       :fail,
-      I18n.t("flash.authentication.missing_role_or_group", :model => session[:group] ? "Role" : "Group")
+      _("Login not allowed, User's %s is missing. Please contact the administrator") %
+      (session[:group] ? "Role" : "Group")
     ) unless session_reset(db_user) # Reset/recreate the session hash
 
     start_url = session[:start_url] # Hang on to the initial start URL
@@ -67,7 +68,7 @@ class UserValidationService
       :controller    => "ems_infra",
       :action        => 'show_list',
       :flash_warning => true,
-      :flash_msg     => I18n.t("flash.non_admin_cannot_access"))
+      :flash_msg     => _("Non-admin users can not access the system until at least 1 VM/Instance has been discovered"))
     )
   end
 
@@ -82,11 +83,11 @@ class UserValidationService
         :action        => 'explorer',
         :flash_warning => true,
         :no_refresh    => true,
-        :flash_msg     => I18n.t("flash.server_still_starting_admin"),
+        :flash_msg     => _("The CFME Server is still starting, you have been redirected to the diagnostics page for problem determination"),
         :escape        => false)
       )
     else
-      ValidateResult.new(:fail, I18n.t("flash.server_still_starting"))
+      ValidateResult.new(:fail, _("The CFME Server is still starting. If this message persists, please contact your CFME administrator."))
     end
   end
 
@@ -98,7 +99,7 @@ class UserValidationService
       user_or_taskid = User.authenticate(user[:name], user[:password], request)
     rescue MiqException::MiqEVMLoginError
       user[:name] = nil
-      return ValidateResult.new(:fail, I18n.t("flash.authentication.error"))
+      return ValidateResult.new(:fail, _("Sorry, the username or password you entered is incorrect."))
     end
 
     if user_or_taskid.kind_of?(User)

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -7,85 +7,33 @@ en:
   # Flash messages shown in the UI
   flash:
     add:
-      cancelled: "Add of new %{model} was cancelled by the user"
       added: '%{model} "%{name}" was added'
 
     authentication:
       error: "Sorry, the username or password you entered is incorrect."
       missing_role_or_group: "Login not allowed, User's %{model} is missing. Please contact the administrator"
 
-    automate:
-      button_cleared: "Automate button %{btn_num} has been cleared"
-      button_set: "Automate button %{btn_num} has been set to %{btn_txt}"
-      custom_button_error: 'Error executing: "%{name}" '
-      custom_button_executed: '"%{name}" was executed'
-      datastore_import_success: "Datastore import was successful.\nNamespaces updated/added: %{namespace_stats}\nClasses updated/added: %{class_stats}\nInstances updated/added: %{instance_stats}\nMethods updated/added: %{method_stats}"
-
-    button:
-      at_least_selected: "At least %{num} %{model} must be selected for %{action}"
-      at_least_2_selected: "At least 2 %{model} must be selected for %{action}"
-      more_than_max_selected: "No more than %{max} %{model} can be selected for %{action}"
-      no_records_selected: "No %{model} were selected to %{button}"
-      typ_not_implemented: "%{typ} Button not yet implemented"
-      one_or_more_selected_for_task: "One or more %{model} must be selected to %{task}"
-      record_gone: "%{model} no longer exists"
-      task_does_not_apply_to_one_of_selected: "%{task} does not apply because you selected at least one %{model}"
-      task_does_not_apply_to_model: "%{task} does not apply to selected %{model}"
-
     copy:
       cancelled: 'Copy %{model} was cancelled by the user'
       copied: 'Copy selected %{model} was saved'
     edit:
-      at_least_1:
-        configured: "At least one %{field} must be configured"
-        selected: "At least one %{field} must be selected"
-        contain: "%{model} must contain at least one %{field}"
-      cancelled: 'Edit of %{model} "%{name}" was cancelled by the user'
-      cancelled_model: "Edit of %{model} was cancelled by the user"
       cancelled_for_class: 'Edit of schema for %{model} "%{name}" was cancelled by the user'
-      cancelled_for_role: 'Edit of %{model} for role "%{role}" was cancelled by the user'
-      error_details: "Error details: %{error}"
-      field_character_not_allowed: '%{field} cannot contain "%{character}"'
       field_in_display_filter: "%{field} is currently being used in the Display Filter"
-      field_required: "%{field} is required"
-      field_requires_entry_point: 'Entry Point must be given for field "%{field}".'
-      field_unique: "%{field} should be unique"
-      field_unique_within_group: "%{field} must be unique for this group"
-      field_value_and_description_reuired: "%{field1} and %{field2} fields can't be blank"
-      field_value_in_use: "%{field} '%{value}' is already in use"
-      field_must_be_changed: "Change %{field} value to submit reconfigure request"
       field_must_be:
-        configured: "%{field} must be configured"
-        numeric: "%{field} must be numeric"
         numeric_greater_than_0: "%{field} must be numeric and greater than zero"
-        integer: "%{field} must be an integer"
-        alphanumeric_and_underscore: "%{field} must be alphanumeric characters and underscores without spaces"
-      field_must_not_be:
-        action_or_controller: "%{field} must not be 'action' or 'controller'"
       field_styling_error:
         first: "Styling for '%{field}', first value is in error: "
         second: "Styling for '%{field}', second value is in error: "
         third: "Styling for '%{field}', third value is in error: "
       filter:
-        field_value_error: "%{field} Value Error: %{msg}"
-        must_be_chosen: "A %{field} must be chosen to commit this expression element"
-        must_be_entered: "A %{field} must be entered to commit this expression element"
         search_reset: "The current search details have been reset"
-      group_reorder: '%{model} Group Reorder'
-      group_reorder_cancelled: '%{model} Group Reorder cancelled'
-      group_reorder_saved: '%{model} Group Reorder saved'
       manage_desktops_cancelled: 'Manage Desktops was cancelled by the user'
       manage_desktops_saved: 'Manage Desktops was saved'
       saved: '%{model} "%{name}" was saved'
       saved_for_class: 'Schema for %{model} "%{name}" was saved'
-      saved_for_role: '%{model} for role "%{role}" was saved'
-      select_required: "%{selection} must be selected"
-      set_to_default: "%{model} set to default"
       user_assignment_cancelled: "Assignment was cancelled by the user"
       user_assignment_initiated: "Assignment changes initiated"
       user_unassignment_initiated: "User Un-Assignment initiated"
-      task_cancelled: "%{task} was cancelled by the user"
-      task_saved: "%{task} saved"
 
       # flash.edit side by side selection box messages
       no_fields_to_move:
@@ -102,53 +50,17 @@ en:
       no_fields_moved:
         left: "No %{field} were moved to the left"
         up: "No %{field} were moved up"
-      select_fields_to_move:
-        up: "Select only one or consecutive %{field} to move up"
-        down: "Select only one or consecutive %{field} to move down"
-        to_the_top: "Select only one or consecutive %{field} to move to the top"
-        to_the_bottom: "Select only one or consecutive %{field} to move to the bottom"
-      adding_fields_exceeds_max: "Fields not added: Adding the selected %{count} fields will exceed the maximum of %{max} fields"
-      email:
-        not_valid: E-mail address '%{type}' is not valid
-
-      # flash.edit tab messages
-      tab_needs:
-        1_field: "%{tab} tab is not available until at least 1 field has been selected"
-        field_configured: "%{tab} tab is not available until %{field} has been configured"
-        field_selected: "%{tab} tab is not available until %{field} field has been selected"
-        sort_field: "%{tab} tab is not available unless a sort field has been selected"
-        time_field: "%{tab} tab is not available unless at least 1 time field has been selected"
-
-    configuration:
-      global_time_profile_cannot_delete: '"%{name}": Global %{model} cannot be deleted'
-      time_profile_in_use: '"%{name}": In use by %{rep_count}, cannot be deleted'
-      ui_settings_saved_for_user: "User Interface settings saved for User %{user}"
 
     image:
       type: "Custom Image must be a %{typ} file"
-      locate_file: "Use the Browse button to locate a %{typ} image file"
       uploaded: 'Custom Image file "%{filename}" successfully uploaded'
-
-    datastore:
-      cannot_be_removed: '"%{name}": cannot be removed, has vms or hosts'
 
     host:
       no_host_selected: "No Hosts were selected to analyze and check compliance"
       analysis_started: "Analyze and Check compliance for this Host has been started"
 
     ops:
-      diagnostics:
-        error_during_orphaned_record_delete: "Error during Orphaned Records delete for user %{userid}: "
-        error_during_worker_restart: "Error during %{wtype} workers restart: "
-        log_collection_initiated: "Log collection for CFME %{object_type} %{name} has been initiated"
-        orphaned_records_deleted: "Orphaned Records for userid %{userid} were successfully deleted"
-        priority_set_for_server: 'CFME Server "%{name}" set as %{priority} for Role "%{role_description}"'
-        task_initiated: "%{task} successfully initiated"
-        task_not_allowed: "%{task} is not allowed for the selected item"
-        workers_restarted: "%{wtype} workers restart initiated successfully"
-        worker_1_restarted: "'%{wtype}' Worker restart initiated successfully"
       rbac:
-        error_during_task: "Error during '%{task}': "
         read_only_role_cannot_delete: "Read only Role can not be deleted"
         read_only_role_cannot_edit: "This Role is Read Only and can not be edited"
         selected_roles_deleted: "All selected Roles were deleted (unless Read Only or in use by one or more Groups)"
@@ -156,126 +68,48 @@ en:
         selected_group_deleted: "All selected Groups were deleted"
         selected_user_deleted: "All selected Users were deleted"
       settings:
-        advanced_settings_saved: "%{filename} file saved"
         custom_logo_type: "Custom logo image must be a .png file"
         custom_login_type: "Custom login image must be a .png file"
         custom_logo_uploaded: 'Custom Logo file "%{filename}" uploaded'
         custom_login_uploaded: 'Custom login file "%{filename}" uploaded'
-        error_during_task: "Error during %{task}: "
-        import_validation_complete: "Import validation complete: %{good_record}, %{bad_record}"
-        locate_file: "Use the Browse button to locate %{typ} file"
-        ldap_group_lookup: "%{field} must be entered to perform LDAP Group Look Up"
-        worker_credentials_validated: "%{wtype} Credentials validated successfully"
-        settings_saved: '%{typ} settings saved for CFME Server "%{name} [%{server_id}]" in Zone "%{zone}"'
-        test_email_sent: 'The test email is being delivered, check "%{email}" to verify it was successful'
-        action_has_been_queued: "%{action} has been initiated for the selected Servers"
-        error_when_queuing_action: "Error occured when queuing action: %{error}"
         rhn:
           missing_information: "Please, fill in the form before saving."
-      export_generation_error: "Export generation returned: Status [%{status}] Message [%{message}]"
 
     provision: 
       cancelled: "Provision %{model} was cancelled by the user"
 
     policy:
-      alert_profile_assignments_saved: 'Alert Profile "%{name}" assignments succesfully saved'
-      task_cancelled_by_user: "%{task} cancelled by user"
       cancelled_import: "Import was cancelled by the user"
-      condition_removed_from_policy: 'Condition "%{cond_name}" has been removed from Policy "%{pol_name}"'
-      policy_event_actions_saved: 'Actions for Policy Event "%{name}" were saved'
-      value_missing_for_field: "%{val} missing for %{field}"
 
     report:
-      generation_error: "Report generation returned: Status [%{status}] Message [%{message}]"
-      not_found_schedule_failed: 'Saved Report "%{name}" not found, Schedule may have failed'
-      preview_error: "Report preview generation returned: Status [%{status}] Message [%{message}]"
       saved_report_doesnt_exist: "Saved Report no longer exists"
-      selected_no_longer_exists: "Selected %{typ} Report no longer exists"
 
     request:
       error_during_sysprep_upload: 'Error during Sysprep "%{name}" file upload: '
-      request_approved_denied: 'Request "%{name}" was %{task}'
       request_resubmitted: "%{typ} Request was re-submitted, you will be notified when your %{title} are ready"
-      request_submitted: "%{typ} Request was Submitted, you will be notified when your %{title} are ready"
-      st_request_submitted: "%{typ} Request was Submitted"
-      sysprep_file_upload: 'Sysprep "%{filename}" upload was successful'
       task_cancelled: "Request %{task} was cancelled by the user"
 
     service_dialog:
       cannot_import_duplicate: "Dialog '%{label}' already exists and was not imported"
 
-    smartproxy:
-      deploy_smaprtproxy_cancelled: 'Deploy of SmartProxy to Host "%{name}" was cancelled'
-      deploy_smaprtproxy_initiated: 'Deploy of SmartProxy to Host "%{name}" was initiated'
-      no_smartproxy_available: 'There are no available SmartProxies to deploy on Host "%{name}"'
-      retrieve_log_started: 'SmartProxy "%{name}" log retrieval has been started . . . refresh page to view the log'
-
-    vm:
-      add_vm_to_service_cancelled: 'Add VM "%{name}" to a Service was cancelled by the user'
-      added_to: '%{model} "%{name}" successfully added to Service "%{to_name}"'
-      create_snapshot_started: 'Create Snapshot for %{model} "%{name}" was started'
-      no_blackbox: '"%{name}": VM does not have BlackBox.'
-      ownership_saved: "Ownership saved for selected %{object_types}"
-      power_off_to_delete_blackbox: '"%{name}": VM needs to be in a Powered Off state to delete the BlackBox.'
-      retirement_removed: "Retirement %{date_text} removed"
-      retirement_set: "Retirement %{date_text} set to %{rdate}"
-      vm_removed_from_service: 'VM successfully removed from service "%{name}"'
-
-    already_exists: '%{model} "%{name}" already exists'
     already_taken: "%{field} has already been taken"
-    cant_delete_current: "Current %{model} \"%{name}\" cannot be deleted"
-    cant_delete_default: "Default %{model} \"%{name}\" cannot be deleted"
     cant_delete_read_only: "Read Only or %{model} in use by one or more %{in_use_by} can not be deleted"
     cant_delete_unassigned: "'%{model}' can not be deleted"
-    cant_edit_read_only: "Read Only %{model} \"%{name}\" can not be edited"
-    cant_delete_sample: "Default %{model} \"%{name}\" can not be deleted"
-    cant_edit_default: "Default %{model} \"%{name}\" can not be edited"
-    cant_edit_unassigned: "'%{model}' can not be edited"
-    cant_edit_sample: "Sample %{model} \"%{name}\" can not be edited"
-    cannot_delete: '"%{field}" %{model} can not be deleted'
     credentials:
       error: "Credential validation returned: %{message}"
-      cancelled: "Edit of credentials for selected %{model} was cancelled by the user"
-    console_access_failed: "Console access failed: %{reason}"
-    discovery_returned_error: "%{model} Discovery returned: "
-    error_during: "Error during '%{task}': "
-    error_with_stat_message: "Error during %{task}: Status [%{status}] Message [%{message}]"
-    error_on_line: "Error on line %{line_num}: %{err_txt}"
     license_invalid: "The CFME license is invalid, please upload a valid license file"
     no_host_defined: "No Host instances have been defined, press a button to Add or Discover one"
-    no_model_found_for_nodetype: "No Class found for explorer tree node type '%{nodetype}'"
-    no_nodetype_found_for_model: "No explorer tree node type found for '%{model}'"
-    no_records_selected_for_delete: 'No %{model} were selected for deletion'
-    no_records_selected_for_task: 'No %{model} were selected for %{task}'
     no_records_selected_to_be_disabled: 'No %{model} were selected to be disabled'
     no_records_selected_to_be_enabled: 'No %{model} were selected to be enabled'
-    no_records_selected_to_be_marked: 'No %{model} were selected to be marked as %{action}'
     non_admin_cannot_access: "Non-admin users can not access the system until at least 1 VM/Instance has been discovered"
     priority_order_saved: "Priority Order was saved"
-    record_no_longer_exists: "%{record_name} no longer exists in the database"
-    record_not_authorized_for_user: "You are not authorized to view %{record_name}"
     server_still_starting: "The CFME Server is still starting.  If this message persists, please contact your CFME administrator."
     server_still_starting_admin: "The CFME Server is still starting, you have been redirected to the diagnostics page for problem determination"
 
     record:
-      deleted: '%{model} "%{name}": Delete successful'
-      error_during_task: "%{model} \"%{name}\": Error during '%{task}': "
       delete_for_1_record_initiated: "The delete for selected %{model} was initiated"
       delete_for_records_initiated: "The delete for selected %{model} initiated"
-      deleted_for_1_record: "The selected %{model} was deleted"
-      deleted_for_records: "The selected %{model} were deleted"
-      item_no_longer_exists: "Last selected %{model} no longer exists"
-      no_longer_exists: "%{model} no longer exists"
-      selected_item_no_longer_exists: "Selected %{model} no longer exists"
-      task_initiated: "%{model}: %{task} successfully initiated"
-      task_initiated_for_model: "%{task} initiated for %{count_model} from the CFME Database"
-      task_initiated_for_record: '"%{record}": %{task} successfully initiated'
-      task_started: "%{model} \"%{name}\": %{task} successfully initiated"
       task_started_for_model: "%{task} for this %{model} has been started"
-      was_loaded: "%{model} \"%{name}\" was successfully loaded"
-
-    repository:
-      default_repository_not_running: 'The Default Repository SmartProxy, "%{name}", is not running, contact your CFME Administrator'
 
     service:
       no_service_selected_to_task: "No Services were selected to %{task}"
@@ -283,70 +117,28 @@ en:
       service_1_task: "This Service has been %{task}"
       service_task: "Selected Services have been %{task}"
 
-    1_not_in_current_region: "%{label} is not in the current region and will be skipped"
-    all_not_in_current_region: "All selected %{label} are not in the current region"
-    count_not_in_current_region: "%{label} are not in the current region and will be skipped"
-    error_during_delete_with_count: "Error during %{count_model} delete from the CFME Database"
-    not_in_current_region: "The selected %{label} is not in the current region"
     schedule_queued_to_run: "The selected Schedule has been queued to run"
     schedules_queued_to_run: "The selected Schedules have been queued to run"
     selected_record_deleted: 'The selected %{model} was deleted'
     selected_records_deleted: 'The selected %{model} were deleted'
-    selected_records_deleted_with_count: "Successfully deleted %{count_model} from the CFME Database"
     selected_records_were_disabled: 'The selected %{model} were disabled'
     selected_records_were_enabled: 'The selected %{model} were enabled'
-    selected_records_were_marked: 'The selected %{model} were marked as %{action}'
-    task_cancelled: "%{task} was cancelled by the user"
 
   # Header text
   cell_header:
     adding_model_record: "Adding a new %{model}"
-    all_model_indexes: "All %{model} Indexes"
-    all_model_records: "All %{model}"
-    all_model_records_for_group: "All %{model} - %{group}"
-    all_type_model_records: "All %{typ} %{model}"
-    best_fit_model: "Best Fit %{model}"
-    buttons_for_model_record: '%{model} for "%{record}"'
-    compare: 'Compare %{model}'
-    dialog_runner_for_record: '%{record} - "%{button_text}"'
-    drift: 'Drift for %{model} "%{name}"'
     editing_model_record: 'Editing %{model} "%{name}"'
-    editing_model_for_record: 'Editing %{model} for "%{name}"'
-    editing_model_record_sequence: 'Editing %{model} sequence for "%{name}"'
-    edit_tags: 'Edit Tags for %{model}'
     evm_relationship: 'Edit CFME Server Relationship for %{model} "%{name}"'
     filtered_model_records: '%{model} - Filtered by "%{filter}"'
-    miq_request_new: 'Provision %{model}'
     model: "%{model}"
-    model_assignments: ' %{model} Assignments'
-    model_client_connections: "%{model} Client Connections"
     model_for_record: '%{model} for "%{name}"'
     model_record: '%{model} "%{name}"'
     model_record_for_group: '%{model} for %{group} "%{name}"'
-    model_record_typ: '%{model} "%{name}" %{typ}'
-    model_record_indexes: 'Indexes for %{model} "%{name}"'
-    model_typ_name: '%{typ} in %{model} "%{name}"'
-    model_settings: "%{model} Settings"
     name: '"%{name}"'
-    name_filter_suffix: ' (Names with "%{name_filter}")'
-    policy_assignment: '%{model} Policy Assignment'
-    policy_sim: '%{model} Policy Simulation'
-    pre_provision: 'Provision %{model} - Select %{typ}'
-    reconfigure: 'Reconfigure %{model}'
-    retire: 'Set/Remove retirement date for %{model}'
-    request_task: '%{task} %{model}'
-    right_size: 'Right Size Recommendation for %{model} "%{name}"'
-    summary: '%{model} Summary'
-    set_ownership: 'Set Ownership for %{model}'
-    show_timelines: 'Timelines for %{model} "%{name}"'
-    utilization: '%{model} Utilization'
-    utilization_summary: 'Capacity & Utilization data for %{model} "%{name}"'
     task_model_record: '%{task} %{model} "%{name}"'
     type_of_model_record: '%{typ} %{model} "%{name}"'
-    type_of_model_records: "%{typ} %{model}"
     type_of_model_record_current: '%{typ} %{model} "%{name}" (current)'
     ui_action_for_model_record: '"%{action}" for %{model} "%{name}"'
-    ui_action_for_item_model_record: '%{action} "%{item_name}" for %{model} "%{name}"'
 
   number:
     # Used in number_with_delimiter()

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -26,7 +26,6 @@ en:
       at_least_2_selected: "At least 2 %{model} must be selected for %{action}"
       more_than_max_selected: "No more than %{max} %{model} can be selected for %{action}"
       no_records_selected: "No %{model} were selected to %{button}"
-      not_implemented: "Button not yet implemented"
       typ_not_implemented: "%{typ} Button not yet implemented"
       one_or_more_selected_for_task: "One or more %{model} must be selected to %{task}"
       record_gone: "%{model} no longer exists"

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -6,9 +6,6 @@ en:
     name: ManageIQ
   # Flash messages shown in the UI
   flash:
-    add:
-      added: '%{model} "%{name}" was added'
-
     authentication:
       error: "Sorry, the username or password you entered is incorrect."
       missing_role_or_group: "Login not allowed, User's %{model} is missing. Please contact the administrator"
@@ -29,7 +26,6 @@ en:
         search_reset: "The current search details have been reset"
       manage_desktops_cancelled: 'Manage Desktops was cancelled by the user'
       manage_desktops_saved: 'Manage Desktops was saved'
-      saved: '%{model} "%{name}" was saved'
       saved_for_class: 'Schema for %{model} "%{name}" was saved'
       user_assignment_cancelled: "Assignment was cancelled by the user"
       user_assignment_initiated: "Assignment changes initiated"

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -6,10 +6,6 @@ en:
     name: ManageIQ
   # Flash messages shown in the UI
   flash:
-    authentication:
-      error: "Sorry, the username or password you entered is incorrect."
-      missing_role_or_group: "Login not allowed, User's %{model} is missing. Please contact the administrator"
-
     copy:
       cancelled: 'Copy %{model} was cancelled by the user'
       copied: 'Copy selected %{model} was saved'
@@ -18,10 +14,6 @@ en:
       field_in_display_filter: "%{field} is currently being used in the Display Filter"
       field_must_be:
         numeric_greater_than_0: "%{field} must be numeric and greater than zero"
-      field_styling_error:
-        first: "Styling for '%{field}', first value is in error: "
-        second: "Styling for '%{field}', second value is in error: "
-        third: "Styling for '%{field}', third value is in error: "
       filter:
         search_reset: "The current search details have been reset"
       manage_desktops_cancelled: 'Manage Desktops was cancelled by the user'
@@ -52,10 +44,6 @@ en:
         selected_group_deleted: "All selected Groups were deleted"
         selected_user_deleted: "All selected Users were deleted"
       settings:
-        custom_logo_type: "Custom logo image must be a .png file"
-        custom_login_type: "Custom login image must be a .png file"
-        custom_logo_uploaded: 'Custom Logo file "%{filename}" uploaded'
-        custom_login_uploaded: 'Custom login file "%{filename}" uploaded'
         rhn:
           missing_information: "Please, fill in the form before saving."
 
@@ -83,12 +71,7 @@ en:
       error: "Credential validation returned: %{message}"
     license_invalid: "The CFME license is invalid, please upload a valid license file"
     no_host_defined: "No Host instances have been defined, press a button to Add or Discover one"
-    no_records_selected_to_be_disabled: 'No %{model} were selected to be disabled'
-    no_records_selected_to_be_enabled: 'No %{model} were selected to be enabled'
-    non_admin_cannot_access: "Non-admin users can not access the system until at least 1 VM/Instance has been discovered"
     priority_order_saved: "Priority Order was saved"
-    server_still_starting: "The CFME Server is still starting.  If this message persists, please contact your CFME administrator."
-    server_still_starting_admin: "The CFME Server is still starting, you have been redirected to the diagnostics page for problem determination"
 
     record:
       delete_for_1_record_initiated: "The delete for selected %{model} was initiated"
@@ -100,11 +83,6 @@ en:
       no_vms_for_record: '"%{name}": does not have any VMs'
       service_1_task: "This Service has been %{task}"
       service_task: "Selected Services have been %{task}"
-
-    schedule_queued_to_run: "The selected Schedule has been queued to run"
-    schedules_queued_to_run: "The selected Schedules have been queued to run"
-    selected_records_were_disabled: 'The selected %{model} were disabled'
-    selected_records_were_enabled: 'The selected %{model} were enabled'
 
   # Header text
   cell_header:

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -13,21 +13,13 @@ en:
     authentication:
       error: "Sorry, the username or password you entered is incorrect."
       missing_role_or_group: "Login not allowed, User's %{model} is missing. Please contact the administrator"
-      session_timed_out: "Session was timed out due to inactivity. Please log in again."
 
     automate:
-      automate_error: "Automation Error: "
       button_cleared: "Automate button %{btn_num} has been cleared"
       button_set: "Automate button %{btn_num} has been set to %{btn_txt}"
       custom_button_error: 'Error executing: "%{name}" '
       custom_button_executed: '"%{name}" was executed'
-      datastore_import_at_least_one: "You must select at least one namespace to import"
-      datastore_import_cancelled: "Datastore import was cancelled"
-      datastore_import_expired: "Error: Datastore import file upload expired"
       datastore_import_success: "Datastore import was successful.\nNamespaces updated/added: %{namespace_stats}\nClasses updated/added: %{class_stats}\nInstances updated/added: %{instance_stats}\nMethods updated/added: %{method_stats}"
-      reset_to_default: "All custom classes and instances have been reset to default"
-      simulation_started: "Automation Simulation has been run"
-      simulation_unavailable: 'Simulation unavailable: Required Class "System/Process" is missing'
 
     button:
       at_least_selected: "At least %{num} %{model} must be selected for %{action}"
@@ -41,9 +33,6 @@ en:
       task_does_not_apply_to_one_of_selected: "%{task} does not apply because you selected at least one %{model}"
       task_does_not_apply_to_model: "%{task} does not apply to selected %{model}"
 
-    capacity:
-      planning_reset: "Planning options have been reset by the user"
-      utilization_data_not_available: "No Utilization data available to generate planning results"
     copy:
       cancelled: 'Copy %{model} was cancelled by the user'
       copied: 'Copy selected %{model} was saved'
@@ -52,15 +41,11 @@ en:
         configured: "At least one %{field} must be configured"
         selected: "At least one %{field} must be selected"
         contain: "%{model} must contain at least one %{field}"
-      aborted: "Edit aborted!  CFME does not support the browser's back button or access from multiple tabs or windows of the same browser.  Please close any duplicate sessions before proceeding."
       cancelled: 'Edit of %{model} "%{name}" was cancelled by the user'
       cancelled_model: "Edit of %{model} was cancelled by the user"
       cancelled_for_class: 'Edit of schema for %{model} "%{name}" was cancelled by the user'
       cancelled_for_role: 'Edit of %{model} for role "%{role}" was cancelled by the user'
-      check_required: "At least one Selection must be checked"
       error_details: "Error details: %{error}"
-      exp_atom_error_1: "There is an error in the selected expression element, perhaps it was imported or edited manually."
-      exp_atom_error_2: "This element should be removed and recreated or you can report the error to your CFME administrator."
       field_character_not_allowed: '%{field} cannot contain "%{character}"'
       field_in_display_filter: "%{field} is currently being used in the Display Filter"
       field_required: "%{field} is required"
@@ -82,25 +67,16 @@ en:
         first: "Styling for '%{field}', first value is in error: "
         second: "Styling for '%{field}', second value is in error: "
         third: "Styling for '%{field}', third value is in error: "
-      field_syntax_error:
-        yaml: "Syntax error in YAML file: "
       filter:
-        current_search_reset: "The current search details have been reset"
         field_value_error: "%{field} Value Error: %{msg}"
         must_be_chosen: "A %{field} must be chosen to commit this expression element"
         must_be_entered: "A %{field} must be entered to commit this expression element"
-        must_be_integer: "The check count value must be an integer to commit this expression element"
         search_reset: "The current search details have been reset"
-        select_expression_element_type: "Select an expression element type"
       group_reorder: '%{model} Group Reorder'
       group_reorder_cancelled: '%{model} Group Reorder cancelled'
       group_reorder_saved: '%{model} Group Reorder saved'
-      host_vnc_range_required: "To configure the Host Default VNC Port Range, both start and end ports are required"
-      host_vnc_range_invalid: "The Host Default VNC Port Range ending port must be equal to or higher than the starting point"
       manage_desktops_cancelled: 'Manage Desktops was cancelled by the user'
       manage_desktops_saved: 'Manage Desktops was saved'
-      passwords_mismatch: "Password/Verify Password do not match"
-      reset: "All changes have been reset"
       saved: '%{model} "%{name}" was saved'
       saved_for_class: 'Schema for %{model} "%{name}" was saved'
       saved_for_role: '%{model} for role "%{role}" was saved'
@@ -109,15 +85,10 @@ en:
       user_assignment_cancelled: "Assignment was cancelled by the user"
       user_assignment_initiated: "Assignment changes initiated"
       user_unassignment_initiated: "User Un-Assignment initiated"
-      userid_pwd_required: "User ID must be entered if Password is entered"
       task_cancelled: "%{task} was cancelled by the user"
       task_saved: "%{task} saved"
-      timer_in_the_past: "Warning: This 'Run Once' timer is in the past and will never run as currently configured"
-      vnc_proxy_fields_required: "When configuring a VNC Proxy, both Address and Port are required"
 
       # flash.edit side by side selection box messages
-      only_some_fields_moved:
-        right: "One or more selected reports are not owned by your group, they cannot be moved"
       no_fields_to_move:
         bottom: "No %{field} were selected to move bottom"
         left: "No %{field} were selected to move left"
@@ -150,18 +121,13 @@ en:
         time_field: "%{tab} tab is not available unless at least 1 time field has been selected"
 
     configuration:
-      config_settings_saved: "Configuration settings saved"
-      default_filter_saved: "Default Filters saved successfully"
-      global_time_profile_cannot_edit: "Global Time Profile cannot be edited"
       global_time_profile_cannot_delete: '"%{name}": Global %{model} cannot be deleted'
       time_profile_in_use: '"%{name}": In use by %{rep_count}, cannot be deleted'
       ui_settings_saved_for_user: "User Interface settings saved for User %{user}"
-      ui_settings_saved_for_session: "User Interface settings saved for this session"
 
     image:
       type: "Custom Image must be a %{typ} file"
       locate_file: "Use the Browse button to locate a %{typ} image file"
-      removed: 'Custom Image successfully removed'
       uploaded: 'Custom Image file "%{filename}" successfully uploaded'
 
     datastore:
@@ -173,21 +139,11 @@ en:
 
     ops:
       diagnostics:
-        appliance_restarted: "CFME Appliance restart initiated successfully"
-        connection_broker_cache_cleared: "Connection Broker cache cleared successfully"
-        edit_log_depot_cancelled: "Edit Log Depot settings was cancelled by the user"
-        end_date_error: "End Date cannot be greater than Start Date"
         error_during_orphaned_record_delete: "Error during Orphaned Records delete for user %{userid}: "
         error_during_worker_restart: "Error during %{wtype} workers restart: "
-        log_collection_error: "Log collection error returned: "
-        log_collection_error_already_in_progress: "Cannot start log collection, a log collection is already in progress within this scope"
-        log_collection_error_no_server_started: "Cannot start log collection, requires a started server"
         log_collection_initiated: "Log collection for CFME %{object_type} %{name} has been initiated"
-        log_depot_saved: "Log Depot Settings were saved"
-        log_depot_validated: "Log Depot Settings were validated"
         orphaned_records_deleted: "Orphaned Records for userid %{userid} were successfully deleted"
         priority_set_for_server: 'CFME Server "%{name}" set as %{priority} for Role "%{role_description}"'
-        setting_priority_not_allowed: "Setting priority is not allowed for the selected item"
         task_initiated: "%{task} successfully initiated"
         task_not_allowed: "%{task} is not allowed for the selected item"
         workers_restarted: "%{wtype} workers restart initiated successfully"
@@ -200,51 +156,24 @@ en:
         selected_roles_not_deleted: "All selected Roles were either Read Only or in use by one or more Groups, none deleted"
         selected_group_deleted: "All selected Groups were deleted"
         selected_user_deleted: "All selected Users were deleted"
-        user_assigned_to_group: "A User must be assigned to a Group"
-        user_group_sequence_cancelled: "Edit Sequence of User Groups was cancelled by the user"
-        user_group_sequence_saved: "User Group Sequence was saved"
       settings:
         advanced_settings_saved: "%{filename} file saved"
-        apply_to_import: "Press the Apply button to import the good records into the CFME database"
-        analysis_affinity_saved: "Analysis Affinity was saved"
-        cu_saved: "Capacity and Utilization Collection settings saved"
-        changing_ui_worker_count: "Changing the UI Workers Count will immediately restart the webserver"
-        config_settings_saved: "Configuration settings saved"
         custom_logo_type: "Custom logo image must be a .png file"
         custom_login_type: "Custom login image must be a .png file"
         custom_logo_uploaded: 'Custom Logo file "%{filename}" uploaded'
         custom_login_uploaded: 'Custom login file "%{filename}" uploaded'
-        custom_url_and_description_required: "Custom Support URL and Description both must be entered."
-        custom_variable_type_to_import: "Choose the type of custom variables to be imported"
-        error_during_email: "Error during sending test email: "
         error_during_task: "Error during %{task}: "
-        db_settings_saved: "Database settings successfully saved, they will take effect upon CFME Server restart"
-        db_settings_validated: "CFME Database settings validation was successful"
         import_validation_complete: "Import validation complete: %{good_record}, %{bad_record}"
-        import_successful: "Records were successfully imported"
-        invalid_import: "No valid import records were found, please upload another file"
-        at_least_1_item_required: "At least one item must be entered to create Analysis Profile"
         locate_file: "Use the Browse button to locate %{typ} file"
         ldap_group_lookup: "%{field} must be entered to perform LDAP Group Look Up"
-        ldap_settings_validated: "LDAP Settings validation was successful"
-        amazon_settings_validated: "Amazon Settings validation was successful"
         worker_credentials_validated: "%{wtype} Credentials validated successfully"
         settings_saved: '%{typ} settings saved for CFME Server "%{name} [%{server_id}]" in Zone "%{zone}"'
-        smartproxy_settings_saved: "SmartProxy default settings saved"
         test_email_sent: 'The test email is being delivered, check "%{email}" to verify it was successful'
-        user_group_assign_role: "A User Group must be assigned a Role"
-        customer_info_saved: "Customer Information successfully saved"
-        customer_info_edit_cancelled: "Edit of Customer Information was cancelled"
-        no_server_selected: "No Server was selected"
         action_has_been_queued: "%{action} has been initiated for the selected Servers"
         error_when_queuing_action: "Error occured when queuing action: %{error}"
         rhn:
-          registration: "Registration"
-          check_for_updates: "Check for updates"
-          update: "Update"
           missing_information: "Please, fill in the form before saving."
       export_generation_error: "Export generation returned: Status [%{status}] Message [%{message}]"
-      tags_saved: "Tag edits were successfully saved"
 
     provision: 
       cancelled: "Provision %{model} was cancelled by the user"
@@ -252,98 +181,49 @@ en:
     policy:
       alert_profile_assignments_saved: 'Alert Profile "%{name}" assignments succesfully saved'
       task_cancelled_by_user: "%{task} cancelled by user"
-      import_not_available: "Import not available due to conflicts"
-      commit_import: "Press commit to Import"
       cancelled_import: "Import was cancelled by the user"
       condition_removed_from_policy: 'Condition "%{cond_name}" has been removed from Policy "%{pol_name}"'
-      policy_assignment_cancelled: "Edit policy assignments was cancelled by the user"
-      policy_assignment_saved: "Policy assignments successfully changed"
       policy_event_actions_saved: 'Actions for Policy Event "%{name}" were saved'
-      no_vm_match : "No VMs match the selection criteria"
-      simulation_generation_error: "Policy Simulation generation returned: "
       value_missing_for_field: "%{val} missing for %{field}"
-      valid_expression: "A valid expression must be present"
 
     report:
-      double_click_folder_name: "Double Click on 'New Folder' to edit"
-      folder_contains_other_reports: "Can not delete folder, one or more reports in the selected folder are not owned by your group"
       generation_error: "Report generation returned: Status [%{status}] Message [%{message}]"
-      has_widgets_cant_delete: "Report cannot be deleted if it's being used by one or more Widgets"
-      no_records_found: "No records found for this report"
-      no_schedules_selected_to_run: 'No Report Schedules were selected to be Run now'
-      not_authorized_for_user: "Report is not authorized for the logged in user"
       not_found_schedule_failed: 'Saved Report "%{name}" not found, Schedule may have failed'
       preview_error: "Report preview generation returned: Status [%{status}] Message [%{message}]"
-      queued: "Report has been successfully queued to run"
       saved_report_doesnt_exist: "Saved Report no longer exists"
       selected_no_longer_exists: "Selected %{typ} Report no longer exists"
-      sort_required_for_chart: "Report can not be saved unless sort field has been configured for Charts"
-      widget_generation_error: "Widget content generation error: "
-      widget_generation_started: "Content generation for this Widget has been initiated"
-      import_file_empty_error: "Import file cannot be empty"
-      widget_import_cancelled: "Widget import cancelled"
-      widget_import_successful: "Widgets imported successfully"
-      widget_import_file_upload_expired: "Error: Widget import file upload expired"
 
     request:
-      cannot_create_workflow: 'Cannot create Request Info, error: '
       error_during_sysprep_upload: 'Error during Sysprep "%{name}" file upload: '
-      locate_upload_file: "Use the Browse button to locate an Upload file"
       request_approved_denied: 'Request "%{name}" was %{task}'
       request_resubmitted: "%{typ} Request was re-submitted, you will be notified when your %{title} are ready"
       request_submitted: "%{typ} Request was Submitted, you will be notified when your %{title} are ready"
-      st_no_dialog_available: "No Ordering Dialog is available"
       st_request_submitted: "%{typ} Request was Submitted"
       sysprep_file_upload: 'Sysprep "%{filename}" upload was successful'
       task_cancelled: "Request %{task} was cancelled by the user"
 
     service_dialog:
       cannot_import_duplicate: "Dialog '%{label}' already exists and was not imported"
-      import_cancelled: "Service dialog import cancelled"
-      import_file_upload_expired: "Error: ImportFileUpload expired"
-      import_successful: "Service dialogs imported successfully"
-      invalid_dialog_field_type: "Error during upload: one of the DialogField types is not supported"
-      non_dialog_yaml: "Error during upload: incorrect Dialog format, only service dialogs can be imported"
-      unsupported_import_format: "Error: the file uploaded is not of the supported format"
-      upload_successful: "Import file was uploaded successfully"
 
     smartproxy:
-      delete_older_not_completed: "The selected job no longer exists, Delete all older Tasks was not completed"
       deploy_smaprtproxy_cancelled: 'Deploy of SmartProxy to Host "%{name}" was cancelled'
       deploy_smaprtproxy_initiated: 'Deploy of SmartProxy to Host "%{name}" was initiated'
-      host_not_powered_on: "The selected SmartProxy can not be managed because the Host is not powered on"
-      host_os_unknown: "Host OS is unknown or there are no available SmartProxy builds for the Host's OS"
-      finish_task_cancel: "Finished Task cannot be cancelled"
-      ldap_info_retrieval_error: "Error retrieving LDAP info: "
-      log_unavailable: "No log available, press Retrieve to get the SmartProxy log"
-      only_1_selected_for_deployment: "Only 1 SmartProxy can be selected for build deployment"
       no_smartproxy_available: 'There are no available SmartProxies to deploy on Host "%{name}"'
-      new_settings_activated: "New settings have been activated"
-      retrieve_log_error: "Retrieve log returned: "
       retrieve_log_started: 'SmartProxy "%{name}" log retrieval has been started . . . refresh page to view the log'
-      selected_task_cancelled: "The selected Task was cancelled"
-      settings_activation_error: "Settings activation returned: "
 
     vm:
       add_vm_to_service_cancelled: 'Add VM "%{name}" to a Service was cancelled by the user'
       added_to: '%{model} "%{name}" successfully added to Service "%{to_name}"'
       create_snapshot_started: 'Create Snapshot for %{model} "%{name}" was started'
-      no_vm_selected_to_delete_blackbox: "No virtual machines were selected to delete Virtual BlackBoxes on"
       no_blackbox: '"%{name}": VM does not have BlackBox.'
-      no_child_vm_to_move_right: "No child VMs to move right, no action taken"
       ownership_saved: "Ownership saved for selected %{object_types}"
-      parent_child_cannot_be_same: "Parent VM can not be one of the child VMs"
       power_off_to_delete_blackbox: '"%{name}": VM needs to be in a Powered Off state to delete the BlackBox.'
-      reconfigure_atleast_1_option: "At least one option must be selected to reconfigure"
-      reconfigure_cancel: "VM Reconfigure Request was cancelled by the user"
       retirement_removed: "Retirement %{date_text} removed"
       retirement_set: "Retirement %{date_text} set to %{rdate}"
-      reconfigure_saved: "VM Reconfigure Request was saved"
       vm_removed_from_service: 'VM successfully removed from service "%{name}"'
 
     already_exists: '%{model} "%{name}" already exists'
     already_taken: "%{field} has already been taken"
-    browse_to_upload_import: "Locate and upload a file to start the import process"
     cant_delete_current: "Current %{model} \"%{name}\" cannot be deleted"
     cant_delete_default: "Default %{model} \"%{name}\" cannot be deleted"
     cant_delete_read_only: "Read Only or %{model} in use by one or more %{in_use_by} can not be deleted"
@@ -356,44 +236,25 @@ en:
     cannot_delete: '"%{field}" %{model} can not be deleted'
     credentials:
       error: "Credential validation returned: %{message}"
-      validated: "Credential validation was successful"
       cancelled: "Edit of credentials for selected %{model} was cancelled by the user"
-      saved: "Credentials/Settings saved successfully"
-    class_schema_sequence_cancelled: "Edit of Class Schema Sequence was cancelled by the user"
-    class_schema_sequence_saved: "Class Schema Sequence was saved"
     console_access_failed: "Console access failed: %{reason}"
-    data_validation_success: "Data validated successfully"
-    db_sequence_cancelled: "Edit of Dashboard Sequence was cancelled by the user"
-    db_sequence_saved: "Dashboard Sequence was saved"
     discovery_returned_error: "%{model} Discovery returned: "
     error_during: "Error during '%{task}': "
     error_with_stat_message: "Error during %{task}: Status [%{status}] Message [%{message}]"
     error_on_line: "Error on line %{line_num}: %{err_txt}"
-    error_building_timeline: "Error building timeline "
-    evm_log_unavailable: "Logs for this CFME Server are not available for viewing"
-    import_success: "Import file was uploaded successfully"
     license_invalid: "The CFME license is invalid, please upload a valid license file"
-    locate_import_file: "Use the Browse button to locate an Import file"
     no_host_defined: "No Host instances have been defined, press a button to Add or Discover one"
     no_model_found_for_nodetype: "No Class found for explorer tree node type '%{nodetype}'"
     no_nodetype_found_for_model: "No explorer tree node type found for '%{model}'"
-    no_usage_data_found: "No usage data found for specified options"
-    no_timeline_events_found: "No events available for this timeline"
-    no_timeline_records_found: "No records found for this timeline"
     no_records_selected_for_delete: 'No %{model} were selected for deletion'
     no_records_selected_for_task: 'No %{model} were selected for %{task}'
     no_records_selected_to_be_disabled: 'No %{model} were selected to be disabled'
     no_records_selected_to_be_enabled: 'No %{model} were selected to be enabled'
     no_records_selected_to_be_marked: 'No %{model} were selected to be marked as %{action}'
-    no_utilization_data_available: "No Utilization data available"
     non_admin_cannot_access: "Non-admin users can not access the system until at least 1 VM/Instance has been discovered"
-    press_back_button: "Press your browser's Back button or click a tab to continue"
-    priority_order_cancelled: "Edit of Priority Order was cancelled by the user"
     priority_order_saved: "Priority Order was saved"
     record_no_longer_exists: "%{record_name} no longer exists in the database"
     record_not_authorized_for_user: "You are not authorized to view %{record_name}"
-    search_not_found: "The selected Filter record was not found"
-    search_requires_input: "The selected Filter can not be set as Default because it requires user input"
     server_still_starting: "The CFME Server is still starting.  If this message persists, please contact your CFME administrator."
     server_still_starting_admin: "The CFME Server is still starting, you have been redirected to the diagnostics page for problem determination"
 
@@ -415,11 +276,7 @@ en:
       was_loaded: "%{model} \"%{name}\" was successfully loaded"
 
     repository:
-      default_repository_doesnt_exist: "The Default Repository SmartProxy no longer exists, contact your CFME Administrator"
-      default_repository_invalid: "The Default Repository SmartProxy is not valid, contact your CFME Administrator"
       default_repository_not_running: 'The Default Repository SmartProxy, "%{name}", is not running, contact your CFME Administrator'
-      no_default_configured: "No Default Repository SmartProxy is configured, contact your CFME Administrator"
-      path_invalid: "Path must be a valid reference to a UNC location"
 
     service:
       no_service_selected_to_task: "No Services were selected to %{task}"
@@ -431,10 +288,7 @@ en:
     all_not_in_current_region: "All selected %{label} are not in the current region"
     count_not_in_current_region: "%{label} are not in the current region and will be skipped"
     error_during_delete_with_count: "Error during %{count_model} delete from the CFME Database"
-    error_no_longer_exists: "Error: Record no longer exists in the database"
-    invalid_button_action: "Invalid button action."
     not_in_current_region: "The selected %{label} is not in the current region"
-    refresh_cu_data: "Refresh of recent C&U data has been initiated"
     schedule_queued_to_run: "The selected Schedule has been queued to run"
     schedules_queued_to_run: "The selected Schedules have been queued to run"
     selected_record_deleted: 'The selected %{model} was deleted'
@@ -444,8 +298,6 @@ en:
     selected_records_were_enabled: 'The selected %{model} were enabled'
     selected_records_were_marked: 'The selected %{model} were marked as %{action}'
     task_cancelled: "%{task} was cancelled by the user"
-    unknown_error: "Unknown error has occurred"
-    user_not_authorized: "The user is not authorized for this task or item."
 
   # Header text
   cell_header:
@@ -465,7 +317,6 @@ en:
     edit_tags: 'Edit Tags for %{model}'
     evm_relationship: 'Edit CFME Server Relationship for %{model} "%{name}"'
     filtered_model_records: '%{model} - Filtered by "%{filter}"'
-    import_export_reports: "Import / Export"
     miq_request_new: 'Provision %{model}'
     model: "%{model}"
     model_assignments: ' %{model} Assignments'

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -110,19 +110,10 @@ en:
 
   # Header text
   cell_header:
-    adding_model_record: "Adding a new %{model}"
-    editing_model_record: 'Editing %{model} "%{name}"'
     evm_relationship: 'Edit CFME Server Relationship for %{model} "%{name}"'
-    filtered_model_records: '%{model} - Filtered by "%{filter}"'
     model: "%{model}"
     model_for_record: '%{model} for "%{name}"'
-    model_record: '%{model} "%{name}"'
-    model_record_for_group: '%{model} for %{group} "%{name}"'
     name: '"%{name}"'
-    task_model_record: '%{task} %{model} "%{name}"'
-    type_of_model_record: '%{typ} %{model} "%{name}"'
-    type_of_model_record_current: '%{typ} %{model} "%{name}" (current)'
-    ui_action_for_model_record: '"%{action}" for %{model} "%{name}"'
 
   number:
     # Used in number_with_delimiter()

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -31,18 +31,6 @@ en:
       user_assignment_initiated: "Assignment changes initiated"
       user_unassignment_initiated: "User Un-Assignment initiated"
 
-      # flash.edit side by side selection box messages
-      no_fields_to_move:
-        bottom: "No %{field} were selected to move bottom"
-        left: "No %{field} were selected to move left"
-        right: "No %{field} were selected to move right"
-        up: "No %{field} were selected to move up"
-        down: "No %{field} were selected to move down"
-        to_the_top: "No %{field} were selected to move to the top"
-        to_the_bottom: "No %{field} were selected to move to the bottom"
-        top: "No %{field} were selected to move top"
-        sync: "No %{field} selected to set to Synchronous"
-        async: "No %{field} selected to set to Asynchronous"
       no_fields_moved:
         left: "No %{field} were moved to the left"
         up: "No %{field} were moved up"

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -103,8 +103,6 @@ en:
 
     schedule_queued_to_run: "The selected Schedule has been queued to run"
     schedules_queued_to_run: "The selected Schedules have been queued to run"
-    selected_record_deleted: 'The selected %{model} was deleted'
-    selected_records_deleted: 'The selected %{model} were deleted'
     selected_records_were_disabled: 'The selected %{model} were disabled'
     selected_records_were_enabled: 'The selected %{model} were enabled'
 


### PR DESCRIPTION
This pull requests removed flash messages from en.yml which were converted
into a gettext form with commits 80fbeeceecf0701ebebdabc6acd484df86af64ea and
3293a52c3ee1d2bff64e56aab6e0864c7c763ceb

Additionaly, this pull requests converts into a gettext form some of the flash messages
which were not replaced completely throughout our code.

Fixes #1290 