### PR TITLE
ActsAsArModel (NetAppFiler) doesn't implement Rails 3/4 syntax.

### DIFF
--- a/vmdb/app/models/miq_provision_workflow.rb
+++ b/vmdb/app/models/miq_provision_workflow.rb
@@ -775,7 +775,8 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
   end
 
   def allowed_datastore_storage_controller(options={})
-    NetAppFiler.pluck(:name).index_by { |n| n }
+    # TODO: NetAppFiler is an ActAsArModel and doesn't support arel syntax yet
+    NetAppFiler.all.collect(&:name).index_by { |n| n }
   end
 
   def allowed_datastore_aggregate(options={})


### PR DESCRIPTION
cc @gmcculloug 