### PR TITLE
Don’t display 0 when there is no region

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -220,7 +220,7 @@ To modify the configuration, use a web browser to access the management page.
         Timezone:          #{timezone}
         Local Database:    #{ApplianceConsole::Utilities.pg_status}
         EVM Database:      #{dbtype} @ #{dbhost}
-        Database/Region:   #{database} / #{region || 0}
+        Database/Region:   #{database} / #{region}
         External Auth:     #{ExternalHttpdAuthentication.config_status}
         EVM Version:       #{version}
         EVM Console:       https://#{ip}


### PR DESCRIPTION
The appliance console summary screen for an appliance with no database still displays a region of 0. This makes it look like it has a database (with region 0) but in truth there is none.

This is confusing for support.

/cc @dajohnso @jcarter12 @jdeubel I seem to recall that one of you wanted this. Am I recalling correctly? thnx