### PR TITLE
Pass ARGV or the subcommand options following a '--' to Trollop.

### DIFF
--- a/vmdb/lib/tasks/evm_dba.rake
+++ b/vmdb/lib/tasks/evm_dba.rake
@@ -45,6 +45,34 @@ module EvmDba
     Dir.chdir(Rails.root)
     EvmDatabaseOps.stop
   end
+
+  # Returns any command ARGV options.
+  #
+  # If ARGV contains the 'end of options' '--' option [1]:
+  # Returns a duplicate of ARGV with all arguments up to and including
+  # the '--' removed.
+  #   [1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
+  #
+  # Otherwise, returns a duplicate of ARGV, since there is no obvious subcommand.
+  #
+  # Example 1:
+  #   bundle exec evm:db:region -- --region 1
+  #
+  # ARGV starts as:
+  #   ["evm:db:region", "--", "--region", "1"]
+  # Returns:
+  #   ["--region", "1"]
+  #
+  # Example 2:
+  #   bundle exec evm:db:region --region 1
+  # ARGV starts as =>
+  #   ["evm:db:region", "--region", "1"]
+  # Returns:
+  #   ["evm:db:region", "--region", "1"]
+  def self.extract_command_options
+    i = ARGV.index("--")
+    i ? ARGV.slice((i + 1)..-1) : ARGV.dup
+  end
 end
 
 namespace :evm do
@@ -97,8 +125,7 @@ namespace :evm do
     desc "clean up database"
     task :gc do
       require 'trollop'
-      ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-      opts = Trollop.options do
+      opts = Trollop.options(EvmDba.extract_command_options) do
         opt :username,   "Username",         :type => :string
         opt :hostname,   "Hostname",         :type => :string
         opt :dbname,     "Database name",    :type => :string
@@ -147,8 +174,7 @@ namespace :evm do
     desc 'Set the region of the current ManageIQ EVM Database (VMDB)'
     task :region do
       require 'trollop'
-      ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-      opts = Trollop::options do
+      opts = Trollop.options(EvmDba.extract_command_options) do
         opt :region, "Region number", :type => :integer, :required => true
       end
 
@@ -190,8 +216,7 @@ namespace :evm do
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
         require 'trollop'
-        ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-        opts = Trollop::options do
+        opts = Trollop.options(EvmDba.extract_command_options) do
           opt :local_file, "Destination file", :type => :string, :required => true
           opt :username,   "Username",         :type => :string
           opt :hostname,   "Hostname",         :type => :string
@@ -207,8 +232,7 @@ namespace :evm do
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
         require 'trollop'
-        ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-        opts = Trollop::options do
+        opts = Trollop.options(EvmDba.extract_command_options) do
           opt :uri,              "Destination depot URI",       :type => :string, :required => true
           opt :uri_username,     "Destination depot username",  :type => :string
           opt :uri_password,     "Destination depot password",  :type => :string
@@ -236,8 +260,7 @@ namespace :evm do
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a local backup file'
       task :local do
         require 'trollop'
-        ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-        opts = Trollop::options do
+        opts = Trollop.options(EvmDba.extract_command_options) do
           opt :local_file, "Destination file", :type => :string, :required => true
           opt :username,   "Username",         :type => :string
           opt :hostname,   "Hostname",         :type => :string
@@ -257,8 +280,7 @@ namespace :evm do
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a remote backup file'
       task :remote do
         require 'trollop'
-        ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-        opts = Trollop::options do
+        opts = Trollop.options(EvmDba.extract_command_options) do
           opt :uri,              "Destination depot URI",       :type => :string, :required => true
           opt :uri_username,     "Destination depot username",  :type => :string
           opt :uri_password,     "Destination depot password",  :type => :string


### PR DESCRIPTION
Rake before 10.4.0 would delete the '--' from ARGV, leaving all other options.
Trollop would then process all of ARGV, including subcommand options.

Starting in rake 10.4.0, ARGV is not modified and our '--' detection only
expected '--' if invoked from rails/runner, not rake directly.
Now, the ARGV passed to trollop included '--'. Trollop, correctly doesn't
process subcommand options following '--', so we must
always extract any subcommand options and pass them to trollop.

Note: Rake 10.4.0 was released November 25, 2014

Fixes #1412
We loosened the rake dependency here: 03c62bcc510

Rake commit that no longer modified ARGV:
https://github.com/ruby/rake/commit/a36505d33f873f8f475a28dc4fc48a913b82e8eb