### PR TITLE
Replace `.foo { |x| x.bar }` pattern with `.foo(&:bar)`

### DIFF
--- a/lib/Amazon/MiqEc2.rb
+++ b/lib/Amazon/MiqEc2.rb
@@ -33,7 +33,7 @@ class MiqEc2
     return if bucket.nil?
 
     # Find the latest timestamp for this ami_location, and get the xml data there
-    objs = bucket.objects.find_all { |o| o.key =~ /\/#{ami_location.gsub('/', '-')}\// }.sort_by { |o| o.key }
+    objs = bucket.objects.find_all { |o| o.key =~ /\/#{ami_location.gsub('/', '-')}\// }.sort_by(&:key)
     return if objs.empty?
 
     error_obj = objs.find { |o| o.key[-5..-1] == "ERROR" }

--- a/lib/MiqVm/MiqVm.rb
+++ b/lib/MiqVm/MiqVm.rb
@@ -182,7 +182,7 @@ class MiqVm
     
     def unmount
 		$log.info "MiqVm.unmount called."
-        @wholeDisks.each { |d| d.close }
+        @wholeDisks.each(&:close)
         @wholeDisks.clear
         if @volumeManager
             @volumeManager.close

--- a/lib/VMwareWebService/MiqVimBroker.rb
+++ b/lib/VMwareWebService/MiqVimBroker.rb
@@ -294,7 +294,7 @@ class MiqVimBroker
             @broker.releaseSession(sessionId)
         else
 			$vim_log.info "Server releaseSession: #{sessionId}"
-			$miqBrokerObjRegistry[sessionId].dup.each { |o| o.release }
+			$miqBrokerObjRegistry[sessionId].dup.each(&:release)
 		end
 	end
 	
@@ -443,7 +443,7 @@ class MiqVimBroker
 		end
 		
 		vim.shutdownConnection
-		$miqBrokerObjRegistryByConn[key].dup.each { |o| o.release }
+		$miqBrokerObjRegistryByConn[key].dup.each(&:release)
 		@connectionHash.delete(key)
 		vim.connectionRemoved
 

--- a/lib/VMwareWebService/test/brokerObjCountTest.rb
+++ b/lib/VMwareWebService/test/brokerObjCountTest.rb
@@ -40,7 +40,7 @@ begin
 	puts "Object counts:"
 	broker.objectCounts.each { |k, v| puts "\t#{k}: #{v}"}
 	
-	objs.each { |o| o.release }
+	objs.each(&:release)
 	
 	puts
 	puts "Object counts:"

--- a/lib/VixDiskLib/test/cookedTest.rb
+++ b/lib/VixDiskLib/test/cookedTest.rb
@@ -95,5 +95,5 @@ diskFiles.each do |vmdk|
     break
 end
 
-vDisks.each { |vDisk| vDisk.close }
+vDisks.each(&:close)
 connection.disconnect

--- a/lib/VixDiskLib/test/vixDiskModTest.rb
+++ b/lib/VixDiskLib/test/vixDiskModTest.rb
@@ -107,5 +107,5 @@ diskFiles.each do |df|
     puts
 end
 
-disks.each { |disk| disk.close }
+disks.each(&:close)
 connection.disconnect

--- a/lib/VixDiskLib/vdl_wrapper.rb
+++ b/lib/VixDiskLib/vdl_wrapper.rb
@@ -172,7 +172,7 @@ class VdlConnection
     if !@vdl_connection
       vim_log.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $vim_log
     else
-      @disks.each { |d| d.close }
+      @disks.each(&:close)
     end
   end
   private :__close_disks__

--- a/lib/VolumeManager/MiqNativeVolumeManager.rb
+++ b/lib/VolumeManager/MiqNativeVolumeManager.rb
@@ -63,7 +63,7 @@ class MiqNativeVolumeManager
     end
     
     def closeAll
-        @wholeDisks.each { |d| d.close }
+        @wholeDisks.each(&:close)
         @logicalVolumes     = Array.new
         @physicalVolumes    = Array.new
         @hiddenVolumes      = Array.new

--- a/lib/VolumeManager/MiqVolumeManager.rb
+++ b/lib/VolumeManager/MiqVolumeManager.rb
@@ -115,7 +115,7 @@ class MiqVolumeManager
     # manager is instantiated through fromNativePvs().
     #
     def closePvols
-    	@allPhysicalVolumes.each { |pv| pv.close }
+    	@allPhysicalVolumes.each(&:close)
     	@allPhysicalVolumes.clear
     end
 

--- a/lib/WriteVm/vmAutomate.rb
+++ b/lib/WriteVm/vmAutomate.rb
@@ -63,8 +63,6 @@ rescue => err
 	$log.error err.backtrace.join("\n")
 	$log.error "MIQ VM UPDATE FAILED"
 ensure
-	rootTrees.each do |r|
-		r.umount
-	end if rootTrees
+	rootTrees.each(&:umount) if rootTrees
 	$log.info "MIQ VM UPDATE END - " + (lo.partialLog ? "partial log" : "full log")
 end

--- a/lib/appliance_console/prompts.rb
+++ b/lib/appliance_console/prompts.rb
@@ -89,7 +89,7 @@ module ApplianceConsole
       collective ||= "#{prompt}s"
       validate = ->(p) { (p.length < max_length) && (p.split(/[\s,;]+/).length <= max_count) }
       error_message = "up to #{max_count} #{prompt}s separated by a space and up to #{max_length} characters"
-      just_ask(collective, default, validate, error_message).split(/[\s,;]+/).collect { |p| p.strip }
+      just_ask(collective, default, validate, error_message).split(/[\s,;]+/).collect(&:strip)
     end
 
     def ask_for_password(prompt, default = nil)

--- a/lib/disk/MiqDisk.rb
+++ b/lib/disk/MiqDisk.rb
@@ -121,7 +121,7 @@ class MiqDisk
     
     def close
         $log.debug "MiqDisk<#{self.object_id}> close, #{@logName}" if $log
-        @partitions.each { |p| p.close } if @partitions
+        @partitions.each(&:close) if @partitions
         @partitions = nil
         d_close
     end

--- a/lib/disk/modules/RhevmDescriptor.rb
+++ b/lib/disk/modules/RhevmDescriptor.rb
@@ -113,7 +113,7 @@ module RhevmDescriptor
   # Close all disks.
   def d_close
     @parent.close if @parent != nil
-    @disks.each {|disk| disk.close}
+    @disks.each(&:close)
   end
 
   # Return size in sectors.

--- a/lib/disk/modules/VMWareDescriptor.rb
+++ b/lib/disk/modules/VMWareDescriptor.rb
@@ -124,7 +124,7 @@ module VMWareDescriptor
 	# Close all disks.
 	def d_close
 		@parent.close if @parent != nil
-		@disks.each {|disk| disk.close}
+		@disks.each(&:close)
 	end
 	
 	# Return size in sectors.

--- a/lib/fs/MiqMountManager.rb
+++ b/lib/fs/MiqMountManager.rb
@@ -77,7 +77,7 @@ class MiqMountManager < MiqFS
     #
 
 	def umount
-		@allFileSystems.each { |fs| fs.umount }
+		@allFileSystems.each(&:umount)
 	end
     
   	# Return free space in file system.

--- a/lib/fs/MiqNativeMountManager.rb
+++ b/lib/fs/MiqNativeMountManager.rb
@@ -106,8 +106,6 @@ if __FILE__ == $0
 	# puts "*** Copied files:"
 	# rootTree.findEach(tdn) { |f| puts "\t#{f}" }
 	
-	rootTrees.each do |r|
-		r.umount
-	end
+	rootTrees.each(&:umount)
 end
 

--- a/lib/metadata/ScanProfile/ScanProfileBase.rb
+++ b/lib/metadata/ScanProfile/ScanProfileBase.rb
@@ -39,7 +39,7 @@ class ScanProfileBase
     return {
       :guid => @params["guid"],
       :name => @params["name"],
-      :scan_items => self.collect { |si| si.to_hash }
+      :scan_items => self.collect(&:to_hash)
     }
   end
   

--- a/lib/metadata/ScanProfile/ScanProfilesBase.rb
+++ b/lib/metadata/ScanProfile/ScanProfilesBase.rb
@@ -51,7 +51,7 @@ class ScanProfilesBase
   end
 
   def to_hash
-    return {:scan_profiles => self.collect { |p| p.to_hash } }
+    return {:scan_profiles => self.collect(&:to_hash) }
   end
 
   def to_yaml

--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -758,7 +758,7 @@ class VmConfig
     sn_list.each do |(id, snapshot)|
       delete_items = []
       snapshot.each {|d| delete_items << d if d.name == 'disk'}
-      delete_items.each {|d| d.remove!}
+      delete_items.each(&:remove!)
     end
   end
 

--- a/lib/openstack/openstack_handle/handle.rb
+++ b/lib/openstack/openstack_handle/handle.rb
@@ -216,7 +216,7 @@ module OpenstackHandle
     end
 
     def tenant_names
-      @tenant_names ||= tenants.collect { |t| t.name }
+      @tenant_names ||= tenants.collect(&:name)
     end
 
     def accessible_tenants
@@ -235,7 +235,7 @@ module OpenstackHandle
     end
 
     def accessible_tenant_names
-      @accessible_tenant_names ||= accessible_tenants.collect { |t| t.name }
+      @accessible_tenant_names ||= accessible_tenants.collect(&:name)
     end
 
     def default_tenant_name

--- a/lib/util/extensions/miq-module.rb
+++ b/lib/util/extensions/miq-module.rb
@@ -53,7 +53,7 @@ class Module
 
   def self.clear_all_cache_with_timeout
     $miq_cache_with_timeout_lock.synchronize(:EX) do
-      $miq_cache_with_timeout.each_value { |v| v.clear }
+      $miq_cache_with_timeout.each_value(&:clear)
     end
   end
 end

--- a/lib/util/extensions/miq_stats.rb
+++ b/lib/util/extensions/miq_stats.rb
@@ -93,6 +93,6 @@ if __FILE__ == $0
   fields.each_index do |i|
     next unless fields[i].size > 0
     puts [ i,  fields[i].mean, fields[i].deviation ] \
-    .collect{|x|x.to_s}.join("\t")
+    .collect(&:to_s).join("\t")
   end
 end

--- a/lib/util/miq-option-parser.rb
+++ b/lib/util/miq-option-parser.rb
@@ -126,7 +126,7 @@ module MiqOptionParser
     rescue ParseError, OptionParser::ParseError => e
       raise if @handle_exceptions == false
       puts "Error while parsing command line:\n    #{e.message}\n"
-      help.execute(command.parents.reverse.collect {|c| c.name}) unless help.nil?
+      help.execute(command.parents.reverse.collect(&:name)) unless help.nil?
       exit
     end
     

--- a/lib/util/miq-process.rb
+++ b/lib/util/miq-process.rb
@@ -20,7 +20,7 @@ class MiqProcess
     when :mswin, :mingw
       WMIHelper.connectServer().run_query("select Handle,Name from Win32_Process where Name = '#{process_name}.exe'") {|p| pids << p.Handle.to_i}
     when :linux, :macosx
-      pids = %x(ps -e | grep #{process_name} | grep -v grep ).split("\n").collect { |r| r.to_i}
+      pids = %x(ps -e | grep #{process_name} | grep -v grep ).split("\n").collect(&:to_i)
     else
       raise "Method MiqProcess.get_active_process_by_name not implemented on this platform [#{Platform::IMPL}]"
     end

--- a/lib/util/system/evm_watchdog.rb
+++ b/lib/util/system/evm_watchdog.rb
@@ -51,7 +51,7 @@ module EvmWatchdog
 
   def self.get_ps_pids(process_name)
     pids = self.ps_for_process(process_name)
-    pids.chomp.split.map {|p| p.to_i}
+    pids.chomp.split.map(&:to_i)
   end
 
   def self.ps_for_process(process_name)

--- a/lib/util/win32/miq-wmi-mswin.rb
+++ b/lib/util/win32/miq-wmi-mswin.rb
@@ -49,7 +49,7 @@ module WmiMswin
   def raise_win32ole_error(err)
       err = err.to_s.split("\n")
       err.delete_at(-1)
-      err.each {|e| e.strip!}
+      err.each(&:strip!)
       raise(WIN32OLERuntimeError, err.join(" - "))
   end
 

--- a/vmdb/app/apis/vmdbws_ops.rb
+++ b/vmdb/app/apis/vmdbws_ops.rb
@@ -711,7 +711,7 @@ module VmdbwsOps
     t0 = Time.now
     vm = FindVmByGuid(vmGuid)
 
-    ids = customAttrs.collect {|ca| ca.id}.compact
+    ids = customAttrs.collect(&:id).compact
     vm.custom_attributes.each do |ca|
       if (ids.include?(ca.id.to_s))
         # Check if we need to update the EMS
@@ -834,7 +834,7 @@ module VmdbwsOps
     $log.info "#{log_header}: enter"
     raise "No list provided for Find#{klass}ByList " if list.nil?
 
-    guids = list.to_miq_a.collect {|ci| ci.guid}
+    guids = list.to_miq_a.collect(&:guid)
     findCIsByGuid(klass, guids)
   end
 
@@ -844,7 +844,7 @@ module VmdbwsOps
     $log.info "#{log_header}: enter"
     raise "No list provided for Find#{klass}ByListId  " if list.nil?
 
-    ids = list.to_miq_a.collect {|ci| ci.id}
+    ids = list.to_miq_a.collect(&:id)
     findCIsById(klass, ids)
   end
 

--- a/vmdb/app/controllers/application_controller/compare.rb
+++ b/vmdb/app/controllers/application_controller/compare.rb
@@ -12,7 +12,7 @@ module ApplicationController::Compare
 
     rpt = get_compare_report(@sb[:compare_db])
     session[:miq_sections] = MiqCompare.sections(rpt)
-    ids = session[:miq_selected].collect {|id| id.to_i}
+    ids = session[:miq_selected].collect(&:to_i)
     @compare = MiqCompare.new( {:ids=>ids,
                                 :include=>session[:miq_sections]},
                             rpt

--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -105,7 +105,7 @@ module ApplicationController::DialogRunner
 
                   elsif field.type.include?("DropDown") && field.required
                      url = url_for(:action => 'dialog_field_changed', :id=>"#{@edit[:rec_id] || "new"}")
-                     page.replace("#{field.name}", :text => "#{select_tag(field.name, options_for_select(field.values.collect{|v| v.reverse}, p[1]), 'data-miq_sparkle_on' => true, 'data-miq_sparkle_off'=> true, 'data-miq_observe'=>{:url=>url}.to_json)}")
+                     page.replace("#{field.name}", :text => "#{select_tag(field.name, options_for_select(field.values.collect(&:reverse), p[1]), 'data-miq_sparkle_on' => true, 'data-miq_sparkle_off'=> true, 'data-miq_observe'=>{:url=>url}.to_json)}")
 
                   elsif field.type.include?("TagControl") && field.single_value? && field.required
                     category_tags = DialogFieldTagControl.category_tags(field.category).map {|cat| [cat[:description], cat[:id]]}

--- a/vmdb/app/controllers/application_controller/explorer.rb
+++ b/vmdb/app/controllers/application_controller/explorer.rb
@@ -668,7 +668,7 @@ module ApplicationController::Explorer
     if [:bottlenecks_tree, :utilization_tree].include?(x_active_tree)
       objects = Array.new
     else
-      objects = rbac_filtered_objects(object.resource_pools).sort_by { |a| a.name.downcase }.delete_if{|o| o.is_default}
+      objects = rbac_filtered_objects(object.resource_pools).sort_by { |a| a.name.downcase }.delete_if(&:is_default)
       if object.default_resource_pool           # Go thru default RP VMs
         objects += rbac_filtered_objects(object.default_resource_pool.vms).sort_by { |a| a.name.downcase }
       end
@@ -782,7 +782,7 @@ module ApplicationController::Explorer
         CustomButton.buttons_for(object.name.split('|').last.split('-').last).each do |uri|
           objects.push(uri) if uri.parent.nil?
         end
-        return objects.sort_by { |a| a.name }
+        return objects.sort_by(&:name)
       else
         #need to show button nodes in button order that they were saved in
         button_order = object[:set_data] && object[:set_data][:button_order] ? object[:set_data][:button_order] : nil
@@ -863,7 +863,7 @@ module ApplicationController::Explorer
     if options[:count_only]
       return options[:type] == :dialogs ? 0 : object.dialog_resources.count
     else
-      return options[:type] == :dialogs ? [] : object.ordered_dialog_resources.collect {|a| a.resource}.compact
+      return options[:type] == :dialogs ? [] : object.ordered_dialog_resources.collect(&:resource).compact
     end
   end
 
@@ -871,7 +871,7 @@ module ApplicationController::Explorer
     if options[:count_only]
       return object.dialog_resources.count
     else
-      return object.ordered_dialog_resources.collect {|a| a.resource}.compact
+      return object.ordered_dialog_resources.collect(&:resource).compact
     end
   end
 
@@ -879,7 +879,7 @@ module ApplicationController::Explorer
     if options[:count_only]
       return object.dialog_resources.count
     else
-      return object.ordered_dialog_resources.collect {|a| a.resource}.compact
+      return object.ordered_dialog_resources.collect(&:resource).compact
     end
   end
 
@@ -949,7 +949,7 @@ module ApplicationController::Explorer
     when :db
       if object[:id].split('-').first == "g"
         objects = MiqGroup.all
-        return options[:count_only] ? objects.count : objects.sort_by { |a| a.name }
+        return options[:count_only] ? objects.count : objects.sort_by(&:name)
       else
         options[:count_only] ? 0 : []
       end
@@ -1029,7 +1029,7 @@ module ApplicationController::Explorer
       view.table.data.each do |s|
         objects.push(MiqReportResult.find_by_id(s["id"]))
       end
-      return options[:count_only] ? objects.count : objects.sort_by { |a| a.name }
+      return options[:count_only] ? objects.count : objects.sort_by(&:name)
     when :vandt # VMs & Templates tree has orphaned and archived nodes
       case object[:id]
       when "orph" # Orphaned
@@ -1091,7 +1091,7 @@ module ApplicationController::Explorer
       end
     when :widgets
       objects = MiqWidget.find_all_by_content_type(WIDGET_CONTENT_TYPE[object[:id].split('-').last])
-      return options[:count_only] ? objects.count : objects.sort_by { |a| a.title }
+      return options[:count_only] ? objects.count : objects.sort_by(&:title)
     else
       return options[:count_only] ? 0 : []
     end

--- a/vmdb/app/controllers/application_controller/tags.rb
+++ b/vmdb/app/controllers/application_controller/tags.rb
@@ -417,7 +417,7 @@ module ApplicationController::Tags
     @edit[:new][:assignments] =
       Classification.find_assigned_entries(@tagitems[0]).collect{|e| e.id unless e.parent.read_only?}
     @tagitems.each do |item|
-      itemassign = Classification.find_assigned_entries(item).collect{|e| e.id} # Get each items assignments
+      itemassign = Classification.find_assigned_entries(item).collect(&:id) # Get each items assignments
       @edit[:new][:assignments].delete_if { |a| !itemassign.include?(a) } # Remove any assignments that are not in the new items assignments
       break if @edit[:new][:assignments].length == 0                      # Stop looking if no assignments are left
     end

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -743,7 +743,7 @@ class DashboardController < ApplicationController
     # Copy ALL display settings into the :css hash so we can easily add new settings
     @settings[:css] ||= Hash.new
     @settings[:css].merge!(@settings[:display])
-    @settings[:display][:theme] = THEMES.first.last unless THEMES.collect{|t| t.last}.include?(@settings[:display][:theme])
+    @settings[:display][:theme] = THEMES.first.last unless THEMES.collect(&:last).include?(@settings[:display][:theme])
     @settings[:css].merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
 
     @css ||= Hash.new

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -514,7 +514,7 @@ module MiqAeCustomizationController::Dialogs
       # replace select tag of default values
       url = url_for(:action=>'dialog_form_field_changed', :id=>"#{@record.id || "new"}")
       none =  [['<None>', nil]]
-      values = key[:values].empty? ? none : none + key[:values].collect {|val| val.reverse}
+      values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]
       page.replace("field_default_value",
                    :text=> "#{select_tag('field_default_value', options_for_select(values, selected), 'data-miq_observe'=>{:interval=>'.5', :url=>url}.to_json)}")
@@ -551,7 +551,7 @@ module MiqAeCustomizationController::Dialogs
       # replace select tag of default values
       url = url_for(:action=>'dialog_form_field_changed', :id=>"#{@record.id || "new"}")
       none =  [['<None>', nil]]
-      values = key[:values].empty? ? none : none + key[:values].collect {|val| val.reverse}
+      values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]
       page.replace("field_default_value",
                    :text => select_tag('field_default_value',

--- a/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -286,7 +286,7 @@ module MiqPolicyController::AlertProfiles
         @assign[:new][:assign_to] = "enterprise"
       else                                                    # Assigned to CIs
         @assign[:new][:assign_to] = aa[:objects].first.class.base_class.to_s.underscore
-        @assign[:new][:objects] = aa[:objects].collect{|o| o.id}.sort!
+        @assign[:new][:objects] = aa[:objects].collect(&:id).sort!
       end
     elsif !aa[:tags].empty?                                   # Tags are assigned
       @assign[:new][:assign_to] = aa[:tags].first.last + "-tags"

--- a/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
@@ -442,7 +442,7 @@ module MiqPolicyController::MiqActions
 
     if ["inherit_parent_tags","remove_tags"].include?(@action.action_type)
       cats = @action.options[:cats].collect{|c| Classification.find_by_name(c)}.compact
-      @temp[:cats] = cats.collect{|c| c.description}.sort{|a,b| a.downcase <=> b.downcase}.join(" | ")
+      @temp[:cats] = cats.collect(&:description).sort{|a,b| a.downcase <=> b.downcase}.join(" | ")
     end
   end
 

--- a/vmdb/app/controllers/miq_policy_controller/policies.rb
+++ b/vmdb/app/controllers/miq_policy_controller/policies.rb
@@ -48,7 +48,7 @@ module MiqPolicyController::Policies
       when "conditions"
         mems = @edit[:new][:conditions].invert                  # Get the ids from the member list box
         policy.conditions.collect{|pc|pc}.each{|c| policy.conditions.delete(c) unless mems.keys.include?(c.id) }  # Remove any conditions no longer in members
-        mems.each_key {|m| policy.conditions.push(Condition.find(m)) unless policy.conditions.collect{|c|c.id}.include?(m) }    # Add any new conditions
+        mems.each_key {|m| policy.conditions.push(Condition.find(m)) unless policy.conditions.collect(&:id).include?(m) }    # Add any new conditions
       end
       if policy.valid? && !@flash_array && policy.save
         if @policy.id.blank? && policy.mode == "compliance"   # New compliance policy

--- a/vmdb/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/vmdb/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -158,7 +158,7 @@ module OpsController::Settings::CapAndU
       cid, cl_hash = h
       c = cl_hash[:cl_rec]
       enabled = cl_hash[:ho_enabled]
-      enabled_host_ids = enabled.collect {|e| e.id}
+      enabled_host_ids = enabled.collect(&:id)
       hosts = (cl_hash[:ho_enabled] + cl_hash[:ho_disabled]).sort {|a,b| a.name.downcase <=> b.name.downcase}
       cl_enabled = enabled_host_ids.length == hosts.length
       if cl_enabled && !enabled.empty?

--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -570,7 +570,7 @@ module OpsController::Settings::Common
       if checked
         all_children.each { |k, v| server[k] = Set.new(v) }
       else
-        server.each_value { |v| v.clear }
+        server.each_value(&:clear)
       end
     end
   end
@@ -1272,7 +1272,7 @@ module OpsController::Settings::Common
   end
 
   def build_smartproxy_affinity_tree(zone)
-    zone.miq_servers.select { |s| s.is_a_proxy? }.sort_by { |s| [s.name, s.id] }.collect do |s|
+    zone.miq_servers.select(&:is_a_proxy?).sort_by { |s| [s.name, s.id] }.collect do |s|
       title = "#{Dictionary.gettext('MiqServer', :type => :model, :notfound => :titleize)}: #{s.name} [#{s.id}]"
       title = "<b class='cfme-bold-node'>#{title} (current)</title>".html_safe if @sb[:my_server_id] == s.id
       {

--- a/vmdb/app/controllers/ops_controller/settings/rhn.rb
+++ b/vmdb/app/controllers/ops_controller/settings/rhn.rb
@@ -19,7 +19,7 @@ module OpsController::Settings::RHN
   end
 
   def rhn_subscription_map
-    @rhn_subscription_map ||= Hash[rhn_subscription_types.map{|pair| pair.reverse}]
+    @rhn_subscription_map ||= Hash[rhn_subscription_types.map(&:reverse)]
   end
 
   included do

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -8,7 +8,7 @@ module ApplicationHelper::Dialogs
       values.push(["<Choose>", nil])
     end
     if field.type.include?("DropDown")
-      values += field.values.collect{|v| v.reverse}
+      values += field.values.collect(&:reverse)
     elsif field.type.include?("TagControl")
       values += category_tags
     end

--- a/vmdb/app/models/account.rb
+++ b/vmdb/app/models/account.rb
@@ -43,7 +43,7 @@ class Account < ActiveRecord::Base
     # Only need to check one direction, as both directions are implied in the xml
     user_map.each do |name, curr_groups|
       acct = parent.accounts.find_by_name_and_accttype(name, 'user')
-      prev_groups = acct.groups.collect { |group| group.name }
+      prev_groups = acct.groups.collect(&:name)
 
       # Remove the common elements from both groups to determine the add/deletes
       common = prev_groups & curr_groups

--- a/vmdb/app/models/bottleneck_event.rb
+++ b/vmdb/app/models/bottleneck_event.rb
@@ -126,7 +126,7 @@ class BottleneckEvent < ActiveRecord::Base
       recs = obj.send(r)
       next if recs.blank?
 
-      result[recs.first.class.name] = recs.collect {|rec| rec.id}
+      result[recs.first.class.name] = recs.collect(&:id)
       recs.each do |child|
         self.child_types_and_ids(child).each do |k,v|
           result[k] ||= []

--- a/vmdb/app/models/chargeback.rb
+++ b/vmdb/app/models/chargeback.rb
@@ -168,7 +168,7 @@ class Chargeback < ActsAsArModel
   end
 
   def self.column_names
-    @column_names ||= self.columns.collect { |c| c.name }.sort
+    @column_names ||= self.columns.collect(&:name).sort
   end
 
   def self.calculate_costs(perf, h, rates)

--- a/vmdb/app/models/chargeback_rate.rb
+++ b/vmdb/app/models/chargeback_rate.rb
@@ -38,9 +38,7 @@ class ChargebackRate < ActiveRecord::Base
     #cb_rates = [{:cb_rate=>obj, :tag=>[Classification.entry_object, klass]} || :object=>object},...]
     #cb_rates.each {|rate| rate[:cb_rate].remove_all_assigned_tos}
     self.validate_rate_type(type)
-    ChargebackRate.find(:all, :conditions => {:rate_type => type.to_s.capitalize}).each do |rate|
-      rate.remove_all_assigned_tos
-    end
+    ChargebackRate.find(:all, :conditions => {:rate_type => type.to_s.capitalize}).each(&:remove_all_assigned_tos)
 
     cb_rates.each do |rate|
       rate[:cb_rate].assign_to_objects(rate[:object]) if rate.has_key?(:object)

--- a/vmdb/app/models/cim_base_storage_extent.rb
+++ b/vmdb/app/models/cim_base_storage_extent.rb
@@ -18,7 +18,7 @@ class CimBaseStorageExtent < ActsAsArModel
   end
 
   def self.base_storage_extent_ids
-    CimComputerSystem.all.collect { |cs| cs.base_storage_extents }.flatten.compact.uniq.collect { |bse| bse.id }
+    CimComputerSystem.all.collect(&:base_storage_extents).flatten.compact.uniq.collect(&:id)
   end
 
   def self.reflections

--- a/vmdb/app/models/cim_storage_extent.rb
+++ b/vmdb/app/models/cim_storage_extent.rb
@@ -92,11 +92,11 @@ class CimStorageExtent < MiqCimInstance
   end
 
   def file_systems
-    logical_disks.collect { |cld| cld.file_system }.compact.uniq
+    logical_disks.collect(&:file_system).compact.uniq
   end
 
   def file_shares
-    file_systems.collect { |cfs| cfs.file_shares }.flatten.compact.uniq
+    file_systems.collect(&:file_shares).flatten.compact.uniq
   end
 
   #########################

--- a/vmdb/app/models/classification.rb
+++ b/vmdb/app/models/classification.rb
@@ -195,7 +195,7 @@ class Classification < ActiveRecord::Base
   def self.find_assigned_entries(obj, ns=DEFAULT_NAMESPACE)
     raise "Class '#{obj.class}' is not eligible for classification" unless obj.respond_to?("tag_with")
 
-    tag_ids = obj.tagged_with(:ns => ns).collect {|tag| tag.id}
+    tag_ids = obj.tagged_with(:ns => ns).collect(&:id)
     self.find_all_by_tag_id(tag_ids) rescue []
   end
 
@@ -367,7 +367,7 @@ class Classification < ActiveRecord::Base
     h["name"] = self.name
     if category?
       ["id", "tag_id", "reserved"].each { |k| h.delete(k) }
-      h["entries"] = self.entries.collect { |e| e.export_to_array }.flatten
+      h["entries"] = self.entries.collect(&:export_to_array).flatten
     else
       ["id", "tag_id", "reserved", "parent_id"].each { |k| h.delete(k) }
     end

--- a/vmdb/app/models/dialog.rb
+++ b/vmdb/app/models/dialog.rb
@@ -32,7 +32,7 @@ class Dialog < ActiveRecord::Base
   end
 
   def dialog_fields
-    self.dialog_tabs.collect {|dt| dt.dialog_fields}.flatten!
+    self.dialog_tabs.collect(&:dialog_fields).flatten!
   end
 
   def field_name_exist?(name)

--- a/vmdb/app/models/dialog_tab.rb
+++ b/vmdb/app/models/dialog_tab.rb
@@ -21,7 +21,7 @@ class DialogTab < ActiveRecord::Base
   end
 
   def dialog_fields
-    self.dialog_groups.collect {|dg| dg.dialog_fields}.flatten!
+    self.dialog_groups.collect(&:dialog_fields).flatten!
   end
 
   def dialog_resources

--- a/vmdb/app/models/disk.rb
+++ b/vmdb/app/models/disk.rb
@@ -50,7 +50,7 @@ class Disk < ActiveRecord::Base
   end
 
   def volumes
-    self.partitions.collect { |p| p.volumes }.flatten.uniq
+    self.partitions.collect(&:volumes).flatten.uniq
   end
 
   def used_percent_of_provisioned
@@ -65,7 +65,7 @@ class Disk < ActiveRecord::Base
     return "Not Applicable" if self.rdm_disk?
     plist = self.partitions
     return "Unknown" if plist.empty?
-    return "True"    if plist.all? {|p| p.aligned?}
+    return "True"    if plist.all?(&:aligned?)
     return "False"   if plist.any? {|p| p.aligned? == false}
     return "Unknown"
   end

--- a/vmdb/app/models/ems_cloud.rb
+++ b/vmdb/app/models/ems_cloud.rb
@@ -5,7 +5,7 @@ class EmsCloud < ExtManagementSystem
   }
 
   def self.types
-    self.subclasses.collect { |c| c.ems_type }
+    self.subclasses.collect(&:ems_type)
   end
 
   def self.supported_subclasses

--- a/vmdb/app/models/ems_cluster.rb
+++ b/vmdb/app/models/ems_cluster.rb
@@ -192,7 +192,7 @@ class EmsCluster < ActiveRecord::Base
   def resource_pools
     # Look for only the resource_pools at the second depth (default depth + 1)
     rels = self.descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect { |r| r.depth }.min
+    min_depth = rels.collect(&:depth).min
     rels = rels.select { |r| r.depth == min_depth + 1 }
     Relationship.resources(rels).sort_by { |r| r.name.downcase }
   end
@@ -200,7 +200,7 @@ class EmsCluster < ActiveRecord::Base
   def resource_pools_with_default
     # Look for only the resource_pools up to the second depth (default depth + 1)
     rels = self.descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect { |r| r.depth }.min
+    min_depth = rels.collect(&:depth).min
     rels = rels.select { |r| r.depth <= min_depth + 1 }
     Relationship.resources(rels).sort_by { |r| r.name.downcase }
   end
@@ -231,19 +231,19 @@ class EmsCluster < ActiveRecord::Base
   end
 
   def base_storage_extents
-    all_hosts.collect { |h| h.base_storage_extents }.flatten.uniq
+    all_hosts.collect(&:base_storage_extents).flatten.uniq
   end
 
   def storage_systems
-    all_hosts.collect { |h| h.storage_systems }.flatten.uniq
+    all_hosts.collect(&:storage_systems).flatten.uniq
   end
 
   def storage_volumes
-    all_hosts.collect { |h| h.storage_volumes }.flatten.uniq
+    all_hosts.collect(&:storage_volumes).flatten.uniq
   end
 
   def file_shares
-    all_hosts.collect { |h| h.file_shares }.flatten.uniq
+    all_hosts.collect(&:file_shares).flatten.uniq
   end
 
   def event_where_clause(assoc=:ems_events)
@@ -326,7 +326,7 @@ class EmsCluster < ActiveRecord::Base
     cl_hash.each do |k,v|
       hosts = hosts_by_id.values_at(*v[:ho_ids]).compact
       unless hosts.empty?
-        v[:ho_enabled], v[:ho_disabled] = hosts.partition { |h| h.perf_capture_enabled? }
+        v[:ho_enabled], v[:ho_disabled] = hosts.partition(&:perf_capture_enabled?)
       else
         v[:ho_enabled] = v[:ho_disabled] = []
       end
@@ -346,7 +346,7 @@ class EmsCluster < ActiveRecord::Base
   end
 
   def hosts_enabled_for_perf_capture
-    self.hosts(:include => [:taggings, :tags]).select { |h| h.perf_capture_enabled? }
+    self.hosts(:include => [:taggings, :tags]).select(&:perf_capture_enabled?)
   end
 
   # Vmware specific

--- a/vmdb/app/models/ems_event.rb
+++ b/vmdb/app/models/ems_event.rb
@@ -394,7 +394,7 @@ class EmsEvent < ActiveRecord::Base
 
     total = 0
     until (batch = self.all(:select => :id, :conditions => {:timestamp => oldest..older_than}, :limit => window)).empty?
-      ids = batch.collect { |b| b.id }
+      ids = batch.collect(&:id)
       ids = ids[0, limit - total] if limit && total + ids.length > limit
 
       $log.info("#{log_header} Purging #{ids.length} events.")

--- a/vmdb/app/models/ems_folder.rb
+++ b/vmdb/app/models/ems_folder.rb
@@ -67,7 +67,7 @@ class EmsFolder < ActiveRecord::Base
   end
 
   def datacenters_only
-    self.folders.select { |f| f.is_datacenter }
+    self.folders.select(&:is_datacenter)
   end
 
   # Cluster relationship methods
@@ -170,7 +170,7 @@ class EmsFolder < ActiveRecord::Base
   end
 
   def folder_path(*args)
-    self.folder_path_objs(*args).collect { |f| f.name }.join('/')
+    self.folder_path_objs(*args).collect(&:name).join('/')
   end
 
   def child_folder_paths(*args)

--- a/vmdb/app/models/ems_infra.rb
+++ b/vmdb/app/models/ems_infra.rb
@@ -8,7 +8,7 @@ class EmsInfra < ExtManagementSystem
   }
 
   def self.types
-    self.subclasses.collect { |c| c.ems_type }
+    self.subclasses.collect(&:ems_type)
   end
 
   def self.supported_subclasses
@@ -16,7 +16,7 @@ class EmsInfra < ExtManagementSystem
   end
 
   def self.supported_types
-    self.supported_subclasses.collect { |c| c.ems_type }
+    self.supported_subclasses.collect(&:ems_type)
   end
 
   #

--- a/vmdb/app/models/ems_redhat.rb
+++ b/vmdb/app/models/ems_redhat.rb
@@ -137,7 +137,7 @@ class EmsRedhat < EmsInfra
     if @version_3_0.nil?
       @version_3_0 =
         if self.api_version.nil?
-          self.with_provider_connection { |rhevm| rhevm.version_3_0? }
+          self.with_provider_connection(&:version_3_0?)
         else
           self.api_version.starts_with?("3.0")
         end
@@ -159,7 +159,7 @@ class EmsRedhat < EmsInfra
     link_path = File.join(base_rhevm_path, datacenter.uid_ems)
 
     # Find the storages we need to mount to access this VM
-    storages = [vm.storage, vm.storage.hosts.first.storages.detect {|s| s.master?}].uniq.compact
+    storages = [vm.storage, vm.storage.hosts.first.storages.detect(&:master?)].uniq.compact
 
     result = {:mount_points => [], :symlinks => [], :base_dir => base_path, :link_path => link_path}
     storages.each do |s|

--- a/vmdb/app/models/ems_refresh.rb
+++ b/vmdb/app/models/ems_refresh.rb
@@ -96,7 +96,7 @@ module EmsRefresh
       recs = c.find(:all, opts)
 
       if recs.length != ids.length
-        missing = ids - recs.collect {|r| r.id}
+        missing = ids - recs.collect(&:id)
         $log.warn "MIQ(#{self.name}.get_ar_objects) Unable to find a record for [#{c}] ids: #{missing.inspect}."
       end
 

--- a/vmdb/app/models/ems_refresh/metadata_relats.rb
+++ b/vmdb/app/models/ems_refresh/metadata_relats.rb
@@ -42,7 +42,7 @@ module EmsRefresh::MetadataRelats
               c_meth = ([:hosts, :clusters].include?(p_type) && c_type == :resource_pools) ? :resource_pools_with_default : c_type
               next unless x.respond_to?(c_meth)
 
-              ids = x.send(c_meth).collect {|x2| x2.id}.uniq
+              ids = x.send(c_meth).collect(&:id).uniq
               relats["#{p_type}_to_#{c_type}".to_sym][x.id] |= ids unless ids.empty?
             end
           end

--- a/vmdb/app/models/ems_refresh/parsers/vc.rb
+++ b/vmdb/app/models/ems_refresh/parsers/vc.rb
@@ -925,7 +925,7 @@ module EmsRefresh::Parsers::Vc
     return result if hostname.nil? && guest_ip.nil?
 
     inv_net.to_miq_a.each do |data|
-      ipv4, ipv6 = data['ipAddress'].to_miq_a.compact.collect { |ip| ip.to_s }.sort.partition { |ip| ip =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/ }
+      ipv4, ipv6 = data['ipAddress'].to_miq_a.compact.collect(&:to_s).sort.partition { |ip| ip =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/ }
       ipv4 << nil if ipv4.empty?
       ipaddresses = ipv4.zip_stretched(ipv6)
 

--- a/vmdb/app/models/ems_refresh/refreshers/refresher_relats_mixin.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/refresher_relats_mixin.rb
@@ -31,7 +31,7 @@ module EmsRefresh::Refreshers::RefresherRelatsMixin
       target.hosts.each do |h|
         vr[:ems_to_hosts] << h.id
 
-        ids = h.storages.collect { |s| s.id }
+        ids = h.storages.collect(&:id)
         vr[:hosts_to_storages][h.id] = ids unless ids.empty?
       end
 
@@ -44,23 +44,23 @@ module EmsRefresh::Refreshers::RefresherRelatsMixin
       target.ems_folders.each do |f|
         vr[:ems_to_folders] << f.id
 
-        ids = f.folders.collect { |f2| f2.id }
+        ids = f.folders.collect(&:id)
         vr[:folders_to_folders][f.id] = ids unless ids.empty?
 
-        ids = f.clusters.collect { |c| c.id }
+        ids = f.clusters.collect(&:id)
         vr[:folders_to_clusters][f.id] = ids unless ids.empty?
 
-        ids = f.hosts.collect { |h| h.id }
+        ids = f.hosts.collect(&:id)
         vr[:folders_to_hosts][f.id] = ids unless ids.empty?
 
-        ids = f.vms.collect { |v| v.id }
+        ids = f.vms.collect(&:id)
         vr[:folders_to_vms][f.id] = ids unless ids.empty?
       end
 
       target.ems_clusters.each do |c|
         vr[:ems_to_clusters] << c.id
 
-        ids = c.hosts.collect { |h| h.id }
+        ids = c.hosts.collect(&:id)
         vr[:clusters_to_hosts][c.id] = ids unless ids.empty?
       end
 
@@ -71,17 +71,17 @@ module EmsRefresh::Refreshers::RefresherRelatsMixin
           vr[relat_type][r.parent.id] << r.id
         end
 
-        ids = r.resource_pools.collect { |r2| r2.id }
+        ids = r.resource_pools.collect(&:id)
         vr[:rps_to_rps][r.id] = ids unless ids.empty?
 
-        ids = r.vms.collect { |v| v.id }
+        ids = r.vms.collect(&:id)
         vr[:rps_to_vms][r.id] = ids unless ids.empty?
       end
 
     when Host
       vr[:ems_to_hosts] << target.id
 
-      ids = target.storages.collect { |s| s.id }
+      ids = target.storages.collect(&:id)
       vr[:hosts_to_storages][target.id] = ids unless ids.empty?
 
       target.vms.each do |v|

--- a/vmdb/app/models/ems_refresh/refreshers/vc_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/vc_refresher.rb
@@ -337,7 +337,7 @@ module EmsRefresh::Refreshers
           begin
             get_vc_data_by_mor(:vm, vm.ems_ref_obj)
             get_vc_data_by_mor(:host, vm.host.ems_ref_obj)
-            get_vc_data_by_mor(:storage, vm.host.storages.collect { |s| s.ems_ref_obj })
+            get_vc_data_by_mor(:storage, vm.host.storages.collect(&:ems_ref_obj))
           ensure
             disconnect_from_ems
           end

--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -41,7 +41,7 @@ module EmsRefresh::SaveInventory
     # Query for all of the Vms once across all EMSes, to handle any moving VMs
     vms_uids = hashes.collect { |h| h[:uid_ems] }.compact
     vms = VmOrTemplate.find_all_by_uid_ems(vms_uids)
-    dup_vms_uids = (vms_uids.duplicates + vms.collect { |v| v.uid_ems }.duplicates).uniq.sort
+    dup_vms_uids = (vms_uids.duplicates + vms.collect(&:uid_ems).duplicates).uniq.sort
     $log.info "#{log_header} Duplicate unique values found: #{dup_vms_uids.inspect}" unless dup_vms_uids.empty?
 
     invalids_found = false
@@ -139,7 +139,7 @@ module EmsRefresh::SaveInventory
         $log.warn("#{log_header} Since failures occurred, not disconnecting for Vms #{self.log_format_deletes(disconnects)}")
       else
         $log.info("#{log_header} Disconnecting Vms #{self.log_format_deletes(disconnects)}")
-        disconnects.each { |v| v.disconnect_inv }
+        disconnects.each(&:disconnect_inv)
       end
     end
   end

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -204,7 +204,7 @@ module EmsRefresh::SaveInventoryInfra
         $log.warn("#{log_header} Since failures occurred, not disconnecting for Hosts #{self.log_format_deletes(disconnects)}")
       else
         $log.info("#{log_header} Disconnecting Hosts #{self.log_format_deletes(disconnects)}")
-        disconnects.each { |h| h.disconnect_inv }
+        disconnects.each(&:disconnect_inv)
       end
     end
   end

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -1,18 +1,18 @@
 class ExtManagementSystem < ActiveRecord::Base
   def self.types
-    [EmsInfra, EmsCloud].collect { |c| c.types }.flatten
+    [EmsInfra, EmsCloud].collect(&:types).flatten
   end
 
   def self.supported_types
-    [EmsInfra, EmsCloud].collect { |c| c.supported_types }.flatten
+    [EmsInfra, EmsCloud].collect(&:supported_types).flatten
   end
 
   def self.leaf_subclasses
-    [EmsInfra, EmsCloud].collect { |c| c.subclasses }.flatten
+    [EmsInfra, EmsCloud].collect(&:subclasses).flatten
   end
 
   def self.supported_subclasses
-    [EmsInfra, EmsCloud].collect { |c| c.supported_subclasses }.flatten
+    [EmsInfra, EmsCloud].collect(&:supported_subclasses).flatten
   end
 
   def self.supported_types_and_descriptions_hash
@@ -351,8 +351,8 @@ class ExtManagementSystem < ActiveRecord::Base
 
   def perf_capture_enabled
     return @perf_capture_enabled unless @perf_capture_enabled.nil?
-    return @perf_capture_enabled = true if self.ems_clusters.any? { |c| c.perf_capture_enabled? }
-    return @perf_capture_enabled = true if self.hosts.any?        { |h| h.perf_capture_enabled? }
+    return @perf_capture_enabled = true if self.ems_clusters.any?(&:perf_capture_enabled?)
+    return @perf_capture_enabled = true if self.hosts.any?(&:perf_capture_enabled?)
     return @perf_capture_enabled = false
   end
   alias perf_capture_enabled? perf_capture_enabled

--- a/vmdb/app/models/file_depot_ftp.rb
+++ b/vmdb/app/models/file_depot_ftp.rb
@@ -46,7 +46,7 @@ class FileDepotFtp < FileDepot
   end
 
   def verify_credentials(_auth_type = nil)
-    with_connection { |c| c.last_response }
+    with_connection(&:last_response)
   rescue
     false
   end

--- a/vmdb/app/models/hardware.rb
+++ b/vmdb/app/models/hardware.rb
@@ -29,15 +29,15 @@ class Hardware < ActiveRecord::Base
   include ReportableMixin
 
   def ipaddresses
-    @ipaddresses ||= self.networks.collect { |n| n.ipaddress }.compact.uniq
+    @ipaddresses ||= self.networks.collect(&:ipaddress).compact.uniq
   end
 
   def hostnames
-    @hostnames ||= self.networks.collect { |n| n.hostname }.compact.uniq
+    @hostnames ||= self.networks.collect(&:hostname).compact.uniq
   end
 
   def mac_addresses
-    @mac_addresses ||= self.nics.collect { |n| n.address }.compact.uniq
+    @mac_addresses ||= self.nics.collect(&:address).compact.uniq
   end
 
   @@dh = {"type" => "device_name", "devicetype" => "device_type", "id" => "location", "present" => "present",

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -997,7 +997,7 @@ class Host < ActiveRecord::Base
   def resource_pools
     # Look for only the resource_pools at the second depth (default depth + 1)
     rels = self.descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect { |r| r.depth }.min
+    min_depth = rels.collect(&:depth).min
     rels = rels.select { |r| r.depth == min_depth + 1 }
     Relationship.resources(rels).sort_by { |r| r.name.downcase }
   end
@@ -1005,7 +1005,7 @@ class Host < ActiveRecord::Base
   def resource_pools_with_default
     # Look for only the resource_pools up to the second depth (default depth + 1)
     rels = self.descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect { |r| r.depth }.min
+    min_depth = rels.collect(&:depth).min
     rels = rels.select { |r| r.depth <= min_depth + 1 }
     Relationship.resources(rels).sort_by { |r| r.name.downcase }
   end
@@ -1606,7 +1606,7 @@ class Host < ActiveRecord::Base
   def self.ready_for_provisioning?(ids)
     errors = ActiveModel::Errors.new(self)
     hosts = self.find_all_by_id(ids)
-    missing = ids - hosts.collect {|v| v.id}
+    missing = ids - hosts.collect(&:id)
     errors.add(:missing_ids, "Unable to find Hosts with the following ids #{missing.inspect}") unless missing.empty?
 
     hosts.each do |host|
@@ -1944,7 +1944,7 @@ class Host < ActiveRecord::Base
   end
 
   def service_names
-    self.system_services.collect {|s| s.name}.uniq.sort
+    self.system_services.collect(&:name).uniq.sort
   end
 
   def enabled_run_level_0_services

--- a/vmdb/app/models/iso_datastore.rb
+++ b/vmdb/app/models/iso_datastore.rb
@@ -48,7 +48,7 @@ class IsoDatastore < ActiveRecord::Base
       end
     end
 
-    db_image_hash.each_value { |image| image.destroy }
+    db_image_hash.each_value(&:destroy)
 
     clear_association_cache
     self.update_attribute(:last_refresh_on, Time.now.utc)

--- a/vmdb/app/models/job_proxy_dispatcher.rb
+++ b/vmdb/app/models/job_proxy_dispatcher.rb
@@ -24,7 +24,7 @@ class JobProxyDispatcher
         Benchmark.realtime_block(:busy_proxies) { self.busy_proxies }
         Benchmark.realtime_block(:busy_resources_for_embedded_scanning) { self.busy_resources_for_embedded_scanning }
 
-        vms_for_jobs = jobs_to_dispatch.collect {|j| j.target_id}
+        vms_for_jobs = jobs_to_dispatch.collect(&:target_id)
         @vms_for_dispatch_jobs, = Benchmark.realtime_block(:vm_find) do
           VmOrTemplate.where(:id => vms_for_jobs)
             .includes(:ext_management_system => :zone, :storage => {:hosts => :miq_proxy})
@@ -215,7 +215,7 @@ class JobProxyDispatcher
         .where(:agent_class      => "MiqServer")
         .where(:target_class     => "VmOrTemplate")
         .where("state != ?", "finished")
-        .select("target_id").collect { |ji| ji.target_id }.compact.uniq
+        .select("target_id").collect(&:target_id).compact.uniq
     return @busy_resources_for_embedded_scanning_hash if vms_in_embedded_scanning.blank?
 
     embedded_scans_by_resource = Hash.new {|h,k| h[k] = 0}

--- a/vmdb/app/models/ldap_region.rb
+++ b/vmdb/app/models/ldap_region.rb
@@ -13,15 +13,15 @@ class LdapRegion < ActiveRecord::Base
   # include ReportableMixin
 
   def is_valid?
-    self.ldap_domains.any? {|d| d.is_valid?}
+    self.ldap_domains.any?(&:is_valid?)
   end
 
   def self.valid_regions
-    self.all.find_all {|r| r.is_valid?}
+    self.all.find_all(&:is_valid?)
   end
 
   def valid_domains
-    self.ldap_domains.all.find_all {|r| r.is_valid?}
+    self.ldap_domains.all.find_all(&:is_valid?)
   end
 
   def user_search(options)

--- a/vmdb/app/models/metric/helper.rb
+++ b/vmdb/app/models/metric/helper.rb
@@ -40,7 +40,7 @@ module Metric::Helper
     start_time = Time.parse(start_time)
     end_time = Time.parse(self.nearest_realtime_timestamp(end_time))
 
-    (start_time..end_time).step_value(20.seconds).collect! { |t| t.iso8601 }
+    (start_time..end_time).step_value(20.seconds).collect!(&:iso8601)
   end
 
   def self.hours_from_range(start_time, end_time = nil)
@@ -50,7 +50,7 @@ module Metric::Helper
     start_time = Time.parse(start_time)
     end_time = Time.parse(self.nearest_hourly_timestamp(end_time))
 
-    (start_time..end_time).step_value(1.hour).collect! { |t| t.iso8601 }
+    (start_time..end_time).step_value(1.hour).collect!(&:iso8601)
   end
 
   def self.nearest_daily_timestamp(ts, tz = nil)

--- a/vmdb/app/models/metric/purging.rb
+++ b/vmdb/app/models/metric/purging.rb
@@ -84,7 +84,7 @@ module Metric::Purging
         end
         break if batch.empty?
 
-        ids = batch.collect { |b| b.id }
+        ids = batch.collect(&:id)
         ids = ids[0, limit - total] if limit && total + ids.length > limit
 
         $log.info("#{log_header} Purging #{ids.length} #{interval} metrics.")

--- a/vmdb/app/models/metric/rollup.rb
+++ b/vmdb/app/models/metric/rollup.rb
@@ -308,8 +308,8 @@ module Metric::Rollup
     metrics = Metric.in_my_region.select("DISTINCT resource_type, resource_id")
     metric_rollups = MetricRollup.in_my_region.select("DISTINCT resource_type, resource_id")
 
-    recs = (metrics + metric_rollups).group_by { |m| m.resource_type }
-    recs.keys.each { |k| recs[k] = recs[k].collect { |r| r.resource_id }.uniq }
+    recs = (metrics + metric_rollups).group_by(&:resource_type)
+    recs.keys.each { |k| recs[k] = recs[k].collect(&:resource_id).uniq }
 
     recs.each_with_object([]) do |(klass, ids), ret|
       ret.concat(klass.constantize.where(:id => ids))

--- a/vmdb/app/models/metric/targets.rb
+++ b/vmdb/app/models/metric/targets.rb
@@ -18,7 +18,7 @@ module Metric::Targets
     targets = zone.ems_clusters + zone.non_clustered_hosts
     targets += zone.storages.select { |s| Storage::SUPPORTED_STORAGE_TYPES.include?(s.store_type) } unless options[:exclude_storages]
 
-    targets = targets.select { |t| t.perf_capture_enabled? }
+    targets = targets.select(&:perf_capture_enabled?)
     targets = targets.collect { |t| t.kind_of?(EmsCluster) ? t.hosts : t }.flatten
 
     targets += capture_vm_targets(targets, Host, options)

--- a/vmdb/app/models/miq_action.rb
+++ b/vmdb/app/models/miq_action.rb
@@ -102,7 +102,7 @@ class MiqAction < ActiveRecord::Base
   end
 
   def miq_policies
-    self.miq_policy_contents.collect {|pe| pe.miq_policy}.uniq
+    self.miq_policy_contents.collect(&:miq_policy).uniq
   end
 
   def self.invoke_actions(apply_policies_to, inputs, succeeded, failed)

--- a/vmdb/app/models/miq_ae_datastore.rb
+++ b/vmdb/app/models/miq_ae_datastore.rb
@@ -126,7 +126,7 @@ module MiqAeDatastore
 
   def self.reset
     $log.info("MIQ(MiqAeDatastore) Clearing datastore") if $log
-    [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| k.delete_all }
+    [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each(&:delete_all)
   end
 
   def self.reset_default_namespace

--- a/vmdb/app/models/miq_ae_instance.rb
+++ b/vmdb/app/models/miq_ae_instance.rb
@@ -111,7 +111,7 @@ class MiqAeInstance < ActiveRecord::Base
   end
 
   def field_names
-    fields = ae_values.collect { |v| v.field_id }
+    fields = ae_values.collect(&:field_id)
     ae_class.ae_fields.select { |x| fields.include?(x.id) }.collect { |f| f.name.downcase }
   end
 

--- a/vmdb/app/models/miq_ae_instance_yaml.rb
+++ b/vmdb/app/models/miq_ae_instance_yaml.rb
@@ -7,7 +7,7 @@ class MiqAeInstanceYaml
 
   def field_names
     raise "ae instance object has not been initialize" unless @ae_instance_obj
-    @ae_instance_obj['object']['fields'].collect { |item| item.keys }.flatten
+    @ae_instance_obj['object']['fields'].collect(&:keys).flatten
   end
 
   def field_value_hash(name)

--- a/vmdb/app/models/miq_alert.rb
+++ b/vmdb/app/models/miq_alert.rb
@@ -87,7 +87,7 @@ class MiqAlert < ActiveRecord::Base
 
     self.alert_assignments[key] ||= begin
       profiles  = MiqAlertSet.assigned_to_target(target, :find_options => {:conditions => ["mode = ?", target.class.base_model.name], :select => "id"})
-      alert_ids = profiles.collect {|p| p.members(:select => "id").collect {|m| m.id}}.flatten.uniq
+      alert_ids = profiles.collect {|p| p.members(:select => "id").collect(&:id)}.flatten.uniq
 
       if alert_ids.empty?
         []

--- a/vmdb/app/models/miq_bulk_import.rb
+++ b/vmdb/app/models/miq_bulk_import.rb
@@ -14,7 +14,7 @@ module MiqBulkImport
     end
     header = reader.shift
 
-    tags = (header - keys).collect{|t| t.dup} if tags.nil?
+    tags = (header - keys).collect(&:dup) if tags.nil?
 
     verified_tags = tags.collect {|t| t if header.include?(t)}.compact
     unless verified_tags.empty?

--- a/vmdb/app/models/miq_cim_association.rb
+++ b/vmdb/app/models/miq_cim_association.rb
@@ -103,7 +103,7 @@ class MiqCimAssociation < ActiveRecord::Base
     total = 0
     aq = self.select(:id).where(:zone_id => zoneId, :status => STATUS_STALE)
     aq.find_in_batches(:batch_size => 100) do |aa|
-      ids = aa.collect { |a| a.id }
+      ids = aa.collect(&:id)
       total += self.delete_all(:id => ids)
     end
     $log.info "MiqCimAssociation.cleanup_by_zone: deleted #{total} stale associations for zone id #{zoneId}"

--- a/vmdb/app/models/miq_cim_virtual_disk.rb
+++ b/vmdb/app/models/miq_cim_virtual_disk.rb
@@ -61,7 +61,7 @@ class MiqCimVirtualDisk < MiqCimInstance
   end
 
   def storage_systems
-    datastore_backing.collect { |cdb| cdb.storage_system }.flatten.compact.uniq
+    datastore_backing.collect(&:storage_system).flatten.compact.uniq
   end
 
   def file_share
@@ -85,7 +85,7 @@ class MiqCimVirtualDisk < MiqCimInstance
   end
 
   def base_storage_extents
-    datastore_backing.collect { |cdb| cdb.base_storage_extents }.flatten.compact.uniq
+    datastore_backing.collect(&:base_storage_extents).flatten.compact.uniq
   end
 
 end

--- a/vmdb/app/models/miq_compare.rb
+++ b/vmdb/app/models/miq_compare.rb
@@ -32,7 +32,7 @@ class MiqCompare
       raise "Must pass an id to MiqCompare" if options[:id].nil?
 
       @model_record_id = options[:id]
-      @ids_orig = options[:timestamps].collect { |ts| ts.utc }
+      @ids_orig = options[:timestamps].collect(&:utc)
       @ids = Array.new(@ids_orig)
     else
       raise "Unknown compare type [#{@mode}]"

--- a/vmdb/app/models/miq_enterprise.rb
+++ b/vmdb/app/models/miq_enterprise.rb
@@ -90,7 +90,7 @@ class MiqEnterprise < ActiveRecord::Base
   end
 
   def perf_capture_enabled
-    @perf_capture_enabled ||= self.ext_management_systems.any? { |ems| ems.perf_capture_enabled? }
+    @perf_capture_enabled ||= self.ext_management_systems.any?(&:perf_capture_enabled?)
   end
   alias perf_capture_enabled? perf_capture_enabled
 end #class MiqEnterprise

--- a/vmdb/app/models/miq_group.rb
+++ b/vmdb/app/models/miq_group.rb
@@ -83,7 +83,7 @@ class MiqGroup < ActiveRecord::Base
         ldap_to_filters = File.exist?(filter_map_file) ? YAML.load_file(filter_map_file) : {}
 
         role_map = YAML.load_file(role_map_file)
-        order = role_map.collect {|h| h.keys}.flatten
+        order = role_map.collect(&:keys).flatten
         groups_to_roles = role_map.inject({}) {|h, g| h[g.keys.first] = g[g.keys.first]; h}
         seq = 1
         order.each do |g|

--- a/vmdb/app/models/miq_host_provision_workflow.rb
+++ b/vmdb/app/models/miq_host_provision_workflow.rb
@@ -75,7 +75,7 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   end
 
   def allowed_ws_hosts(options={})
-    Host.where("mac_address is not NULL").select { |h| h.ipmi_enabled }
+    Host.where("mac_address is not NULL").select(&:ipmi_enabled)
   end
 
   def allowed_ems(options={})
@@ -108,7 +108,7 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
 
   # This is for summary screen display purposes only
   def update_selected_storage_names(values)
-    values[:attached_ds_names] = Storage.find_all_by_id(values[:attached_ds], :select => "name").collect {|h| h.name}
+    values[:attached_ds_names] = Storage.find_all_by_id(values[:attached_ds], :select => "name").collect(&:name)
   end
 
   def ws_template_fields(values, fields)

--- a/vmdb/app/models/miq_policy.rb
+++ b/vmdb/app/models/miq_policy.rb
@@ -117,12 +117,12 @@ class MiqPolicy < ActiveRecord::Base
   end
 
   def miq_events
-    self.miq_policy_contents.collect {|e| e.miq_event}.uniq
+    self.miq_policy_contents.collect(&:miq_event).uniq
   end
   alias events miq_events
 
   def miq_actions
-    self.miq_policy_contents.collect {|e| e.miq_action}.compact.uniq
+    self.miq_policy_contents.collect(&:miq_action).compact.uniq
   end
   alias actions miq_actions
 

--- a/vmdb/app/models/miq_product_feature.rb
+++ b/vmdb/app/models/miq_product_feature.rb
@@ -53,7 +53,7 @@ class MiqProductFeature < ActiveRecord::Base
   def self.features
     @feature_cache ||= begin
       self.all(:include => [:parent, :children]).inject({}) do |h,f|
-        child_idents = f.children.collect { |c| c.identifier }
+        child_idents = f.children.collect(&:identifier)
         parent_ident = f.parent.identifier if f.parent
         details      = DETAIL_ATTRS.inject({}) {|dh,a| dh[a] = f.send(a); dh}
         h[f.identifier] = {:parent => parent_ident, :children => child_idents, :details => details}
@@ -66,7 +66,7 @@ class MiqProductFeature < ActiveRecord::Base
     # Build an array of arrays as [[feature_type, name, identifier], ...]
     c_array = children.collect { |c| [self.feature_details(c)[:feature_type], self.feature_details(c)[:name], c] }
     # Sort by feature_type and name forcing the ordering of feature_type to match FEATURE_TYPE_ORDER
-    c_array.sort_by { |ftype, name, ident| [FEATURE_TYPE_ORDER.index(ftype), name] }.collect {|c| c.last}
+    c_array.sort_by { |ftype, name, ident| [FEATURE_TYPE_ORDER.index(ftype), name] }.collect(&:last)
   end
 
   def self.seed

--- a/vmdb/app/models/miq_provision_request.rb
+++ b/vmdb/app/models/miq_provision_request.rb
@@ -120,7 +120,7 @@ class MiqProvisionRequest < MiqRequest
   end
 
   def vms
-    self.miq_provisions.collect {|p| p.vm}.compact
+    self.miq_provisions.collect(&:vm).compact
   end
 end
 

--- a/vmdb/app/models/miq_provision_vmware_via_pxe/pxe.rb
+++ b/vmdb/app/models/miq_provision_vmware_via_pxe/pxe.rb
@@ -7,7 +7,7 @@ module MiqProvisionVmwareViaPxe::Pxe
     result = vm.hardware.nics.detect {|n| n.address && n.lan.try(:name) == network_name}.try(:address)
     if result.blank?
       # Sort by device name to control return order.  VMware names nics like: Network adapter 1, Network adapter 2
-      nics = vm.hardware.nics.select {|n| n.address}.sort_by {|n| n.device_name}
+      nics = vm.hardware.nics.select(&:address).sort_by(&:device_name)
       unless nics.blank?
         mac_addresses = nics.collect {|n| [n.device_name, n.address]}
         $log.info("MIQ(#{self.class.name}#get_mac_address_of_nic_on_requested_vlan) Vlan lookup did not return a matching MAC address.  Returning first available address from: <#{mac_addresses.inspect}>")

--- a/vmdb/app/models/miq_provision_vmware_workflow.rb
+++ b/vmdb/app/models/miq_provision_vmware_workflow.rb
@@ -106,7 +106,7 @@ class MiqProvisionVmwareWorkflow < MiqProvisionInfraWorkflow
   ]
 
   def get_timezones(options={})
-    SYSPREP_TIMEZONES.collect {|t| t.reverse}
+    SYSPREP_TIMEZONES.collect(&:reverse)
   end
 
   def self.allowed_templates_vendor

--- a/vmdb/app/models/miq_proxy.rb
+++ b/vmdb/app/models/miq_proxy.rb
@@ -658,15 +658,15 @@ class MiqProxy < ActiveRecord::Base
   end
 
   def hosts
-    self.storages.collect {|s| s.hosts}.flatten.compact.push(self.host).uniq
+    self.storages.collect(&:hosts).flatten.compact.push(self.host).uniq
   end
 
   def vms
-    self.storages.collect {|s| s.vms}.flatten.compact.uniq
+    self.storages.collect(&:vms).flatten.compact.uniq
   end
 
   def miq_templates
-    self.storages.collect {|s| s.miq_templates}.flatten.compact.uniq
+    self.storages.collect(&:miq_templates).flatten.compact.uniq
   end
 
   def storages

--- a/vmdb/app/models/miq_region.rb
+++ b/vmdb/app/models/miq_region.rb
@@ -110,7 +110,7 @@ class MiqRegion < ActiveRecord::Base
   end
 
   def assigned_roles
-    self.miq_servers.collect { |s| s.assigned_roles }.flatten.uniq.compact
+    self.miq_servers.collect(&:assigned_roles).flatten.uniq.compact
   end
 
   def role_active?(role_name)

--- a/vmdb/app/models/miq_report/generator.rb
+++ b/vmdb/app/models/miq_report/generator.rb
@@ -410,9 +410,9 @@ module MiqReport::Generator
     raise "Report table is nil" if rpt.table.nil?
 
     rpt_data = if self.db_options[:row_col] && self.db_options[:row_val]
-      rpt.table.find_all {|d| d.data.has_key?(self.db_options[:row_col]) && (d.data[self.db_options[:row_col]] == self.db_options[:row_val])}.collect {|d| d.data}
+      rpt.table.find_all {|d| d.data.has_key?(self.db_options[:row_col]) && (d.data[self.db_options[:row_col]] == self.db_options[:row_val])}.collect(&:data)
     else
-      rpt.table.collect {|d| d.data}
+      rpt.table.collect(&:data)
     end
   end
 
@@ -556,9 +556,9 @@ module MiqReport::Generator
     return data if data.blank?
 
     # Build a tempory table so that ruport sorting can be used to sort data before summarizing pivot data
-    column_names = (data.first.keys.collect {|k| k.to_s} + self.col_order).uniq
+    column_names = (data.first.keys.collect(&:to_s) + self.col_order).uniq
     data = Ruport::Data::Table.new(:data => data, :column_names => column_names)
-    data = self.sort_table(data, self.rpt_options[:pivot][:group_cols].collect {|c| c.to_s}, :order => :ascending)
+    data = self.sort_table(data, self.rpt_options[:pivot][:group_cols].collect(&:to_s), :order => :ascending)
 
     # build grouping options for subtotal
     options = self.col_order.inject({}) do |h,col|

--- a/vmdb/app/models/miq_report/generator/async.rb
+++ b/vmdb/app/models/miq_report/generator/async.rb
@@ -5,7 +5,7 @@ module MiqReport::Generator::Async
       options[:userid] ||= "system"
       sync = VMDB::Config.new("vmdb").config[:product][:report_sync]
 
-      task = MiqTask.create(:name => "Generate Reports: #{options[:reports].collect {|r| r.name}.inspect}")
+      task = MiqTask.create(:name => "Generate Reports: #{options[:reports].collect(&:name).inspect}")
       MiqQueue.put(
         :queue_name  => "generic",
         :role        => "reporting",

--- a/vmdb/app/models/miq_report/search.rb
+++ b/vmdb/app/models/miq_report/search.rb
@@ -26,7 +26,7 @@ module MiqReport::Search
       ids      = ids[offset..offset + limit - 1]
     end
     data         = self.db_class.find_all_by_id(ids, :include => includes)
-    targets_hash = data.index_by { |obj| obj.id } if options[:targets_hash]
+    targets_hash = data.index_by(&:id) if options[:targets_hash]
     self.build_table(data, self.db, options)
     return self.table, self.extras[:attrs_for_paging].merge(:paged_read_from_cache => true, :targets_hash => targets_hash)
   end
@@ -77,10 +77,10 @@ module MiqReport::Search
     assoc ||= self.db_class.base_model.to_s.pluralize.underscore  # Derive association from base model
     ref = parent.class.reflections_with_virtual[assoc.to_sym]
     if ref.nil? || ref.kind_of?(VirtualReflection)
-      targets = parent.send(assoc).collect {|t| t.id} # assoc is either a virtual reflection or a method so just call the association and collect the ids
+      targets = parent.send(assoc).collect(&:id) # assoc is either a virtual reflection or a method so just call the association and collect the ids
     else
       #TODO: Can we use the pre-built _ids methods that come with Rails?
-      targets = parent.send(assoc).send(:find, :all, :select => 'id').collect {|t| t.id}
+      targets = parent.send(assoc).send(:find, :all, :select => 'id').collect(&:id)
     end
     return targets
   end

--- a/vmdb/app/models/miq_report_result.rb
+++ b/vmdb/app/models/miq_report_result.rb
@@ -97,7 +97,7 @@ class MiqReportResult < ActiveRecord::Base
     end
     self.update_attribute(:last_accessed_on, Time.now.utc)
     self.purge_for_user
-    self.html_details.all(options.merge(:order => "id asc")).collect { |h| h.data }
+    self.html_details.all(options.merge(:order => "id asc")).collect(&:data)
   end
 
   def save_for_user(userid)

--- a/vmdb/app/models/miq_request.rb
+++ b/vmdb/app/models/miq_request.rb
@@ -213,7 +213,7 @@ class MiqRequest < ActiveRecord::Base
   end
 
   def v_approved_by
-    self.miq_approvals.collect {|a| a.stamper_name}.compact.join(", ")
+    self.miq_approvals.collect(&:stamper_name).compact.join(", ")
   end
 
   def v_approved_by_email

--- a/vmdb/app/models/miq_server.rb
+++ b/vmdb/app/models/miq_server.rb
@@ -233,7 +233,7 @@ class MiqServer < ActiveRecord::Base
     if svr.vm_id.nil?
       vms = Vm.find_all_by_mac_address_and_hostname_and_ipaddress(mac_address, hostname, ipaddr)
       if vms.length > 1
-        $log.warn "Found multiple Vms that may represent this MiqServer: #{vms.collect { |v| v.id }.sort.inspect}"
+        $log.warn "Found multiple Vms that may represent this MiqServer: #{vms.collect(&:id).sort.inspect}"
       elsif vms.length == 1
         svr_hash[:vm_id] = vms.first.id
       end

--- a/vmdb/app/models/miq_server/role_management.rb
+++ b/vmdb/app/models/miq_server/role_management.rb
@@ -111,7 +111,7 @@ module MiqServer::RoleManagement
   end
 
   def server_role_names
-    self.server_roles.collect { |r| r.name }.sort
+    self.server_roles.collect(&:name).sort
   end
   alias my_roles            server_role_names
   alias assigned_role_names server_role_names
@@ -162,11 +162,11 @@ module MiqServer::RoleManagement
   end
 
   def inactive_role_names
-    self.inactive_roles.collect { |r| r.name }.sort
+    self.inactive_roles.collect(&:name).sort
   end
 
   def active_role_names
-    self.active_roles.collect { |r| r.name }.sort
+    self.active_roles.collect(&:name).sort
   end
 
   def active_role
@@ -183,7 +183,7 @@ module MiqServer::RoleManagement
   end
 
   def licensed_role_names
-    self.licensed_roles.collect { |r| r.name }.sort
+    self.licensed_roles.collect(&:name).sort
   end
 
   def licensed_role
@@ -211,7 +211,7 @@ module MiqServer::RoleManagement
       }
     end
 
-    assigned_roles = servers.collect { |s| s.assigned_roles }.flatten.uniq.compact
+    assigned_roles = servers.collect(&:assigned_roles).flatten.uniq.compact
     assigned_roles.each do |r|
       next unless roles_to_sync.include?(r)
       role_name = r.name

--- a/vmdb/app/models/miq_server/server_monitor.rb
+++ b/vmdb/app/models/miq_server/server_monitor.rb
@@ -13,7 +13,7 @@ module MiqServer::ServerMonitor
 
     # Mark all messages currently being worked on by the not responding server's workers as error
     $log.info("#{log_prefix} Cleaning all active messages being processed by #{self.format_full_log_msg}")
-    self.miq_workers.each {|w| w.clean_active_messages}
+    self.miq_workers.each(&:clean_active_messages)
   end
 
   def make_master_server(last_master)
@@ -24,7 +24,7 @@ module MiqServer::ServerMonitor
       all_servers = parent.miq_servers
 
       $log.debug "#{log_prefix} Double checking that nothing has changed"
-      master = all_servers.detect { |s| s.is_master? }
+      master = all_servers.detect(&:is_master?)
       if (last_master.nil? && !master.nil?) || (!last_master.nil? && !master.nil? && last_master.id != master.id)
         $log.info "#{log_prefix} Aborting master server takeover as another server has taken control first."
         return nil
@@ -53,7 +53,7 @@ module MiqServer::ServerMonitor
     # Check all of the other servers and see if we have new servers, servers have stopped, or servers have stopped responding
     all_servers = self.find_other_started_servers_in_region
 
-    current_ids = all_servers.collect { |s| s.id }
+    current_ids = all_servers.collect(&:id)
     last_ids    = @last_servers.keys
     added       = current_ids - last_ids
     removed     = last_ids - current_ids

--- a/vmdb/app/models/miq_server/status_management.rb
+++ b/vmdb/app/models/miq_server/status_management.rb
@@ -28,7 +28,7 @@ module MiqServer::StatusManagement
       status = MiqSystem.memory
       unless status.empty?
         $log.info("#{log_prefix} [#{svr_name}] System Status:")
-        status.keys.sort_by { |k| k.to_s }.each { |k| $log.info("#{log_prefix} [#{svr_name}]     #{k}: #{status[k]}") }
+        status.keys.sort_by(&:to_s).each { |k| $log.info("#{log_prefix} [#{svr_name}]     #{k}: #{status[k]}") }
       end
 
       disks = MiqSystem.disk_usage
@@ -72,11 +72,11 @@ module MiqServer::StatusManagement
       end
 
       queue_count = MiqQueue.nested_count_by(%w(state zone role))
-      states = queue_count.keys.sort_by { |k| k.to_s }
+      states = queue_count.keys.sort_by(&:to_s)
       states.each { |state| $log.info("#{log_prefix} [#{svr_name}] MiqQueue count for state=[#{state.inspect}] by zone and role: #{queue_count[state].inspect}") }
 
       job_count = Job.nested_count_by(%w(state zone type))
-      states = job_count.keys.sort_by { |k| k.to_s }
+      states = job_count.keys.sort_by(&:to_s)
       states.each { |state| $log.info("#{log_prefix} [#{svr_name}] Job count for state=[#{state.inspect}] by zone and process_type: #{job_count[state].inspect}") }
     end
   end

--- a/vmdb/app/models/miq_server/update_management.rb
+++ b/vmdb/app/models/miq_server/update_management.rb
@@ -5,16 +5,16 @@ module MiqServer::UpdateManagement
 
   module ClassMethods
     def queue_update_registration_status(*ids)
-      servers = self.where(:id => ids.flatten).each { |s| s.queue_update_registration_status }
+      servers = self.where(:id => ids.flatten).each(&:queue_update_registration_status)
     end
 
     def queue_check_updates(*ids)
       ids     = [MiqServer.my_server.id] if ids.blank?
-      servers = self.where(:id => ids.flatten).each { |s| s.queue_check_updates }
+      servers = self.where(:id => ids.flatten).each(&:queue_check_updates)
     end
 
     def queue_apply_updates(*ids)
-      self.where(:id => ids.flatten).each { |s| s.queue_apply_updates }
+      self.where(:id => ids.flatten).each(&:queue_apply_updates)
     end
   end
 

--- a/vmdb/app/models/miq_server/worker_management/monitor.rb
+++ b/vmdb/app/models/miq_server/worker_management/monitor.rb
@@ -70,7 +70,7 @@ module MiqServer::WorkerManagement::Monitor
       w.destroy
     end
     self.miq_workers.delete(*processed_workers) unless processed_workers.empty?
-    processed_workers.collect {|w| w.id}
+    processed_workers.collect(&:id)
   end
 
   def check_pending_stop(class_name = nil)
@@ -96,7 +96,7 @@ module MiqServer::WorkerManagement::Monitor
       worker_delete(w.pid)
     end
     self.miq_workers.delete(*processed_workers) unless processed_workers.empty?
-    processed_workers.collect {|w| w.id}
+    processed_workers.collect(&:id)
   end
 
   def do_system_limit_exceeded

--- a/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -11,7 +11,7 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
       self.clean_worker_records(class_name)
     end
 
-    return true if self.miq_workers.all? { |w| w.is_stopped? }
+    return true if self.miq_workers.all?(&:is_stopped?)
 
     if self.quiesce_workers_loop_timeout?
       killed_workers = []
@@ -51,7 +51,7 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
 
     # Mark all messages currently being worked on by the not responding server's workers as error
     $log.info("#{log_prefix} Cleaning all active messages being processed by MiqServer")
-    self.miq_workers.each { |w| w.clean_active_messages }
+    self.miq_workers.each(&:clean_active_messages)
   end
 
   def quiesce_workers_loop_timeout?

--- a/vmdb/app/models/miq_storage_metric.rb
+++ b/vmdb/app/models/miq_storage_metric.rb
@@ -199,7 +199,7 @@ class MiqStorageMetric < ActiveRecord::Base
       query = query.where(:rollup_type => rollup_type) unless rollup_type.nil?
       total = 0
       query.find_in_batches(:batch_size => window) do |ma|
-        ids = ma.collect { |m| m.id }
+        ids = ma.collect(&:id)
         total += mc.delete_all(:id => ids)
       end
       gtotal += total
@@ -214,7 +214,7 @@ class MiqStorageMetric < ActiveRecord::Base
   # Called directly from MiqStorageMetric.
   #
   def self.sub_class_names
-    self.select('DISTINCT type').collect { |c| c.type }
+    self.select('DISTINCT type').collect(&:type)
   end
 
   #

--- a/vmdb/app/models/miq_task.rb
+++ b/vmdb/app/models/miq_task.rb
@@ -251,7 +251,7 @@ class MiqTask < ActiveRecord::Base
     cond[1] << ts.utc
 
     $log.info("#{log_prefix} cond.flatten: #{cond.flatten.inspect}")
-    ids = where(cond.flatten).select("id").collect {|j| j.id}
+    ids = where(cond.flatten).select("id").collect(&:id)
 
     self.delete_by_id(ids)
   end

--- a/vmdb/app/models/miq_user_role.rb
+++ b/vmdb/app/models/miq_user_role.rb
@@ -27,7 +27,7 @@ class MiqUserRole < ActiveRecord::Base
   }
 
   def feature_identifiers
-    self.miq_product_features.collect {|f| f.identifier}
+    self.miq_product_features.collect(&:identifier)
   end
 
   def allows?(options={})

--- a/vmdb/app/models/miq_user_scope.rb
+++ b/vmdb/app/models/miq_user_scope.rb
@@ -41,7 +41,7 @@ class MiqUserScope
 
   def merge_managed(*args)
     grouped = args.flatten.compact.group_by {|v| v.split("/")[0..2]}
-    grouped.values.collect {|inner| inner.uniq}
+    grouped.values.collect(&:uniq)
   end
 
   def merge_belongsto(*args)

--- a/vmdb/app/models/miq_vim_broker_worker.rb
+++ b/vmdb/app/models/miq_vim_broker_worker.rb
@@ -20,7 +20,7 @@ class MiqVimBrokerWorker < MiqWorker
   end
 
   def self.emses_to_monitor
-    EmsVmware.where(:zone_id => MiqServer.my_server.zone_id).includes(:authentications).select { |e| e.authentication_valid? }
+    EmsVmware.where(:zone_id => MiqServer.my_server.zone_id).includes(:authentications).select(&:authentication_valid?)
   end
 
   def self.available?

--- a/vmdb/app/models/miq_widget.rb
+++ b/vmdb/app/models/miq_widget.rb
@@ -155,7 +155,7 @@ class MiqWidget < ActiveRecord::Base
       :class_name  => self.class.name,
       :instance_id => self.id ).all
 
-    unless messages.any? { |m| m.unfinished? }
+    unless messages.any?(&:unfinished?)
       unless task.state == MiqTask::STATE_FINISHED
         task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_TIMEOUT, "Timed out stalled task.")
       end
@@ -456,7 +456,7 @@ class MiqWidget < ActiveRecord::Base
   end
 
   def timezones_for_users(users)
-    users.to_miq_a.collect { |u| u.get_timezone }.uniq.sort
+    users.to_miq_a.collect(&:get_timezone).uniq.sort
   end
 
   def available_for_group?(group)

--- a/vmdb/app/models/miq_worker.rb
+++ b/vmdb/app/models/miq_worker.rb
@@ -172,7 +172,7 @@ class MiqWorker < ActiveRecord::Base
   # Grab all the classes in the hierarchy but ActiveRecord::Base and Object (and BasicObject on 1.9)
   def self.path_to_my_worker_settings
     excluded = %w(ActiveRecord::Base Object BasicObject)
-    @path_to_my_worker_settings ||= self.hierarchy.reject {|c| excluded.include?(c.name)}.reverse.collect {|c| c.corresponding_helper }
+    @path_to_my_worker_settings ||= self.hierarchy.reject {|c| excluded.include?(c.name)}.reverse.collect(&:corresponding_helper)
   end
 
   def self.fetch_worker_settings_from_server(miq_server, options = {})
@@ -223,11 +223,11 @@ class MiqWorker < ActiveRecord::Base
   end
 
   def self.stop_workers(server_id = nil)
-    self.server_scope(server_id).each { |w| w.stop }
+    self.server_scope(server_id).each(&:stop)
   end
 
   def self.restart_workers(server_id = nil)
-    self.find_current(server_id).each { |w| w.restart }
+    self.find_current(server_id).each(&:restart)
   end
 
   def self.clean_workers
@@ -242,7 +242,7 @@ class MiqWorker < ActiveRecord::Base
   end
 
   def self.status_update
-    self.find_current.each { |w| w.status_update }
+    self.find_current.each(&:status_update)
   end
 
   def self.log_status(level = :info)

--- a/vmdb/app/models/mixins/active_vm_aggregation_mixin.rb
+++ b/vmdb/app/models/mixins/active_vm_aggregation_mixin.rb
@@ -10,7 +10,7 @@ module ActiveVmAggregationMixin
   end
 
   def active_vms
-    self.vms.select { |vm| vm.active? }
+    self.vms.select(&:active?)
   end
 
   def active_vm_aggregation(field_name)

--- a/vmdb/app/models/mixins/aggregation_mixin.rb
+++ b/vmdb/app/models/mixins/aggregation_mixin.rb
@@ -85,7 +85,7 @@ module AggregationMixin
   def all_storages
     hosts = self.all_hosts
     MiqPreloader.preload(hosts, :storages)
-    hosts.collect { |h| h.storages }.flatten.compact.uniq
+    hosts.collect(&:storages).flatten.compact.uniq
   end
 
   def aggregate_hardware(from, field, targets = nil)

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -10,7 +10,7 @@ module AuthenticationMixin
       zone = MiqServer.my_server.zone
       assoc = self.name.tableize
       assocs = zone.respond_to?(assoc) ? zone.send(assoc) : []
-      assocs.each { |ci| ci.authentication_check_types_queue }
+      assocs.each(&:authentication_check_types_queue)
     end
   end
 

--- a/vmdb/app/models/mixins/compliance_mixin.rb
+++ b/vmdb/app/models/mixins/compliance_mixin.rb
@@ -13,7 +13,7 @@ module ComplianceMixin
   def last_compliance
     return @last_compliance unless @last_compliance.nil?
     @last_compliance = if association_cache.include?(:compliances)
-      self.compliances.sort_by { |c| c.timestamp }.last
+      self.compliances.sort_by(&:timestamp).last
     else
       self.compliances.order("timestamp DESC").first
     end

--- a/vmdb/app/models/mixins/miq_policy_mixin.rb
+++ b/vmdb/app/models/mixins/miq_policy_mixin.rb
@@ -49,7 +49,7 @@ module MiqPolicyMixin
       prof = MiqPolicySet.find(pid)
       next unless prof
 
-      plist = prof.members.collect {|p| p.name}
+      plist = prof.members.collect(&:name)
       presults = resolve_policies(plist, event)
 
       next if presults.empty? # skip profiles that had no policies due to the event not matching or no policies in scope
@@ -108,7 +108,7 @@ module MiqPolicyMixin
           next unless t.respond_to?(assoc)
           t.send(assoc).get_policies unless t.send(assoc).nil?
         }).compact.flatten.uniq
