### PR TITLE
[WIP] Nil save inventory 3

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/rhevm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/rhevm.rb
@@ -320,7 +320,8 @@ module EmsRefresh::Parsers::Rhevm
       }
 
       result << new_result
-      guest_device[:network] = new_result unless guest_device.nil?
+      # set network device to empty (stating it does not exist) vs nil (it is unknown)
+      guest_device[:network] = guest_device ? new_result : {}
     end
     return result
   end
@@ -470,7 +471,7 @@ module EmsRefresh::Parsers::Rhevm
     # So if there is only 1 of each link them together.
     if result.length == 1 && guest_device_uids.length == 1
       guest_device = guest_device_uids[guest_device_uids.keys.first]
-      guest_device[:network] = result.first unless guest_device.nil?
+      guest_device[:network] = guest_device ? result.first : {}
     end
 
     return result

--- a/vmdb/app/models/ems_refresh/parsers/vc.rb
+++ b/vmdb/app/models/ems_refresh/parsers/vc.rb
@@ -514,7 +514,8 @@ module EmsRefresh::Parsers::Vc
       }
 
       result << new_result
-      guest_device[:network] = new_result unless guest_device.nil?
+      # set network device to empty (stating it does not exist) vs nil (it is unknown)
+      guest_device[:network] = guest_device ? new_result : {}
     end
     return result
   end


### PR DESCRIPTION
We are no longer calling save inventory methods for nil hashes.

network used to delete a network for a nil hash coming in.
Since they are no longer coming in, they would not get deleted.

Now we're passing in a blank.
Business back to usual.

(MiqScvmmInventory: found while searching wasn't worth pulling out into own pr)

/cc @Fryguy @gmcculloug @brandondunne 