### PR TITLE
Store next naming index in custom_attributes

### DIFF
--- a/vmdb/app/models/miq_region.rb
+++ b/vmdb/app/models/miq_region.rb
@@ -19,7 +19,7 @@ class MiqRegion < ActiveRecord::Base
   acts_as_miq_taggable
   include ReportableMixin
   include UuidMixin
-
+  include NamingSequenceMixin
   include AggregationMixin
   # Since we've overridden the implementation of methods from AggregationMixin,
   # we must also override the :uses portion of the virtual columns.

--- a/vmdb/app/models/mixins/naming_sequence_mixin.rb
+++ b/vmdb/app/models/mixins/naming_sequence_mixin.rb
@@ -1,0 +1,17 @@
+module NamingSequenceMixin
+  extend ActiveSupport::Concern
+
+  included do
+    # these are possible naming sequences because there is no constraint to source column
+    has_many :naming_sequences, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  end
+
+  def next_naming_sequence(name, source)
+    lock do
+      record = naming_sequences.where(:name => name, :source => source).first_or_initialize
+      record.update_attributes!(:value => record.value.to_i + 1)
+
+      record.value
+    end
+  end
+end

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -27,6 +27,13 @@ describe MiqRegion do
       MiqRegion.count.should == 1
     end
 
+    it "should increment naming sequence number after each call" do
+      MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming").should == 1
+      MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming").should == 2
+      MiqRegion.my_region.next_naming_sequence("anothertest$n{3}", "naming").should == 1
+      MiqRegion.my_region.next_naming_sequence("anothertest$n{3}", "naming").should == 2
+    end
+
     context "with cloud and infra EMSes" do
 
       before :each do


### PR DESCRIPTION
With this implemenation naming indexes are global through current region.
The binding can be changed to other models through NamingIndexMixin.

https://bugzilla.redhat.com/show_bug.cgi?id=1173336