### PR TITLE
do not pass `id` to the requeue method

### DIFF
--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -441,6 +441,7 @@ class MiqQueue < ActiveRecord::Base
 
   def requeue(options = {})
     options.reverse_merge!(self.attributes.symbolize_keys)
+    options.delete(:id)
     MiqQueue.put(options)
   end
 


### PR DESCRIPTION
This is causing a warning in our logs on 3.2 and a test failure on Rails
4.  We don't want to actually create a record with the same id, so we
shouldn't pass the id to the requeue method.