### PR TITLE
Dynamic checkbox dialogs

### DIFF
--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -211,6 +211,18 @@ module ApplicationController::DialogRunner
     end
   end
 
+  def dynamic_checkbox_refresh
+    @edit = session[:edit]
+
+    dialog = @edit[:wf].dialog
+
+    field = dialog.field(params[:name])
+
+    respond_to do |format|
+      format.json { render :json => {:field_name => field.name, :checked => field.checked?}, :status => 200 }
+    end
+  end
+
   private     #######################
 
   def dialog_reset_form

--- a/vmdb/app/models/dialog_field_check_box.rb
+++ b/vmdb/app/models/dialog_field_check_box.rb
@@ -6,7 +6,7 @@ class DialogFieldCheckBox < DialogField
   after_initialize :default_resource_action
 
   def checked?
-    %w(1 t).include?(default_value)
+    default_value == "t"
   end
 
   def default_value

--- a/vmdb/app/models/dialog_field_check_box.rb
+++ b/vmdb/app/models/dialog_field_check_box.rb
@@ -1,7 +1,47 @@
 class DialogFieldCheckBox < DialogField
+  AUTOMATE_VALUE_FIELDS = %w(default_value required)
+
+  has_one :resource_action, :as => :resource, :dependent => :destroy
+
+  after_initialize :default_resource_action
+
+  def checked?
+    ['1', 't'].include?(default_value)
+  end
+
+  def default_value
+    write_attribute(:default_value, values_from_automate) if dynamic
+    read_attribute(:default_value)
+  end
+
+  def initial_values
+    false
+  end
+
+  def script_error_values
+    "<Script error>"
+  end
+
+  def normalize_automate_values(automate_hash)
+    self.class::AUTOMATE_VALUE_FIELDS.each do |key|
+      send("#{key}=", automate_hash[key]) if automate_hash.key?(key)
+    end
+
+    return initial_values if automate_hash["default_value"].blank?
+    automate_hash["default_value"].to_s
+  end
+
   private
+
+  def default_resource_action
+    build_resource_action if resource_action.nil?
+  end
 
   def required_value_error?
     value != "t"
+  end
+
+  def values_from_automate
+    DynamicDialogFieldValueProcessor.values_from_automate(self)
   end
 end

--- a/vmdb/app/models/dialog_field_check_box.rb
+++ b/vmdb/app/models/dialog_field_check_box.rb
@@ -6,7 +6,7 @@ class DialogFieldCheckBox < DialogField
   after_initialize :default_resource_action
 
   def checked?
-    ['1', 't'].include?(default_value)
+    %w(1 t).include?(default_value)
   end
 
   def default_value

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -36,7 +36,7 @@
             &nbsp;
             =_('Only 1 Date or Date/Time element can be present in a Dialog')
 
-      - if %w(DialogFieldRadioButton DialogFieldTextAreaBox DialogFieldTextBox).include?(@edit[:field_typ])
+      - if %w(DialogFieldRadioButton DialogFieldTextAreaBox DialogFieldTextBox DialogFieldCheckBox).include?(@edit[:field_typ])
         %tr
           %td.key=_('Dynamic')
           %td

--- a/vmdb/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -37,8 +37,7 @@
                           = text_area_tag(field.id, field.sample_text, :size => "50x6", :disabled => true)
 
                         - when "DialogFieldCheckBox"
-                          - checked = field.default_value != "f"
-                          = check_box_tag("field.id", value = "1", checked = checked, :disabled => true)
+                          = check_box_tag("field.id", value = "1", false, :disabled => true)
                         - when "DialogFieldDateControl", "DialogFieldDateTimeControl"
                           - if field.show_past_dates
                             :javascript

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -72,12 +72,28 @@
             });
 
       - when 'DialogFieldCheckBox'
