### PR TITLE
Set HTTP verb to GET for jqplot chart ajax requests.

### DIFF
--- a/vmdb/app/helpers/jqplot_helper.rb
+++ b/vmdb/app/helpers/jqplot_helper.rb
@@ -5,6 +5,7 @@ module JqplotHelper
 jQuery(document).ready(function($) {
     $j.ajax({
       url:      "#{url}",
+      type:     "get",
       dataType: "json",
       success:  function(chart) {
         $j.jqplot('#{chart_id}', chart.data, jqplot_process_options(chart.options));


### PR DESCRIPTION
Fixes regression caused by bd5d35c614e63601c154c0fc62dfff4fb385caa1.