### PR TITLE
Removed 'miqObserveCheckboxes' JS method.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -1005,31 +1005,6 @@ function miqClickAndPop(el) {
   return false;
 }
 
-// Set up checkbox observers
-function miqObserveCheckboxes() {
-  $j('[data-miq_observe_checkbox]').each(function(index) {
-    var parms = $j.parseJSON(this.getAttribute('data-miq_observe_checkbox'));
-    var url = parms.url;
-    var el = $j(this);
-    el.unbind('change')
-    el.change(function() {
-      if (el.attr('data-miq_sparkle_on')){
-        miqJqueryRequest(url, {
-          beforeSend: true,
-          complete: true,
-          data: el.attr('id') + '=' + encodeURIComponent(el.prop('checked') ? 1 : null),
-          no_encoding: true
-        });
-      } else {
-        miqJqueryRequest(url, {
-          data: el.attr('id') + '=' + encodeURIComponent(el.prop('checked') ? 1 : null),
-          no_encoding: true
-        });
-      }
-    })
-  })
-}
-
 //method takes 4 parameters tabs div id, active tab label, url to go to when tab is changed, and whether to check for abandon changes or not
 function miq_jquery_tabs_init(options){
 

--- a/vmdb/app/assets/javascripts/miq_ujs_bindings.js
+++ b/vmdb/app/assets/javascripts/miq_ujs_bindings.js
@@ -60,22 +60,17 @@ $j(document).ready(function(){
 		}
 	});
 
-	// Bind click support for checkboxes, seems only click event works in FF/IE/Chrome
-	// TODO: This binding is commented out because it doesn't work under dhtmlx tabs, may use later
-//	$j('[data-miq_observe_checkbox]').live('click', function() {
-//		var parms = $j.parseJSON(this.getAttribute('data-miq_observe_checkbox'));
-//		var url = parms.url;
-//		var sparkleOn = this.getAttribute('data-miq_sparkle_on');	// Grab miq_sparkle settings
-//		var sparkleOff = this.getAttribute('data-miq_sparkle_off');
-//		new $j.ajax(url,
-//										{
-//											dataType: 'script',
-//											beforeSend: function() {if (sparkleOn) miqSparkle(true);},
-//											complete: function() {if (sparkleOff) miqSparkle(false);},
-//											parameters:this.id + '=' + encodeURIComponent(this.checked ? this.value : 'null')
-//										}
-//		);
-//	});
+  $j('[data-miq_observe_checkbox]').live('click', function() {
+    var el = $j(this);
+    var parms = $j.parseJSON(el.attr('data-miq_observe_checkbox'));
+    var url = parms.url;
+    var options = {
+      data: el.attr('id') + '=' + encodeURIComponent(el.prop('checked') ? el.val() : 'null'),
+    };
+    if (el.attr('data-miq_sparkle_on')) options['beforeSend'] = true
+    if (el.attr('data-miq_sparkle_on')) options['complete'] = true
+    miqJqueryRequest(url, options);
+  });
 
 // Following example code from http://www.alfajango.com/blog/rails-3-remote-links-and-forms/
 //

--- a/vmdb/app/views/catalog/_form_basic_info.html.haml
+++ b/vmdb/app/views/catalog/_form_basic_info.html.haml
@@ -109,8 +109,3 @@
         %td
           = text_field_tag("provision_cost", @edit[:new][:provision_cost], :maxlength => MAX_NAME_LEN,
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/configuration/_timeprofile_days_hours.html.haml
+++ b/vmdb/app/views/configuration/_timeprofile_days_hours.html.haml
@@ -72,6 +72,3 @@
                                   @edit[:new][:profile][:hours].include?(i),
                                   :disabled => disabled,
                                   "data-miq_observe_checkbox" => url_json)
-  -# Need this to bind checkbox observers when under DHTMLX tabs %>
-  -# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  %script miqObserveCheckboxes();

--- a/vmdb/app/views/configuration/_timeprofile_form.html.haml
+++ b/vmdb/app/views/configuration/_timeprofile_form.html.haml
@@ -95,6 +95,3 @@
                       %img{:src => "/images/icons/new/report.png", :valign => "middle", :border => "0", :height =>"20", :width => "20"}
                     %td= r.name
                     %td= r.title
-  -# Need this to bind checkbox observers when under DHTMLX tabs %>
-  -# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  %script miqObserveCheckboxes();

