### PR TITLE
@edit[:organizations] is nil for SAT5 and RHSM Hosted

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/rhn.rb
+++ b/vmdb/app/controllers/ops_controller/settings/rhn.rb
@@ -129,7 +129,7 @@ module OpsController::Settings::RHN
     options = {:required => [:userid, :password]}
     db.update_authentication(auth, options)
     db.registration_organization = @edit[:new][:customer_org]
-    db.registration_organization_display_name = @edit[:organizations].key(@edit[:new][:customer_org])
+    db.registration_organization_display_name = @edit[:organizations].try(:key, @edit[:new][:customer_org])
 
     begin
       db.save!


### PR DESCRIPTION
[skip ci]
https://bugzilla.redhat.com/show_bug.cgi?id=1164032



```
[----] I, [2015-02-16T08:47:36.975529 #2295:1302810]  INFO -- : Started POST "/ops/settings_update/rhn_edit?button=save" for 127.0.0.1 at 2015-02-16 03:47:36 -0500
[----] I, [2015-02-16T08:47:36.979839 #2295:1302810]  INFO -- : Processing by OpsController#settings_update as JS
[----] I, [2015-02-16T08:47:36.979911 #2295:1302810]  INFO -- :   Parameters: {"button"=>"save", "id"=>"rhn_edit"}
[----] F, [2015-02-16T08:47:37.003299 #2295:1302810] FATAL -- : Error caught: [NoMethodError] undefined method `key' for nil:NilClass
/var/www/miq/vmdb/app/controllers/ops_controller/settings/rhn.rb:132:in `rhn_save_subscription'
/var/www/miq/vmdb/app/controllers/ops_controller/settings/common.rb:271:in `settings_update_save'
/var/www/miq/vmdb/app/controllers/ops_controller/settings/common.rb:175:in `settings_update'
/opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.17/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
/opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.17/lib/abstract_controller/base.rb:167:in `process_action'
/opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.17/lib/action_controller/metal/rendering.rb:10:in `process_action'
/opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.17/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
```