### PR TITLE
SCVMM Provision a VM from template.

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -22,7 +22,9 @@ class EmsMicrosoft < EmsInfra
     # above warning when rspec tests are run.
     silence_warnings { require 'winrm' }
 
-    WinRM::WinRMWebService.new(auth_url, :ssl, :user => username, :pass => password, :disable_sspi => true)
+    winrm = WinRM::WinRMWebService.new(auth_url, :ssl, :user => username, :pass => password, :disable_sspi => true)
+    winrm.set_timeout(1800)
+    winrm
   end
 
   def self.auth_url(hostname, port = nil)

--- a/vmdb/app/models/ems_microsoft/powershell.rb
+++ b/vmdb/app/models/ems_microsoft/powershell.rb
@@ -39,11 +39,17 @@ class EmsMicrosoft
         error = results[:data].collect { |d| d[:stderr] }.join
         $scvmm_log.error("#{log_header} #{error}") unless error.blank?
       end
+
+      def parse_json_results(results)
+        output = results[:data].collect { |d| d[:stdout] }.join
+        JSON.parse(output)
+      end
     end
 
     def run_dos_command(command)
       log_header = "MIQ(#{self.class.name}##{__method__})"
       $scvmm_log.debug("#{log_header} Execute DOS command <#{command}>...")
+      results = []
 
       _result, timings = Benchmark.realtime_block(:execution) do
         with_provider_connection do |connection|
@@ -53,6 +59,25 @@ class EmsMicrosoft
       end
 
       $scvmm_log.debug("#{log_header} Execute DOS command <#{command}>...Complete - Timings: #{timings}")
+
+      results
+    end
+
+    def run_powershell_script(script)
+      log_header = "MIQ(#{self.class.name}##{__method__})"
+      $scvmm_log.debug("#{log_header} Execute Powershell Script...")
+      results = []
+
+      _result, timings = Benchmark.realtime_block(:execution) do
+        with_provider_connection do |connection|
+          results = connection.run_powershell_script(script)
+          self.class.log_dos_error_results(results)
+        end
+      end
+
+      $scvmm_log.debug("#{log_header} Execute Powershell script... Complete - Timings: #{timings}")
+
+      results
     end
   end
 end

--- a/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -18,6 +18,8 @@ function get_vms{
   }
   $dvds = Get-SCVirtualDVDDrive -VM $_ | Select-Object -ExpandProperty "ISO"
   $vm_hash["DVDs"] = $dvds
+  $vmnet = Get-SCVirtualNetworkAdapter -VM $_ | Select-Object VMNetwork
+  $vm_hash["vmnet"] = $vmnet
   $results[$id]= $vm_hash
  }
  return $results
@@ -33,6 +35,8 @@ function get_images{
   $i_hash["Properties"] = $_
   $dvds = Get-SCVirtualDVDDrive -VMTemplate $_ | Select-Object -ExpandProperty "ISO"
   $i_hash["DVDs"] = $dvds
+  $vmnet = Get-SCVirtualNetworkAdapter -VMTemplate $_ | Select-Object VMNetwork
+  $i_hash["vmnet"] = $vmnet
   $results[$id]= $i_hash
  }
  return $results