--- a/vmdb/app/views/configuration/_ui_1.html.haml
+++ b/vmdb/app/views/configuration/_ui_1.html.haml
@@ -96,7 +96,3 @@
                                "data-miq_observe" => url_json)
 
       = render :partial => '/layouts/form_buttons'
-
-    -# Need this to bind checkbox observers when under DHTMLX tabs
-    -# TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-    %script miqObserveCheckboxes();

--- a/vmdb/app/views/layouts/_ae_resolve_options.html.erb
+++ b/vmdb/app/views/layouts/_ae_resolve_options.html.erb
@@ -161,7 +161,3 @@
 					<% end %>
 				</table>
 			</fieldset>
-
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/layouts/_discover.html.haml
+++ b/vmdb/app/views/layouts/_discover.html.haml
@@ -68,5 +68,3 @@
                  :alt   => t = _("Cancel"),
                  :title => t,
                  :type  => "submit")
-
-%script miqObserveCheckboxes();

--- a/vmdb/app/views/layouts/_role_visibility.html.erb
+++ b/vmdb/app/views/layouts/_role_visibility.html.erb
@@ -70,7 +70,4 @@
         </tr>
       <% end %>
   </table>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 </div>

--- a/vmdb/app/views/layouts/_tl_options.html.erb
+++ b/vmdb/app/views/layouts/_tl_options.html.erb
@@ -144,9 +144,6 @@
       <% end %>
       <%= "* Dates/Times on this page are based on time zone: #{session[:user_tz]}." %>
     </fieldset>
-    <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-    <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-    <script>miqObserveCheckboxes();</script>
   <% end %>
 </div>
 

--- a/vmdb/app/views/layouts/exp_atom/_editor.html.haml
+++ b/vmdb/app/views/layouts/exp_atom/_editor.html.haml
@@ -97,6 +97,3 @@
     miq_cal_dateFrom = null;
     miq_cal_dateTo = null;
 
-- # Need this to bind checkbox observers
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_ae_class/_class_fields.html.haml
+++ b/vmdb/app/views/miq_ae_class/_class_fields.html.haml
@@ -133,8 +133,3 @@
                     = text_field_tag("field_#{fname}", session[:field_data][fname.to_sym],
                       "data-miq_observe" => obs)
 
-      - # Need this to bind checkbox observers when under DHTMLX tabs
-      - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-      :javascript
-        miqObserveCheckboxes();
-

--- a/vmdb/app/views/miq_ae_class/_copy_objects_form.html.haml
+++ b/vmdb/app/views/miq_ae_class/_copy_objects_form.html.haml
@@ -60,5 +60,3 @@
           %tr{:class => cycle('row0 no-hover', 'row1 no-hover')}
             %td
               = item
-%script
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_ae_class/_ns_list.html.haml
+++ b/vmdb/app/views/miq_ae_class/_ns_list.html.haml
@@ -51,7 +51,3 @@
                 value   = "1",
                 checked = @edit[:new][:enabled],
                 "data-miq_observe_checkbox" => {:url => url}.to_json)
-    - # Need this to bind checkbox observers when under DHTMLX tabs
-    - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-    :javascript
-      miqObserveCheckboxes();

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -225,6 +225,3 @@
             = check_box_tag('field_reconfigurable', '1',
               @edit[:field_reconfigurable],
               "data-miq_observe_checkbox" => {:url => url}.to_json)
-
-%script
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_ae_customization/_dialog_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_form.html.haml
@@ -21,7 +21,3 @@
     = render :partial => 'layouts/ae_tree_select'
     </div>
     = render(:partial => 'dialog_field_form')
-  - # Need this to bind checkbox observers when under DHTMLX tabs %>
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_capacity/_bottlenecks_options.html.haml
+++ b/vmdb/app/views/miq_capacity/_bottlenecks_options.html.haml
@@ -31,7 +31,3 @@
   %form#hiddenForm
     %input.filter1{:type => "hidden", :name => "filter1", :value => @sb[:bottlenecks][:tl_options][:fltr1]}
   - #= "* Dates/Times on this page are based on UTC Time."
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_capacity/_planning_options.html.haml
+++ b/vmdb/app/views/miq_capacity/_planning_options.html.haml
@@ -233,8 +233,3 @@
               "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true,
               "data-miq_observe"     => {:url => url}.to_json)
