### PR TITLE
Fixed values in pull downs on ownership screen

### DIFF
--- a/vmdb/app/views/shared/views/_ownership.html.haml
+++ b/vmdb/app/views/shared/views/_ownership.html.haml
@@ -12,7 +12,8 @@
           - if @edit[:ownership_items].length > 1
             - opts = [["<#{_("Don't change")}>", ApplicationController::CiProcessing::DONT_CHANGE_OWNER], ["<#{_('No Owner')}>", nil]]
           - else
-            - opts =  [["<#{_('No Owner')}>", nil]] + @users.sort
+            - opts =  [["<#{_('No Owner')}>", nil]]
+          - opts += @users.sort
           = select_tag("user_name",
             options_for_select(opts, @edit[:new][:user]),
             "data-miq_sparkle_on"  => true,
@@ -26,7 +27,8 @@
           - if @edit[:ownership_items].length > 1
             - opts = [["<#{_("Don't change")}>", ApplicationController::CiProcessing::DONT_CHANGE_OWNER], ["<#{_('No Group')}>", nil]]
           - else
-            - opts = [["<#{_("No Group")}>", nil]] + @groups.sort
+            - opts = [["<#{_("No Group")}>", nil]]
+          - opts += @groups.sort
           = select_tag("group_name",
             options_for_select(opts, @edit[:new][:group]),
             "data-miq_sparkle_on"  => true,


### PR DESCRIPTION
Fixed code to populate correct values in pull downs on ownership screen, this broke during haml conversion.

@dclarizio please review/test.