### PR TITLE
Fix the indexes for ems_events.

### DIFF
--- a/vmdb/db/migrate/20150202212058_fix_indexes_on_ems_events.rb
+++ b/vmdb/db/migrate/20150202212058_fix_indexes_on_ems_events.rb
@@ -1,0 +1,11 @@
+class FixIndexesOnEmsEvents < ActiveRecord::Migration
+  def up
+    rename_index :ems_events, "index_ems_events_on_vm_id",      "index_ems_events_on_vm_or_template_id"
+    rename_index :ems_events, "index_ems_events_on_dest_vm_id", "index_ems_events_on_dest_vm_or_template_id"
+  end
+
+  def down
+    rename_index :ems_events, "index_ems_events_on_vm_or_template_id",      "index_ems_events_on_vm_id"
+    rename_index :ems_events, "index_ems_events_on_dest_vm_or_template_id", "index_ems_events_on_dest_vm_id"
+  end
+end


### PR DESCRIPTION
Columns have been renamed from vm_id to vm_or_template_id, dest_vm_id to dest_vm_or_template_id.
But the indexes have not been updated.