### PR TITLE
Generic fix for all breadcrumb related issues in vm controller

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1253,6 +1253,7 @@ class ApplicationController < ActionController::Base
   # Handle the breadcrumb array by either adding, or resetting to, the passed in breadcrumb
   def drop_breadcrumb(new_bc, onlyreplace=false) # if replace = true, only add this bc if it was already there
     # if the breadcrumb is in the array, remove it and all below by counting how many to pop
+    return if skip_breadcrumb?
     remove = 0
     @breadcrumbs.each do |bc|
       if remove > 0         # already found a match,
@@ -2737,5 +2738,9 @@ class ApplicationController < ActionController::Base
 
   def flip_sort_direction(direction)
     direction == "ASC" ? "DESC" : "ASC" # flip ascending/descending
+  end
+
+  def skip_breadcrumb?
+    false
   end
 end

--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -369,21 +369,16 @@ module ApplicationController::CiProcessing
   def reconfigure_update
     return unless load_edit("reconfigure__new")
     reconfigure_get_form_vars
-    url = @breadcrumbs[1][:url].split('/')
     case params[:button]
     when "cancel"
-      flash = _("VM Reconfigure Request was cancelled by the user")
+      add_flash(_("VM Reconfigure Request was cancelled by the user"))
       if @edit[:explorer]
-        add_flash(flash)
         @sb[:action] = nil
         replace_right_cell
       else
+        session[:flash_msgs] = @flash_array
         render :update do |page|
-          if url[2] == "show"
-            page.redirect_to :controller=>url[1], :action =>url[2], :id=>url[3], :flash_msg=>flash
-          else
-            page.redirect_to :action=>@lastaction, :flash_msg=>flash
-          end
+          page.redirect_to(@breadcrumbs[-2][:url])
         end
       end
     when "submit"
@@ -962,7 +957,7 @@ module ApplicationController::CiProcessing
                         } )
     else
       @breadcrumbs = Array.new
-      bc_name = breadcrumb_name
+      bc_name = breadcrumb_name(model)
       bc_name += " - " + session["#{self.class.session_key_prefix}_type".to_sym].titleize if session["#{self.class.session_key_prefix}_type".to_sym]
       bc_name += " (filtered)" if @filters && (!@filters[:tags].blank? || !@filters[:cats].blank?)
       action = %w(container service vm_cloud vm_infra vm_or_template).include?(self.class.table_name) ? "explorer" : "show_list"
@@ -979,7 +974,7 @@ module ApplicationController::CiProcessing
     end
   end
 
-  def breadcrumb_name
+  def breadcrumb_name(_model)
     ui_lookup_for_model(self.class.model_name).pluralize
   end
 

--- a/vmdb/app/controllers/ems_cluster_controller.rb
+++ b/vmdb/app/controllers/ems_cluster_controller.rb
@@ -291,7 +291,7 @@ class EmsClusterController < ApplicationController
     return label, condition, breadcrumb_suffix
   end
 
-  def breadcrumb_name
+  def breadcrumb_name(_model)
     title_for_clusters
   end
 

--- a/vmdb/app/controllers/host_controller.rb
+++ b/vmdb/app/controllers/host_controller.rb
@@ -630,7 +630,7 @@ class HostController < ApplicationController
 
   private ############################
 
-  def breadcrumb_name
+  def breadcrumb_name(_model)
     title_for_hosts
   end
 

--- a/vmdb/app/controllers/mixins/vm_show_mixin.rb
+++ b/vmdb/app/controllers/mixins/vm_show_mixin.rb
@@ -165,4 +165,8 @@ module VmShowMixin
     session[:polArr]          = @polArr unless @polArr.nil?
     session[:policy_options]  = @policy_options unless @policy_options.nil?
   end
+
+  def breadcrumb_name(model)
+    ui_lookup_for_model(model || self.class.model_name).pluralize
+  end
 end

--- a/vmdb/app/controllers/provider_foreman_controller.rb
+++ b/vmdb/app/controllers/provider_foreman_controller.rb
@@ -816,7 +816,7 @@ class ProviderForemanController < ApplicationController
     @flash_array = nil if params[:button] != "reset"
   end
 
-  def breadcrumb_name
+  def breadcrumb_name(_model)
     "#{ui_lookup(:ui_title => 'foreman')} #{ui_lookup(:model => 'ExtManagementSystem')}"
   end
 

--- a/vmdb/app/controllers/vm_cloud_controller.rb
+++ b/vmdb/app/controllers/vm_cloud_controller.rb
@@ -85,4 +85,8 @@ class VmCloudController < ApplicationController
   def tagging_explorer_controller?
     @explorer
   end
