### PR TITLE
Migration changes for Rails 4

### DIFF
--- a/vmdb/db/migrate/20100908214807_recreate_relationships.rb
+++ b/vmdb/db/migrate/20100908214807_recreate_relationships.rb
@@ -19,7 +19,8 @@ class RecreateRelationships < ActiveRecord::Migration
     remove_index :relationships, :relationship
     remove_index :relationships, [:parent_type, :parent_id]
     remove_index :relationships, [:child_type, :child_id]
-    drop_table :relationships, :relationships_orig
+    drop_table :relationships
+    drop_table :relationships_orig if table_exists?(:relationships_orig)
 
     create_table :relationships do |t|
       t.string  :resource_type

--- a/vmdb/db/migrate/20150202212058_fix_indexes_on_ems_events.rb
+++ b/vmdb/db/migrate/20150202212058_fix_indexes_on_ems_events.rb
@@ -1,11 +1,19 @@
 class FixIndexesOnEmsEvents < ActiveRecord::Migration
   def up
-    rename_index :ems_events, "index_ems_events_on_vm_id",      "index_ems_events_on_vm_or_template_id"
-    rename_index :ems_events, "index_ems_events_on_dest_vm_id", "index_ems_events_on_dest_vm_or_template_id"
+    if find_index_by_name(:ems_events, "index_ems_events_on_vm_id")
+      rename_index :ems_events, "index_ems_events_on_vm_id",      "index_ems_events_on_vm_or_template_id"
+    end
+    if find_index_by_name(:ems_events, "index_ems_events_on_dest_vm_id")
+      rename_index :ems_events, "index_ems_events_on_dest_vm_id", "index_ems_events_on_dest_vm_or_template_id"
+    end
   end
 
   def down
     rename_index :ems_events, "index_ems_events_on_vm_or_template_id",      "index_ems_events_on_vm_id"
     rename_index :ems_events, "index_ems_events_on_dest_vm_or_template_id", "index_ems_events_on_dest_vm_id"
+  end
+
+  def find_index_by_name(table, name)
+    indexes(table).find { |i| i.name == name }
   end
 end


### PR DESCRIPTION
1. `drop_table` doesn't take two table names to drop, so we should drop them indivitually.
2. Rails 4 will do the index renaming automatically, so renaming indexes may not be necessary.