### PR TITLE
Replace authentication_(valid|invalid)? with (has|missing)_credentials?

### DIFF
--- a/vmdb/app/models/ems_amazon.rb
+++ b/vmdb/app/models/ems_amazon.rb
@@ -35,7 +35,7 @@ class EmsAmazon < EmsCloud
   end
 
   def connect(options = {})
-    raise "no credentials defined" if self.authentication_invalid?(options[:auth_type])
+    raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
     username = options[:user] || self.authentication_userid(options[:auth_type])
     password = options[:pass] || self.authentication_password(options[:auth_type])
@@ -44,7 +44,7 @@ class EmsAmazon < EmsCloud
   end
 
   def verify_credentials(auth_type=nil, options={})
-    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(auth_type)
+    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
 
     begin
       # EC2 does Lazy Connections, so call a cheap function

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -31,7 +31,7 @@ class EmsMicrosoft < EmsInfra
   end
 
   def connect(options = {})
-    raise "no credentials defined" if self.authentication_invalid?(options[:auth_type])
+    raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
     username = options[:user] || authentication_userid(options[:auth_type])
     password = options[:pass] || authentication_password(options[:auth_type])
@@ -41,7 +41,7 @@ class EmsMicrosoft < EmsInfra
   end
 
   def verify_credentials(_auth_type = nil, options = {})
-    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(options[:auth_type])
+    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(options[:auth_type])
 
     begin
       run_dos_command("hostname")

--- a/vmdb/app/models/ems_redhat.rb
+++ b/vmdb/app/models/ems_redhat.rb
@@ -33,7 +33,7 @@ class EmsRedhat < EmsInfra
   end
 
   def connect(options = {})
-    raise "no credentials defined" if self.authentication_invalid?(options[:auth_type])
+    raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
     server   = options[:ip]      || self.address
     port     = options[:port]    || self.port

--- a/vmdb/app/models/ems_vmware.rb
+++ b/vmdb/app/models/ems_vmware.rb
@@ -71,7 +71,7 @@ class EmsVmware < EmsInfra
   end
 
   def verify_credentials(auth_type=nil, options={})
-    raise "no credentials defined" if self.authentication_invalid?(auth_type)
+    raise "no credentials defined" if self.missing_credentials?(auth_type)
 
     begin
       with_provider_connection(:use_broker => false, :auth_type => auth_type) {}

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -209,6 +209,7 @@ class ExtManagementSystem < ActiveRecord::Base
 
   def refresh_ems
     raise "no #{ui_lookup(:table => "ext_management_systems")} credentials defined" if self.missing_credentials?
+    raise "#{ui_lookup(:table => "ext_management_systems")} failed last authentication check" unless self.authentication_status_ok?
     EmsRefresh.queue_refresh(self)
   end
 

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -208,8 +208,7 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def refresh_ems
-    raise "no #{ui_lookup(:table => "ext_management_systems")} credentials defined" if self.authentication_invalid?
-    raise "refresh requires a valid user id and password" if self.authentication_invalid?
+    raise "no #{ui_lookup(:table => "ext_management_systems")} credentials defined" if self.missing_credentials?
     EmsRefresh.queue_refresh(self)
   end
 

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -822,7 +822,9 @@ class Host < ActiveRecord::Base
   end
 
   def refresh_ems
-    raise "No #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
+    raise "No #{ui_lookup(:table => "ext_management_systems")} defined" unless self.ext_management_system
+    raise "No #{ui_lookup(:table => "ext_management_systems")} credentials defined" unless self.ext_management_system.has_credentials?
+    raise "#{ui_lookup(:table => "ext_management_systems")} failed last authentication check" unless self.ext_management_system.authentication_status_ok?
     EmsRefresh.queue_refresh(self)
   end
 

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -789,8 +789,9 @@ class Host < ActiveRecord::Base
   def scannable_status
     s = self.refreshable_status
     if s[:show] == false && s[:enabled] == false
-      if self.authentication_valid?(:ipmi) || !self.ipmi_address.blank?
-        if self.authentication_invalid?(:ipmi)
+      # TODO: Simplify these conditions
+      if self.has_credentials?(:ipmi) || !self.ipmi_address.blank?
+        if self.missing_credentials?(:ipmi)
           s.merge!(:show => true, :enabled => false, :message => "Provide credentials for IPMI")
         elsif self.ipmi_address.blank?
           s.merge!(:show => true, :enabled => false, :message => "Provide an IPMI Address")
@@ -821,7 +822,7 @@ class Host < ActiveRecord::Base
   end
 
   def refresh_ems
-    raise "No #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.authentication_valid?
+    raise "No #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
     EmsRefresh.queue_refresh(self)
   end
 
@@ -1109,7 +1110,7 @@ class Host < ActiveRecord::Base
   end
 
   def verify_credentials(auth_type=nil, options={})
-    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(auth_type)
+    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
     raise MiqException::MiqHostError, "Logon to platform [#{self.os_image_name}] not supported" if auth_type.to_s != 'ipmi' && self.os_image_name !~ /linux_*/
 
     case auth_type.to_s
