### PR TITLE
Add into VimService methods moveIntoFolder_Task and createVM_Task

### DIFF
--- a/lib/VMwareWebService/MiqVimFolder.rb
+++ b/lib/VMwareWebService/MiqVimFolder.rb
@@ -73,6 +73,37 @@ class MiqVimFolder
 	    waitForTask(taskMor)
 	end # def addStandaloneHost
 
+	# Places vCenterObject into current folder, removing it from other folders
+	def moveIntoFolder(vCenterObject)
+		oMor = nil
+		oMor = (vCenterObject.kind_of?(Hash) ? vCenterObject['MOR'] : vCenterObject) if vCenterObject
+		
+		$vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: calling moveIntoFolder_Task" if $vim_log
+		taskMor = @invObj.moveIntoFolder_Task(@fMor, oMor)
+		$vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: returned from moveIntoFolder_Task" if $vim_log
+		$vim_log.debug "MiqVimFolder::moveIntoFolder: taskMor = #{taskMor}" if $vim_log
+		waitForTask(taskMor)
+	end
+	
+	# Creates empty VM, that can be installed later from ISO or whatever
+	# 
+	# configSpec   - describes VM details, it should be filled in calling code since there are too many possible options
+	# pool         - VMware resource pool new VM will belong to
+	# host         - VMware host this VM should start on, it can be nil if pool is on DRS cluster or single-host cluster
+	#
+	# Returns MOR of new VM
+	def createVM(configSpec, pool, host=nil)
+		hMor = pMor = nil
+		hMor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
+		pMor = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
+		
+		$vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM calling createVM_Task" if $vim_log
+		taskMor = @invObj.createVM_Task(@fMor, configSpec, pMor, hMor)
+		$vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM returned from createVM_Task" if $vim_log
+		$vim_log.debug "MiqVimFolder::createVM: taskMor = #{taskMor}" if $vim_log
+		waitForTask(taskMor)
+	end
+		
 	def createFolder(fname)
 		@invObj.createFolder(@fMor, fname)
 	end

--- a/lib/VMwareWebService/VimService.rb
+++ b/lib/VMwareWebService/VimService.rb
@@ -181,40 +181,6 @@ class VimService < Handsoap::Service
 		return(parse_response(response, 'CloneVM_TaskResponse')['returnval'])
 	end
 	
-	def moveIntoFolder_Task(fMor, oMor)
-		response = invoke("n1:MoveIntoFolder_Task") do |message|
-			message.add "n1:_this", fMor do |i|
-				i.set_attr "type", fMor.vimType
-			end
-			message.add "n1:list", oMor do |i|
-				i.set_attr "type", oMor.vimType
-			end
-		end
-		return parse_response(response, 'MoveIntoFolder_TaskResponse')['returnval']
-	end
-	
-	def createVM_Task(fMor, vmcs, pool, hMor)
-		response = invoke("n1:CreateVM_Task") do |message|
-			message.add "n1:_this", fMor do |i|
-				i.set_attr "type", fMor.vimType
-			end
-			message.add "n1:config" do |i|
-				i.set_attr "xsi:type", vmcs.xsiType
-				marshalObj(i, vmcs)
-			end
-			message.add "n1:pool", pool do |i|
-				i.set_attr "type", "ResourcePool"
-			end
-			# hMor is not mandatory since it's ok to miss it for DRS clusters or single host clusters
-			if hMor != nil then
-				message.add "n1:host", hMor do |i|
-					i.set_attr "type", hMor.vimType
-				end
-			end
-		end
-		return parse_response(response, 'CreateVM_TaskResponse')['returnval']
-	end
-	
 	def createAlarm(alarmManager, mor, aSpec)
 		response = invoke("n1:CreateAlarm") do |message|
 			message.add "n1:_this", alarmManager do |i|
@@ -305,6 +271,28 @@ class VimService < Handsoap::Service
 			message.add "n1:quiesce", quiesce
 		end		
 		return(parse_response(response, 'CreateSnapshot_TaskResponse')['returnval'])
