### PR TITLE
limit the query, then convert to an Array

### DIFF
--- a/vmdb/app/models/metric/ci_mixin.rb
+++ b/vmdb/app/models/metric/ci_mixin.rb
@@ -46,6 +46,7 @@ module Metric::CiMixin
     perf = associated_metrics(interval_name)
       .select("MIN(timestamp) AS first_ts, MAX(timestamp) AS last_ts")
       .group(:resource_id)
+      .limit(1).to_a
       .first
     perf.nil? ? [] : [
       perf.first_ts.kind_of?(String) ? Time.parse("#{perf.first_ts} UTC") : perf.first_ts,

--- a/vmdb/app/models/vim_usage.rb
+++ b/vmdb/app/models/vim_usage.rb
@@ -75,7 +75,7 @@ class VimUsage < ActsAsArModel
       .where(:capture_interval_name => interval_name, :resource_type => "VmOrTemplate")
       .select("MIN(timestamp) AS first_ts, MAX(timestamp) AS last_ts")
       .group(:resource_type)
-      .first
+      .limit(1).to_a.first
     perf.nil? ? [] : [
       perf.first_ts.kind_of?(String) ? Time.zone.parse(perf.first_ts) : perf.first_ts,
       perf.last_ts.kind_of?(String)  ? Time.zone.parse(perf.last_ts)  : perf.last_ts


### PR DESCRIPTION
Rails 4 will add an `ORDER BY` clause when you call `first` on a
relation.  We don't have a column to ORDER BY in this case, so lets set
a limit, execute the query, then get the first element.