### PR TITLE
Psych gem version bump

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -39,7 +39,7 @@ gem "rufus-lru",            "~>1.0.3",       :require => false
 gem "uuidtools",            "~>2.1.3",       :require => false
 gem "sass",                 "3.1.20",        :require => false
 gem "trollop",              "~>1.16.2",      :require => false
-gem "psych",                "~>2.0.10"
+gem "psych",                "~>2.0.12"
 gem "foreman_api",          "~>0.1.11",      :require => false  # used by lib/manageiq_foreman
 
 # qpid group is needed to gate the inclusion of qpid_messaging gem on platforms


### PR DESCRIPTION
Psych 2.0.12 fixed an issue with parsing hashes with instance variables when it is referenced multiple times.
This Psych issue caused the connection failure to Vim Broker.