### PR TITLE
remove tests for virtual reflections with strings

### DIFF
--- a/vmdb/spec/lib/extensions/ar_virtual_spec.rb
+++ b/vmdb/spec/lib/extensions/ar_virtual_spec.rb
@@ -388,12 +388,6 @@ describe VirtualFields do
         c.name.should == :vref1
       end
 
-      it "with string name" do
-        c = TestClass.virtual_has_one "vref1"
-        c.should be_kind_of(VirtualReflection)
-        c.name.should == :vref1
-      end
-
       it("with has_one macro")    { TestClass.virtual_has_one(:vref1).macro.should    == :has_one }
       it("with has_many macro")   { TestClass.virtual_has_many(:vref1).macro.should   == :has_many }
       it("with belongs_to macro") { TestClass.virtual_belongs_to(:vref1).macro.should == :belongs_to }
@@ -421,12 +415,6 @@ describe VirtualFields do
           c.name.should == :vref1
         end
 
-        it "with string name" do
-          c = TestClass.send(virtual_method, "vref1")
-          c.should be_kind_of(VirtualReflection)
-          c.name.should == :vref1
-        end
-
         it "without uses" do
           c = TestClass.send(virtual_method, :vref1)
           c.uses.should           be_nil
@@ -445,7 +433,7 @@ describe VirtualFields do
       it "" do
         {
           :vref1  => {:macro => :has_one},
-          "vref2" => {:macro => :has_many},
+          :vref2  => {:macro => :has_many},
         }.each do |name, options|
           TestClass.send "virtual_#{options[:macro]}", name
         end
@@ -460,7 +448,7 @@ describe VirtualFields do
 
         {
           :vref1  => {:macro => :has_one},
-          "vref2" => {:macro => :has_many},
+          :vref2  => {:macro => :has_many},
         }.each do |name, options|
           TestClass.send "virtual_#{options[:macro]}", name
         end


### PR DESCRIPTION
Rails doesn't allow associations to be defined with string names (you
will get an exception), so we should follow suit in virtual reflections.
In Rails 4, we've changed virtual reflections to create real Rails
reflections, then wrap and extend them.  In Rails 4, you'll get an
exception when creating virtual associations with string names, so lets
remove or fix these tests