### PR TITLE
Add missing .includes, .limit from PR #1351

### DIFF
--- a/vmdb/app/models/vim_performance_daily.rb
+++ b/vmdb/app/models/vim_performance_daily.rb
@@ -65,6 +65,8 @@ class VimPerformanceDaily < MetricRollup
     options.delete :conditions
     select = options.delete :select
     order = options.delete :order
+    includes = options.delete :include
+    limit = options.delete :limit
     raise "Unsupported options #{options.keys}" unless options.empty?
 
     case cnt
@@ -72,6 +74,8 @@ class VimPerformanceDaily < MetricRollup
       scope = klass
       scope = scope.select(select) if select
       scope = scope.order(order) if order
+      scope = scope.includes(includes) if includes
+      scope = scope.limit(limit) if limit
       scope = scope.where(wheres) if wheres
       scope.to_a
     else

--- a/vmdb/app/models/vim_performance_daily.rb
+++ b/vmdb/app/models/vim_performance_daily.rb
@@ -63,20 +63,20 @@ class VimPerformanceDaily < MetricRollup
 
     # FIXME we should push these up to the callers
     options.delete :conditions
-    select = options.delete :select
-    order = options.delete :order
+    select   = options.delete :select
+    order    = options.delete :order
     includes = options.delete :include
-    limit = options.delete :limit
+    limit    = options.delete :limit
     raise "Unsupported options #{options.keys}" unless options.empty?
 
     case cnt
     when :all
       scope = klass
-      scope = scope.select(select) if select
-      scope = scope.order(order) if order
+      scope = scope.select(select)     if select
+      scope = scope.order(order)       if order
       scope = scope.includes(includes) if includes
-      scope = scope.limit(limit) if limit
-      scope = scope.where(wheres) if wheres
+      scope = scope.limit(limit)       if limit
+      scope = scope.where(wheres)      if wheres
       scope.to_a
     else
       raise "Unsupported finder value #{cnt}"


### PR DESCRIPTION
I ran into this testing IPv6 on my appliance at appliance startup.

This was broken with the arel changes from #1351 

Note, since the affected dashboard widgets are the "top weekly consumers", I had to manually reset my widget dashboard using the "refresh" looking arrow seen below in order to force the widget to be generated immediately instead of waiting for the next day:

![screen shot 2015-01-26 at 4 53 28 pm](https://cloud.githubusercontent.com/assets/19339/5909154/ea256e66-a57b-11e4-87e5-8d1c843449db.png)
