### PR TITLE
default MiqPassword.key_root

### DIFF
--- a/lib/spec/util/miq-password_spec.rb
+++ b/lib/spec/util/miq-password_spec.rb
@@ -219,6 +219,20 @@ describe MiqPassword do
     expect(x).to eq("some :password: ******** and another :password: ********")
   end
 
+  context ".key_root" do
+    it "defaults key_root" do
+      expect(ENV).to receive(:[]).with("KEY_ROOT").and_return("/certs")
+      MiqPassword.key_root = nil
+      expect(MiqPassword.key_root).to eq("/certs")
+    end
+
+    it "overrides key_root" do
+      expect(ENV).not_to receive(:[])
+      MiqPassword.key_root = "/abc"
+      expect(MiqPassword.key_root).to eq("/abc")
+    end
+  end
+
   def erberize(password, passmethod = "MiqPassword")
     "<%= #{passmethod}.decrypt(\"#{password}\") %>"
   end

--- a/lib/util/miq-password.rb
+++ b/lib/util/miq-password.rb
@@ -179,7 +179,10 @@ class MiqPassword
   end
 
   class << self
-    attr_accessor :key_root
+    attr_writer :key_root
+    def key_root
+      @key_root ||= ENV["KEY_ROOT"]
+    end
   end
 
   def self.extract_erb_encrypted_value(value)

--- a/system/LINK/etc/default/evm
+++ b/system/LINK/etc/default/evm
@@ -21,6 +21,8 @@ export QPID_LOAD_MODULE=/usr/lib64/qpid/client/sslconnector.so
 # OpenStack server
 # - CFME does not currently support client ssl certificate for authentication
 export QPID_SSL_CERT_DB=/etc/qpid/certs
+# Location of certificates and provider keys
+export KEY_ROOT=/var/www/miq/vmdb/certs
 
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /opt/rh/postgresql92/enable ]] && source /opt/rh/postgresql92/enable


### PR DESCRIPTION
Sometimes automate needs access to raw passwords via `MiqPassword`.
The scripts have been hardcoding the `key_root`.

This change sets the default so our customer's automate scripts are not setting it.

While it would be nice to not default this value, it is this value 100% of the time in production, and only different on dev boxes.

https://bugzilla.redhat.com/show_bug.cgi?id=1126569

/cc @gmcculloug @tinaafitz @Fryguy 