### PR TITLE
remove some Psych monkey patches

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -37,6 +37,7 @@ gem "rufus-lru",            "~>1.0.3",       :require => false
 gem "uuidtools",            "~>2.1.3",       :require => false
 gem "sass",                 "3.1.20",        :require => false
 gem "trollop",              "~>1.16.2",      :require => false
+gem "psych",                "~>2.0.10"
 
 # qpid group is needed to gate the inclusion of qpid_messaging gem on platforms
 # where the qpid-cpp-client-devel package is not available.  This includes

--- a/lib/spec/util/extensions/miq-yaml_spec.rb
+++ b/lib/spec/util/extensions/miq-yaml_spec.rb
@@ -3,88 +3,21 @@ require "spec_helper"
 $:.push(File.expand_path(File.join(File.dirname(__FILE__), %w{.. .. .. util extensions})))
 require 'miq-yaml'
 
-# Class to test complex key yaml dump patch
-class BaseballTeam
-  attr_accessor :name
-  def initialize(name); self.name = name; end
-end
-
 # Subclass of Hash to test instance variables support patch
 class SubHash < Hash
   attr_accessor :val
 end
 
 describe YAML do
-  it 'Hash#to_yaml without instance variables' do
-    h = Hash.new
-    h.merge!(:a => 1, :b => 2)
-
-    y = YAML.dump(h)
-
-    h2 = YAML.load(y)
-    h2.should be_instance_of Hash
-    h2.should == h
-  end
-
-  it 'SubHash#to_yaml with instance variables' do
-    h = SubHash.new
-    h.merge!(:a => 1, :b => 2)
-    h.val = 3
-
-    y = YAML.dump(h)
-
-    h2 = YAML.load(y)
-    h2.should be_instance_of SubHash
-    h2.should == h
-    h2.val.should == 3
-  end
-
-  context "with Hash with a complex key" do
-    before(:each) do
-      @hash = {BaseballTeam.new("New York Mets") => "national"}
-
-      @expected1 = <<-EOL
----
-? !ruby/object:BaseballTeam
-  name: New York Mets
-: national
-EOL
-
-      @expected2 = <<-EOL
----
-- ? !ruby/object:BaseballTeam
-    name: New York Mets
-  : national
-EOL
-
-      @expected3 = <<-EOL
----
-- teams:
-    ? !ruby/object:BaseballTeam
-      name: New York Mets
-    : national
-EOL
-
-    end
-
-    it 'Hash#to_yaml' do
-      @hash.to_yaml.should == @expected1
-    end
-
-    it 'Hash#to_yaml(StringIO)' do
-      string_io = StringIO.new
-      @hash.to_yaml(string_io)
-      string_io.rewind
-      string_io.read.should == @expected1
-    end
-
-    it 'Array#to_yaml with that Hash' do
-      # Test when the complex key is dumped on a line with the "-" from the Array
-      [@hash].to_yaml.should == @expected2
-    end
-
-    it 'Array#to_yaml with that Hash deep embedded' do
-      [{"teams" => @hash}].to_yaml.should == @expected3
-    end
+  it 'loads the old ivar format' do
+    hash = YAML.load <<-eoyml
+--- !ruby/hash:SubHash
+:a: 1
+:b: 2
+__iv__@val: 3
+eoyml
+    hash[:a].should == 1
+    hash[:b].should == 2
+    hash.val.should == 3
   end
 end

--- a/lib/util/extensions/miq-yaml.rb
+++ b/lib/util/extensions/miq-yaml.rb
@@ -5,28 +5,6 @@ require 'yaml'
 
 module Psych
   module Visitors
-    class YAMLTree
-      def visit_Hash o
-        tag      = o.class == ::Hash ? nil : "!ruby/hash:#{o.class}"
-        implicit = !tag
-
-        register(o, @emitter.start_mapping(nil, tag, implicit, Psych::Nodes::Mapping::BLOCK))
-
-        o.each do |k,v|
-          accept k
-          accept v
-        end
-
-        #### Add in the instance variables, see https://github.com/tenderlove/psych/issues/43
-        o.instance_variables.each do |m|
-          accept "__iv__#{m}"
-          accept o.instance_variable_get(m)
-        end
-
-        @emitter.end_mapping
-      end
-    end
-
     class ToRuby
       def revive_hash hash, o
         @st[o.anchor] = hash if o.anchor
@@ -46,6 +24,7 @@ module Psych
               hash[key] = accept(v)
             end
 
+          # We need to migrate all old YAML before we can remove this
           #### Reapply the instance variables, see https://github.com/tenderlove/psych/issues/43
           elsif key.to_s[0..5] == "__iv__"
             hash.instance_variable_set(key.to_s[6..-1], accept(v))


### PR DESCRIPTION
I fixed the instance variable bug in Psych, so we can remove some monkey
patches.  We still need to keep the monkey patch that revives ivars
using the special key because there could be some YAML stored in a
database or something that still uses that.