### PR TITLE
make MiqAeDigraph#find_by_data O(1)

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -273,7 +273,7 @@ module MiqAeEngine
     end
 
     def root(attrib = nil)
-      return nil if @graph.roots.nil? || @graph.roots.empty?
+      return nil if @graph.roots.empty?
       return @graph.roots.first if attrib.nil?
       return @graph.roots.first.attributes[attrib.downcase]
     end
@@ -335,7 +335,7 @@ module MiqAeEngine
       id = @graph.find_by_data(obj)
       return [] if id.nil?
       kids = @graph.children(id)
-      return [] if kids.nil?
+      return [] if kids.empty?
       return kids.collect { |vid| @graph[vid] }
     end
 


### PR DESCRIPTION
This patch introduces a node object to wrap each data object added to
the digraph.  The node object keeps track of it's parents and children
so that we don't have to look up parents and children in a hash (just
ask the node).  This simplifies various methods in the digraph object.

This also introduces a hash to map data to nodes.  The previous
implementation used Hash#keys which is an O(n) operation depending on
the number of nodes we store.  Since we now keep a map of data to nodes,
looking up a node should be a constant time hash lookup.