### PR TITLE
Last value in chart zeroed by hard

### DIFF
--- a/vmdb/lib/report_formatter/chart_common.rb
+++ b/vmdb/lib/report_formatter/chart_common.rb
@@ -117,7 +117,7 @@ module ReportFormatter
           else
             series.push(:value => val)
           end
-          allnil = false if val.nil? || nils2zero
+          allnil = false if !val.nil? || nils2zero
         end
         series[-1] = 0 if allnil                    # XML/SWF Charts can't handle all nils, set the last value to 0
         add_axis_category_text(categories)


### PR DESCRIPTION
Right now, the last value in the chart was always made zero.

The correct condition is: if there is at least one not nil value,
it can't make the last value zero. Otherwise all values are nil
and it will change the last value to zero(due to chart cannot
handle all values to be nil).