### PR TITLE
Remove call to Form.Element.EventObserver from miqObserveCheckboxes

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -1010,14 +1010,12 @@ function miqObserveCheckboxes() {
   $j('[data-miq_observe_checkbox]').each(function(index) {
     var parms = $j.parseJSON(this.getAttribute('data-miq_observe_checkbox'));
     var url = parms.url;
-    el = $(this.id);  // Get the prototype object for this element (IE7 workaround)
-    el.stopObserving();
-    new Form.Element.EventObserver(this.id, function(element, value) {
-      var sparkleOn = this.element.getAttribute('data-miq_sparkle_on'); // Grab miq_sparkle settings
-      var sparkleOff = this.element.getAttribute('data-miq_sparkle_off');
+    var el = $j('#' + this.id);
+    el.unbind('change')
+    el.change(function() {
       miqJqueryRequest(url, {beforeSend: true,
         complete: true,
-        data:element.id + '=' + encodeURIComponent(value),
+        data:this.id + '=' + encodeURIComponent(el.prop('checked') ? 1 : null),
         no_encoding: true
       });
     })


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/1192

@dclarizio, @h-kataria please review.