### PR TITLE
Reset Logging's shared instance variable to avoid test contamination.

### DIFF
--- a/lib/spec/appliance_console/logging_spec.rb
+++ b/lib/spec/appliance_console/logging_spec.rb
@@ -12,6 +12,9 @@ describe ApplianceConsole::Logging do
 
   before do
     subject.logger = nil
+    # ApplianceConsole::Logging's interactive flag uses a shared module instance variable
+    # It probably shouldn't be shared.  Hacky fix is to reset the flag back to true.
+    subject.interactive = true
   end
 
   it "should not have default logger when setting" do


### PR DESCRIPTION
ApplianceConsole::Logging's interactive flag uses a shared module instance variable
It probably shouldn't be shared.  Hacky fix is to reset the flag back to true.

This test, when run first, reset's the interactive flag to false:
https://github.com/jrafanie/manageiq/blob/60baad55f45a3de437a0b2a413a1e126774ff2dc/lib/spec/appliance_console/database_configuration_spec.rb#L33

Failing test recreation:
bundle exec rspec ./spec/appliance_console/database_configuration_spec.rb:32 ./spec/appliance_console/logging_spec.rb:41

Isolated using: https://github.com/shelbyd/rspec-bisect