### PR TITLE
Changed role_allows? method to return true for common hidden features.

### DIFF
--- a/vmdb/app/models/miq_product_feature.rb
+++ b/vmdb/app/models/miq_product_feature.rb
@@ -28,6 +28,10 @@ class MiqProductFeature < ActiveRecord::Base
     feat[:parent] if feat
   end
 
+  def self.parent_for_feature(identifier)
+    find_by_identifier(feature_parent(identifier))
+  end
+
   def self.feature_children(identifier)
     feat = self.features[identifier.to_s]
     children = (feat && !feat[:hidden] ? feat[:children] : [])

--- a/vmdb/app/models/user.rb
+++ b/vmdb/app/models/user.rb
@@ -176,7 +176,13 @@ class User < ActiveRecord::Base
     return false if self.miq_user_role.nil?
     feature = MiqProductFeature.find_by_identifier(options[:identifier])
     identifiers = {:identifiers => [options[:identifier]]}
-    feature.try(:hidden) ? miq_user_role.allows_any?(identifiers) : miq_user_role.allows?(options)
+    if feature.try(:hidden)
+      parent_feature = MiqProductFeature.parent_for_feature(options[:identifier])
+      # always return true for common features that are hidden and are under hidden parent
+      parent_feature.try(:hidden) ? true : miq_user_role.allows_any?(identifiers)
+    else
+      miq_user_role.allows?(options)
+    end
   end
 
   def role_allows_any?(options={})

--- a/vmdb/spec/controllers/application_controller_spec.rb
+++ b/vmdb/spec/controllers/application_controller_spec.rb
@@ -33,8 +33,8 @@ describe ApplicationController do
 
   context "#assert_privileges" do
     before do
-      EvmSpecHelper.seed_specific_product_features("host_new", "host_edit")
-      feature = MiqProductFeature.find_all_by_identifier("host_new")
+      EvmSpecHelper.seed_specific_product_features("host_new", "host_edit", "perf_reload")
+      feature = MiqProductFeature.find_all_by_identifier(["host_new"])
       test_user_role  = FactoryGirl.create(:miq_user_role,
                                            :name                 => "test_user_role",
                                            :miq_product_features => feature)
@@ -55,6 +55,12 @@ describe ApplicationController do
       lambda do
         controller.send(:assert_privileges, "host_edit")
       end.should raise_error(MiqException::RbacPrivilegeException, msg)
+    end
+
+    it "should not raise an error for common hidden feature under a hidden parent" do
+      lambda do
+        controller.send(:assert_privileges, "perf_reload")
+      end.should_not raise_error
     end
   end
 


### PR DESCRIPTION
Changed role_allows? method to return true for common hidden features that are for read only buttons are used from different screen and are under a hidden parent.

https://bugzilla.redhat.com/show_bug.cgi?id=1191222
https://bugzilla.redhat.com/show_bug.cgi?id=1191197

@dclarizio please review/test.