### PR TITLE
`phase` is a string, so we should be setting and getting strings

### DIFF
--- a/vmdb/spec/models/miq_provision_redhat_via_iso_spec.rb
+++ b/vmdb/spec/models/miq_provision_redhat_via_iso_spec.rb
@@ -60,21 +60,21 @@ describe MiqProvisionRedhatViaIso do
         end
 
         it "when phase is poll_destination_powered_off_in_vmdb" do
-          @vm_prov.phase = :poll_destination_powered_off_in_vmdb
+          @vm_prov.phase = "poll_destination_powered_off_in_vmdb"
 
           @vm.should_receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == :poll_destination_powered_off_in_vmdb
+          @vm_prov.phase.should == "poll_destination_powered_off_in_vmdb"
         end
 
         it "when phase is not poll_destination_powered_off_in_vmdb" do
-          @vm_prov.phase = :post_provision
+          @vm_prov.phase = "post_provision"
 
           @vm.should_not_receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == :post_provision
+          @vm_prov.phase.should == "post_provision"
         end
       end
     end

--- a/vmdb/spec/models/miq_provision_redhat_via_pxe_spec.rb
+++ b/vmdb/spec/models/miq_provision_redhat_via_pxe_spec.rb
@@ -60,21 +60,21 @@ describe MiqProvisionRedhatViaPxe do
         end
 
         it "when phase is poll_destination_powered_off_in_vmdb" do
-          @vm_prov.phase = :poll_destination_powered_off_in_vmdb
+          @vm_prov.phase = "poll_destination_powered_off_in_vmdb"
 
           @vm.should_receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == :poll_destination_powered_off_in_vmdb
+          @vm_prov.phase.should == "poll_destination_powered_off_in_vmdb"
         end
 
         it "when phase is not poll_destination_powered_off_in_vmdb" do
-          @vm_prov.phase = :post_provision
+          @vm_prov.phase = "post_provision"
 
           @vm.should_not_receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == :post_provision
+          @vm_prov.phase.should == "post_provision"
         end
       end
     end


### PR DESCRIPTION
Rails 4 will automatically type cast to the column type, which is a
string.  This patch just changes the tests to be in line with the
database column types

/cc @gmcculloug 