### PR TITLE
include and join against the taggings table

### DIFF
--- a/vmdb/lib/extensions/ar_taggable.rb
+++ b/vmdb/lib/extensions/ar_taggable.rb
@@ -139,7 +139,7 @@ module ActsAsTaggable
 
   def tagged_with(options = {})
     tagging = Tagging.arel_table
-    query = Tag.includes(:taggings)
+    query = Tag.includes(:taggings).joins(:taggings)
     query = query.where(tagging[:taggable_type].eq self.class.base_class.name)
     query = query.where(tagging[:taggable_id].eq self.id)
     ns    = Tag.get_namespace(options)


### PR DESCRIPTION
since we're referencing the table in the where clause, we need to join
against the table.  We can change this to `references` in Rails 4, but
not Rails 3