### PR TITLE
nodes can only ever have one parent, so use an accessor

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_digraph.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_digraph.rb
@@ -38,10 +38,7 @@ module MiqAeEngine
     def delete(id)
       @data_to_node.delete(id.data)
       @nodes.delete(id)
-      @nodes.each do |node|
-        node.parent = nil if node.parent == id
-        node.children.delete id
-      end
+      id.children.each { |node| node.parent = nil }
     end
 
     def [](id)

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_digraph.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_digraph.rb
@@ -1,8 +1,8 @@
 module MiqAeEngine
   class MiqAeDigraph
-    class Node < Struct.new(:data, :parents, :children)
+    class Node < Struct.new(:data, :parent, :children)
       def initialize(data)
-        super(data, [], [])
+        super(data, nil, [])
       end
     end
 
@@ -16,7 +16,7 @@ module MiqAeEngine
     end
 
     def roots
-      @nodes.select { |n| n.parents.empty? }.collect(&:data)
+      @nodes.reject(&:parent).collect(&:data)
     end
 
     def vertex(data)
@@ -39,7 +39,7 @@ module MiqAeEngine
       @data_to_node.delete(id.data)
       @nodes.delete(id)
       @nodes.each do |node|
-        node.parents.delete id
+        node.parent = nil if node.parent == id
         node.children.delete id
       end
     end
@@ -48,8 +48,8 @@ module MiqAeEngine
       id.data
     end
 
-    def parents(id)
-      id.parents
+    def parent(id)
+      id.parent
     end
 
     def children(id)
@@ -58,7 +58,7 @@ module MiqAeEngine
 
     def link_parent_child(parent, child)
       parent.children << child
-      child.parents << parent
+      child.parent = parent
     end
   end
 

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -296,7 +296,7 @@ module MiqAeEngine
       if path == "/"
         return roots[0] if obj.nil?
         while true
-          parent = parents(obj).first
+          parent = parent(obj)
           return obj if parent.nil?
           obj = parent
         end
@@ -306,7 +306,7 @@ module MiqAeEngine
           part = plist.shift
           next if part.blank? || part == "."
           raise MiqAeException::InvalidPathFormat, "bad part [#{part}] in path [#{path}]" if (part != "..")
-          obj = parents(obj).first
+          obj = parent(obj)
         end
       else
         obj = find_named_ancestor(path)
@@ -321,7 +321,7 @@ module MiqAeEngine
       ns    = (plist.length == 0) ? "*" : plist.join('/')
 
       obj = current_object
-      while obj = parents(obj).first
+      while obj = parent(obj)
         next unless klass.casecmp(obj.klass).zero?
         break if ns == "*"
         ns_split = obj.namespace.split('/')
@@ -339,12 +339,12 @@ module MiqAeEngine
       return kids.collect { |vid| @graph[vid] }
     end
 
-    def parents(obj)
+    def parent(obj)
       id = @graph.find_by_data(obj)
-      return [] if id.nil?
-      parents = @graph.parents(id)
-      return [] if parents.nil?
-      parents.collect { |vid| @graph[vid] }
+      return nil if id.nil?
+      parent = @graph.parent(id)
+      return nil if parent.nil?
+      @graph[parent]
     end
 
     def overlay_namespace(scheme, uri, ns, klass, instance)


### PR DESCRIPTION
Whenever [vertex is called](https://github.com/manageiq/manageiq/blob/master/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb#L134), it [always generates a new node](https://github.com/ManageIQ/manageiq/blob/85ee925462f13338e2af060adf93aad2ef0a5160/vmdb/lib/miq_automation_engine/engine/miq_ae_digraph.rb#L22-27).  Generating a new node is [immediately followed by possibly linking a parent](https://github.com/manageiq/manageiq/blob/master/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb#L135-138).

The only place a parent is added to a node is **immediately after
creating a new node**.  Since the parent is only ever added to new
nodes, then that node can only ever have one parent.  This patch removes
the notion of "multiple parents" for a node.

/cc @mkanoor 