### PR TITLE
Remove using emstype for determining the type given an ems instance

### DIFF
--- a/vmdb/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -46,7 +46,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_port
-    ["openstack", "openstack_infra", "rhevm"].include?(@ems.emstype) ? {:label => "API Port", :value => @ems.port} : nil
+    @ems.supports_port? ? {:label => "API Port", :value => @ems.port} : nil
   end
 
   def textual_guid

--- a/vmdb/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_infra_helper/textual_summary.rb
@@ -40,7 +40,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_port
-    ["openstack", "openstack_infra", "rhevm"].include?(@ems.emstype) ? {:label => "API Port", :value => @ems.port} : nil
+    @ems.supports_port? ? {:label => "API Port", :value => @ems.port} : nil
   end
 
   def textual_cpu_resources

--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -9,6 +9,14 @@ class EmsOpenstack < EmsCloud
     @description ||= "OpenStack".freeze
   end
 
+  def supports_port?
+    true
+  end
+
+  def supports_authentication?(authtype)
+    %w(default amqp).include?(authtype.to_s)
+  end
+
   #
   # Operations
   #

--- a/vmdb/app/models/ems_openstack_infra.rb
+++ b/vmdb/app/models/ems_openstack_infra.rb
@@ -8,4 +8,12 @@ class EmsOpenstackInfra < EmsInfra
   def self.description
     @description ||= "OpenStack Infrastructure".freeze
   end
+
+  def supports_port?
+    true
+  end
+
+  def supports_authentication?(authtype)
+    %w(default amqp).include?(authtype.to_s)
+  end
 end

--- a/vmdb/app/models/ems_redhat.rb
+++ b/vmdb/app/models/ems_redhat.rb
@@ -7,6 +7,14 @@ class EmsRedhat < EmsInfra
     @description ||= "Red Hat Enterprise Virtualization Manager".freeze
   end
 
+  def supports_port?
+    true
+  end
+
+  def supports_authentication?(authtype)
+    %w(default metrics).include?(authtype.to_s)
+  end
+
   def self.raw_connect(server, port, username, password, service = "Service")
     require 'ovirt'
     params = {

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -143,6 +143,15 @@ class ExtManagementSystem < ActiveRecord::Base
     model_name_from_emstype(emstype).constantize
   end
 
+  # UI methods for determining availability of fields
+  def supports_port?
+    false
+  end
+
+  def supports_authentication?(authtype)
+    authtype.to_s == "default"
+  end
+
   # UI method for determining which icon to show for a particular EMS
   def image_name
     emstype.downcase


### PR DESCRIPTION
Added ExtManagementSystem#supports_port and #supports_authentication?
helper methods for the UI to query on specific supported features.

This is part of an effort to completely remove emstype column.  It is
overloaded for a number of uses, so I'm removing those uses one by one.