### PR TITLE
Externalizing Apache config parameters for 2.4 support

### DIFF
--- a/lib/appliance_console/certificate_authority.rb
+++ b/lib/appliance_console/certificate_authority.rb
@@ -108,8 +108,9 @@ module ApplianceConsole
       ).request
       if cert.complete?
         say "configuring apache to use certs"
-        FileUtils.cp("#{TEMPLATES}/etc/httpd/conf.d/cfme-https-cert.conf", "/etc/httpd/conf.d/cfme-https-cert.conf")
-        LinuxAdmin::Service.new("httpd").restart
+        FileUtils.cp("#{TEMPLATES}/etc/httpd/conf.d/cfme-https-cert.conf",
+                     Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join("etc/httpd/conf.d/cfme-https-cert.conf").to_s)
+        LinuxAdmin::Service.new(ENV['MIQ_APACHE_SERVICE_NAME']).restart
       end
       self.api = cert.status
     end

--- a/lib/appliance_console/external_httpd_authentication.rb
+++ b/lib/appliance_console/external_httpd_authentication.rb
@@ -81,7 +81,7 @@ module ApplianceConsole
 
     def post_activation
       say("\nRestarting sssd and httpd ...")
-      %w(sssd httpd).each { |service| LinuxAdmin::Service.new(service).restart }
+      ['sssd', ENV['MIQ_APACHE_SERVICE_NAME']].each { |service| LinuxAdmin::Service.new(service).restart }
 
       say("Configuring sssd to start upon reboots ...")
       LinuxAdmin::Service.new("sssd").enable

--- a/lib/appliance_console/external_httpd_configuration.rb
+++ b/lib/appliance_console/external_httpd_configuration.rb
@@ -18,8 +18,9 @@ EOS
       HTTP_KEYTAB         = "/etc/http.keytab"
 
       EXTERNAL_AUTH_FILE  = "conf.d/cfme-external-auth"
-      HTTPD_EXTERNAL_AUTH = "/etc/httpd/#{EXTERNAL_AUTH_FILE}"
-      HTTPD_CONFIG        = "/etc/httpd/conf.d/cfme-https-application.conf"
+
+      HTTPD_EXTERNAL_AUTH = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join("etc/httpd/#{EXTERNAL_AUTH_FILE}").to_s
+      HTTPD_CONFIG        = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join("etc/httpd/conf.d/cfme-https-application.conf").to_s
 
       GETSEBOOL_COMMAND   = "/usr/sbin/getsebool"
       SETSEBOOL_COMMAND   = "/usr/sbin/setsebool"
@@ -70,7 +71,7 @@ EOS
         config_file_write(config, HTTPD_CONFIG, timestamp)
 
         say("Restarting httpd ...")
-        LinuxAdmin::Service.new("httpd").restart
+        LinuxAdmin::Service.new(ENV['MIQ_APACHE_SERVICE_NAME']).restart
       end
 
       #

--- a/system/LINK/etc/default/evm
+++ b/system/LINK/etc/default/evm
@@ -5,9 +5,15 @@
 export RAILS_ENV=production
 export APPLIANCE=true
 export HOME=${HOME:-/root}
+
 # workaround for virtual memory spike observed with RHEL6
 export MALLOC_ARENA_MAX=1
 export MALLOC_MMAP_THRESHOLD=131072
+
+# Apache environment variables that MIQ scripts use
+export MIQ_APACHE_ROOT_DIR=/opt/rh/httpd24/root/
+export MIQ_APACHE_SERVICE_NAME=httpd24-httpd
+export MIQ_APACHE_PACKAGE_NAME=httpd24-httpd
 
 # Environment variables required to enable SSL for the Qpid C++ client.  This
 # allows CFME to collect OpenStack events from Qpid over SSL.
@@ -22,7 +28,17 @@ export QPID_LOAD_MODULE=/usr/lib64/qpid/client/sslconnector.so
 # - CFME does not currently support client ssl certificate for authentication
 export QPID_SSL_CERT_DB=/etc/qpid/certs
 
+# This is needed only if we are using Apache from SCL which is installed into
+# a different directory
+scl_apache=1
+if [ -n "$scl_apache" ] && [ ! -h /opt/rh/httpd24/root/var/www/html ]
+then
+  mv /opt/rh/httpd24/root/var/www/html /opt/rh/httpd24/root/var/www/html_24
+  ln -s /var/www/html /opt/rh/httpd24/root/var/www/html
+fi
+
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /opt/rh/postgresql92/enable ]] && source /opt/rh/postgresql92/enable
 [[ -s /opt/rh/nodejs010/enable ]] && source /opt/rh/nodejs010/enable
-[[ -s /etc/default/evm_productization ]] && source /etc/default/evm_productization
+[[ -s /opt/rh/httpd24/enable ]] && source /opt/rh/httpd24/enable
+export PATH=$PATH:/opt/rubies/ruby-2.0.0-p598/bin

