### PR TITLE
Patternfly styling cleanup 3

### DIFF
--- a/vmdb/app/assets/stylesheets/template.css.erb
+++ b/vmdb/app/assets/stylesheets/template.css.erb
@@ -259,9 +259,9 @@ div.panecontent .flobj { margin-left: 40px;}
 .flobj { position: absolute;z-index: auto;width: 72px;}
 .flobj p { margin: 0 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif !important;}
 .a72 { padding: 3px  0 0 5px; width: 28px; height: 28px;font-size: 1.3em;line-height: 1.8em;} 
-.b72 { padding: 3px 0 0 37px; width: 28px; height: 28px;font-size: 1.3em;line-height: 1.8em;}
+.b72 { padding: 3px 0 0 37px; font-size: 1.3em;line-height: 1.8em;}
 .c72 { padding: 38px 0 0 5px; width: 31px; height: 31px;font-size: 1.3em;line-height: 1.7em;}
-.d72 { padding: 38px 0 0 39px; width: 31px; height: 31px;font-size: 1.3em;line-height: 1.7em;}  
+.d72 { padding: 38px 0 0 39px; font-size: 1.3em;line-height: 1.7em;}  
 .e72 { padding: 6px  0 0 6px; width: 35px; height: 35px;font-size: 1.3em;line-height: 2em;}
 .f72 { padding: 22px 0 0 24px; width: 24px; height: 24px;}
 .g72 { padding: 16px 0 0 19px; width: 24px; height: 24px;}

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1768,7 +1768,7 @@ module ApplicationHelper
           ["about","rss","server_build","product_update","miq_policy","miq_ae_class",
            "miq_capacity_utilization","miq_capacity_planning","miq_capacity_bottlenecks","miq_capacity_waste","chargeback",
            "miq_ae_export","miq_ae_automate_button","miq_ae_tools","miq_policy_export","miq_policy_rsop","report",
-           "ops", "pxe", "exception"].include?(@layout) || 
+           "ops", "pxe", "exception"].include?(@layout) ||
           (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
         unless @explorer
           @show_taskbar = true

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1768,7 +1768,8 @@ module ApplicationHelper
           ["about","rss","server_build","product_update","miq_policy","miq_ae_class",
            "miq_capacity_utilization","miq_capacity_planning","miq_capacity_bottlenecks","miq_capacity_waste","chargeback",
            "miq_ae_export","miq_ae_automate_button","miq_ae_tools","miq_policy_export","miq_policy_rsop","report",
-           "ops","pxe","exception"].include?(@layout) || (@layout == "configuration" && @tabform != "ui_4"))
+           "ops", "pxe", "exception"].include?(@layout) || 
+          (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
         unless @explorer
           @show_taskbar = true
         end

--- a/vmdb/app/views/layouts/_breadcrumbs.html.haml
+++ b/vmdb/app/views/layouts/_breadcrumbs.html.haml
@@ -6,3 +6,5 @@
           = h(breadcrumbs[:name])
     %li.active
       = @title
+- else
+  %br

--- a/vmdb/app/views/layouts/_page_center.html.haml
+++ b/vmdb/app/views/layouts/_page_center.html.haml
@@ -28,23 +28,19 @@
       - elsif  @layout == "dashboard" && (controller.action_name == "show" || controller.action_name == "change_tab")
         .col-sm-12.col-md-12
           .cpage-header.page-header-bleed-right
-            %div{:style => "margin-top: 27px"}
+            %br
             = render :partial => '/layouts/tabs'
           = yield
-
           /  .col-sm-4.col-md-3.sidebar-pf.sidebar-pf-right
           /  .sidebar-header.sidebar-header-bleed-left.sidebar-header-bleed-right
 
       - else
-        .col-sm-12.col-md-12
+        .col-sm-12.col-md-12.max-height
           - if taskbar_in_header?
             .row#main_taskbar
               .col-md-12
                 = render :partial => "layouts/taskbar"
-          / .row#main_search
-          /   .col-md-12
-          /     = render :partial => '/layouts/searchbarNEW'
-          .row{:style => "margin-top: 27px"}
+          .row
             .col-md-12
               = render :partial => "layouts/breadcrumbs"
               - if layout_uses_tabs?
@@ -52,17 +48,3 @@
           .row#main_content
             .col-md-12
               = yield
-
-
-      / #side-nav.col-md-2
-      /   .sidebar-header.sidebar-header-bleed-left.sidebar-header-bleed-right
-      /     %ul.nav.nav-list.affix
-      /       %li
-      /         %a{:href => "#one"}
-      /           One
-      /       %li
-      /         %a{:href => "#two"}
-      /           Two
-      /       %li
-      /         %a{:href => "#three"}
-      /           Three


### PR DESCRIPTION
* Added class to allow scrolling for screens without listnavs (this was only an issue beyond the breakpoint)
* Added vertical spacing when breadcrumb not present  (needed for tabs)
* Fixed Quadicon padding issue cause by conflict with Pattermfly

Issue: #1574