### PR TITLE
return the value rather than setting the ivar

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1794,12 +1794,13 @@ class ApplicationController < ActionController::Base
   end
 
   def get_view_calculate_gtl_type(db_sym)
-    @gtl_type = @settings[:views][db_sym] unless ['scanitemset', 'miqschedule', 'pxeserver', 'customizationtemplate'].include?(db_sym.to_s)
+    gtl_type = nil
+    gtl_type = @settings[:views][db_sym] unless ['scanitemset', 'miqschedule', 'pxeserver', 'customizationtemplate'].include?(db_sym.to_s)
     # Force list view for certain types and areas
-    @gtl_type = 'list' if ['filesystems', 'registry_items', 'chargeback_rates', 'miq_request'].include?(@listicon)
-    @gtl_type = 'list' if @gtl_type.nil?
-    @gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
-    @gtl_type
+    gtl_type = 'list' if ['filesystems', 'registry_items', 'chargeback_rates', 'miq_request'].include?(@listicon)
+    gtl_type = 'list' if gtl_type.nil?
+    gtl_type = 'grid' if 'vm' == db_sym.to_s && request.parameters[:controller] == 'service'
+    gtl_type
   end
   private :get_view_calculate_gtl_type
 


### PR DESCRIPTION
[the `get_view_calculate_gtl_type` caller sets the `@gtl_type` ivar](https://github.com/tenderlove/manageiq/blob/d168cdbfe0de910f61d3ae5d9347f1abb2d546cd/vmdb/app/controllers/application_controller.rb#L1889) so there is no reason to set it multiple times