### PR TITLE
Foreman reporting models

### DIFF
--- a/vmdb/app/models/configuration_manager.rb
+++ b/vmdb/app/models/configuration_manager.rb
@@ -1,10 +1,15 @@
 class ConfigurationManager < ActiveRecord::Base
   include NewWithTypeStiMixin
   include EmsRefresh::Manager
+  include ReportableMixin
+
+  acts_as_miq_taggable
   belongs_to :provider
 
   has_many :configured_systems,     :dependent => :destroy
   has_many :configuration_profiles, :dependent => :destroy
 
   delegate :zone, :my_zone, :zone_name, :to => :provider
+
+  virtual_column :name,                :type => :string,      :uses => :provider
 end

--- a/vmdb/app/models/configuration_profile.rb
+++ b/vmdb/app/models/configuration_profile.rb
@@ -1,4 +1,7 @@
 class ConfigurationProfile < ActiveRecord::Base
   include NewWithTypeStiMixin
+  include ReportableMixin
+
+  acts_as_miq_taggable
   belongs_to :configuration_manager
 end

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -1,5 +1,8 @@
 class ConfiguredSystem < ActiveRecord::Base
   include NewWithTypeStiMixin
+  include ReportableMixin
+
+  acts_as_miq_taggable
   belongs_to :configuration_manager
   belongs_to :configuration_profile
   belongs_to :operating_system_flavor

--- a/vmdb/app/models/customization_script.rb
+++ b/vmdb/app/models/customization_script.rb
@@ -1,4 +1,7 @@
 class CustomizationScript < ActiveRecord::Base
   include NewWithTypeStiMixin
+  include ReportableMixin
+
+  acts_as_miq_taggable
   belongs_to :provisioning_manager
 end

--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -10,6 +10,8 @@ class MiqExpression
     CloudResourceQuota
     CloudTenant
     Compliance
+    ConfiguredSystemForeman
+    ConfigurationManager
     EmsCloud
     EmsCluster
     EmsClusterPerformance
@@ -61,6 +63,12 @@ class MiqExpression
     cloud_tenants
     compliances
     compliance_details
+    configuration_profiles
+    configuration_managers
+    configured_systems
+    customization_scripts
+    customization_script_media
+    customization_script_ptables
     disks
     ems_events
     ems_clusters
@@ -102,6 +110,7 @@ class MiqExpression
     orchestration_stack_parameters
     orchestration_stack_resources
     orchestration_templates
+    operating_system_flavors
     partitions
     ports
     processes

--- a/vmdb/app/models/operating_system_flavor.rb
+++ b/vmdb/app/models/operating_system_flavor.rb
@@ -5,4 +5,10 @@ class OperatingSystemFlavor < ActiveRecord::Base
   belongs_to :provisioning_manager
 
   has_and_belongs_to_many :customization_scripts
+  has_and_belongs_to_many :customization_script_ptables,
+                          :join_table              => :customization_scripts_operating_system_flavors,
+                          :association_foreign_key => :customization_script_id
+  has_and_belongs_to_many :customization_script_media,
+                          :join_table              => :customization_scripts_operating_system_flavors,
+                          :association_foreign_key => :customization_script_id
 end

--- a/vmdb/app/models/operating_system_flavor.rb
+++ b/vmdb/app/models/operating_system_flavor.rb
@@ -1,4 +1,7 @@
 class OperatingSystemFlavor < ActiveRecord::Base
+  include ReportableMixin
+
+  acts_as_miq_taggable
   belongs_to :provisioning_manager
 
   has_and_belongs_to_many :customization_scripts

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -4,6 +4,8 @@ class ProvisioningManager < ActiveRecord::Base
 
   has_many :operating_system_flavors, :dependent => :destroy
   has_many :customization_scripts,    :dependent => :destroy
+  has_many :customization_script_ptables
+  has_many :customization_script_media
 
   delegate :zone, :my_zone, :zone_name, :to => :provider
 

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -6,4 +6,6 @@ class ProvisioningManager < ActiveRecord::Base
   has_many :customization_scripts,    :dependent => :destroy
 
   delegate :zone, :my_zone, :zone_name, :to => :provider
+
+  virtual_column :name,                :type => :string,      :uses => :provider
 end

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -16,8 +16,8 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
   let(:provisioning_manager) { Provider.first.provisioning_manager }
   let(:osfs) { provisioning_manager.operating_system_flavors }
   let(:customization_scripts) { provisioning_manager.customization_scripts }
-  let(:media) { customization_scripts.where(:type => "CustomizationScriptMedium") }
-  let(:ptables) { customization_scripts.where(:type => "CustomizationScriptPtable") }
+  let(:media) { provisioning_manager.customization_script_media }
+  let(:ptables) { provisioning_manager.customization_script_ptables }
   let(:configuration_manager) { Provider.first.configuration_manager }
 
   it "will perform a full refresh on api v2" do
@@ -77,6 +77,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
       "manager_ref" => "4"
     )
     expect(osf.customization_scripts).to include(mine(ptables), mine(media))
+    expect(osf.customization_script_ptables).to include(mine(ptables))
+    expect(osf.customization_script_ptables).not_to include(mine(media))
+    expect(osf.customization_script_media).to include(mine(media))
   end
 
   def assert_configuration_table_counts


### PR DESCRIPTION
Add tagging and reporting to foreman models

**UPDATE:**

- added `ConfiguredSystemForeman` back.
- pluralize `customization_script_media`, `customization_script_ptables`.
- defined `customization_script_{media,ptable}` in `ProvisioningManager`.
/cc @gmcculloug 