### PR TITLE
Fix _x_gtl failing when view is nil

### DIFF
--- a/vmdb/app/views/layouts/_x_gtl.html.haml
+++ b/vmdb/app/views/layouts/_x_gtl.html.haml
@@ -11,7 +11,7 @@
 
 #gtl_div{:style => "height: inherit;background-color: #fff;"}
   - view       ||= @view
-  - table      = view.sub_table ? view.sub_table : view.table
+  - table      = view.sub_table ? view.sub_table : view.table unless view.nil?
   - action_url ||= "explorer"
   - @gtl_type = "grid" if @gtl_type.nil?
   - if view.nil? || table.data.length == 0
@@ -24,14 +24,15 @@
     - if @bottom_msg
       = h(@bottom_msg)
   #records_div{:style => rec_display}
-    - unless @embedded
-      - if render_flash_msg? && table.data.length > 0
-        = render :partial => "layouts/flash_msg"
-    - if @gtl_type.nil? || @gtl_type == "grid"
-      = render :partial => "layouts/gtl/grid", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url}
-    - elsif @gtl_type == "tile"
-      = render :partial => "layouts/gtl/tile", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url}
-    - elsif @gtl_type == "list"
-      = render :partial => "layouts/gtl/list", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url, :listicon_image => listicon_image}
+    - if table && table.data.length > 0
+      - unless @embedded
+        - if render_flash_msg?
+          = render :partial => "layouts/flash_msg"
+      - if @gtl_type.nil? || @gtl_type == "grid"
+        = render :partial => "layouts/gtl/grid", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url}
+      - elsif @gtl_type == "tile"
+        = render :partial => "layouts/gtl/tile", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url}
+      - elsif @gtl_type == "list"
+        = render :partial => "layouts/gtl/list", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url, :listicon_image => listicon_image}
     %br
     %br


### PR DESCRIPTION
In the templete, view was actually tested for nil but view.table wasn't.

Partially fixes #1544 in that "No records found" is shown instead of the error message.

Please note that this does not adress refreshing the left side instance list, nor the fact that the flash message is shown twice.