### PR TITLE
Change automation examples to use before(:suite) instead of before(:all)

### DIFF
--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   # end
 
   # Preconfigure and auto-tag specs in the automation subdirectory a la rspec-rails
-  config.include RSpec::Rails::AutomationExampleGroup, :type => :automation, :example_group => {
+  config.include AutomationExampleGroup, :type => :automation, :example_group => {
     :file_path => config.escaped_path(%w[spec automation])
   }
   config.include RSpec::Fire

--- a/vmdb/spec/support/automation_example_group.rb
+++ b/vmdb/spec/support/automation_example_group.rb
@@ -1,16 +1,27 @@
 module AutomationExampleGroup
   extend ActiveSupport::Concern
 
+  class << self
+    attr_accessor :fixtures_loaded
+  end
+
   included do
     metadata[:type] = :automation
 
-    before(:all) do
-      MiqAeDatastore.reset
-      MiqAeDatastore.reset_manageiq_domain
-    end
+    unless AutomationExampleGroup.fixtures_loaded
+      RSpec.configure do |config|
+        config.before(:suite) do
+          puts "** Resetting ManageIQ domain"
+          MiqAeDatastore.reset
+          MiqAeDatastore.reset_manageiq_domain
+        end
 
-    after(:all) do
-      MiqAeDatastore.reset
+        config.after(:suite) do
+          MiqAeDatastore.reset
+        end
+      end
+
+      AutomationExampleGroup.fixtures_loaded = true
     end
   end
 end

--- a/vmdb/spec/support/automation_example_group.rb
+++ b/vmdb/spec/support/automation_example_group.rb
@@ -1,18 +1,16 @@
-module RSpec::Rails
-  module AutomationExampleGroup
-    extend ActiveSupport::Concern
+module AutomationExampleGroup
+  extend ActiveSupport::Concern
 
-    included do
-      metadata[:type] = :automation
+  included do
+    metadata[:type] = :automation
 
-      before(:all) do
-        MiqAeDatastore.reset
-        MiqAeDatastore.reset_manageiq_domain
-      end
+    before(:all) do
+      MiqAeDatastore.reset
+      MiqAeDatastore.reset_manageiq_domain
+    end
 
-      after(:all) do
-        MiqAeDatastore.reset
-      end
+    after(:all) do
+      MiqAeDatastore.reset
     end
   end
 end


### PR DESCRIPTION
The usage of :all was a bug as :suite was the intention all along.
This drops the test:automation suite from 32 seconds to 14 seconds.

@gmcculloug Please review.  The second commit is really the one to look at.

