### PR TITLE
Define the test file location in one place.

### DIFF
--- a/lib/spec/db/MiqBdb/miq_bdb_page_spec.rb
+++ b/lib/spec/db/MiqBdb/miq_bdb_page_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
 require 'db/MiqBdb/MiqBdb'
+require "#{__dir__}/test_files"
 
 describe MiqBerkeleyDB::MiqBdbPage do
-  MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME = File.expand_path(File.join(File.dirname(__FILE__), %w{data rpm Provideversion}))
 
   before do
-    bdb = MiqBerkeleyDB::MiqBdb.new(MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME)
+    bdb = MiqBerkeleyDB::MiqBdb.new(MiqBdb::TestFiles::RPM_PROVIDE_VERSION)
     bdb.pages { |p| @page = p }
   end
 

--- a/lib/spec/db/MiqBdb/miq_bdb_spec.rb
+++ b/lib/spec/db/MiqBdb/miq_bdb_spec.rb
@@ -1,17 +1,16 @@
 require "spec_helper"
 
 require 'db/MiqBdb/MiqBdb'
+require "#{__dir__}/test_files"
 
 describe MiqBerkeleyDB::MiqBdb do
-  MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME = File.expand_path(File.join(File.dirname(__FILE__), %w{data rpm Provideversion}))
-  MIQ_BDB_RPM_PACKAGES_FILENAME        = File.expand_path(File.join(File.dirname(__FILE__), %w{data rpm Packages}))
 
   it "#new" do
-    lambda { described_class.new(MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME).close }.should_not raise_error
+    lambda { described_class.new(MiqBdb::TestFiles::RPM_PROVIDE_VERSION).close }.should_not raise_error
   end
 
   it "#pages" do
-    bdb = described_class.new(MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME)
+    bdb = described_class.new(MiqBdb::TestFiles::RPM_PROVIDE_VERSION)
 
     nkeys = 0
 
@@ -28,7 +27,7 @@ describe MiqBerkeleyDB::MiqBdb do
 
   context "Hash Database" do
     it "validates" do
-      bdb = described_class.new(MIQ_BDB_RPM_PACKAGES_FILENAME)
+      bdb = described_class.new(MiqBdb::TestFiles::RPM_PACKAGES)
       bdb.db.should be_kind_of(MiqBerkeleyDB::MiqBdbHashDatabase)
 
       # Assert that the number of keys in header is what was extracted

--- a/lib/spec/db/MiqBdb/miq_bdb_util_spec.rb
+++ b/lib/spec/db/MiqBdb/miq_bdb_util_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
 require 'db/MiqBdb/MiqBdbUtil'
+require "#{__dir__}/test_files"
 
 describe MiqBerkeleyDB::MiqBdbUtil do
-  MIQ_BDB_RPM_NAME_FILENAME = File.expand_path(File.join(File.dirname(__FILE__), %w{data rpm Name}))
 
   it "#getkeys" do
     bdbUtil = described_class.new()
-    keys = bdbUtil.getkeys(MIQ_BDB_RPM_NAME_FILENAME)
+    keys = bdbUtil.getkeys(MiqBdb::TestFiles::RPM_NAME)
     keys.size.should == 690
   end
 

--- a/lib/spec/db/MiqBdb/test_files.rb
+++ b/lib/spec/db/MiqBdb/test_files.rb
@@ -1,0 +1,7 @@
+module MiqBdb
+  module TestFiles
+    RPM_PROVIDE_VERSION = File.join(__dir__, %w{data rpm Provideversion})
+    RPM_PACKAGES        = File.join(__dir__, %w{data rpm Packages})
+    RPM_NAME            = File.join(__dir__, %w{data rpm Name})
+  end
+end


### PR DESCRIPTION
Fixes the following warnings:
lib/spec/db/MiqBdb/miq_bdb_spec.rb:6: warning: already initialized constant MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME
lib/spec/db/MiqBdb/miq_bdb_page_spec.rb:6: warning: previous definition of MIQ_BDB_RPM_PROVIDE_VERSION_FILENAME was here

Note, I'm using [`__dir__`](http://ruby-doc.org/core-2.0/Kernel.html#method-i-__dir__), new to ruby 2.0 to clean up some of this verbose code.