### PR TITLE
Search box missing on explorer screens

### DIFF
--- a/vmdb/app/views/stylesheets/_template50.html.haml
+++ b/vmdb/app/views/stylesheets/_template50.html.haml
@@ -1,4 +1,7 @@
 :css
   @media (min-width: 992px) { 
-    body { padding-top: #{session[:custom_logo] ? 116 : 100}px !important } 
+    body {padding-top: #{session[:custom_logo] ? 116 : 100}px !important} 
   }
+
+  #searchbox              {top: #{@explorer ? 138 : 63}px;}
+  #searchbox.whitelabeled {top: 40px;}


### PR DESCRIPTION
* search box positioning had been accidentally deleted in a prior merge

Issue: #1574 