### PR TITLE
Filter out EventEx by default to avoid event storm damage.

### DIFF
--- a/vmdb/config/event_handling.tmpl.yml
+++ b/vmdb/config/event_handling.tmpl.yml
@@ -1345,6 +1345,7 @@ filtered_events:
   AlarmSnmpFailedEvent:
   AlarmStatusChangedEvent:
   AlreadyAuthenticatedSessionEvent:
+  EventEx:
   UNASSIGNED:                               # RHEV filtered events
   USER_REMOVE_VG:
   USER_REMOVE_VG_FAILED:


### PR DESCRIPTION
Though I don't necessarily agree with blocking EventEx wholesale as
there may be important events lost, the opposing argument is that, in
practice, when there is an event storm, they are usually EventEx events,
and the event storm brings down the entire system.  We have experienced
this many times at customer sites, and the downside is not worth the
upside.

Users can remove this value from the filtering if needed, and put in
more specific filtering of events.  Additionally, we still cut a log
message when we filter out the event, so its presence is still available
in the log.

https://bugzilla.redhat.com/show_bug.cgi?id=1079489