-
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_policy/_action_options.html.haml
+++ b/vmdb/app/views/miq_policy/_action_options.html.haml
@@ -269,8 +269,3 @@
                   %td{:align => "left", :valign => "top", :nowrap => 1}
                     = check_box_tag("cat_#{cat.first}", "1", checked, "data-miq_observe_checkbox" => observe)
                   = h(cat.last)
-
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_policy/_alert_details.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_details.html.haml
@@ -278,8 +278,3 @@
                         %td
                           = oa.description
               %hr
-- if @edit
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_policy/_alert_evm_event.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_evm_event.html.haml
@@ -11,8 +11,3 @@
             "data-miq_sparkle_off"      => true,
             "data-miq_observe_checkbox" => {:url => url}.to_json)
   %hr
-- if @edit
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_policy/_alert_mgmt_event.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_mgmt_event.html.haml
@@ -18,8 +18,3 @@
               :maxlength => MAX_DESC_LEN,
               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %hr
-- if @edit
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes()

--- a/vmdb/app/views/miq_policy/_alert_snmp.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_snmp.html.haml
@@ -73,8 +73,3 @@
               :maxlength => MAX_DESC_LEN,
               "data-miq_observe" => observe_with_interval)
   %hr
-- if @edit
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_policy/_policy_details.html.haml
+++ b/vmdb/app/views/miq_policy/_policy_details.html.haml
@@ -261,9 +261,3 @@
                     %td
                       = pp.description
   %br
-
-- if @edit
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_policy/_rsop_results.html.haml
+++ b/vmdb/app/views/miq_policy/_rsop_results.html.haml
@@ -54,8 +54,3 @@
     &nbsp;
     %strong
       =_("* Enter Policy Simulation options on the left and press Submit")
-
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_proxy/_form.html.haml
+++ b/vmdb/app/views/miq_proxy/_form.html.haml
@@ -91,7 +91,3 @@
               :onclick => "miqAjaxButton('#{url_for(:action => 'create', :id => 'new', :button => 'cancel')}');")
   - else
     = render :partial => '/layouts/edit_form_buttons', :locals  => {:record_id => @miq_proxy.id, :ajax_buttons => true}
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/miq_proxy/_tasks_options.html.haml
+++ b/vmdb/app/views/miq_proxy/_tasks_options.html.haml
@@ -85,7 +85,3 @@
               :remote                => true,
               :title                 => t)
   %hr
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_request/_prov_field.html.haml
+++ b/vmdb/app/views/miq_request/_prov_field.html.haml
@@ -482,7 +482,3 @@
             = form_tag({:controller => path[:controller], :action => "explorer"}, :multipart => true) do
               = file_field("upload", "file")
               = submit_tag("Upload", :class => "upload")
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/miq_request/_prov_options.html.haml
+++ b/vmdb/app/views/miq_request/_prov_options.html.haml
@@ -78,7 +78,3 @@
             :remote                => true,
             :title                 => t)
   %hr
-  - # Need this to bind checkbox observers when under DHTMLX tabs
-  - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-  :javascript
-    miqObserveCheckboxes();

--- a/vmdb/app/views/ops/_ap_form_file.html.erb
+++ b/vmdb/app/views/ops/_ap_form_file.html.erb
@@ -77,8 +77,3 @@
 					</tbody>
 				</table>
 	</fieldset>
-
-
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/ops/_ap_form_set.html.erb
+++ b/vmdb/app/views/ops/_ap_form_set.html.erb
@@ -52,6 +52,3 @@
 		</table>
 	</fieldset>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/ops/_category_form.html.erb
+++ b/vmdb/app/views/ops/_category_form.html.erb
@@ -123,6 +123,3 @@
 	</fieldset>
 <% end %>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/ops/_ldap_domain_form.html.erb
+++ b/vmdb/app/views/ops/_ldap_domain_form.html.erb
@@ -121,6 +121,3 @@
   <%= render :partial => 'ldap_server_entries', :locals=>{:entry=>nil,:domain_id=>"#{@edit[:ldap_domain_id] || "new"}"} %>
  <% end %>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/ops/_rbac_group_details.html.erb
+++ b/vmdb/app/views/ops/_rbac_group_details.html.erb
@@ -217,11 +217,6 @@
           </div>
         </fieldset>
       </dd>