@@ -1133,7 +1134,7 @@ class Host < ActiveRecord::Base
   end
 
   def verify_credentials_with_ssh(auth_type=nil, options={})
-    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(auth_type)
+    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
     raise MiqException::MiqHostError, "Logon to platform [#{self.os_image_name}] not supported" unless self.os_image_name =~ /linux_*/
 
     begin
@@ -1153,7 +1154,7 @@ class Host < ActiveRecord::Base
   end
 
   def verify_credentials_with_ipmi(auth_type=nil)
-    raise "No credentials defined for IPMI" if self.authentication_invalid?(auth_type)
+    raise "No credentials defined for IPMI" if self.missing_credentials?(auth_type)
 
     require 'miq-ipmi'
     address = self.ipmi_address
@@ -1265,7 +1266,7 @@ class Host < ActiveRecord::Base
       self.ipaddress   = ipaddr
       self.vmm_vendor  = "vmware"
       self.vmm_product = "Esx"
-      if self.authentication_valid?(:ws)
+      if self.has_credentials?(:ws)
         begin
           with_provider_connection(:ip => ipaddr) do |vim|
             $log.info "#{log_header} VIM Information for ESX Host with IP Address: [#{ipaddr}], Information: #{vim.about.inspect}"
@@ -1583,7 +1584,7 @@ class Host < ActiveRecord::Base
   end
 
   def ipmi_config_valid?(include_mac_addr=false)
-    if self.authentication_valid?(:ipmi) && !self.ipmi_address.blank?
+    if self.has_credentials?(:ipmi) && !self.ipmi_address.blank?
       if include_mac_addr == true
         if self.mac_address.blank?
           return false
@@ -1777,7 +1778,7 @@ class Host < ActiveRecord::Base
 
       # Skip SSH for ESXi hosts
       unless self.is_vmware_esxi?
-        if self.authentication_invalid?
+        if self.missing_credentials?
           $log.warn "#{log_header} No credentials defined for #{log_target}"
           task.update_status("Finished", "Warn", "Scanning incomplete due to Credential Issue")  if task
           return

--- a/vmdb/app/models/host_microsoft.rb
+++ b/vmdb/app/models/host_microsoft.rb
@@ -4,7 +4,7 @@ require 'MiqScvmm'
 
 class HostMicrosoft < Host
   def verify_credentials(auth_type=nil, options={})
-    raise "no credentials defined" if self.authentication_invalid?(auth_type)
+    raise "no credentials defined" if self.missing_credentials?(auth_type)
 
     return verify_credentials_windows(self.ipaddress, *self.auth_user_pwd(auth_type)) if MiqServer.my_server(true).has_role?(authentication_check_role)
 

--- a/vmdb/app/models/host_redhat.rb
+++ b/vmdb/app/models/host_redhat.rb
@@ -5,7 +5,7 @@ class HostRedhat < Host
   end
 
   def verify_credentials(auth_type=nil, options={})
-    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(auth_type)
+    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
     raise MiqException::MiqHostError, "Logon to platform [#{self.os_image_name}] not supported" if auth_type.to_s != 'ipmi' && self.os_image_name !~ /linux_*/
 
     case auth_type.to_s

--- a/vmdb/app/models/host_vmware_esx.rb
+++ b/vmdb/app/models/host_vmware_esx.rb
@@ -107,7 +107,7 @@ class HostVmwareEsx < HostVmware
   end
 
   def verify_credentials_with_ws(auth_type=nil)
-    raise "No credentials defined" if self.authentication_invalid?(auth_type)
+    raise "No credentials defined" if self.missing_credentials?(auth_type)
 
     begin
       with_provider_connection(:use_broker => false, :auth_type => auth_type) {}
@@ -129,7 +129,7 @@ class HostVmwareEsx < HostVmware
   end
 
   def refresh_logs
-    if self.authentication_invalid?
+    if self.missing_credentials?
       $log.warn "MIQ(Host.refresh_logs) No credentials defined for Host [#{self.name}]"
       return
     end

--- a/vmdb/app/models/miq_host_provision/state_machine.rb
+++ b/vmdb/app/models/miq_host_provision/state_machine.rb
@@ -10,7 +10,7 @@ module MiqHostProvision::StateMachine
     raise "Unable to find PXE server with id [#{get_option(:pxe_server_id)}]"                  if self.pxe_server.nil?
     raise "Unable to find PXE image with id [#{get_option(:pxe_image_id)}]"                    if self.pxe_image.nil?
     raise "Host [#{self.host_name}] does not have a valid Mac Address"                         if self.host.mac_address.blank?
-    raise "Host [#{self.host_name}] does not have valid IPMI credentials"                      if self.host.authentication_invalid?(:ipmi)
+    raise "Host [#{self.host_name}] does not have valid IPMI credentials"                      if self.host.missing_credentials?(:ipmi)
     raise "Host [#{self.host_name}] does not have an IP Address configured"                    if self.ip_address.blank?
     raise "Host [#{self.host_name}] has #{self.host.v_total_vms} VMs"                          if self.host.v_total_vms > 0
     raise "Host [#{self.host_name}] has #{self.host.v_total_miq_templates} Templates"          if self.host.v_total_miq_templates > 0

