### PR TITLE
[api] - adding support for VM tags

### DIFF
--- a/vmdb/app/controllers/api_controller/tags.rb
+++ b/vmdb/app/controllers/api_controller/tags.rb
@@ -7,42 +7,61 @@ class ApiController
     #
 
     def tags_query_resource(object)
-      object ? object.tags : {}
+      object ? object.tags.where(Tag.arel_table[:name].matches "#{TAG_NAMESPACE}%") : {}
     end
 
     def tags_assign_resource(object, _type, id = nil, data = nil)
-      category, name = tag_specified(id, data)
-      ci_set_tag(object, category, name)   if category && name
+      tag_spec = tag_specified(id, data)
+      tag_subcollection_action(tag_spec) do
+        api_log_info("Assigning #{tag_ident(tag_spec)}")
+        ci_set_tag(object, tag_spec)
+      end
     end
 
     def tags_unassign_resource(object, _type, id = nil, data = nil)
-      category, name = tag_specified(id, data)
-      ci_unset_tag(object, category, name) if category && name
+      tag_spec = tag_specified(id, data)
+      tag_subcollection_action(tag_spec) do
+        api_log_info("Unassigning #{tag_ident(tag_spec)}")
+        ci_unset_tag(object, tag_spec)
+      end
     end
 
-    #
-    # Helper Procs
-    #
-
     private
+
+    def tag_ident(tag_spec)
+      "Tag: category:'#{tag_spec[:category]}' name:'#{tag_spec[:name]}'"
+    end
+
+    def tag_subcollection_action(tag_spec)
+      if tag_spec[:category] && tag_spec[:name]
+        result = yield if block_given?
+      else
+        result = action_result(false, "Missing tag category or name")
+      end
+
+      add_parent_href_to_result(result)
+      add_tag_to_result(result, tag_spec)
+      log_result(result)
+      result
+    end
 
     def tag_specified(id, data)
       if id.to_i > 0
         klass  = collection_config[:tags][:klass].constantize
         tagobj = klass.find(id)
-        return tag_path_to_name(tagobj.name) unless tagobj.id.blank?
+        return tag_path_to_spec(tagobj.name).merge(:id => tagobj.id)
       end
 
       parse_tag(data)
     end
 
     def parse_tag(data)
-      return [nil, nil] if data.blank?
+      return {} if data.blank?
 
       category = data["category"]
       name     = data["name"]
-      return [category, name] if category && name
-      return tag_path_to_name(name) if name && name[0] == '/'
+      return {:category => category, :name => name} if category && name
+      return tag_path_to_spec(name) if name && name[0] == '/'
 
       parse_tag_from_href(data)
     end
@@ -53,23 +72,45 @@ class ApiController
                klass = collection_config[:tags][:klass].constantize
                klass.find(href.split('/').last)
              end
-      tag.present? ? tag_path_to_name(tag.name) : [nil, nil]
+      tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}
     end
 
-    def tag_path_to_name(path)
+    def tag_path_to_spec(path)
       tag_path = (path[0..7] == TAG_NAMESPACE) ? path[8..-1] : path
       parts    = tag_path.split('/')
-      [parts[1], parts[2]]
+      {:category => parts[1], :name => parts[2]}
     end
 
-    def ci_set_tag(ci, category, name)
-      return true if ci.is_tagged_with?(name, :ns => "#{TAG_NAMESPACE}/#{category}")
-      Classification.classify(ci, category, name)
+    def ci_set_tag(ci, tag_spec)
+      if ci_is_tagged_with?(ci, tag_spec)
+        desc = "Already tagged with #{tag_ident(tag_spec)}"
+        success = true
+      else
+        desc = "Assigning #{tag_ident(tag_spec)}"
+        Classification.classify(ci, tag_spec[:category], tag_spec[:name])
+        success = ci_is_tagged_with?(ci, tag_spec)
+      end
+      action_result(success, desc)
+    rescue => err
+      action_result(false, err.to_s)
     end
 
-    def ci_unset_tag(ci, category, name)
-      return true unless ci.is_tagged_with?(name, :ns => "#{TAG_NAMESPACE}/#{category}")
-      Classification.unclassify(ci, category, name)
+    def ci_unset_tag(ci, tag_spec)
+      if ci_is_tagged_with?(ci, tag_spec)
+        desc = "Unassigning #{tag_ident(tag_spec)}"
+        Classification.unclassify(ci, tag_spec[:category], tag_spec[:name])
+        success = !ci_is_tagged_with?(ci, tag_spec)
+      else
+        desc = "Not tagged with #{tag_ident(tag_spec)}"
+        success = true
+      end
+      action_result(success, desc)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def ci_is_tagged_with?(ci, tag_spec)
+      ci.is_tagged_with?(tag_spec[:name], :ns => "#{TAG_NAMESPACE}/#{tag_spec[:category]}")
     end
   end
 end

