### PR TITLE
add aar_colums to VmdbDatabaseSetting fixes #1634

### DIFF
--- a/vmdb/app/models/rbac.rb
+++ b/vmdb/app/models/rbac.rb
@@ -455,7 +455,11 @@ module Rbac
   end
 
   def self.method_with_scope(ar_scope, options)
-    apply_options(ar_scope, options).all
+    if ar_scope < ActsAsArModel
+      ar_scope.find(:all, options)
+    else
+      apply_options(ar_scope, options).all
+    end
   end
 
   def self.apply_scope(klass, scope)

--- a/vmdb/app/models/vmdb_database_setting.rb
+++ b/vmdb/app/models/vmdb_database_setting.rb
@@ -1,4 +1,9 @@
 class VmdbDatabaseSetting < ActiveRecord::Base
+  class << self
+    attr_accessor :aar_columns
+  end
+  self.aar_columns = []
+
   self.table_name = 'pg_settings'
 
   virtual_belongs_to :vmdb_database

--- a/vmdb/lib/acts_as_ar_model.rb
+++ b/vmdb/lib/acts_as_ar_model.rb
@@ -114,6 +114,14 @@ class ActsAsArModel
     true
   end
 
+  def self.reflect_on_association(name)
+    virtual_reflection(name)
+  end
+
+  def self.compute_type(name)
+    ActiveRecord::Base.send :compute_type, name
+  end
+
   def initialize(values = {})
     self.attributes = {}
     values.each do |attr, value|

--- a/vmdb/spec/controllers/ops_controller_spec.rb
+++ b/vmdb/spec/controllers/ops_controller_spec.rb
@@ -28,6 +28,16 @@ describe OpsController do
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
     session[:settings] = {:views => {}, :perpage => {:list => 10}}
     post :change_tab, :tab_id => 'db_settings', :format => :json
+  end
+
+  it 'can view the db_connections tab' do
+    FactoryGirl.create(:vmdb_database)
+    EvmSpecHelper.create_guid_miq_server_zone
+    session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
+                                     :active_tab  => 'db_connections',
+                                     :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
+    session[:settings] = {:views => {}, :perpage => {:list => 10}}
+    post :change_tab, :tab_id => 'db_connections', :format => :json
     expect(response.status).to eq(200)
   end
 

--- a/vmdb/spec/controllers/ops_controller_spec.rb
+++ b/vmdb/spec/controllers/ops_controller_spec.rb
@@ -21,6 +21,16 @@ describe OpsController do
     end
   end
 
+  it 'can view the db_settings tab' do
+    EvmSpecHelper.create_guid_miq_server_zone
+    session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
+                                     :active_tab  => 'db_settings',
+                                     :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
+    session[:settings] = {:views => {}, :perpage => {:list => 10}}
+    post :change_tab, :tab_id => 'db_settings', :format => :json
+    expect(response.status).to eq(200)
+  end
+
   #  def rbac_user_edit
   #
   # def rbac_user_set_record_vars(user)


### PR DESCRIPTION
also adds a test to verify that it works.  aar_columns seems very dangerous because [it's being mutated](https://github.com/ManageIQ/manageiq/blob/6ab984cf574fdc85e7bb29a345dcecc99b332eaa/vmdb/app/models/miq_report/generator.rb#L629) and is on a class.  Since it's on a class, that means the mutations can persist between requests.  This must cause a bug somewhere.