### PR TITLE
Don't turn off the spinner for charts/timelines.

### DIFF
--- a/vmdb/app/assets/javascripts/miq_ujs_bindings.js
+++ b/vmdb/app/assets/javascripts/miq_ujs_bindings.js
@@ -36,11 +36,13 @@ $(document).ready(function(){
       var el = $(this);
       el.unbind('change')
       el.change(function() {
-        miqJqueryRequest(url, {beforeSend: true,
-          complete: true,
+        var options = {
+          no_encoding: true,
           data: el.attr('id') + '=' + encodeURIComponent(el.prop('value')),
-          no_encoding: true
-        });
+        };
+        if (el.attr('data-miq_sparkle_on')) options['beforeSend'] = true
+        if (el.attr('data-miq_sparkle_off')) options['complete'] = true
+        miqJqueryRequest(url, options);
 			})
 		} else {
       $(this).off(); // Use jQuery to turn off observe_field, prevents multi ajax transactions
@@ -67,7 +69,7 @@ $(document).ready(function(){
       data: el.attr('id') + '=' + encodeURIComponent(el.prop('checked') ? el.val() : 'null'),
     };
     if (el.attr('data-miq_sparkle_on')) options['beforeSend'] = true
-    if (el.attr('data-miq_sparkle_on')) options['complete'] = true
+    if (el.attr('data-miq_sparkle_off')) options['complete'] = true
     miqJqueryRequest(url, options);
   });
 

--- a/vmdb/app/presenters/explorer_presenter.rb
+++ b/vmdb/app/presenters/explorer_presenter.rb
@@ -212,7 +212,8 @@ class ExplorerPresenter
       $('.dhtmlxInfoBarLabel').filter(':visible').append($('#clear_search')[0]);
       miqResizeTaskbarCell();"
 
-    @out << set_spinner_off
+    # Don't turn off spinner for charts/timelines
+    @out << set_spinner_off unless @options[:ajax_action]
   end
 
   def build_calendar


### PR DESCRIPTION
Fixed to not turn off the spinner for chart/timelines, let the chart/timeline related methods turn it off once data is generated.

https://bugzilla.redhat.com/show_bug.cgi?id=1187836

@dclarizio please review/test.