-        presults = t.resolve_profiles(profiles.collect{|p| p.id}, eventobj)
+        presults = t.resolve_profiles(profiles.collect(&:id), eventobj)
         target_result = presults.inject("allow") { |s,r| break "deny" if r["result"] == "deny"; s }
 
         result_list = presults.collect {|r| r["result"]}.uniq
@@ -122,7 +122,7 @@ module MiqPolicyMixin
       eventobj = event.kind_of?(String) ? MiqEvent.find_by_name(event) : MiqEvent.extract_objects(event)
       raise "No event found for [#{event}]" if eventobj.nil?
 
-      targets =  targets.first.kind_of?(self) ? targets.collect {|t| t.id} : targets
+      targets =  targets.first.kind_of?(self) ? targets.collect(&:id) : targets
 
       opts = {
         :action       => "#{self.name} - Resultant Set of Policy, Event: [#{eventobj.description}]",

--- a/vmdb/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/vmdb/app/models/mixins/miq_provision_quota_mixin.rb
@@ -188,7 +188,7 @@ module MiqProvisionQuotaMixin
                                 *scheduled_range])
     # Make sure we skip the current MiqProvisionRequest in the calculation.
     skip_id = self.class.name == "MiqProvisionRequest" ? self.id : self.miq_provision_request.id
