### PR TITLE
default `class_or_name` to `Object`

### DIFF
--- a/vmdb/app/models/rbac.rb
+++ b/vmdb/app/models/rbac.rb
@@ -362,7 +362,7 @@ module Rbac
     # Example with args:    :named_scope => [in_region, 1]
     scope             = options.delete(:named_scope) || NO_SCOPE
 
-    class_or_name     = options.delete(:class)
+    class_or_name     = options.delete(:class) { Object }
     conditions        = options.delete(:conditions)
     where_clause      = options.delete(:where_clause)
     sub_filter        = options.delete(:sub_filter)


### PR DESCRIPTION
if a class isn't passed in, then `class_or_name` will be nil.  Due to a
change in constantize, `''` will raise an exception when you call
`constantize` on it.

For example:

Rails 3.2:

```
irb(main):001:0> nil.to_s.constantize
=> Object
irb(main):002:0> exit
```

Rails 4.2:

```
irb(main):001:0> nil.to_s.constantize
NameError: wrong constant name
	from /Users/aaron/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/bundler/gems/rails-d5e329e8ce1e/activesupport/lib/active_support/inflector/methods.rb:254:in `const_get'
	from /Users/aaron/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/bundler/gems/rails-d5e329e8ce1e/activesupport/lib/active_support/inflector/methods.rb:254:in `constantize'
	from /Users/aaron/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/bundler/gems/rails-d5e329e8ce1e/activesupport/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
```

If we default to `Object`, then everything should work.