### PR TITLE
Upgrade io-extra for Ruby 2.2 support

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -25,7 +25,7 @@ gem "ffi",                  "~>1.9.3",       :require => false
 gem "ffi-vix_disk_lib",     "~>1.0.1",       :require => false  # used by lib/VixDiskLib
 gem "fog",                  "~>1.28.0",      :require => false
 gem "httpclient",           "~>2.5.3",       :require => false
-gem "io-extra",             "=1.2.6",        :require => false
+gem "io-extra",             "~>1.2.8",       :require => false
 gem "linux_admin",          ">=0.10", "<1",  :require => false
 gem "log4r",                "=1.1.8",        :require => false
 gem "memoist",              "~>0.11.0",      :require => false

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -25,7 +25,7 @@ class RawBlockIO
     @seekPos        = 0
 
     # Enable directio (raw)
-    @rawDisk_file.directio = 1
+    @rawDisk_file.directio = IO::DIRECTIO_ON
 
     $log.debug "RawBlockIO: opened #{@filename}, size = #{@size} (#{@sizeInBlocks} blocks)"
   end


### PR DESCRIPTION
@roliveri  Please review.  I can't even start to run our app on Ruby 2.2 unless I upgrade this.

Changelog:

```
== 1.2.8 - 29-Dec-2014
* Updated for compatibility with Ruby 2.2.x.

== 1.2.7 - 10-Aug-2013
* Direct IO is now supported on Darwin, and some bugs in the directio
  methods have been fixed. Thanks go to Genki Takiuchi for the patches.
* Fixed a bug in fdwalk and closefrom when using Ruby 1.9.3 where
  closing reserved file descriptors would segfault the interpreter.
  Thanks go to Eric Wong for the patch.
* Fixed a bug in the fdwalk method where it was not honoring the
  lowfd argument, and added a test for it.
* The rb_thread_call_without_gvl function is now used internally in
  place of rb_thread_blocking_region for Ruby 2.x.
```