-    load_ids = queued_requests.collect {|q| q.instance_id}
+    load_ids = queued_requests.collect(&:instance_id)
     load_ids.delete(skip_id)
     provisions = MiqProvisionRequest.find_all_by_id(load_ids)
 

--- a/vmdb/app/models/mixins/ownership_mixin.rb
+++ b/vmdb/app/models/mixins/ownership_mixin.rb
@@ -17,7 +17,7 @@ module OwnershipMixin
     def set_ownership(ids, options)
       errors = ActiveModel::Errors.new(self)
       objects = self.find_all_by_id(ids)
-      missing = ids - objects.collect {|obj| obj.id}
+      missing = ids - objects.collect(&:id)
       errors.add(:missing_ids, "Unable to find #{self.name.pluralize} with the following ids #{missing.inspect}") unless missing.empty?
 
       objects.each do |obj|

--- a/vmdb/app/models/mixins/per_ems_type_worker_mixin.rb
+++ b/vmdb/app/models/mixins/per_ems_type_worker_mixin.rb
@@ -21,7 +21,7 @@ module PerEmsTypeWorkerMixin
     end
 
     def any_valid_ems_in_zone?
-      self.emses_in_zone.any? { |e| e.authentication_valid? }
+      self.emses_in_zone.any?(&:authentication_valid?)
     end
   end
 end

