### PR TITLE
only try to constantize if there is a string to constantize

### DIFF
--- a/vmdb/config/initializers/yaml_autoloader.rb
+++ b/vmdb/config/initializers/yaml_autoloader.rb
@@ -4,7 +4,11 @@ module Psych
   module Visitors
     class ToRuby # ruby-1.9.3-p125/lib/ruby/1.9.1/psych/visitors/to_ruby.rb
       def resolve_class_with_constantize(klass_name)
-        klass_name.constantize
+        if klass_name
+          klass_name.constantize
+        else
+          resolve_class_without_constantize(klass_name)
+        end
       rescue
         resolve_class_without_constantize(klass_name)
       end


### PR DESCRIPTION
this is raising and catching tons of exceptions.  That slows the process
down, and makes running with `ruby -d` very noisy.