### PR TITLE
Rename startup screen drop down shortcuts that have EVM Admin

### DIFF
--- a/vmdb/db/fixtures/miq_shortcuts.yml
+++ b/vmdb/db/fixtures/miq_shortcuts.yml
@@ -160,12 +160,12 @@
   :rbac_feature_name: bottlenecks
   :startup: true
 - :name: miq_proxys
-  :description: EVM Admin / SmartProxies
+  :description: Configure / SmartProxies
   :url: /miq_proxy/show_list
   :rbac_feature_name: miq_proxy_show_list
   :startup: true
 - :name: miq_proxy_tasks
-  :description: EVM Admin / Tasks
+  :description: Configure / Tasks
   :url: /miq_proxy/index?jobs_tab=alltasks
   :rbac_feature_name: tasks
   :startup: true


### PR DESCRIPTION
Two shortcuts had "EVM Admin" string in them

https://bugzilla.redhat.com/show_bug.cgi?id=1191489
https://bugzilla.redhat.com/show_bug.cgi?id=1192635