--- a/vmdb/app/models/miq_provision/options_helper.rb
+++ b/vmdb/app/models/miq_provision/options_helper.rb
@@ -26,7 +26,7 @@ module MiqProvision::OptionsHelper
     ems = source.ext_management_system
     raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is not attached to a Management System" if ems.nil?
     raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is attached to <#{ems.class.name}: #{ems.name}> that does not support Provisioning" unless MiqProvision::SUPPORTED_EMS_CLASSES.include?(ems.class.name)
-    raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is attached to <#{ems.class.name}: #{ems.name}> with invalid credentials" if ems.authentication_invalid?
+    raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is attached to <#{ems.class.name}: #{ems.name}> with invalid credentials" if ems.missing_credentials?
     source
   end
 

--- a/vmdb/app/models/miq_provision/options_helper.rb
+++ b/vmdb/app/models/miq_provision/options_helper.rb
@@ -26,7 +26,7 @@ module MiqProvision::OptionsHelper
     ems = source.ext_management_system
     raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is not attached to a Management System" if ems.nil?
     raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is attached to <#{ems.class.name}: #{ems.name}> that does not support Provisioning" unless MiqProvision::SUPPORTED_EMS_CLASSES.include?(ems.class.name)
-    raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is attached to <#{ems.class.name}: #{ems.name}> with invalid credentials" if ems.missing_credentials?
+    raise MiqException::MiqProvisionError, "#{source.class.name} [#{source.name}] is attached to <#{ems.class.name}: #{ems.name}> with missing credentials" if ems.missing_credentials?
     source
   end
 

--- a/vmdb/app/models/miq_proxy.rb
+++ b/vmdb/app/models/miq_proxy.rb
@@ -243,7 +243,7 @@ class MiqProxy < ActiveRecord::Base
 
     if self.host.vmm_product.to_s.downcase.include?("esx")
       # We need to have userid and password configured for the host for this to work.
-      if self.host.authentication_valid?(:ws)
+      if self.host.has_credentials?(:ws)
         if agentCfg[:emsLocal].blank?
           self.settings[:emsLocal] = default_key
           updated = true
@@ -997,7 +997,7 @@ class MiqProxy < ActiveRecord::Base
     host_plat = self.host.platform.to_s.downcase
 
     raise MiqException::MiqDeploymentError, "Deploy #{MIQHOST_PRODUCT_NAME} Cannot deploy update: [#{update.name if update.name}], id: [#{update.id}] which requires platform: [#{requ_plat}] to [#{host_plat}]" unless requ_plat == host_plat