-    <% if @edit %>
-      <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-      <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-      <script>miqObserveCheckboxes();</script>
-    <% end %>
   </dl>
 </div>
 <%# Initialize jQuery UI tabs based on tabs ul %>

--- a/vmdb/app/views/ops/_schedule_form.haml
+++ b/vmdb/app/views/ops/_schedule_form.haml
@@ -46,8 +46,3 @@
     = render :partial => "schedule_form_filter"
 
   = render :partial => "schedule_form_timer"
-
--# Need this to bind checkbox observers when under DHTMLX tabs
--# TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/ops/_settings_authentication_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_authentication_tab.html.erb
@@ -279,7 +279,4 @@
   <% end %>
 
   <hr>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 <% end %>

--- a/vmdb/app/views/ops/_settings_cu_collection_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_cu_collection_tab.html.erb
@@ -90,7 +90,4 @@
 			</dl>
 		<% end %>
 	<div style="padding-bottom:20px;"></div>
- 	<%# Need this to bind checkbox observers when under DHTMLX tabs %>
- 	<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
- 	<script>miqObserveCheckboxes();</script>
 <% end %>

--- a/vmdb/app/views/ops/_settings_custom_logos_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_custom_logos_tab.html.erb
@@ -91,7 +91,4 @@
       </td>
     </tr>
   </table>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 <% end %>

--- a/vmdb/app/views/ops/_settings_host_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_host_tab.html.erb
@@ -26,7 +26,4 @@
 				</table>
 			</fieldset>
     <div style="padding-bottom:20px;"></div>
- 	<%# Need this to bind checkbox observers when under DHTMLX tabs %>
- 	<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
- 	<script>miqObserveCheckboxes();</script>
 <% end %>

--- a/vmdb/app/views/ops/_settings_rhn_edit_tab.haml
+++ b/vmdb/app/views/ops/_settings_rhn_edit_tab.haml
@@ -96,8 +96,3 @@
     Forgot your login or password? Look it up at
     %a{:target => 'rh_lost_passwd', :href => 'http://redhat.com/forgot_password'}
       http://redhat.com/forgot_password
-
--# Need this to bind checkbox observers when under DHTMLX tabs
--# TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-%script
-  miqObserveCheckboxes();

--- a/vmdb/app/views/ops/_settings_rhn_tab.haml
+++ b/vmdb/app/views/ops/_settings_rhn_tab.haml
@@ -26,8 +26,3 @@
   = render :partial => 'ops/rhn/server_table'
 
 %div{:style => 'padding-bottom:20px;'}
-
--# Need this to bind checkbox observers when under DHTMLX tabs
--# TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-%script
-  miqObserveCheckboxes();

--- a/vmdb/app/views/ops/_settings_server_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_server_tab.html.erb
@@ -345,7 +345,4 @@
     </dd>
   </dl>
   <div style="padding-bottom:20px;"></div>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 <% end %>

--- a/vmdb/app/views/ops/_settings_smartproxy_affinity_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_smartproxy_affinity_tab.html.erb
@@ -3,9 +3,6 @@
 	<%= render :partial => "layouts/flash_msg" %>
 	<%#  SmartProxy Affinity Tab %>
 	<%= render :partial => "smartproxy_affinity" %>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 <% end %>
 
 

--- a/vmdb/app/views/ops/_settings_smartproxy_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_smartproxy_tab.html.erb
@@ -72,7 +72,4 @@
       </td>
     </tr>
   </table>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 <% end %>

--- a/vmdb/app/views/pxe/_iso_img_form.html.haml
+++ b/vmdb/app/views/pxe/_iso_img_form.html.haml
@@ -11,8 +11,3 @@
           = select_tag("image_typ",
             options_for_select(img_types, @edit[:new][:img_type]),
             "data-miq_observe" => {:url => url}.to_json)
-
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/pxe/_pxe_img_form.html.haml
+++ b/vmdb/app/views/pxe/_pxe_img_form.html.haml
@@ -18,8 +18,3 @@
             "data-miq_observe_checkbox" => {:url => url}.to_json)
           &nbsp;&nbsp;
           =_('* Checking this box will remove this setting from all other PXE Images on this PXE Server')
-
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-:javascript
-  miqObserveCheckboxes();

--- a/vmdb/app/views/report/_db_form.html.erb
+++ b/vmdb/app/views/report/_db_form.html.erb
@@ -39,6 +39,3 @@
     <%= render :partial => "db_widgets" %>
   <% if read_only %> * Dashboard name cannot be changed<% end %>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/report/_form_chart.html.erb
