### PR TITLE
Fix XFS file "time" methods.

### DIFF
--- a/lib/fs/MiqFS/modules/XFS.rb
+++ b/lib/fs/MiqFS/modules/XFS.rb
@@ -156,17 +156,17 @@ module XFS
 
   # Returns a Ruby Time object.
   def fs_fileAtime_obj(fobj)
-    fobj.inode.aTime
+    fobj.inode.access_time
   end
 
   # Returns a Ruby Time object.
   def fs_fileCtime_obj(fobj)
-    fobj.inode.cTime
+    fobj.inode.create_time
   end
 
   # Returns a Ruby Time obect.
   def fs_fileMtime_obj(fobj)
-    fobj.inode.mTime
+    fobj.inode.modification_time
   end
 
   # New FileObject instance.

--- a/lib/fs/xfs/inode.rb
+++ b/lib/fs/xfs/inode.rb
@@ -300,15 +300,15 @@ module XFS
     end
 
     def access_time
-      @access_time ||= Time.at(@in['atime'])
+      @access_time ||= Time.at(@in['atime_secs'])
     end
 
     def create_time
-      @create_time ||= Time.at(@in['ctime'])
+      @create_time ||= Time.at(@in['ctime_secs'])
     end
 
     def modification_time
-      @modification_time ||= Time.at(@in['mtime'])
+      @modification_time ||= Time.at(@in['mtime_secs'])
     end
 
     def d_time

--- a/lib/fs/xfs/inode.rb
+++ b/lib/fs/xfs/inode.rb
@@ -311,10 +311,6 @@ module XFS
       @modification_time ||= Time.at(@in['mtime_secs'])
     end
 
-    def d_time
-      @d_time ||= Time.at(@in['dtime'])
-    end
-
     def permissions
       @permissions ||= @in['file_mode'] & (MSK_PERM_OWNER | MSK_PERM_GROUP | MSK_PERM_USER)
     end
@@ -355,7 +351,6 @@ module XFS
       out += "ATime Secs/NSecs: #{@in['atime_secs']}/#{@in['atime_nsecs']}\n"
       out += "CTime Secs/NSecs: #{@in['ctime_secs']}/#{@in['ctime_nsecs']}\n"
       out += "MTime Secs/NSecs: #{@in['mtime_secs']}/#{@in['mtime_nsecs']}\n"
-      out += "DTime        : #{@in['dTime']}\n"
       out += "GID          : #{@in['gid']}\n"
       out += "Link count   : #{@in['num_links']}\n"
       out += "Old Link cnt : #{@in['old_num_links']}\n"


### PR DESCRIPTION
The file "time" metadata methods for XFS were failing,
causing the file fleecing to fail.
https://bugzilla.redhat.com/show_bug.cgi?id=1160859
https://bugzilla.redhat.com/show_bug.cgi?id=1161266