### PR TITLE
Fix flash message click handler javascript error

### DIFF
--- a/vmdb/app/assets/javascripts/import.js
+++ b/vmdb/app/assets/javascripts/import.js
@@ -54,7 +54,7 @@ var clearMessages = function() {
 
 var flashMessageClickHandler = function() {
   clearMessages();
-  this.hide();
+  $(this).hide();
 };
 
 var showSuccessMessage = function(message) {


### PR DESCRIPTION
Found this while I was fixing a different bug.

Easiest way to see it is to go to Cloud Intelligence -> Reports -> Import/Export -> Widgets. Import something so that a flash message appears (can be anything since it happens on error messages too). Click on the flash message to get rid of it, it should go away instead of erroring.