### PR TITLE
[api] Disabling policies subcollection for vms

### DIFF
--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -557,7 +557,6 @@
     :klass: Vm
     :subcollections:
     - :tags
-    - :policies
     - :accounts
     - :software
     :collection_actions:


### PR DESCRIPTION
- Needing to temporarily disable policies subcollection for vms', i.e. /vms/:vm_id/policies until that gets implemented.