--- a/vmdb/app/models/mixins/per_ems_worker_mixin.rb
+++ b/vmdb/app/models/mixins/per_ems_worker_mixin.rb
@@ -20,7 +20,7 @@ module PerEmsWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      self.all_ems_in_zone.select { |e| e.authentication_valid? }
+      self.all_ems_in_zone.select(&:authentication_valid?)
     end
 
     def desired_queue_names
@@ -30,7 +30,7 @@ module PerEmsWorkerMixin
 
     def sync_workers
       ws      = self.find_current_or_starting
-      current = ws.collect { |w| w.queue_name }.sort
+      current = ws.collect(&:queue_name).sort
       desired = self.has_required_role? ? self.desired_queue_names.sort : []
       result  = { :adds => [], :deletes => [] }
 

--- a/vmdb/app/models/mixins/per_storage_manager_type_worker_mixin.rb
+++ b/vmdb/app/models/mixins/per_storage_manager_type_worker_mixin.rb
@@ -21,7 +21,7 @@ module PerStorageManagerTypeWorkerMixin
     end
 
     def any_valid_storage_manager_in_zone?
-      self.storage_managers_in_zone.any? { |s| s.authentication_valid? }
+      self.storage_managers_in_zone.any?(&:authentication_valid?)
     end
   end
 end

