### PR TITLE
Ignore any files starting with Gemfile.lock

### DIFF
--- a/vmdb/.gitignore
+++ b/vmdb/.gitignore
@@ -6,8 +6,8 @@
 /data/
 /productization
 BUILD
-Gemfile.lock
 Gemfile.dev.rb
+Gemfile.lock*
 GUID
 REGION
 SyntaxCheck


### PR DESCRIPTION
Allow for branch based lockfiles named Gemfile.lock.master, etc.
[skip ci]