### PR TITLE
eager load association

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -17,7 +17,7 @@ module EmsRefresh::SaveInventory
     log_header = "MIQ(#{self.name}.save_vms_inventory) EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if target.kind_of?(ExtManagementSystem) || target.kind_of?(Host)
-      target.vms_and_templates(true).dup
+      target.vms_and_templates(true).to_a.dup
     elsif target.kind_of?(Vm)
       [target.ruby_clone]
     else


### PR DESCRIPTION
Associations are not eagerly loaded in Rails 4.  This code assumed that
`disconnects` would be eagerly loaded.  In Rails 4 it was not eagerly
loaded, and would mutate records that had been added to the association
but were not supposed to be mutate.

This commit loads the association and keeps the list in memory so that
only the correct records will be mutated