@@ -44,6 +48,8 @@ function get_host_inventory {
  $hosts | ForEach-Object {
   $host_hash = @{}
   $host_hash["NetworkAdapters"] = @(Get-VMHostNetworkAdapter -VMHost $_)
+  $host_hash["VirtualSwitch"] = @(Get-SCVirtualNetwork -VMHost $_)
+  # $host_hash["VLANs"] = @(Get-SCVirtualNetwork -VMHost $_ | Select-Object -ExpandProperty "VMHostNetworkAdapters" | Select-Object -ExpandProperty "SubnetVLans")
   $host_hash["Properties"] = $_
   $results[$_.ID] = $host_hash
   $_.DiskVolumes | where-object VolumeLabel -ne "System Reserved" | ForEach-Object {

--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -95,9 +95,9 @@ module EmsRefresh::Parsers
       name  = p[:ClusterName]
 
       new_result = {
-        :ems_ref      => uid,
-        :uid_ems      => uid,
-        :name         => name,
+        :ems_ref => uid,
+        :uid_ems => uid,
+        :name    => name,
       }
       set_relationship_on_hosts(new_result, nodes)
 

--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -98,7 +98,6 @@ module EmsRefresh::Parsers
         :ems_ref      => uid,
         :uid_ems      => uid,
         :name         => name,
-        :ems_children => {:resource_pools => [default_resource_pool(name, uid)]}
       }
       set_relationship_on_hosts(new_result, nodes)
 
@@ -520,19 +519,6 @@ module EmsRefresh::Parsers
 
     def unclustered_hosts
       @data[:hosts].select { |h| h[:ems_cluster].nil? }
-    end
-
-    def default_resource_pool(name, uid)
-      default_res_pool = {
-        :name         => "Default for Cluster #{name}",
-        :uid_ems      => "#{uid}_respool",
-        :is_default   => true,
-        :ems_children => {:vms => []}
-      }
-      @data[:resource_pools] = [default_res_pool]
-      @data_index.store_path(:resource_pools, "#{uid}_respool", [default_res_pool])
-
-      default_res_pool
     end
 
     def identify_primary_ip(nics, host)

--- a/vmdb/app/models/miq_provision.rb
+++ b/vmdb/app/models/miq_provision.rb
@@ -31,8 +31,8 @@ class MiqProvision < MiqProvisionTask
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
-  SUBCLASSES            = %w(MiqProvisionCloud MiqProvisionRedhat MiqProvisionVmware)
-  SUPPORTED_EMS_CLASSES = %w(EmsVmware EmsRedhat EmsAmazon EmsOpenstack)
+  SUBCLASSES            = %w(MiqProvisionCloud MiqProvisionRedhat MiqProvisionVmware MiqProvisionMicrosoft)
+  SUPPORTED_EMS_CLASSES = %w(EmsVmware EmsRedhat EmsAmazon EmsOpenstack EmsMicrosoft)
 
   def self.base_model
     MiqProvision

--- a/vmdb/app/models/miq_provision/state_machine.rb
+++ b/vmdb/app/models/miq_provision/state_machine.rb
@@ -106,4 +106,13 @@ module MiqProvision::StateMachine
     end
   end
 
+  private
+
+  def clone_direction
+    "[#{source.name}] to #{destination_type} [#{dest_name}]"
+  end
+
+  def for_destination
+    "#{destination_type} id: [#{destination.id}], name: [#{dest_name}]"
+  end
 end

--- a/vmdb/app/models/miq_provision_infra_workflow.rb
+++ b/vmdb/app/models/miq_provision_infra_workflow.rb
@@ -2,6 +2,7 @@ class MiqProvisionInfraWorkflow < MiqProvisionVirtWorkflow
   SUBCLASSES = %w{
     MiqProvisionRedhatWorkflow
     MiqProvisionVmwareWorkflow
+    MiqProvisionMicrosoftWorkflow
   }
 
   def set_or_default_hardware_field_values(vm)

--- a/vmdb/app/models/miq_provision_microsoft.rb
+++ b/vmdb/app/models/miq_provision_microsoft.rb
@@ -1,0 +1,9 @@
+class MiqProvisionMicrosoft < MiqProvision
+  include_concern 'Cloning'
+  include_concern 'Placement'
+  include_concern 'StateMachine'
+end
+
+# Preload any subclasses of this class, so that they will be part of the
+#   conditions that are generated on queries against this class.
+Dir.glob(Rails.root.join("app", "models", "miq_provision_microsoft_*.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision_microsoft/cloning.rb
+++ b/vmdb/app/models/miq_provision_microsoft/cloning.rb
@@ -1,0 +1,132 @@
+module MiqProvisionMicrosoft::Cloning
+  DRIVE_LETTER     = /[a-z][:]/i
+
+  def log_clone_options(clone_options)
+    log_header = "MIQ(#{self.class.name}#log_clone_options)"
+
+    $log.info("#{log_header} Provisioning [#{source.name}] to [#{clone_options[:name]}]")
+    $log.info("#{log_header} Source Image:                    [#{clone_options[:image_ref]}]")
+
+    dumpObj(clone_options, "#{log_header} Clone Options: ", $log, :info)
+    dumpObj(options,  "#{log_header} Prov Options:  ", $log, :info)
+  end
+
+  def clone_complete?
+    # TODO: monitor job state when asynchronous cloning is in place.
+    true
+  end
+
+  def find_destination_in_vmdb(ems_ref)
+    VmMicrosoft.where(:name => dest_name, :ems_ref => ems_ref).first
+  end
+
+  def prepare_for_clone_task
+    if dest_name.blank?
+      raise MiqException::MiqProvisionError, "Provision Request's Destination VM Name=[#{dest_name}] cannot be blank"
+    end
+
+    if source.ext_management_system.vms.where(:name => dest_name).any?
+      raise MiqException::MiqProvisionError, "A VM with name: [#{dest_name}] already exists"
+    end
+
+    {
+      :name      => dest_name,
+      :host      => dest_host,
+      :datastore => dest_datastore,
+    }
+  end
+
+  def dest_mount_point
+    dest_datastore.name.scan(DRIVE_LETTER).last.to_s
+  end
+
+  def dest_virtual_network
+    get_option(:vlan)
+  end
+
+  def startup_ram
+    get_option(:vm_memory)
+  end
+
+  def memory_limit
+    get_option(:memory_limit)
+  end
+
+  def min_memory
+    get_option(:memory_reserve)
+  end
+
+  def cpu_max
+    get_option(:cpu_limit)
+  end
+
+  def cpu_reserve
+    get_option(:cpu_reserve)
+  end
+
+  def cpu_count
+    get_option(:number_of_cpus)
+  end
+
+  def dynamic_mem_min
+    get_option(:vm_minimum_memory)
+  end
+
+  def dynamic_mem_max
+    get_option(:vm_maximum_memory)
+  end
+
+  def memory_ps_script
+    if get_option(:vm_dynamic_memory)
+      "-DynamicMemoryEnabled $true \
+       -MemoryMB #{startup_ram} \
+       -DynamicMemoryMaximumMB #{dynamic_mem_max} \
+       -DynamicMemoryMinimumMB #{dynamic_mem_min}"
+    else
+      "-DynamicMemoryEnabled $false \
+       -MemoryMB #{startup_ram}"
+    end
+  end
+
+  def template_ps_script
+    "(Get-SCVMTemplate -Name #{source.name})"
+  end
+
+  def logical_network_ps_script
+    "(Get-SCLogicalNetwork -Name '#{dest_virtual_network}')"
+  end
+
+  def network_adapter_ps_script
+    if dest_virtual_network.nil?
+      raise MiqException::MiqProvisionError, "Virtual Network is not available"
+    end
+
+    "$adapter = $vm | SCVirtualNetworkAdapter; \
+     Set-SCVirtualNetworkAdapter \
+      -VirtualNetworkAdapter $adapter \
+      -LogicalNetwork #{logical_network_ps_script} | Out-Null;"
+  end
+
+  def build_ps_script
+    <<-PS_SCRIPT
+      $vm = New-SCVirtualMachine \
+        -Name #{dest_name} \
+        -VMHost #{dest_host} \
+        -Path #{dest_mount_point} \
+        -VMTemplate #{template_ps_script}; \
+      Set-SCVirtualMachine -VM $vm \
+        -CPUCount #{cpu_count} \
+        -CPUReserve #{cpu_reserve} \
+        -CPUMaximumPercent #{cpu_max} \
+        #{memory_ps_script} | Out-Null;  \
+      #{network_adapter_ps_script} \
+      $vm | Select-Object ID | ConvertTo-Json
+    PS_SCRIPT
+  end
+
+  def start_clone(_clone_options)
+    json_results = source.ext_management_system.run_powershell_script(build_ps_script)
+    vm_json      = EmsMicrosoft.parse_json_results(json_results)
+    phase_context[:new_vm_ems_ref] = vm_json["ID"]
+  end
+end

--- a/vmdb/app/models/miq_provision_microsoft/cloning.rb
+++ b/vmdb/app/models/miq_provision_microsoft/cloning.rb
@@ -98,7 +98,8 @@ module MiqProvisionMicrosoft::Cloning
 
   def network_adapter_ps_script
     if dest_virtual_network.nil?
-      raise MiqException::MiqProvisionError, "Virtual Network is not available"
+      $scvmm_log.info("Virtual Network is not available, network adapter will not be set")
+      return
     end
 
     "$adapter = $vm | SCVirtualNetworkAdapter; \

--- a/vmdb/app/models/miq_provision_microsoft/placement.rb
+++ b/vmdb/app/models/miq_provision_microsoft/placement.rb
@@ -1,0 +1,39 @@
+module MiqProvisionMicrosoft::Placement
+  protected
+
+  def placement
+    log_header = "MIQ(#{self.class.name}.placement)"
+    desired    = manual_placement
+
+    if desired[:host].nil? || desired[:storage].nil?
+      raise MiqException::MiqProvisionError, "Unable to find a suitable environment"
+    end
+
+    [:host, :storage].each do |key|
+      object = desired[key]
+      next if object.nil?
+      $log.info("#{log_header} Using #{key.to_s.titleize} Id: [#{object.id}], Name: [#{object.name}]")
+      options["dest_#{key}".to_sym] = [object.id, object.name]
+    end
+  end
+
+  private
+
+  def manual_placement
+    update_placement_info
+  end
+
+  def update_placement_info(result = {})
+    result[:host]    = selected_placement_host if result[:host].nil?
+    result[:storage] = selected_placement_ds   if result[:storage].nil?
+    result
+  end
+
+  def selected_placement_host
+    Host.where(:id => get_option(:placement_host_name)).first
+  end
+
+  def selected_placement_ds
+    Storage.where(:id => get_option(:placement_ds_name)).first
+  end
+end

--- a/vmdb/app/models/miq_provision_microsoft/state_machine.rb
+++ b/vmdb/app/models/miq_provision_microsoft/state_machine.rb
@@ -1,0 +1,37 @@
+module MiqProvisionMicrosoft::StateMachine
+  def create_destination
+    signal :determine_placement
+  end
+
+  def determine_placement
+    placement
+
+    signal :prepare_provision
+  end
+
+  def start_clone_task
+    update_and_notify_parent(:message => "Starting Clone of #{clone_direction}")
+    log_clone_options(phase_context[:clone_options])
+    start_clone(phase_context[:clone_options])
+    phase_context.delete(:clone_options)
+
+    signal :poll_clone_complete
+  end
+
+  def poll_clone_complete
+    update_and_notify_parent(:message => "Waiting for clone of #{clone_direction}")
+
+    if clone_complete?
+      phase_context.delete(:clone_task_ref)
+      EmsRefresh.queue_refresh(dest_host.ext_management_system)
+      signal :poll_destination_in_vmdb
+    else
+      requeue_phase
+    end
+  end
+
+  def customize_destination
+    update_and_notify_parent(:message => "Starting New #{destination_type} Customization")
+    signal :autostart_destination
+  end
+end

--- a/vmdb/app/models/miq_provision_microsoft_workflow.rb
+++ b/vmdb/app/models/miq_provision_microsoft_workflow.rb
@@ -46,4 +46,10 @@ class MiqProvisionMicrosoftWorkflow < MiqProvisionInfraWorkflow
   def allowed_datacenters(_options = {})
     allowed_ci(:datacenter, [:cluster, :host, :folder])
   end
+  
+  def allowed_clusters(options={})
+    filtered_targets = process_filter_all(:cluster_filter, EmsCluster)
+    filtered_ids = filtered_targets.collect(&:id)
+    allowed_ci(:cluster, [:host], filtered_ids)
+  end
 end

--- a/vmdb/app/models/miq_provision_microsoft_workflow.rb
+++ b/vmdb/app/models/miq_provision_microsoft_workflow.rb
@@ -1,0 +1,49 @@
+class MiqProvisionMicrosoftWorkflow < MiqProvisionInfraWorkflow
+  def dialog_name_from_automate(message = 'get_dialog_name')
+    super(message, {'platform' => 'microsoft'})
+  end
+
+  def allowed_provision_types(_options = {})
+    {
+      "microsoft" => "Microsoft"
+    }
+  end
+
+  def self.allowed_templates_vendor
+    'microsoft'
+  end
+
+  def update_field_visibility(_options = {})
+    super
+
+    if get_value(@values[:vm_dynamic_memory])
+      display_flag = :edit
+    else
+      display_flag = :hide
+    end
+    show_fields(display_flag, [:vm_minimum_memory, :vm_maximum_memory])
+  end
+
+  def allowed_vlans(options = {})
+    if @allowed_vlan_cache.nil?
+      @vlan_options ||= options
+      vlans = {}
+      src = get_source_and_targets
+      return vlans if src.blank?
+
+      unless @vlan_options[:vlans] == false
+        rails_logger('allowed_vlans', 0)
+        hosts = get_selected_hosts(src)
+        hosts.each { |h| h.switches.each { |s| vlans[s.name] = s.name } }
+        rails_logger('allowed_vlans', 1)
+      end
+
+      @allowed_vlan_cache = vlans
+    end
+    filter_by_tags(@allowed_vlan_cache, options)
+  end
+
+  def allowed_datacenters(_options = {})
+    allowed_ci(:datacenter, [:cluster, :host, :folder])
+  end
+end

--- a/vmdb/app/models/miq_provision_microsoft_workflow.rb
+++ b/vmdb/app/models/miq_provision_microsoft_workflow.rb
@@ -46,8 +46,8 @@ class MiqProvisionMicrosoftWorkflow < MiqProvisionInfraWorkflow
   def allowed_datacenters(_options = {})
     allowed_ci(:datacenter, [:cluster, :host, :folder])
   end
-  
-  def allowed_clusters(options={})
+
+  def allowed_clusters(_options = {})
     filtered_targets = process_filter_all(:cluster_filter, EmsCluster)
     filtered_ids = filtered_targets.collect(&:id)
     allowed_ci(:cluster, [:host], filtered_ids)

--- a/vmdb/app/models/miq_provision_vmware/state_machine.rb
+++ b/vmdb/app/models/miq_provision_vmware/state_machine.rb
@@ -83,12 +83,4 @@ module MiqProvisionVmware::StateMachine
     self.destination.start
   end
 
-  def clone_direction
-    "[#{self.source.name}] to #{destination_type} [#{dest_name}]"
-  end
-
-  def for_destination
-    "#{destination_type} id: [#{self.destination.id}], name: [#{dest_name}]"
-  end
-
 end

--- a/vmdb/app/models/template_infra.rb
+++ b/vmdb/app/models/template_infra.rb
@@ -9,7 +9,7 @@ class TemplateInfra < MiqTemplate
   default_value_for :cloud, false
 
   def self.eligible_for_provisioning
-    super.where(:type => %w(TemplateRedhat TemplateVmware))
+    super.where(:type => %w(TemplateRedhat TemplateVmware TemplateMicrosoft))
   end
 
   private

--- a/vmdb/app/views/miq_request/_prov_field.html.haml
+++ b/vmdb/app/views/miq_request/_prov_field.html.haml
@@ -217,7 +217,12 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             - #  Display notes if available
             = field_hash[:notes]
-      - elsif [:instance_type, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1, :vm_tag_2, :vm_tag_3, :vm_tag_4, :vm_tag_5, :vm_tag_6, :vm_tag_7, :vm_tag_8, :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement, :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address, :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode, :vlan, :cloud_tenant, :src_configuration_profile_id].include?(field)
+      - elsif [:instance_type, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1,
+               :vm_tag_2, :vm_tag_3, :vm_tag_4, :vm_tag_5, :vm_tag_6, :vm_tag_7, :vm_tag_8,
+               :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement,
+               :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address,
+               :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
+               :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory, :vm_maximum_memory].include?(field)
         - # ### Pull Down fields
         - # ### Multiple select Pull Down fields
         - multiple = field == :security_groups
@@ -414,7 +419,8 @@
             - # Just show the field value %>
             - # Description is in the second, last, array element
             = options[field].last
-      - elsif [:linked_clone, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid, :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start].include?(field)
+      - elsif [:linked_clone, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid,
+               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory].include?(field)
         - # ### Checkbox fields
         %td{:style => "vertical-align: top;"}
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/vmdb/app/views/shared/views/_prov_dialog.html.haml
+++ b/vmdb/app/views/shared/views/_prov_dialog.html.haml
@@ -141,7 +141,9 @@
             :keys                       => keys,
             :extra_table_attributes     => "width=100%"})
   - when :hardware
-    - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket, :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring]
+    - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket,
+              :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring,
+              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory]
     - label = wf.is_a?(MiqProvisionCloudWorkflow) ? "Properties" : "Hardware"
     = render(:partial => "#{prefix}prov_dialog_fieldset",
       :locals         => {:workflow => wf,

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_microsoft.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_microsoft.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqProvisionMicrosoft < MiqAeServiceMiqProvision
+  end
+end

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -1,0 +1,538 @@
+---
+:name: miq_provision_microsoft_dialogs_template
+:description: Sample Microsoft VM Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+
+            :order: []
+
+            :single_select: []
+
+            :exclude: []
+
+          :display: :edit
+          :required_tags: []
+
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: static
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :ip_addr:
+          :description: IP Address
+          :required: false
+          :notes: (Enter starting IP address)
+          :display: :edit
+          :data_type: :string
+          :notes_display: :hide
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :hide
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_cluster_name:
+          :values_from:
+            :method: :allowed_clusters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :show
+          :data_type: :integer
+        :cluster_filter:
+          :values_from:
+            :options:
+              :category: :EmsCluster
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :hide
+          :default: false
+          :data_type: :boolean
+        :placement_dc_name:
+          :values_from:
+            :method: :allowed_datacenters
+          :auto_select_single: true
+          :description: Name
+          :required: false
+          :display: :show
+          :data_type: :integer
+        :placement_host_name:
+          :values_from:
+            :method: :allowed_hosts
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Host Name
+        :placement_ds_name:
+          :values_from:
+            :method: :allowed_storages
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Datastore Name
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: VM Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: VM Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :provision_type:
+          :values_from:
+            :method: :allowed_provision_types
+          :description: Provision Type
+          :required: true
+          :display: :hide
+          :default: iso
+          :data_type: :string
+        :linked_clone:
+          :values:
+            false: 0
+            true: 1
+          :description: Linked Clone
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :vm_name:
+          :description: VM Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+        :pxe_image_id:
+          :values_from:
+            :method: :allowed_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :iso_image_id:
+          :values_from:
+            :method: :allowed_iso_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :pxe_server_id:
+          :values_from:
+            :method: :allowed_pxe_servers
+          :auto_select_single: false
+          :description: Server
+          :required: true
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+        :stateless:
+          :values:
+            false: 0
+            true: 1
+          :description: Stateless
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+      :display: :show
+    :network:
+      :description: Network
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
+              :dvs: true
+              :vlans: true
+            :method: :allowed_vlans
+          :description: vLan
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :mac_address:
+          :description: MAC Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+      :display: :show
+    :hardware:
+      :description: Hardware
+      :fields:
+        :disk_format:
+          :values:
+            preallocated: Preallocated
+            thin: Thin
+            default: Default
+          :description: Disk Format
+          :required: false
+          :display: :hide
+          :default: default
+          :data_type: :string
+        :cpu_limit:
+          :description: CPU (%)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :number_of_cpus:
+          :values:
+            1: "1"
+            2: "2"
+            4: "4"
+            8: "8"
+            16: "16"
+          :description: Number of CPUS
+          :required: false
+          :display: :edit
+          :default: 2
+          :data_type: :integer
+        :cores_per_socket:
+          :values:
+            1: "1"
+            2: "2"
+            4: "4"
+            8: "8"
+          :description: Cores per Socket
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+        :cpu_reserve:
+          :description: CPU (%)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :vm_dynamic_memory:
+          :values:
+            false: 0
+            true: 1
+          :description: Dynamic Memory
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :vm_memory:
+          :values:
+            "8192": "8192"
+            "4096": "4096"
+            "2048": "2048"
+            "1024": "1024"
+          :description: Startup Memory (MB)
+          :required: false
+          :display: :edit
+          :default: "1024"
+          :data_type: :string
+        :vm_maximum_memory:
+          :values:
+            "8192": "8192"
+            "4096": "4096"
+            "2048": "2048"
+            "1024": "1024"
+          :description: Maximum RAM (MB)
+          :required: false
+          :display: :hide
+          :default: "1024"
+          :data_type: :string
+        :vm_minimum_memory:
+          :values:
+            "8192": "8192"
+            "4096": "4096"
+            "2048": "2048"
+            "1024": "1024"
+          :description: Minimum RAM (MB)
+          :required: false
+          :display: :hide
+          :default: "1024"
+          :data_type: :string
+        :network_adapters:
+          :values:
+            1: "1"
+            2: "2"
+            3: "3"
+            4: "4"
+          :description: Network Adapters
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :network
+  - :customize
+  - :schedule

--- a/vmdb/spec/factories/miq_provision_microsoft.rb
+++ b/vmdb/spec/factories/miq_provision_microsoft.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_provision_microsoft do
+  end
+end

--- a/vmdb/spec/factories/template_microsoft.rb
+++ b/vmdb/spec/factories/template_microsoft.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory(:template_microsoft, :class => "TemplateMicrosoft", :parent => :template_infra) { vendor "microsoft" }
+end

--- a/vmdb/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
@@ -30,7 +30,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
       assert_specific_host
       assert_specific_vm
       assert_specific_storage
-      # assert_relationship_tree # TODO: fix default resource pool dependency
+      assert_relationship_tree
     end
   end
 
@@ -39,7 +39,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
     EmsFolder.count.should           == 4 # HACK: Folder structure for UI a la VMware
     EmsCluster.count.should          == 1
     Host.count.should                == 3
-    ResourcePool.count.should        == 1
+    ResourcePool.count.should        == 0
     Vm.count.should                  == 23
     VmOrTemplate.count.should        == 28
     CustomAttribute.count.should     == 0
@@ -55,7 +55,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
     Snapshot.count.should            == 9
     Switch.count.should              == 0
     SystemService.count.should       == 0
-    Relationship.count.should        == 36
+    Relationship.count.should        == 35
 
     MiqQueue.count.should            == 28
     Storage.count.should             == 6
@@ -68,7 +68,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
     )
     @ems.ems_folders.size.should         == 4 # HACK: Folder structure for UI a la VMware
     @ems.ems_clusters.size.should        == 1
-    @ems.resource_pools.size.should      == 1
+    @ems.resource_pools.size.should      == 0
 
     @ems.storages.size.should            == 6
     @ems.hosts.size.should               == 3
@@ -99,14 +99,6 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
       :ems_ref => "0be27f13-2a7a-4803-8d12-a460b94fdd71",
       :uid_ems => "0be27f13-2a7a-4803-8d12-a460b94fdd71",
       :name    => "US_East",
-    )
-
-    @default_rp = @cluster.default_resource_pool
-    @default_rp.should have_attributes(
-      :ems_ref    => nil,
-      :uid_ems    => "0be27f13-2a7a-4803-8d12-a460b94fdd71_respool",
-      :name       => "Default for Cluster US_East",
-      :is_default => true
     )
   end
 
