### PR TITLE
Add Rails cops to rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ SpaceInsideHashLiteralBraces:
 #
 # Enabled/Disabled
 #
+AllCops:
+  RunRailsCops: true
 Documentation:
   Enabled: false
 Encoding:


### PR DESCRIPTION
I didn't realize Rails cops were disabled by default...this enables them.

cc @skateman 