### PR TITLE
no longer require klass for save_inventory_multi

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -152,12 +152,12 @@ module EmsRefresh::SaveInventory
     # the value collected during our metadata scan.
     return if parent.kind_of?(Vm) && !(parent.drift_states.size.zero? || parent.operating_system.nil? || parent.operating_system.product_name.blank?)
 
-    self.save_inventory_single(:operating_system, OperatingSystem, parent, hash)
+    save_inventory_single(:operating_system, parent, hash)
   end
 
   def save_hardware_inventory(parent, hash)
     return if hash.nil?
-    self.save_inventory_single(:hardware, Hardware, parent, hash, [:disks, :guest_devices, :networks])
+    save_inventory_single(:hardware, parent, hash, [:disks, :guest_devices, :networks])
     parent.save!
   end
 
@@ -177,7 +177,7 @@ module EmsRefresh::SaveInventory
     end
 
     deletes = hardware.guest_devices.where(:device_type => ["ethernet", "storage"]).to_a.dup
-    self.save_inventory_multi(:guest_devices, GuestDevice, hardware, hashes, deletes, [:device_type, :uid_ems], [:network, :miq_scsi_targets], [:switch, :lan])
+    save_inventory_multi(:guest_devices, hardware, hashes, deletes, [:device_type, :uid_ems], [:network, :miq_scsi_targets], [:switch, :lan])
     self.store_ids_for_new_records(hardware.guest_devices, hashes, [:device_type, :uid_ems])
   end
 
@@ -191,14 +191,14 @@ module EmsRefresh::SaveInventory
     end
 
     deletes = hardware.disks(true).dup
-    self.save_inventory_multi(:disks, Disk, hardware, hashes, deletes, [:controller_type, :location], nil, [:storage, :backing])
+    save_inventory_multi(:disks, hardware, hashes, deletes, [:controller_type, :location], nil, [:storage, :backing])
   end
 
   def save_network_inventory(guest_device, hash)
     if hash.nil?
       guest_device.network = nil
     else
-      self.save_inventory_single(:network, Network, guest_device, hash, nil, :guest_device)
+      save_inventory_single(:network, guest_device, hash, nil, :guest_device)
       hash[:id] = guest_device.network.id
     end
   end
@@ -214,9 +214,9 @@ module EmsRefresh::SaveInventory
       saved_hashes, new_hashes = hashes.partition { |h| h[:id] }
       saved_hashes.each { |h| deletes.delete_if { |d| d.id == h[:id] } } unless deletes.empty? || saved_hashes.empty?
 
-      self.save_inventory_multi(:networks, Network, hardware, new_hashes, deletes, :ipaddress, nil, :guest_device)
+      save_inventory_multi(:networks, hardware, new_hashes, deletes, :ipaddress, nil, :guest_device)
     when :scan
-      self.save_inventory_multi(:networks, Network, hardware, hashes, deletes, [:description, :guid])
+      save_inventory_multi(:networks, hardware, hashes, deletes, [:description, :guid])
     end
   end
 
@@ -228,27 +228,27 @@ module EmsRefresh::SaveInventory
     when :scan    then parent.system_services(true).dup
     end
 
-    self.save_inventory_multi(:system_services, SystemService, parent, hashes, deletes, [:typename, :name])
+    save_inventory_multi(:system_services, parent, hashes, deletes, [:typename, :name])
   end
 
   def save_guest_applications_inventory(parent, hashes)
     deletes = parent.guest_applications(true).dup
-    self.save_inventory_multi(:guest_applications, GuestApplication, parent, hashes, deletes, [:arch, :typename, :name, :version])
+    save_inventory_multi(:guest_applications, parent, hashes, deletes, [:arch, :typename, :name, :version])
   end
 
   def save_advanced_settings_inventory(parent, hashes)
     deletes = parent.advanced_settings(true).dup
-    self.save_inventory_multi(:advanced_settings, AdvancedSetting, parent, hashes, deletes, :name)
+    save_inventory_multi(:advanced_settings, parent, hashes, deletes, :name)
   end
 
   def save_patches_inventory(parent, hashes)
     deletes = parent.patches(true).dup
-    self.save_inventory_multi(:patches, Patch, parent, hashes, deletes, :name)
+    save_inventory_multi(:patches, parent, hashes, deletes, :name)
   end
 
   def save_os_processes_inventory(os, hashes)
     deletes = os.processes(true).dup
