### PR TITLE
[WIP] single host refresh

### DIFF
--- a/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
@@ -13,11 +13,17 @@ module ManageiqForeman
       # NOP
     end
 
-    def refresh_configuration(_target = nil)
-      {
-        :hosts      => connection.all(:hosts),
-        :hostgroups => connection.denormalized_hostgroups,
-      }
+    def refresh_configuration(target = nil)
+      if target
+        {
+          :hosts => [connection.host(target.manager_ref)]
+        }
+      else
+        {
+          :hosts      => connection.all(:hosts),
+          :hostgroups => connection.denormalized_hostgroups,
+        }
+      end
     end
 
     def refresh_provisioning(_target = nil)

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -91,6 +91,7 @@ module EmsRefresh
             :manager_ref                => cs["id"].to_s,
             :hostname                   => cs["name"],
             :configuration_profile      => id_lookup(profiles, cs, "hostgroup_id"),
+            :configuration_profile_ref  => cs["hostgroup_id"],
             :operating_system_flavor_id => id_lookup(operatingsystems, cs, "operatingsystem_id"),
           }
         end

--- a/vmdb/app/models/ems_refresh/refreshers/foreman_configuration_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/foreman_configuration_refresher.rb
@@ -8,14 +8,18 @@ module EmsRefresh
 
       def parse_inventory(manager, targets)
         foreman = ManageiqForeman::Inventory.from_attributes(manager.connection_attrs)
-        raw_ems_data = foreman.refresh_configuration(targets)
+        raw_ems_data = foreman.refresh_configuration(determine_target(targets))
         fetch_provisioning_manager_data(raw_ems_data, manager.provider.provisioning_manager)
         EmsRefresh::Parsers::Foreman.configuration_inv_to_hashes(raw_ems_data)
       end
 
       def save_inventory(manager, targets, hashes)
         EmsRefresh.save_configuration_manager_inventory(manager, hashes, targets[0])
-        EmsRefresh.queue_refresh(manager.provider.provisioning_manager) if hashes[:needs_provisioning_refresh]
+        if hashes[:needs_provisioning_refresh]
+          EmsRefresh.queue_refresh(manager.provider.provisioning_manager)
+        elsif hashes[:needs_configuration_refresh]
+          EmsRefresh.queue_refresh(manager)
+        end
       end
 
       private
@@ -29,6 +33,10 @@ module EmsRefresh
 
       def manager_ref_hash(records)
         Hash[records.collect { |r| [r.manager_ref, r.id] }]
+      end
+
+      def determine_target(targets)
+        targets[0].kind_of?(ConfiguredSystem) ? targets[0].manager_ref : nil
       end
     end
   end


### PR DESCRIPTION
For foreman, refreshes a single host.

If the hostgroup is unknown, it queues a full refresh.

Only single refreshes for a ConfiguredSystem (foreman Host) not a ConfigurationProfile (foreman hostgroup)

/cc @Fryguy @gmcculloug @brandondunne 