### PR TITLE
Replaced all prototype element references from $('xx') to $j('#xx')

### DIFF
--- a/vmdb/app/assets/javascripts/cfme_application.js
+++ b/vmdb/app/assets/javascripts/cfme_application.js
@@ -4,15 +4,15 @@
 function miqOnLoad() {
 
   miq_widget_dd_url = "dashboard/widget_dd_done";     // controller to be used in url in miqDropComplete method
-  if ($('col1')) miqInitDashboardCols();  // Initialize the dashboard column sortables
-  if ($('widget_select_div')) miqInitWidgetPulldown();  // Initialize the dashboard widget pulldown
+  if (miqDomElementExists('col1')) miqInitDashboardCols();  // Initialize the dashboard column sortables
+  if (miqDomElementExists('widget_select_div')) miqInitWidgetPulldown();  // Initialize the dashboard widget pulldown
 
   if (typeof init_dhtmlx_layout != "undefined") {
     miqInitDhtmlxLayout();  // Need this since IE will not run JS correctly until after page is loaded
   }
 
   Event.observe(document, 'mousemove', miqGetMouseXY);
-  if ($('compare_grid')) {  // Need to do this here for IE, rather then right after the grid is initialized
+  if (miqDomElementExists('compare_grid')) {  // Need to do this here for IE, rather then right after the grid is initialized
     compare_grid.enableAutoHeight(true);
     compare_grid.enableAutoWidth(true);
   }
@@ -33,7 +33,7 @@ function miqOnLoad() {
 
   if (typeof miq_tree_focus == "string") eval(miq_tree_focus);      // Focus on certain tree node, if set
 
-  if ($('clear_search') != "undefined")                             // Position clear search link in right cell header
+  if (miqDomElementExists('clear_search'))                             // Position clear search link in right cell header
     $j('.dhtmlxInfoBarLabel:visible').append($j('#clear_search')[0])  // Find the right cell header div
 
   if (typeof miq_after_onload == "string") eval(miq_after_onload);  // Run MIQ after onload code if present
@@ -83,54 +83,54 @@ function miqGetMouseXY(e){
 
 // Prefill text entry field when blank
 function miqLoginPrefill() {
-  if ($('user_name')) miqPrefill($('user_name'));
-  if ($('user_password')) miqPrefill($('user_password'));
-  if ($('user_new_password')) miqPrefill($('user_new_password'));
-  if ($('user_verify_password')) miqPrefill($('user_verify_password'));
-  if ($('user_name')) self.setTimeout('miqLoginPrefill()',200); // Retry in .2 seconds, if user name field is present
+  if (miqDomElementExists('user_name')) miqPrefill($j('#user_name'));
+  if (miqDomElementExists('user_password')) miqPrefill($j('#user_password'));
+  if (miqDomElementExists('user_new_password')) miqPrefill($j('#user_new_password'));
+  if (miqDomElementExists('user_verify_password')) miqPrefill($j('#user_verify_password'));
+  if (miqDomElementExists('user_name')) self.setTimeout('miqLoginPrefill()',200); // Retry in .2 seconds, if user name field is present
 }
 
 // Prefill expression value text entry fields when blank
 function miqExpressionPrefill(count) {
-  if ($('chosen_value') && $('chosen_value').type.startsWith('text')) {
-    miqPrefill($('chosen_value'), '/images/layout/expression/' + miq_val1_type + '.png');
+  if (miqDomElementExists('chosen_value') && $j('#chosen_value').type.startsWith('text')) {
+    miqPrefill($j('#chosen_value'), '/images/layout/expression/' + miq_val1_type + '.png');
     $j('#chosen_value').prop('title', miq_val1_title);
     $j('#chosen_value').prop('alt', miq_val1_title);
   }
-  if ($('chosen_cvalue') && $('chosen_cvalue').type.startsWith('text')) {
-    miqPrefill($('chosen_cvalue'), '/images/layout/expression/' + miq_val2_type + '.png');
+  if (miqDomElementExists('chosen_cvalue') && $j('#chosen_cvalue').type.startsWith('text')) {
+    miqPrefill($j('#chosen_cvalue'), '/images/layout/expression/' + miq_val2_type + '.png');
     $j('#chosen_cvalue').prop('title', miq_val2_title);
     $j('#chosen_cvalue').prop('alt', miq_val2_title);
   }
-  if ($('chosen_regkey') && $('chosen_regkey').type.startsWith('text')) {
-    miqPrefill($('chosen_regkey'), '/images/layout/expression/string.png');
+  if (miqDomElementExists('chosen_regkey') && $j('#chosen_regkey').type.startsWith('text')) {
+    miqPrefill($j('#chosen_regkey'), '/images/layout/expression/string.png');
     var title = "Registry Key";
     $j('#chosen_regkey').prop('title', title);
     $j('#chosen_regkey').prop('alt', title);
   }
-  if ($('chosen_regval') && $('chosen_regval').type.startsWith('text')) {
-    miqPrefill($('chosen_regval'), '/images/layout/expression/string.png');
+  if (miqDomElementExists('chosen_regval') && $j('#chosen_regval').type.startsWith('text')) {
+    miqPrefill($j('#chosen_regval'), '/images/layout/expression/string.png');
     var title = "Registry Key Value";
     $j('#chosen_regval').prop('title', title);
     $j('#chosen_regval').prop('alt', title);
   }
-  if ($('miq_date_1_0') && $('miq_date_1_0').type.startsWith('text')) {
-    miqPrefill($('miq_date_1_0'), '/images/layout/expression/' + miq_val1_type + '.png');
+  if (miqDomElementExists('miq_date_1_0') && $j('#miq_date_1_0').type.startsWith('text')) {
+    miqPrefill($j('#miq_date_1_0'), '/images/layout/expression/' + miq_val1_type + '.png');
     $j('#miq_date_1_0').prop('title', miq_val1_title);
     $j('#miq_date_1_0').prop('alt', miq_val1_title);
   }
-  if ($('miq_date_1_1') && $('miq_date_1_1').type.startsWith('text')) {
-    miqPrefill($('miq_date_1_1'), '/images/layout/expression/' + miq_val1_type + '.png');
+  if (miqDomElementExists('miq_date_1_1') && $j('#miq_date_1_1').type.startsWith('text')) {
+    miqPrefill($j('#miq_date_1_1'), '/images/layout/expression/' + miq_val1_type + '.png');
     $j('#miq_date_1_1').prop('title', miq_val1_title);
     $j('#miq_date_1_1').prop('alt', miq_val1_title);
   }
-  if ($('miq_date_2_0') && $('miq_date_2_0').type.startsWith('text')) {
-    miqPrefill($('miq_date_2_0'), '/images/layout/expression/' + miq_val2_type + '.png');
+  if (miqDomElementExists('miq_date_2_0') && $j('#miq_date_2_0').type.startsWith('text')) {
+    miqPrefill($j('#miq_date_2_0'), '/images/layout/expression/' + miq_val2_type + '.png');
     $j('#miq_date_2_0').prop('title', miq_val2_title);
     $j('#miq_date_2_0').prop('alt', miq_val2_title);
   }
-  if ($('miq_date_2_1') && $('miq_date_2_1').type.startsWith('text')) {
-    miqPrefill($('miq_date_2_1'), '/images/layout/expression/' + miq_val2_type + '.png');
+  if (miqDomElementExists('miq_date_2_1') && $j('#miq_date_2_1').type.startsWith('text')) {
+    miqPrefill($j('#miq_date_2_1'), '/images/layout/expression/' + miq_val2_type + '.png');
     $j('#miq_date_2_1').prop('title', miq_val2_title);
     $j('#miq_date_2_1').prop('alt', miq_val2_title);
   }
@@ -183,16 +183,16 @@ function miqPrefill(element, image, blank_image) {
 function miqGetTZO() {
   var uDate = new Date();
   if(uDate)
-    if ($('user_TZO')) $('user_TZO').value=uDate.getTimezoneOffset()/60;
+    if (miqDomElementExists('user_TZO')) $j('#user_TZO').val(uDate.getTimezoneOffset()/60);
 }
 
 // Get user's browswer info
 function miqGetBrowserInfo() {
   var bd;
   bd = miqBrowserDetect();
-  if ($('browser_name')) $('browser_name').value=bd.browser;
-  if ($('browser_version')) $('browser_version').value=bd.version;
-  if ($('browser_os')) $('browser_os').value=bd.OS;
+  if (miqDomElementExists('browser_name')) $j('#browser_name').val(bd.browser);
+  if (miqDomElementExists('browser_version')) $j('#browser_version').val(bd.version);
+  if (miqDomElementExists('browser_os')) $j('#browser_os').val(bd.OS);
 }
 
 // Turn highlight on or off
@@ -243,8 +243,9 @@ function miqCheckForChanges() {
     if (cfmeAngularApplication.$scope.form.$dirty)
       return confirm("Abandon changes?");
     } else {
-        if ((($('buttons_on') && $('buttons_on').visible()) || typeof miq_changes != "undefined") &&
-          $j('#ignore_form_changes').length == 0)
+        if (((miqDomElementExists('buttons_on') && $j('#buttons_on').is(":visible")) ||
+          typeof miq_changes != "undefined") &&
+          !miqDomElementExists('ignore_form_changes'))
             return confirm("Abandon changes?");
     }
   return true;
@@ -264,7 +265,7 @@ function miqNewTagPrompt() {
   text = prompt('Enter new tags, separated by blanks','');
     if (text == null) return false;
   else {
-    $('new_tag').value = text;
+    $j('#new_tag').val(text);
     return true;
 } }
 
@@ -319,7 +320,7 @@ function toggleConvertButtonToLink(button, url, toggle) {
 // parms: button_div=<id of div with buttons to update>, override=<forced state>
 function miqUpdateAllCheckboxes(button_div,override) {
   miqSparkle(true);
-  if ($j('#masterToggle').length > 0) {
+  if (miqDomElementExists('masterToggle')) {
     var state = $j('#masterToggle').prop('checked');
     if ( override != null ) state = override;
     if (typeof gtl_list_grid == "undefined" && ($$('input[id=listcheckbox]').length>0)) {             // No dhtmlx grid on the screen
@@ -340,7 +341,7 @@ function miqUpdateAllCheckboxes(button_div,override) {
         gtl_list_grid.cells(id, 0).setValue(state ? 1:0);
       })
       crows = gtl_list_grid.getCheckedRows(0);
-      $('miq_grid_checks').value = crows
+      $j('#miq_grid_checks').val(crows);
       count = crows == "" ? 0:crows.split(",").length;
       miqSetButtons(count, button_div);
     }
@@ -739,18 +740,18 @@ function miqAjaxAuth(button){
     miqEnableLoginFields(false);
     miqJqueryRequest('/dashboard/authenticate', {beforeSend: true, data: Form.serialize('login_div')});
   } else if (button == 'more' || button == 'back') {
-    miqJqueryRequest('/dashboard/authenticate?' + Form.serialize($('login_div')) + '&button=' + button);
+    miqJqueryRequest('/dashboard/authenticate?' + Form.serialize($j('#login_div')) + '&button=' + button);
   } else {
     miqEnableLoginFields(false);
-    miqAsyncAjax('/dashboard/authenticate?' + Form.serialize($('login_div')) + '&button=' + button);
+    miqAsyncAjax('/dashboard/authenticate?' + Form.serialize($j('#login_div')) + '&button=' + button);
   }
 }
 
 function miqEnableLoginFields(enabled){
-  $('user_name').readOnly = !enabled;
-  $('user_password').readOnly = !enabled;
-  if ($('user_new_password')) $('user_new_password').readOnly = !enabled;
-  if ($('user_verify_password')) $('user_verify_password').readOnly = !enabled;
+  $j('#user_name').prop('readonly', !enabled);
+  $j('#user_password').prop('readonly', !enabled);
+  if (miqDomElementExists('user_new_password')) $j('#user_new_password').prop('readonly', !enabled);
+  if (miqDomElementExists('user_verify_password')) $j('#user_verify_password').prop('readonly', !enabled);
 }
 
 // Attach text area with id = id + "_lines" to work with the text area id passed in
@@ -810,7 +811,7 @@ function miqBuildCalendar(){
     var el = $j(this);
     var cal = new dhtmlxCalendarObject(el.attr('id'));
     cal.setDateFormat("%m/%d/%Y");
-    if (this.value == "" && typeof miq_cal_dateTo != "undefined"){
+    if (el.val() == "" && typeof miq_cal_dateTo != "undefined"){
       cal.setDate(miq_cal_dateTo);
     } else {
       cal.setDate(this.value);
@@ -897,7 +898,7 @@ function miqBuildExplorerView(options){
       ]
     });
     expLayout.on('render',function() {
-      if ($('main_div')) {
+      if (miqDomElementExists('main_div')) {
         miqBuildMainLayout(this, settings.header);
       }
     });
@@ -934,7 +935,7 @@ function miqBuildExplorerView(options){
 function miqBuildMainLayout(parentLayout, header){
   var el = parentLayout.getUnitByPosition('center').get('wrap');
 //  parentLayout.getUnitByPosition('center').set('header', "Test");
-  if ($('paging_div')) var paging_height = 35; else var paging_height = 0;
+  if (miqDomElementExists('paging_div')) var paging_height = 35; else var paging_height = 0;
   var mainLayout = new YAHOO.widget.Layout(el, {
 //  var mainLayout = new YAHOO.widget.Layout('center_div', {
     parent: parentLayout,
@@ -1192,9 +1193,9 @@ function miqSpinner(status){
         top: 'auto', // Top position relative to parent in px
         left: 'auto' // Left position relative to parent in px
       };
-      spinner = new Spinner(opts).spin($('spinner_div'));
+      spinner = new Spinner(opts).spin($j('#spinner_div'));
     } else {
-      spinner.spin($('spinner_div'));
+      spinner.spin($j('#spinner_div'));
     }
   } else {
     if (typeof spinner != "undefined") spinner.stop();
@@ -1237,3 +1238,8 @@ function miqJqueryRequest(url, options) {
 
   new $j.ajax(options['no_encoding'] ? url : encodeURI(url), ajax_options);
 }
+
+function miqDomElementExists(element){
+  return $j('#' + element).length
+}
+

--- a/vmdb/app/assets/javascripts/cfme_dynatree.js
+++ b/vmdb/app/assets/javascripts/cfme_dynatree.js
@@ -327,7 +327,7 @@ function cfmeGetChecked(node, treename) {
     }
   }
   count = selectedKeys.length
-  if ($('center_tb'))
+  if (miqDomElementExists('center_tb'))
     miqSetButtons(count, "center_tb");
   else
     miqSetButtons(count, "center_buttons_div");
@@ -348,9 +348,9 @@ function cfmeCheckAll(cb, treename) {
   });
 
   var count = selectedKeys.length
-  if ($('center_tb'))
+  if (miqDomElementExists('center_tb'))
     miqSetButtons(count, "center_tb");
-  else if ($('center_buttons_div'))
+  else if (miqDomElementExists('center_buttons_div'))
     miqSetButtons(count, "center_buttons_div");
 
   if (count > 0) {

--- a/vmdb/app/assets/javascripts/miq_dhtmlxgrid.js
+++ b/vmdb/app/assets/javascripts/miq_dhtmlxgrid.js
@@ -47,9 +47,9 @@ function miqRequestRowSelected(row_id) {
 // Handle checkbox
 function miqGridOnCheck(row_id, cell_idx, state) {
   crows = gtl_list_grid.getCheckedRows(0);
-  $('miq_grid_checks').value = crows
+  $j('#miq_grid_checks').val(crows);
   count = crows == "" ? 0:crows.split(",").length;
-  if ($('center_tb')) miqSetButtons(count, "center_tb");
+  if (miqDomElementExists('center_tb')) miqSetButtons(count, "center_tb");
   else miqSetButtons(count, "center_buttons_div");
 }
 
@@ -58,24 +58,24 @@ function miqCheck_AE_All(button_div,gridname) {
   var state = true;
   var crows = "";
   if (typeof ns_list_grid != "undefined" && gridname == "ns_list_grid") {
-    state = $('Toggle1').checked;
+    state = $j('#Toggle1').prop('checked');
     ns_list_grid.checkAll(state ? true : false)
     crows = ns_list_grid.getCheckedRows(0);
   } else if (typeof ns_grid != "undefined" && gridname == "ns_grid") {
-    state = $('Toggle2').checked;
+    state = $j('#Toggle2').prop('checked');
     ns_grid.checkAll(state ? true:false)
     crows = ns_grid.getCheckedRows(0);
   } else if (typeof instance_grid != "undefined" && gridname == "instance_grid") {
-    state = $('Toggle3').checked;
+    state = $j('#Toggle3').prop('checked');
     instance_grid.checkAll(state ? true:false)
     crows = instance_grid.getCheckedRows(0);
   } else if (typeof class_methods_grid != "undefined" && gridname == "class_methods_grid") {
-    state = $('Toggle4').checked;
+    state = $j('#Toggle4').prop('checked');
     class_methods_grid.checkAll(state ? true:false)
     crows = class_methods_grid.getCheckedRows(0);
   }
-  if ($('miq_grid_checks')) $('miq_grid_checks').value = crows
-  if ($('miq_grid_checks2')) $('miq_grid_checks2').value = crows
+  if (miqDomElementExists('miq_grid_checks')) $j('#miq_grid_checks').val(crows)
+  if (miqDomElementExists('miq_grid_checks2')) $j('#miq_grid_checks2').val(crows)
   count = crows == "" ? 0:crows.split(",").length;
   miqSetButtons(count, button_div);
   miqSparkle(false);
@@ -197,7 +197,7 @@ function miqOnAECheck(row_id, cell_idx, state) {
   count = crows == "" ? 0:crows.split(",").length;  
   //if ($('policy_bar'))  miqSetButtons(count, "policy_bar");
   //if ($('policy_bar2')) miqSetButtons(count, "policy_bar2");
-  if ($('center_tb')) miqSetButtons(count, "center_tb");
+  if (miqDomElementExists('center_tb')) miqSetButtons(count, "center_tb");
   else miqSetButtons(count, "center_buttons_div");
 }
 

--- a/vmdb/app/assets/javascripts/miq_dhtmlxtoolbar.js
+++ b/vmdb/app/assets/javascripts/miq_dhtmlxtoolbar.js
@@ -174,8 +174,8 @@ function miqToolbarOnClick(id){
 	var params;
 	if (typeof button.url_parms != "undefined") {
 		if (button.url_parms.endsWith("_div")) {
-			if ($('miq_grid_checks'))
-				params = "miq_grid_checks=" + $('miq_grid_checks').value;
+			if (miqDomElementExists('miq_grid_checks'))
+				params = "miq_grid_checks=" + $j('#miq_grid_checks').val();
 			else
 				params = Form.serialize(button.url_parms);
 		} else {

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -141,9 +141,13 @@ class ApplicationController < ActionController::Base
     @keep_compare = true
     panel = params[:panel]
     render :update do |page|
-      @panels[panel] = !@panels[panel]
-      direction = @panels[panel] ? 'down' : 'up'
-      page << "$('#{j_str(panel)}').visualEffect('slide_#{direction}', {duration: 0.3});"
+      if @panels[panel] == 'down'
+        @panels[panel] = 'up'
+        page << "$j('##{j_str(panel)}').slideUp('medium');"
+      else
+        @panels[panel] = 'down'
+        page << "$j('##{j_str(panel)}').slideDown('medium');"
+      end
     end
     # FIXME: the @panels end up in the session eventually
     #        so there's a issue with the possibility of inserting arbitrary
@@ -253,7 +257,7 @@ class ApplicationController < ActionController::Base
     if miq_task.task_results.blank? || miq_task.status != "Ok"  # Check to see if any results came back or status not Ok
       add_flash(_("Report generation returned: Status [%{status}] Message [%{message}]") % {:status  => miq_task.status, :message => miq_task.message}, :error)
       render :update do |page|
-        page << "if ($('flash_msg_div_report_list')){"
+        page << "if (miqDomElementExists('flash_msg_div_report_list')){"
         page.replace("flash_msg_div_report_list", :partial => "layouts/flash_msg",
                                                   :locals  => {:div_num => "_report_list"})
         page << "} else {"
@@ -2124,7 +2128,7 @@ class ApplicationController < ActionController::Base
         page.replace("pc_div_2", :partial=>'/layouts/pagingcontrols', :locals=>{:pages=>@pages, :action_url=>action_url})
       else                                          # No grid, replace the gtl div
         page.replace_html("main_div", :partial=>"layouts/gtl")                                                  # Replace the main div area contents
-        page << "$('adv_div').visualEffect('slide_up', {duration:0.3});" if params[:entry]
+        page << "$j('#adv_div').slideUp(0.3);" if params[:entry]
       end
     end
   end
@@ -2715,7 +2719,7 @@ class ApplicationController < ActionController::Base
 
   def render_flash_not_applicable_to_model(type)
     add_flash(_("%{task} does not apply to selected %{model}") % {:model => ui_lookup(:table => "miq_template"), :task  => type.capitalize}, :error)
-    render_flash { |page| page << '$(\'main_div\').scrollTop = 0;' }
+    render_flash { |page| page << '$j(\'#main_div\').scrollTop();' }
   end
 
   def set_gettext_locale

--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -190,7 +190,7 @@ module ApplicationController::CiProcessing
     vms = find_checked_items
     if VmOrTemplate.includes_template?(vms.map(&:to_i).uniq)
       add_flash(_("%{task} does not apply to selected %{model}") % {:model=>ui_lookup(:table => "miq_template"), :task=>"Set Retirement Dates"}, :error)
-      render_flash { |page| page << '$(\'main_div\').scrollTop = 0;' }
+      render_flash { |page| page << '$j(\'#main_div\').scrollTop();' }
       return
     end
     # check to see if coming from show_list or drilled into vms from another CI
@@ -291,7 +291,7 @@ module ApplicationController::CiProcessing
         session[:retire_warn] = ""
         page << javascript_hide("remove_button")
         page << javascript_disable_field('retirement_warn')
-        page << "$('retirement_warn').value = '';"
+        page << "$j('#retirement_warn').val('');"
       else
         page << javascript_show("remove_button")
         page << javascript_enable_field('retirement_warn')
@@ -313,7 +313,7 @@ module ApplicationController::CiProcessing
     else
       if VmOrTemplate.includes_template?(recs)
         add_flash(_("%{task} does not apply to selected %{model}") % {:model=>ui_lookup(:table => "miq_template"), :task=>"Right-Size Recommendations"}, :error)
-        render_flash { |page| page << '$(\'main_div\').scrollTop = 0;' }
+        render_flash { |page| page << '$j(\'#main_div\').scrollTop();' }
         return
       end
     end
@@ -843,36 +843,36 @@ module ApplicationController::CiProcessing
         if params[:from_first] =~ /[\D]/
           temp = params[:from_first].gsub(/[\.]/,"")
           field_shift = true if params[:from_first] =~ /[\.]/ && params[:from_first].gsub(/[\.]/,"") =~ /[0-9]/ && temp.gsub!(/[\D]/,"").nil?
-          page << "$('from_first').value= '#{j_str(params[:from_first]).gsub(/[\D]/,"")}';"
+          page << "$j('#from_first').val('#{j_str(params[:from_first]).gsub(/[\D]/, "")}');"
           page << javascript_focus('from_second') if field_shift
         else
-          page << "$('to_first').value='#{j_str(params[:from_first])}';"
+          page << "$j('#to_first').val('#{j_str(params[:from_first])}');"
           page << javascript_focus('from_second') if params[:from_first].length == 3
         end
       elsif params[:from_second]
         if params[:from_second] =~ /[\D]/
           temp = params[:from_second].gsub(/[\.]/,"")
           field_shift = true if params[:from_second] =~ /[\.]/ && params[:from_second].gsub(/[\.]/,"") =~ /[0-9]/ && temp.gsub!(/[\D]/,"").nil?
-          page << "$('from_second').value= '#{j_str(params[:from_second].gsub(/[\D]/,""))}';"
+          page << "$j('#from_second').val('#{j_str(params[:from_second].gsub(/[\D]/, ""))}');"
           page << javascript_focus('from_third') if field_shift
         else
-          page << "$('to_second').value='#{j_str(params[:from_second])}';"
+          page << "$j('#to_second').val('#{j_str(params[:from_second])}');"
           page << javascript_focus('from_third') if params[:from_second].length == 3
         end
       elsif params[:from_third]
         if params[:from_third] =~ /[\D]/
           temp = params[:from_third].gsub(/[\.]/,"")
           field_shift = true if params[:from_third] =~ /[\.]/ && params[:from_third].gsub(/[\.]/,"") =~ /[0-9]/ && temp.gsub!(/[\D]/,"").nil?
-          page << "$('from_third').value= '#{j_str(params[:from_third].gsub(/[\D]/,""))}';"
+          page << "$j('#from_third').val('#{j_str(params[:from_third].gsub(/[\D]/, ""))}');"
           page << javascript_focus('from_fourth') if field_shift
         else
-          page << "$('to_third').value='#{j_str(params[:from_third])}';"
+          page << "$j('#to_third').val('#{j_str(params[:from_third])}');"
           page << javascript_focus('from_fourth') if params[:from_third].length == 3
         end
       elsif params[:from_fourth] && params[:from_fourth] =~ /[\D]/
-        page << "$('from_fourth').value= '#{j_str(params[:from_fourth].gsub(/[\D]/,""))}';"
+        page << "$j('#from_fourth').val('#{j_str(params[:from_fourth].gsub(/[\D]/, ""))}');"
       elsif params[:to_fourth] && params[:to_fourth] =~ /[\D]/
-        page << "$('to_fourth').value= '#{j_str(params[:to_fourth].gsub(/[\D]/,""))}';"
+        page << "$j('#to_fourth').val('#{j_str(params[:to_fourth].gsub(/[\D]/, ""))}');"
       end
       if request.parameters[:controller] == "ems_cloud" || (params[:discover_type_ipmi] && params[:discover_type_ipmi].to_s == "1")
         @ipmi = true
@@ -993,12 +993,12 @@ module ApplicationController::CiProcessing
     end
     if recs.length < 1
       add_flash(_("One or more %{model} must be selected to %{task}") % {:model=>Dictionary::gettext(db.to_s, :type=>:model, :notfound=>:titleize).pluralize, :task=>"Reconfigure"}, :error)
-      render_flash { |page| page << '$(\'main_div\').scrollTop = 0;' }
+      render_flash { |page| page << '$j(\'#main_div\').scrollTop();' }
       return
     else
       if VmOrTemplate.includes_template?(recs)
         add_flash(_("%{task} does not apply because you selected at least one %{model}") % {:model=>ui_lookup(:table => "miq_template"), :task=>"Reconfigure"}, :error)
-        render_flash { |page| page << '$(\'main_div\').scrollTop = 0;' }
+        render_flash { |page| page << '$j(\'#main_div\').scrollTop();' }
         return
       end
       @edit[:reconfigure_items] = Array.new # Set the array of set ownership items
@@ -1096,7 +1096,7 @@ module ApplicationController::CiProcessing
       vms = find_checked_items
       if method == 'retire_now' && VmOrTemplate.includes_template?(vms)
         add_flash(_("%{task} does not apply to selected %{model}") % {:model=>ui_lookup(:table => "miq_template"), :task=>"Retire"}, :error)
-        render_flash { |page| page << '$(\'main_div\').scrollTop = 0;' }
+        render_flash { |page| page << '$j(\'#main_div\').scrollTop();' }
         return
       end
 

--- a/vmdb/app/controllers/application_controller/tags.rb
+++ b/vmdb/app/controllers/application_controller/tags.rb
@@ -47,7 +47,7 @@ module ApplicationController::Tags
       page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
       page.replace("tab_div", :partial=>"layouts/mytags")
       newtags.split.each do |tag|
-        page << "$('mytag_#{j_str(tag.downcase)}').visualEffect('pulsate');"
+        page << jquery_pulsate_element("mytag_#{j_str(tag.downcase)}")
       end
     end
   end
@@ -138,7 +138,9 @@ module ApplicationController::Tags
       end
       page.replace("cat_tags_div", :partial=>"layouts/tag_edit_cat_tags")
       page.replace("assignments_div", :partial=>"layouts/tag_edit_assignments") unless params[:tag_cat]
-      page << "$('#{j_str(params[:tag_add])}_tr').visualEffect('pulsate');" if params[:tag_add]
+      if params[:tag_add]
+        page << jquery_pulsate_element("#{j_str(params[:tag_add])}_tr")
+      end
     end
   end
 
@@ -152,7 +154,7 @@ module ApplicationController::Tags
     render :update do |page|
       page.replace("value_div", :partial=>"layouts/classify_value")
       page.replace("table_div", :partial=>"layouts/classify_table")
-      page << "$('#{entry.id}_tr').visualEffect('pulsate');"
+      page << jquery_pulsate_element("#{entry.id}_tr")
     end
   end
 

--- a/vmdb/app/controllers/application_controller/timelines.rb
+++ b/vmdb/app/controllers/application_controller/timelines.rb
@@ -113,13 +113,13 @@ module ApplicationController::Timelines
       page << "miq_cal_dateTo = new Date(#{@tl_options[:edate]});" unless @tl_options[:edate].nil?
       page << 'miqBuildCalendar();'
       if @tl_options[:tl_show] == "timeline"
-        page << "$('filter1').value='#{@tl_options[:fltr1]}';"
-        page << "$('filter2').value='#{@tl_options[:fltr2]}';"
-        page << "$('filter3').value='#{@tl_options[:fltr3]}';"
+        page << "$j('#filter1').val('#{@tl_options[:fltr1]}');"
+        page << "$j('#filter2').val('#{@tl_options[:fltr2]}');"
+        page << "$j('#filter3').val('#{@tl_options[:fltr3]}');"
       else
         @tl_options[:events].sort.each_with_index do |e,i|
           fltr = "pol_fltr#{i+1}".to_sym
-          page << "$('filter#{i+1}').value='#{@tl_options[fltr]}';"
+          page << "$j('#filter#{i + 1}').val('#{@tl_options[fltr]}');"
         end
       end
       page << "miqSparkle(false);"

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -525,7 +525,7 @@ class CatalogController < ApplicationController
       page << javascript_hide("ae_tree_select_div")
       page << javascript_hide("blocker_div")
       page << javascript_hide("#{ae_tree_key}_div")
-      page << "$('#{ae_tree_key}').value = '#{@edit[:new][ae_tree_key]}';"
+      page << "$j('##{ae_tree_key}').val('#{@edit[:new][ae_tree_key]}');"
       page << "$j('##{ae_tree_key}').prop('title', '#{@edit[:new][ae_tree_key]}');"
       @edit[:ae_tree_select] = false
       page << javascript_for_miq_button_visibility(@changed)

--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -71,9 +71,9 @@ class ConfigurationController < ApplicationController
         page.replace_html("main_div", :partial => "ui_4") # Replace the main div area contents
         if c_buttons && c_xml
           page << javascript_for_toolbar_reload('center_tb', c_buttons, c_xml)
-          page << "$('center_buttons_div').show();"
+          page << "$j('#center_buttons_div').show();"
         else
-          page << "$('center_buttons_div').hide();"
+          page << "$j('#center_buttons_div').hide();"
         end
       end
     end
@@ -217,7 +217,7 @@ class ConfigurationController < ApplicationController
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace("tab_div", :partial => "configuration/ui_5")
         newtags.each do |tag|
-          page << "$('mytag_#{tag}').visualEffect('pulsate');"
+          page << jquery_pulsate_element("mytag#{tag}")
         end
       end
     end

--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -217,13 +217,13 @@ module EmsCommon
         page.replace_html("form_div", :partial => "shared/views/ems_common/form")
         unless @ems.kind_of?(EmsCloud)
           # Hide/show C&U credentials tab
-          page << "$('metrics_li').#{params[:server_emstype] == "rhevm" ? "show" : "hide"}();"
+          page << "$j('#metrics_li').#{params[:server_emstype] == "rhevm" ? "show" : "hide"}();"
         end
         if ["openstack", "openstack_infra"].include?(params[:server_emstype])
-          page << "$('port').value = #{j_str(@edit[:new][:port].to_s)};"
+          page << "$j('#port').val(#{j_str(@edit[:new][:port].to_s)});"
         end
         # Hide/show port field
-        page << "$('port_tr').#{["openstack", "openstack_infra", "rhevm"].include?(params[:server_emstype]) ? "show" : "hide"}();"
+        page << "$j('#port_tr').#{%w(openstack openstack_infra rhevm).include?(params[:server_emstype]) ? "show" : "hide"}();"
       end
       if changed != session[:changed]
         session[:changed] = changed

--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -1091,7 +1091,7 @@ class MiqAeClassController < ApplicationController
       end
     end
     render :update do |page|
-      page << "if ($('cls_method_data')){"
+      page << "if (miqDomElementExists('cls_method_data')){"
         page.replace("flash_msg_div_class_methods", :partial=>"layouts/flash_msg", :locals=>{:div_num=>"_class_methods"})
         page << "var ta = document.getElementById('cls_method_data');"
       page << "} else {"
@@ -1102,11 +1102,11 @@ class MiqAeClassController < ApplicationController
       page << "ta.scrollTop = (#{line.to_i}-1) * lineHeight;"
       if line > 0
         if @sb[:row_selected]
-          page << "$('cls_method_data_lines').scrollTop = ta.scrollTop;"
-          page << "$('cls_method_data').scrollTop = ta.scrollTop;"
+          page << "$j('#cls_method_data_lines').scrollTop(ta.scrollTop);"
+          page << "$j('#cls_method_data').scrollTop(ta.scrollTop);"
         else
-          page << "$('method_data_lines').scrollTop = ta.scrollTop;"
-          page << "$('method_data').scrollTop = ta.scrollTop;"
+          page << "$j('#method_data_lines').scrollTop(ta.scrollTop);"
+          page << "$j('#method_data').scrollTop(ta.scrollTop);"
         end
       end
     end
@@ -1135,11 +1135,11 @@ class MiqAeClassController < ApplicationController
           if session[:field_data][:datatype] == "password"
             page << javascript_hide("field_default_value")
             page << javascript_show("field_password_value")
-            page << "$('field_password_value').value = '';"
+            page << "$j('#field_password_value').val('');"
           else
             page << javascript_hide("field_password_value")
             page << javascript_show("field_default_value")
-            page << "$('field_default_value').value = '';"
+            page << "$j('#field_default_value').val('');"
           end
         end
         params.keys.each do |field|
@@ -1150,12 +1150,12 @@ class MiqAeClassController < ApplicationController
             if @edit[:new][:fields][f[1].to_i]['datatype'] == "password"
               page << javascript_hide(def_field)
               page << javascript_show(pwd_field)
-              page << "$('#{pwd_field}').value='';"
+              page << "$j('##{pwd_field}').val('');"
               @edit[:new][:fields][f[1].to_i]['default_value'] = nil
             else
               page << javascript_hide(pwd_field)
               page << javascript_show(def_field)
-              page << "$('#{def_field}').value='';"
+              page << "$j('##{def_field}').val('');"
               @edit[:new][:fields][f[1].to_i]['default_value'] = nil
             end
           end
@@ -1203,22 +1203,22 @@ class MiqAeClassController < ApplicationController
           if session[:field_data][:datatype] == "password"
             page << javascript_hide("cls_field_default_value")
             page << javascript_show("cls_field_password_value")
-            page << "$('cls_field_password_value').value = '';"
+            page << "$j('#cls_field_password_value').val('');"
           else
             page << javascript_hide("cls_field_password_value")
             page << javascript_show("cls_field_default_value")
-            page << "$('cls_field_default_value').value = '';"
+            page << "$j('#cls_field_default_value').val('');"
           end
         end
         if params[:method_field_datatype]
           if session[:field_data][:datatype] == "password"
             page << javascript_hide("method_field_default_value")
             page << javascript_show("method_field_password_value")
-            page << "$('method_field_password_value').value = '';"
+            page << "$j('#method_field_password_value').val('');"
           else
             page << javascript_hide("method_field_password_value")
             page << javascript_show("method_field_default_value")
-            page << "$('method_field_default_value').value = '';"
+            page << "$j('#method_field_default_value').val('');"
           end
         end
 
@@ -1237,12 +1237,12 @@ class MiqAeClassController < ApplicationController
             if @edit[:new][:fields][f[1].to_i]['datatype'] == "password"
               page << javascript_hide(def_field)
               page << javascript_show(pwd_field)
-              page << "$('#{pwd_field}').value='';"
+              page << "$j('##{pwd_field}').val('');"
               @edit[:new][:fields][f[1].to_i]['default_value'] = nil
             else
               page << javascript_hide(pwd_field)
               page << javascript_show(def_field)
-              page << "$('#{def_field}').value='';"
+              page << "$j('##{def_field}').val('');"
               @edit[:new][:fields][f[1].to_i]['default_value'] = nil
             end
           end

--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -427,7 +427,7 @@ module MiqAeCustomizationController::Dialogs
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("field_values_div", :partial=>"field_values", :locals=>{:entry=>"new", :edit=>true})
         page << javascript_focus('entry_name')
-        page << "$('entry_name').select();"
+        page << "$j('#entry_name').select();"
       end
       session[:entry] = "new"
     else
@@ -441,7 +441,7 @@ module MiqAeCustomizationController::Dialogs
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("field_values_div", :partial=>"field_values", :locals=>{:entry=>entry, :edit=>true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('entry_#{j_str(params[:field])}').select();"
+        page << "$j('#entry_#{j_str(params[:field])}').select();"
 
      end
       session[:entry] = entry

--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -768,7 +768,7 @@ class OpsController < ApplicationController
       page << "cfmeDynatree_activateNodeSilently('#{x_active_tree}', '#{x_node}');"
       page << "miqSparkle(false);"
       page << javascript_focus_if_exists('server_company')
-      page << "if ($('flash_msg_div')) {"
+      page << "if (miqDomElementExists('flash_msg_div')) {"
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "}"
       if @ajax_action

--- a/vmdb/app/controllers/ops_controller/ops_rbac.rb
+++ b/vmdb/app/controllers/ops_controller/ops_rbac.rb
@@ -601,7 +601,7 @@ module OpsController::OpsRbac
                        :locals  => {:type => "classifications", :action_url => 'rbac_group_field_changed'}) if @refresh_div
 
           # Only update description field value if ldap group user field was selected
-          page << "$('description').value = '#{j_str(@edit[:new][:description])}'" if params[:ldap_groups_user]
+          page << "$j('#description').val('#{j_str(@edit[:new][:description])}');" if params[:ldap_groups_user]
           page << javascript_for_tree_checkbox_clicked(tree_name) if params[:check] && tree_name
 
           # don't do anythingto lookup box when checkboxes on the right side are checked

--- a/vmdb/app/controllers/ops_controller/settings.rb
+++ b/vmdb/app/controllers/ops_controller/settings.rb
@@ -133,7 +133,7 @@ module OpsController::Settings
     @edit = session[:edit]  # Need to reload @edit so it stays in the session
     port = params[:user_proxies_mode] == "ldap" ? "389" : "636"
     render :update do |page|
-      page << "$('user_proxies_ldapport').value='#{port}'"
+      page << "$j('#user_proxies_ldapport').val('#{port}');"
     end
   end
 

--- a/vmdb/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/vmdb/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -62,7 +62,7 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace_html("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>session[:edit_filename], :edit=>true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('entry_#{j_str(params[:field])}').select();"
+        page << "$j('#entry_#{j_str(params[:field])}').select();"
       end
     elsif params[:edit_entry] == "edit_registry"
       session[:reg_data] = Hash.new
@@ -72,7 +72,7 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>session[:reg_data], :edit=>true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('entry_#{j_str(params[:field])}').select();"
+        page << "$j('#entry_#{j_str(params[:field])}').select();"
       end
     elsif params[:edit_entry] == "edit_nteventlog"
       session[:nteventlog_data] = Hash.new
@@ -92,7 +92,7 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>session[:nteventlog_data], :edit=>true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('entry_#{j_str(params[:field])}').select();"
+        page << "$j('#entry_#{j_str(params[:field])}').select();"
       end
     else
       session[:edit_filename] = ""
@@ -102,7 +102,7 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ap_form_div", :partial=>"ap_form", :locals=>{:entry=>"new", :edit=>true})
         page << javascript_focus('entry_name')
-        page << "$('entry_name').select();"
+        page << "$j('#entry_name').select();"
       end
     end
   end

--- a/vmdb/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/vmdb/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -66,8 +66,8 @@ module OpsController::Settings::CapAndU
     # need to create an array of items, if their or their children's capture has been changed then make the changed one blue.
     render :update do |page|                    # Use JS to update the display
       page.replace_html(@refresh_div, :partial=>@refresh_partial) if @refresh_div
-      page << "$('clusters_div').#{params[:all_clusters] == "1" ? "hide" : "show"}()" if params[:all_clusters]
-      page << "$('storages_div').#{params[:all_storages] == "1" ? "hide" : "show"}()" if params[:all_storages]
+      page << "$j('#clusters_div').#{params[:all_clusters] == "1" ? "hide" : "show"}()" if params[:all_clusters]
+      page << "$j('#storages_div').#{params[:all_storages] == "1" ? "hide" : "show"}()" if params[:all_storages]
       if params[:id] || params[:check_all] #|| (params[:tree_name] == "cu_datastore_tree" && params[:check_all])
         if (params[:id] && params[:id].split('_')[0] == "Datastore") || (params[:tree_name] == "cu_datastore_tree" && params[:check_all])
           # change nodes to blue if they were changed during current edit session

--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -62,9 +62,11 @@ module OpsController::Settings::Common
           page << javascript_show("email_verify_button_off")
         end
 
-        verb = @smtp_auth_none ? 'disable' : 'enable'
-        page << "$('smtp_user_name').#{verb}();"
-        page << "$('smtp_password').#{verb}();"
+        if @smtp_auth_none
+          page << javascript_disable_field('smtp_user_name')
+        else
+          page << javascript_enable_field('smtp_user_name')
+        end
 
         if @changed || @login_text_changed
           page << javascript_hide_if_exists("server_options_on")
@@ -118,7 +120,7 @@ module OpsController::Settings::Common
           page << set_element_visible("ldap_default_group_div", !@edit[:new][:authentication][:ldap_role])
         end
         if @authldapport_reset
-          page << "$('authentication_ldapport').value = '#{@edit[:new][:authentication][:ldapport]}'"
+          page << "$j('#authentication_ldapport').val('#{@edit[:new][:authentication][:ldapport]}');"
         end
         if @reset_verify_button
           if !@edit[:new][:authentication][:ldaphost].empty? && @edit[:new][:authentication][:ldapport] != nil

--- a/vmdb/app/controllers/ops_controller/settings/ldap.rb
+++ b/vmdb/app/controllers/ops_controller/settings/ldap.rb
@@ -285,7 +285,7 @@ module OpsController::Settings::Ldap
     return unless load_edit("ldap_domain_edit__#{params[:id]}","replace_cell__explorer")
     ldap_domain_get_form_vars
     render :update do |page|                    # Use JS to update the display
-      page << "$('entry_port').value = '#{params[:entry_mode] == "ldaps" ? '636' : '389' }'"
+      page << "$j('#entry_port').val('#{params[:entry_mode] == "ldaps" ? '636' : '389' }');"
       page << "miqSparkle(false);"
     end
   end
@@ -317,7 +317,7 @@ module OpsController::Settings::Ldap
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ldap_server_entries_div", :partial=>"ldap_server_entries", :locals=>{:entry=>"new", :edit=>true,:domain_id=>params[:domain_id]})
         page << javascript_focus('entry_name')
-        page << "$('entry_name').select();"
+        page << "$j('#entry_name').select();"
       end
       session[:entry] = "new"
     else
@@ -326,7 +326,7 @@ module OpsController::Settings::Ldap
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("ldap_server_entries_div", :partial=>"ldap_server_entries", :locals=>{:entry=>entry, :edit=>true,:domain_id=>params[:domain_id]})
         page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('entry_#{j_str(params[:field])}').select();"
+        page << "$j('#entry_#{j_str(params[:field])}').select();"
       end
       session[:entry] = entry
     end

--- a/vmdb/app/controllers/ops_controller/settings/schedules.rb
+++ b/vmdb/app/controllers/ops_controller/settings/schedules.rb
@@ -156,9 +156,9 @@ module OpsController::Settings::Schedules
       if params[:time_zone]
         page << "miq_cal_dateFrom = new Date(#{(Time.now - 1.month).in_time_zone(@edit[:tz]).strftime("%Y,%m,%d")});"
         page << "miqBuildCalendar();"
-        page << "$('miq_date_1').value = '#{@edit[:new][:start_date]}';"
-        page << "$('start_hour').value = '#{@edit[:new][:start_hour].to_i}';"
-        page << "$('start_min').value = '#{@edit[:new][:start_min].to_i}';"
+        page << "$j('#miq_date_1').val('#{@edit[:new][:start_date]}');"
+        page << "$j('#start_hour').val('#{@edit[:new][:start_hour].to_i}');"
+        page << "$j('#start_min').val('#{@edit[:new][:start_min].to_i}');"
         page.replace_html("tz_span", @timezone_abbr)
       end
       changed = (@edit[:new] != @edit[:current])

--- a/vmdb/app/controllers/ops_controller/settings/tags.rb
+++ b/vmdb/app/controllers/ops_controller/settings/tags.rb
@@ -157,7 +157,7 @@ module OpsController::Settings::Tags
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("classification_entries_div", :partial=>"classification_entries", :locals=>{:entry=>"new", :edit=>true})
         page << javascript_focus('entry_name')
-        page << "$('entry_name').select();"
+        page << "$j('#entry_name').select();"
       end
       session[:entry] = "new"
     else
@@ -166,7 +166,7 @@ module OpsController::Settings::Tags
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
         page.replace("classification_entries_div", :partial=>"classification_entries", :locals=>{:entry=>entry, :edit=>true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('entry_#{j_str(params[:field])}').select();"
+        page << "$j('#entry_#{j_str(params[:field])}').select();"
       end
       session[:entry] = entry
     end
@@ -204,7 +204,9 @@ module OpsController::Settings::Tags
     ce_build_screen # Build the Classification Edit screen
     render :update do |page|
       page.replace(:tab_div, :partial => "settings_co_tags_tab")
-      page << "$('#{entry.id}_tr').visualEffect('pulsate');" unless no_changes
+      unless no_changes
+        page << jquery_pulsate_element("#{entry.id}_tr")
+      end
     end
   end
 

--- a/vmdb/app/controllers/report_controller/schedules.rb
+++ b/vmdb/app/controllers/report_controller/schedules.rb
@@ -182,9 +182,9 @@ module ReportController::Schedules
       if params[:time_zone]
         page << "miq_cal_dateFrom = new Date(#{(Time.now - 1.month).in_time_zone(@edit[:tz]).strftime("%Y,%m,%d")});"
         page << "miqBuildCalendar();"
-        page << "$('miq_date_1').value = '#{@edit[:new][:start_date]}';"
-        page << "$('start_hour').value = '#{@edit[:new][:start_hour].to_i}';"
-        page << "$('start_min').value = '#{@edit[:new][:start_min].to_i}';"
+        page << "$j('#miq_date_1').val('#{@edit[:new][:start_date]}');"
+        page << "$j('#start_hour').val('#{@edit[:new][:start_hour].to_i}');"
+        page << "$j('#start_min').val('#{@edit[:new][:start_min].to_i}');"
         page.replace_html("tz_span", @timezone_abbr)
       end
       if @email_refresh

--- a/vmdb/app/controllers/report_controller/widgets.rb
+++ b/vmdb/app/controllers/report_controller/widgets.rb
@@ -163,9 +163,9 @@ module ReportController::Widgets
       if params[:time_zone]
         page << "miq_cal_dateFrom = new Date(#{(Time.now - 1.month).in_time_zone(@edit[:tz]).strftime("%Y,%m,%d")});"
         page << "miqBuildCalendar();"
-        page << "$('miq_date_1').value = '#{@edit[:new][:start_date]}';"
-        page << "$('start_hour').value = '#{@edit[:new][:start_hour].to_i}';"
-        page << "$('start_min').value = '#{@edit[:new][:start_min].to_i}';"
+        page << "$j('#miq_date_1').val('#{@edit[:new][:start_date]}');"
+        page << "$j('#start_hour').val('#{@edit[:new][:start_hour].to_i}');"
+        page << "$j('#start_min').val('#{@edit[:new][:start_min].to_i}');"
         page.replace_html("tz_span", @timezone_abbr)
       end
       changed = (@edit[:new] != @edit[:current])

--- a/vmdb/app/controllers/service_controller.rb
+++ b/vmdb/app/controllers/service_controller.rb
@@ -429,7 +429,7 @@ class ServiceController < ApplicationController
         page << "dhxLayoutB.cells('c').expand();"
       end
 
-      page << "$('main_div').scrollTop = 0;"  # Scroll to top of main div
+      page << "$j('#main_div').scrollTop();"  # Scroll to top of main div
 
       # Clear the JS gtl_list_grid var if changing to a type other than list
       if @gtl_type && @gtl_type != "list"

--- a/vmdb/app/helpers/automate_tree_helper.rb
+++ b/vmdb/app/helpers/automate_tree_helper.rb
@@ -19,7 +19,7 @@ module AutomateTreeHelper
         page << set_element_visible("#{edit_key}_div", true)
         @edit[:new][edit_key] = @edit[:automate_tree_selected_path]
         if @edit[:new][edit_key]
-          page << "$('#{edit_key}').value = '#{@edit[:new][edit_key]}';"
+          page << "$j('##{edit_key}').val('#{@edit[:new][edit_key]}');"
           page << "$j('##{edit_key}').prop('title', '#{@edit[:new][edit_key]}');"
         end
         page.replace("form_div", :partial => "copy_objects_form") if params[:controller] == "miq_ae_class"

--- a/vmdb/app/helpers/js_helper.rb
+++ b/vmdb/app/helpers/js_helper.rb
@@ -84,4 +84,8 @@ module JsHelper
   def javascript_hide_if_exists(element)
     "if ($j('##{j_str(element)}').length) #{javascript_hide(element)}".html_safe
   end
+
+  def jquery_pulsate_element(element)
+    "$j('##{element}').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();".html_safe
+  end
 end

--- a/vmdb/app/presenters/explorer_presenter.rb
+++ b/vmdb/app/presenters/explorer_presenter.rb
@@ -140,7 +140,7 @@ class ExplorerPresenter
     @out << "miq_widget_dd_url = '#{@options[:miq_widget_dd_url]}';" if @options[:miq_widget_dd_url]
 
     # Always set 'def' view in left cell as active in case it was changed to show compare/drift sections
-    @out << "if ($('custom_left_cell_div')) dhxLayout.cells('a').view('def').setActive();"
+    @out << "if ($j('#custom_left_cell_div')) dhxLayout.cells('a').view('def').setActive();"
 
     # Update elements in the DOM with rendered partials
     @options[:update_partials].each { |element, content| @out << update_partial(element, content) }
@@ -170,7 +170,7 @@ class ExplorerPresenter
     end
 
     # Scroll to top of main div
-    @out << "$('main_div').scrollTop = 0;"
+    @out << "$j('#main_div').scrollTop(0);"
 
     @out << "dhxLayoutB.cells('b').setText('#{escape_javascript(ERB::Util::h(@options[:right_cell_text]))}');" if @options[:right_cell_text]
 

--- a/vmdb/app/views/layouts/_log_viewer.html.erb
+++ b/vmdb/app/views/layouts/_log_viewer.html.erb
@@ -8,4 +8,4 @@
 
 	<%= text_area("logview","data", :value=>@log, :readonly=>true, :style=>"height:#{h}px;", :wrap=>"off") %>
 
-<%= javascript_tag "$('logview_data').scrollTop = $('logview_data').scrollHeight - $('logview_data').clientHeight;" %>
+<%= javascript_tag "$j('#logview_data').scrollTop($j('#logview_data').prop('scrollHeight') - $j('#logview_data').prop('clientHeight'));" %>

--- a/vmdb/app/views/miq_proxy/_log_viewer.html.haml
+++ b/vmdb/app/views/miq_proxy/_log_viewer.html.haml
@@ -23,4 +23,5 @@
 
   = text_area_tag("logview", @proxy_log, :readonly => "readonly")
 
-= javascript_tag("$('logview').scrollTop = $('logview').scrollHeight - $('logview').clientHeight;")
+= javascript_tag "$j('#logview').scrollTop($j('#logview').prop('scrollHeight') - $j('#logview').prop('clientHeight'));"
+

--- a/vmdb/app/views/ops/_log_viewer.html.erb
+++ b/vmdb/app/views/ops/_log_viewer.html.erb
@@ -8,4 +8,4 @@
               :readonly => true, 
               :style    => "height:#{center_div_height}px;width:100%;") 
 %>
-<%= javascript_tag "$('logview_data').scrollTop = $('logview_data').scrollHeight - $('logview_data').clientHeight;" %>
+<%= javascript_tag "$j('#logview_data').scrollTop($j('#logview_data').prop('scrollHeight') - $j('#logview_data').prop('clientHeight'));" %>


### PR DESCRIPTION
- After converting calls to use $j('#xxx') format, added a common JS method that checks for length of element to check existence of element in DOM.
- Updated any other prototype specific calls that didn't work after changing element references to use $j

#1418 

@dclarizio @martinpovolny please review/test.
@AparnaKarve if you get a chance can you test this.