### PR TITLE
Add optional thin_provisioned parameter into vm.add_disk method

### DIFF
--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -719,7 +719,7 @@ class MiqVimVm
 	# If backingFile is just the datastore name, "[storage 1]" for example,
 	#    file names will be generated as appropriate.
 	#
-	def addDisk(backingFile, sizeInMB, label=nil, summary=nil)
+	def addDisk(backingFile, sizeInMB, label=nil, summary=nil, thinProvisioned=false)
 	    ck, un = getScsiCandU
 	    raise "addDisk: no SCSI controller found" if !ck
 
@@ -751,7 +751,7 @@ class MiqVimVm
 							# bck.diskMode = VirtualDiskMode::Independent_nonpersistent
 							bck.diskMode		= VirtualDiskMode::Independent_persistent
 						    bck.split			= "false"
-						    bck.thinProvisioned	= "false"
+						    bck.thinProvisioned	= thinProvisioned.to_s
 						    bck.writeThrough	= "false"
 						    bck.fileName		= backingFile
 							begin

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -751,7 +751,8 @@ class MiqVimVm
 							# bck.diskMode = VirtualDiskMode::Independent_nonpersistent
 							bck.diskMode		= VirtualDiskMode::Independent_persistent
 						    bck.split			= "false"
-						    bck.thinProvisioned	= thinProvisioned.to_s
+						    # Handle both cases - thinProvisioned passed as boolean and as string
+						    bck.thinProvisioned = (thinProvisioned.to_s.downcase == "true" ? "true" : "false")
 						    bck.writeThrough	= "false"
 						    bck.fileName		= backingFile
 							begin

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -751,8 +751,7 @@ class MiqVimVm
 							# bck.diskMode = VirtualDiskMode::Independent_nonpersistent
 							bck.diskMode		= VirtualDiskMode::Independent_persistent
 						    bck.split			= "false"
-						    # Handle both cases - thinProvisioned passed as boolean and as string
-						    bck.thinProvisioned = (thinProvisioned.to_s.downcase == "true" ? "true" : "false")
+						    bck.thinProvisioned	= thinProvisioned.to_s
 						    bck.writeThrough	= "false"
 						    bck.fileName		= backingFile
 							begin

--- a/vmdb/app/models/ems_vmware.rb
+++ b/vmdb/app/models/ems_vmware.rb
@@ -351,7 +351,7 @@ class EmsVmware < EmsInfra
   end
 
   def vm_add_disk(vm, options={})
-    invoke_vim_ws(:addDisk, vm, options[:user_event], options[:diskName], options[:diskSize])
+    invoke_vim_ws(:addDisk, vm, options[:user_event], options[:diskName], options[:diskSize], nil, nil, options[:thinProvisioned])
   end
 
   def vm_remove_disk_by_file(vm, options={})

--- a/vmdb/app/models/vm_or_template/operations/configuration.rb
+++ b/vmdb/app/models/vm_or_template/operations/configuration.rb
@@ -71,13 +71,13 @@ module VmOrTemplate::Operations::Configuration
     raw_disconnect_floppies
   end
 
-  def raw_add_disk(disk_name, disk_size_mb)
+  def raw_add_disk(disk_name, disk_size_mb, thin_provisioned=false)
     raise "VM has no EMS, unable to add disk" unless self.ext_management_system
-    run_command_via_parent(:vm_add_disk, :diskName => disk_name, :diskSize => disk_size_mb)
+    run_command_via_parent(:vm_add_disk, :diskName => disk_name, :diskSize => disk_size_mb, :thinProvisioned => thin_provisioned)
   end
 
-  def add_disk(disk_name, disk_size_mb)
-    raw_add_disk(disk_name, disk_size_mb)
+  def add_disk(disk_name, disk_size_mb, thin_provisioned=false)
+    raw_add_disk(disk_name, disk_size_mb, thin_provisioned)
   end
 
   def spec_reconfigure(spec)


### PR DESCRIPTION
Hi all. It's me again and one more pull request to solve the issue we encountered recently.

Thin provisioning is commonly used to overcommit storages. New parameter allowes to choose disk provisioning type in custom scripts. Default behaviour left unchanged - without new param disk is added as thick.