### PR TITLE
Send correct Accept header with Ajax requests.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -1241,13 +1241,13 @@ function miqJqueryRequest(url, options) {
   options = options || {};
   ajax_options = {};
 
-  if (options['dataType']) ajax_options['dataType'] = options['dataType'] || 'script';
-
-  if (options['data']) ajax_options['data'] = options['data'];
-
+  if (options['dataType'] === undefined) {
+    ajax_options['accepts']  = { script: '*/*;q=0.5, ' + $j.ajaxSettings.accepts.script };
+    ajax_options['dataType'] = 'script';
+  }
+  if (options['data'])       ajax_options['data']       = options['data'];
   if (options['beforeSend']) ajax_options['beforeSend'] = function(request) { miqSparkle(true); };
-
-  if (options['complete']) ajax_options['complete'] = function(request) { miqSparkle(false); };
+  if (options['complete'])   ajax_options['complete']   = function(request) { miqSparkle(false); };
 
   new $j.ajax(options['no_encoding'] ? url : encodeURI(url), ajax_options);
 }


### PR DESCRIPTION
Fixes: #1367

Adding `Accept:` header to the Ajax requests the same way that jquery_ujs does is need to make the rails 'respond_to do |format|' blocks work.

And in turn this fixes #1367 probably broken by the prototype-->jquery conversion or even before by the tree component replacement.