### PR TITLE
Make more stuff work in simulate_queue_worker.

### DIFF
--- a/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -33,6 +33,7 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
     $log.info("#{log_prefix} Stopping all active workers")
 
     @quiesce_started_on = Time.now.utc
+    @worker_monitor_settings ||= {}
     @quiesce_loop_timeout = @worker_monitor_settings[:quiesce_loop_timeout] || 5.minutes
     worker_monitor_poll = (@worker_monitor_settings[:poll] || 1.seconds).to_i_with_method
 


### PR DESCRIPTION
When playing with VNC console from developer setup I hit into @worker_monitor_settings being `nil`.

This just makes developer's job easier by allowing more stuff to be worker stuff being simulated from rails console.