### PR TITLE
save_inventory: Hash nil checks 1

### DIFF
--- a/vmdb/app/models/advanced_setting.rb
+++ b/vmdb/app/models/advanced_setting.rb
@@ -9,8 +9,7 @@ class AdvancedSetting < ActiveRecord::Base
 
   def self.add_missing_elements(parent, xmlNode, findPath)
     hashes = xml_to_hashes(xmlNode, findPath)
-    return if hashes.nil?
-    EmsRefresh.save_advanced_settings_inventory(parent, hashes)
+    EmsRefresh.save_advanced_settings_inventory(parent, hashes) if hashes
   end
 
   def self.xml_to_hashes(xmlNode, findPath)

--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -232,25 +232,21 @@ module EmsRefresh::SaveInventory
   end
 
   def save_guest_applications_inventory(parent, hashes)
-    return if hashes.nil?
     deletes = parent.guest_applications(true).dup
     self.save_inventory_multi(:guest_applications, GuestApplication, parent, hashes, deletes, [:arch, :typename, :name, :version])
   end
 
   def save_advanced_settings_inventory(parent, hashes)
-    return if hashes.nil?
     deletes = parent.advanced_settings(true).dup
     self.save_inventory_multi(:advanced_settings, AdvancedSetting, parent, hashes, deletes, :name)
   end
 
   def save_patches_inventory(parent, hashes)
-    return if hashes.nil?
     deletes = parent.patches(true).dup
     self.save_inventory_multi(:patches, Patch, parent, hashes, deletes, :name)
   end
 
   def save_os_processes_inventory(os, hashes)
-    return if hashes.nil?
     deletes = os.processes(true).dup
     self.save_inventory_multi(:processes, OsProcess, os, hashes, deletes, :pid)
   end
@@ -286,7 +282,6 @@ module EmsRefresh::SaveInventory
   end
 
   def save_filesystems_inventory(parent, hashes)
-    return if hashes.nil?
     deletes = parent.filesystems(true).dup
     self.save_inventory_multi(:filesystems, Filesystem, parent, hashes, deletes, :name)
   end
@@ -309,7 +304,6 @@ module EmsRefresh::SaveInventory
   end
 
   def save_event_logs_inventory(os, hashes)
-    return if hashes.nil?
     deletes = os.event_logs(true).dup
     self.save_inventory_multi(:event_logs, EventLog, os, hashes, deletes, :uid)
   end

--- a/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
@@ -67,7 +67,7 @@ module EmsRefresh::SaveInventoryCloud
       self.send("save_#{k}_inventory", ems, hashes[k], target)
     end
 
-    link_volumes_to_base_snapshots(hashes[:cloud_volumes])
+    link_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
 
     ems.save!
     hashes[:id] = ems.id
@@ -380,7 +380,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def link_volumes_to_base_snapshots(hashes)
-    return if hashes.nil?
     base_snapshot_to_volume = hashes.each_with_object({}) do |h, bsh|
       next unless (base_snapshot = h[:base_snapshot])
       (bsh[base_snapshot[:id]] ||= []) << h[:id]

--- a/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
@@ -64,7 +64,7 @@ module EmsRefresh::SaveInventoryCloud
 
     # Save and link other subsections
     child_keys.each do |k|
-      self.send("save_#{k}_inventory", ems, hashes[k], target)
+      send("save_#{k}_inventory", ems, hashes[k], target) if hashes.key?(k)
     end
 
     link_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
@@ -78,7 +78,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_flavors_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.flavors(true)
@@ -93,7 +92,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_availability_zones_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.availability_zones(true)
@@ -108,7 +106,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_tenants_inventory(ems, hashes, target = nil)
-    return unless hashes
     target ||= ems
 
     ems.cloud_tenants(true)
@@ -123,7 +120,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_resource_quotas_inventory(ems, hashes, target = nil)
-    return unless hashes
     target ||= ems
 
     ems.cloud_resource_quotas(true)
@@ -142,7 +138,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_key_pairs_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.key_pairs(true)
@@ -158,7 +153,6 @@ module EmsRefresh::SaveInventoryCloud
 
 
   def save_cloud_networks_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_networks(true)
@@ -185,7 +179,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_subnets_inventory(cloud_network, hashes)
-    return if hashes.nil?
     deletes = cloud_network.cloud_subnets(true).dup
 
     hashes.each do |h|
@@ -199,7 +192,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_security_groups_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.security_groups(true)
@@ -236,7 +228,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_floating_ips_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.floating_ips(true)
@@ -257,8 +248,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_orchestration_templates_inventory(_ems, hashes, _target = nil)
-    return if hashes.nil?
-
     # cloud_stack_template does not belong to an ems;
     # only to create new if necessary, but not to update existing template
     templates = OrchestrationTemplate.find_or_create_by_contents(hashes)
