### PR TITLE
just return a hash for the in-memory session

### DIFF
--- a/vmdb/config/initializers/session_memory_store.rb
+++ b/vmdb/config/initializers/session_memory_store.rb
@@ -14,7 +14,6 @@ module ActionDispatch
       def get_session(env, session_id)
         session_id ||= generate_sid
         session = GLOBAL_HASH_TABLE[session_id] || {}
-        session = Rack::Session::Abstract::SessionHash.new(self, env).merge(session)
         [session_id, session]
       end
 


### PR DESCRIPTION
The session middleware will construct a session hash for us.  Worse,
when we try to construct the session hash in this method, it will cause
an infinite loop in Rails 4!