-        - checked = ['1', 't'].include?(wf.value(field.name))
-        = check_box_tag(field.name, "1", checked,
+        = check_box_tag(field.name, "1", field.checked?,
                         :disabled                   => !edit,
+                        :class                      => "dynamic-checkbox-#{field.id}",
                         "data-miq_sparkle_on"       => true,
                         "data-miq_sparkle_off"      => true,
                         "data-miq_observe_checkbox" => {:url => url}.to_json)
+
+        - if field.dynamic && field.show_refresh_button?
+          = button_tag('Refresh', :id => "refresh-dynamic-checkbox-#{field.id}", :class => "btn btn-default")
+
+          :javascript
+            $('#refresh-dynamic-checkbox-#{field.id}').click(function() {
+              miqSparkleOn();
+
+              var fieldId = "#{field.id}";
+              var fieldName = "#{field.name}";
+
+              $.post('dynamic_checkbox_refresh', {name: fieldName}, function(data) {
+                $('.dynamic-checkbox-' + fieldId).prop('checked', data.checked);
+                miqSparkleOff();
+              });
+            });
 
       - when 'DialogFieldDateControl', 'DialogFieldDateTimeControl'
         - t = Time.now.in_time_zone(session[:user_tz]) + 1.day

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -36,6 +36,7 @@ Vmdb::Application.routes.draw do
   dialog_runner_post = %w(
     dialog_field_changed
     dialog_form_button_pressed
+    dynamic_checkbox_refresh
     dynamic_list_refresh
     dynamic_radio_button_refresh
     dynamic_text_box_refresh
@@ -351,6 +352,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         create
+        dynamic_checkbox_refresh
         dynamic_list_refresh
         dynamic_radio_button_refresh
         dynamic_text_box_refresh

--- a/vmdb/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/vmdb/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -40,4 +40,24 @@ describe CatalogController do
       end
     end
   end
+
+  describe "#dynamic_checkbox_refresh" do
+    include_context "valid session"
+
+    let(:dialog) { active_record_instance_double("Dialog") }
+    let(:wf) { double(:dialog => dialog) }
+    let(:dialog_field) { active_record_instance_double("DialogFieldCheckBox", :checked? => true, :name => "potato") }
+
+    let(:params)  { {:name => "name"} }
+    let(:session) { {:edit => {:wf => wf}} }
+
+    before do
+      dialog.stub(:field).with("name").and_return(dialog_field)
+    end
+
+    it "returns the correct json response" do
+      xhr :post, :dynamic_checkbox_refresh, params, session
+      expect(response.body).to eq({:field_name => "potato", :checked => true}.to_json)
+    end
+  end
 end

--- a/vmdb/spec/models/dialog_field_check_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_check_box_spec.rb
@@ -1,6 +1,124 @@
 require "spec_helper"
 
 describe DialogFieldCheckBox do
+  describe "#default_value" do
+    let(:dialog_field) { described_class.new(:dynamic => dynamic, :default_value => "test") }
+
+    context "when the dialog field is dynamic" do
+      let(:dynamic) { true }
+
+      before do
+        DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("processor")
+      end
+
+      it "returns the values from the value processor" do
+        expect(dialog_field.default_value).to eq("processor")
+      end
+    end
+
+    context "when the dialog field is not dynamic" do
+      let(:dynamic) { false }
+
+      it "returns the current value" do
+        expect(dialog_field.default_value).to eq("test")
+      end
+    end
+  end
+
+  describe "#checked?" do
+    let(:dialog_field) { described_class.new(:default_value => default_value) }
+
+    context "when the default value is 't'" do
+      let(:default_value) { "t" }
+
+      it "returns true" do
+        expect(dialog_field.checked?).to be_true
+      end
+    end
+
+    context "when the default value is '1'" do
+      let(:default_value) { "1" }
+
+      it "returns true" do
+        expect(dialog_field.checked?).to be_true
+      end
+    end
+
+    context "when the default value is anything else" do
+      let(:default_value) { "potato" }
+
+      it "returns false" do
+        expect(dialog_field.checked?).to be_false
+      end
+    end
+  end
+
+  describe "#initial_values" do
+    let(:dialog_field) { described_class.new }
+
+    it "returns false" do
+      expect(dialog_field.initial_values).to be_false
+    end
+  end
+
+  describe "#script_error_values" do
+    let(:dialog_field_checkbox) { described_class.new }
+
+    it "returns the script error value" do
+      expect(dialog_field_checkbox.script_error_values).to eq("<Script error>")
+    end
+  end
+
+  describe "#normalize_automate_values" do
+    let(:dialog_field) { described_class.new }
+    let(:automate_hash) do
+      {
+        "default_value"  => default_value,
+        "required"       => true
+      }
+    end
+
+    shared_examples_for "DialogFieldCheckbox#normalize_automate_values" do
+      before do
+        dialog_field.normalize_automate_values(automate_hash)
+      end
+
+      it "sets the required" do
+        expect(dialog_field.required).to be_true
+      end
+    end
+
+    context "when the automate hash has a default value" do
+      let(:default_value) { 1 }
+
+      it_behaves_like "DialogFieldCheckbox#normalize_automate_values"
+
+      it "sets the default value" do
+        dialog_field.normalize_automate_values(automate_hash)
+        expect(dialog_field.default_value).to eq(1)
+      end
+
+      it "returns the default value in a string format" do
+        expect(dialog_field.normalize_automate_values(automate_hash)).to eq("1")
+      end
+    end
+
+    context "when the automate hash does not have a default value" do
+      let(:default_value) { nil }
+
+      it_behaves_like "DialogFieldCheckbox#normalize_automate_values"
+
+      it "sets the default value" do
+        dialog_field.normalize_automate_values(automate_hash)
+        expect(dialog_field.default_value).to eq(nil)
+      end
+
+      it "returns the initial values" do
+        expect(dialog_field.normalize_automate_values(automate_hash)).to eq(false)
+      end
+    end
+  end
+
   describe "#validate" do
     let(:dialog_field_check_box) do
       described_class.new(:label    => 'dialog_field_check_box',

--- a/vmdb/spec/models/dialog_field_check_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_check_box_spec.rb
@@ -36,16 +36,8 @@ describe DialogFieldCheckBox do
       end
     end
 
-    context "when the default value is '1'" do
-      let(:default_value) { "1" }
-
-      it "returns true" do
-        expect(dialog_field.checked?).to be_true
-      end
-    end
-
     context "when the default value is anything else" do
-      let(:default_value) { "potato" }
+      let(:default_value) { "1" }
 
       it "returns false" do
         expect(dialog_field.checked?).to be_false

--- a/vmdb/spec/models/dialog_field_check_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_check_box_spec.rb
@@ -73,8 +73,8 @@ describe DialogFieldCheckBox do
     let(:dialog_field) { described_class.new }
     let(:automate_hash) do
       {
-        "default_value"  => default_value,
-        "required"       => true
+        "default_value" => default_value,
+        "required"      => true
       }
     end
 

--- a/vmdb/spec/routing/shared_examples/dialog_runner_examples.rb
+++ b/vmdb/spec/routing/shared_examples/dialog_runner_examples.rb
@@ -2,6 +2,7 @@ shared_examples_for "A controller that has dialog runner routes" do
   %w(
     dialog_field_changed
     dialog_form_button_pressed
+    dynamic_checkbox_refresh
     dynamic_list_refresh
     dynamic_radio_button_refresh
     dynamic_text_box_refresh


### PR DESCRIPTION
Allows users to set checkbox settings dynamically.

Related Trello story: https://trello.com/c/3kMuXyDv

@gmcculloug Right now, it is determining the checked state based on if the value is '1' or 't' (this is how it was before). Should we change this to accept more values, such as true, "true", 1, etc, or is whoever is creating the dynamic checkbox be expected to make the conversion to '1' or 't'?