### PR TITLE
Bz1114656 rhev events ignore history

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -31,7 +31,7 @@ gem "log4r",                "=1.1.8",        :require => false
 gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
-gem "ovirt",                "~>0.2.2",       :require => false
+gem "ovirt",                "~>0.3.0",       :require => false
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false
 gem "rubyzip",              "=0.9.5",        :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646

--- a/lib/ovirt_provider/events/ovirt_event_monitor.rb
+++ b/lib/ovirt_provider/events/ovirt_event_monitor.rb
@@ -1,0 +1,34 @@
+class OvirtEventMonitor
+  def initialize(options={})
+    @options = options
+  end
+
+  def inventory
+    @inventory ||= Ovirt::Inventory.new(@options)
+  end
+
+  def start
+    trap(:TERM) { $rhevm_log.info "EventMonitor#start: ignoring SIGTERM" }
+    @since          = nil
+    @inventory      = nil
+    @monitor_events = true
+  end
+
+  def stop
+    @monitor_events = false
+  end
+
+  def each_batch
+    while @monitor_events do
+      events = inventory.events(@since).sort_by { |e| e[:id].to_i }
+      @since = events.last[:id].to_i unless events.empty?
+      yield events
+    end
+  end
+
+  def each
+    each_batch do |events|
+      events.each { |e| yield e }
+    end
+  end
+end

--- a/lib/ovirt_provider/events/ovirt_event_monitor.rb
+++ b/lib/ovirt_provider/events/ovirt_event_monitor.rb
@@ -20,8 +20,11 @@ class OvirtEventMonitor
 
   def each_batch
     while @monitor_events do
-      events = inventory.events(@since).sort_by { |e| e[:id].to_i }
+      # grab only the most recent event if this is the first time through
+      query_options = @since ? {:since => @since} : {:max => 1}
+      events = inventory.events(query_options).sort_by { |e| e[:id].to_i }
       @since = events.last[:id].to_i unless events.empty?
+
       yield events
     end
   end

--- a/lib/ovirt_provider/events/ovirt_event_monitor.rb
+++ b/lib/ovirt_provider/events/ovirt_event_monitor.rb
@@ -4,6 +4,7 @@ class OvirtEventMonitor
   end
 
   def inventory
+    require 'ovirt'
     @inventory ||= Ovirt::Inventory.new(@options)
   end
 

--- a/lib/ovirt_provider/events/ovirt_event_monitor.rb
+++ b/lib/ovirt_provider/events/ovirt_event_monitor.rb
@@ -1,5 +1,5 @@
 class OvirtEventMonitor
-  def initialize(options={})
+  def initialize(options = {})
     @options = options
   end
 
@@ -20,7 +20,7 @@ class OvirtEventMonitor
   end
 
   def each_batch
-    while @monitor_events do
+    while @monitor_events
       # grab only the most recent event if this is the first time through
       query_options = @since ? {:since => @since} : {:max => 1}
       events = inventory.events(query_options).sort_by { |e| e[:id].to_i }

--- a/vmdb/lib/workers/event_catcher_redhat.rb
+++ b/vmdb/lib/workers/event_catcher_redhat.rb
@@ -2,8 +2,8 @@ require 'workers/event_catcher'
 
 class EventCatcherRedhat < EventCatcher
   def event_monitor_handle
-    require 'ovirt'
-    @event_monitor_handle ||= Ovirt::EventMonitor.new(
+    require 'ovirt_provider/events/ovirt_event_monitor'
+    @event_monitor_handle ||= OvirtEventMonitor.new(
       :server     => @ems.ipaddress,
       :port       => @ems.port,
       :username   => @ems.authentication_userid,


### PR DESCRIPTION
When querying for events, the event monitor needs to be able to specify a maximum number of events to retrieve on the first attempt to retrieve events.  Without this capability, the event monitor will grab *all* of the events from the Ovirt server.  In some cases, this could amount to tens of thousands of historical events.

Before this change, previous versions of the Ovirt REST API would interpret a request for events with no query parameters as a request for the most recent event only.  The latest Ovirt REST API version interprets the same request as wanting *all* historical events.

This change ensures that queries against newer Ovirt REST APIs will react the same as if it were querying the older Ovirt REST API.

Also, the ovirt event monitor is specific to the ManageIQ application and should remain in the ManageIQ codebase instead of in the ovirt gem.

Depends on https://github.com/ManageIQ/ovirt/pull/17
This should also likely generate a gemfile change since the ovirt gem will probably bump versions.

https://bugzilla.redhat.com/show_bug.cgi?id=1114656