--- a/vmdb/app/models/pxe_server.rb
+++ b/vmdb/app/models/pxe_server.rb
@@ -41,7 +41,7 @@ class PxeServer < ActiveRecord::Base
   end
 
   def synchronize_advertised_images
-    self.pxe_menus.each { |m| m.synchronize }
+    self.pxe_menus.each(&:synchronize)
     sync_windows_images
     clear_association_cache
     self.update_attribute(:last_refresh_on, Time.now.utc)

--- a/vmdb/app/models/relationship.rb
+++ b/vmdb/app/models/relationship.rb
@@ -33,7 +33,7 @@ class Relationship < ActiveRecord::Base
 
   def self.resources(relationships)
     MiqPreloader.preload(relationships, :resource)
-    relationships.collect { |r| r.resource }
+    relationships.collect(&:resource)
   end
 
   def self.resource_pair(relationship)
@@ -41,15 +41,15 @@ class Relationship < ActiveRecord::Base
   end
 
   def self.resource_pairs(relationships)
-    relationships.collect { |r| r.resource_pair }
+    relationships.collect(&:resource_pair)
   end
 
   def self.resource_ids(relationships)
-    relationships.collect { |r| r.resource_id }
+    relationships.collect(&:resource_id)
   end
 
   def self.resource_types(relationships)
-    relationships.collect { |r| r.resource_type }.uniq
+    relationships.collect(&:resource_type).uniq
   end
 
   def self.resource_pairs_to_ids(resource_pairs)

--- a/vmdb/app/models/resource_pool.rb
+++ b/vmdb/app/models/resource_pool.rb
@@ -161,7 +161,7 @@ class ResourcePool < ActiveRecord::Base
   end
 
   def all_host_ids
-    self.all_hosts.collect {|h| h.id}
+    self.all_hosts.collect(&:id)
   end
 
   # Virtual cols for parents
@@ -206,6 +206,6 @@ class ResourcePool < ActiveRecord::Base
   end
 
   def absolute_path(*args)
-    absolute_path_objs(*args).collect { |o| o.name }.join("/")
+    absolute_path_objs(*args).collect(&:name).join("/")
   end
 end

--- a/vmdb/app/models/service.rb
+++ b/vmdb/app/models/service.rb
@@ -68,7 +68,7 @@ class Service < ActiveRecord::Base
   end
 
   def indirect_vms
-    self.all_service_children.collect { |s| s.direct_vms }.flatten.compact
+    self.all_service_children.collect(&:direct_vms).flatten.compact
   end
 
   def direct_vms
