### PR TITLE
Remove using emstype directly for determining the EMS image.

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1202,7 +1202,7 @@ class ApplicationController < ActionController::Base
     pn = "#{p}new/"
 
     case item.class.base_class.to_s
-    when "ExtManagementSystem"   then "#{pn}/vendor-#{item.emstype.downcase}.png"
+    when "ExtManagementSystem"   then "#{pn}/vendor-#{item.image_name}.png"
     when "Filesystem"            then "#{p}ico/win/#{item.image_name.downcase}.ico"
     when "Host"                  then "#{pn}vendor-#{item.vmm_vendor.downcase}.png"
     when "MiqEvent"              then "#{pn}event-#{item.name.downcase}.png"

--- a/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -205,7 +205,7 @@ module MiqPolicyController::AlertProfiles
             icon = "tag.png"
           else
             if @assign[:new][:assign_to] == "ext_management_system"
-              icon = "vendor-#{o.emstype.downcase}.png"
+              icon = "vendor-#{o.image_name}.png"
             elsif @assign[:new][:assign_to] == "resource_pool"
               icon = o.vapp ? "vapp.png" : "resource_pool.png"
             else

--- a/vmdb/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/vmdb/app/helpers/availability_zone_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module AvailabilityZoneHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_cloud")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_cloud_show")
       h[:title] = "Show this Availability Zone's #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_cloud', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/vmdb/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -24,7 +24,7 @@ module CloudTenantHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_cloud")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_cloud_show")
       h[:title] = "Show this Cloud Tenant's #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_cloud', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -68,7 +68,7 @@ module EmsClusterHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_infra")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_infra_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_infra', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/flavor_helper/textual_summary.rb
+++ b/vmdb/app/helpers/flavor_helper/textual_summary.rb
@@ -64,7 +64,7 @@ module FlavorHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_cloud")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_cloud_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_cloud', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/host_helper/textual_summary.rb
+++ b/vmdb/app/helpers/host_helper/textual_summary.rb
@@ -206,7 +206,7 @@ module HostHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_infra")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_infra_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_infra', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/miq_proxy_helper/textual_summary.rb
+++ b/vmdb/app/helpers/miq_proxy_helper/textual_summary.rb
@@ -54,7 +54,7 @@ module MiqProxyHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_infra")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_infra_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_infra', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/security_group_helper/textual_summary.rb
+++ b/vmdb/app/helpers/security_group_helper/textual_summary.rb
@@ -49,7 +49,7 @@ module SecurityGroupHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_cloud")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_cloud_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_cloud', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -206,7 +206,7 @@ module VmCloudHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_cloud")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_cloud_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_cloud', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/vm_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_helper/textual_summary.rb
@@ -249,7 +249,7 @@ module VmHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_infra")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_infra_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_infra', :action => 'show', :id => ems)

--- a/vmdb/app/helpers/vm_infra_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_infra_helper/textual_summary.rb
@@ -239,7 +239,7 @@ module VmCloudHelper::TextualSummary
     ems = @record.ext_management_system
     return nil if ems.nil?
     label = ui_lookup(:table => "ems_infra")
-    h = {:label => label, :image => "vendor-#{ems.emstype.downcase}", :value => ems.name}
+    h = {:label => label, :image => "vendor-#{ems.image_name}", :value => ems.name}
     if role_allows(:feature => "ems_infra_show")
       h[:title] = "Show parent #{label} '#{ems.name}'"
       h[:link]  = url_for(:controller => 'ems_infra', :action => 'show', :id => ems)

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -142,6 +142,11 @@ class ExtManagementSystem < ActiveRecord::Base
     model_name_from_emstype(emstype).constantize
   end
 
+  # UI method for determining which icon to show for a particular EMS
+  def image_name
+    emstype.downcase
+  end
+
   def authentication_check_role
     'ems_operations'
   end

--- a/vmdb/app/presenters/tree_node_builder.rb
+++ b/vmdb/app/presenters/tree_node_builder.rb
@@ -48,7 +48,7 @@ class TreeNodeBuilder
   def build
     case object
     when AvailabilityZone     then generic_node(object.name, "availability_zone.png", "Availability Zone: #{object.name}")
-    when ExtManagementSystem  then generic_node(object.name, "vendor-#{object.emstype.downcase}.png",
+    when ExtManagementSystem  then generic_node(object.name, "vendor-#{object.image_name}.png",
       "#{ui_lookup(:table=>object.kind_of?(EmsInfra) ? "ems_infra" : "ems_cloud")}: #{object.name}")
     when ChargebackRate       then generic_node(object.description, "chargeback_rates.png")
     when Condition            then generic_node(object.description, "miq_condition.png")

--- a/vmdb/app/views/layouts/_listicon.html.erb
+++ b/vmdb/app/views/layouts/_listicon.html.erb
@@ -60,7 +60,7 @@
     <img src="/images/icons/new/<%= icon_image == nil ? 'miq_alert' : icon_image %>.png" valign="middle" border="0" height="20" width="20" />
   <% elsif db == "ExtManagementSystem" %>
       <% ems = @targets_hash[from_cid(@id)] if @targets_hash %>
-        <img src="/images/icons/new/vendor-<%=h(ems.emstype.downcase) %>.png" valign="middle" border="0" height="20" width="20"  />
+        <img src="/images/icons/new/vendor-<%=h(ems.image_name) %>.png" valign="middle" border="0" height="20" width="20"  />
   <% elsif db == "LdapServer" %>
     <img src="/images/icons/new/ldap_server.png" valign="middle" border="0" height="20" width="20"  />
   <% elsif db == "MiqSchedule" %>

--- a/vmdb/app/views/layouts/quadicon/_ext_management_system.html.erb
+++ b/vmdb/app/views/layouts/quadicon/_ext_management_system.html.erb
@@ -7,7 +7,7 @@
   <% if item.is_a?(EmsCloud) %>
     <div class="flobj b<%= size %>"><p><%= item.total_miq_templates %></p></div>
   <% end %>
-	<div class="flobj c<%= size %>"><img src="/images/icons/new/vendor-<%= h(item.emstype.downcase) %>.png"/></div>
+	<div class="flobj c<%= size %>"><img src="/images/icons/new/vendor-<%= h(item.image_name) %>.png"/></div>
 	<div class="flobj d<%= size %>">
 		<%
 			case item.authentication_status
@@ -28,7 +28,7 @@
 	<% end %>
 <% else %>
 	<div class="flobj" ><img src="/images/icons/<%= size %>/base-single.png"></div>
-	<div class="flobj e<%= size %>"><img src="/images/icons/new/vendor-<%= h(item.emstype.downcase) %>.png" width="<%= width * 1.8 %>" height="<%= height * 1.8 %>"></div>
+	<div class="flobj e<%= size %>"><img src="/images/icons/new/vendor-<%= h(item.image_name) %>.png" width="<%= width * 1.8 %>" height="<%= height * 1.8 %>"></div>
 
 <% end %>
 <% if typ == :listnav %><%# Listnav, no href needed %>


### PR DESCRIPTION
This is part of an effort to completely remove emstype column.  It is
overloaded for a number of uses, so I'm removing those uses one by one.