### PR TITLE
Fixed disappearing datetime in page footer

### DIFF
--- a/vmdb/app/views/layouts/explorer.html.haml
+++ b/vmdb/app/views/layouts/explorer.html.haml
@@ -9,7 +9,6 @@
 
 = render :partial => "layouts/page_header"
 = render :partial => "layouts/page_center"
-= render :partial => "layouts/page_footer"
 
 #context_div
 #layout_div


### PR DESCRIPTION
I noticed that on some pages (for example `Control -> Explorer` or `Optimize -> Utilization`) was page footer rendered two times, and after second rendering, datetime in page footer disappeared
This PR fixes that bug.