### PR TITLE
Fixed styling for the dynatree nodes in the Entry point popups

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_dynatree.js
+++ b/vmdb/app/assets/javascripts/cfme_dynatree.js
@@ -128,6 +128,12 @@ function cfme_dynatree_node_add_class(treename, key, klass){
   node.render();
 }
 
+function cfme_dynatree_node_remove_class(treename, key){
+  node = $j("#" + treename + "box").dynatree('getTree').getNodeByKey(key);
+  node.data.addClass = "";
+  node.render();
+}
+
 function cfme_dynatree_redraw(treename){
   $j("#" + treename + "box").dynatree('getTree').redraw();
 }
@@ -464,4 +470,12 @@ function miqMenuChangeRow(grid,action,click_url) {
       break;
   }
   return ret;
+}
+
+function cfmeSetAETreeNodeSelectionClass(id, prevId, bValidNode) {
+  if(prevId != "")
+    cfme_dynatree_node_remove_class("automate_tree", prevId);
+
+  if(bValidNode == "true")
+    cfme_dynatree_node_add_class("automate_tree", id, "ae-valid-node");
 }

--- a/vmdb/app/assets/javascripts/dynatree_1.2.4/skin-cfme/ui.dynatree.css.erb
+++ b/vmdb/app/assets/javascripts/dynatree_1.2.4/skin-cfme/ui.dynatree.css.erb
@@ -427,9 +427,9 @@ span.dynatree-selected a
   color: #fff !important;
 }
 
-fieldset span.dynatree-active a  /*active styling for Entry Point pop up*/
+ span.ae-valid-node a  /*active styling for Entry Point pop up*/
 {
-  font-family: OpenSansSemibold,Arial,Helvetica,sans-serif;
+	color: #fff;
 }
 
 span.dynatree-node:hover
@@ -580,7 +580,8 @@ span.dynatree-drop-target.dynatree-drop-after a
 }
 
 /* show item as selected in specific non-explorer trees */
-span.dynatree-cfme-active a
+span.dynatree-cfme-active a,
+span.ae-valid-node a
 {
     background-color: #40a0ce !important;
     color: white !important; /* @ IE6 */

--- a/vmdb/app/assets/stylesheets/template.css.erb
+++ b/vmdb/app/assets/stylesheets/template.css.erb
@@ -330,7 +330,7 @@ ul#searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px; bac
 /* Automate Specific */
 .checkall { padding: 0 0 7px 7px;} /*styling for automate (Check All) */
 #automate_tree_div { position: absolute; z-index: 49; left:100px; padding: 10px; overflow-y: none; background: #fff;}
-#automate_tree_box { width: 550px; height:300px; top: 43px; padding: 15px 5px 5px 0;color:#000;overflow-Y:scroll}
+#automate_treebox { width: 550px; height:300px; top: 43px; padding: 15px 5px 5px 0;color:#000;overflow-Y:scroll}
 /* End Automate Specific */
 
 /* Chargeback Specific */

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -516,6 +516,7 @@ class CatalogController < ApplicationController
   def ae_tree_select_discard
     ae_tree_key = get_ae_tree_edit_key(params[:typ])
     @edit = session[:edit]
+    @edit[:new][params[:typ]] = nil
     @edit[:new][ae_tree_key] = ''
     #build_ae_tree(:automate, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
     render :update do |page|

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1691,6 +1691,10 @@ module ApplicationHelper
     return js
   end
 
+  def javascript_for_ae_node_selection(id, prev_id, select)
+    "cfmeSetAETreeNodeSelectionClass('#{id}', '#{prev_id}', '#{select ? true : false}');".html_safe
+  end
+
   # Generate lines of JS <text> for render page, replacing "~" with the <sub_array> elements
   def js_multi_lines(sub_array, text)
     js_array = []

--- a/vmdb/app/views/catalog/_form_basic_info.html.haml
+++ b/vmdb/app/views/catalog/_form_basic_info.html.haml
@@ -50,7 +50,7 @@
             %tr
               %td
                 = text_field_tag("fqname", @edit[:new][:fqname],
-                  :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide");')
+                  :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
               %td
                 - display = @edit[:new][:fqname] != "" ? "" : "display:none"
                 #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
@@ -72,7 +72,7 @@
               %td
                 = text_field_tag("reconfigure_fqname",
                   @edit[:new][:reconfigure_fqname],
-                  :onFocus => 'miqShowAE_Tree("reconfigure")',
+                  :onFocus => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
                   "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
               %td
                 #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
@@ -93,7 +93,7 @@
             %tr
               %td
                 = text_field_tag("retire_fqname", @edit[:new][:retire_fqname],
-                  :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide");')
+                  :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
               %td
                 #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
                   = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => "Remove this Retirement Entry Point"),

--- a/vmdb/app/views/layouts/_ae_tree_select.html.erb
+++ b/vmdb/app/views/layouts/_ae_tree_select.html.erb
@@ -4,9 +4,9 @@
   <%= hidden_field_tag(:ignore_form_changes) %>
 
     <p class="legend">Select Entry Point <%=entry_point%></p>
-    <div id="automate_tree_box"></div>
+    <div id="automate_treebox"></div>
     <%= render(:partial => "layouts/dynatree",
-               :locals => {:tree_id             => "automate_tree_box",
+               :locals => {:tree_id             => "automate_treebox",
                            :tree_name           => "automate_tree",
                            :json_tree           => @temp[:automate_tree],
                            :onclick             => "cfmeOnClick_SelectAETreeNode",

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -116,7 +116,7 @@
             %td.wide
               = text_field_tag('field_entry_point',
                 @edit[:field_entry_point],
-                :onFocus => 'miqShowAE_Tree("field_entry_point");')
+                :onFocus => 'miqShowAE_Tree("field_entry_point");miqButtons(false, "automate");')
           %tr
             %td.key=_('Show Refresh Button')
             %td


### PR DESCRIPTION
```<fieldset>``` was removed when we added Patternfly buttons to the form, therefore the dynatree CSS that was using fieldset had to be fixed.

#1292