### PR TITLE
SCVMM - Unclustered hosts missing from relationship tree when a cluster is present

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -481,11 +481,15 @@ module EmsRefresh::Parsers
     end
 
     def set_host_folder_children
-      if @data[:clusters].empty?
-        {:hosts => @data[:hosts]}
-      else
-        {:clusters => @data[:clusters]}
-      end
+      results = {}
+      results[:clusters] = @data[:clusters] unless @data[:clusters].empty?
+      results[:hosts]    = unclustered_hosts
+
+      results
+    end
+
+    def unclustered_hosts
+      @data[:hosts].select { |h| h[:ems_cluster].nil? }
     end
 
     def identify_primary_ip(nics, host)

--- a/vmdb/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
@@ -55,7 +55,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
     Snapshot.count.should            == 9
     Switch.count.should              == 0
     SystemService.count.should       == 0
-    Relationship.count.should        == 34
+    Relationship.count.should        == 35
 
     MiqQueue.count.should            == 28
     Storage.count.should             == 6
@@ -245,7 +245,8 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
       [EmsFolder, "Datacenters", {:is_datacenter => false}] => {
         [EmsFolder, "SCVMM", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {
-            [EmsCluster, "US_East"] => {}
+            [EmsCluster, "US_East"]                    => {},
+            [HostMicrosoft, "hyperv-h01.manageiq.com"] => {},
           },
           [EmsFolder, "vm", {:is_datacenter => false}]   => {
             [TemplateMicrosoft, "testvm1"]                                                            => {},


### PR DESCRIPTION
When a SCVMM provider contains both clustered hosts and unclustered host(s) we are omitting the unclustered hosts from the relationship tree. This PR addresses this.

https://bugzilla.redhat.com/show_bug.cgi?id=1193183