### PR TITLE
Fix class_name in module MiqAeServiceObjectCommon.

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -409,7 +409,7 @@ module MiqAeMethodService
     end
 
     def class_name
-      @object.klass
+      @object.class.name
     end
 
     def instance_name


### PR DESCRIPTION
Found the class_name method in MiqAeServiceObjectCommon was broken when trying to retrieve the underneath event object's class in Automate. 
The event object might be of either MiqEvent or EmsEvent.