### PR TITLE
remove $SAFE setting in eval

### DIFF
--- a/vmdb/app/models/condition.rb
+++ b/vmdb/app/models/condition.rb
@@ -305,7 +305,6 @@ class Condition < ActiveRecord::Base
       $log.debug("#{log_prefix} Script:\n#{script}")
       begin
         t = Thread.new do
-          script = "$SAFE = 3\n#{script}"
           Thread.current["result"] = _eval(context, script)
         end
         to = 20 # allow 20 seconds for script to complete


### PR DESCRIPTION
$SAFE isn't supported anymore, so we should delete it.  Also, this
breaks the tests in Rails 4.  Rails 4 keeps connection pools per process
id.  `Process.pid` violates $SAFE = 3, so Rails can't look up the
connection pool to use inside this eval.

The test that fails is here:

https://github.com/tenderlove/manageiq/blob/d168cdbfe0de910f61d3ae5d9347f1abb2d546cd/vmdb/spec/models/miq_expression/miq_expression_spec.rb#L285

We could also change `inspect` to not access the database, but I'm not
sure how this code is used.  Other production applications may look up
the database connection, which would cause their code to break