### PR TITLE
Remove unreachable code2

### DIFF
--- a/lib/Verbs/implementations/MicrosoftOpsWin.rb
+++ b/lib/Verbs/implementations/MicrosoftOpsWin.rb
@@ -36,12 +36,6 @@ module MicrosoftOpsWin
 		# Start the VM.
 		# 
 		ost.value = "start() = 1" if @msCom.start(vmName)
-		
-		# Don't worry if the disk rename fails during start
-		#		begin
-		#			renameDisks(*diskNames(vmName))
-		#		rescue => e
-		#		end
 	end
 	
 	def StopVM(ost)
@@ -50,8 +44,6 @@ module MicrosoftOpsWin
 		
 		diskFile, diskFileSave, bbFileSave = diskNames(vmName)
 		ost.value = "stop() = 1" if @msCom.stop(vmName)
-		
-		#		renameDisks(*diskNames(vmName)) if isSmart?(vmName)
 	end
 	
 	def GetHeartbeat(ost)
@@ -102,7 +94,6 @@ module MicrosoftOpsWin
 		vmName = getVmFile(ost)
 		
 		ost.value = "suspend() = 1" if @msCom.suspend(vmName)
-		#		renameDisks(*diskNames(vmName)) if isSmart?(vmName)
 	end
 
 	def PauseVM(ost)
@@ -110,7 +101,6 @@ module MicrosoftOpsWin
 		vmName = getVmFile(ost)
 
 		ost.value = "pause() = 1" if @msCom.pause(vmName)
-		#		renameDisks(*diskNames(vmName)) if isSmart?(vmName)
 	end
 
 	def ShutdownGuest(ost)

--- a/lib/Verbs/implementations/SharedOps.rb
+++ b/lib/Verbs/implementations/SharedOps.rb
@@ -404,29 +404,6 @@ module SharedOps
     @vmdbDriver ||= MiqservicesClient.get_driver(ost.config)
 	end
 		
-	def renameDisks (diskFile, diskFileSave, bbFileSave)
-		
-		return	#NOP
-		
-		attempt = 0
-		begin
-			#
-			# Now that the VM has started, let's reset...
-			# 
-			# Save the VM's disk file.
-			# 
-			File.rename(diskFile, diskFileSave) if File.exist?(diskFile)
-			#
-			# Restore the black box.
-			# 
-			File.rename(bbFileSave, diskFile) if File.exist?(bbFileSave)
-		rescue => err #Errno::EACCES
-			sleep(0.1)
-			attempt+=1
-			retry unless attempt > 20
-		end
-	end
-	
 	def isSmart?(vmName)
 		# Set Internal blackbox smart flag to true, if not already
 		bb = Manageiq::BlackBox.new(vmName)

--- a/lib/Verbs/implementations/VmwareOpsLinux.rb
+++ b/lib/Verbs/implementations/VmwareOpsLinux.rb
@@ -31,12 +31,6 @@ module VMWareOpsLinux
 		# Start the VM.
 		# 
 		ost.value = MiqUtil.runcmd("vmware-cmd \"#{vmName}\" start", ost.test)
-
-        # Don't worry if the disk rename fails during start
-#		begin
-#            renameDisks(*diskNames(vmName))    
-#        rescue => e
-#        end
 	end
 
 	def StopVM(ost)
@@ -45,8 +39,6 @@ module VMWareOpsLinux
 
         diskFile, diskFileSave, bbFileSave = diskNames(vmName)
 		ost.value = MiqUtil.runcmd("vmware-cmd \"#{vmName}\" stop", ost.test)
-#        sleep(0.5)
-#        renameDisks(*diskNames(vmName))
 	end
 
 	def GetHeartbeat(ost)
@@ -97,7 +89,6 @@ module VMWareOpsLinux
 		vmName = getVmFile(ost)
 
 		ost.value = MiqUtil.runcmd("vmware-cmd \"#{vmName}\" suspend", ost.test)
-#        renameDisks(*diskNames(vmName))
 	end
 	
 end

--- a/lib/Verbs/implementations/VmwareOpsWin.rb
+++ b/lib/Verbs/implementations/VmwareOpsWin.rb
@@ -41,13 +41,6 @@ module VMWareOpsWin
 		begin
 			if @vmwareCom.start(vmName)
 				ost.value = "start() = 1" 
-
-				# Don't worry if the disk rename fails during start
-				#		begin
-				#			renameDisks(*diskNames(vmName))
-				#		rescue => e
-				#		end
-
 				eventStatus = "ok"
 			end
 		ensure
@@ -66,9 +59,6 @@ module VMWareOpsWin
 		begin
 			if @vmwareCom.stop(vmName)
 				ost.value = "stop() = 1" 
-
-				#		renameDisks(*diskNames(vmName)) if isSmart?(vmName)
-
 				eventStatus = "ok"
 			end
 		ensure
@@ -138,9 +128,6 @@ module VMWareOpsWin
 		begin
 			if @vmwareCom.suspend(vmName)
 				ost.value = "suspend() = 1" 
-				
-				#		renameDisks(*diskNames(vmName)) if isSmart?(vmName)
-				
 				eventStatus = "ok"
 			end
 		ensure


### PR DESCRIPTION
SharedOps.renameDisks returns at the beginning so it's not needed. …
rubocop --only Lint/UnreachableCode

This may conflict with #1289, but it appears to not be included in that PR.  cc @gmcculloug 