### PR TITLE
Fix Bootstrap - Slickgrid styling conflict

### DIFF
--- a/vmdb/app/assets/stylesheets/product_slickgrid.css
+++ b/vmdb/app/assets/stylesheets/product_slickgrid.css
@@ -3,9 +3,7 @@
 }
 
 .cell-bkg {
-    border-left: 1px #999 solid;
-    border-right: 1px #999 solid;
-    background-image: url(/images/layout/stripe_bg2.png);
+    background-color: #f2f2f2;
     color:#403990;
     font-weight: bold;
 }
@@ -90,7 +88,7 @@
     -moz-transform: rotate(-90deg);
     -ms-transform: rotate(-90deg);
     padding-bottom: 30px;
-    padding-left: 20px;
+    margin-left: 17px !important;
 }
 
 .toggle {

--- a/vmdb/app/assets/stylesheets/slick.grid.css
+++ b/vmdb/app/assets/stylesheets/slick.grid.css
@@ -5,6 +5,14 @@ No built-in (selected, editable, highlight, flashing, invalid, loading, :focus) 
 classes should alter those!
 */
 
+/*Override Bootstrap box-sizing*/
+.slick-header-column.ui-state-default
+ {
+  -webkit-box-sizing: content-box;
+     -moz-box-sizing: content-box;
+          box-sizing: content-box;
+}
+
 .slick-header.ui-state-default, .slick-headerrow.ui-state-default {
   width: 100%;
   overflow: hidden;
@@ -112,6 +120,7 @@ classes should alter those!
   white-space: nowrap;
   cursor: default;
   color: #4d5258;
+  height: 34px !important;
 }
 
 .slick-cell:first-child {


### PR DESCRIPTION
* override default bootstrap css boxsizing for slickgrid screens (compare and drift)
* update styling

Issue: #1574 
before:
![screen shot 2015-02-16 at 3 16 06 pm](https://cloud.githubusercontent.com/assets/1287144/6220571/dfb848c8-b605-11e4-9f3c-88c23c71ceba.png)
After:
![screen shot 2015-02-16 at 5 56 43 pm](https://cloud.githubusercontent.com/assets/1287144/6220572/dfb97fea-b605-11e4-950b-54a0a698546d.png)

![screen shot 2015-02-16 at 6 04 17 pm](https://cloud.githubusercontent.com/assets/1287144/6220605/450c750a-b606-11e4-9586-e0b3c98e5680.png)