@@ -83,7 +83,7 @@ class Service < ActiveRecord::Base
   # Processes tasks received from the UI and queues them
   def self.process_tasks(options)
     raise "No ids given to process_tasks" if options[:ids].blank?
-    raise "Unknown task, #{options[:task]}" unless self.instance_methods.collect { |m| m.to_s }.include?(options[:task])
+    raise "Unknown task, #{options[:task]}" unless self.instance_methods.collect(&:to_s).include?(options[:task])
     options[:userid] ||= "system"
     self.invoke_tasks_queue(options)
   end

--- a/vmdb/app/models/service/retirement_management.rb
+++ b/vmdb/app/models/service/retirement_management.rb
@@ -5,14 +5,12 @@ module Service::RetirementManagement
   module ClassMethods
     def retirement_check
       services = Service.where("retires_on IS NOT NULL OR retired = ?", true)
-      services.each { |service| service.retirement_check }
+      services.each(&:retirement_check)
     end
   end
 
   def before_retirement
-    services.each do |s|
-      s.retire_now
-    end
+    services.each(&:retire_now)
     self.service_resources.each do |sr|
       sr.resource.retire_now if sr.resource.respond_to?(:retire_now)
     end

--- a/vmdb/app/models/service_template_provision_task.rb
+++ b/vmdb/app/models/service_template_provision_task.rb
@@ -91,7 +91,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
       $log.info("#{log_header} #{message}")
       update_and_notify_parent(:state => 'provisioned', :message => message)
     else
-      self.miq_request_tasks.each {|task| task.deliver_to_automate}
+      self.miq_request_tasks.each(&:deliver_to_automate)
       message = "Service Provision started"
       $log.info("#{log_header} #{message}")
       update_and_notify_parent(:message => message)

--- a/vmdb/app/models/snia_local_file_system.rb
+++ b/vmdb/app/models/snia_local_file_system.rb
@@ -94,7 +94,7 @@ class SniaLocalFileSystem < MiqCimInstance
   end
 
   def cim_virtual_disks
-    cim_datastores.collect { |cds| cds.cim_virtual_disks }.flatten.compact.uniq
+    cim_datastores.collect(&:cim_virtual_disks).flatten.compact.uniq
   end
 
   ##################

--- a/vmdb/app/models/tag.rb
+++ b/vmdb/app/models/tag.rb
@@ -66,10 +66,10 @@ class Tag < ActiveRecord::Base
       tag_names.concat list.split(/\s/)
 
       # strip whitespace from the names
-      tag_names = tag_names.map { |t| t.strip }
+      tag_names = tag_names.map(&:strip)
 
       # delete any blank tag names
-      tag_names = tag_names.delete_if { |t| t.empty? }
+      tag_names = tag_names.delete_if(&:empty?)
 
       return tag_names.uniq
     else

--- a/vmdb/app/models/time_profile.rb
+++ b/vmdb/app/models/time_profile.rb
@@ -18,11 +18,11 @@ class TimeProfile < ActiveRecord::Base
   after_save   :rebuild_daily_metrics_on_save
 
   def self.find_all_with_entire_tz(*args)
-    self.all(*args).select { |tp| tp.entire_tz? }
+    self.all(*args).select(&:entire_tz?)
   end
 
   def self.all_timezones(*args)
-    self.all(*args).collect { |tp| tp.tz }.uniq
+    self.all(*args).collect(&:tz).uniq
   end
 
   def self.seed
@@ -81,7 +81,7 @@ class TimeProfile < ActiveRecord::Base
   end
 
   def days=(arr)
-    arr = arr.collect {|d| d.to_i}
+    arr = arr.collect(&:to_i)
     self.profile_will_change! if self.profile[:days] != arr
     self.profile[:days] = arr
   end
@@ -91,7 +91,7 @@ class TimeProfile < ActiveRecord::Base
   end
 
   def hours=(arr)
-    arr = arr.collect {|d| d.to_i}
+    arr = arr.collect(&:to_i)
     self.profile_will_change! if self.profile[:hours] != arr
     self.profile[:hours] = arr
   end

--- a/vmdb/app/models/user.rb
+++ b/vmdb/app/models/user.rb
@@ -856,7 +856,7 @@ class User < ActiveRecord::Base
     log_prefix  = "MIQ(User#match_groups)"
 
     return [] if groups.empty?
-    groups = groups.collect { |g| g.downcase }
+    groups = groups.collect(&:downcase)
 
     miq_groups  = MiqServer.my_server.miq_groups
     miq_groups  = MiqServer.my_server.zone.miq_groups if miq_groups.empty?

--- a/vmdb/app/models/vim_performance_analysis.rb
+++ b/vmdb/app/models/vim_performance_analysis.rb
@@ -90,7 +90,7 @@ module VimPerformanceAnalysis
       return target.storages if target.kind_of?(Host)
 
       if target.kind_of?(EmsCluster)
-        return target.hosts.collect {|h| h.storages}.flatten.compact
+        return target.hosts.collect(&:storages).flatten.compact
       else
         raise "unable to get storages for #{target.class}"
       end

--- a/vmdb/app/models/vim_performance_daily.rb
+++ b/vmdb/app/models/vim_performance_daily.rb
@@ -54,8 +54,8 @@ class VimPerformanceDaily < MetricRollup
     # all the regions in the database. We only want one match from each region
     # otherwise we'll end up with duplicate daily rows.
     tp     = ext_options[:time_profile]
-    tps    = TimeProfile.rollup_daily_metrics.all.select { |p| p.profile == tp.profile }.group_by {|t| t.region_id}.values.flatten if tp
-    tp_ids = tps.nil? ? [] : tps.collect {|t| t.id}
+    tps    = TimeProfile.rollup_daily_metrics.all.select { |p| p.profile == tp.profile }.group_by(&:region_id).values.flatten if tp
+    tp_ids = tps.nil? ? [] : tps.collect(&:id)
     #
 
     klass = ext_options[:class] || MetricRollup
@@ -263,12 +263,12 @@ class VimPerformanceDaily < MetricRollup
 
   def self.process_only_cols(options)
     unless options[:only_cols].nil?
-      options[:only_cols] =  options[:only_cols].collect {|c| c.to_sym} if options[:only_cols]
+      options[:only_cols] =  options[:only_cols].collect(&:to_sym) if options[:only_cols]
       options[:only_cols] += options[:only_cols].collect {|c| c.to_s[4..-1].to_sym if c.to_s.starts_with?("min_") || c.to_s.starts_with?("max_")}.compact
       options[:only_cols] += options[:only_cols].collect {|c| c.to_s.split("_")[2..-2].join("_").to_sym if c.to_s.starts_with?("abs_")}.compact
       options[:only_cols] += [:cpu_ready_delta_summation, :cpu_wait_delta_summation, :cpu_used_delta_summation] if options[:only_cols].find {|c| c.to_s.starts_with?("v_pct_")}
       options[:only_cols] += [:derived_storage_total, :derived_storage_free] if options[:only_cols].include?(:v_derived_storage_used)
-      options[:only_cols] += Metric::BASE_COLS.collect {|c| c.to_sym}
+      options[:only_cols] += Metric::BASE_COLS.collect(&:to_sym)
     end
   end
 

--- a/vmdb/app/models/vim_performance_tag_value.rb
+++ b/vmdb/app/models/vim_performance_tag_value.rb
@@ -60,14 +60,14 @@ class VimPerformanceTagValue < ActiveRecord::Base
       conditions = [
         "resource_type = ? AND resource_id IN (?) AND (timestamp >= ? AND timestamp < ?) AND tag_names LIKE ? AND capture_interval_name = 'hourly'",
         children.first.class.base_class.name,
-        children.collect {|c| c.id},
+        children.collect(&:id),
         ts, ts + 1.day, "%#{options[:category]}/%"
       ]
     else
       klass, meth = Metric::Helper.class_and_association_for_interval_name(parent_perf.capture_interval_name)
       conditions = {
         :resource_type         => children.first.class.base_class.name,
-        :resource_id           => children.collect {|c| c.id},
+        :resource_id           => children.collect(&:id),
         :timestamp             => parent_perf.timestamp,
         :capture_interval_name => parent_perf.capture_interval_name
       }

--- a/vmdb/app/models/vm_amazon/operations.rb
+++ b/vmdb/app/models/vm_amazon/operations.rb
@@ -4,7 +4,7 @@ module VmAmazon::Operations
 
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless self.ext_management_system
-    with_provider_object { |instance| instance.terminate }
+    with_provider_object(&:terminate)
     self.update_attributes!(:raw_power_state => "pending") # show state as suspended
   end
 end

--- a/vmdb/app/models/vm_amazon/operations/guest.rb
+++ b/vmdb/app/models/vm_amazon/operations/guest.rb
@@ -4,7 +4,7 @@ module VmAmazon::Operations::Guest
   end
 
   def raw_reboot_guest
-    with_provider_object { |instance| instance.reboot }
+    with_provider_object(&:reboot)
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "pending") # show state as suspended
   end

--- a/vmdb/app/models/vm_amazon/operations/power.rb
+++ b/vmdb/app/models/vm_amazon/operations/power.rb
@@ -8,13 +8,13 @@ module VmAmazon::Operations::Power
   end
 
   def raw_start
-    with_provider_object { |instance| instance.start }
+    with_provider_object(&:start)
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "pending") # show state as suspended
   end
 
   def raw_stop
-    with_provider_object { |instance| instance.stop }
+    with_provider_object(&:stop)
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "pending") # show state as suspended
   end

--- a/vmdb/app/models/vm_openstack/operations.rb
+++ b/vmdb/app/models/vm_openstack/operations.rb
@@ -4,7 +4,7 @@ module VmOpenstack::Operations
 
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless self.ext_management_system
-    with_provider_object { |instance| instance.destroy }
+    with_provider_object(&:destroy)
     self.update_attributes!(:state => "suspended")
   end
 end

--- a/vmdb/app/models/vm_openstack/operations/guest.rb
+++ b/vmdb/app/models/vm_openstack/operations/guest.rb
@@ -8,7 +8,7 @@ module VmOpenstack::Operations::Guest
   end
 
   def raw_reboot_guest
-    with_provider_object { |instance| instance.reboot }
+    with_provider_object(&:reboot)
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "SUSPENDED")
   end

--- a/vmdb/app/models/vm_or_template/retirement_management.rb
+++ b/vmdb/app/models/vm_or_template/retirement_management.rb
@@ -5,9 +5,9 @@ module VmOrTemplate::RetirementManagement
   module ClassMethods
     def retirement_check
       zone    = MiqServer.my_server.zone
-      ems_ids = zone.ext_management_systems(:select => :id).collect { |e| e.id }.flatten
+      ems_ids = zone.ext_management_systems(:select => :id).collect(&:id).flatten
       vms     = Vm.where("(retires_on IS NOT NULL OR retired = ?) AND ems_id IN (?)", true, ems_ids)
-      vms.each { |vm| vm.retirement_check }
+      vms.each(&:retirement_check)
     end
   end
 

--- a/vmdb/app/models/vm_or_template/right_sizing.rb
+++ b/vmdb/app/models/vm_or_template/right_sizing.rb
@@ -133,23 +133,17 @@ module VmOrTemplate::RightSizing
 
   def max_mem_usage_absolute_average_max_over_time_period
     perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect do |p|
-      p.abs_max_mem_usage_absolute_average_value
-    end.compact.max
+    perfs.collect(&:abs_max_mem_usage_absolute_average_value).compact.max
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
     perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect do |p|
-      p.cpu_usagemhz_rate_average
-    end.compact.max
+    perfs.collect(&:cpu_usagemhz_rate_average).compact.max
   end
 
   def derived_memory_used_max_over_time_period
     perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect do |p|
-      p.derived_memory_used
-    end.compact.max
+    perfs.collect(&:derived_memory_used).compact.max
   end
 
   private

--- a/vmdb/app/models/vm_or_template/vmware_shared/refresh_on_scan.rb
+++ b/vmdb/app/models/vm_or_template/vmware_shared/refresh_on_scan.rb
@@ -6,7 +6,7 @@ module VmOrTemplate::VmwareShared::RefreshOnScan
   def refresh_advanced_settings
     return if self.ext_management_system.nil?
 
-    extra_config = self.with_provider_object { |vim_vm| vim_vm.extraConfig }
+    extra_config = self.with_provider_object(&:extraConfig)
     return if extra_config.nil?
 
     hashes = extra_config.collect do |k, v|

--- a/vmdb/app/models/vm_redhat/operations.rb
+++ b/vmdb/app/models/vm_redhat/operations.rb
@@ -3,6 +3,6 @@ module VmRedhat::Operations
   include_concern 'Power'
 
   def raw_destroy
-    with_provider_object { |rhevm_vm| rhevm_vm.destroy }
+    with_provider_object(&:destroy)
   end
 end

--- a/vmdb/app/models/vm_redhat/operations/guest.rb
+++ b/vmdb/app/models/vm_redhat/operations/guest.rb
@@ -4,7 +4,7 @@ module VmRedhat::Operations::Guest
   end
 
   def raw_shutdown_guest
-    with_provider_object { |rhevm_vm| rhevm_vm.shutdown }
+    with_provider_object(&:shutdown)
   rescue Ovirt::VmIsNotRunning
   end
 end

--- a/vmdb/app/models/vm_redhat/operations/power.rb
+++ b/vmdb/app/models/vm_redhat/operations/power.rb
@@ -4,16 +4,16 @@ module VmRedhat::Operations::Power
   end
 
   def raw_start
-    with_provider_object { |rhevm_vm| rhevm_vm.start }
+    with_provider_object(&:start)
   rescue Ovirt::VmAlreadyRunning
   end
 
   def raw_stop
-    with_provider_object { |rhevm_vm| rhevm_vm.stop }
+    with_provider_object(&:stop)
   rescue Ovirt::VmIsNotRunning
   end
 
   def raw_suspend
-    with_provider_object { |rhevm_vm| rhevm_vm.suspend }
+    with_provider_object(&:suspend)
   end
 end

--- a/vmdb/app/models/vmdb_database/metric_capture.rb
+++ b/vmdb/app/models/vmdb_database/metric_capture.rb
@@ -32,7 +32,7 @@ module VmdbDatabase::MetricCapture
   end
 
   def capture_table_metrics(timestamp = Time.now)
-    vmdb_tables.each { |table| table.capture_metrics }
+    vmdb_tables.each(&:capture_metrics)
   end
 
   def rollup_metrics(timestamp = Time.now)

--- a/vmdb/app/models/volume.rb
+++ b/vmdb/app/models/volume.rb
@@ -54,7 +54,7 @@ class Volume < ActiveRecord::Base
 
         # Handle duplicate partition names (Generally only in the case of Windows with blank partition names)
         if found.length > 1
-          dup_partitions[name] = found.collect { |f| f.id } if dup_partitions[name].nil?
+          dup_partitions[name] = found.collect(&:id) if dup_partitions[name].nil?
           found_id = dup_partitions[name].shift
           found = found.detect { |f| f.id == found_id }
         else
@@ -72,7 +72,7 @@ class Volume < ActiveRecord::Base
 
         # Handle duplicate volume names (Generally only in the case of Windows with blank volume names)
         if found.length > 1
-          dup_volumes[name] = found.collect { |f| f.id } if dup_volumes[name].nil?
+          dup_volumes[name] = found.collect(&:id) if dup_volumes[name].nil?
           found_id = dup_volumes[name].shift
           found = found.detect { |f| f.id == found_id }
         else

--- a/vmdb/app/models/zone.rb
+++ b/vmdb/app/models/zone.rb
@@ -61,7 +61,7 @@ class Zone < ActiveRecord::Base
   end
 
   def assigned_roles
-    self.miq_servers.collect { |s| s.assigned_roles }.flatten.uniq.compact
+    self.miq_servers.collect(&:assigned_roles).flatten.uniq.compact
   end
 
   def role_active?(role_name)
@@ -73,7 +73,7 @@ class Zone < ActiveRecord::Base
   end
 
   def active_role_names
-    self.miq_servers.collect {|s| s.active_role_names}.flatten.uniq
+    self.miq_servers.collect(&:active_role_names).flatten.uniq
   end
 
   def self.default_zone
@@ -105,7 +105,7 @@ class Zone < ActiveRecord::Base
   end
 
   def log_collection_active?
-    self.miq_servers.any? { |s| s.log_collection_active? }
+    self.miq_servers.any?(&:log_collection_active?)
   end
 
   def log_collection_active_recently?(since = nil)
@@ -125,27 +125,27 @@ class Zone < ActiveRecord::Base
   end
 
   def host_ids
-    hosts.collect { |h| h.id }
+    hosts.collect(&:id)
   end
 
   def hosts
     MiqPreloader.preload(self, :ext_management_systems => :hosts)
-    self.ext_management_systems.collect { |e| e.hosts }.flatten
+    self.ext_management_systems.collect(&:hosts).flatten
   end
 
   def non_clustered_hosts
     MiqPreloader.preload(self, :ext_management_systems => :hosts)
-    self.ext_management_systems.collect { |e| e.non_clustered_hosts }.flatten
+    self.ext_management_systems.collect(&:non_clustered_hosts).flatten
   end
 
   def clustered_hosts
     MiqPreloader.preload(self, :ext_management_systems => :hosts)
-    self.ext_management_systems.collect { |e| e.clustered_hosts }.flatten
+    self.ext_management_systems.collect(&:clustered_hosts).flatten
   end
 
   def ems_clusters
     MiqPreloader.preload(self, :ext_management_systems => :ems_clusters)
-    self.ext_management_systems.collect { |e| e.ems_clusters }.flatten
+    self.ext_management_systems.collect(&:ems_clusters).flatten
   end
 
   def ems_infras
@@ -158,7 +158,7 @@ class Zone < ActiveRecord::Base
 
   def availability_zones
     MiqPreloader.preload(self.ems_clouds, :availability_zones)
-    self.ems_clouds.collect { |e| e.availability_zones }.flatten
+    self.ems_clouds.collect(&:availability_zones).flatten
   end
 
   def vms_without_availability_zone
@@ -170,38 +170,38 @@ class Zone < ActiveRecord::Base
 
   def vms_and_templates
     MiqPreloader.preload(self, :ext_management_systems => :vms_and_templates)
-    self.ext_management_systems.collect { |e| e.vms_and_templates }.flatten
+    self.ext_management_systems.collect(&:vms_and_templates).flatten
   end
 
   def vms
     MiqPreloader.preload(self, :ext_management_systems => :vms)