-    self.save_inventory_multi(:processes, OsProcess, os, hashes, deletes, :pid)
+    save_inventory_multi(:processes, os, hashes, deletes, :pid)
   end
 
   def save_firewall_rules_inventory(parent, hashes, mode = :refresh)
@@ -269,7 +269,7 @@ module EmsRefresh::SaveInventory
       end
 
     deletes = parent.firewall_rules(true).dup
-    self.save_inventory_multi(:firewall_rules, FirewallRule, parent, hashes, deletes, find_key, nil, [:source_security_group])
+    save_inventory_multi(:firewall_rules, parent, hashes, deletes, find_key, nil, [:source_security_group])
 
     parent.save!
     self.store_ids_for_new_records(parent.firewall_rules, hashes, find_key)
@@ -278,12 +278,12 @@ module EmsRefresh::SaveInventory
   def save_custom_attributes_inventory(parent, hashes)
     return if hashes.nil?
     deletes = parent.ems_custom_attributes(true).dup
-    self.save_inventory_multi(:ems_custom_attributes, CustomAttribute, parent, hashes, deletes, [:section, :name])
+    save_inventory_multi(:ems_custom_attributes, parent, hashes, deletes, [:section, :name])
   end
 
   def save_filesystems_inventory(parent, hashes)
     deletes = parent.filesystems(true).dup
-    self.save_inventory_multi(:filesystems, Filesystem, parent, hashes, deletes, :name)
+    save_inventory_multi(:filesystems, parent, hashes, deletes, :name)
   end
 
   def save_snapshots_inventory(vm, hashes)
@@ -292,7 +292,7 @@ module EmsRefresh::SaveInventory
     hashes.each { |h| h[:parent_id] = nil } # Delink all snapshots
 
     deletes = vm.snapshots(true).dup
-    self.save_inventory_multi(:snapshots, Snapshot, vm, hashes, deletes, :uid)
+    save_inventory_multi(:snapshots, vm, hashes, deletes, :uid)
 
     # Reset the relationship tree for the snapshots
     vm.snapshots.each do |s|
@@ -305,6 +305,6 @@ module EmsRefresh::SaveInventory
 
   def save_event_logs_inventory(os, hashes)
     deletes = os.event_logs(true).dup
-    self.save_inventory_multi(:event_logs, EventLog, os, hashes, deletes, :uid)
+    save_inventory_multi(:event_logs, os, hashes, deletes, :uid)
   end
 end

--- a/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
@@ -85,7 +85,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    self.save_inventory_multi(:flavors, Flavor, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:flavors, ems, hashes, deletes, :ems_ref)
     self.store_ids_for_new_records(ems.flavors, hashes, :ems_ref)
   end
 
@@ -99,7 +99,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    self.save_inventory_multi(:availability_zones, AvailabilityZone, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:availability_zones, ems, hashes, deletes, :ems_ref)
     self.store_ids_for_new_records(ems.availability_zones, hashes, :ems_ref)
   end
 
@@ -113,7 +113,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    self.save_inventory_multi(:cloud_tenants, CloudTenant, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:cloud_tenants, ems, hashes, deletes, :ems_ref)
     self.store_ids_for_new_records(ems.cloud_tenants, hashes, :ems_ref)
   end
 
@@ -131,7 +131,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:cloud_tenant, :id)
     end
 
-    self.save_inventory_multi(:cloud_resource_quotas, CloudResourceQuota, ems, hashes, deletes, [:ems_ref, :name], nil, :cloud_tenant)
+    save_inventory_multi(:cloud_resource_quotas, ems, hashes, deletes, [:ems_ref, :name], nil, :cloud_tenant)
     self.store_ids_for_new_records(ems.cloud_resource_quotas, hashes, [:ems_ref, :name])
   end
 
@@ -145,7 +145,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    self.save_inventory_multi(:key_pairs, AuthPrivateKey, ems, hashes, deletes, :name)
+    save_inventory_multi(:key_pairs, ems, hashes, deletes, :name)
     self.store_ids_for_new_records(ems.key_pairs, hashes, :name)
   end
 
@@ -166,7 +166,6 @@ module EmsRefresh::SaveInventoryCloud
     end
 
     save_inventory_multi(:cloud_networks,
-                         CloudNetwork,
                          ems,
                          hashes,
                          deletes,
@@ -183,7 +182,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:availability_zone_id] = h.fetch_path(:availability_zone, :id)
     end
 
