### PR TITLE
allow extra params in save_child_inventory

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
@@ -63,9 +63,7 @@ module EmsRefresh::SaveInventoryCloud
     ]
 
     # Save and link other subsections
-    child_keys.each do |k|
-      send("save_#{k}_inventory", ems, hashes[k], target) if hashes.key?(k)
-    end
+    save_child_inventory(ems, hashes, child_keys, target)
 
     link_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
 

--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -88,8 +88,8 @@ module EmsRefresh::SaveInventoryHelper
     keys.each { |k| hash[k] = backup.delete(k) if backup.has_key?(k) }
   end
 
-  def save_child_inventory(obj, hashes, child_keys)
-    child_keys.each { |k| send("save_#{k}_inventory", obj, hashes[k]) if hashes.key?(k) }
+  def save_child_inventory(obj, hashes, child_keys, *args)
+    child_keys.each { |k| send("save_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
   end
 
   def store_ids_for_new_records(records, hashes, keys)

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -52,9 +52,7 @@ module EmsRefresh::SaveInventoryInfra
     child_keys = [:storages, :clusters, :hosts, :vms, :folders, :resource_pools, :customization_specs]
 
     # Save and link other subsections
-    child_keys.each do |k|
-      send("save_#{k}_inventory", ems, hashes[k], target) if hashes.key?(k)
-    end
+    save_child_inventory(ems, hashes, child_keys, target)
 
     ems.save!
     hashes[:id] = ems.id


### PR DESCRIPTION
Saving all manager/ems need to save all child keys, but they also want to pass a target.

This allows save_child_inventory to be used in that way.

/cc @Fryguy @brandondunne 