### PR TITLE
Menu Plugins For external sites

### DIFF
--- a/vmdb/app/assets/stylesheets/main.less
+++ b/vmdb/app/assets/stylesheets/main.less
@@ -23,3 +23,5 @@
 @login-container-bg-color:                  #000000;
 @login-container-bg-color-rgba:             rgba(0, 0, 0, 0.2);
 @login-container-details-border-color-rgba: rgba(0, 0, 0, 0.5);      // added new variable to login.less
+
+iframe, .iframe { width: 100%; height: 100% }

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -11,6 +11,20 @@ class DashboardController < ApplicationController
     redirect_to :action => 'show'
   end
 
+  skip_before_filter :set_csp_header, :only => :iframe # FIXME only frame-src
+  skip_before_filter :set_x_frame_options_header, :only => :iframe
+
+  def iframe
+    item = if params[:id].present?
+             Menu::Manager.item(params[:id])
+           elsif params[:sid].present?
+             Menu::Manager.section(params[:sid])
+           end
+    @big_iframe = true
+    @layout     = nil
+    render :locals => {:iframe_src => item.href}
+  end
+
   def csp_report
     report = ActiveSupport::JSON.decode(request.body.read)
     $log.warn("security warning, CSP violation report follows: #{report.inspect}")

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -11,7 +11,7 @@ class DashboardController < ApplicationController
     redirect_to :action => 'show'
   end
 
-  skip_before_filter :set_csp_header, :only => :iframe # FIXME only frame-src
+  skip_before_filter :set_csp_header, :only => :iframe # FIXME: only frame-src
   skip_before_filter :set_x_frame_options_header, :only => :iframe
 
   def iframe

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -15,13 +15,15 @@ class DashboardController < ApplicationController
   skip_before_filter :set_x_frame_options_header, :only => :iframe
 
   def iframe
-    item = if params[:id].present?
-             Menu::Manager.item(params[:id])
-           elsif params[:sid].present?
-             Menu::Manager.section(params[:sid])
-           end
+    @layout = nil
+    if params[:id].present?
+      item = Menu::Manager.item(params[:id])
+      @layout = item.id if item.present?
+    elsif params[:sid].present?
+      item = Menu::Manager.section(params[:sid])
+      @layout = (item.items[0].id rescue nil)
+    end
     @big_iframe = true
-    @layout     = nil
     render :locals => {:iframe_src => item.href}
   end
 

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2526,6 +2526,8 @@ module ApplicationHelper
     # FIXME: exception behavior to remove
     test_layout = 'my_tasks' if %w(my_tasks my_ui_tasks all_tasks all_ui_tasks).include?(@layout)
 
+    return "dropdown-menu" if big_iframe
+
     Menu::Manager.item_in_section?(test_layout, nav_id) ? "nav navbar-nav navbar-persistent" : "dropdown-menu"
   end
 
@@ -2654,5 +2656,9 @@ module ApplicationHelper
 
   def need_prov_dialogs?(type)
     !type.starts_with?("generic")
+  end
+
+  def big_iframe
+    @big_iframe
   end
 end

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2658,7 +2658,5 @@ module ApplicationHelper
     !type.starts_with?("generic")
   end
 
-  def big_iframe
-    @big_iframe
-  end
+  attr_reader :big_iframe
 end

--- a/vmdb/app/models/miq_product_feature.rb
+++ b/vmdb/app/models/miq_product_feature.rb
@@ -7,7 +7,8 @@ class MiqProductFeature < ActiveRecord::Base
   validates_uniqueness_of :identifier
 
   FIXTURE_DIR  = File.join(Rails.root, "db/fixtures")