--- a/vmdb/app/helpers/api_helper/results.rb
+++ b/vmdb/app/helpers/api_helper/results.rb
@@ -14,9 +14,21 @@ module ApiHelper
       hash
     end
 
+    def add_parent_href_to_result(hash)
+      hash[:href] = "#{@req[:base]}#{@req[:prefix]}/#{@req[:collection]}/#{@req[:c_id]}"
+      hash
+    end
+
     def add_task_to_result(hash, task_id)
       hash[:task_id]   = task_id
       hash[:task_href] = "#{@req[:base]}#{@req[:prefix]}/tasks/#{task_id}"
+      hash
+    end
+
+    def add_tag_to_result(hash, tag_spec)
+      hash[:tag_category] = tag_spec[:category] if tag_spec[:category].present?
+      hash[:tag_name]     = tag_spec[:name] if tag_spec[:name].present?
+      hash[:tag_href]     = "#{@req[:base]}#{@req[:prefix]}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
       hash
     end
 

--- a/vmdb/app/models/classification.rb
+++ b/vmdb/app/models/classification.rb
@@ -23,6 +23,8 @@ class Classification < ActiveRecord::Base
     :in => %w{ string integer boolean },
     :message => "should be one of 'string', 'integer' or 'boolean'"
 
+  virtual_column :name, :type => :string
+
   DEFAULT_NAMESPACE = "/managed"
 
   default_value_for :read_only,    false

--- a/vmdb/app/models/tag.rb
+++ b/vmdb/app/models/tag.rb
@@ -1,5 +1,8 @@
 class Tag < ActiveRecord::Base
   has_many :taggings, :dependent => :destroy
+  has_one :classification
+  virtual_has_one :category
+  virtual_has_one :categorization
 
   def self.to_tag(name, options = {})
     File.join(Tag.get_namespace(options), name)
@@ -103,5 +106,30 @@ class Tag < ActiveRecord::Base
 
   def ==(comparison_object)
     super || name.downcase == comparison_object.to_s.downcase
+  end
+
+  def category
+    @category ||= Classification.find_by_name(name_path.split('/').first, nil)
+  end
+
+  def show
+    category && category.show
+  end
+
+  def categorization
+    @categorization ||= begin
+      !show ? {} : {
+        "name"         => classification.name,
+        "description"  => classification.description,
+        "category"     => {"name" => category.name, "description" => category.description},
+        "display_name" => "#{category.description}: #{classification.description}"
+      }
+    end
+  end
+
+  private
+
+  def name_path
+    @name_path ||= name.dup.sub!(%r{/[^/]*/}, "")
   end
 end

--- a/vmdb/app/models/tag.rb
+++ b/vmdb/app/models/tag.rb
@@ -1,8 +1,8 @@
 class Tag < ActiveRecord::Base
   has_many :taggings, :dependent => :destroy
   has_one :classification
-  virtual_has_one :category
-  virtual_has_one :categorization
+  virtual_has_one :category,       :class_name => "Classification"
+  virtual_has_one :categorization, :class_name => "Hash"
 
   def self.to_tag(name, options = {})
     File.join(Tag.get_namespace(options), name)
@@ -113,23 +113,25 @@ class Tag < ActiveRecord::Base
   end
 
   def show
-    category && category.show
+    category.try(:show)
   end
 
   def categorization
-    @categorization ||= begin
-      !show ? {} : {
-        "name"         => classification.name,
-        "description"  => classification.description,
-        "category"     => {"name" => category.name, "description" => category.description},
-        "display_name" => "#{category.description}: #{classification.description}"
-      }
-    end
+    @categorization ||= if !show
+                          {}
+                        else
+                          {
+                            "name"         => classification.name,
+                            "description"  => classification.description,
+                            "category"     => {"name" => category.name, "description" => category.description},
+                            "display_name" => "#{category.description}: #{classification.description}"
+                          }
+                        end
   end
 
   private
 
   def name_path
-    @name_path ||= name.dup.sub!(%r{/[^/]*/}, "")
+    @name_path ||= name.sub(%r{^/[^/]*/}, "")
   end
 end

--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -521,6 +521,7 @@
   :tags:
     :description: Tags
     :options:
+    - :collection
     - :subcollection
     :methods: *70174834085620
     :klass: Tag