-    raise MiqException::MiqDeploymentError, "#{MIQHOST_PRODUCT_NAME} deployment requires a valid user id and password" if self.host.authentication_invalid? && deploy_options[:userid].blank?
+    raise MiqException::MiqDeploymentError, "#{MIQHOST_PRODUCT_NAME} deployment requires a valid user id and password" if self.host.missing_credentials? && deploy_options[:userid].blank?
 
     options = {
       :target_id => self.host.id,

--- a/vmdb/app/models/miq_schedule.rb
+++ b/vmdb/app/models/miq_schedule.rb
@@ -302,7 +302,7 @@ class MiqSchedule < ActiveRecord::Base
 
   def validate_file_depot
     if self.sched_action.kind_of?(Hash) && self.sched_action[:method] == "db_backup" && self.file_depot
-      errors.add(:file_depot, "is missing credentials") if !file_depot.uri.to_s.starts_with?("nfs") && file_depot.authentication_invalid?
+      errors.add(:file_depot, "is missing credentials") if !file_depot.uri.to_s.starts_with?("nfs") && file_depot.missing_credentials?
       errors.add(:file_depot, "is missing uri") if file_depot.uri.blank?
     end
   end

--- a/vmdb/app/models/miq_smis_agent.rb
+++ b/vmdb/app/models/miq_smis_agent.rb
@@ -111,7 +111,7 @@ class MiqSmisAgent < StorageManager
   def verify_credentials(auth_type=nil)
     # Verification of creds for other SMA types is handled though mixinx.
     raise "Credential validation requires the SMIS Agent type be set." if self.agent_type.blank?
-    raise "no credentials defined" if self.authentication_invalid?(auth_type)
+    raise "no credentials defined" if self.missing_credentials?(auth_type)
 
     begin
       self.connect

--- a/vmdb/app/models/miq_vim_broker_worker.rb
+++ b/vmdb/app/models/miq_vim_broker_worker.rb
@@ -20,7 +20,7 @@ class MiqVimBrokerWorker < MiqWorker
   end
 
   def self.emses_to_monitor
-    EmsVmware.where(:zone_id => MiqServer.my_server.zone_id).includes(:authentications).select(&:has_credentials?)
+    EmsVmware.where(:zone_id => MiqServer.my_server.zone_id).includes(:authentications).select(&:authentication_status_ok?)
   end
 
   def self.available?

--- a/vmdb/app/models/miq_vim_broker_worker.rb
+++ b/vmdb/app/models/miq_vim_broker_worker.rb
@@ -20,7 +20,7 @@ class MiqVimBrokerWorker < MiqWorker
   end
 
   def self.emses_to_monitor
-    EmsVmware.where(:zone_id => MiqServer.my_server.zone_id).includes(:authentications).select(&:authentication_valid?)
+    EmsVmware.where(:zone_id => MiqServer.my_server.zone_id).includes(:authentications).select(&:has_credentials?)
   end
 
   def self.available?

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -34,13 +34,12 @@ module AuthenticationMixin
     authentication_component(type, :password_encrypted)
   end
 
-  def authentication_valid?(type = nil)
+  def has_credentials?(type = nil)
     !!authentication_component(type, :userid)
   end
-  alias :has_credentials? :authentication_valid?
 
-  def authentication_invalid?(type = nil)
-    !authentication_valid?(type)
+  def missing_credentials?(type = nil)
+    !has_credentials?(type)
   end
 
   def authentication_status
@@ -158,7 +157,7 @@ module AuthenticationMixin
     header = "MIQ(#{self.class.name}.authentication_check) type: [#{types.inspect}] for [#{self.id}] [#{self.name}]"
     auth = authentication_best_fit(types)
 
-    unless self.authentication_valid?(types)
+    unless self.has_credentials?(types)
       $log.warn("#{header} Validation failed due to error: [#{Authentication::ERRORS[:incomplete]}]")
       auth.validation_failed(:incomplete) if auth
       return false

--- a/vmdb/app/models/mixins/ems_openstack_mixin.rb
+++ b/vmdb/app/models/mixins/ems_openstack_mixin.rb
@@ -24,7 +24,7 @@ module EmsOpenstackMixin
   def openstack_handle(options = {})
     require 'openstack/openstack_handle'
     @openstack_handle ||= begin
-      raise "no credentials defined" if self.authentication_invalid?(options[:auth_type])
+      raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
       username = options[:user] || self.authentication_userid(options[:auth_type])
       password = options[:pass] || self.authentication_password(options[:auth_type])
@@ -98,7 +98,7 @@ module EmsOpenstackMixin
   def verify_credentials(auth_type=nil, options={})
     auth_type ||= 'default'
 
-    raise MiqException::MiqHostError, "No credentials defined" if self.authentication_invalid?(auth_type)
+    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
 
     options.merge!(:auth_type => auth_type)
     case auth_type.to_s

--- a/vmdb/app/models/mixins/file_depot_mixin.rb
+++ b/vmdb/app/models/mixins/file_depot_mixin.rb
@@ -53,7 +53,7 @@ module FileDepotMixin
 
   def validate_depot_credentials
     # This only checks that credentials are present
-    errors.add(:file_depot, "is missing credentials") if self.requires_credentials? && self.authentication_invalid?
+    errors.add(:file_depot, "is missing credentials") if self.requires_credentials? && self.missing_credentials?
   end
 
   def verify_depot_credentials(auth_type=nil)
@@ -71,7 +71,7 @@ module FileDepotMixin
   end
 
   def mnt
-    raise "No credentials defined" if self.requires_credentials? && self.authentication_invalid?
+    raise "No credentials defined" if self.requires_credentials? && self.missing_credentials?
 
     return @mnt if @mnt
     @mnt = self.class.mnt_instance(self.depot_settings)

--- a/vmdb/app/models/mixins/vim_connect_mixin.rb
+++ b/vmdb/app/models/mixins/vim_connect_mixin.rb
@@ -3,7 +3,7 @@ module VimConnectMixin
     log_header = "MIQ(#{self.class.name}.connect)"
 
     options[:auth_type] ||= :ws
-    raise "no credentials defined" if self.authentication_invalid?(options[:auth_type])
+    raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
     options[:fault_tolerant] = true unless options.has_key?(:fault_tolerant)
 

--- a/vmdb/app/models/netapp_remote_service.rb
+++ b/vmdb/app/models/netapp_remote_service.rb
@@ -523,7 +523,7 @@ class NetappRemoteService < StorageManager
   end
 
   def verify_credentials(auth_type=nil)
-    raise "no credentials defined" if self.authentication_invalid?(auth_type)
+    raise "no credentials defined" if self.missing_credentials?(auth_type)
 
     begin
       self.volume_list_info

--- a/vmdb/app/models/storage.rb
+++ b/vmdb/app/models/storage.rb
@@ -87,7 +87,7 @@ class Storage < ActiveRecord::Base
   end
 
   def active_hosts_with_credentials
-    self.active_hosts.select(&:authentication_valid?)
+    self.active_hosts.select(&:has_credentials?)
   end
 
   def active_hosts_in_zone(zone_name)

--- a/vmdb/app/models/storage.rb
+++ b/vmdb/app/models/storage.rb
@@ -82,12 +82,12 @@ class Storage < ActiveRecord::Base
     self.ext_management_systems.select { |ems| ems.my_zone == zone_name }
   end
 
-  def active_hosts_with_credentials_in_zone(zone_name)
-    self.active_hosts_with_credentials.select { |h| h.my_zone == zone_name }
+  def active_hosts_with_authentication_status_ok_in_zone(zone_name)
+    self.active_hosts_with_authentication_status_ok.select { |h| h.my_zone == zone_name }
   end
 
-  def active_hosts_with_credentials
-    self.active_hosts.select(&:has_credentials?)
+  def active_hosts_with_authentication_status_ok
+    self.active_hosts.select(&:authentication_status_ok?)
   end
 
   def active_hosts_in_zone(zone_name)
@@ -362,7 +362,7 @@ class Storage < ActiveRecord::Base
     log_header = "MIQ(Storage.scan)"
     raise(MiqException::MiqUnsupportedStorage, "Action not supported for #{ui_lookup(:table => "storages")} type [#{self.store_type}], [#{self.name}] with id: [#{self.id}]") unless SUPPORTED_STORAGE_TYPES.include?(self.store_type)
 
-    hosts = self.active_hosts_with_credentials
+    hosts = self.active_hosts_with_authentication_status_ok
     raise(MiqException::MiqStorageError,       "Check that a Host is running and has valid credentials for #{ui_lookup(:table => "storages")} [#{self.name}] with id: [#{self.id}]") if hosts.empty?
 
     task_name = "SmartState Analysis for [#{self.name}]"
@@ -531,7 +531,7 @@ class Storage < ActiveRecord::Base
       miq_task.state_active unless miq_task.nil?
     end
 
-    hosts = active_hosts_with_credentials_in_zone(MiqServer.my_zone)
+    hosts = active_hosts_with_authentication_status_ok_in_zone(MiqServer.my_zone)
     if hosts.empty?
       message = "There are no active Hosts with valid credentials connected to Storage: [#{self.name}] in Zone: [#{MiqServer.my_zone}]."
       $log.warn "#{log_header} #{message}"

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1165,7 +1165,9 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def refresh_ems
-    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
+    raise "No #{ui_lookup(:table => "ext_management_systems")} defined" unless self.ext_management_system
+    raise "No #{ui_lookup(:table => "ext_management_systems")} credentials defined" unless self.ext_management_system.has_credentials?
+    raise "#{ui_lookup(:table => "ext_management_systems")} failed last authentication check" unless self.ext_management_system.authentication_status_ok?
     EmsRefresh.queue_refresh(self)
   end
 
@@ -1176,12 +1178,16 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def refresh_ems_sync
-    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
+    raise "No #{ui_lookup(:table => "ext_management_systems")} defined" unless self.ext_management_system
+    raise "No #{ui_lookup(:table => "ext_management_systems")} credentials defined" unless self.ext_management_system.has_credentials?
+    raise "#{ui_lookup(:table => "ext_management_systems")} failed last authentication check" unless self.ext_management_system.authentication_status_ok?
     EmsRefresh.refresh(self)
   end
 
   def refresh_on_reconfig
-    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
+    raise "No #{ui_lookup(:table => "ext_management_systems")} defined" unless self.ext_management_system
+    raise "No #{ui_lookup(:table => "ext_management_systems")} credentials defined" unless self.ext_management_system.has_credentials?
+    raise "#{ui_lookup(:table => "ext_management_systems")} failed last authentication check" unless self.ext_management_system.authentication_status_ok?
     EmsRefresh.reconfig_refresh(self)
   end
 

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -328,7 +328,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   def run_command_via_parent(verb, options = {})
     # TODO: Need to break this logic out into a method that can look at the verb and the vm and decide the best way to invoke it - Virtual Center WS, ESX WS, Storage Proxy.
-    if self.ext_management_system && self.ext_management_system.has_credentials? && self.ext_management_system.respond_to?(verb)
+    if self.ext_management_system && self.ext_management_system.authentication_status_ok? && self.ext_management_system.respond_to?(verb)
       $log.info("MIQ(#{self.class.name}#run_command_via_parent) Invoking [#{verb}] through EMS: [#{self.ext_management_system.name}]")
       options = {:user_event => "EVM Console Request Action [#{verb}], VM [#{self.name}]"}.merge(options)
       self.ext_management_system.send(verb, self, options)
@@ -1064,7 +1064,7 @@ class VmOrTemplate < ActiveRecord::Base
     # MiqServer coresident proxy needs to contact the host and provide credentials.
     # Remove any MiqServer instances if we do not have credentials
     rsc = self.scan_via_ems? ? self.ext_management_system : self.host
-    proxies.delete_if {|p| MiqServer === p} if rsc && rsc.missing_credentials?
+    proxies.delete_if {|p| MiqServer === p} if rsc && !rsc.authentication_status_ok?
 
     return proxies
   end

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -328,7 +328,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   def run_command_via_parent(verb, options = {})
     # TODO: Need to break this logic out into a method that can look at the verb and the vm and decide the best way to invoke it - Virtual Center WS, ESX WS, Storage Proxy.
-    if self.ext_management_system && self.ext_management_system.authentication_valid? && self.ext_management_system.respond_to?(verb)
+    if self.ext_management_system && self.ext_management_system.has_credentials? && self.ext_management_system.respond_to?(verb)
       $log.info("MIQ(#{self.class.name}#run_command_via_parent) Invoking [#{verb}] through EMS: [#{self.ext_management_system.name}]")
       options = {:user_event => "EVM Console Request Action [#{verb}], VM [#{self.name}]"}.merge(options)
       self.ext_management_system.send(verb, self, options)
@@ -1064,7 +1064,7 @@ class VmOrTemplate < ActiveRecord::Base
     # MiqServer coresident proxy needs to contact the host and provide credentials.
     # Remove any MiqServer instances if we do not have credentials
     rsc = self.scan_via_ems? ? self.ext_management_system : self.host
-    proxies.delete_if {|p| MiqServer === p} if rsc && rsc.authentication_invalid?
+    proxies.delete_if {|p| MiqServer === p} if rsc && rsc.missing_credentials?
 
     return proxies
   end
@@ -1165,7 +1165,7 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def refresh_ems
-    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.authentication_valid?
+    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
     EmsRefresh.queue_refresh(self)
   end
 
@@ -1176,12 +1176,12 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def refresh_ems_sync
-    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.authentication_valid?
+    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
     EmsRefresh.refresh(self)
   end
 
   def refresh_on_reconfig
-    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.authentication_valid?
+    raise "no #{ui_lookup(:table => "ext_management_systems")} or credentials defined" unless self.ext_management_system && self.ext_management_system.has_credentials?
     EmsRefresh.reconfig_refresh(self)
   end
 

--- a/vmdb/lib/workers/vim_broker_worker.rb
+++ b/vmdb/lib/workers/vim_broker_worker.rb
@@ -25,7 +25,7 @@ class VimBrokerWorker < WorkerBase
   def self.emses_and_hosts_to_monitor
     emses = MiqVimBrokerWorker.emses_to_monitor
     MiqPreloader.preload(emses, :hosts => :authentications)
-    hosts = emses.collect(&:hosts).flatten.uniq.select(&:authentication_valid?)
+    hosts = emses.collect(&:hosts).flatten.uniq.select(&:has_credentials?)
     return emses + hosts
   end
 

--- a/vmdb/lib/workers/vim_broker_worker.rb
+++ b/vmdb/lib/workers/vim_broker_worker.rb
@@ -25,7 +25,7 @@ class VimBrokerWorker < WorkerBase
   def self.emses_and_hosts_to_monitor
     emses = MiqVimBrokerWorker.emses_to_monitor
     MiqPreloader.preload(emses, :hosts => :authentications)
-    hosts = emses.collect(&:hosts).flatten.uniq.select(&:has_credentials?)
+    hosts = emses.collect(&:hosts).flatten.uniq.select(&:authentication_status_ok?)
     return emses + hosts
   end
 

--- a/vmdb/spec/lib/workers/vim_broker_worker_spec.rb
+++ b/vmdb/spec/lib/workers/vim_broker_worker_spec.rb
@@ -19,6 +19,7 @@ describe VimBrokerWorker do
     described_class.any_instance.stub(:sync_config)
     described_class.any_instance.stub(:set_connection_pool_size)
     EmsVmware.any_instance.stub(:authentication_check).and_return(true)
+    EmsVmware.any_instance.stub(:authentication_status_ok?).and_return(true)
   end
 
   it "#after_initialize" do

--- a/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_spec.rb
@@ -8,7 +8,7 @@ describe EmsRefresh::Refreshers::VcRefresher do
 
     EmsVmware.any_instance.stub(:connect).and_return(FakeMiqVimHandle.new)
     EmsVmware.any_instance.stub(:disconnect).and_return(true)
-    EmsVmware.any_instance.stub(:authentication_valid?).and_return(true)
+    EmsVmware.any_instance.stub(:has_credentials?).and_return(true)
   end
 
   it "will perform a full refresh" do

--- a/vmdb/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/vmdb/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -57,8 +57,8 @@ module JobProxyDispatcherEmbeddedScanSpec
         MiqServer.any_instance.stub(:is_vix_disk? => true)
         MiqServer.any_instance.stub(:is_a_proxy? => true)
         MiqServer.any_instance.stub(:has_active_role? => true)
-        EmsVmware.any_instance.stub(:missing_credentials? => false)
-        Host.any_instance.stub(:missing_credentials? => false)
+        EmsVmware.any_instance.stub(:authentication_status_ok? => true)
+        Host.any_instance.stub(:authentication_status_ok? => true)
         MiqProxy.any_instance.stub(:state).and_return("on")
 
         @hosts, @proxies, @storages, @vms, @repo_vms = self.build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :proxies => NUM_COS_PROXIES, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)