-    self.save_inventory_multi(:cloud_subnets, CloudSubnet, cloud_network, hashes, deletes, :ems_ref, nil, :availability_zone)
+    save_inventory_multi(:cloud_subnets, cloud_network, hashes, deletes, :ems_ref, nil, :availability_zone)
 
     cloud_network.save!
     self.store_ids_for_new_records(cloud_network.cloud_subnets, hashes, :ems_ref)
@@ -206,7 +205,6 @@ module EmsRefresh::SaveInventoryCloud
     end
 
     save_inventory_multi(:security_groups,
-                         SecurityGroup,
                          ems, hashes,
                          deletes,
                          :ems_ref,
@@ -241,7 +239,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:cloud_tenant, :id) if h.key?(:cloud_tenant)
     end
 
-    self.save_inventory_multi(:floating_ips, FloatingIp, ems, hashes, deletes, :ems_ref, nil, [:vm, :cloud_tenant])
+    save_inventory_multi(:floating_ips, ems, hashes, deletes, :ems_ref, nil, [:vm, :cloud_tenant])
     self.store_ids_for_new_records(ems.floating_ips, hashes, :ems_ref)
   end
 
@@ -267,7 +265,6 @@ module EmsRefresh::SaveInventoryCloud
     end
 
     stacks = save_inventory_multi(:orchestration_stacks,
-                                  OrchestrationStack,
                                   ems,
                                   hashes,
                                   deletes,
@@ -290,7 +287,6 @@ module EmsRefresh::SaveInventoryCloud
     deletes = orchestration_stack.parameters(true).dup
 
     save_inventory_multi(:parameters,
-                         OrchestrationStackParameter,
                          orchestration_stack,
                          hashes,
                          deletes,
@@ -301,7 +297,6 @@ module EmsRefresh::SaveInventoryCloud
     deletes = orchestration_stack.outputs(true).dup
 
     save_inventory_multi(:outputs,
-                         OrchestrationStackOutput,
                          orchestration_stack,
                          hashes,
                          deletes,
@@ -312,7 +307,6 @@ module EmsRefresh::SaveInventoryCloud
     deletes = orchestration_stack.resources(true).dup
 
     save_inventory_multi(:resources,
-                         OrchestrationStackResource,
                          orchestration_stack,
                          hashes,
                          deletes,
@@ -336,7 +330,7 @@ module EmsRefresh::SaveInventoryCloud
       # Defer setting :cloud_volume_snapshot_id until after snapshots are saved.
     end
 
-    self.save_inventory_multi(:cloud_volumes, CloudVolume, ems, hashes, deletes, :ems_ref, nil, [:tenant, :availability_zone, :base_snapshot])
+    save_inventory_multi(:cloud_volumes, ems, hashes, deletes, :ems_ref, nil, [:tenant, :availability_zone, :base_snapshot])
     self.store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 
@@ -356,7 +350,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_volume_id] = h.fetch_path(:volume, :id)
     end
 
-    self.save_inventory_multi(:cloud_volume_snapshots, CloudVolumeSnapshot, ems, hashes, deletes, :ems_ref, nil, [:tenant, :volume])
+    save_inventory_multi(:cloud_volume_snapshots, ems, hashes, deletes, :ems_ref, nil, [:tenant, :volume])
     self.store_ids_for_new_records(ems.cloud_volume_snapshots, hashes, :ems_ref)
   end
 
@@ -386,7 +380,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:tenant, :id)
     end
 
-    self.save_inventory_multi(:cloud_object_store_containers, CloudObjectStoreContainer, ems, hashes, deletes, :ems_ref, nil, :tenant)
+    save_inventory_multi(:cloud_object_store_containers, ems, hashes, deletes, :ems_ref, nil, :tenant)
     self.store_ids_for_new_records(ems.cloud_object_store_containers, hashes, :ems_ref)
   end
 
@@ -406,7 +400,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_object_store_container_id] = h.fetch_path(:container, :id)
     end
 
-    self.save_inventory_multi(:cloud_object_store_objects, CloudObjectStoreObject, ems, hashes, deletes, :ems_ref, nil, [:tenant, :container])
+    save_inventory_multi(:cloud_object_store_objects, ems, hashes, deletes, :ems_ref, nil, [:tenant, :container])
     self.store_ids_for_new_records(ems.cloud_object_store_objects, hashes, :ems_ref)
   end
 end

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -219,7 +219,7 @@ module EmsRefresh::SaveInventoryInfra
       []
     end
 
-    self.save_inventory_multi(:ems_folders, EmsFolder, ems, hashes, deletes, :uid_ems, nil, :ems_children)
+    save_inventory_multi(:ems_folders, ems, hashes, deletes, :uid_ems, nil, :ems_children)
     self.store_ids_for_new_records(ems.ems_folders, hashes, :uid_ems)
   end
   alias_method :save_ems_folders_inventory, :save_folders_inventory
@@ -234,7 +234,7 @@ module EmsRefresh::SaveInventoryInfra
       []
     end
 
-    self.save_inventory_multi(:ems_clusters, EmsCluster, ems, hashes, deletes, :uid_ems, nil, :ems_children)
+    save_inventory_multi(:ems_clusters, ems, hashes, deletes, :uid_ems, nil, :ems_children)
     self.store_ids_for_new_records(ems.ems_clusters, hashes, :uid_ems)
   end
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
@@ -251,28 +251,28 @@ module EmsRefresh::SaveInventoryInfra
       []
     end
 
-    self.save_inventory_multi(:resource_pools, ResourcePool, ems, hashes, deletes, :uid_ems, nil, :ems_children)
+    save_inventory_multi(:resource_pools, ems, hashes, deletes, :uid_ems, nil, :ems_children)
     self.store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
   end
 
   def save_customization_specs_inventory(ems, hashes, target = nil)
     deletes = ems.customization_specs(true).dup
-    self.save_inventory_multi(:customization_specs, CustomizationSpec, ems, hashes, deletes, :name)
+    save_inventory_multi(:customization_specs, ems, hashes, deletes, :name)
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
     deletes = guest_device.miq_scsi_targets(true).dup
-    self.save_inventory_multi(:miq_scsi_targets, MiqScsiTarget, guest_device, hashes, deletes, :uid_ems, :miq_scsi_luns)
+    save_inventory_multi(:miq_scsi_targets, guest_device, hashes, deletes, :uid_ems, :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
     deletes = miq_scsi_target.miq_scsi_luns(true).dup
-    self.save_inventory_multi(:miq_scsi_luns, MiqScsiLun, miq_scsi_target, hashes, deletes, :uid_ems)
+    save_inventory_multi(:miq_scsi_luns, miq_scsi_target, hashes, deletes, :uid_ems)
   end
 
   def save_switches_inventory(host, hashes)
     deletes = host.switches(true).dup
-    self.save_inventory_multi(:switches, Switch, host, hashes, deletes, :uid_ems, :lans)
+    save_inventory_multi(:switches, host, hashes, deletes, :uid_ems, :lans)
 
     host.save!
 
@@ -291,11 +291,11 @@ module EmsRefresh::SaveInventoryInfra
 
   def save_lans_inventory(switch, hashes)
     deletes = switch.lans(true).dup
-    self.save_inventory_multi(:lans, Lan, switch, hashes, deletes, :uid_ems)
+    save_inventory_multi(:lans, switch, hashes, deletes, :uid_ems)
   end
 
   def save_storage_files_inventory(storage, hashes)
     deletes = storage.storage_files(true).dup
-    self.save_inventory_multi(:storage_files, StorageFile, storage, hashes, deletes, :name)
+    save_inventory_multi(:storage_files, storage, hashes, deletes, :name)
   end
 end


### PR DESCRIPTION
No longer passes the `klass` to `save_inventory_{multi,single}`.
Use ActiveRecord's `build` method instead.

**UPDATE 2:**
Basically, 2 lines changed in `save_inventory_helper.rb`:

```ruby
  # change 1: remove klass variable
  def save_inventory(type, ~~klass~~, parent, hash, deletes, new_records, record_index, record_index_columns, find_key, child_keys, remove_keys)
     key_backup = backup_keys(hash, remove_keys)
 
     found = find_key.blank? ? parent.send(type) : self.save_inventory_record_index_fetch(record_index, record_index_columns, hash, find_key)
     if found.nil?
       # change 2: use build instead of klass.new
       found = find_key ? parent.send(type).build(hash) : parent.send("build_#{type}", hash)
       new_records.blank? ? parent.send("#{type}=", found) : new_records << found
     else
       key_backup.merge!(backup_keys(hash, [:type]))
       found.update_attributes!(hash)
       deletes.delete(found) unless deletes.blank?
     end
 
     save_child_inventory(found, key_backup, child_keys)
     restore_keys(hash, remove_keys, key_backup)
   end
```

~~Before we were using `new_records` **and** `find_key` to determine "is this an association?" Now we are just using `find_key`~~

/cc @brandondunne @gmcculloug @Fryguy @jrafanie 