### PR TITLE
Fixed code to populate values in all pull down in provisioning dialogs.

### DIFF
--- a/vmdb/app/views/miq_request/_prov_field.html.haml
+++ b/vmdb/app/views/miq_request/_prov_field.html.haml
@@ -135,12 +135,13 @@
           - elsif @edit && field_hash[:display] == :edit && field_hash[:values] && !@edit[:stamp_typ]
             - # Allow editing of the text field
             - if field_hash[:values].blank?
-              - opts = [["<#{_('No Choices Available')}>", nil]] + (Array(field_hash[:values].invert).sort_by { |a| a.first.to_i })
+              - opts = [["<#{_('No Choices Available')}>", nil]]
             - else
               - if field_hash[:default]
                 - opts = []
               - else
                 - opts = [["<#{_('Choose')}>", nil]]
+              - opts += (Array(field_hash[:values].invert).sort_by { |a| a.first.to_i })
             = select_tag(field_id,
               options_for_select(opts, options[field].is_a?(Array) ? options[field].first : options[field]),
               :disabled              => disabled,
@@ -190,10 +191,6 @@
             - # Allow editing of this pulldown field
             - if field_hash[:values].blank?
               - opts = [["<#{_('No Choices Available')}>", nil]]
-              - if field_hash[:data_type] == :integer
-                - opts += Array(field_hash[:values].invert).sort_by(&:first)
-              - else
-                - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
             - else
               - if field_hash[:required]
                 - if field_hash[:default]
@@ -202,6 +199,10 @@
                   - opts = [["<#{_('Choose')}>", nil]]
               - else
                 - opts = [["<#{_('None')}>", nil]]
+              - if field_hash[:data_type] == :integer
+                - opts += Array(field_hash[:values].invert).sort_by(&:first)
+              - else
+                - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
             = select_tag(field_id,
               options_for_select(opts, options[field].is_a?(Array) ? options[field].first : options[field]),
               :disabled              => disabled,
@@ -226,10 +227,6 @@
             - # Allow editing of this pulldown field
             - if field_hash[:values].blank?
               - opts = [["<#{_('No Choices Available')}>", nil]]
-              - if field_hash[:data_type] == :integer
-                - opts += Array(field_hash[:values].invert).sort_by(&:last)
-              - else
-                - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
             - else
               - if field_hash[:required]
                 - if field_hash[:default]
@@ -238,7 +235,10 @@
                   - opts = [["<#{_('Choose')}>", nil]]
               - else
                 - opts = [["<#{_('None')}>", nil]]
-            
+              - if field_hash[:data_type] == :integer
+                - opts += Array(field_hash[:values].invert).sort_by(&:last)
+              - else
+                - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
             = select_tag(field_id,
               options_for_select(opts, (options[field].is_a?(Array) && !multiple) ? options[field].first : options[field]),
               :multiple              => multiple,
@@ -321,7 +321,7 @@
               = render :partial => "#{pfx}prov_windows_image_grid", :locals => {:field_id => field_id}
             - else
               - if field_hash[:values].blank?
-                - opts = [["<#{_('No Choices Available')}>", nil]] + Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
+                - opts = [["<#{_('No Choices Available')}>", nil]]
               - else
                 - if field_hash[:required]
                   - if field_hash[:default]
@@ -330,6 +330,7 @@
                     - opts = [["<#{_('Choose')}>", nil]]
                 - else
                   - opts = [["<#{_('None')}>", nil]]
+                - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
               = select_tag(field_id,
                 options_for_select(opts, options[field].is_a?(Array) ? options[field].first : options[field]),
                 :style                 => "width: auto;",
@@ -357,15 +358,15 @@
             - # Allow editing of this pulldown field
             - if field_hash[:values].blank?
               - opts = [["<#{_('No Choices Available')}>", nil]]
-              - if field_hash[:data_type] == :integer
-                - opts += Array(field_hash[:values].invert).sort_by(&:last)
-              - else
-                - opts += Array(field_hash[:values].invert).sort_by(&:first)
             - else
               - if field_hash[:default]
                 - opts = []
               - else
                 - opts = [["<#{_('Choose')}>", nil]]
+              - if field_hash[:data_type] == :integer
+                - opts += Array(field_hash[:values].invert).sort_by(&:last)
+              - else
+                - opts += Array(field_hash[:values].invert).sort_by(&:first)
             = select_tag(field_id,
               options_for_select(opts, options[field].is_a?(Array) ? options[field].first : options[field]),
               :disabled              => disabled,
@@ -390,7 +391,7 @@
               - # Description is in the second, last, array element
             - else
               - if field_hash[:values].blank?
-                - opts = [["<#{_('No Choices Available')}>", nil]] + field_hash[:values]
+                - opts = [["<#{_('No Choices Available')}>", nil]]
               - else
                 - if field_hash[:required]
                   - if field_hash[:default]
@@ -399,6 +400,7 @@
                     - opts = [["<#{_('Choose')}>", nil]]
                 - else
                   - opts = [["<#{_('None')}>", nil]]
+                - opts += field_hash[:values]
               = select_tag(field_id,
                 options_for_select(opts, options[field].is_a?(Array) ? options[field].first : options[field]),
                 :disabled              => disabled,

--- a/vmdb/app/views/miq_request/_prov_host_grid.html.haml
+++ b/vmdb/app/views/miq_request/_prov_host_grid.html.haml
@@ -33,12 +33,15 @@
         - @id = row.id
         - if options[:wf].class.to_s == "MiqHostProvisionWorkflow"
           %tr{:class => cycle('row0', 'row1'), :nowrap => 1}
+            - options[:host_columns].each do |col|
+              %td{:align => "left", :onmouseover => "ChangeColor(this, true);", :onmouseout => "ChangeColor(this, false);"}
+                = h(row.send(col))
         - else
           - cls = @edit[:new][:placement_host_name] && @edit[:new][:placement_host_name][0] == @id ? "row3" : cycle('row0', 'row1')
           %tr{:class => cls, :onclick => "miqAjax('/miq_request/prov_field_changed/?#{field_id}=#{@id}&id=#{id}');", :nowrap => 1}
-        - options[:host_columns].each do |col|
-          %td{:align => "left", :onmouseover => "ChangeColor(this, true);", :onmouseout => "ChangeColor(this, false);"}
-            = h(row.send(col))
+            - options[:host_columns].each do |col|
+              %td{:align => "left", :onmouseover => "ChangeColor(this, true);", :onmouseout => "ChangeColor(this, false);"}
+                = h(row.send(col))
     %tfoot
       %tr
         %td{:colspan => "40"}


### PR DESCRIPTION
Moved code that sets pull down values to correct if/else block, this issue was introduced with haml conversion in https://github.com/ManageIQ/manageiq/pull/1227

#1375 
@gmcculloug please review/test.