--- a/vmdb/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/vmdb/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -57,8 +57,8 @@ module JobProxyDispatcherEmbeddedScanSpec
         MiqServer.any_instance.stub(:is_vix_disk? => true)
         MiqServer.any_instance.stub(:is_a_proxy? => true)
         MiqServer.any_instance.stub(:has_active_role? => true)
-        EmsVmware.any_instance.stub(:authentication_invalid? => false)
-        Host.any_instance.stub(:authentication_invalid? => false)
+        EmsVmware.any_instance.stub(:missing_credentials? => false)
+        Host.any_instance.stub(:missing_credentials? => false)
         MiqProxy.any_instance.stub(:state).and_return("on")
 
         @hosts, @proxies, @storages, @vms, @repo_vms = self.build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :proxies => NUM_COS_PROXIES, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)

--- a/vmdb/spec/models/job_proxy_dispatcher_spec.rb
+++ b/vmdb/spec/models/job_proxy_dispatcher_spec.rb
@@ -38,8 +38,8 @@ module JobProxyDispatcherSpec
           MiqServer.any_instance.stub(:is_vix_disk? => true)
           MiqServer.any_instance.stub(:is_a_proxy? => true)
           MiqServer.any_instance.stub(:has_active_role? => true)
-          EmsVmware.any_instance.stub(:authentication_invalid? => false)
-          Host.any_instance.stub(:authentication_invalid? => false)
+          EmsVmware.any_instance.stub(:missing_credentials? => false)
+          Host.any_instance.stub(:missing_credentials? => false)
 
           @hosts, @proxies, @storages, @vms, @repo_vms = self.build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :proxies => NUM_COS_PROXIES, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)
         end