@@ -253,9 +245,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
       [EmsFolder, "Datacenters", {:is_datacenter => false}] => {
         [EmsFolder, "SCVMM", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {
-            [EmsCluster, "US_East"]                    => {
-              [ResourcePool, "Default for Cluster US_East", {:is_default => true}] => {}
-            },
+            [EmsCluster, "US_East"]                    => {},
             [HostMicrosoft, "hyperv-h01.manageiq.com"] => {},
           },
           [EmsFolder, "vm", {:is_datacenter => false}]   => {

--- a/vmdb/spec/models/miq_provision_microsoft/placement_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft/placement_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe MiqProvisionMicrosoft do
+  context "::Placement" do
+    before do
+      ems      = FactoryGirl.create(:ems_microsoft_with_authentication)
+      template = FactoryGirl.create(:template_microsoft, :ext_management_system => ems)
+      vm       = FactoryGirl.create(:vm_microsoft)
+      @host    = FactoryGirl.create(:host_microsoft, :ext_management_system => ems)
+      @storage = FactoryGirl.create(:storage)
+      options  = {:src_vm_id => template.id}
+
+      @task = FactoryGirl.create(
+        :miq_provision_microsoft,
+        :source      => template,
+        :destination => vm,
+        :state       => 'pending',
+        :status      => 'Ok',
+        :options     => options)
+    end
+
+    it "#manual_placement raise error" do
+      @task.options[:placement_auto] = false
+      expect { @task.send(:placement) }.to raise_error(MiqException::MiqProvisionError)
+    end
+
+    it "#manual_placement" do
+      @task.options[:placement_host_name] = @host.id
+      @task.options[:placement_ds_name]   = @storage.id
+      @task.options[:placement_auto]      = false
+
+      check
+    end
+
+    def check
+      @task.send(:placement)
+      @task.options[:dest_host].should eql([@host.id, @host.name])
+    end
+  end
+end

--- a/vmdb/spec/models/miq_provision_microsoft/state_machine_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft/state_machine_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+
+describe MiqProvisionMicrosoft do
+  context "::StateMachine" do
+    before do
+      ems      = FactoryGirl.create(:ems_microsoft_with_authentication)
+      template = FactoryGirl.create(:template_microsoft, :ext_management_system => ems)
+      vm       = FactoryGirl.create(:vm_microsoft)
+      options  = {:src_vm_id => template.id}
+
+      @task = FactoryGirl.create(
+        :miq_provision_microsoft,
+        :source      => template,
+        :destination => vm,
+        :state       => 'pending',
+        :status      => 'Ok',
+        :options     => options)
+
+      @task.stub(:miq_request => double("MiqRequest").as_null_object)
+      @task.stub(:dest_host => FactoryGirl.create(:host_microsoft, :ext_management_system => ems))
+    end
+
+    it "#create_destination" do
+      @task.should_receive(:determine_placement)
+
+      @task.create_destination
+    end
+
+    it "#determine_placement" do
+      @task.stub(:placement)
+
+      @task.should_receive(:prepare_provision)
+
+      @task.determine_placement
+    end
+
+    it "#start_clone_task" do
+      @task.stub(:update_and_notify_parent)
+      @task.stub(:log_clone_options)
+      @task.stub(:start_clone)
+
+      @task.should_receive(:poll_clone_complete)
+
+      @task.start_clone_task
+    end
+
+    context "#poll_clone_complete" do
+      it "cloning" do
+        @task.should_receive(:clone_complete?).and_return(false)
+        @task.should_receive(:requeue_phase)
+
+        @task.poll_clone_complete
+      end
+
+      it "clone complete" do
+        @task.should_receive(:clone_complete?).and_return(true)
+        EmsRefresh.should_receive(:queue_refresh)
+        @task.should_receive(:poll_destination_in_vmdb)
+
+        @task.poll_clone_complete
+      end
+    end
+
+    it "#customize_destination" do
+      # @task.stub(:get_provider_destination).and_return(nil)
+      @task.stub(:update_and_notify_parent)
+
+      @task.should_receive(:autostart_destination)
+
+      @task.customize_destination
+    end
+  end
+end

--- a/vmdb/spec/models/miq_provision_microsoft_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft_spec.rb
@@ -106,8 +106,7 @@ describe MiqProvisionMicrosoft do
       end
 
       it "set adapter" do
-        expect { @vm_prov.send(:network_adapter_ps_script) }.to raise_error(
-          MiqException::MiqProvisionError, "Virtual Network is not available")
+        expect(@vm_prov.network_adapter_ps_script).to be_nil
       end
     end
 
@@ -126,7 +125,7 @@ describe MiqProvisionMicrosoft do
       end
 
       it "set adapter" do
-        expect { @vm_prov.send(:network_adapter_ps_script) }.to_not raise_error
+        expect(@vm_prov.network_adapter_ps_script).to_not be_nil
       end
     end
   end

--- a/vmdb/spec/models/miq_provision_microsoft_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft_spec.rb
@@ -1,0 +1,133 @@
+require "spec_helper"
+
+describe MiqProvisionMicrosoft do
+  context "A new provision request," do
+    before(:each) do
+      @os = OperatingSystem.new(:product_name => 'Microsoft Windows')
+      User.any_instance.stub(:role).and_return("admin")
+      @user        = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
+      @approver    = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'approver')
+      UiTaskSet.stub(:find_by_name).and_return(@approver)
+      @target_vm_name = 'clone test'
+      @ems         = FactoryGirl.create(:ems_microsoft_with_authentication)
+      @vm_template = FactoryGirl.create(
+        :template_microsoft,
+        :name                  => "template1",
+        :ext_management_system => @ems,
+        :operating_system      => @os,
+        :cpu_limit             => -1,
+        :cpu_reserve           => 0)
+      @vm          = FactoryGirl.create(:vm_microsoft, :name => "vm1",       :location => "abc/def.xml")
+      @pr          = FactoryGirl.create(:miq_provision_request, :userid => @user.userid, :src_vm_id => @vm_template.id)
+      @options = {
+        :pass           => 1,
+        :vm_name        => @target_vm_name,
+        :vm_target_name => @target_vm_name,
+        :number_of_vms  => 1,
+        :cpu_limit      => -1,
+        :cpu_reserve    => 0,
+        :provision_type => "microsoft",
+        :src_vm_id      => [@vm_template.id, @vm_template.name]
+      }
+    end
+
+    context "SCVMM provisioning" do
+      before(:each) do
+        @vm_prov     = FactoryGirl.create(
+          :miq_provision_microsoft,
+          :userid       => @user.userid,
+          :miq_request  => @pr,
+          :source       => @vm_template,
+          :request_type => 'template',
+          :state        => 'pending',
+          :status       => 'Ok',
+          :options      => @options)
+      end
+
+      it "#workflow" do
+        MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+        @vm_prov.workflow.class.should eq MiqProvisionMicrosoftWorkflow
+      end
+    end
+
+    context "#prepare_for_clone_task" do
+      before do
+        @host = FactoryGirl.create(:host_microsoft, :ems_ref => "test_ref")
+        @vm_prov = FactoryGirl.create(
+          :miq_provision_microsoft,
+          :userid       => @user.userid,
+          :miq_request  => @pr,
+          :source       => @vm_template,
+          :request_type => 'template',
+          :state        => 'pending',
+          :status       => 'Ok',
+          :options      => @options)
+        @vm_prov.stub(:dest_host).and_return(@host)
+      end
+
+      it "with default options" do
+        clone_options = @vm_prov.prepare_for_clone_task
+        clone_options[:name].should == @target_vm_name
+        clone_options[:host].should == @host
+      end
+    end
+
+    context "#parse mount point" do
+      before do
+        @datastore = FactoryGirl.create(:storage, :name => "C:\\directoryname\\test_datastore")
+        @vm_prov = FactoryGirl.create(
+          :miq_provision_microsoft,
+          :userid       => @user.userid,
+          :miq_request  => @pr,
+          :source       => @vm_template,
+          :request_type => 'template',
+          :state        => 'pending',
+          :status       => 'Ok',
+          :options      => @options)
+        @vm_prov.stub(:dest_datastore).and_return(@datastore)
+      end
+
+      it "valid drive" do
+        @vm_prov.dest_mount_point.should == "C:"
+      end
+    end
+
+    context "#no network adapter available" do
+      before do
+        @vm_prov = FactoryGirl.create(
+          :miq_provision_microsoft,
+          :userid       => @user.userid,
+          :miq_request  => @pr,
+          :source       => @vm_template,
+          :request_type => 'template',
+          :state        => 'pending',
+          :status       => 'Ok',
+          :options      => @options)
+      end
+
+      it "set adapter" do
+        expect { @vm_prov.send(:network_adapter_ps_script) }.to raise_error(
+          MiqException::MiqProvisionError, "Virtual Network is not available")
+      end
+    end
+
+    context "#network adapter available" do
+      before do
+        @options[:vlan] = "virtualnetwork1"
+        @vm_prov = FactoryGirl.create(
+          :miq_provision_microsoft,
+          :userid       => @user.userid,
+          :miq_request  => @pr,
+          :source       => @vm_template,
+          :request_type => 'template',
+          :state        => 'pending',
+          :status       => 'Ok',
+          :options      => @options)
+      end
+
+      it "set adapter" do
+        expect { @vm_prov.send(:network_adapter_ps_script) }.to_not raise_error
+      end
+    end
+  end
+end

--- a/vmdb/spec/models/miq_provision_microsoft_workflow_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft_workflow_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe MiqProvisionMicrosoftWorkflow do
+  before do
+    MiqRegion.seed
+  end
+
+  context "With a Valid Template," do
+    let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
+    let(:provider) { FactoryGirl.create(:ems_microsoft) }
+    let(:template) { FactoryGirl.create(:template_microsoft, :name => "template", :ext_management_system => provider) }
+
+    before do
+      MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+      MiqProvisionMicrosoftWorkflow.any_instance.stub(:update_field_visibility)
+    end
+
+    it "pass platform attributes to automate" do
+      MiqAeEngine.should_receive(:resolve_automation_object)
+      MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
+        name.should eq("REQUEST")
+        attrs.should have_attributes(
+          'request'                   => 'UI_PROVISION_INFO',
+          'message'                   => 'get_pre_dialog_name',
+          'dialog_input_request_type' => 'template',
+          'dialog_input_target_type'  => 'vm',
+          'platform_category'         => 'infra',
+          'platform'                  => 'microsoft'
+        )
+      end
+
+      MiqProvisionMicrosoftWorkflow.new({}, admin.userid)
+    end
+
+    context "#allowed_vlans" do
+      let(:workflow) { MiqProvisionMicrosoftWorkflow.new({:src_vm_id => template.id}, admin.userid) }
+
+      before do
+        @host   = FactoryGirl.create(:host_microsoft, :ext_management_system => provider)
+        @vswitch = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
+
+        workflow.stub(:get_selected_hosts).and_return([@host])
+      end
+
+      it "should return a vlan name" do
+        vlans = workflow.allowed_vlans
+        vlans.keys.should match_array [@vswitch.name]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provision a VM from a template without support for the following:

- customizations - we will omit this piece of the workflow, it will be added sometime in the future.
- automatic placement - leave this to the field for now.
- the clone runs synchronously

There is some duplication of code between the MSFT and Red Hat provisioning files. It might be wise to create a superclass for each to inherit from. I will look into this in more detail.
