### PR TITLE
Fix configuration of LDAP authentication

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -290,6 +290,7 @@ module OpsController::Settings::Common
         render_flash
         return
       end
+      @edit[:new][:authentication][:ldaphost].reject!(&:blank?) if @edit[:new][:authentication][:ldaphost]
       @changed = (@edit[:new] != @edit[:current].config)
       @update = MiqServer.find(@sb[:selected_server_id]).get_config("vmdb")
     when "settings_workers"                                   # Workers Settings
@@ -723,8 +724,6 @@ module OpsController::Settings::Common
       auth[:ldaphost][0] = params[:authentication_ldaphost_1] if params[:authentication_ldaphost_1]
       auth[:ldaphost][1] = params[:authentication_ldaphost_2] if params[:authentication_ldaphost_2]
       auth[:ldaphost][2] = params[:authentication_ldaphost_3] if params[:authentication_ldaphost_3]
-
-      auth[:ldaphost].reject!(&:blank?)
 
       auth[:follow_referrals] = (params[:follow_referrals].to_s == "1") if params[:follow_referrals]
       auth[:get_direct_groups] = (params[:get_direct_groups].to_s == "1") if params[:get_direct_groups]


### PR DESCRIPTION
The buggy scenario was:
1. Configure LDAP authentication, fill in all three fields for LDAP
   host names, e.g. ldap01, ldap02, ldap03
2. Hit save button
3. Delete ldap02
4. Delete ldap03
5. Hit save button
6. ldap01 and ldap03 would show in the list

https://bugzilla.redhat.com/show_bug.cgi?id=1190826