### PR TITLE
Fixed maximum length for the SMTP host name to the RFC specified 255

### DIFF
--- a/vmdb/app/views/ops/_settings_server_tab.html.erb
+++ b/vmdb/app/views/ops/_settings_server_tab.html.erb
@@ -194,7 +194,7 @@
               <td class="wide">
                 <%= text_field_tag("smtp_host",
                   @edit[:new][:smtp][:host],
-                  :maxlength=>30,
+                  :maxlength=>255,
                   "data-miq_observe"=>{:interval=>'.5', :url=>url}.to_json) %>
               </td>
             </tr>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1184967