--- a/system/cfme-setup.sh
+++ b/system/cfme-setup.sh
@@ -20,10 +20,11 @@ sed -i 's@ACTIVE_CONSOLES=/dev/tty\[1-6\]@ACTIVE_CONSOLES=/dev/tty3@' /etc/sysco
 setsebool -P httpd_can_network_connect on
 
 # backup the default ssl.conf
-mv /etc/httpd/conf.d/ssl.conf{,.orig}
+SSL_CONF_FILE=${MIQ_APACHE_ROOT_DIR}etc/httpd/conf.d/ssl.conf
+mv $SSL_CONF_FILE{,.orig}
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1020042
-cat <<'EOF' > /etc/httpd/conf.d/ssl.conf
+cat <<'EOF' > $SSL_CONF_FILE
 # This file intentionally left blank.  CFME maintains its own SSL
 # configuration.  The presence of this file prevents the version
 # supplied by mod_ssl from being installed when the mod_ssl package is

--- a/vmdb/app/models/miq_server/rhn_mirror.rb
+++ b/vmdb/app/models/miq_server/rhn_mirror.rb
@@ -2,7 +2,7 @@ require 'linux_admin'
 
 module MiqServer::RhnMirror
   extend ActiveSupport::Concern
-  APACHE_MIRROR_CONF_FILE = "/etc/httpd/conf.d/cfme-https-mirror.conf"
+  APACHE_MIRROR_CONF_FILE = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join("etc/httpd/conf.d/cfme-https-mirror.conf").to_s
   YUM_MIRROR_CONF_FILE    = "/etc/yum.repos.d/cfme-mirror.repo"
 
   def configure_rhn_mirror_client

--- a/vmdb/app/models/miq_ui_worker.rb
+++ b/vmdb/app/models/miq_ui_worker.rb
@@ -12,8 +12,8 @@ class MiqUiWorker < MiqWorker
     end
   end
 
-  BALANCE_MEMBER_CONFIG_FILE = '/etc/httpd/conf.d/cfme-balancer-ui.conf'
-  REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/cfme-redirects-ui'
+  BALANCE_MEMBER_CONFIG_FILE = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join('etc/httpd/conf.d/cfme-balancer-ui.conf').to_s
+  REDIRECTS_CONFIG_FILE      = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join('etc/httpd/conf.d/cfme-redirects-ui').to_s
   STARTING_PORT              = 3000
   LB_METHOD                  = :busy
   REDIRECTS                  = '/'

--- a/vmdb/app/models/miq_web_service_worker.rb
+++ b/vmdb/app/models/miq_web_service_worker.rb
@@ -2,8 +2,8 @@ class MiqWebServiceWorker < MiqWorker
   REQUIRED_ROLE = 'web_services'
   self.required_roles = [REQUIRED_ROLE]
 
-  BALANCE_MEMBER_CONFIG_FILE = '/etc/httpd/conf.d/cfme-balancer-ws.conf'
-  REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/cfme-redirects-ws'
+  BALANCE_MEMBER_CONFIG_FILE = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join('etc/httpd/conf.d/cfme-balancer-ws.conf').to_s
+  REDIRECTS_CONFIG_FILE      = Pathname.new(ENV['MIQ_APACHE_ROOT_DIR']).join('etc/httpd/conf.d/cfme-redirects-ws').to_s
   STARTING_PORT              = 4000
   LB_METHOD                  = :busy
   REDIRECTS                  = ['/Miqservices/', '/miqservices/', '/vmdbws/', '/api']

--- a/vmdb/lib/miq_apache.rb
+++ b/vmdb/lib/miq_apache.rb
@@ -79,7 +79,7 @@ module MiqApache
 
     def self.httpd_status
       begin
-        res = MiqUtil.runcmd('/etc/init.d/httpd status')
+        res = MiqUtil.runcmd("/etc/init.d/#{ENV['MIQ_APACHE_PACKAGE_NAME']} status")
       rescue RuntimeError => err
         res = err.to_s
         return false, res if res =~ /^httpd (is stopped|dead but pid file exists)$/
@@ -121,7 +121,7 @@ module MiqApache
     end
 
     def self.version
-       MiqUtil.runcmd("rpm -qa --queryformat '%{VERSION}' httpd")
+      MiqUtil.runcmd("rpm -qa --queryformat '%{VERSION}' #{ENV['MIQ_APACHE_PACKAGE_NAME']}")
     end
 
     def self.config_ok?

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
+ENV['MIQ_APACHE_ROOT_DIR'] ||= '/'
+ENV['MIQ_APACHE_SERVICE_NAME'] ||= 'httpd'
+ENV['MIQ_APACHE_PACKAGE_NAME'] ||= 'httpd'
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/autorun'
 require 'rspec/rails'


### PR DESCRIPTION
Software Collection Libraries (SCL) install different versions
of Apache in /opt/rh/httpdXX to differentiate the one that ships
with the OS.

These changes externalize the Apache config parameters so that we
can support a different version of Apache other than the standard one
by just changing the /etc/default/evm