### PR TITLE
Changed catalog initialization methods to handle array values.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -11,23 +11,47 @@
 # Inputs: $evm.root['service_template_provision_task'].dialog_options
 #
 
-# Look for service dialog variables in the dialog options hash that start with "tag_[0-9]",
-def get_tags_hash(dialog_options)
-  # Setup regular expression for service dialog tags
-  tags_regex = /^dialog_tag_\d*_(.*)/
+# array_entry example - Classification::1
+def vmdb_object_from_array_entry(entry)
+  model, id = entry.split("::")
+  $evm.vmdb(model, id.to_i) if model && id
+end
 
-  tags_hash = {}
+def array_value(hash, hash_key, value)
+  if hash.key?(hash_key)
+    values = hash[hash_key]
+    values = "#{values},#{value}"
+    values[0] = "" if values[0] == ","
+  else
+    value
+  end
+end
+
+def get_tags_hash(dialog_options)
+  # Setup regular expressions for service dialog tags
+  tags_regex       = /^dialog_tag_\d*_(.*)/
+  tags_array_regex = /^Array::dialog_tag_\d*_(.*)/
+  tags_hash        = {}
 
   # Loop through all of the tags and build an options_hash from them
-  dialog_options.each do |k, v|
-    if tags_regex =~ k
-      # Convert key to symbol
-      tag_category = Regexp.last_match[1].to_sym
-      tag_value = v.downcase
+  dialog_options.each do |key, value|
+    next if value.blank?
 
-      unless tag_value.blank?
-        $evm.log("info", "Adding category:<#{tag_category.inspect}> tag:<#{tag_value.inspect}> to tags_hash")
+    if tags_regex =~ key
+      tag_category = Regexp.last_match[1].to_sym
+      tag_value = value.downcase
+      $evm.log("info", "Adding category:<#{tag_category.inspect}> tag:<#{tag_value.inspect}> to tags_hash")
+      tags_hash[tag_category] = tag_value
+    # Classification::1,Classification::2
+    elsif tags_array_regex =~ key
+      tag_category = Regexp.last_match[1].to_sym
+      value.split(",").each do |entry|
+        vmdb_obj = vmdb_object_from_array_entry(entry)
+        next if vmdb_obj.blank?
+        tag_value = array_value(tags_hash, tag_category, vmdb_obj.to_tag)
+        next if tag_value.blank?
         tags_hash[tag_category] = tag_value
+        $evm.log("info", "Adding category:<#{tag_category.inspect}> tag:<#{tag_value.inspect}> to tags_hash")
       end
     end
   end
@@ -38,37 +62,49 @@ end
 # Look for service dialog variables in the dialog options hash that start with "option_[0-9]",
 def get_options_hash(dialog_options)
   # Setup regular expression for service dialog tags
-  options_regex = /^dialog_option_\d*_(.*)/
-  options_hash = {}
+  options_regex       = /^dialog_option_\d*_(.*)/
+  options_array_regex = /^Array::dialog_option_\d*_(.*)/
+  options_hash        = {}
 
   # Loop through all of the options and build an options_hash from them
-  dialog_options.each do |k, v|
-    if options_regex =~ k
+  dialog_options.each do |key, value|
+    if options_regex =~ key
       option_key = Regexp.last_match[1].to_sym
-      option_value = v
+      option_value = value
 
       unless option_value.blank?
-        $evm.log("info", "Adding option_key:<#{option_key.inspect}> option_value:<#{option_value.inspect}> to options_hash")
+        $evm.log("info", "Adding key:<#{option_key.inspect}> value:<#{option_value.inspect}>")
         options_hash[option_key] = option_value
       end
