### PR TITLE
limit description length to 255

### DIFF
--- a/vmdb/app/models/miq_policy.rb
+++ b/vmdb/app/models/miq_policy.rb
@@ -34,8 +34,10 @@ class MiqPolicy < ActiveRecord::Base
 
   attr_accessor :reserved
 
+  DESCRIPTION_LIMIT = 255
+
   def description=(value)
-    super(value ? value.truncate(MiqPolicy.columns_hash['description'].limit) : value)
+    super(value ? value.truncate(DESCRIPTION_LIMIT) : value)
   end
 
   # Note: Built-in policies only support one event and one action.


### PR DESCRIPTION
the miq_policies table [doesn't actually have a limit set on description
in the database](https://github.com/ManageIQ/manageiq/blob/55d2ae6a6c4410fd7df7e47efc81748eb8459823/vmdb/db/migrate/20100302205959_collapsed_initial_migration.rb#L784), so Rails 4 will return `nil` for the length limit.  It seems like the test wants the column to be limited to 255, so lets just put that in a constant.