### PR TITLE
Dont auto create database.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
 before_install:
 - "echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc"
 - echo "1" > vmdb/REGION
+- cp vmdb/config/database.pg.yml vmdb/config/database.yml
 - psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
 - rake build:shared_objects
 - cd $TEST_ROOT

--- a/system/cfme-setup.sh
+++ b/system/cfme-setup.sh
@@ -47,8 +47,3 @@ EOF
 # will remove this once app is no longer running as root
 /usr/sbin/semanage fcontext -a -t user_home_dir_t "/root(/)?"
 /sbin/restorecon /root
-
-# Copy the postgres template yml to database.yml if it doesn't exist
-db_yml="/var/www/miq/vmdb/config/database.yml"
-db_template="/var/www/miq/vmdb/config/database.pg.yml"
-[ ! -f $db_yml ] && [ -f $db_template ] && cp $db_template $db_yml

--- a/vmdb/config/preinitializer.rb
+++ b/vmdb/config/preinitializer.rb
@@ -19,11 +19,3 @@ if $print_gc_on_signal
   require 'miq_ree_gc'
   MiqReeGc.print_gc_info_on_signal($print_extra_gc_stats, :SIGALRM)
 end
-
-# Copy the postgres template yml to database.yml if it doesn't exist
-db_yml = File.join(File.dirname(__FILE__), 'database.yml')
-unless File.exist?(db_yml)
-  db_template = File.join(File.dirname(__FILE__), 'database.pg.yml')
-  require 'fileutils'
-  FileUtils.cp(db_template, db_yml) if File.exist?(db_template)
-end


### PR DESCRIPTION
In a few places we create a `database.yml` file. It makes it tricky to know if the appliance is configured yet.

My suggestion is to create the file when we actually configure the database. Testing RHEL should be easy, but testing CentOS does require making this change and going through CentOS image creation.

Just wanted to know what people thought.

This is to help address 2 BZs (maybe more): [1095558](https://bugzilla.redhat.com/show_bug.cgi?id=1095558) and [1158638](https://bugzilla.redhat.com/show_bug.cgi?id=1158638)

/cc @jrafanie @Fryguy 