@@ -266,7 +255,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_orchestration_stacks_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.orchestration_stacks(true)
@@ -301,7 +289,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_parameters_inventory(orchestration_stack, hashes)
-    return if hashes.nil?
     deletes = orchestration_stack.parameters(true).dup
 
     save_inventory_multi(:parameters,
@@ -313,7 +300,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_outputs_inventory(orchestration_stack, hashes)
-    return if hashes.nil?
     deletes = orchestration_stack.outputs(true).dup
 
     save_inventory_multi(:outputs,
@@ -325,7 +311,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_resources_inventory(orchestration_stack, hashes)
-    return if hashes.nil?
     deletes = orchestration_stack.resources(true).dup
 
     save_inventory_multi(:resources,
@@ -337,7 +322,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_volumes_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_volumes(true)
@@ -359,7 +343,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_volume_snapshots(true)
@@ -391,7 +374,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_object_store_containers_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_object_store_containers(true)
@@ -411,7 +393,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_object_store_objects_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_object_store_objects(true)

--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -89,7 +89,7 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def save_child_inventory(obj, hashes, child_keys)
-    child_keys.each { |k| self.send("save_#{k}_inventory", obj, hashes[k]) if hashes.has_key?(k) }
+    child_keys.each { |k| send("save_#{k}_inventory", obj, hashes[k]) if hashes.key?(k) }
   end
 
   def store_ids_for_new_records(records, hashes, keys)

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -53,8 +53,7 @@ module EmsRefresh::SaveInventoryInfra
 
     # Save and link other subsections
     child_keys.each do |k|
-      meth = [:folders, :clusters].include?(k) ? "ems_#{k}" : k
-      self.send("save_#{meth}_inventory", ems, hashes[k], target)
+      send("save_#{k}_inventory", ems, hashes[k], target) if hashes.key?(k)
     end
 
     ems.save!
@@ -214,7 +213,7 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
-  def save_ems_folders_inventory(ems, hashes, target = nil)
+  def save_folders_inventory(ems, hashes, target = nil)
     return if hashes.nil?
     target = ems if target.nil?
 
@@ -228,8 +227,9 @@ module EmsRefresh::SaveInventoryInfra
     self.save_inventory_multi(:ems_folders, EmsFolder, ems, hashes, deletes, :uid_ems, nil, :ems_children)
     self.store_ids_for_new_records(ems.ems_folders, hashes, :uid_ems)
   end
+  alias_method :save_ems_folders_inventory, :save_folders_inventory
 
-  def save_ems_clusters_inventory(ems, hashes, target = nil)
+  def save_clusters_inventory(ems, hashes, target = nil)
     return if hashes.nil?
     target = ems if target.nil?
 
@@ -243,6 +243,7 @@ module EmsRefresh::SaveInventoryInfra
     self.save_inventory_multi(:ems_clusters, EmsCluster, ems, hashes, deletes, :uid_ems, nil, :ems_children)
     self.store_ids_for_new_records(ems.ems_clusters, hashes, :uid_ems)
   end
+  alias_method :save_ems_clusters_inventory, :save_clusters_inventory
 
   def save_resource_pools_inventory(ems, hashes, target = nil)
     return if hashes.nil?

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -68,7 +68,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_storages_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
     log_header = "MIQ(#{self.name}.save_storages_inventory) EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -99,7 +98,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_hosts_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
     log_header = "MIQ(#{self.name}.save_hosts_inventory) EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -214,7 +212,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_folders_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.ems_folders(true)
@@ -230,7 +227,6 @@ module EmsRefresh::SaveInventoryInfra
   alias_method :save_ems_folders_inventory, :save_folders_inventory
 
   def save_clusters_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.ems_clusters(true)
@@ -246,7 +242,6 @@ module EmsRefresh::SaveInventoryInfra
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
 
   def save_resource_pools_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.resource_pools(true)
@@ -263,25 +258,21 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_customization_specs_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     deletes = ems.customization_specs(true).dup
     self.save_inventory_multi(:customization_specs, CustomizationSpec, ems, hashes, deletes, :name)
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
-    return if hashes.nil?
     deletes = guest_device.miq_scsi_targets(true).dup
     self.save_inventory_multi(:miq_scsi_targets, MiqScsiTarget, guest_device, hashes, deletes, :uid_ems, :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
-    return if hashes.nil?
     deletes = miq_scsi_target.miq_scsi_luns(true).dup
     self.save_inventory_multi(:miq_scsi_luns, MiqScsiLun, miq_scsi_target, hashes, deletes, :uid_ems)
   end
 
   def save_switches_inventory(host, hashes)
-    return if hashes.nil?
     deletes = host.switches(true).dup
     self.save_inventory_multi(:switches, Switch, host, hashes, deletes, :uid_ems, :lans)
 
@@ -301,13 +292,11 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_lans_inventory(switch, hashes)
-    return if hashes.nil?
     deletes = switch.lans(true).dup
     self.save_inventory_multi(:lans, Lan, switch, hashes, deletes, :uid_ems)
   end
 
   def save_storage_files_inventory(storage, hashes)
-    return if hashes.nil?
     deletes = storage.storage_files(true).dup
     self.save_inventory_multi(:storage_files, StorageFile, storage, hashes, deletes, :name)
   end

--- a/vmdb/app/models/event_log.rb
+++ b/vmdb/app/models/event_log.rb
@@ -9,10 +9,7 @@ class EventLog < ActiveRecord::Base
 
   def self.add_missing_elements(parent, xmlNode)
     hashes = xml_to_hashes(xmlNode)
-    return if hashes.nil?
-
-    os = parent.operating_system
-    EmsRefresh.save_event_logs_inventory(os, hashes)
+    EmsRefresh.save_event_logs_inventory(parent.operating_system, hashes) if hashes
   end
 
   def self.xml_to_hashes(xmlNode)

--- a/vmdb/app/models/filesystem.rb
+++ b/vmdb/app/models/filesystem.rb
@@ -20,8 +20,7 @@ class Filesystem < ActiveRecord::Base
     options[:scan_item_id] = scan_item.id unless scan_item.nil?
 
     hashes = xml_to_hashes(xmlNode, options)
-    return if hashes.nil?
-    EmsRefresh.save_filesystems_inventory(parent, hashes)
+    EmsRefresh.save_filesystems_inventory(parent, hashes) if hashes
   end
 
   def self.xml_to_hashes(xmlNode, options = {})

--- a/vmdb/app/models/firewall_rule.rb
+++ b/vmdb/app/models/firewall_rule.rb
@@ -22,8 +22,7 @@ class FirewallRule < ActiveRecord::Base
     return if parent.operating_system.nil?
 
     hashes = xml_to_hashes(xmlNode, findPath)
-    return if hashes.nil?
-    EmsRefresh.save_firewall_rules_inventory(parent.operating_system, hashes, :scan)
+    EmsRefresh.save_firewall_rules_inventory(parent.operating_system, hashes, :scan) if hashes
   end
 
   def self.xml_to_hashes(xmlNode, findPath)

--- a/vmdb/app/models/guest_application.rb
+++ b/vmdb/app/models/guest_application.rb
@@ -12,8 +12,7 @@ class GuestApplication < ActiveRecord::Base
 
   def self.add_missing_elements(parent, xmlNode, findPath)
     hashes = xml_to_hashes(xmlNode, findPath)
-    return if hashes.nil?
-    EmsRefresh.save_guest_applications_inventory(parent, hashes)
+    EmsRefresh.save_guest_applications_inventory(parent, hashes) if hashes
   end
 
   def self.xml_to_hashes(xmlNode, findPath)

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1524,7 +1524,7 @@ class Host < ActiveRecord::Base
     begin
       sp = HostScanProfiles.new(ScanItem.get_profile("host default"))
       files = sp.parse_data_files(ssu)
-      EmsRefresh.save_filesystems_inventory(self, files)
+      EmsRefresh.save_filesystems_inventory(self, files) if files
     rescue
       #$log.log_backtrace($!)
     end

--- a/vmdb/app/models/os_process.rb
+++ b/vmdb/app/models/os_process.rb
@@ -11,8 +11,7 @@ class OsProcess < ActiveRecord::Base
     return if parent.operating_system.nil?
 
     hashes = xml_to_hashes(xmlNode, findPath)
-    return if hashes.nil?
-    EmsRefresh.save_os_processes_inventory(parent.operating_system, hashes)
+    EmsRefresh.save_os_processes_inventory(parent.operating_system, hashes) if hashes
   end
 
   def self.xml_to_hashes(xmlNode, findPath)

--- a/vmdb/app/models/patch.rb
+++ b/vmdb/app/models/patch.rb
@@ -20,8 +20,7 @@ class Patch < ActiveRecord::Base
   end
 
   def self.process_array(parent, hashes)
-    return if hashes.blank?
-    EmsRefresh.save_patches_inventory(parent, hashes)
+    EmsRefresh.save_patches_inventory(parent, hashes) unless hashes.blank?
   end
 
   def self.highest_patch_level(target)

--- a/vmdb/app/models/system_service.rb
+++ b/vmdb/app/models/system_service.rb
@@ -36,8 +36,7 @@ class SystemService < ActiveRecord::Base
 
   def self.add_missing_elements(parent, xmlNode, findPath)
     hashes = xml_to_hashes(xmlNode, findPath)
-    return if hashes.nil?
-    EmsRefresh.save_system_services_inventory(parent, hashes, :scan)
+    EmsRefresh.save_system_services_inventory(parent, hashes, :scan) if hashes
   end
 
   def self.xml_to_hashes(xmlNode, findPath, typeName=nil)


### PR DESCRIPTION
Remove all the `hash.nil?` checks inside the `save_##_inventory` methods.

Most of the callers into `save_##_inventory` methods already ensure the `hash` passed in is not nil.
There is no need to perform this check in the receiver.

The goal of this series is to make it so **all** `save_##_inventory` calls check the nil first, or at least construct the hash so it can't be nil.

/cc @gmcculloug @Fryguy @brandondunne @jrafanie 