### PR TITLE
Removes redundant call EmsOpenstack.find_by_id

### DIFF
--- a/vmdb/app/models/ems_event/parsers/openstack.rb
+++ b/vmdb/app/models/ems_event/parsers/openstack.rb
@@ -5,8 +5,6 @@ module EmsEvent::Parsers::Openstack
 
     $log.debug("#{log_header} event: [#{event[:content]["event_type"]}]") if $log && $log.debug?
 
-    ems = EmsOpenstack.find_by_id(ems_id)
-
     # attributes that are common to all notifications
     event_hash = {
       :event_type     => event[:content]["event_type"],


### PR DESCRIPTION
Return value from EmsOpenstack.find_by_id in
EmsEvent::Parsers::Openstack is not stored or used in any way.

find_by_* finder methods do not raise anything when record does not exist
so aside from connecting to db and writing some sql into logs this call does
nothing.