-  FIXTURE_YAML = File.join(FIXTURE_DIR, "#{self.table_name}.yml")
+  FIXTURE_PATH = File.join(FIXTURE_DIR, self.table_name)
+  FIXTURE_YAML = "#{FIXTURE_PATH}.yml"
 
   DETAIL_ATTRS = [
     :name,
@@ -83,6 +84,11 @@ class MiqProductFeature < ActiveRecord::Base
     log_header = "MIQ(#{self.name}.seed_features)"
     idents_from_hash = []
     self.seed_from_hash(YAML.load_file(FIXTURE_YAML), idents_from_hash)
+
+    root_feature = MiqProductFeature.where(:identifier => 'everything').first
+    Dir.glob(File.join(FIXTURE_PATH, "*.yml")).each do |fixture|
+      self.seed_from_hash(YAML.load_file(fixture), idents_from_hash, root_feature)
+    end
 
     idents_from_db = self.all.collect(&:identifier)
     deletes = idents_from_db - (idents_from_db & idents_from_hash)

--- a/vmdb/app/presenters/menu/custom_loader.rb
+++ b/vmdb/app/presenters/menu/custom_loader.rb
@@ -33,6 +33,9 @@ module Menu
     def create_custom_menu_item(properties)
       rbac = properties['rbac'].each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
       item_type = properties.key?('item_type') ? properties['item_type'].to_sym : :detault
+      %w(id name rbac parent).each do |property|
+        raise Menu::Manager::InvalidMenuDefinition, "incomplete definition -- missing #{property}" if properties[property].blank?
+      end
       item = CustomItem.new(properties['id'], properties['name'], properties['feature'], rbac, properties['href'], item_type)
       item.parent = properties['parent'].to_sym
       item

--- a/vmdb/app/presenters/menu/custom_loader.rb
+++ b/vmdb/app/presenters/menu/custom_loader.rb
@@ -19,7 +19,6 @@ module Menu
 
     def load_custom_item(file_name)
       properties = YAML.load(File.open(file_name))
-
       if properties['type'] == 'section'
         @sections << create_custom_menu_section(properties)
       else
@@ -29,7 +28,6 @@ module Menu
 
     class CustomItem < Item
       attr_accessor :parent
-      # FIXME: :order?
     end
 
     def create_custom_menu_item(properties)
@@ -40,11 +38,9 @@ module Menu
     end
 
     def create_custom_menu_section(properties)
-      if properties.key?('section_type')
-        Section.new(properties['id'].to_sym, properties['name'], [], properties['section_type'].to_sym)
-      else
-        Section.new(properties['id'].to_sym, properties['name'])
-      end
+      section_type = properties.key?('section_type') ? properties['section_type'].to_sym : :default
+      after = properties.key?('after') ? properties['after'].to_sym : nil
+      Section.new(properties['id'].to_sym, properties['name'], [], section_type, after)
     end
   end
 end

--- a/vmdb/app/presenters/menu/custom_loader.rb
+++ b/vmdb/app/presenters/menu/custom_loader.rb
@@ -32,15 +32,18 @@ module Menu
 
     def create_custom_menu_item(properties)
       rbac = properties['rbac'].each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-      item = CustomItem.new(properties['id'], properties['name'], properties['feature'], rbac, properties['url'])
+      item_type = properties.key?('item_type') ? properties['item_type'].to_sym : :detault
+      item = CustomItem.new(properties['id'], properties['name'], properties['feature'], rbac, properties['href'], item_type)
       item.parent = properties['parent'].to_sym
       item
     end
 
     def create_custom_menu_section(properties)
+      placement    = properties.key?('placement')    ? properties['placement'].to_sym    : :default
+      after        = properties.key?('after')        ? properties['after'].to_sym        : nil
       section_type = properties.key?('section_type') ? properties['section_type'].to_sym : :default
-      after = properties.key?('after') ? properties['after'].to_sym : nil
-      Section.new(properties['id'].to_sym, properties['name'], [], section_type, after)
+      href         = properties.key?('href')         ? properties['href'].to_sym         : nil
+      Section.new(properties['id'].to_sym, properties['name'], [], placement, after, section_type, href)
     end
   end
 end

--- a/vmdb/app/presenters/menu/custom_loader.rb
+++ b/vmdb/app/presenters/menu/custom_loader.rb
@@ -43,10 +43,10 @@ module Menu
 
     def create_custom_menu_section(properties)
       placement    = properties.key?('placement')    ? properties['placement'].to_sym    : :default
-      after        = properties.key?('after')        ? properties['after'].to_sym        : nil
+      before       = properties.key?('before')       ? properties['before'].to_sym       : nil
       section_type = properties.key?('section_type') ? properties['section_type'].to_sym : :default
       href         = properties.key?('href')         ? properties['href'].to_sym         : nil
-      Section.new(properties['id'].to_sym, properties['name'], [], placement, after, section_type, href)
+      Section.new(properties['id'].to_sym, properties['name'], [], placement, before, section_type, href)
     end
   end
 end

--- a/vmdb/app/presenters/menu/item.rb
+++ b/vmdb/app/presenters/menu/item.rb
@@ -1,3 +1,14 @@
 module Menu
-  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href)
+  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type) do
+    def initialize(an_id, name, features, rbac_feature, href, type = :default)
+      super
+    end
+
+    def url
+      case type
+      when :big_iframe then "/dashboard/iframe?id=#{id}"
+      else                  href
+      end
+    end
+  end
 end

