### PR TITLE
Use AwesomeSpawn::CommandResult instead of double

### DIFF
--- a/lib/spec/appliance_console/certificate_spec.rb
+++ b/lib/spec/appliance_console/certificate_spec.rb
@@ -99,9 +99,6 @@ describe ApplianceConsole::Certificate do
   end
 
   def response(ret_code = 0)
-    double("CommandResult", :success?    => ret_code == 0,
-                            :failure     => ret_code != 0,
-                            :failure?    => ret_code != 0,
-                            :exit_status => ret_code)
+    AwesomeSpawn::CommandResult.new("cmd", "output", "", ret_code)
   end
 end

--- a/lib/spec/appliance_console/principal_spec.rb
+++ b/lib/spec/appliance_console/principal_spec.rb
@@ -44,9 +44,6 @@ describe ApplianceConsole::Principal do
   end
 
   def response(ret_code = 0)
-    double("CommandResult", :success?    => ret_code == 0,
-                            :failure     => ret_code != 0,
-                            :failure?    => ret_code != 0,
-                            :exit_status => ret_code)
+    AwesomeSpawn::CommandResult.new("cmd", "output", "", ret_code)
   end
 end


### PR DESCRIPTION
@Fryguy This gets rid of the code that I patched yesterday.
This makes the tests less fragile and hopefully makes it more future proof.

~~I'm also looking into implementing dry_run in awesome spawn.~~