### PR TITLE
Fixed Retirement date remove button functionality.

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -830,19 +830,22 @@ function miqBuildCalendar(){
 
     // Create an observer for the date field if the html5 attr is specified
     if (this.getAttribute('data-miq_observe_date')) {
-      cal.attachEvent("onClick", function(){
-        var parms = $j.parseJSON(el.attr('data-miq_observe_date'));
-        var url = parms.url;
-        var urlstring = url + '?' + el.prop('id') + '=' + el.val(); //  tack on the id and value to the URL
-        if (el.attr('data-miq_sparkle_on')) {
-          miqJqueryRequest(urlstring, {beforeSend: true});
-        } else {
-          miqJqueryRequest(urlstring);
-        }
-      });
+      el.change(function() { miqSendDateRequest(el); })
+      cal.attachEvent("onClick", function(){ miqSendDateRequest(el); });
     }
 
   });
+}
+
+function miqSendDateRequest(el){
+  var parms = $j.parseJSON(el.attr('data-miq_observe_date'));
+  var url = parms.url;
+  var urlstring = url + '?' + el.prop('id') + '=' + el.val(); //  tack on the id and value to the URL
+  if (el.attr('data-miq_sparkle_on')) {
+    miqJqueryRequest(urlstring, {beforeSend: true});
+  } else {
+    miqJqueryRequest(urlstring);
+  }
 }
 
 // Build an explorer view using a YUI layout and a jQuery accordion

--- a/vmdb/app/views/shared/views/_retire.html.erb
+++ b/vmdb/app/views/shared/views/_retire.html.erb
@@ -18,7 +18,7 @@
 					<%= hidden_span_if(session[:retire_date] == nil, :id=>"remove_button") %>
 						<%= link_to_function(image_tag('/images/icons/16/clear.png',
 																				:border=>"0", :alt=>"Set to blank"),
-																"$('miq_date_1').value=''")
+																"$j('#miq_date_1').val('').change();")
 						%>
 					</span>
 				</td>


### PR DESCRIPTION
- Added code to trigger change event when Retirement date remove button is pressed and and miq_Date_1 value is cleared out. Changed JS code to send up transaction to server when change event is triggered, moved code that sends request upto server into a separate function so it can be called for both onclick and change events.

#1384 

@AparnaKarve @skateman please review/test.