### PR TITLE
Removed ServiceTemplate from the list of Button Classes

### DIFF
--- a/vmdb/app/models/custom_button.rb
+++ b/vmdb/app/models/custom_button.rb
@@ -13,7 +13,7 @@ class CustomButton < ActiveRecord::Base
   include UuidMixin
   acts_as_miq_set_member
 
-  BUTTON_CLASSES = %w{ Vm Host ExtManagementSystem Storage EmsCluster MiqTemplate Service ServiceTemplate}
+  BUTTON_CLASSES = %w(Vm Host ExtManagementSystem Storage EmsCluster MiqTemplate Service)
 
   def self.buttons_for(other, applies_to_id=nil)
     if other.kind_of?(Class)

--- a/vmdb/app/presenters/tree_builder_buttons.rb
+++ b/vmdb/app/presenters/tree_builder_buttons.rb
@@ -9,8 +9,6 @@ class TreeBuilderButtons  < TreeBuilderAeCustomization
   def x_get_tree_roots(options)
     resolve = Hash.new
     CustomButton.button_classes.each{|db| resolve[db] = ui_lookup(:model=>db)}
-    #deleting ServiceTemplate, don't need to show those in automate buttons tree
-    resolve.delete_if {|key, value| key == "ServiceTemplate" }
     @sb[:target_classes] = resolve.invert
     resolve = Array(resolve.invert).sort
     resolve.collect { |typ| {:id => "ab_#{typ[1]}", :text => typ[0], :image => buttons_node_image(typ[1]), :tip => typ[0]} }


### PR DESCRIPTION
Currently the ```ServiceTemplate``` button class is not displayed in the Automate Buttons Tree but is being displayed in the list. 
This is because for the tree, we simply discard ```"ServiceTemplate"``` from the hash that builds the tree.
A cleaner approach would be to exclude ```ServiceTemplate``` from the ```BUTTON_CLASSES``` array altogether since we do not need it anyway.

https://bugzilla.redhat.com/show_bug.cgi?id=1098038