### PR TITLE
Fix authentication validity check pre worker start

### DIFF
--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -48,6 +48,10 @@ module AuthenticationMixin
     ordered_auths.last.try(:status) || "None"
   end
 
+  def authentication_status_ok?(type = nil)
+    authentication_best_fit(type).try(:status) == "Valid"
+  end
+
   def auth_user_pwd(type = nil)
     cred = authentication_best_fit(type)
     return nil if cred.nil? || cred.userid.blank?

--- a/vmdb/app/models/mixins/per_ems_type_worker_mixin.rb
+++ b/vmdb/app/models/mixins/per_ems_type_worker_mixin.rb
@@ -21,7 +21,7 @@ module PerEmsTypeWorkerMixin
     end
 
     def any_valid_ems_in_zone?
-      self.emses_in_zone.any?(&:authentication_valid?)
+      self.emses_in_zone.any?(&:authentication_status_ok?)
     end
   end
 end

--- a/vmdb/app/models/mixins/per_ems_worker_mixin.rb
+++ b/vmdb/app/models/mixins/per_ems_worker_mixin.rb
@@ -20,7 +20,7 @@ module PerEmsWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      self.all_ems_in_zone.select(&:authentication_valid?)
+      self.all_ems_in_zone.select(&:authentication_status_ok?)
     end
 
     def desired_queue_names

--- a/vmdb/app/models/mixins/per_storage_manager_type_worker_mixin.rb
+++ b/vmdb/app/models/mixins/per_storage_manager_type_worker_mixin.rb
@@ -21,7 +21,7 @@ module PerStorageManagerTypeWorkerMixin
     end
 
     def any_valid_storage_manager_in_zone?
-      self.storage_managers_in_zone.any?(&:authentication_valid?)
+      self.storage_managers_in_zone.any?(&:authentication_status_ok?)
     end
   end
 end

--- a/vmdb/spec/models/miq_event_catcher_openstack_infra_spec.rb
+++ b/vmdb/spec/models/miq_event_catcher_openstack_infra_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqEventCatcherOpenstackInfra do
   before do
     @ems = FactoryGirl.create(:ems_openstack_infra)
-    @ems.stub(:authentication_valid?).and_return(true)
+    @ems.stub(:authentication_status_ok?).and_return(true)
     MiqEventCatcherOpenstackInfra.stub(:all_ems_in_zone).and_return([@ems])
   end
 

--- a/vmdb/spec/models/miq_event_catcher_openstack_spec.rb
+++ b/vmdb/spec/models/miq_event_catcher_openstack_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqEventCatcherOpenstack do
   before do
     @ems = FactoryGirl.create(:ems_openstack)
-    @ems.stub(:authentication_valid?).and_return(true)
+    @ems.stub(:authentication_status_ok?).and_return(true)
     MiqEventCatcherOpenstack.stub(:all_ems_in_zone).and_return([@ems])
   end
 

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -160,6 +160,35 @@ describe AuthenticationMixin do
         @orig_ems_user, @orig_ems_pwd = @ems.auth_user_pwd(:default)
       end
 
+      it "#authentication_status_ok? true if no type, default is Valid" do
+        @auth.update_attribute(:status, "Valid")
+        @ems.authentication_status_ok?.should be_true
+      end
+
+      it "#authentication_status_ok? true if no type, default is Valid and second one is Invalid" do
+        @auth.update_attribute(:status, "Valid")
+        @ems.authentications << FactoryGirl.build(:authentication, :authtype => :some_type, :status => "Invalid")
+        @ems.authentication_status_ok?.should be_true
+      end
+
+      it "#authentication_status_ok? false if no type, default is Invalid and second one is Valid" do
+        @auth.update_attribute(:status, "Invalid")
+        @ems.authentications << FactoryGirl.build(:authentication, :authtype => :some_type, :status => "Valid")
+        @ems.authentication_status_ok?.should be_false
+      end
+
+      it "#authentication_status_ok? true if type is Valid" do
+        @auth.update_attribute(:status, "Invalid")
+        @ems.authentications << FactoryGirl.build(:authentication, :authtype => :some_type, :status => "Valid")
+        @ems.authentication_status_ok?(:some_type).should be_true
+      end
+
+      it "#authentication_status_ok? false if type is Invalid" do
+        @auth.update_attribute(:status, "Valid")
+        @ems.authentications << FactoryGirl.build(:authentication, :authtype => :some_type, :status => "Invalid")
+        @ems.authentication_status_ok?(:some_type).should be_false
+      end
+
       it "should return 'Invalid' authentication_status with one valid, one invalid" do
         highest = "Invalid"
         @auth.update_attribute(:status, "Valid")


### PR DESCRIPTION
**Check the authentication was last good, not if it has credentials.**
authentication_valid? is aliased as has_credentials?

This pre-worker start code was meant to check that the credentials were last
good when we connected, not that we knew the userid.

This fixes an issue when the provider is disconnected and ems based workers
(refresh, event catcher, etc.) start, fail to connect and exit.  It then would
immediately get restarted again because we have the provider's userid, only to
fail to connect again and exit.  This would cause worker "thrashing" and high
CPU usage.

Now, the server will not start workers for ems's after the first
authentication failure occurs.

https://bugzilla.redhat.com/show_bug.cgi?id=1024865

cc @akrzos @psav 

Note, this should fix other situations where the authentication was known(userid) but not truly valid, such as invalid username/password,  unreachable provider, missing password, or other random authentication failures from the provider.

EDIT:

Note, it's much easier to recreate/test this by giving the provider a bad password and saving without validating credentials.  The event catcher will continually stop/start.