### PR TITLE
Only execute timed SCVMM refresh if a SCVMM provider exists

### DIFF
--- a/vmdb/lib/workers/schedule_worker/jobs.rb
+++ b/vmdb/lib/workers/schedule_worker/jobs.rb
@@ -74,7 +74,9 @@ class ScheduleWorker < WorkerBase
     end
 
     def ems_refresh_all_scvmm_timer
-      queue_work_on_each_zone(:class_name  => "EmsMicrosoft", :method_name => "refresh_all_ems_timer")
+      if EmsMicrosoft.any?
+        queue_work_on_each_zone(:class_name  => "EmsMicrosoft", :method_name => "refresh_all_ems_timer")
+      end
     end
 
     def miq_alert_evaluate_hourly_timer


### PR DESCRIPTION
This schedule is in place to maintain an up to date SCVMM inventory. This is required because event support is not in place to do so. We still kick off the timer every 15 minutes but this PR ensures a SCVMM provider actually exists before proceeding with the EMS refresh. Making this check so frequently is required to capture newly added SCVMM providers.

There are many ways to check for an EmsMicrosoft instance but i found this the easiest to read, personal preference.

https://bugzilla.redhat.com/show_bug.cgi?id=1184637