### PR TITLE
Removed redundant setSortImgState call against DhtmlxGrid object.

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -1449,8 +1449,6 @@ class CatalogController < ApplicationController
 
     presenter[:osf_node] = x_node
 
-    presenter[:extra_js] << "if (typeof gtl_list_grid != 'undefined') gtl_list_grid.setSortImgState(true, 3, 'asc');"
-
     # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
     presenter[:extra_js] << "miq_changes = undefined;"
     presenter[:extra_js] << "miqOneTrans = 0;"                  #resetting miqOneTrans when tab loads


### PR DESCRIPTION
Don't need to call setSortImgState on a DhtmlxGrid object when x_gtl partial is being replaced, this was causing an issue in IE, was preventing Catalog explorer screens to load in IE.

https://bugzilla.redhat.com/show_bug.cgi?id=1180252
https://bugzilla.redhat.com/show_bug.cgi?id=1179503

@epwinchell can you test this in IE.
@dclarizio please review/test