### PR TITLE
don't do is_a checks on collections before wrapping

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -88,9 +88,15 @@ module MiqAeMethodService
         next if method_name.to_sym == :id
         self.association = method_name if options[:association]
         define_method(method_name) do |*params|
-          ret = object_send(options[:method] || method_name, *params)
+          method = options[:method] || method_name
+          ret = object_send(method, *params)
           return options[:override_return] if options.has_key?(:override_return)
-          return wrap_results(ret)
+          reflection = @object.class.reflection_with_virtual(method)
+          if reflection && reflection.collection?
+            wrap_results(ret.to_a)
+          else
+            wrap_results(ret)
+          end
         end
       end
     end


### PR DESCRIPTION
the `wrap_results` method will to an is_a check on the return value
object in order to decide how to wrap the object.  In Rails 4,
collections will return a collection proxy which is not an array.  This
commit will check to see if the method is a collection before falling
back to the original wrap_results implementation.