--- a/vmdb/spec/factories/classification.rb
+++ b/vmdb/spec/factories/classification.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
   end
 
   factory :classification_department, :parent => :classification do
-    name        "deparment"
+    name        "department"
     description "Department"
   end
 

--- a/vmdb/spec/models/tag_spec.rb
+++ b/vmdb/spec/models/tag_spec.rb
@@ -38,4 +38,33 @@ describe Tag do
       described_class.filter_ns([nil, "/managed/abc"], nil).should == ["/managed/abc"]
     end
   end
+
+  context "categorization" do
+    before(:each) do
+      FactoryGirl.create(:classification_department_with_tags)
+
+      @tag_details    = {:category => "department", :name => "finance", :path => "/managed/department/finance"}
+      @tag            = Tag.find_by_name(@tag_details[:path])
+      @category       = Classification.find_by_name(@tag_details[:category], nil)
+      @classification = @tag.classification
+    end
+
+    it "tag category should match category" do
+      expect(@tag.category).to eq(@category)
+    end
+
+    it "tag show should reflect category show" do
+      expect(@tag.show).to eq(@category.show)
+    end
+
+    it "tag categorization" do
+      categorization = @tag.categorization
+      expected_categorization = {"name"         => @classification.name,
+                                 "description"  => @classification.description,
+                                 "category"     => {"name" => @category.name, "description" => @category.description},
+                                 "display_name" => "#{@category.description}: #{@classification.description}"}
+
+      expect(categorization).to eq(expected_categorization)
+    end
+  end
 end

--- a/vmdb/spec/requests/api/tags_spec.rb
+++ b/vmdb/spec/requests/api/tags_spec.rb
@@ -86,7 +86,8 @@ describe ApiController do
 
       expect(@success).to be_true
       expect(@code).to eq(200)
-      expect(@result["id"]).to match(tag_url)
+      expect(@result["href"]).to match(tag_url)
+      expect(@result["id"]).to eq(tag.id)
       expect(@result["name"]).to eq(tag.name)
       expect(@result).to have_key("category")
       expect(@result["category"]["name"]).to eq(tag.category.name)
@@ -106,7 +107,8 @@ describe ApiController do
 
       expect(@success).to be_true
       expect(@code).to eq(200)
-      expect(@result["id"]).to match(tag_url)
+      expect(@result["href"]).to match(tag_url)
+      expect(@result["id"]).to eq(tag.id)
       expect(@result["name"]).to eq(tag.name)
       expect(@result).to have_key("categorization")
       cat = @result["categorization"]

