### PR TITLE
[WIP] Deprecate miq_provision status method.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -4,7 +4,7 @@
 # Get current provisioning status
 task = $evm.root['miq_provision']
 task_status = task['status']
-result = task.status
+result = task.statemachine_task_status
 
 $evm.log('info', "ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task_status}>")
 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -6,7 +6,7 @@
 prov = $evm.root['miq_provision'] || $evm.root['miq_host_provision']
 
 # Get current provisioning status
-result = prov.status
+result = prov.statemachine_task_status
 
 $evm.log('info', "ProvisionCheck returned <#{result}>")
 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration.rb
@@ -3,7 +3,7 @@
 #
 
 # Get current provisioning status
-result = $evm.root["vm_migrate_task"].status
+result = $evm.root["vm_migrate_task"].statemachine_task_status
 
 $evm.log('info', "returned <#{result}>")
 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -5,7 +5,7 @@
 # Get current provisioning status
 task = $evm.root['miq_provision']
 task_status = task['status']
-result = task.status
+result = task.statemachine_task_status
 
 $evm.log('info', "ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task_status}>")
 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -9,7 +9,7 @@ $evm.log("info", "===========================================")
 # Get current provisioning status
 task = $evm.root['service_template_provision_task']
 task_status = task['status']
-result = task.status
+result = task.statemachine_task_status
 
 $evm.log('info', "Service ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task_status}>")
 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/groupsequencecheck.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/groupsequencecheck.rb
@@ -11,7 +11,7 @@ task = $evm.root['service_template_provision_task']
 
 # check if the task is in a runnable state, otherwise abort processing
 unless task.attributes['status'] == 'Ok'
-  $evm.log('info', "Aborting due to task status: <#{task.status}>  task real status: <#{task.attributes['status']}> for Task: <#{task.id}> Description: <#{task.description}> state: <#{task.state}>.")
+  $evm.log('info', "Aborting due to task status: <#{task.statemachine_task_status}>  task real status: <#{task.attributes['status']}> for Task: <#{task.id}> Description: <#{task.description}> state: <#{task.state}>.")
   exit MIQ_ABORT
 end
 

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_automation_task.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_automation_task.rb
@@ -2,7 +2,7 @@ module MiqAeMethodService
   class MiqAeServiceAutomationTask < MiqAeServiceMiqRequestTask
     expose :automation_request, :association => true
 
-    def status
+    def statemachine_task_status
       ar_method do
         if ['finished'].include?(@object.state)
           @object.status.to_s.downcase

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_host_provision.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_host_provision.rb
@@ -3,7 +3,7 @@ module MiqAeMethodService
     expose :miq_host_provision_request, :association => true
     expose :host,                       :association => true
 
-    def status
+    def statemachine_task_status
       ar_method do
         if ['finished', 'provisioned'].include?(@object.state)
           @object.host_rediscovered? ? 'ok' : 'error'

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
@@ -44,7 +44,7 @@ module MiqAeMethodService
       object_send(:set_folder, folder_path)
     end
 
-    def status
+    def statemachine_task_status
       ar_method do
         if ['finished', 'provisioned'].include?(@object.state)
           if @object.status.to_s.downcase == 'error' || @object.vm.nil?

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
@@ -19,5 +19,9 @@ module MiqAeMethodService
       object_send(:update_and_notify_parent, :state => 'finished', :message => msg)
     end
 
+    def status
+      $miq_ae_logger.warn("[DEPRECATION] status method is deprecated.  Please use statemachine_task_status instead.")
+      statemachine_task_status
+    end
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service_reconfigure_task.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service_reconfigure_task.rb
@@ -16,7 +16,7 @@ module MiqAeMethodService
       end
     end
 
-    def status
+    def statemachine_task_status
       ar_method do
         if @object.state == 'finished'
           @object.status.to_s.downcase

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb
@@ -22,7 +22,7 @@ module MiqAeMethodService
       end
     end
 
-    def status
+    def statemachine_task_status
       ar_method do
         if ['finished', 'provisioned'].include?(@object.state)
           @object.status.to_s.downcase

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_migrate_task.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_vm_migrate_task.rb
@@ -1,6 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceVmMigrateTask < MiqAeServiceMiqRequestTask
-    def status
+    def statemachine_task_status
       ar_method do
         if ['finished', 'migrated'].include?(@object.state)
           'ok'


### PR DESCRIPTION
Deprecate status method in favor of new statemachine_task_status.
Added DEPRECATION warning log message.