### PR TITLE
Vm or template split bug

### DIFF
--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1160,7 +1160,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   def self.refresh_ems(vm_ids)
     vm_ids = [vm_ids] unless vm_ids.kind_of?(Array)
-    vm_ids = vm_ids.collect { |id| [Vm, id] }
+    vm_ids = vm_ids.collect { |id| [base_class, id] }
     EmsRefresh.queue_refresh(vm_ids)
   end
 

--- a/vmdb/spec/models/vm_or_template_spec.rb
+++ b/vmdb/spec/models/vm_or_template_spec.rb
@@ -413,4 +413,16 @@ describe VmOrTemplate do
       end
     end
   end
+
+  context ".refresh_ems queues refresh for proper class" do
+    [:template_vmware, :vm_vmware].each do |vm_or_template|
+      let(:instance) {FactoryGirl.create(vm_or_template)}
+
+      it "#{vm_or_template.to_s.classify}" do
+        EmsRefresh.should_receive(:queue_refresh).with([[VmOrTemplate, instance.id]])
+
+        instance.class.refresh_ems(instance.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Individual Template refreshes were failing because the ar_record could not be found for a Vm with the id of the template.