### PR TITLE
Provision status method fix

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
@@ -47,7 +47,11 @@ module MiqAeMethodService
     def status
       ar_method do
         if ['finished', 'provisioned'].include?(@object.state)
-          @object.vm.nil? ? 'error' : 'ok'
+          if @object.status.to_s.downcase == 'error' || @object.vm.nil?
+            'error'
+          else
+            'ok'
+          end
         else
           'retry'
         end


### PR DESCRIPTION
Fixed bug where miq_provision status method was returning incorrect value.

Fixed issue in miq_provision status method where the result for a
finished or provisioned state is determined solely on the existence
of the vm.  It needs to consider the object state as well. 

https://bugzilla.redhat.com/show_bug.cgi?id=1025761