### PR TITLE
don't do is_a? checks on association return values

### DIFF
--- a/vmdb/lib/extensions/ar_to_model_hash.rb
+++ b/vmdb/lib/extensions/ar_to_model_hash.rb
@@ -90,7 +90,7 @@ module ToModelHash
           recs = self.tags.collect { |t| Classification.tag_to_model_hash(t) }
         else
           recs = self.send(k)
-          single_rec = !recs.kind_of?(Array)
+          single_rec = !iterable?(self.class, k)
           recs = recs.to_miq_a.collect { |c| c.to_model_hash_recursive(v) }
           recs = recs.first if single_rec
         end
@@ -99,6 +99,12 @@ module ToModelHash
     end
 
     return result
+  end
+
+  def iterable?(klass, association)
+    reflection = klass.virtual_reflection(association) ||
+      klass.reflect_on_association(association)
+    reflection && reflection.collection?
   end
 
   def to_model_hash_build_preload(options)

--- a/vmdb/lib/extensions/ar_to_model_hash.rb
+++ b/vmdb/lib/extensions/ar_to_model_hash.rb
@@ -102,8 +102,7 @@ module ToModelHash
   end
 
   def iterable?(klass, association)
-    reflection = klass.virtual_reflection(association) ||
-      klass.reflect_on_association(association)
+    reflection = klass.reflection_with_virtual(association)
     reflection && reflection.collection?
   end
 

--- a/vmdb/lib/extensions/ar_virtual.rb
+++ b/vmdb/lib/extensions/ar_virtual.rb
@@ -161,6 +161,10 @@ module VirtualFields
     reflections.merge(virtual_reflections)
   end
 
+  def reflection_with_virtual(association)
+    virtual_reflection(association) || reflect_on_association(association)
+  end
+
 
   #
   # Common methods for Virtual Fields

--- a/vmdb/lib/extensions/ar_virtual.rb
+++ b/vmdb/lib/extensions/ar_virtual.rb
@@ -133,6 +133,10 @@ module VirtualFields
     virtual_reflections.has_key?(name.to_sym)
   end
 
+  def virtual_reflection(name)
+    virtual_reflections[name.to_sym]
+  end
+
   #
   # Accessors for fields, with inheritance
   #


### PR DESCRIPTION
associations in Rails 4 return an association proxy, so testing the type
of object will not work.  Instead, look up the reflection from the model
and ask if the reflection is a collection.