--- a/vmdb/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/vmdb/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -77,7 +77,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
               MiqServer.my_server(true)
               @server1.deactivate_all_roles
               @server1.role    = 'smartproxy'
-              Host.any_instance.stub(:authentication_invalid? => false)
+              Host.any_instance.stub(:missing_credentials? => false)
             end
 
             it "will have no roles active" do
@@ -106,7 +106,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
             context "a vm template and invalid VC authentication" do
               before(:each) do
-                EmsVmware.any_instance.stub(:authentication_invalid? => true)
+                EmsVmware.any_instance.stub(:missing_credentials? => true)
                 @vm.stub(:template? => true)
                 @ems1 = FactoryGirl.create(:ems_vmware, :name => "Ems1")
                 @vm.ext_management_system = @ems1
@@ -119,7 +119,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
             context "a vm and invalid host authentication" do
               before(:each) do
-                Host.any_instance.stub(:authentication_invalid? => true)
+                Host.any_instance.stub(:missing_credentials? => true)
                 @vm.stub(:template? => false)
               end
               it "Vm#storage2active_proxies will return only repo host" do

--- a/vmdb/spec/models/miq_vim_broker_worker_spec.rb
+++ b/vmdb/spec/models/miq_vim_broker_worker_spec.rb
@@ -5,9 +5,7 @@ describe MiqVimBrokerWorker do
     guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
     other_ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
