### PR TITLE
Add an "unknown" EC2 flavor, and fall back to it

### DIFF
--- a/lib/Amazon/MiqEc2InstanceTypes.rb
+++ b/lib/Amazon/MiqEc2InstanceTypes.rb
@@ -987,6 +987,30 @@ module MiqEc2InstanceTypes
 
   # Types that are no longer advertised
   DISCONTINUED_TYPES = {
+    "unknown" => {
+      :disabled                => true,
+      :name                    => "unknown",
+      :family                  => "unknown",
+      :description             => "unknown",
+      :memory                  => 0.megabytes,
+      :vcpu                    => 1,
+      :ebs_only                => true,
+      :instance_store_size     => 0,
+      :instance_store_volumes  => 0,
+      :architecture            => [],
+      :virtualization_type     => [],
+      :network_performance     => :low_to_moderate,
+      :physical_processor      => nil,
+      :processor_clock_speed   => nil,
+      :intel_aes_ni            => nil,
+      :intel_avx               => nil,
+      :intel_avx2              => nil,
+      :intel_turbo             => nil,
+      :ebs_optimized_available => nil,
+      :enhanced_networking     => nil,
+      :cluster_networking      => nil,
+    },
+
     # cc1.4xlarge is not available in any of the documentation, but if you
     #   launch a new instance, it's still available to choose.
     "cc1.4xlarge" => {

--- a/vmdb/app/models/ems_refresh/parsers/ec2.rb
+++ b/vmdb/app/models/ems_refresh/parsers/ec2.rb
@@ -333,7 +333,8 @@ module EmsRefresh::Parsers
 
       flavor_uid = instance.instance_type
       @known_flavors << flavor_uid
-      flavor = @data_index.fetch_path(:flavors, flavor_uid)
+      flavor = @data_index.fetch_path(:flavors, flavor_uid) ||
+        @data_index.fetch_path(:flavors, "unknown")
 
       private_network = {
         :ipaddress => instance.private_ip_address,


### PR DESCRIPTION
Hopefully its hardware configuration is so obviously-useless that it can't be mistaken for real data.

Having the VM show up with very bogus data seems better than the alternative -- skipping over it and pretending it doesn't exist at all.

@Fryguy hopefully you have some input on my choices of null-ish data: am I doing anything that's likely to break something (e.g., 0 RAM), or is there anything I can make even more clearly wrong (0 / -1 CPUs, perhaps)?

https://bugzilla.redhat.com/show_bug.cgi?id=1081600