### PR TITLE
Resume "shutdown" instances in OpenStack

### DIFF
--- a/vmdb/app/models/vm_openstack/operations/power.rb
+++ b/vmdb/app/models/vm_openstack/operations/power.rb
@@ -8,6 +8,7 @@ module VmOpenstack::Operations::Power
       case raw_power_state
       when "PAUSED"    then connection.unpause_server(ems_ref)
       when "SUSPENDED" then connection.resume_server(ems_ref)
+      when "SHUTDOWN"  then connection.resume_server(ems_ref)
       when "STOPPED"   then connection.start_server(ems_ref)
       end
     end

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
@@ -468,6 +468,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
       :ems_ref_obj           => nil,
       :vendor                => "OpenStack",
       :power_state           => "off",
+      :raw_power_state       => "SHUTDOWN", # openstack bug?  suspended libvirt instances show up as "shutdown"
       :location              => "unknown",
       :tools_status          => nil,
       :boot_time             => nil,


### PR DESCRIPTION
There's a number of problems leading to the cause of this bug.  This fix
attempts to handle one of those problems.  But, it's possible that this problem
will creep up again, and we may have to deal with this same problem again later.

The issue is because of three things happening at the same time:

1) OpenStack does not correctly set the power_state for suspended instances.
   The vm_state is set to "suspended" while the power_state ends up as "shutdown".
   It's possible that this is specific to libvirt instances.  I'm not altogether
   certain yet.

2) OpenStack does not handle discrepancies between vm_status and power_state
   when the vm_status is "suspended":
https://github.com/openstack/nova/blob/47fc1a6e5674fadecca253629d36430ceb5c8471/nova/compute/manager.py#L5912-L5918

3) ManageIQ did not previously handle starting a "shutdown" openstack instance.

With this patch, ManageIQ handles "shutdown" openstack instances as if they are
"suspended" to match the way OpenStack handled suspended libvirt instances.

https://bugzilla.redhat.com/show_bug.cgi?id=1183757