### PR TITLE
eagerly load the relation so that we can use the mutation function

### DIFF
--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -570,7 +570,7 @@ class MiqRequestWorkflow
     rails_logger('allowed_tags', 0)
     st = Time.now
     @tags = {}
-    class_tags = Classification.where(:show => true).includes(:tag)
+    class_tags = Classification.where(:show => true).includes(:tag).to_a
     class_tags.reject!(&:read_only?) # Can't do in query because column is a string.
 
     exclude_list  = options[:exclude].blank?       ? [] : options[:exclude].collect(&:to_s)


### PR DESCRIPTION
we can't mutate relations in Rails 4, so this commit eagerly loads the
relation (converting it to an array) so that the mutation, `reject!`
works.