### PR TITLE
Handle file_exists? always returning true for missing files

### DIFF
--- a/vmdb/app/models/file_depot_ftp.rb
+++ b/vmdb/app/models/file_depot_ftp.rb
@@ -88,7 +88,7 @@ class FileDepotFtp < FileDepot
   end
 
   def file_exists?(file_or_directory)
-    !!ftp.nlst(file_or_directory.to_s)
+    !ftp.nlst(file_or_directory.to_s).empty?
   rescue Net::FTPPermError
     false
   end

--- a/vmdb/app/models/file_depot_ftp.rb
+++ b/vmdb/app/models/file_depot_ftp.rb
@@ -1,7 +1,7 @@
 require 'net/ftp'
 
 class FileDepotFtp < FileDepot
-  attr_reader :ftp
+  attr_accessor :ftp
 
   def self.uri_prefix
     "ftp"
@@ -87,6 +87,12 @@ class FileDepotFtp < FileDepot
     end
   end
 
+  def file_exists?(file_or_directory)
+    !!ftp.nlst(file_or_directory.to_s)
+  rescue Net::FTPPermError
+    false
+  end
+
   private
 
   def create_directory_structure(directory_path)
@@ -96,12 +102,6 @@ class FileDepotFtp < FileDepot
       $log.info("#{log_header(__method__)} creating #{path}")
       ftp.mkdir(path.to_s)
     end
-  end
-
-  def file_exists?(file_or_directory)
-    !!ftp.nlst(file_or_directory.to_s)
-  rescue Net::FTPPermError
-    false
   end
 
   def upload(source, destination)

--- a/vmdb/spec/models/file_depot_ftp_spec.rb
+++ b/vmdb/spec/models/file_depot_ftp_spec.rb
@@ -9,6 +9,27 @@ describe FileDepotFtp do
   let(:file_depot_ftp) { FileDepotFtp.new(:uri => "ftp://server.example.com/uploads") }
   let(:log_file)       { LogFile.new(:resource => @miq_server, :local_file => "/tmp/file.txt") }
 
+  context "#file_exists?" do
+    it "true if file exists" do
+      file_depot_ftp.ftp = double(:nlst => ["somefile"])
+
+      expect(file_depot_ftp.file_exists?("somefile")).to be_true
+    end
+
+    it "false if ftp raises on missing file" do
+      file_depot_ftp.ftp = double
+      file_depot_ftp.ftp.should_receive(:nlst).and_raise(Net::FTPPermError)
+
+      expect(file_depot_ftp.file_exists?("somefile")).to be_false
+    end
+
+    it "false if file missing" do
+      file_depot_ftp.ftp = double(:nlst => [])
+
+      expect(file_depot_ftp.file_exists?("somefile")).to be_false
+    end
+  end
+
   context "#upload_file" do
     it "does not already exist" do
       file_depot_ftp.should_receive(:connect).and_return(connection)


### PR DESCRIPTION
Net::FTP#nlst returns an array, so check for empty. 
Some ftp servers return an error when you ask for nlst on a missing file/directory.
Others, will return normally with an empty list.

We had tested with an ftp that does the error situation.
This commit fixes the "empty list" situation.

https://bugzilla.redhat.com/show_bug.cgi?id=1190812