### PR TITLE
CGI Escape user/pw in proxy settings

### DIFF
--- a/vmdb/lib/vmdb/util.rb
+++ b/vmdb/lib/vmdb/util.rb
@@ -14,7 +14,9 @@ module VMDB
       proxy = proxy.dup
 
       user     = proxy.delete(:user)
+      user     &&= CGI.escape(user)
       password = proxy.delete(:password)
+      password &&= CGI.escape(password)
       userinfo = "#{user}:#{password}".chomp(":") unless user.blank?
 
       proxy[:userinfo]   = userinfo

--- a/vmdb/spec/lib/vmdb/util_spec.rb
+++ b/vmdb/spec/lib/vmdb/util_spec.rb
@@ -37,6 +37,15 @@ describe VMDB::Util do
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321)
     end
 
+    it "with unescaped user value" do
+      password = "secret#"
+      config = {:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => password}}
+      VMDB::Config.any_instance.stub(:config => config)
+      userinfo = "testuser:secret%23"
+      uri_parts = {:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => userinfo}
+      described_class.http_proxy_uri.should == URI::Generic.build(uri_parts)
+    end
+
     it "with scheme overridden" do
       VMDB::Config.any_instance.stub(:config => {:http_proxy => {:scheme => "https", :host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"}})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "https", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser:secret")


### PR DESCRIPTION
Usernames or passwords used in the http_proxy setting that use non-url-friendly
characters cause the following error:

  URI::InvalidComponentError: bad component(expected user component)

By escaping the username and password, this error is avoided.

https://bugzilla.redhat.com/show_bug.cgi?id=1186502