+	end
+	
+	def createVM_Task(fMor, vmcs, pool, hMor)
+		response = invoke("n1:CreateVM_Task") do |message|
+			message.add "n1:_this", fMor do |i|
+				i.set_attr "type", fMor.vimType
+			end
+			message.add "n1:config" do |i|
+				i.set_attr "xsi:type", vmcs.xsiType
+				marshalObj(i, vmcs)
+			end
+			message.add "n1:pool", pool do |i|
+				i.set_attr "type", "ResourcePool"
+			end
+			# hMor is not mandatory since it's ok to miss it for DRS clusters or single host clusters
+			if hMor != nil then
+				message.add "n1:host", hMor do |i|
+					i.set_attr "type", hMor.vimType
+				end
+			end
+		end
+		return parse_response(response, 'CreateVM_TaskResponse')['returnval']
 	end
 	
 	def currentTime
@@ -524,6 +512,18 @@ class VimService < Handsoap::Service
 		return(parse_response(response, 'MigrateVM_TaskResponse')['returnval'])
 	end
 
+	def moveIntoFolder_Task(fMor, oMor)
+		response = invoke("n1:MoveIntoFolder_Task") do |message|
+			message.add "n1:_this", fMor do |i|
+				i.set_attr "type", fMor.vimType
+			end
+			message.add "n1:list", oMor do |i|
+				i.set_attr "type", oMor.vimType
+			end
+		end
+		return parse_response(response, 'MoveIntoFolder_TaskResponse')['returnval']
+	end
+	
 	def relocateVM_Task(vmMor, cspec, priority="defaultPriority")
 		response = invoke("n1:RelocateVM_Task") do |message|
 			message.add "n1:_this", vmMor do |i|

--- a/lib/VMwareWebService/VimService.rb
+++ b/lib/VMwareWebService/VimService.rb
@@ -181,6 +181,40 @@ class VimService < Handsoap::Service
 		return(parse_response(response, 'CloneVM_TaskResponse')['returnval'])
 	end
 	
+	def moveIntoFolder_Task(fMor, oMor)
+		response = invoke("n1:MoveIntoFolder_Task") do |message|
+			message.add "n1:_this", fMor do |i|
+				i.set_attr "type", fMor.vimType
+			end
+			message.add "n1:list", oMor do |i|
+				i.set_attr "type", oMor.vimType
+			end
+		end
+		return parse_response(response, 'MoveIntoFolder_TaskResponse')['returnval']
+	end
+	
+	def createVM_Task(fMor, vmcs, pool, hMor)
+		response = invoke("n1:CreateVM_Task") do |message|
+			message.add "n1:_this", fMor do |i|
+				i.set_attr "type", fMor.vimType
+			end
+			message.add "n1:config" do |i|
+				i.set_attr "xsi:type", vmcs.xsiType
+				marshalObj(i, vmcs)
+			end
+			message.add "n1:pool", pool do |i|
+				i.set_attr "type", "ResourcePool"
+			end
+			# hMor is not mandatory since it's ok to miss it for DRS clusters or single host clusters
+			if hMor != nil then
+				message.add "n1:host", hMor do |i|
+					i.set_attr "type", hMor.vimType
+				end
+			end
+		end
+		return parse_response(response, 'CreateVM_TaskResponse')['returnval']
+	end
+	
 	def createAlarm(alarmManager, mor, aSpec)
 		response = invoke("n1:CreateAlarm") do |message|
 			message.add "n1:_this", alarmManager do |i|


### PR DESCRIPTION
These methods are not required for default MIQ classes. However, it's good sometimes to have them in VimService when writing MIQ extensions.

As you see from the names:
- moveIntoFolder_Task moves an object (VM or whatever) into vCenter folder
- createVM_Task creates empty VM that can be installed later from iso or whatever

Required request and response schemes are in wsdl used by MIQ already, but VimService does not provide now methods to make these vCenter calls. The patch just adds the methods.