### PR TITLE
Fix .flatten in exp_editor.

### DIFF
--- a/vmdb/app/views/layouts/_exp_editor.html.haml
+++ b/vmdb/app/views/layouts/_exp_editor.html.haml
@@ -72,7 +72,7 @@
                       :title                 => title)
     %div{:style => "padding:10px"}
       - @edit[@expkey][:exp_table].each do |token|
-        - if ! %w(AND OR ( ) ???).include?(token.flatten.first)
+        - if ! %w(AND OR ( ) ???).include?([token].flatten.first)
           = link_to(token.first,
                     {:action => 'exp_token_pressed',
                      :token  => token.last},


### PR DESCRIPTION
Fixing the bug below:

```
----] F, [2015-02-18T17:23:33.917544 #17790:a5de94] FATAL -- : Error caught: [NoMethodError] undefined method `flatten' for "(":String
/home/martin/Projects/manageiq/vmdb/app/views/layouts/_exp_editor.html.haml:75:in `block in _app_views_layouts__exp_editor_html_haml___2106179921272178194_101523260'
/home/martin/Projects/manageiq/vmdb/app/views/layouts/_exp_editor.html.haml:74:in `each'
/home/martin/Projects/manageiq/vmdb/app/views/layouts/_exp_editor.html.haml:74:in `_app_views_layouts__exp_editor_html_haml___2106179921272178194_101523260'
/home/martin/.rvm/gems/ruby-2.0.0-p353@cfme/bundler/gems/rails-8f014fba21f9/actionpack/lib/action_view/template.rb:145:in `block in render'
```

I have no idea what's happening there but the missing `[ ]` around the item after the haml/gettext work cause the problem. Probably more elaborate cleanup would be needed to remove these strange bits.