### PR TITLE
compare default value against a string

### DIFF
--- a/vmdb/spec/models/dialog_field_check_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_check_box_spec.rb
@@ -81,13 +81,13 @@ describe DialogFieldCheckBox do
     end
 
     context "when the automate hash has a default value" do
-      let(:default_value) { 1 }
+      let(:default_value) { '1' }
 
       it_behaves_like "DialogFieldCheckbox#normalize_automate_values"
 
       it "sets the default value" do
         dialog_field.normalize_automate_values(automate_hash)
-        expect(dialog_field.default_value).to eq(1)
+        expect(dialog_field.default_value).to eq('1')
       end
 
       it "returns the default value in a string format" do

--- a/vmdb/spec/models/dialog_field_text_area_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_area_box_spec.rb
@@ -53,13 +53,13 @@ describe DialogFieldTextAreaBox do
     end
 
     context "when the automate hash has a default value" do
-      let(:default_value) { 123 }
+      let(:default_value) { '123' }
 
       it_behaves_like "DialogFieldTextBox#normalize_automate_values"
 
       it "sets the default_value" do
         dialog_field.normalize_automate_values(automate_hash)
-        expect(dialog_field.default_value).to eq(123)
+        expect(dialog_field.default_value).to eq('123')
       end
 
       it "returns the default value in string format" do

--- a/vmdb/spec/models/dialog_field_text_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_box_spec.rb
@@ -222,13 +222,13 @@ describe DialogFieldTextBox do
     end
 
     context "when the automate hash has a default value" do
-      let(:default_value) { 123 }
+      let(:default_value) { '123' }
 
       it_behaves_like "DialogFieldTextBox#normalize_automate_values"
 
       it "sets the default_value" do
         dialog_field.normalize_automate_values(automate_hash)
-        expect(dialog_field.default_value).to eq(123)
+        expect(dialog_field.default_value).to eq('123')
       end
 
       it "returns the default value in string format" do


### PR DESCRIPTION
`default_value` [is a string](https://github.com/ManageIQ/manageiq/blob/10dfdd3655f22a6820c937b2cdcd5776bf3e0ddd/vmdb/db/migrate/20120514132616_create_dialogs.rb#L37) so it will get typecast as a string in Rails 4.  We should compare against strings rather than integers so that this test works between rails versions