### PR TITLE
Ruby versions less than 2.0 are unsupported

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -1,3 +1,5 @@
+raise "Ruby versions less than 2.0 are unsupported!" if RUBY_VERSION < "2.0.0"
+
 source 'https://rubygems.org'
 
 gem "bundler", "~>1.3"


### PR DESCRIPTION
It's time to yell if you're still trying to use ruby 1.9.3 with manageiq.