### PR TITLE
Allow rspec options from `.rspec` to be overridden

### DIFF
--- a/vmdb/lib/tasks/evm_test_helper.rb
+++ b/vmdb/lib/tasks/evm_test_helper.rb
@@ -6,8 +6,8 @@ module EvmTestHelper
   AUTOMATION_SPECS  = FileList['spec/automation/**/*_spec.rb']
 
   def self.init_rspec_task(t, rspec_opts = [])
-    rspec_opts_file = ".rspec#{"_ci" if ENV['CI']}"
-    t.rspec_opts = ['--options', "\"#{Rails.root.join(rspec_opts_file)}\""] + rspec_opts
+    rspec_opts = ['--options', "\"#{Rails.root.join(".rspec_ci")}\""] + rspec_opts if ENV['CI']
+    t.rspec_opts = rspec_opts
     t.verbose = false
   end
 


### PR DESCRIPTION
Defaults are defined in `.rspec`
- If you specify `--options .rspec`, then only `.rspec` is used.

So developers can not customize it.

- If you don’t specify `--options .rspec`, `.rspec` will still be used, but
other files like `.rspec-local` will override.

This change passes in `--options .rspec_ci` for ci systems,
but does not pass it in for developers, since it is not needed.

/cc @Fryguy @jrafanie 