### PR TITLE
Breadcrumb trail contains an extra 'crumb' that needs to be removed

### DIFF
--- a/vmdb/app/views/layouts/_breadcrumbs.html.haml
+++ b/vmdb/app/views/layouts/_breadcrumbs.html.haml
@@ -1,6 +1,6 @@
 - if @breadcrumbs && @breadcrumbs.length > 1
   %ol.breadcrumb
-    - @breadcrumbs.each do |breadcrumbs|
+    - @breadcrumbs[0...-1].each do |breadcrumbs|
       %li
         %a{:href => breadcrumbs[:url], :onclick => "return miqCheckForChanges()"}
           = h(breadcrumbs[:name])


### PR DESCRIPTION
This was introduced in PR #1370 (during the erb->haml conversion)

I came across this issue while working on https://bugzilla.redhat.com/show_bug.cgi?id=1121759
Notice the extra path in the breadcrumb trail in the attached image.

![screen shot 2015-02-09 at 1 06 49 pm](https://cloud.githubusercontent.com/assets/1538216/6115918/ee5d074a-b05d-11e4-9b35-57c8b9549be2.png)