--- a/vmdb/spec/requests/api/tags_spec.rb
+++ b/vmdb/spec/requests/api/tags_spec.rb
@@ -1,0 +1,368 @@
+#
+# REST API Request Tests - /api/tags
+#
+require 'spec_helper'
+
+describe ApiController do
+
+  include Rack::Test::Methods
+
+  before(:each) do
+    init_api_spec_env
+
+    @zone       = FactoryGirl.create(:zone, :name => "api_zone")
+    @miq_server = FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => @zone)
+    @ems        = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    @host       = FactoryGirl.create(:host)
+
+    Host.any_instance.stub(:miq_proxy).and_return(@miq_server)
+
+    @vm1           = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+    @vm1_url       = "#{@cfme[:vms_url]}/#{@vm1.id}"
+    @vm1_tags_url  = "#{@vm1_url}/tags"
+
+    @vm2           = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+    @vm2_url       = "#{@cfme[:vms_url]}/#{@vm2.id}"
+    @vm2_tags_url  = "#{@vm2_url}/tags"
+
+    FactoryGirl.create(:classification_department_with_tags)
+    FactoryGirl.create(:classification_cost_center_with_tags)
+
+    @tag1 = {:category => "department", :name => "finance", :path => "/managed/department/finance"}
+    @tag2 = {:category => "cc",         :name => "001",     :path => "/managed/cc/001"}
+
+    Classification.classify(@vm2, @tag1[:category], @tag1[:name])
+    Classification.classify(@vm2, @tag2[:category], @tag2[:name])
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  context "Tag collection" do
+    it "query all tags" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get @cfme[:tags_url]
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("name")
+      expect(@result["name"]).to eq("tags")
+      expect(@result).to have_key("resources")
+      expect(@result["resources"].size).to eq(Tag.count)
+    end
+
+    it "query a tag with an invalid Id" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get "#{@cfme[:tags_url]}/999999"
+
+      expect(@success).to be_false
+      expect(@code).to eq(404)
+    end
+
+    it "query tags with expanded resources" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get "#{@cfme[:tags_url]}?expand=resources"
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      results = @result["resources"]
+      expect(results.size).to eq(Tag.count)
+      expect(results.all? { |r| r.key?("id") }).to be_true
+      expect(results.all? { |r| r.key?("name") }).to be_true
+    end
+
+    it "query tag details with multiple virtual attributes" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      tag = Tag.last
+      tag_url = "#{@cfme[:tags_url]}/#{tag.id}"
+      attr_list = "category.name,category.description,classification.name,classification.description"
+
+      @success = run_get "#{tag_url}?attributes=#{attr_list}"
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result["id"]).to match(tag_url)
+      expect(@result["name"]).to eq(tag.name)
+      expect(@result).to have_key("category")
+      expect(@result["category"]["name"]).to eq(tag.category.name)
+      expect(@result["category"]["description"]).to eq(tag.category.description)
+      expect(@result).to have_key("classification")
+      expect(@result["classification"]["name"]).to eq(tag.classification.name)
+      expect(@result["classification"]["description"]).to eq(tag.classification.description)
+    end
+
+    it "query tag details with categorization" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      tag = Tag.last
+      tag_url = "#{@cfme[:tags_url]}/#{tag.id}"
+
+      @success = run_get "#{tag_url}?attributes=categorization"
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result["id"]).to match(tag_url)
+      expect(@result["name"]).to eq(tag.name)
+      expect(@result).to have_key("categorization")
+      cat = @result["categorization"]
+      expect(cat["name"]).to eq(tag.classification.name)
+      expect(cat["description"]).to eq(tag.classification.description)
+      expect(cat).to have_key("category")
+      expect(cat["category"]["name"]).to eq(tag.category.name)
+      expect(cat["category"]["description"]).to eq(tag.category.description)
+      expect(cat["display_name"]).not_to be_empty
+    end
+
+    it "query all tags with categorization" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get "#{@cfme[:tags_url]}?expand=resources&attributes=categorization"
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      results = @result["resources"]
+      expect(results.size).to eq(Tag.count)
+      expect(results.all? { |r| r.key?("id") }).to be_true
+      expect(results.all? { |r| r.key?("name") }).to be_true
+      expect(results.all? { |r| r.key?("categorization") }).to be_true
+    end
+  end
+
+  context "Vm Tag subcollection" do
+    it "query all tags of a Vm with no tags" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get @vm1_tags_url
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result["name"]).to eq("tags")
+      expect(@result["subcount"]).to eq(0)
+      expect(@result["resources"].size).to eq(0)
+    end
+
+    it "query all tags of a Vm" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get @vm2_tags_url
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result["name"]).to eq("tags")
+      expect(@result["count"]).to eq(Tag.count)
+      expect(@result["subcount"]).to eq(2)
+      expect(@result["resources"].size).to eq(2)
+    end
+
+    it "query all tags of a Vm and verify tag category and names" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_get "#{@vm2_tags_url}?expand=resources"
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result["name"]).to eq("tags")
+      expect(@result["count"]).to eq(Tag.count)
+      expect(@result["resources"].size).to eq(2)
+      results = @result["resources"]
+      expect(resources_include_suffix?(results, "name", @tag1[:path])).to be_true
+      expect(resources_include_suffix?(results, "name", @tag2[:path])).to be_true
+    end
+
+    it "assigns a tag to a Vm without appropriate role" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign,
+                                                          :category => @tag1[:category],
+                                                          :name     => @tag1[:name]))
+      expect(@success).to be_false
+      expect(@code).to eq(403)
+    end
+
+    it "assigns a tag to a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign,
+                                                          :category => @tag1[:category],
+                                                          :name     => @tag1[:name]))
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(1)
+      result = results.first
+      expect(result["success"]).to be_true
+      expect(result["href"]).to match(@vm1_url)
+      expect(result["tag_category"]).to eq(@tag1[:category])
+      expect(result["tag_name"]).to eq(@tag1[:name])
+    end
+
+    it "assigns a tag to a Vm by name path" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign, :name => @tag1[:path]))
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(1)
+      result = results.first
+      expect(result["success"]).to be_true
+      expect(result["href"]).to match(@vm1_url)
+      expect(result["tag_category"]).to eq(@tag1[:category])
+      expect(result["tag_name"]).to eq(@tag1[:name])
+    end
+
+    it "assigns a tag to a Vm by href" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      tag = Tag.find_by_name(@tag1[:path])
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign, :href => "#{@cfme[:tags_url]}/#{tag.id}"))
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(1)
+      result = results.first
+      expect(result["success"]).to be_true
+      expect(result["href"]).to match(@vm1_url)
+      expect(result["tag_category"]).to eq(@tag1[:category])
+      expect(result["tag_name"]).to eq(@tag1[:name])
+    end
+
+    it "assigns an invalid tag by href to a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign, :href => "#{@cfme[:tags_url]}/999999"))
+
+      expect(@success).to be_false
+      expect(@code).to eq(404)
+    end
+
+    it "assigns an invalid tag to a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign, :name => "/managed/bad_category/bad_name"))
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      result = @result["results"].first
+      expect(result["success"]).to be_false
+      expect(result["href"]).to match(@vm1_url)
+      expect(result["tag_category"]).to eq("bad_category")
+      expect(result["tag_name"]).to eq("bad_name")
+    end
+
+    it "assigns multiple tags to a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_requests(:assign, [{:name => @tag1[:path]}, {:name => @tag2[:path]}]))
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(2)
+      expect(results.first["success"]).to be_true
+      expect(results.first["href"]).to match(@vm1_url)
+      expect(results.first["tag_category"]).to eq(@tag1[:category])
+      expect(results.first["tag_name"]).to eq(@tag1[:name])
+      expect(results.second["success"]).to be_true
+      expect(results.second["href"]).to match(@vm1_url)
+      expect(results.second["tag_category"]).to eq(@tag2[:category])
+      expect(results.second["tag_name"]).to eq(@tag2[:name])
+    end
+
+    it "assigns tags by mixed specification to a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :assign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      tag2 = Tag.find_by_name(@tag2[:path])
+      @success = run_post(@vm1_tags_url, gen_requests(:assign, [{:name => @tag1[:path]},
+                                                                {:href => "#{@cfme[:tags_url]}/#{tag2.id}"}]))
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(2)
+      expect(results.first["success"]).to be_true
+      expect(results.first["href"]).to match(@vm1_url)
+      expect(results.first["tag_category"]).to eq(@tag1[:category])
+      expect(results.first["tag_name"]).to eq(@tag1[:name])
+      expect(results.second["success"]).to be_true
+      expect(results.second["href"]).to match(@vm1_url)
+      expect(results.second["tag_category"]).to eq(@tag2[:category])
+      expect(results.second["tag_name"]).to eq(@tag2[:name])
+    end
+
+    it "unassigns a tag from a Vm without appropriate role" do
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm1_tags_url, gen_request_data(:assign,
+                                                          :category => @tag1[:category],
+                                                          :name     => @tag1[:name]))
+      expect(@success).to be_false
+      expect(@code).to eq(403)
+    end
+
+    it "unassigns a tag from a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :unassign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      @success = run_post(@vm2_tags_url, gen_request_data(:unassign,
+                                                          :category => @tag1[:category],
+                                                          :name     => @tag1[:name]))
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(1)
+      result = results.first
+      expect(result["success"]).to be_true
+      expect(result["href"]).to match(@vm2_url)
+      expect(result["tag_category"]).to eq(@tag1[:category])
+      expect(result["tag_name"]).to eq(@tag1[:name])
+      expect(@vm2.tags.count).to eq(1)
+      expect(@vm2.tags.first.name).to eq(@tag2[:path])
+    end
+
+    it "unassigns multiple tags from a Vm" do
+      update_user_role(@role, subcollection_action_identifier(:vms, :tags, :unassign))
+      basic_authorize @cfme[:user], @cfme[:password]
+
+      tag2 = Tag.find_by_name(@tag2[:path])
+      @success = run_post(@vm2_tags_url, gen_requests(:unassign, [{:name => @tag1[:path]},
+                                                                  {:href => "#{@cfme[:tags_url]}/#{tag2.id}"}]))
+
+      expect(@success).to be_true
+      expect(@code).to eq(200)
+      expect(@result).to have_key("results")
+      results = @result["results"]
+      expect(results.size).to eq(2)
+      expect(results.first["success"]).to be_true
+      expect(results.first["href"]).to match(@vm2_url)
+      expect(results.first["tag_category"]).to eq(@tag1[:category])
+      expect(results.first["tag_name"]).to eq(@tag1[:name])
+      expect(results.second["success"]).to be_true
+      expect(results.second["href"]).to match(@vm2_url)
+      expect(results.second["tag_category"]).to eq(@tag2[:category])
+      expect(results.second["tag_name"]).to eq(@tag2[:name])
+      expect(@vm2.tags.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
    [api] - adding support for VM tags
    
    - query only /managed tags in subcollection
    - updated tag model to allow querying the related classification and category
    - added a categorization Tag model virtual reflection to return a hash of relevant category and classification details.
    - enable /tags as primary collection
    - Updated tag assign/unassign to use action results for better feedback
    - Adding Tagging Specs
