### PR TITLE
use standard simple-rss gem

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -25,7 +25,7 @@ gem "actionwebservice",               "=3.1.0",       :require => false, :git =>
 gem "net-ldap",                       "~>0.7.0",      :require => false
 gem "rubyrep",                        "=1.2.0",       :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-2"
 gem "soap4r",                         "=1.6.0",       :require => false, :git => "git://github.com/ManageIQ/soap4r.git", :tag => "v1.6.0-2"
-gem "simple-rss",                     "=1.2.3",       :require => false, :git => "git://github.com/ManageIQ/simple-rss.git", :tag => "v1.2.3-8"
+gem "simple-rss",                     "~>1.3.1",      :require => false
 gem "winrm",                          "=1.1.3",       :require => false, :git => "git://github.com/ManageIQ/WinRM.git", :tag => "v1.1.3-1"
 gem "ziya",                           "=2.3.0",       :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 


### PR DESCRIPTION
The only part we have that master does not is a `has_rdoc` flag in a rakefile that we don't use.

/cc @jrafanie this looks close to the same. any final thoughts?