### PR TITLE
remove nil checks for save_ems_cloud_inventory

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
@@ -64,7 +64,7 @@ module EmsRefresh::SaveInventoryCloud
 
     # Save and link other subsections
     child_keys.each do |k|
-      self.send("save_#{k}_inventory", ems, hashes[k], target)
+      self.send("save_#{k}_inventory", ems, hashes[k], target) if hashes.key?(k)
     end
 
     link_volumes_to_base_snapshots(hashes[:cloud_volumes])
@@ -78,7 +78,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_flavors_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.flavors(true)
@@ -93,7 +92,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_availability_zones_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.availability_zones(true)
@@ -108,7 +106,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_tenants_inventory(ems, hashes, target = nil)
-    return unless hashes
     target ||= ems
 
     ems.cloud_tenants(true)
@@ -123,7 +120,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_resource_quotas_inventory(ems, hashes, target = nil)
-    return unless hashes
     target ||= ems
 
     ems.cloud_resource_quotas(true)
@@ -142,7 +138,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_key_pairs_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.key_pairs(true)
@@ -158,7 +153,6 @@ module EmsRefresh::SaveInventoryCloud
 
 
   def save_cloud_networks_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_networks(true)
@@ -185,7 +179,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_subnets_inventory(cloud_network, hashes)
-    return if hashes.nil?
     deletes = cloud_network.cloud_subnets(true).dup
 
     hashes.each do |h|
@@ -199,7 +192,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_security_groups_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.security_groups(true)
@@ -236,7 +228,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_floating_ips_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.floating_ips(true)
@@ -257,8 +248,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_orchestration_templates_inventory(_ems, hashes, _target = nil)
-    return if hashes.nil?
-
     # cloud_stack_template does not belong to an ems;
     # only to create new if necessary, but not to update existing template
     templates = OrchestrationTemplate.find_or_create_by_contents(hashes)
@@ -266,7 +255,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_orchestration_stacks_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.orchestration_stacks(true)
@@ -301,7 +289,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_parameters_inventory(orchestration_stack, hashes)
-    return if hashes.nil?
     deletes = orchestration_stack.parameters(true).dup
 
     save_inventory_multi(:parameters,
@@ -313,7 +300,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_outputs_inventory(orchestration_stack, hashes)
-    return if hashes.nil?
     deletes = orchestration_stack.outputs(true).dup
 
     save_inventory_multi(:outputs,
@@ -325,7 +311,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_resources_inventory(orchestration_stack, hashes)
-    return if hashes.nil?
     deletes = orchestration_stack.resources(true).dup
 
     save_inventory_multi(:resources,
@@ -337,7 +322,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_volumes_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_volumes(true)
@@ -359,7 +343,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_volume_snapshots(true)
@@ -392,7 +375,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_object_store_containers_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_object_store_containers(true)
@@ -412,7 +394,6 @@ module EmsRefresh::SaveInventoryCloud
   end
 
   def save_cloud_object_store_objects_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.cloud_object_store_objects(true)

--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -89,7 +89,7 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def save_child_inventory(obj, hashes, child_keys)
-    child_keys.each { |k| self.send("save_#{k}_inventory", obj, hashes[k]) if hashes.has_key?(k) }
+    child_keys.each { |k| send("save_#{k}_inventory", obj, hashes[k]) if hashes.key?(k) }
   end
 
   def store_ids_for_new_records(records, hashes, keys)

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -69,7 +69,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_storages_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
     log_header = "MIQ(#{self.name}.save_storages_inventory) EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -100,7 +99,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_hosts_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
     log_header = "MIQ(#{self.name}.save_hosts_inventory) EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -215,7 +213,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_ems_folders_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.ems_folders(true)
@@ -230,7 +227,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_ems_clusters_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.ems_clusters(true)
@@ -245,7 +241,6 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_resource_pools_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     target = ems if target.nil?
 
     ems.resource_pools(true)
@@ -262,25 +257,21 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_customization_specs_inventory(ems, hashes, target = nil)
-    return if hashes.nil?
     deletes = ems.customization_specs(true).dup
     self.save_inventory_multi(:customization_specs, CustomizationSpec, ems, hashes, deletes, :name)
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
-    return if hashes.nil?
     deletes = guest_device.miq_scsi_targets(true).dup
     self.save_inventory_multi(:miq_scsi_targets, MiqScsiTarget, guest_device, hashes, deletes, :uid_ems, :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
-    return if hashes.nil?
     deletes = miq_scsi_target.miq_scsi_luns(true).dup
     self.save_inventory_multi(:miq_scsi_luns, MiqScsiLun, miq_scsi_target, hashes, deletes, :uid_ems)
   end
 
   def save_switches_inventory(host, hashes)
-    return if hashes.nil?
     deletes = host.switches(true).dup
     self.save_inventory_multi(:switches, Switch, host, hashes, deletes, :uid_ems, :lans)
 
@@ -300,13 +291,11 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_lans_inventory(switch, hashes)
-    return if hashes.nil?
     deletes = switch.lans(true).dup
     self.save_inventory_multi(:lans, Lan, switch, hashes, deletes, :uid_ems)
   end
 
   def save_storage_files_inventory(storage, hashes)
-    return if hashes.nil?
     deletes = storage.storage_files(true).dup
     self.save_inventory_multi(:storage_files, StorageFile, storage, hashes, deletes, :name)
   end


### PR DESCRIPTION
This PR: Focusing on the save_inventory methods for infra and cloud

---
High Level: remove all the hash.nil? checks inside the save_##_inventory methods.

Most of the callers into save_##_inventory methods already ensure the hash passed in is not nil.
So there is no need to perform this check in the receiver.

The goal of this series is to make it so all save_##_inventory calls check the nil first.

/cc @gmcculloug @Fryguy @brandondunne @jrafanie