--- a/vmdb/app/presenters/menu/manager.rb
+++ b/vmdb/app/presenters/menu/manager.rb
@@ -61,9 +61,9 @@ module Menu
 
     def merge_sections(sections)
       sections.each do |section|
-        if section.after
-          position = @menu.index { |existing_section| existing_section.id == section.after }
-          @menu.insert(position + 1, section)
+        if section.before
+          position = @menu.index { |existing_section| existing_section.id == section.before }
+          @menu.insert(position, section)
         else
           @menu << section
         end

--- a/vmdb/app/presenters/menu/manager.rb
+++ b/vmdb/app/presenters/menu/manager.rb
@@ -29,7 +29,7 @@ module Menu
 
     def section(section_id)
       if section_id.kind_of?(String) # prevent .to_sym call on section_id
-        section_id = @id_to_section.keys.detect{ |k| k.to_s == section_id }
+        section_id = @id_to_section.keys.detect { |k| k.to_s == section_id }
       end
       @id_to_section[section_id]
     end

--- a/vmdb/app/presenters/menu/manager.rb
+++ b/vmdb/app/presenters/menu/manager.rb
@@ -6,7 +6,7 @@ module Menu
       extend Forwardable
 
       delegate [:menu, :tab_features_by_id, :tab_features_by_name, :tab_name,
-                :each_feature_title_with_subitems, :item_in_section?] => :instance
+                :each_feature_title_with_subitems, :item_in_section?, :item, :section] => :instance
     end
 
     private
@@ -14,10 +14,24 @@ module Menu
     class InvalidMenuDefinition < Exception
     end
 
-    def menu(type = :default)
+    def menu(placement = :default)
       @menu.each do |menu_section|
-        yield menu_section if menu_section.type == type
+        yield menu_section if menu_section.placement == placement
       end
+    end
+
+    def item(item_id)
+      @menu.each do |menu_section|
+        the_item = menu_section.items.detect { |item| item.id == item_id }
+        return the_item if the_item.present?
+      end
+    end
+
+    def section(section_id)
+      if section_id.kind_of?(String) # prevent .to_sym call on section_id
+        section_id = @id_to_section.keys.detect{ |k| k.to_s == section_id }
+      end
+      @id_to_section[section_id]
     end
 
     def item_in_section?(item_id, section_id)
@@ -49,7 +63,7 @@ module Menu
       sections.each do |section|
         if section.after
           position = @menu.index { |existing_section| existing_section.id == section.after }
-          @menu.insert(position+1, section)
+          @menu.insert(position + 1, section)
         else
           @menu << section
         end

--- a/vmdb/app/presenters/menu/section.rb
+++ b/vmdb/app/presenters/menu/section.rb
@@ -1,11 +1,18 @@
 module Menu
-  Section = Struct.new(:id, :name, :items, :type, :after) do
-    def initialize(an_id, name, items = [], type = :default, after = nil)
+  Section = Struct.new(:id, :name, :items, :placement, :after, :type, :href) do
+    def initialize(an_id, name, items = [], placement = :default, after = nil, type = :default, href = nil)
       super
     end
 
     def features
       Array(items).collect(&:feature).compact
+    end
+
+    def url
+      case type
+      when :big_iframe then "/dashboard/iframe?sid=#{id}"
+      else                  "/dashboard/maintab/?tab=#{id}"
+      end
     end
   end
 end

