### PR TITLE
Fix Build: Support all awesome spawn command result fields

### DIFF
--- a/lib/spec/appliance_console/certificate_spec.rb
+++ b/lib/spec/appliance_console/certificate_spec.rb
@@ -99,6 +99,9 @@ describe ApplianceConsole::Certificate do
   end
 
   def response(ret_code = 0)
-    double("CommandResult", :success? => ret_code == 0, :failure => ret_code != 0, :exit_status => ret_code)
+    double("CommandResult", :success?    => ret_code == 0,
+                            :failure     => ret_code != 0,
+                            :failure?    => ret_code != 0,
+                            :exit_status => ret_code)
   end
 end

--- a/lib/spec/appliance_console/principal_spec.rb
+++ b/lib/spec/appliance_console/principal_spec.rb
@@ -44,6 +44,9 @@ describe ApplianceConsole::Principal do
   end
 
   def response(ret_code = 0)
-    double("CommandResult", :success? => ret_code == 0, :failure => ret_code != 0, :exit_status => ret_code)
+    double("CommandResult", :success?    => ret_code == 0,
+                            :failure     => ret_code != 0,
+                            :failure?    => ret_code != 0,
+                            :exit_status => ret_code)
   end
 end


### PR DESCRIPTION
Awesome spawn uses one more method.
We were using a double, added the method to the double

/cc @Fryguy @jrafanie 