### PR TITLE
Exclude resources that do not have a physical id

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/ec2.rb
+++ b/vmdb/app/models/ems_refresh/parsers/ec2.rb
@@ -465,6 +465,9 @@ module EmsRefresh::Parsers
       # convert the AWS Resource Summary collection to an array to avoid the same API getting called twice
       raw_resources = stack.resource_summaries.to_a
 
+      # physical_resource_id can be empty if the resource was not successfully created; ignore such
+      raw_resources.reject! { |r| r[:physical_resource_id].nil? }
+
       get_stack_resources(raw_resources)
 
       child_stacks = []


### PR DESCRIPTION
This is bug fixing. Split from original PR #1320. 
There @Fryguy asked whether we could ignore it here, or later on when it's used. Since the `physical_resource_id` is used as an unique identifier, it causes problem at inventory if the identifier is `nil`. So we'd better to exclude them here unless come up a method to generate an unique identifier for empty physical resources.