### PR TITLE
Include quota helper in application controller

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -24,6 +24,8 @@ class ApplicationController < ActionController::Base
   include JsHelper
   helper JsHelper
 
+  helper CloudResourceQuotaHelper
+
   include_concern 'Automate'
   include_concern 'CiProcessing'
   include_concern 'Compare'

--- a/vmdb/app/controllers/miq_request_controller.rb
+++ b/vmdb/app/controllers/miq_request_controller.rb
@@ -5,8 +5,6 @@ class MiqRequestController < ApplicationController
   after_filter :cleanup_action
   after_filter :set_session_data
 
-  helper CloudResourceQuotaHelper
-
   def index
 #   show_list
 #   render :action=>"show_list"


### PR DESCRIPTION
The CloudResourceQuotaHelper was originally only included in the
MiqRequestController for handling provisioning requests.  However, it appears
that there are other controllers that can access the provisioning workflow;
namely the VmCloudController.

When a controller other than MiqRequestController attempts to render
provisioning workflow pages, the user sees the error described in the linked bug
below.

Instead of trying to track down all of the controllers that somehow play a part
in provisioning requests, the CloudResourceQuotaHelper is now part of the base
application controller and available to all controllers.

https://bugzilla.redhat.com/show_bug.cgi?id=1190852