### PR TITLE
set the primary key on VmdbDatabaseSetting to nil

### DIFF
--- a/vmdb/app/models/vmdb_database_setting.rb
+++ b/vmdb/app/models/vmdb_database_setting.rb
@@ -1,5 +1,6 @@
 class VmdbDatabaseSetting < ActiveRecord::Base
   self.table_name = 'pg_settings'
+  self.primary_key = nil
 
   virtual_belongs_to :vmdb_database
   virtual_column :description,      :type => :string


### PR DESCRIPTION
there is no pk on this table, and when you call methods like `first` in
rails 4, it will try to sort by the pk which doesn't exist in this case