### PR TITLE
make power_state= a public method.

### DIFF
--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1932,10 +1932,6 @@ class VmOrTemplate < ActiveRecord::Base
 
   private
 
-  def power_state=(new_power_state)
-    super
-  end
-
   def calculate_power_state
     self.class.calculate_power_state(raw_power_state)
   end


### PR DESCRIPTION
FactoryGirl has changed such that it [uses `public_send` for setting
attributes](https://github.com/thoughtbot/factory_girl/blob/deaf5529fb93945dea50e45af6c7d8817863da12/lib/factory_girl/attribute_assigner.rb#L16).  Since we [use FactoryGirl to set `power_state` in our tests](https://github.com/ManageIQ/manageiq/blob/200d92ccf31c6fbd0ce8cbf486572fbf005bf4a6/vmdb/spec/requests/api/vms_spec.rb#L215), the tests will break if we try to upgrade FactoryGirl.

This commit makes the method public again.

This private method was introduced in 3261abf9, so /cc @blomquisg 
