### PR TITLE
Distinguish class(path) and association

### DIFF
--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -1005,6 +1005,7 @@ en:
       template_infra:              Template
       vm:                          VM and Instance
       vm_cloud:                    Instance
+      vm_clouds:                   Instances
       vm_infra:                    Virtual Machine
       vm_or_template:              Virtual Machine
       vms:                         VMs

--- a/vmdb/spec/models/miq_expression/model_details_spec.rb
+++ b/vmdb/spec/models/miq_expression/model_details_spec.rb
@@ -87,18 +87,28 @@ describe MiqExpression do
   context ".build_relats" do
     it "AvailabilityZone" do
       result = described_class.build_relats("AvailabilityZone")
-      expect(result.fetch_path(:reflections, :ext_management_system, :parent, :path).split(".").last).to eq("ems_cloud")
+      expect(result.fetch_path(:reflections, :ext_management_system, :parent, :class_path).split(".").last).to eq("ems_cloud")
+      expect(result.fetch_path(:reflections, :ext_management_system, :parent, :assoc_path).split(".").last).to eq("ext_management_system")
     end
 
     it "VmInfra" do
       result = described_class.build_relats("VmInfra")
-      expect(result.fetch_path(:reflections, :evm_owner, :parent, :path).split(".").last).to eq("evm_owner")
-      expect(result.fetch_path(:reflections, :linux_initprocesses, :parent, :path).split(".").last).to eq("linux_initprocesses")
+      expect(result.fetch_path(:reflections, :evm_owner, :parent, :class_path).split(".").last).to eq("evm_owner")
+      expect(result.fetch_path(:reflections, :evm_owner, :parent, :assoc_path).split(".").last).to eq("evm_owner")
+      expect(result.fetch_path(:reflections, :linux_initprocesses, :parent, :class_path).split(".").last).to eq("linux_initprocesses")
+      expect(result.fetch_path(:reflections, :linux_initprocesses, :parent, :assoc_path).split(".").last).to eq("linux_initprocesses")
     end
 
     it "Vm" do
       result = described_class.build_relats("Vm")
-      expect(result.fetch_path(:reflections, :users, :parent, :path).split(".").last).to eq("users")
+      expect(result.fetch_path(:reflections, :users, :parent, :class_path).split(".").last).to eq("users")
+      expect(result.fetch_path(:reflections, :users, :parent, :assoc_path).split(".").last).to eq("users")
+    end
+
+    it "OrchestrationStack" do
+      result = described_class.build_relats("OrchestrationStack")
+      expect(result.fetch_path(:reflections, :vms, :parent, :class_path).split(".").last).to eq("vm_clouds")
+      expect(result.fetch_path(:reflections, :vms, :parent, :assoc_path).split(".").last).to eq("vms")
     end
   end
 
@@ -115,9 +125,16 @@ describe MiqExpression do
       expect(subject).to eq(@ref.name.to_s)
     end
 
-    it "when class name is a subclass of association name" do
-      @ref = AvailabilityZone.reflect_on_association(:ext_management_system)
-      expect(subject).to eq(@ref.klass.to_s.underscore)
+    context "when class name is a subclass of association name" do
+      it "one_to_one relation" do
+        @ref = AvailabilityZone.reflect_on_association(:ext_management_system)
+        expect(subject).to eq(@ref.klass.model_name.singular)
+      end
+
+      it "one_to_many relation" do
+        @ref = OrchestrationStack.reflect_on_association(:vms)
+        expect(subject).to eq(@ref.klass.model_name.plural)
+      end
     end
   end
 end


### PR DESCRIPTION
There was a problem with `MiqExpress.model_details` when the model has an association of a subclass. For example model `OrchestrationStack`
```!ruby
has_many   :vms, :class_name => "VmCloud"
```
`get_relats(model)` results a `parent` hash like
```!ruby
:vms:
    :columns:
     ...
    :parent:
      :macro: :has_many
      :path: OrchestrationStack.vm_cloud
      :assoc: :vms
      :assoc_class: VmCloud
      :root: OrchestrationStack
      :direction: :down
      :multivalue: true
```
`model_details("OrchestrationStack", :typ=>"count")` for association `vms` calls `get_table_details("OrchestrationStack.vm_cloud")`, which returns `["OrchestrationStack.Instance", "OrchestrationStack.vm_cloud"]`. The first element is desired because it translates an accurate human readable term. The second element is used to retrieve instances. Here it is the problem, because `OrchestrationStack.vm_cloud` is not a valid method. It should be `OrchestrationStack.vms` instead.

The attempt fix is to translate `parent[:path]` to human readable while keep the association for instances retrieval. 

The same fix applies to the case `model_details("OrchestrationStack", :typ=>"find")`. I have not changed anything for the case `typ=>"tag"`. Maybe we should.

The second part of the fix is to correct pluralization for the path. In the above example the relation hash `parent[:path]` should be `OrchestrationStack.vm_clouds` rather than `OrchestrationStack.vm_cloud`. The resulting translation should be `Instances` rather than `Instance`.