--- a/vmdb/app/presenters/menu/section.rb
+++ b/vmdb/app/presenters/menu/section.rb
@@ -1,6 +1,6 @@
 module Menu
-  Section = Struct.new(:id, :name, :items, :type) do
-    def initialize(an_id, name, items = [], type = :default)
+  Section = Struct.new(:id, :name, :items, :type, :after) do
+    def initialize(an_id, name, items = [], type = :default, after = nil)
       super
     end
 

--- a/vmdb/app/presenters/menu/section.rb
+++ b/vmdb/app/presenters/menu/section.rb
@@ -1,6 +1,6 @@
 module Menu
-  Section = Struct.new(:id, :name, :items, :placement, :after, :type, :href) do
-    def initialize(an_id, name, items = [], placement = :default, after = nil, type = :default, href = nil)
+  Section = Struct.new(:id, :name, :items, :placement, :before, :type, :href) do
+    def initialize(an_id, name, items = [], placement = :default, before = nil, type = :default, href = nil)
       super
     end
 

--- a/vmdb/app/views/dashboard/iframe.html.haml
+++ b/vmdb/app/views/dashboard/iframe.html.haml
@@ -1,0 +1,2 @@
+.iframe
+  %iframe{:src => iframe_src}

--- a/vmdb/app/views/layouts/_page_center.html.haml
+++ b/vmdb/app/views/layouts/_page_center.html.haml
@@ -1,4 +1,6 @@
--if inner_layout_present?
+-if big_iframe
+  = yield
+-elsif inner_layout_present?
   .container-fluid{:style => "overflow: hidden; height: 100%; background: #fff;"}
     .row{:style => "height: 100%"}
       .col-md-12#center_div{:style => "height: 100%"}

--- a/vmdb/app/views/layouts/_page_header.html.haml
+++ b/vmdb/app/views/layouts/_page_header.html.haml
@@ -20,7 +20,7 @@
             %ul.dropdown-menu#custom_menu_div
               - menu_section.items.each do |menu_item|
                 %li
