### PR TITLE
Update smtp host & domain allowed values to 64 characters

### DIFF
--- a/vmdb/app/views/ops/_settings_server_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_server_tab.html.erb
@@ -194,7 +194,7 @@
               <td class="wide">
                 <%= text_field_tag("smtp_host",
                   @edit[:new][:smtp][:host],
-                  :maxlength=>30,
+                  :maxlength=>64,
                   "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
               </td>
             </tr>
@@ -212,7 +212,7 @@
               <td class="wide">
                 <%= text_field_tag("smtp_domain",
                                     @edit[:new][:smtp][:domain],
-                                    :maxlength=>30,
+                                    :maxlength=>64,
                                     "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
               </td>
             </tr>


### PR DESCRIPTION
Update smtp host & domain allowed values to 64 characters for complex naming

https://bugzilla.redhat.com/show_bug.cgi?id=1184250