### PR TITLE
Remove references to old VimClientBase.

### DIFF
--- a/lib/Scvmm/test/MiqScvmmBrokerServer.rb
+++ b/lib/Scvmm/test/MiqScvmmBrokerServer.rb
@@ -3,7 +3,6 @@ $:.push("#{File.dirname(__FILE__)}/..")
 
 require 'rubygems'
 require 'log4r'
-#require 'VimClientBase'
 require 'MiqScvmmBroker'
 
 #
@@ -29,7 +28,6 @@ trap(:INT) do
 	exit 0
 end
 
-# VimClientBase.wiredump_file = "wire_dump.out"
 #$miq_wiredump = false
 
 MiqScvmmBroker.preLoad        = true

--- a/lib/VMwareWebService/test/MiqVimPerfTest.rb
+++ b/lib/VMwareWebService/test/MiqVimPerfTest.rb
@@ -18,7 +18,7 @@ $vim_log = Log4r::Logger.new 'toplog'
 Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
 $vim_log.add 'err_console'
 
-# VimClientBase.wiredump_file = "perf.txt"
+# MiqVimClientBase.wiredump_file = "perf.txt"
 
 begin
     vim = MiqVim.new(SERVER, USERNAME, PASSWORD)

--- a/lib/VMwareWebService/test/vdlBrowserTest.rb
+++ b/lib/VMwareWebService/test/vdlBrowserTest.rb
@@ -25,7 +25,7 @@ $stderr.sync = true
 $stdout.sync = true
 
 # $DEBUG = true
-# VimClientBase.wiredump_file = "clone.txt"
+# MiqVimClientBase.wiredump_file = "clone.txt"
 
 SRC_VM      = "rpo-test2"
 

--- a/lib/VcoWebService/MiqVcoClientBase.rb
+++ b/lib/VcoWebService/MiqVcoClientBase.rb
@@ -128,4 +128,4 @@ class MiqVcoClientBase < VcoService
         is_ok
     end
 	
-end # class MiqVimClientBase
+end # class MiqVcoClientBase

--- a/lib/WriteVm/test/automateTest.rb
+++ b/lib/WriteVm/test/automateTest.rb
@@ -4,7 +4,7 @@ $:.push("#{File.dirname(__FILE__)}/..")
 
 require 'rubygems'
 require 'log4r'
-require 'VimClientBase'
+require 'MiqVimClientBase'
 require 'MiqVim'
 require 'MiqVimBroker'
 require 'MiqDisk'

--- a/lib/WriteVm/test/automateTest.rb
+++ b/lib/WriteVm/test/automateTest.rb
@@ -4,7 +4,6 @@ $:.push("#{File.dirname(__FILE__)}/..")
 
 require 'rubygems'
 require 'log4r'
-require 'MiqVimClientBase'
 require 'MiqVim'
 require 'MiqVimBroker'
 require 'MiqDisk'

--- a/lib/WriteVm/test/readLog.rb
+++ b/lib/WriteVm/test/readLog.rb
@@ -4,7 +4,7 @@ $:.push("#{File.dirname(__FILE__)}/..")
 
 require 'rubygems'
 require 'log4r'
-require 'VimClientBase'
+require 'MiqVimClientBase'
 require 'MiqVim'
 require 'MiqVimBroker'
 require 'MiqDisk'

--- a/lib/WriteVm/test/readLog.rb
+++ b/lib/WriteVm/test/readLog.rb
@@ -4,7 +4,6 @@ $:.push("#{File.dirname(__FILE__)}/..")
 
 require 'rubygems'
 require 'log4r'
-require 'MiqVimClientBase'
 require 'MiqVim'
 require 'MiqVimBroker'
 require 'MiqDisk'

--- a/lib/discovery/modules/VMwareEsxVcProbe.rb
+++ b/lib/discovery/modules/VMwareEsxVcProbe.rb
@@ -27,7 +27,7 @@ class VMwareEsxVcProbe
 		# First check if we can access the VMware webservice before even trying the port scans.
 		$log.debug "VMwareEsxVcProbe: probing ip = #{ost.ipaddr}" if $log
 		begin
-      vcb = MiqVimClientBase.new(ost.ipaddr, "test", "test")
+      MiqVimClientBase.new(ost.ipaddr, "test", "test")
 		rescue => err
 			$log.debug "VMwareEsxVcProbe: Failed to connect to VMware webservice: #{err}. ip = #{ost.ipaddr}" if $log
 			return

--- a/lib/discovery/modules/VMwareEsxVcProbe.rb
+++ b/lib/discovery/modules/VMwareEsxVcProbe.rb
@@ -2,13 +2,7 @@ $:.push("#{File.dirname(__FILE__)}/..")
 $:.push("#{File.dirname(__FILE__)}/../../VMwareWebService")
 
 require 'PortScan'
-begin
-  $miq_vim_soap_lib = "soap4r"
-  require 'VimClientBase'
-rescue LoadError
-  $miq_vim_soap_lib = "handsoap"
-  require 'MiqVimClientBase'
-end
+require 'MiqVimClientBase'
 
 class VMwareEsxVcProbe
     
@@ -33,11 +27,7 @@ class VMwareEsxVcProbe
 		# First check if we can access the VMware webservice before even trying the port scans.
 		$log.debug "VMwareEsxVcProbe: probing ip = #{ost.ipaddr}" if $log
 		begin
-      if $miq_vim_soap_lib == "handsoap"
-			  vcb = MiqVimClientBase.new(ost.ipaddr, "test", "test")
-		  else
-			  vcb =    VimClientBase.new(ost.ipaddr, "test", "test")
-	    end
+      vcb = MiqVimClientBase.new(ost.ipaddr, "test", "test")
 		rescue => err
 			$log.debug "VMwareEsxVcProbe: Failed to connect to VMware webservice: #{err}. ip = #{ost.ipaddr}" if $log
 			return


### PR DESCRIPTION
The VimClientBase has been gone for some time now (removed in April 2013
in 87c9132d), but there were still traces, including a global variable.

@jrafanie @roliveri Please review.