### PR TITLE
properly override multi level foreman hostgroups

### DIFF
--- a/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
@@ -26,7 +26,7 @@ module ManageiqForeman
         all += small.to_a
         break if small.empty? || all.size >= small.total
       end
-      paged_response(all)
+      PagedResponse.new(all)
     end
 
     # filter:
@@ -75,24 +75,21 @@ module ManageiqForeman
     private
 
     def fetch(resource, action = :index, filter = {})
-      paged_response(raw(resource).send(action, filter).first)
+      PagedResponse.new(raw(resource).send(action, filter).first)
     end
 
     def denormalize_ancestors!(records)
       records.each do |record|
-        ancestor_ids(record["ancestry"]).each do |ancestor_id|
+        ancestor_ids(record["ancestry"]).reverse.each do |ancestor_id|
           ancestor = records.detect { |r| r["id"] == ancestor_id }
           ancestor.each_pair { |n, v| record[n] ||= v unless v.nil? } if ancestor
         end
       end
+      records
     end
 
     def ancestor_ids(str)
       (str || "").split("/").collect(&:to_i)
-    end
-
-    def paged_response(resource)
-      PagedResponse.new(resource)
     end
 
     def raw(resource)

--- a/lib/manageiq_foreman/lib/manageiq_foreman/paged_response.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/paged_response.rb
@@ -2,28 +2,26 @@ module ManageiqForeman
   # like the WillPaginate collection
   class PagedResponse
     include Enumerable
+    extend Forwardable
 
     attr_accessor :page
     attr_accessor :total
-    attr_accessor :size # subtotal
     attr_accessor :results
+
     # per_page, search, sort
     def initialize(json)
       if json.kind_of?(Hash) && json["results"]
         @results = json["results"]
         @total   = json["total"].to_i
-        @size    = @results.size
         @page    = json["page"]
       else
         @results = json.kind_of?(Array) ? json : Array[json]
-        @total = @size = json.size
+        @total = json.size
         @page  = 1
       end
     end
 
-    def each(&block)
-      results.each(&block)
-    end
+    def_delegators :results, :each, :[], :empty?, :size
 
     # modify the structure inline
     def map!(&block)
@@ -31,12 +29,8 @@ module ManageiqForeman
       self
     end
 
-    def [](name)
-      results[name]
-    end
-
-    def empty?
-      size == 0 # results.empty?
+    def ==(other)
+      results == other.results
     end
   end
 end

--- a/lib/manageiq_foreman/spec/connection_spec.rb
+++ b/lib/manageiq_foreman/spec/connection_spec.rb
@@ -39,7 +39,7 @@ describe ManageiqForeman::Connection do
 
   describe "#denormalized_hostgroups" do
     # can't denormalize hostgroups with partial lists
-    context "with all hostgroups" do
+    context "with parent children" do
       let(:orig)         { connection.hostgroups }
       let(:orig_child)   { orig.detect { |r| r["name"] == 'ProviderRefreshSpec-ChildHostGroup' } }
       let(:parent)       { results.detect { |r| r["name"] == 'ProviderRefreshSpec-HostGroup' } }
@@ -73,6 +73,47 @@ describe ManageiqForeman::Connection do
         expect(merge_child["ptable_id"]).to eq(12)
       end
     end
+
+    context "with multi levels" do
+      it "inherits value" do
+        expect(connection).to receive(:all).with(:hostgroups, {}).and_return(rs([
+          {"id" => 1, "operatingsystem_id" => 4},
+          {"id" => 2, "operatingsystem_id" => nil, "ancestry" => "1"},
+          {"id" => 3, "operatingsystem_id" => nil, "ancestry" => "1/2"},
+        ]))
+        expect(connection.denormalized_hostgroups).to eq(rs([
+          {"id" => 1, "operatingsystem_id" => 4},
+          {"id" => 2, "operatingsystem_id" => 4, "ancestry" => "1"},
+          {"id" => 3, "operatingsystem_id" => 4, "ancestry" => "1/2"},
+        ]))
+      end
+
+      it "overrides value" do
+        expect(connection).to receive(:all).with(:hostgroups, {}).and_return(rs([
+          {"id" => 1, "operatingsystem_id" => 4},
+          {"id" => 2, "operatingsystem_id" => nil, "ancestry" => "1"},
+          {"id" => 3, "operatingsystem_id" => 6, "ancestry" => "1/2"},
+        ]))
+        expect(connection.denormalized_hostgroups).to eq(rs([
+          {"id" => 1, "operatingsystem_id" => 4},
+          {"id" => 2, "operatingsystem_id" => 4, "ancestry" => "1"},
+          {"id" => 3, "operatingsystem_id" => 6, "ancestry" => "1/2"},
+        ]))
+      end
+
+      it "overrides parent values" do
+        expect(connection).to receive(:all).with(:hostgroups, {}).and_return(rs([
+          {"id" => 1, "operatingsystem_id" => 4},
+          {"id" => 2, "operatingsystem_id" => 5, "ancestry" => "1"},
+          {"id" => 3, "operatingsystem_id" => nil, "ancestry" => "1/2"},
+        ]))
+        expect(connection.denormalized_hostgroups).to eq(rs([
+          {"id" => 1, "operatingsystem_id" => 4},
+          {"id" => 2, "operatingsystem_id" => 5, "ancestry" => "1"},
+          {"id" => 3, "operatingsystem_id" => 5, "ancestry" => "1/2"},
+        ]))
+      end
+    end
   end
 
   describe "simple accessor methods" do
@@ -99,5 +140,20 @@ describe ManageiqForeman::Connection do
         end
       end
     end
+  end
+
+  def rs(arr)
+    ManageiqForeman::PagedResponse.new(
+      "total"    => arr.count,
+      "subtotal" => arr.count,
+      "page"     => 1,
+      "per_page" => [arr.count, 20].max,
+      "search"   => nil,
+      "sort"     => {
+        "by"    => nil,
+        "order" => nil,
+      },
+      "results"  => arr,
+    )
   end
 end

--- a/lib/manageiq_foreman/spec/paged_response_spec.rb
+++ b/lib/manageiq_foreman/spec/paged_response_spec.rb
@@ -29,4 +29,13 @@ describe ManageiqForeman::PagedResponse do
     end
     it { expect(mapped_response.results).to eq([{"id" => "a"}, {"id" => "aa"}, {"id" => "aaa"}]) }
   end
+
+  describe "comparison" do
+    let(:a) { described_class.new([{"id" => "a"}, {"id" => "b"}]) }
+    let(:b) { described_class.new([{"id" => "a"}, {"id" => "b"}]) }
+    let(:x) { described_class.new([{"id" => "b"}, {"id" => "b"}]) }
+    it { expect(a).to eq(a) }
+    it { expect(a).to eq(b) }
+    it { expect(a).not_to eq(x) }
+  end
 end


### PR DESCRIPTION
Multiple layers of foreman host groups did not properly override values.

**before**
top: val1, mid: val2, bottom: nil => top: val1, mid: val2, bottom: **val1**

**after**
top: val1, mid: val2, bottom: nil => top: val1, mid: val2, bottom: **val2**

/cc @gmcculloug @brandondunne @Fryguy 