-    self.ext_management_systems.collect { |e| e.vms }.flatten
+    self.ext_management_systems.collect(&:vms).flatten
   end
 
   def miq_templates
     MiqPreloader.preload(self, :ext_management_systems => :miq_templates)
-    self.ext_management_systems.collect { |e| e.miq_templates }.flatten
+    self.ext_management_systems.collect(&:miq_templates).flatten
   end
 
   def vm_or_template_ids
-    vms_and_templates.collect { |v| v.id }
+    vms_and_templates.collect(&:id)
   end
 
   def vm_ids
-    vms.collect { |v| v.id }
+    vms.collect(&:id)
   end
 
   def miq_template_ids
-    miq_templates.collect { |t| t.id }
+    miq_templates.collect(&:id)
   end
 
   def storages
     MiqPreloader.preload(self, :ext_management_systems => {:hosts => :storages})
-    self.ext_management_systems.collect { |e| e.storages }.flatten.uniq
+    self.ext_management_systems.collect(&:storages).flatten.uniq
   end
 
   def miq_proxies
-    ems_ids = self.ext_management_systems.collect {|e| e.id }
+    ems_ids = self.ext_management_systems.collect(&:id)
     MiqProxy.includes(:host).where("hosts.ems_id in (?)", ems_ids).to_a
   end
 

--- a/vmdb/app/presenters/tree_builder_chargeback_assignments.rb
+++ b/vmdb/app/presenters/tree_builder_chargeback_assignments.rb
@@ -21,7 +21,7 @@ class TreeBuilderChargebackAssignments  < TreeBuilder
     case options[:type]
     when :cb_assignments, :cb_rates
       rates = ChargebackRate.all
-      rate_types = rates.collect {|s| s.rate_type}.uniq.sort
+      rate_types = rates.collect(&:rate_type).uniq.sort
 
       if count_only
         rate_types.length

--- a/vmdb/app/presenters/tree_builder_chargeback_rates.rb
+++ b/vmdb/app/presenters/tree_builder_chargeback_rates.rb
@@ -21,7 +21,7 @@ class TreeBuilderChargebackRates < TreeBuilder
     case options[:type]
     when :cb_assignments, :cb_rates
       rates = ChargebackRate.all
-      rate_types = rates.collect {|s| s.rate_type}.uniq.sort
+      rate_types = rates.collect(&:rate_type).uniq.sort
 
       if count_only
         rate_types.length

--- a/vmdb/app/presenters/tree_builder_service_dialogs.rb
+++ b/vmdb/app/presenters/tree_builder_service_dialogs.rb
@@ -18,7 +18,7 @@ class TreeBuilderServiceDialogs  < TreeBuilderAeCustomization
       if options[:count_only]
         objects = object.dialog_resources
       else
-        objects = object.ordered_dialog_resources.collect {|a| a.resource}.compact
+        objects = object.ordered_dialog_resources.collect(&:resource).compact
       end
     end
     count_only_or_objects(options[:count_only], objects, nil)

--- a/vmdb/db/migrate/20101028195038_remove_custom_fields_from_vms_hosts.rb
+++ b/vmdb/db/migrate/20101028195038_remove_custom_fields_from_vms_hosts.rb
@@ -30,7 +30,7 @@ class RemoveCustomFieldsFromVmsHosts < ActiveRecord::Migration
 
     say_with_time("Remove non-VC CustomAttributes") do
       deletes = CustomAttribute.select('id').where("source != 'VC'")
-      CustomAttribute.delete(deletes.collect{|ca| ca.id})
+      CustomAttribute.delete(deletes.collect(&:id))
     end
     remove_column :custom_attributes, :source
   end

--- a/vmdb/db/migrate/20121205171738_add_type_to_authentications.rb
+++ b/vmdb/db/migrate/20121205171738_add_type_to_authentications.rb
@@ -14,7 +14,7 @@ class AddTypeToAuthentications < ActiveRecord::Migration
 
   def down
     say_with_time("Deleting non 'AuthUseridPassword' type authenications") do
-      Authentication.where("type != 'AuthUseridPassword'").each { |a| a.destroy }
+      Authentication.where("type != 'AuthUseridPassword'").each(&:destroy)
     end
 
     remove_column :authentications, :type

--- a/vmdb/lib/acts_as_ar_model.rb
+++ b/vmdb/lib/acts_as_ar_model.rb
@@ -51,7 +51,7 @@ class ActsAsArModel
   end
 
   def self.column_names_symbols
-    @column_names_symbols ||= self.column_names.collect { |c| c.to_sym }
+    @column_names_symbols ||= self.column_names.collect(&:to_sym)
   end
 
   def self.set_columns_hash(hash)

--- a/vmdb/lib/amazon_auth.rb
+++ b/vmdb/lib/amazon_auth.rb
@@ -56,6 +56,6 @@ class AmazonAuth
   end
 
   def get_memberships(user)
-    user.groups.collect {|x| x.name}
+    user.groups.collect(&:name)
   end
 end

--- a/vmdb/lib/extensions/ar_column_names.rb
+++ b/vmdb/lib/extensions/ar_column_names.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   class Base
     def self.column_names_symbols
-      @column_names_symbols ||= self.column_names.collect { |c| c.to_sym }
+      @column_names_symbols ||= self.column_names.collect(&:to_sym)
     end
   end
 end

--- a/vmdb/lib/extensions/ar_extract_objects.rb
+++ b/vmdb/lib/extensions/ar_extract_objects.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     def self.extract_ids(*objects)
       is_array = objects.length > 1 || objects.first.kind_of?(Array)
       objects = objects.flatten
-      ret = objects.first.kind_of?(self) ? objects.collect { |o| o.id } : objects
+      ret = objects.first.kind_of?(self) ? objects.collect(&:id) : objects
       return is_array ? ret : ret.first
     end
   end

--- a/vmdb/lib/extensions/ar_region.rb
+++ b/vmdb/lib/extensions/ar_region.rb
@@ -121,7 +121,7 @@ module ArRegion
 
     # Partition the passed AR objects into local and remote sets
     def partition_objs_by_remote_region(objs)
-      objs.partition { |o| o.in_current_region? }
+      objs.partition(&:in_current_region?)
     end
 
     # Partition the passed ids into local and remote sets

--- a/vmdb/lib/extensions/ar_taggable.rb
+++ b/vmdb/lib/extensions/ar_taggable.rb
@@ -18,7 +18,7 @@ module ActsAsTaggable
     elsif tags.is_a?(String)
       tag_names.push((separator.is_a?(Proc) ? separator.call(tags) : tags.split(separator)))
     end
-    tag_names.flatten.map { |name| name.strip }.uniq.compact
+    tag_names.flatten.map(&:strip).uniq.compact
   end
 
   module ClassMethods

--- a/vmdb/lib/lun_durable_names.rb
+++ b/vmdb/lib/lun_durable_names.rb
@@ -11,7 +11,7 @@ class LunDurableName
 
     @namespace    = vimDn.namespace.to_s
     @namespace_id = vimDn.namespaceId.to_i
-    @data     = vimDn.data.collect { |d| d.to_i }.pack("C" * vimDn.data.length) unless vimDn.data.nil?
+    @data     = vimDn.data.collect(&:to_i).pack("C" * vimDn.data.length) unless vimDn.data.nil?
   end
 
   def ==(other)

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -160,7 +160,7 @@ module MiqAeEngine
 
   def self.format_benchmark_counts(bm)
     formatted = ''
-    bm.keys.select { |k| k.to_s.downcase =~ /_count$/ }.sort_by { |k| k.to_s }.each do |k|
+    bm.keys.select { |k| k.to_s.downcase =~ /_count$/ }.sort_by(&:to_s).each do |k|
       formatted << ', ' unless formatted.blank?
       formatted << "#{k}=>#{bm[k]}"
     end
@@ -174,7 +174,7 @@ module MiqAeEngine
     total_time = bm[:total_time]
     threshold  = 0                                                                               # show everything
     threshold  = (total_time * BENCHMARK_TIME_THRESHOLD_PERCENT) if total_time.kind_of?(Numeric) # only show times > threshold of the total
-    bm.keys.select { |k| k.to_s.downcase =~ /_time$/ }.sort_by { |k| k.to_s }.each do |k|
+    bm.keys.select { |k| k.to_s.downcase =~ /_time$/ }.sort_by(&:to_s).each do |k|
       next unless bm[k] >= threshold
       formatted << ', ' unless formatted.blank?
       formatted << "#{k}=>#{bm[k]}"

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -25,7 +25,7 @@ module MiqAeEngine
 
     def self.invoke_builtin(aem, obj, inputs)
       mname = "miq_#{aem.data.blank? ? aem.name.downcase : aem.data.downcase}"
-      raise  MiqAeException::MethodNotFound, "Built-In Method [#{mname}] does not exist" unless MiqAeBuiltinMethod.public_methods.collect { |m| m.to_s }.include?(mname)
+      raise  MiqAeException::MethodNotFound, "Built-In Method [#{mname}] does not exist" unless MiqAeBuiltinMethod.public_methods.collect(&:to_s).include?(mname)
 
       # Create service, since built-in method may be calling things that assume there is one
       svc = MiqAeMethodService::MiqAeService.new(obj.workspace)

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_hardware.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_hardware.rb
@@ -9,7 +9,7 @@ module MiqAeMethodService
     expose :host,             :association => true
 
     def mac_addresses
-      object_send(:nics).collect { |n| n.address }
+      object_send(:nics).collect(&:address)
     end
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -42,7 +42,7 @@ module MiqAeMethodService
 
     def ems_custom_keys
       ar_method do
-        @object.ems_custom_attributes.collect { |c| c.name }
+        @object.ems_custom_attributes.collect(&:name)
       end
     end
 

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -97,7 +97,7 @@ module MiqAeMethodService
 
     def ems_custom_keys
       ar_method do
-        @object.ems_custom_attributes.collect { |c| c.name }
+        @object.ems_custom_attributes.collect(&:name)
       end
     end
 

--- a/vmdb/lib/miq_storage_defs.rb
+++ b/vmdb/lib/miq_storage_defs.rb
@@ -26,7 +26,7 @@ module MiqStorageDefs
 
   def self.classes_based_on
     cbo = Hash.new
-    hier_arrays = CIM_CLASS_HIER.values.collect { |a| a.dup }
+    hier_arrays = CIM_CLASS_HIER.values.collect(&:dup)
 
     more = true
     while more do

--- a/vmdb/lib/tasks/evm_application.rb
+++ b/vmdb/lib/tasks/evm_application.rb
@@ -86,7 +86,7 @@ class EvmApplication
   end
 
   def self.output_workers_status(workers)
