### PR TITLE
Make FileDepot eager-load all its subclasses on load.

### DIFF
--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -45,4 +45,5 @@ class FileDepot < ActiveRecord::Base
 end
 
 # load all plugins
+#VMDB::Util.eager_load_subclasses("FileDepot")
 Dir.glob(File.join(File.dirname(__FILE__), "file_depot_*.rb")).sort.each { |f| require_dependency f rescue true }

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -43,3 +43,6 @@ class FileDepot < ActiveRecord::Base
     @file = file
   end
 end
+
+# load all plugins
+Dir.glob(File.join(File.dirname(__FILE__), "file_depot_*.rb")).sort.each { |f| require_dependency f rescue true }

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -45,5 +45,4 @@ class FileDepot < ActiveRecord::Base
 end
 
 # load all plugins
-#VMDB::Util.eager_load_subclasses("FileDepot")
-Dir.glob(File.join(File.dirname(__FILE__), "file_depot_*.rb")).sort.each { |f| require_dependency f rescue true }
+VMDB::Util.eager_load_subclasses('FileDepot')

--- a/vmdb/app/models/file_depot_ftp.rb
+++ b/vmdb/app/models/file_depot_ftp.rb
@@ -129,3 +129,5 @@ class FileDepotFtp < FileDepot
     [authentication_userid, authentication_password]
   end
 end
+
+VMDB::Util.eager_load_subclasses('FileDepotFtp')

--- a/vmdb/config/environment.rb
+++ b/vmdb/config/environment.rb
@@ -3,8 +3,3 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application
 Vmdb::Application.initialize!
-
-# Eager load Subclasses
-BASE_CLASSES = ["FileDepot"]
-
-BASE_CLASSES.each { |klass| VMDB::Util.eager_load_subclasses(klass) }

--- a/vmdb/lib/vmdb/util.rb
+++ b/vmdb/lib/vmdb/util.rb
@@ -1,9 +1,13 @@
 module VMDB
   module Util
+    # load all direct subclasses
     def self.eager_load_subclasses(klass)
       ActiveSupport::Dependencies.autoload_paths.each do |root|
-        Dir.glob(File.join(root, "#{klass.underscore}_*.rb")).each do |file|
-          File.basename(file, '.*').camelize.constantize
+        Dir.glob(File.join(root, "#{klass.underscore}_*.rb")).sort.each do |file|
+          name = File.basename(file, '.*')
+          if name =~ /^#{klass.underscore}_[^_]*$/  # filter out sub-subclasses
+            require_dependency file
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes problems in development mode where a (unrelated) class gets reloaded and suddenly FileDepot.supported_protocols is empty

For more details, please see https://github.com/ManageIQ/manageiq/pull/1276