+    elsif options_array_regex =~ key
+      option_key = Regexp.last_match[1].to_sym
+      value.split(",").each do |entry|
+        vmdb_obj = vmdb_object_from_array_entry(entry)
+        next if vmdb_obj.blank?
+
+        option_value = array_value(options_hash, option_key, vmdb_obj.description)
+        options_hash[option_key] = option_value unless option_value.blank?
+        $evm.log("info", "Adding key:<#{option_key.inspect}> value:<#{option_value.inspect}> to options_hash")
+      end
     else
-      unless v.nil?
-        $evm.log("info", "Adding option:<#{k.to_sym.inspect}> value:<#{v.inspect}> to options_hash")
-        options_hash[k.to_sym] = v
+      unless value.nil?
+        $evm.log("info", "Adding option:<#{key.to_sym.inspect}> value:<#{value.inspect}> to options_hash")
+        options_hash[key.to_sym] = value
       end
     end
   end
-  $evm.log("info", "Inspecting options_hash:<#{options_hash.inspect}>")
   options_hash
 end
 
 # Look in tags_hash for tags and tag the service
 def tag_service(service, tags_hash)
-  # Look for tags with a sequence_id of 0 to tag the destination Service
   unless tags_hash.nil?
-    tags_hash.each do |k, v|
-      $evm.log("info", "Adding Tag:<#{k.inspect}/#{v.inspect}> to Service:<#{service.name}>")
-      service.tag_assign("#{k}/#{v}")
+    tags_hash.each do |_k, v|
+      v.split(",").each do |e|
+        $evm.log("info", "Adding Tag:<#{e}> to Service:<#{service.name}>")
+        service.tag_assign("#{e.downcase}")
+      end
+      $evm.log("info", "service tags: <#{service.tags}")
     end
   end
 end
@@ -81,8 +117,9 @@ service = service_template_provision_task.destination
 $evm.log("info", "Detected Service:<#{service.name}> Id:<#{service.id}>")
 
 # Get dialog options from options hash
-# {:dialog=>{"option_0_myvar"=>"myprefix", "option_1_vservice_workers"=>"2", "tag_0_environment"=>"test", "tag_0_location"=>"paris",
-# "option_2_vm_memory"=>"2048", "option_0_vlan"=>"Internal", "option_1_cores_per_socket"=>"1"}}
+# {:dialog=>{"option_0_myvar"=>"myprefix", "option_1_vservice_workers"=>"2", "tag_0_environment"=>"test",
+# "tag_0_location"=>"paris", # "option_2_vm_memory"=>"2048", "option_0_vlan"=>"Internal",
+# "option_1_cores_per_socket"=>"1"}}
 dialog_options = service_template_provision_task.dialog_options
 $evm.log("info", "Inspecting Dialog Options:<#{dialog_options.inspect}>")
 
@@ -102,14 +139,16 @@ service_template_provision_task.miq_request_tasks.each do |t|
   unless t.miq_request_tasks.nil?
     grandchild_tasks = t.miq_request_tasks
     grandchild_tasks.each do |gc|
-      $evm.log("info", "Detected Grandchild Task ID:<#{gc.id}> Description:<#{gc.description}> source type:<#{gc.source_type}>")
+      $evm.log("info", "Detected Task ID:<#{gc.id}> Desc:<#{gc.description}> source type:<#{gc.source_type}>")
 
       # If child task is provisioning then apply tags and options
       if gc.source_type == "template"
         unless tags_hash.nil?
           tags_hash.each do |k, v|
-            $evm.log("info", "Adding Tag:<#{k.inspect}/#{v.inspect}> to Provisioning ID:<#{gc.id}>")
-            gc.add_tag(k, v)
+            v.split(",").each do |e|
+              $evm.log("info", "Adding Tag:<#{e}> to Provisioning ID:<#{gc.id}>")
+              gc.add_tag(k, e)
+            end
           end
         end
         unless options_hash.nil?


### PR DESCRIPTION
Service dialogs tag_control passes array format to methods and need to
be parsed for tags and options hashes.

https://bugzilla.redhat.com/show_bug.cgi?id=1184267