### PR TITLE
Fixed HAML syntax.

### DIFF
--- a/vmdb/app/views/layouts/_multi_auth_credentials.html.haml
+++ b/vmdb/app/views/layouts/_multi_auth_credentials.html.haml
@@ -102,6 +102,6 @@
                                                               :id     => "#{record.id || "new"}")}.to_json)
 %hr
 %script{:type => "text/javascript"}
-  //method takes hash that can have 4 keys: tabs div id, active tab label,
-  //url to go to when tab is changed, and whether to check for abandon changes or not
+  -# method takes hash that can have 4 keys: tabs div id, active tab label,
+  -# url to go to when tab is changed, and whether to check for abandon changes or not
   miq_jquery_tabs_init({tabs_div: "auth_tabs"})


### PR DESCRIPTION
This was causing Authentication Credentials tabs to disappear on Provider Add screen when selection was made on Type Pull down.

@dclarizio please review/test.