### PR TITLE
Expose Openstack cloud_volume and cloud_object_store models to automate.

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_object_store_container.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_object_store_container.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudObjectStoreContainer < MiqAeServiceModelBase
+    expose :ext_management_system,      :association => true
+    expose :cloud_tenant,               :association => true
+    expose :cloud_object_store_objects, :association => true
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_object_store_object.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_object_store_object.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudObjectStoreObject < MiqAeServiceModelBase
+    expose :ext_management_system,        :association => true
+    expose :cloud_tenant,                 :association => true
+    expose :cloud_object_store_container, :association => true
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume.rb
@@ -1,0 +1,10 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudVolume < MiqAeServiceModelBase
+    expose :ext_management_system,  :association => true
+    expose :availability_zone,      :association => true
+    expose :cloud_tenant,           :association => true
+    expose :base_snapshot,          :association => true
+    expose :cloud_volume_snapshots, :association => true
+    expose :attachments,            :association => true
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_amazon.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_amazon.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudVolumeAmazon < MiqAeServiceCloudVolume
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_openstack.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_openstack.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudVolumeOpenstack < MiqAeServiceCloudVolume
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_snapshot.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_snapshot.rb
@@ -1,0 +1,8 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudVolumeSnapshot < MiqAeServiceModelBase
+    expose :ext_management_system, :association => true
+    expose :cloud_tenant,          :association => true
+    expose :cloud_volume,          :association => true
+    expose :based_volumes,         :association => true
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_snapshot_amazon.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_snapshot_amazon.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudVolumeSnapshotAmazon < MiqAeServiceCloudVolumeSnapshot
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_snapshot_openstack.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume_snapshot_openstack.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceCloudVolumeSnapshotOpenstack < MiqAeServiceCloudVolumeSnapshot
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_disk.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_disk.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceDisk < MiqAeServiceModelBase
+    expose :hardware, :association => true
+    expose :storage,  :association => true
+    expose :backing,  :association => true
+  end
+end


### PR DESCRIPTION
Create automate service models for:
  CloudVolume, CloudVolumeAmazon, CloudVolumeOpenstack
  CloudVolumeSnapshot, CloudVolumeSnapshotAmazon, CloudVolumeSnapshotOpenstack
  CloudObjectStoreContainer, CloudObjectStoreObject

Also expose relationships with other models.

https://bugzilla.redhat.com/show_bug.cgi?id=1142494