### PR TITLE
set `raw_power_state` instead of `power_state`

### DIFF
--- a/vmdb/spec/requests/api/vms_spec.rb
+++ b/vmdb/spec/requests/api/vms_spec.rb
@@ -212,7 +212,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :start))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:start))
@@ -229,7 +229,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :start))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "off")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOff")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:start))
@@ -248,8 +248,8 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :start))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "off")
-      vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "off")
+      vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOff")
+      vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOff")
 
       vm1_url = "#{@cfme[:vms_url]}/#{vm1.id}"
       vm2_url = "#{@cfme[:vms_url]}/#{vm2.id}"
@@ -291,7 +291,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :stop))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "off")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOff")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:stop))
@@ -308,7 +308,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :stop))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:stop))
@@ -327,8 +327,8 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :stop))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
-      vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+      vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
+      vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
 
       vm1_url = "#{@cfme[:vms_url]}/#{vm1.id}"
       vm2_url = "#{@cfme[:vms_url]}/#{vm2.id}"
@@ -370,7 +370,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :suspend))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "off")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOff")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:suspend))
@@ -387,7 +387,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :suspend))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "suspended")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "suspended")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:suspend))
@@ -404,7 +404,7 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :suspend))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+      vm = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
       vm_url = "#{@cfme[:vms_url]}/#{vm.id}"
 
       @success = run_post(vm_url, gen_request(:suspend))
@@ -423,8 +423,8 @@ describe ApiController do
       update_user_role(@role, action_identifier(:vms, :suspend))
       basic_authorize @cfme[:user], @cfme[:password]
 
-      vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
-      vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :power_state => "on")
+      vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
+      vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :ems_id => @ems.id, :raw_power_state => "poweredOn")
 
       vm1_url = "#{@cfme[:vms_url]}/#{vm1.id}"
       vm2_url = "#{@cfme[:vms_url]}/#{vm2.id}"


### PR DESCRIPTION
FactoryGirl has changed such that it [uses `public_send` for setting
attributes](https://github.com/thoughtbot/factory_girl/blob/deaf5529fb93945dea50e45af6c7d8817863da12/lib/factory_girl/attribute_assigner.rb#L16).  Since we [use FactoryGirl to set `power_state` in our tests](https://github.com/ManageIQ/manageiq/blob/200d92ccf31c6fbd0ce8cbf486572fbf005bf4a6/vmdb/spec/requests/api/vms_spec.rb#L215), the tests will break if we try to upgrade FactoryGirl.

This commit changes the tests to use `raw_power_state` instead of
`power_state` so the tests will work with newer FactoryGirl.