### PR TITLE
Disable bundle install concurrency during kickstart of appliance.

### DIFF
--- a/system/LINK/etc/default/evm_bundler
+++ b/system/LINK/etc/default/evm_bundler
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export BUNDLE_WITHOUT=test:metric_fu:development
-export BUNDLE_JOBS=4
+export BUNDLE_JOBS=1
 
 # This is an environment variable we set in one place in the event
 # we want to use --local, --deployment, etc.


### PR DESCRIPTION
Temporary workaround for #1664 

cc @Fryguy @tenderlove 

This file is sourced in during the kickstart build of our appliances.  We can re-enable concurrency in the bundle install once we track down and fix the thread unsafe code.