### PR TITLE
Remove default platforms from EMS and Host

### DIFF
--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -99,8 +99,6 @@ class ExtManagementSystem < ActiveRecord::Base
 
   alias clusters ems_clusters # Used by web-services to return clusters as the property name
 
-  DEFAULT_PLATFORMS   = %w(microsoft redhat vmware amazon openstack)
-
   EMS_DISCOVERY_TYPES = {
     'vmware'    => 'virtualcenter',
     'microsoft' => 'scvmm',
@@ -214,7 +212,7 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def self.ems_discovery_types
-    EMS_DISCOVERY_TYPES.values_at(*DEFAULT_PLATFORMS).compact
+    EMS_DISCOVERY_TYPES.values
   end
 
   def disconnect_inv

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -15,16 +15,6 @@ require 'HostScanProfiles'
 class Host < ActiveRecord::Base
   include NewWithTypeStiMixin
 
-  UNMANAGED_PLATFORMS = {
-    'vmware'    => "VMware ESX",
-    "microsoft" => "Microsoft Hyper-V"
-  }
-
-  PLATFORM_TO_USER_OS = {
-    'vmware'    => "linux_generic",
-    'microsoft' => "windows_generic"
-  }
-
   VENDOR_TYPES = {
     # DB            Displayed
     "microsoft"       => "Microsoft",
@@ -35,13 +25,14 @@ class Host < ActiveRecord::Base
     nil               => "Unknown",
   }
 
-  DEFAULT_PLATFORMS    = %w(redhat vmware amazon openstack_infra ipmi)
-
   HOST_DISCOVERY_TYPES = {
-    'vmware'    => 'esx',
-    'microsoft' => 'hyperv',
-    'kvm'       => 'kvm',
-    'ipmi'      => 'ipmi'
+    'vmware' => 'esx',
+    'ipmi'   => 'ipmi'
+  }
+
+  HOST_CREATE_OS_TYPES = {
+    'VMware ESX' => 'linux_generic',
+    # 'Microsoft Hyper-V' => 'windows_generic'
   }
 
   validates_presence_of     :name
@@ -2221,14 +2212,11 @@ class Host < ActiveRecord::Base
   # Host Discovery Types and Platforms
 
   def self.host_discovery_types
-    HOST_DISCOVERY_TYPES.values_at(*DEFAULT_PLATFORMS).compact
+    HOST_DISCOVERY_TYPES.values
   end
 
-  def self.host_platforms
-    DEFAULT_PLATFORMS.each_with_object({}) do |key, hash|
-      next unless UNMANAGED_PLATFORMS.has_key?(key)
-      hash[UNMANAGED_PLATFORMS[key]] = PLATFORM_TO_USER_OS[key]
-    end
+  def self.host_create_os_types
+    HOST_CREATE_OS_TYPES
   end
 
   def has_compliance_policies?

--- a/vmdb/app/views/host/_form.html.haml
+++ b/vmdb/app/views/host/_form.html.haml
@@ -39,7 +39,7 @@
           %td.key=_('Host platform')
           %td.wide
             = select_tag("user_assigned_os",
-              options_for_select([["<#{_('not specified')}>", nil]] + Host.host_platforms.to_a,
+              options_for_select([["<#{_('not specified')}>", nil]] + Host.host_create_os_types.to_a,
               @edit[:new][:user_assigned_os]),
               "data-miq_observe" => { :url => url }.to_json)
       %tr

--- a/vmdb/spec/models/ext_management_system_spec.rb
+++ b/vmdb/spec/models/ext_management_system_spec.rb
@@ -41,7 +41,7 @@ describe ExtManagementSystem do
       "virtualcenter"
     ]
 
-    expect(ExtManagementSystem.ems_discovery_types).to eq(expected_types)
+    expect(ExtManagementSystem.ems_discovery_types).to match_array(expected_types)
   end
 
   context "with two small envs" do

--- a/vmdb/spec/models/host_spec.rb
+++ b/vmdb/spec/models/host_spec.rb
@@ -314,22 +314,14 @@ describe Host do
         Host.lookUpHost(@bad_partial_hostname_multi, nil).should be_nil
       end
     end
+  end
 
-    context "discovery types and platforms" do
-      before do
-        @host = FactoryGirl.create(:host_vmware)
-      end
+  it ".host_discovery_types" do
+    expect(Host.host_discovery_types).to match_array ["esx", "ipmi"]
+  end
 
-      it ".host_discovery_types returns an Array" do
-        expected_array = [ "esx", "ipmi" ]
-        expect(Host.host_discovery_types).to eq(expected_array)
-      end
-
-      it ".host_platforms returns a Hash" do
-        expected_hash = { "VMware ESX" => "linux_generic" }
-        expect(Host.host_platforms).to eq(expected_hash)
-      end
-    end
+  it ".host_create_os_types" do
+    expect(Host.host_create_os_types).to eq("VMware ESX" => "linux_generic")
   end
 
   context "host validation" do


### PR DESCRIPTION
This code was transferred from the old licensing code in 01f9ab52 and 0d9f1d8d, but isn't needed anymore in this form.