### PR TITLE
don't call delete_if on an association proxy

### DIFF
--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1042,7 +1042,7 @@ class VmOrTemplate < ActiveRecord::Base
         hosts = [self.myhost]
       else
         store = self.storage
-        hosts = store.hosts if hosts.empty? && store
+        hosts = store.hosts.to_a if hosts.empty? && store
         hosts = [self.myhost] if hosts.empty?
 
         # VMware needs a VMware host to resolve datastore names


### PR DESCRIPTION
we can't call `delete_if` on an association proxy, so this converts the
association to an array before we do any processing