### PR TITLE
Be lenient with guard clauses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,8 @@ Documentation:
   Enabled: false
 Encoding:
   Enabled: false
+GuardClause:
+  Enabled: false
 SingleLineBlockParams:
   Enabled: false
 SingleSpaceBeforeFirstArg:


### PR DESCRIPTION
Rubocop is complaining on the following code:

```
class MyClass
  def my_method
    if @x
      method1
      method2
    end
  end
end
```

It prefers:

```
class MyClass
  def my_method
   return unless @x
   method1
   method2
  end
end
```

While this makes sense in many cases, 1/3 of the time it is much uglier.
Can we just remove this check?