+
+  def skip_breadcrumb?
+    controller_referrer? && breadcrumb_prohibited_for_action?
+  end
 end

--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1478,6 +1478,10 @@ module VmCommon
         get_node_info("root")
         return
       else
+        if params[:id].nil?
+          @breadcrumbs.clear
+          drop_breadcrumb({:name => breadcrumb_name(model), :url => "/#{controller_name}/explorer"}, false)
+        end
         @right_cell_text = _("%{model} \"%{name}\"") % {:name=>@record.name, :model=>"#{ui_lookup(:model => model && model != "VmOrTemplate" ? model : TreeBuilder.get_model_for_prefix(@nodetype))}"}
       end
     else      # Get list of child VMs of this node

--- a/vmdb/app/controllers/vm_infra_controller.rb
+++ b/vmdb/app/controllers/vm_infra_controller.rb
@@ -74,4 +74,8 @@ class VmInfraController < ApplicationController
   def tagging_explorer_controller?
     @explorer
   end
+
+  def skip_breadcrumb?
+    controller_referrer? && breadcrumb_prohibited_for_action?
+  end
 end

--- a/vmdb/app/controllers/vm_or_template_controller.rb
+++ b/vmdb/app/controllers/vm_or_template_controller.rb
@@ -56,4 +56,8 @@ class VmOrTemplateController < ApplicationController
   def tagging_explorer_controller?
     @explorer
   end
+
+  def skip_breadcrumb?
+    controller_referrer? && breadcrumb_prohibited_for_action?
+  end
 end

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2913,5 +2913,13 @@ module ApplicationHelper
     end
   end
 
+  def controller_referrer?
+    controller_name == Rails.application.routes.recognize_path(request.referrer)[:controller]
+  end
+
+  def breadcrumb_prohibited_for_action?
+    !%w(accordion_select tree_select).include?(action_name)
+  end
+
   attr_reader :big_iframe
 end

--- a/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
@@ -225,7 +225,7 @@ describe HostController do
     end
 
     it "plularizes breadcrumb name" do
-      expect(controller.send(:breadcrumb_name)).to eq("Hosts")
+      expect(controller.send(:breadcrumb_name, nil)).to eq("Hosts")
     end
   end
 end

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -239,7 +239,7 @@ describe ProviderForemanController do
   end
 
   it "singularizes breadcrumb name" do
-    expect(controller.send(:breadcrumb_name)).to eq("#{ui_lookup(:ui_title => "foreman")} Provider")
+    expect(controller.send(:breadcrumb_name, nil)).to eq("#{ui_lookup(:ui_title => "foreman")} Provider")
   end
 
   it "renders tagging editor" do

--- a/vmdb/spec/controllers/vm_or_template_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_or_template_controller_spec.rb
@@ -114,4 +114,33 @@ describe VmOrTemplateController do
       end
     end
   end
+
+  context "skip or drop breadcrumb" do
+    before do
+      session[:settings] = {:views => {}, :perpage => {:list => 10}}
+      session[:userid] = User.current_user.userid
+      session[:eligible_groups] = []
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+      @vm_or_template = VmOrTemplate.create(:name     => "test_vm_or_template",
+                                            :location => "test_vm_or_template_location",
+                                            :vendor   => "vmware")
+      get :explorer
+      request.env['HTTP_REFERER'] = request.fullpath
+    end
+
+    it 'skips dropping a breadcrumb when a button action is executed' do
+      post :x_button, :id => @vm_or_template.id, :pressed => 'miq_template_ownership'
+      breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
+      expect(breadcrumbs.size).to eq(1)
+      expect(breadcrumbs).to include(:name => "VMs and Instances", :url => "/vm_or_template/explorer")
+    end
+
+    it 'drops a breadcrumb when an action allowing breadcrumbs is executed' do
+      post :accordion_select, :id => "templates_images_filter"
+      breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
+      expect(breadcrumbs.size).to eq(1)
+      expect(breadcrumbs).to include(:name => "VM Templates and Images", :url => "/vm_or_template/explorer")
+    end
+  end
 end


### PR DESCRIPTION
When in VM Summary screen, breadcrumb path should be created only when transitioning into non-vm_infra controllers. This would generically fix all breadcrumb issues related to VMs.

https://bugzilla.redhat.com/show_bug.cgi?id=1121759
https://bugzilla.redhat.com/show_bug.cgi?id=1195401