### PR TITLE
refactor VmdbDatabaseSetting to use the singleton database.

### DIFF
--- a/vmdb/app/models/vmdb_database_setting.rb
+++ b/vmdb/app/models/vmdb_database_setting.rb
@@ -11,9 +11,15 @@ class VmdbDatabaseSetting < ActsAsArModel
 
   virtual_belongs_to :vmdb_database
 
+  attr_accessor :vmdb_database
+
   def initialize(values = {})
-    values[:vmdb_database] ||= self.class.vmdb_database
+    @vmdb_database = VmdbDatabase.my_database
     super(values)
+  end
+
+  def vmdb_database_id
+    vmdb_database.id
   end
 
   #
@@ -33,14 +39,6 @@ class VmdbDatabaseSetting < ActsAsArModel
     Arel::Table.new(self.name)
   end
 
-  def vmdb_database
-    VmdbDatabase.find_by_id(self.vmdb_database_id)
-  end
-
-  def vmdb_database=(db)
-    self.vmdb_database_id = db.id
-  end
-
   #
   # Finders
   #
@@ -58,10 +56,6 @@ class VmdbDatabaseSetting < ActsAsArModel
   end
 
   protected
-
-  def self.vmdb_database
-    @vmdb_database ||= VmdbDatabase.my_database
-  end
 
   def self.vmdb_database_settings
     settings = ActiveRecord::Base.connection.configuration_settings

--- a/vmdb/spec/models/vmdb_database_setting_spec.rb
+++ b/vmdb/spec/models/vmdb_database_setting_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe VmdbDatabaseSetting do
+  before :each do
+    @db = FactoryGirl.create(:vmdb_database)
+  end
+
+  it 'has database settings' do
+    expect(@db.vmdb_database_settings.length).to be > 0
+    @db.vmdb_database_settings.each do |setting|
+      expect(setting.vmdb_database).to eql(@db)
+    end
+  end
+
+  it 'can find settings' do
+    settings = VmdbDatabaseSetting.all
+    expect(settings.length).to be > 0
+  end
+
+  it 'sets a default database' do
+    setting = VmdbDatabaseSetting.new
+    expect(setting.vmdb_database).to eql(@db)
+  end
+
+  [
+    :name,
+    :description,
+    :value,
+    :minimum_value,
+    :maximum_value,
+    :unit,
+    :vmdb_database_id
+  ].each do |field|
+    it "has a #{field}" do
+      setting = VmdbDatabaseSetting.all.first
+      expect(setting.send(field)).to be
+    end
+  end
+end


### PR DESCRIPTION
VmdbDatabase will only return settings objects [if it's in the current
region](https://github.com/ManageIQ/manageiq/blob/7d8b8ba1a88a1e6154b1266acb1ba43c6be8b6ba/vmdb/app/models/vmdb_database.rb#L17-19).
If it is in the current region, then [`my_region_number` should equal
the region number](https://github.com/ManageIQ/manageiq/blob/7d8b8ba1a88a1e6154b1266acb1ba43c6be8b6ba/vmdb/lib/extensions/ar_region.rb#L137-139),
and `my_database` will return the right value.

In other words, it's safe to set the `vmdb_database` to `my_database` by
default.  That means we can avoid doing a query in `vmdb_database` on
the settings object.

This commit also adds some specs for the settings object (since it
didn't have any specs before).