-                  %a{:href    => menu_item.href,
+                  %a{:href    => menu_item.url,
                      :onclick => 'return miqCheckForChanges()'}= menu_item.name
 
         = render :partial => "layouts/user_options"

--- a/vmdb/app/views/layouts/_page_header.html.haml
+++ b/vmdb/app/views/layouts/_page_header.html.haml
@@ -13,15 +13,17 @@
       %ul{:class => "nav navbar-nav navbar-utility"}
         %li{:class => "brand-white-label #{session[:custom_logo] ? "whitelabeled" : ""}"}
         -Menu::Manager.menu(:top_right) do |menu_section|
-          %li.dropdown
-            %a{:href => "#", :class => "dropdown-toggle", "data-toggle" => "dropdown"}
-              = menu_section.name
-              %b.caret
-            %ul.dropdown-menu#custom_menu_div
-              - menu_section.items.each do |menu_item|
-                %li
-                  %a{:href    => menu_item.url,
-                     :onclick => 'return miqCheckForChanges()'}= menu_item.name
+          -if role_allows(:main_tab_id => menu_section.id)
+            %li.dropdown
+              %a{:href => "#", :class => "dropdown-toggle", "data-toggle" => "dropdown"}
+                = menu_section.name
+                %b.caret
+              %ul.dropdown-menu#custom_menu_div
+                - menu_section.items.each do |menu_item|
+                  -if role_allows(menu_item.rbac_feature)
+                    %li
+                      %a{:href    => menu_item.url,
+                         :onclick => 'return miqCheckForChanges()'}= menu_item.name
 
         = render :partial => "layouts/user_options"
       = render :partial => "layouts/page_header_navbar"

--- a/vmdb/app/views/layouts/_page_header_navbar.html.haml
+++ b/vmdb/app/views/layouts/_page_header_navbar.html.haml
@@ -2,14 +2,14 @@
   -Menu::Manager.menu do |menu_section|
     -if role_allows(:main_tab_id => menu_section.id)
       %li(class="#{primary_nav_class(menu_section.id)}")
-        %a{:href         => "/dashboard/maintab/?tab=#{menu_section.id}",
-           :class        => "dropdown-toggle visible-xs visible-sm", 
-           "data-toggle" => "dropdown", 
+        %a{:href         => menu_section.url,
+           :class        => "dropdown-toggle visible-xs visible-sm",
+           "data-toggle" => "dropdown",
            :onclick      => 'return miqCheckForChanges()'}
           = h(menu_section.name)
-        %a{:href        => "/dashboard/maintab/?tab=#{menu_section.id}",
-           :class       => "dropdown-toggle visible-md visible-lg", 
-           "data-hover" => "dropdown", 
+        %a{:href         => menu_section.url,
+           :class       => "dropdown-toggle visible-md visible-lg",
+           "data-hover" => "dropdown",
            "data-delay" => "1000",
            :onclick     => 'return miqCheckForChanges()'}
           = h(menu_section.name)
@@ -18,5 +18,5 @@
           - menu_section.items.each do |menu_item|
             -if role_allows(menu_item.rbac_feature)
               %li(class="#{secondary_nav_class(menu_item.id)}")
-                %a{:href    => menu_item.href,
+                %a{:href    => menu_item.url,
                    :onclick => 'return miqCheckForChanges()'}= menu_item.name

--- a/vmdb/app/views/stylesheets/_template50.html.haml
+++ b/vmdb/app/views/stylesheets/_template50.html.haml
@@ -1,7 +1,20 @@
 :css
-  @media (min-width: 992px) { 
-    body {padding-top: #{session[:custom_logo] ? 116 : 100}px !important} 
-  }
-
   #searchbox              {top: #{@explorer ? 138 : 63}px;}
   #searchbox.whitelabeled {top: 40px;}
+
+-if big_iframe
+  :css
+    @media (min-width: 992px) { 
+      .navbar-nav ul > li > ul {
+        display:none
+      }
+      body {
+        padding-top: #{session[:custom_logo] ? 83 : 70}px !important} 
+    }
+-else
+  :css
+    @media (min-width: 992px) { 
+      body {
+        padding-top: #{session[:custom_logo] ? 116 : 100}px !important
+      } 
+    }

--- a/vmdb/app/views/stylesheets/_template50.html.haml
+++ b/vmdb/app/views/stylesheets/_template50.html.haml
@@ -3,18 +3,15 @@
   #searchbox.whitelabeled {top: 40px;}
 
 -if big_iframe
+  - padding_top = session[:custom_logo] ? 83 : 70
   :css
-    @media (min-width: 992px) { 
-      .navbar-nav ul > li > ul {
-        display:none
-      }
-      body {
-        padding-top: #{session[:custom_logo] ? 83 : 70}px !important} 
+    @media (min-width: 992px) {
+      .navbar-nav ul > li > ul { display:none }
+      body { padding-top: #{padding_top}px !important }
     }
 -else
+  - padding_top = session[:custom_logo] ? 116 : 100
   :css
-    @media (min-width: 992px) { 
-      body {
-        padding-top: #{session[:custom_logo] ? 116 : 100}px !important
-      } 
+    @media (min-width: 992px) {
+      body { padding-top: #{padding_top}px !important }
     }

--- a/vmdb/app/views/stylesheets/_template50.html.haml
+++ b/vmdb/app/views/stylesheets/_template50.html.haml
@@ -6,6 +6,7 @@
   - padding_top = session[:custom_logo] ? 83 : 70
   :css
     @media (min-width: 992px) {
+      .navbar-pf ul > li.active { margin-bottom: 0 !important; }
       .navbar-nav ul > li > ul { display:none }
       body { padding-top: #{padding_top}px !important }
     }

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -307,6 +307,7 @@ Vmdb::Application.routes.draw do
     :dashboard => {
       :get => %w(
         auth_error
+        iframe
         change_tab
         index
         login


### PR DESCRIPTION
## Using Menu Plugins ##

For plugins that implement integration with an external web site we need a possibility to define:

 1. Menu sections and menu items
  1. for top_right menu
  1. for main menu
 1. RBAC features for the menu items that are editable using Config --> Configuration --> Role

Custom menu sections and items can be defined under `vmdb/product/menubar`.

Custom RBAC features can be defined under `vmdb/db/fixtures/miq_product_features/`.

Assignments of the custom RBAC features to pre-defined roles can be defined under `vmdb/db/fixtures/miq_user_roles`.

For the current version of ManageIQ a package with a UI plugin should drop appropriate files into these locations.

**A custom menu section definition is a yaml file with these keys:**
```
type: section
name: Red Hat
id: redhat
before: svc
placement: top_right
section_type: big_iframe
href: http://www.redhat.com
```

 * `type`, `name`, `id` are mandatory
 * `placement` with value of `top_right` means top-right menu, omitted or `default` means main menu
 * `section_type` `default` creates a menu section with the same type as built-in menu sections; `big_iframe` requires a defined `href` and creates a menu section that when clicked replaces the 2nd menu level and all below with an iframe containing site given in the `href`. This is only valid for main menu items.
 * `before` allows to define the position of the menu section relative to other menu secrion

**A custom menu item definition is a yaml file withe these keys:**
```
type: item
name: Homepage
id: rht3
feature: redhat
rbac:
  feature: redhat
parent: redhat
href: http://www.redhat.com
item_type: big_iframe
```
 * `type`, `name`, `id`, `parent`, `feature` and `rbac` are mandatory
 * `feature` has to be defined as RBAC feature
 * `rbac` contains arguments passwd to `role_allows?` call when a decision about whether a menu item should be presented to a particular user is done
 * `item_type` and `href` ha similar meaning as `section_type` above
 * `parent` must reference an existing menu section


---

DONE:
  * Menu Section definition including `default` and `top_right` *placement*. And possibility to specify ordering by *after*.
  * Settings/Access Control/Role knows about items that exist as features and can edit them.
  * Allow adding of RBAC features (now only existing features will be saved when editing a Role in Settings/Access Control/Role which is enough for testing but not for production)
  * Styling

Future work:
 * restore CSP header and X-Frame-Options header; now these are disabled for `/dashboard/iframe`, we should just relax them by adding some URLs for the plugin
 * maybe? Implement `rake` task for post-inst scripts for plugins

Example usage
----

**product/menubar/custom_redhat_section.yml**
```
type: section
name: Red Hat
id: redhat
before: svc
section_type: big_iframe
href: http://www.redhat.com
```

**product/menubar/custom_redhat.yml**
```
type: item
name: Homepage
id: rht3
feature: redhat
rbac:
  feature: redhat
parent: redhat
href: http://www.redhat.com
item_type: big_iframe
```

**product/menubar/custom_redhat_courses.yml**
```
type: item
name: Courses
id: rht2
feature: redhat
rbac:
  feature: redhat
parent: redhat
href: http://www.redhat.com/en/services/training/all-courses-exams
item_type: big_iframe
```

![custom-menu](https://cloud.githubusercontent.com/assets/51095/6288736/64631086-b91b-11e4-8a56-7cc437f52807.png)

 1. custom menu based on the definition above
 1. settings in the `Configure/Configuration/Access Control/Roles` (the "About" is replaced with the correct text in current PR)
 1. custom menu with *placement*: `top_right`                                                                                

**product/menubar/top_right_section1.yml**
```
type: section                                                                                       
name: Custom section 1                                                                              
placement: top_right                                                                                
id: custom_top  
```

**db/fixtures/miq_product_features/redhat-miq_product_features.yml**
```
---
:name: Red Hat
:description: Access to Red Hat sectioin
:feature_type: node
:identifier: redhat
:children:

- :name: Red Hat Forums
  :description: Access to Red Hat forums
  :feature_type: node
  :identifier: redhat_forum
- :name: Red Hat Whatever
  :description: Access to Red Hat whatever...
  :feature_type: node
  :identifier: redhat_whatever
```

**db/fixtures/miq_user_roles/redhat.yml**
```
--- 

- :name: EvmRole-super_administrator
  :miq_product_feature_identifiers:
  - redhat
  - redhat_forum
  - redhat_whatever
```

![menu-new](https://cloud.githubusercontent.com/assets/51095/6485935/98a477fc-c287-11e4-8c5c-2aa66e03acb6.png)
