### PR TITLE
require files that aren't automatically required

### DIFF
--- a/vmdb/spec/models/dialog_yaml_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_yaml_serializer_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "dialog_tab_serializer"
 
 describe DialogYamlSerializer do
   let(:dialog_tab_serializer) { instance_double("DialogTabSerializer") }


### PR DESCRIPTION
`instance_double` doesn't hit `const_missing`, so the model is never
required which means that this test will fail when it is run in
isloation, but could randomly fail when run with the suite (depending on
the order of tests).

require the model so that the constant is available.