### PR TITLE
switch from hash syntax to finder syntax

### DIFF
--- a/vmdb/app/models/miq_schedule.rb
+++ b/vmdb/app/models/miq_schedule.rb
@@ -16,8 +16,9 @@ class MiqSchedule < ActiveRecord::Base
   belongs_to  :miq_search
 
   scope :in_zone, lambda { |zone_name|
-    { :include => :zone, :conditions => ["zones.name = ?", zone_name] }
+    includes(:zone).where("zones.name" => zone_name)
   }
+
   scope :updated_since, lambda { |time|
     { :conditions => ["updated_at > ?", time] }
   }


### PR DESCRIPTION
we need to use the hash syntax of `where` with rails 4 so that it will
pick up the fact that it needs to eagerly join against the zones table
for the where clause.

I also just switched it to use newer finder syntax.

This fixes this test on Rails 4:

spec/lib/workers/schedule_worker_spec.rb