### PR TITLE
path parameters is always symbol => string

### DIFF
--- a/vmdb/spec/support/view_spec_helper.rb
+++ b/vmdb/spec/support/view_spec_helper.rb
@@ -19,6 +19,6 @@ module ViewSpecHelper
   end
 
   def set_controller_for_view(controller_name)
-    controller.request.path_parameters["controller"] = controller_name
+    controller.request.path_parameters[:controller] = controller_name
   end
 end


### PR DESCRIPTION
path parameters are always symbol => string on Rails 4.  This is to be
in line with `url_for` parameters which are also symbol => string.
Setting to a string will cause errors on Rails 4, but using a symbol
should work for both.