-    data = workers.sort_by { |w| w.type }.collect do |w|
+    data = workers.sort_by(&:type).collect do |w|
       [ w.type,
         w.status,
         w.id,

--- a/vmdb/lib/vmdb/logging.rb
+++ b/vmdb/lib/vmdb/logging.rb
@@ -125,7 +125,7 @@ module Vmdb
         config[key] = config[key].upcase unless config[key].nil?
 
         level = config[key]
-        if level && !VMDBLogger::Severity.constants.collect { |c| c.to_s }.include?(level)
+        if level && !VMDBLogger::Severity.constants.collect(&:to_s).include?(level)
           valid = false
           errors << [key, "#{key}, \"#{level}\", is invalid. Should be one of: #{VMDBLogger::Severity.constants.join(", ")}"]
         end

--- a/vmdb/lib/workers/replication_worker.rb
+++ b/vmdb/lib/workers/replication_worker.rb
@@ -37,7 +37,7 @@ class ReplicationWorker < WorkerBase
     dest_conf[:adapter] ||= "postgresql"
     region = MiqRegion.my_region
     host_user_pass = dest_conf.values_at(:host, :port, :username, :password, :database, :adapter)
-    return host_user_pass.none? { |c| c.blank? } && MiqRegionRemote.region_valid?(region.guid, region.region, *host_user_pass)
+    return host_user_pass.none?(&:blank?) && MiqRegionRemote.region_valid?(region.guid, region.region, *host_user_pass)
   end
 
   def log_status_interval

--- a/vmdb/lib/workers/schedule_worker.rb
+++ b/vmdb/lib/workers/schedule_worker.rb
@@ -464,7 +464,7 @@ class ScheduleWorker < WorkerBase
   end
 
   def rufus_remove_stale_schedules
-    active_tags = MiqSchedule.in_zone(MiqServer.my_zone).collect {|s| s.tag }
+    active_tags = MiqSchedule.in_zone(MiqServer.my_zone).collect(&:tag)
     @user_scheduler.find_jobs(CLASS_TAG).each do |rufus_job|
       if (active_tags & rufus_job.tags).empty?
         $log.info("MIQ(Schedule.rufus_remove_stale_schedules) Unscheduling Tag: #{rufus_job.tags.inspect}")
@@ -476,7 +476,7 @@ class ScheduleWorker < WorkerBase
   def rufus_remove_schedules_by_tag(tag)
     rufus_jobs = @user_scheduler.find_jobs(tag)
     $log.info("MIQ(Schedule.rufus_remove_schedules_by_tag) Unscheduling #{rufus_jobs.length} jobs with tag: #{tag}") unless rufus_jobs.empty?
-    rufus_jobs.each {|rufus_job| rufus_job.unschedule}
+    rufus_jobs.each(&:unschedule)
   end
 
   def after_sync_active_roles

--- a/vmdb/lib/workers/vim_broker_worker.rb
+++ b/vmdb/lib/workers/vim_broker_worker.rb
@@ -9,7 +9,7 @@ class VimBrokerWorker < WorkerBase
     # Global Work Queue
     @queue = Queue.new
 
-    @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition { |e| e.authentication_check }
+    @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition(&:authentication_check)
     start_broker_server(@initial_emses_to_monitor)
     @worker.update_attributes(:uri => DRb.uri)
     $log.info("#{self.log_prefix} DRb URI: #{DRb.uri}")
@@ -25,7 +25,7 @@ class VimBrokerWorker < WorkerBase
   def self.emses_and_hosts_to_monitor
     emses = MiqVimBrokerWorker.emses_to_monitor
     MiqPreloader.preload(emses, :hosts => :authentications)
-    hosts = emses.collect { |e| e.hosts }.flatten.uniq.select { |h| h.authentication_valid? }
+    hosts = emses.collect(&:hosts).flatten.uniq.select(&:authentication_valid?)
     return emses + hosts
   end
 

--- a/vmdb/spec/apis/vmdbws_inventory_spec.rb
+++ b/vmdb/spec/apis/vmdbws_inventory_spec.rb
@@ -267,7 +267,7 @@ describe VmdbwsController, :apis => true do
 
     it 'should return Cluster information for FindClusterById' do
       new_cluster =  FactoryGirl.create(:ems_cluster,   :name => "cluster 2")
-      all_cluster_ids = EmsCluster.find(:all).collect {|c| c.id}
+      all_cluster_ids = EmsCluster.find(:all).collect(&:id)
       all_clusters = invoke(:FindClustersById,all_cluster_ids)
       all_clusters.should have(EmsCluster.count).things
       db_cluster = EmsCluster.first
@@ -342,7 +342,7 @@ describe VmdbwsController, :apis => true do
     end
 
     it 'should return Resource Pool information for FindResourcePoolById' do
-      all_resource_pool_ids = ResourcePool.find(:all).collect {|r| r.id}
+      all_resource_pool_ids = ResourcePool.find(:all).collect(&:id)
       all_resource_pools = invoke(:FindResourcePoolsById,all_resource_pool_ids)
       all_resource_pools.should have(ResourcePool.count).things
       db_resource_pool = ResourcePool.first
@@ -437,7 +437,7 @@ describe VmdbwsController, :apis => true do
     end
 
     it 'should return Datastore information for FindDatastoreById' do
-      all_storage_ids = Storage.find(:all).collect {|s| s.id}
+      all_storage_ids = Storage.find(:all).collect(&:id)
       all_datastores = invoke(:FindDatastoresById,all_storage_ids)
       all_datastores.should have(Storage.count).things
       db_storage = Storage.first

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -7,7 +7,7 @@ describe ApplicationHelper do
 
       before do
         val_array = [["cat", "Cat"], ["dog", "Dog"]]
-        @val_array_reversed = val_array.collect{|v| v.reverse}
+        @val_array_reversed = val_array.collect(&:reverse)
         @field = DialogFieldDropDownList.new(:values => val_array)
       end
 

--- a/vmdb/spec/lib/ems_event_helper_spec.rb
+++ b/vmdb/spec/lib/ems_event_helper_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe EmsEventHelper do
   context "fb12322 - MiqAeEvent.build_evm_event blows up expecting inputs[:policy] to be an instance of MiqPolicy, but it is a hash of { :vmdb_class => 'MiqPolicy', :vmdb_id => 42}" do
     before(:each) do
-      [Zone, ExtManagementSystem, Host, Vm, Storage, EmsEvent, MiqEvent, MiqPolicy, MiqAction, MiqPolicyContent, MiqPolicySet].each { |klass| klass.delete_all }
+      [Zone, ExtManagementSystem, Host, Vm, Storage, EmsEvent, MiqEvent, MiqPolicy, MiqAction, MiqPolicyContent, MiqPolicySet].each(&:delete_all)
 
       @zone      = FactoryGirl.create(:zone)
       @ems       = FactoryGirl.create(:ems_vmware,

--- a/vmdb/spec/migrations/20120620215904_convert_old_states_to_new_format_spec.rb
+++ b/vmdb/spec/migrations/20120620215904_convert_old_states_to_new_format_spec.rb
@@ -11,8 +11,8 @@ describe ConvertOldStatesToNewFormat do
 
         disable_paralleism { migrate }
 
-        actual   = state_stub.order(:id).all.collect { |s| s.data }
-        expected = load_data_file("#{filename}_expected").collect { |e| e.to_yaml }
+        actual   = state_stub.order(:id).all.collect(&:data)
+        expected = load_data_file("#{filename}_expected").collect(&:to_yaml)
 
         actual.zip(expected).each_with_index do |(a, e), i|
           a.should eq(e), "on index #{i}"

--- a/vmdb/spec/models/ems_cloud_spec.rb
+++ b/vmdb/spec/models/ems_cloud_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe EmsCloud do
   it ".types" do
-    expected_types = [EmsAmazon, EmsOpenstack].collect { |e| e.ems_type }
+    expected_types = [EmsAmazon, EmsOpenstack].collect(&:ems_type)
     described_class.types.should match_array(expected_types)
   end
 
@@ -12,7 +12,7 @@ describe EmsCloud do
   end
 
   it ".supported_types" do
-    expected_types = [EmsAmazon, EmsOpenstack].collect { |e| e.ems_type }
+    expected_types = [EmsAmazon, EmsOpenstack].collect(&:ems_type)
     described_class.supported_types.should match_array(expected_types)
   end
 

--- a/vmdb/spec/models/ems_infra_spec.rb
+++ b/vmdb/spec/models/ems_infra_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe EmsInfra do
   it ".types" do
-    expected_types = [EmsVmware, EmsRedhat, EmsMicrosoft, EmsKvm, EmsOpenstackInfra].collect { |e| e.ems_type }
+    expected_types = [EmsVmware, EmsRedhat, EmsMicrosoft, EmsKvm, EmsOpenstackInfra].collect(&:ems_type)
     described_class.types.should match_array(expected_types)
   end
 
@@ -12,7 +12,7 @@ describe EmsInfra do
   end
 
   it ".supported_types" do
-    expected_types = [EmsVmware, EmsMicrosoft, EmsRedhat, EmsOpenstackInfra].collect { |e| e.ems_type }
+    expected_types = [EmsVmware, EmsMicrosoft, EmsRedhat, EmsOpenstackInfra].collect(&:ems_type)
     described_class.supported_types.should match_array(expected_types)
   end
 

--- a/vmdb/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/vmdb/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -15,7 +15,7 @@ describe EmsRefresh::MetadataRelats do
       @cluster.add_resource_pool(@rp)
       @rp.add_vm(@vm)
 
-      [@ems, @folder, @cluster, @rp, @host, @vm].each { |o| o.reload }
+      [@ems, @folder, @cluster, @rp, @host, @vm].each(&:reload)
       MiqQueue.delete_all
     end
 
@@ -47,7 +47,7 @@ describe EmsRefresh::MetadataRelats do
         @host.set_child(@rp2)
         @folder.add_host(@host)
 
-        [@folder, @host, @rp2].each { |o| o.reload }
+        [@folder, @host, @rp2].each(&:reload)
         MiqQueue.delete_all
       end
 

--- a/vmdb/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/vmdb/spec/models/ems_refresh/save_inventory_spec.rb
@@ -19,7 +19,7 @@ describe EmsRefresh::SaveInventory do
 
         vms = Vm.all
         vms.length.should == 2
-        v1, v2 = vms.sort_by { |v| v.id }
+        v1, v2 = vms.sort_by(&:id)
 
         v1.id.should      == @vm1.id
         v1.uid_ems.should == @vm1.uid_ems
@@ -40,7 +40,7 @@ describe EmsRefresh::SaveInventory do
         connected.length.should    == 2
 
         d      = disconnected.first
-        c1, c2 = connected.sort_by { |c| c.id }
+        c1, c2 = connected.sort_by(&:id)
 
         d.id.should      == @vm2.id
         d.uid_ems.should == @vm2.uid_ems
@@ -73,7 +73,7 @@ describe EmsRefresh::SaveInventory do
         connected.length.should    == 2
 
         d      = disconnected.first
-        c1, c2 = connected.sort_by { |c| c.id }
+        c1, c2 = connected.sort_by(&:id)
 
         d.id.should           == @vm2.id
         d.uid_ems.should      == @vm2.uid_ems
@@ -92,7 +92,7 @@ describe EmsRefresh::SaveInventory do
 
         vms = Vm.all
         vms.length.should == 2
-        v1, v2 = vms.sort_by { |v| v.id }
+        v1, v2 = vms.sort_by(&:id)
 
         v1.id.should      == @vm1.id
         v1.uid_ems.should == @vm1.uid_ems
@@ -121,7 +121,7 @@ describe EmsRefresh::SaveInventory do
         connected.length.should    == 2
 
         d      = disconnected.first
-        c1, c2 = connected.sort_by { |c| c.id }
+        c1, c2 = connected.sort_by(&:id)
 
         d.id.should           == @vm2.id
         d.uid_ems.should      == @vm2.uid_ems
@@ -140,7 +140,7 @@ describe EmsRefresh::SaveInventory do
 
         vms = Vm.all
         vms.length.should == 2
-        v1, v2 = vms.sort_by { |v| v.id }
+        v1, v2 = vms.sort_by(&:id)
 
         v1.id.should      == @vm1.id
         v1.uid_ems.should == @vm1.uid_ems
@@ -165,7 +165,7 @@ describe EmsRefresh::SaveInventory do
 
         vms = Vm.all
         vms.length.should == 2
-        v1, v2 = vms.sort_by { |v| v.id }
+        v1, v2 = vms.sort_by(&:id)
 
         v1.id.should      == @vm1.id
         v1.uid_ems.should == @vm1.uid_ems
@@ -218,7 +218,7 @@ describe EmsRefresh::SaveInventory do
 
         vms = Vm.all
         vms.length.should == 2
-        v1, v2 = vms.sort_by { |v| v.id }
+        v1, v2 = vms.sort_by(&:id)
 
         v1.id.should      == @vm1.id
         v1.uid_ems.should == @vm1.uid_ems
@@ -241,7 +241,7 @@ describe EmsRefresh::SaveInventory do
         connected.length.should    == 2
 
         d      = disconnected.first
-        c1, c2 = connected.sort_by { |c| c.id }
+        c1, c2 = connected.sort_by(&:id)
 
         d.id.should       == @vm2.id
         d.uid_ems.should  == @vm2.uid_ems
@@ -282,7 +282,7 @@ describe EmsRefresh::SaveInventory do
     puts "**VMS BEFORE"
     puts Vm.all.collect { |v| [v.id, v.name, v.uid_ems, v.ems_ref_obj, v.ems_ref, v.ems_id].inspect }.join("\n")
     puts "**DATA"
-    puts data.collect   { |d| d.inspect }.join("\n")
+    puts data.collect(&:inspect).join("\n")
   end
 
   def dump_after

--- a/vmdb/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/vmdb/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -13,7 +13,7 @@ module JobProxyDispatcherEmbeddedScanSpec
     NUM_STORAGES = 3
 
     def assert_at_most_x_scan_jobs_per_y_resource(x_scans, y_resource)
-      vms_in_embedded_scanning = Job.find(:all, :conditions => ["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"], :select => "target_id").collect {|ji| ji.target_id}.compact.uniq
+      vms_in_embedded_scanning = Job.find(:all, :conditions => ["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"], :select => "target_id").collect(&:target_id).compact.uniq
       vms_in_embedded_scanning.length.should > 0
 
       method = case y_resource
@@ -69,7 +69,7 @@ module JobProxyDispatcherEmbeddedScanSpec
           MiqVimBrokerWorker.stub(:available_in_zone?).and_return(true)
           #JobProxyDispatcher.stub(:start_job_on_proxy).and_return(nil)
 
-          @jobs = @vms.collect { |vm| vm.scan }
+          @jobs = @vms.collect(&:scan)
         end
 
         context "and embedded scans on ems" do

--- a/vmdb/spec/models/job_proxy_dispatcher_spec.rb
+++ b/vmdb/spec/models/job_proxy_dispatcher_spec.rb
@@ -62,10 +62,10 @@ module JobProxyDispatcherSpec
           it "should have #{NUM_COS_PROXIES} active cos based proxies on hosts" do
             NUM_COS_PROXIES.should == @proxies.length
             #miqServers = self.class.miq_servers_for_scan.find_all { |svr| !svr.has_vm_scan_affinity? }
-            host_proxies = @hosts.find_all {|h| h.is_a_proxy?}.length
+            host_proxies = @hosts.find_all(&:is_a_proxy?).length
             NUM_COS_PROXIES.should == host_proxies
 
-            active_host_proxies = @hosts.find_all {|h| h.is_proxy_active?}.length
+            active_host_proxies = @hosts.find_all(&:is_proxy_active?).length
             NUM_COS_PROXIES.should == active_host_proxies
           end
 
@@ -110,7 +110,7 @@ module JobProxyDispatcherSpec
               cfg.config.store_path(:repository_scanning, :defaultsmartproxy, @repo_proxy.id)
               VMDB::Config.stub(:new).and_return(cfg)
             end
-            @jobs = (@vms + @repo_vms).collect { |vm| vm.scan }
+            @jobs = (@vms + @repo_vms).collect(&:scan)
 
             MiqProxy.any_instance.stub(:state).and_return("on")
             #TODO: Create real contexts out of this

--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -600,7 +600,7 @@ describe Metric do
                                                       :resource  => @host1,
                                                       :timestamp => "2010-04-14T22:00:00Z")
           metrics = Metric::Finders.find_all_by_day([@vm1, @host1], "2010-04-14T00:00:00Z", 'hourly', @time_profile)
-          metrics.collect { |m| m.resource_type }.uniq.sort.should == %w(VmOrTemplate Host).uniq.sort
+          metrics.collect(&:resource_type).uniq.sort.should == %w(VmOrTemplate Host).uniq.sort
         end
 
         context "calling perf_rollup to daily on the Vm" do

--- a/vmdb/spec/models/miq_alert_spec.rb
+++ b/vmdb/spec/models/miq_alert_spec.rb
@@ -60,7 +60,7 @@ describe MiqAlert do
       end
 
       it "should queue up the correct alert for each event" do
-        guids = @events_to_alerts.collect {|e| e.last}.uniq
+        guids = @events_to_alerts.collect(&:last).uniq
         messages =  MiqQueue.all(:order => "id")
         messages.length.should == @events_to_alerts.length
 
@@ -177,9 +177,7 @@ describe MiqAlert do
         MiqAlert.all.each {|a| a.update_attribute(:enabled, true) } # enable out of the box alerts
         @original_assigned     = MiqAlert.assigned_to_target(@vm, "vm_perf_complete") # force cache load
         @original_assigned_all = MiqAlert.assigned_to_target(@vm)                     # force cache load
-        MiqAlertSet.all.each do |a|
-          a.remove_all_assigned_tos
-        end
+        MiqAlertSet.all.each(&:remove_all_assigned_tos)
 
         @assigned_now     = MiqAlert.assigned_to_target(@vm, "vm_perf_complete")
         @assigned_all_now = MiqAlert.assigned_to_target(@vm)

--- a/vmdb/spec/models/miq_database_spec.rb
+++ b/vmdb/spec/models/miq_database_spec.rb
@@ -93,7 +93,7 @@ describe MiqDatabase do
 
       it "will fetch initial tables" do
         tables = @db.vmdb_tables
-        tables.collect {|t| t.name }.should match_array @expected_tables
+        tables.collect(&:name).should match_array @expected_tables
       end
 
       it "will create tables once" do

--- a/vmdb/spec/models/miq_server_spec.rb
+++ b/vmdb/spec/models/miq_server_spec.rb
@@ -327,7 +327,7 @@ describe MiqServer do
           ['ems_operations',         0]
         ].each { |r, max| @server_roles << FactoryGirl.create(:server_role, :name => r, :max_concurrent => max) }
 
-        @miq_server.role    = @server_roles.collect { |r| r.name }.join(',')
+        @miq_server.role    = @server_roles.collect(&:name).join(',')
 
       end
 

--- a/vmdb/spec/models/miq_widget_spec.rb
+++ b/vmdb/spec/models/miq_widget_spec.rb
@@ -682,7 +682,7 @@ describe MiqWidget do
       end
 
       it "wdiget content" do
-        MiqQueue.all.each { |q| q.deliver }
+        MiqQueue.all.each(&:deliver)
 
         MiqWidgetContent.count.should eq(1)
         MiqWidgetContent.all.each do |content|
@@ -693,7 +693,7 @@ describe MiqWidget do
       end
 
       it "when group is deleted" do
-        MiqQueue.all.each { |q| q.deliver }
+        MiqQueue.all.each(&:deliver)
         MiqWidgetContent.count.should eq(1)
 
         @group2.users.destroy_all
@@ -702,7 +702,7 @@ describe MiqWidget do
       end
 
       it "when user is deleted" do
-        MiqQueue.all.each { |q| q.deliver }
+        MiqQueue.all.each(&:deliver)
         MiqWidgetContent.count.should eq(1)
 
         @user1.destroy

--- a/vmdb/spec/models/mixins/relationship_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/relationship_mixin_spec.rb
@@ -313,7 +313,7 @@ describe RelationshipMixin do
       rels[child].parent = rels[parent]
       rels[child].save!
     end
-    objs.each { |o| o.unmemoize_all }
+    objs.each(&:unmemoize_all)
   end
 
   def recurse_relationship_tree(tree, &block)

--- a/vmdb/spec/models/server_role_spec.rb
+++ b/vmdb/spec/models/server_role_spec.rb
@@ -16,7 +16,7 @@ describe ServerRole do
     end
 
     it "should return all names" do
-      @server_roles.collect {|s| s.name}.sort.should == ServerRole.all_names.sort
+      @server_roles.collect(&:name).sort.should == ServerRole.all_names.sort
     end
 
     it "should respond to master_supported? properly" do

--- a/vmdb/spec/models/service_template_spec.rb
+++ b/vmdb/spec/models/service_template_spec.rb
@@ -258,7 +258,7 @@ end
 
 def add_and_save_service(p,c)
   p.add_resource(c)
-  p.service_resources.each {|sr| sr.save}
+  p.service_resources.each(&:save)
 end
 
 def print_svc(svc, indent="")

--- a/vmdb/spec/models/storage_spec.rb
+++ b/vmdb/spec/models/storage_spec.rb
@@ -404,7 +404,7 @@ describe Storage do
           miq_task.name.should    == "SmartState Analysis for All Storages"
           miq_task.state.should   == MiqTask::STATE_QUEUED
           cdata = miq_task.context_data
-          cdata[:targets].should  match_array Storage.scan_eligible_storages.collect { |s| s.id }
+          cdata[:targets].should  match_array Storage.scan_eligible_storages.collect(&:id)
           cdata[:complete].should be_empty
           cdata[:pending].should  be_empty
         end
@@ -412,7 +412,7 @@ describe Storage do
         it "#scan_timer(zone)" do
           miq_task = Storage.scan_timer(@zone.name)
           miq_task.name.should == "SmartState Analysis for All Storages in Zone \"#{@zone.name}\""
-          miq_task.context_data[:targets].should match_array Storage.scan_eligible_storages(@zone.name).collect { |s| s.id }
+          miq_task.context_data[:targets].should match_array Storage.scan_eligible_storages(@zone.name).collect(&:id)
         end
 
       end

--- a/vmdb/spec/models/vm_spec.rb
+++ b/vmdb/spec/models/vm_spec.rb
@@ -51,7 +51,7 @@ describe Vm do
       @parent_vm.with_relationship_type("genealogy") { @parent_vm.add_child(@vm) }
       @vm.with_relationship_type("genealogy")        { @vm.add_child(@child_vm) }
 
-      [@rp, @parent_vm, @vm, @child_vm].each { |o| o.clear_relationships_cache }
+      [@rp, @parent_vm, @vm, @child_vm].each(&:clear_relationships_cache)
     end
 
     context "#destroy" do

--- a/vmdb/tools/create_evm_snapshot.rb
+++ b/vmdb/tools/create_evm_snapshot.rb
@@ -15,7 +15,7 @@ ids  = $2.split(',').collect { |id| id.strip!; id.blank? ? nil : id.to_i }.compa
 case type
 when 'vm'
   vms = Vm.find_all_by_id(ids)
-  puts "Warning: Unable to find Vms for the following ids: #{ids - vms.collect { |vm| vm.id }}" if ids.length != vms.length
+  puts "Warning: Unable to find Vms for the following ids: #{ids - vms.collect(&:id)}" if ids.length != vms.length
   return if vms.empty?
 
   descs = []
@@ -24,7 +24,7 @@ when 'vm'
   end
 when 'job'
   jobs = Job.find_all_by_id(ids)
-  puts "Warning: Unable to find Jobs for the following ids: #{ids - jobs.collect { |job| job.id }}" if ids.length != jobs.length
+  puts "Warning: Unable to find Jobs for the following ids: #{ids - jobs.collect(&:id)}" if ids.length != jobs.length
   return if jobs.empty?
 
   vms   = []

--- a/vmdb/tools/db_printers/print_network.rb
+++ b/vmdb/tools/db_printers/print_network.rb
@@ -26,7 +26,7 @@ Host.find(:all).each do |host|
     end
 
     pnics_grouped.each do |pa|
-      puts "  pNIC: #{pa.collect { |pnic| pnic.device_name }.join(", ")}"
+      puts "  pNIC: #{pa.collect(&:device_name).join(", ")}"
       pnic = pa[0]
       unless pnic.switch.nil?
         print_switch("    ", pnic.switch)

--- a/vmdb/tools/db_printers/print_relationships.rb
+++ b/vmdb/tools/db_printers/print_relationships.rb
@@ -6,7 +6,7 @@ def print_rels(subtree, indent = '')
   end
 end
 
-roots = Relationship.roots.sort_by { |rel| rel.resource_pair }
+roots = Relationship.roots.sort_by(&:resource_pair)
 roots.each do |root|
   print_rels(root.subtree.arrange)
   puts; puts

--- a/vmdb/tools/log_processing/perf_timings.rb
+++ b/vmdb/tools/log_processing/perf_timings.rb
@@ -24,7 +24,7 @@ def dump_csv(type, hashes)
 
     keys = hashes[0].keys
     keys.delete_if { |k, v| [:time, :total_time].include?(k) }
-    keys = keys.sort_by { |k| k.to_s }
+    keys = keys.sort_by(&:to_s)
     keys = keys.unshift(:time)
     keys += [:unaccounted, :total_time]
 

--- a/vmdb/tools/purge_all_storage_data.rb
+++ b/vmdb/tools/purge_all_storage_data.rb
@@ -30,7 +30,7 @@ begin
     total = 0
     log "-- Purging table: #{tn}..."
     sc.select(:id).find_in_batches(:batch_size => 500) do |ma|
-      ids = ma.collect { |m| m.id }
+      ids = ma.collect(&:id)
       total += sc.delete_all(:id => ids)
     end
     gtotal += total


### PR DESCRIPTION
Used rubocop autocorrect for SymbolProc cop:

    rubocop -a --only SymbolProc

---

@jrafanie Please review.  All those :sparkles: shinies :sparkles: in your finders PR inspired me.