### PR TITLE
change VmdbDatabaseSetting to be an AR model

### DIFF
--- a/vmdb/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/vmdb/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -176,24 +176,6 @@ module ActiveRecord
         return nil
       end
 
-      def configuration_settings
-        data = select(<<-SQL, "Configuration Settings")
-                          SELECT *
-                            FROM pg_settings
-                            ORDER BY name
-                         SQL
-
-        data.each do |datum|
-          # Synthesize short_desc and extra_desc into a new field called description
-          datum['description']  = datum['short_desc']
-          datum['description'] += "  #{datum['extra_desc']}" unless datum['extra_desc'].nil?
-
-          datum.keys.each { |key| datum[key] ||= "" }
-        end
-
-        data
-      end
-
       # Taken from: https://github.com/bucardo/check_postgres/blob/2.19.0/check_postgres.pl#L3492
       # and referenced here: http://wiki.postgresql.org/wiki/Show_database_bloat
       # check_postgres is Copyright (C) 2007-2012, Greg Sabino Mullane

--- a/vmdb/spec/models/vmdb_database_setting_spec.rb
+++ b/vmdb/spec/models/vmdb_database_setting_spec.rb
@@ -19,7 +19,35 @@ describe VmdbDatabaseSetting do
 
   it 'sets a default database' do
     setting = VmdbDatabaseSetting.new
-    expect(setting.vmdb_database).to eql(@db)
+    expect(setting.vmdb_database).to eq(@db)
+  end
+
+  it 'aliases min_val to minimum_value' do
+    setting = VmdbDatabaseSetting.where('min_val is not null').first
+    expect(setting.min_val).to eq(setting.minimum_value)
+  end
+
+  it 'aliases max_val to maximum_value' do
+    setting = VmdbDatabaseSetting.where('max_val is not null').first
+    expect(setting.max_val).to eq(setting.maximum_value)
+  end
+
+  it 'aliases setting to value' do
+    setting = VmdbDatabaseSetting.where('setting is not null').first
+    expect(setting.value).to eq(setting.setting)
+  end
+
+  it 'combines short_desc and extra_desc for description' do
+    setting = VmdbDatabaseSetting.where(:extra_desc => nil).first
+    expect(setting.description).to eq(setting.short_desc)
+
+    setting = VmdbDatabaseSetting.where('extra_desc is not null').first
+    expect(setting.description).to eq("#{setting.short_desc}  #{setting.extra_desc}")
+  end
+
+  it 'defaults unit to a blank string' do
+    setting = VmdbDatabaseSetting.where(:unit => nil).first
+    expect(setting.unit).to eq("")
   end
 
   [

--- a/vmdb/spec/models/vmdb_database_setting_spec.rb
+++ b/vmdb/spec/models/vmdb_database_setting_spec.rb
@@ -45,6 +45,15 @@ describe VmdbDatabaseSetting do
     expect(setting.description).to eq("#{setting.short_desc}  #{setting.extra_desc}")
   end
 
+  it 'does not mutate short_desc' do
+    setting = VmdbDatabaseSetting.where('extra_desc is not null').first
+    short_desc = setting.short_desc.dup
+    desc = setting.description.dup
+
+    expect(setting.description).to eq(desc)
+    expect(setting.short_desc).to eq(short_desc)
+  end
+
   it 'defaults unit to a blank string' do
     setting = VmdbDatabaseSetting.where(:unit => nil).first
     expect(setting.unit).to eq("")


### PR DESCRIPTION
this converts VmdbDatabaseSetting to be an active record model rather
than inheriting from ActsAsArModel.  Now we can use Rails finders with
the model without maintaining our own implementation (for this model).