### PR TITLE
Foreman provider object

### DIFF
--- a/vmdb/app/models/configuration_manager_foreman.rb
+++ b/vmdb/app/models/configuration_manager_foreman.rb
@@ -1,7 +1,14 @@
 class ConfigurationManagerForeman < ConfigurationManager
-  delegate :connection_attrs, :name, :to => :provider
+  delegate :raw_connect, :connection_attrs, :name, :to => :provider
 
   def self.ems_type
     "foreman_configuration".freeze
+  end
+
+  def with_provider_connection(options = {})
+    raise "no block given" unless block_given?
+    log_header = "MIQ(#{self.class.name}.with_provider_connection)"
+    $log.info("#{log_header} Connecting through #{self.class.name}: [#{name}]")
+    yield raw_connect(options)
   end
 end

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -1,2 +1,13 @@
 class ConfiguredSystemForeman < ConfiguredSystem
+  include ProviderObjectMixin
+
+  def provider_object(connection = nil)
+    (connection || raw_connect).host(manager_ref)
+  end
+
+  private
+
+  def connection_source(options = {})
+    options[:connection_source] || configuration_manager
+  end
 end

--- a/vmdb/app/models/provider_foreman.rb
+++ b/vmdb/app/models/provider_foreman.rb
@@ -23,6 +23,10 @@ class ProviderForeman < Provider
     @ems_type ||= "foreman".freeze
   end
 
+  def raw_connect(attrs = {})
+    ManageiqForeman::Connection.new(connection_attrs.merge(attrs))
+  end
+
   private
 
   def build_managers

--- a/vmdb/app/models/provisioning_manager_foreman.rb
+++ b/vmdb/app/models/provisioning_manager_foreman.rb
@@ -1,5 +1,5 @@
 class ProvisioningManagerForeman < ProvisioningManager
-  delegate :connection_attrs, :name, :to => :provider
+  delegate :raw_connect, :connection_attrs, :name, :to => :provider
 
   def self.ems_type
     "foreman_provisioning".freeze


### PR DESCRIPTION
Introduce a foreman `Host` to be a provider object for the ConfiguredSystem.
It stores the `manager_id`.

depends on #1819 (that introduces the foreman `Host` object)

/cc @blomquisg @brandondunne @gmcculloug @Fryguy 