+++ b/vmdb/app/views/report/_form_chart.html.erb
@@ -37,6 +37,3 @@
   <% end %>
   <hr>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/report/_form_sort.html.erb
+++ b/vmdb/app/views/report/_form_sort.html.erb
@@ -181,6 +181,3 @@
       </table>
   <% end %>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/report/_schedule_email_options.html.haml
+++ b/vmdb/app/views/report/_schedule_email_options.html.haml
@@ -26,5 +26,3 @@
                               Array(@edit[:new][:email][:attach]).include?(:pdf),
                               "data-miq_observe_checkbox" => url_json)
               PDF
-    %script
-      miqObserveCheckboxes();

--- a/vmdb/app/views/report/_schedule_form.html.erb
+++ b/vmdb/app/views/report/_schedule_form.html.erb
@@ -40,6 +40,3 @@
                                                       :record=>@schedule}) %>
   <%= render :partial => "schedule_email_options" %>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/report/_widget_form.html.erb
+++ b/vmdb/app/views/report/_widget_form.html.erb
@@ -44,6 +44,3 @@
 
   <% if @edit[:read_only] %> * Fields are read only for default Widgets<% end %>
 </div>
-<%# Need this to bind checkbox observers when under DHTMLX tabs %>
-<%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-<script>miqObserveCheckboxes();</script>

--- a/vmdb/app/views/service/_st_form.html.haml
+++ b/vmdb/app/views/service/_st_form.html.haml
@@ -81,10 +81,6 @@
                           options_for_select(Array.new(@edit[:new][:rsc_groups].length) { |j| j + 1 }, (i + 1).to_s),
                           "data-miq_sparkle_on" => true,
                           "data-miq_observe"    => {:url => url}.to_json)
-    - # Need this to bind checkbox observers when under DHTMLX tabs
-    - # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-    :javascript
-      miqObserveCheckboxes();
   - elsif @edit[:new][:service_type] == "atomic"
     %dl.col1
       %dd

--- a/vmdb/app/views/shared/buttons/_ab_form.html.erb
+++ b/vmdb/app/views/shared/buttons/_ab_form.html.erb
@@ -94,7 +94,4 @@
              :locals  => {:rec_id  => "#{@custom_button.id || "new"}",
                           :action  => "automate_button_field_changed"}
   %>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 </div>

--- a/vmdb/app/views/shared/buttons/_group_form.html.erb
+++ b/vmdb/app/views/shared/buttons/_group_form.html.erb
@@ -58,7 +58,4 @@
   <%= render :partial => "shared/buttons/column_lists" %>
 
 <% end %>
-  <%# Need this to bind checkbox observers when under DHTMLX tabs %>
-  <%# TODO: Remove when DHTMLX tabs are converted to jQuery tabs  %>
-  <script>miqObserveCheckboxes();</script>
 </div>

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -183,6 +183,3 @@
           - value = wf.value(field.name) || ''
           - classification_ids = value.split(',')
           = h(Classification.where(:id => classification_ids).collect(&:description).join(', '))
-
-%script
-  miqObserveCheckboxes();

--- a/vmdb/app/views/vm_common/_policy_options.html.haml
+++ b/vmdb/app/views/vm_common/_policy_options.html.haml
@@ -30,7 +30,4 @@
             "data-miq_sparkle_off" => true,
             "data-miq_observe_checkbox" => url2)
           = "&nbsp;Failed".html_safe
-- # Need this to bind checkbox observers when under DHTMLX tabs
-- # TODO: Remove when DHTMLX tabs are converted to jQuery tabs
-%script
-  miqObserveCheckboxes();
+

--- a/vmdb/app/views/vm_common/_reconfigure.html.haml
+++ b/vmdb/app/views/vm_common/_reconfigure.html.haml
@@ -87,6 +87,3 @@
             - @embedded = true
             - @gtl_type = "list"
             = render :partial => "layouts/gtl"
-
-:javascript
-  miqObserveCheckboxes();


### PR DESCRIPTION
Removed 'miqObserveCheckboxes' JS method, uncommented/fixed code to use UJS checkbox binding click support. Removed calls to miqObserveCheckboxes method from the views.

#1192 
@dclarizio @martinpovolny please review/test.

@AparnaKarve can you test this.