-
-    # General stubbing for testing any worker (methods called during initialize)
-    EmsVmware.any_instance.stub(:authentication_check).and_return(true)
+    EmsVmware.any_instance.stub(:authentication_status_ok? => true)
   end
 
   it ".emses_to_monitor" do

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -16,9 +16,9 @@ describe AuthenticationMixin do
     context "##{method}" do
       let(:expected) do
         case method
-        when :authentication_valid?
+        when :has_credentials?
           false
-        when :authentication_invalid?
+        when :missing_credentials?
           true
         else
           nil
@@ -48,9 +48,9 @@ describe AuthenticationMixin do
         t.stub(:authentication_best_fit => double(required_field => "test"))
 
         expected = case method
-        when :authentication_valid?
+        when :has_credentials?
           true
-        when :authentication_invalid?
+        when :missing_credentials?
           false
         else
           "test"
@@ -64,8 +64,8 @@ describe AuthenticationMixin do
   include_examples "authentication_components", :authentication_password, :password
   include_examples "authentication_components", :authentication_userid, :userid
   include_examples "authentication_components", :authentication_password_encrypted, :password_encrypted
-  include_examples "authentication_components", :authentication_valid?, :userid
-  include_examples "authentication_components", :authentication_invalid?, :userid
+  include_examples "authentication_components", :has_credentials?, :userid
+  include_examples "authentication_components", :missing_credentials?, :userid
 
   context "required fields" do
     context "requires one field" do
@@ -258,17 +258,17 @@ describe AuthenticationMixin do
       end
 
       it "should have valid_authentication" do
-        @ems.authentication_valid?.should be_true
+        @ems.has_credentials?.should be_true
       end
 
       it "should have invalid authentication if userid nil" do
         @auth.update_attribute(:userid, nil)
-        @ems.authentication_invalid?.should be_true
+        @ems.missing_credentials?.should be_true
       end
 
       it "should have invalid authentication ems's authentication is nil" do
         @ems.authentications = []
-        @ems.authentication_invalid?.should be_true
+        @ems.missing_credentials?.should be_true
       end
 
       it "should have correct userid" do
@@ -330,7 +330,7 @@ describe AuthenticationMixin do
 
       context "with host invalid authentication due to no authentication row or incomplete userid" do
         before(:each) do
