### PR TITLE
A DatabaseBackup is linked to a region via it's ID range.

### DIFF
--- a/vmdb/app/models/database_backup.rb
+++ b/vmdb/app/models/database_backup.rb
@@ -19,9 +19,7 @@ class DatabaseBackup < ActiveRecord::Base
   end
 
   def self.backup(options)
-    bup = self.new
-    MiqRegion.my_region.database_backups << bup
-    bup.backup(options)
+    self.create.backup(options)
   end
 
   def backup(options)


### PR DESCRIPTION
It's not required to link them explicitly since the region's ID range will tell us what region a DatabaseBackup resides.

Fixes:
DEPRECATION WARNING: You're trying to create an attribute `miq_region_id'. Writing arbitrary attributes on a model is deprecated. Please just use `attr_writer` etc. (called from backup at ...app/models/database_backup.rb:23)

See also b79c8d203b23a91847f019930c3251ef9b005286