### PR TITLE
Run vm remove_from_disk via MiqQueue

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceVmOrTemplate < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_service_ems_operations_mixin"
+    include MiqAeServiceEmsOperationsMixin
+
     expose :ext_management_system, :association => true
     expose :storage,               :association => true
     expose :host,                  :association => true
@@ -15,7 +18,6 @@ module MiqAeMethodService
     expose :ems_blue_folder,       :association => true, :method => :parent_blue_folder
     expose :resource_pool,         :association => true, :method => :parent_resource_pool
     expose :datacenter,            :association => true, :method => :parent_datacenter
-    expose :remove_from_disk,                            :method => :vm_destroy, :override_return => true
     expose :registered?
     expose :to_s
     expose :event_threshold?
@@ -193,6 +195,10 @@ module MiqAeMethodService
     def snapshot_operation(task, options = {})
       options.merge!(:ids=>[self.id], :task=>task.to_s)
       Vm.process_tasks(options)
+    end
+
+    def remove_from_disk(sync = true)
+      sync_or_async_ems_operation(sync, "vm_destroy", [])
     end
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_vmware.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_vmware.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceVmVmware < MiqAeServiceVmInfra
+    require_relative "mixins/miq_ae_service_ems_operations_mixin"
+    include MiqAeServiceEmsOperationsMixin
+
     def set_number_of_cpus(count, options = {})
       sync_or_async_ems_operation(options[:sync], "set_number_of_cpus", [count])
     end
@@ -10,32 +13,6 @@ module MiqAeMethodService
 
     def add_disk(disk_name, disk_size_mb, options = {})
       sync_or_async_ems_operation(options[:sync], "add_disk", [disk_name, disk_size_mb])
-    end
-
-    private
-
-    def sync_or_async_ems_operation(sync, method_name, args)
-      ar_method do
-        queue_options = {
-          :class_name  => @object.class.name,
-          :instance_id => @object.id,
-          :method_name => method_name,
-          :args        => args,
-          :zone        => @object.my_zone,
-          :role        => "ems_operations",
-          :task_id     => nil               # Clear task_id to allow running synchronously under current worker process
-        }
-
-        if sync
-          task_options = {:name => method_name.titleize, :userid => "system"}
-          task_id = MiqTask.generic_action_with_callback(task_options, queue_options)
-          MiqTask.wait_for_taskid(task_id)
-        else
-          MiqQueue.put(queue_options)
-        end
-      end
-
-      true
     end
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/mixins/miq_ae_service_ems_operations_mixin.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/mixins/miq_ae_service_ems_operations_mixin.rb
@@ -1,0 +1,27 @@
+module MiqAeServiceEmsOperationsMixin
+  extend ActiveSupport::Concern
+
+  # Instance Methods
+  def sync_or_async_ems_operation(sync, method_name, args)
+    ar_method do
+      queue_options = {
+        :class_name  => @object.class.name,
+        :instance_id => @object.id,
+        :method_name => method_name,
+        :args        => args,
+        :zone        => @object.my_zone,
+        :role        => "ems_operations",
+        :task_id     => nil               # Clear task_id to allow running synchronously under current worker process
+      }
+
+      if sync
+        task_options = {:name => method_name.titleize, :userid => "system"}
+        task_id = MiqTask.generic_action_with_callback(task_options, queue_options)
+        MiqTask.wait_for_taskid(task_id)
+      else
+        MiqQueue.put(queue_options)
+      end
+    end
+    true
+  end
+end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_vmware_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_vmware_spec.rb
@@ -51,5 +51,15 @@ module MiqAeServiceVmVmwareSpec
           :args        => ['disk_1', 100])
       )
     end
+
+    it "#remove_from_disk async"do
+      service_vm.remove_from_disk(false)
+
+      MiqQueue.first.should have_attributes(
+        @base_queue_options.merge(
+          :method_name => 'vm_destroy',
+          :args        => [])
+      )
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1183167

Previously the removal of a vm needed the Automate Role and VIM broker
on the same server. This PR allows the vm remove_from_disk to be
routed to the appropriate worker which has the ems_operations role.