### PR TITLE
we also pass relation objects to this method, so check for those

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -241,7 +241,7 @@ module MiqAeEngine
 
   def self.create_automation_attribute(key, value)
     case value
-    when Array
+    when Array, ActiveRecord::Relation
       [self.create_automation_attribute_array_key(key), self.create_automation_attribute_array_value(value)]
     when ActiveRecord::Base
       [self.create_automation_attribute_key(value, key), self.create_automation_attribute_value(value)]


### PR DESCRIPTION
The tests seem to pass Relation objects to this method, like here:

  https://github.com/manageiq/manageiq/blob/d168cdbfe0de910f61d3ae5d9347f1abb2d546cd/vmdb/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb#L320

So we need to check for relation objects too

I'm not super happy with this change, because we really shouldn't be doing is_a checks unless we can guarantee that only certain types will be passed to the method.  However, this got more tests green on Rails 4.