-          @host.stub(:authentication_valid?).and_return(false)
+          @host.stub(:has_credentials?).and_return(false)
         end
 
         it "should return false when calling authentication_check" do
@@ -352,7 +352,7 @@ describe AuthenticationMixin do
 
       context "with ems invalid authentication due to no authentication row or incomplete userid" do
         before(:each) do
-          @ems.stub(:authentication_valid?).and_return(false)
+          @ems.stub(:has_credentials?).and_return(false)
         end
 
         it "should return false when calling authentication_check" do

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -257,16 +257,16 @@ describe AuthenticationMixin do
         @ems.authentication_status.should == 'None'
       end
 
-      it "should have valid_authentication" do
+      it "should have credentials" do
         @ems.has_credentials?.should be_true
       end
 
-      it "should have invalid authentication if userid nil" do
+      it "should have missing credentials if userid nil" do
         @auth.update_attribute(:userid, nil)
         @ems.missing_credentials?.should be_true
       end
 
-      it "should have invalid authentication ems's authentication is nil" do
+      it "should have missing credentials if ems's authentication is nil" do
         @ems.authentications = []
         @ems.missing_credentials?.should be_true
       end
@@ -328,7 +328,7 @@ describe AuthenticationMixin do
         queued_auth_checks.first.deliver
       end
 
-      context "with host invalid authentication due to no authentication row or incomplete userid" do
+      context "with host missing credentials due to no authentication row or incomplete userid" do
         before(:each) do
           @host.stub(:has_credentials?).and_return(false)
         end
@@ -350,7 +350,7 @@ describe AuthenticationMixin do
         end
       end
 
-      context "with ems invalid authentication due to no authentication row or incomplete userid" do
+      context "with ems missing credentials due to no authentication row or incomplete userid" do
         before(:each) do
           @ems.stub(:has_credentials?).and_return(false)
         end

--- a/vmdb/spec/models/storage_spec.rb
+++ b/vmdb/spec/models/storage_spec.rb
@@ -172,10 +172,10 @@ describe Storage do
       end
     end
 
-    context "on a host with credentials" do
+    context "on a host authentication status ok" do
       before(:each) do
         Authentication.any_instance.stub(:after_authentication_changed)
-        FactoryGirl.create(:authentication, :resource => @host1)
+        FactoryGirl.create(:authentication, :resource => @host1, :status => "Valid")
       end
 
       it "#ext_management_systems" do
@@ -193,19 +193,19 @@ describe Storage do
         @storage3.ext_management_systems_in_zone(@zone2.name).should == [@ems2]
       end
 
-      it "#active_hosts_with_credentials" do
-        @storage1.active_hosts_with_credentials.should == [@host1]
-        @storage2.active_hosts_with_credentials.should == []
-        @storage3.active_hosts_with_credentials.should == [@host1]
+      it "#active_hosts_with_authentication_status_ok" do
+        @storage1.active_hosts_with_authentication_status_ok.should == [@host1]
+        @storage2.active_hosts_with_authentication_status_ok.should == []
+        @storage3.active_hosts_with_authentication_status_ok.should == [@host1]
       end
 
-      it "#active_hosts_with_credentials_in_zone" do
-        @storage1.active_hosts_with_credentials_in_zone(@zone.name).should  == [@host1]
-        @storage1.active_hosts_with_credentials_in_zone(@zone2.name).should == []
-        @storage2.active_hosts_with_credentials_in_zone(@zone.name).should  == []
-        @storage2.active_hosts_with_credentials_in_zone(@zone2.name).should == []
-        @storage3.active_hosts_with_credentials_in_zone(@zone.name).should  == [@host1]
-        @storage3.active_hosts_with_credentials_in_zone(@zone2.name).should == []
+      it "#active_hosts_with_authentication_status_ok_in_zone" do
+        @storage1.active_hosts_with_authentication_status_ok_in_zone(@zone.name).should  == [@host1]
+        @storage1.active_hosts_with_authentication_status_ok_in_zone(@zone2.name).should == []
+        @storage2.active_hosts_with_authentication_status_ok_in_zone(@zone.name).should  == []
+        @storage2.active_hosts_with_authentication_status_ok_in_zone(@zone2.name).should == []
+        @storage3.active_hosts_with_authentication_status_ok_in_zone(@zone.name).should  == [@host1]
+        @storage3.active_hosts_with_authentication_status_ok_in_zone(@zone2.name).should == []
       end
 
       it "#scan" do


### PR DESCRIPTION
authentication_valid? is badly named since it only means we had the userid, not
that the authentication was valid.

Calling code "may" have assumed it meant that the authentication was valid.

For example, #1691 shows how client code was duped into thinking authentication_valid?
meant more than has_credentials? and caused workers to continually restart when
the authentications couldn't be validated due to bad password, unreachable systems, etc.

has_credentials? or missing_credentials? is closer to the truth.

The resulting calling code seems to read much clearer now.

Followup to #1691

Rather than keep authentication_valid? and _invalid?, it's probably better to just remove all traces of the confusing method names.