### PR TITLE
change default value test to use strings

### DIFF
--- a/vmdb/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/vmdb/spec/models/dialog_field_drop_down_list_spec.rb
@@ -63,7 +63,7 @@ describe DialogFieldDropDownList do
 
     context "#initialize_with_values" do
       before(:each) do
-        @df.values = [[3, "X"], [2, "Y"], [1, "Z"]]
+        @df.values = [["3", "X"], ["2", "Y"], ["1", "Z"]]
       end
 
       it "no default value" do
@@ -73,13 +73,13 @@ describe DialogFieldDropDownList do
       end
 
       it "with default value" do
-        @df.default_value = 1
+        @df.default_value = "1"
         @df.initialize_with_values({})
-        @df.value.should == 1
+        @df.value.should == "1"
       end
 
       it "with non-matching default value" do
-        @df.default_value = 4
+        @df.default_value = "4"
         @df.initialize_with_values({})
         @df.value.should == nil
       end

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -110,7 +110,7 @@ describe DialogFieldRadioButton do
         context "when the dialog field is dynamic" do
           before do
             dialog_field_radio_button.dynamic = true
-            dialog_field_radio_button.default_value = [["test", 321]]
+            dialog_field_radio_button.default_value = "test"
             dialog_field_radio_button.initialize_with_values("lolvalues")
           end
 
@@ -122,7 +122,7 @@ describe DialogFieldRadioButton do
           end
 
           it "sets value from default value attribute" do
-            expect(dialog_field_radio_button.instance_variable_get(:@value)).to eq([["test", 321]])
+            expect(dialog_field_radio_button.instance_variable_get(:@value)).to eq("test")
           end
         end
 


### PR DESCRIPTION
The `default_value` column is a string, so Rails 4 will cast it to a
string, which makes this test fail.  Change the test to use strings so
it matches with the database type