### PR TITLE
Allow objects with managers to be refreshed

### DIFF
--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -8,4 +8,10 @@ class ConfiguredSystem < ActiveRecord::Base
   belongs_to :operating_system_flavor
 
   has_one    :computer_system, :dependent => :destroy
+
+  alias_method :manager, :configuration_manager
+
+  def name
+    hostname
+  end
 end

--- a/vmdb/app/models/ems_refresh.rb
+++ b/vmdb/app/models/ems_refresh.rb
@@ -34,6 +34,8 @@ module EmsRefresh
         t.ext_management_systems.first
       elsif t.respond_to?(:ext_management_system) && t.ext_management_system
         t.ext_management_system
+      elsif t.respond_to?(:manager) && t.manager
+        t.manager
       elsif t.kind_of?(Host) && t.acts_as_ems?
         t
       else
@@ -58,7 +60,11 @@ module EmsRefresh
 
     # Split the targets into refresher groups
     groups = targets.group_by do |t|
-      ems = t.respond_to?(:ext_management_system) ? t.ext_management_system : t
+      ems = case
+            when t.respond_to?(:ext_management_system) then t.ext_management_system
+            when t.respond_to?(:manager)               then t.manager
+            else                                            t
+            end
       ems.kind_of?(EmsVmware) ? "vc" : ems.emstype.to_s
     end
 

--- a/vmdb/app/models/ems_refresh/manager.rb
+++ b/vmdb/app/models/ems_refresh/manager.rb
@@ -2,13 +2,13 @@ module EmsRefresh
   module Manager
     extend ActiveSupport::Concern
     module ClassMethods
-      unless defined?(ems_type)
+      unless respond_to?(:ems_type)
         def ems_type
         end
       end
     end
 
-    unless defined?(emstype)
+    unless respond_to?(:emstype)
       def emstype
         self.class.ems_type
       end

--- a/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/base_refresher.rb
@@ -36,7 +36,11 @@ module EmsRefresh::Refreshers
       self.targets_by_ems_id = Hash.new { |h, k| h[k] = Array.new }
 
       targets.each do |t|
-        ems = t.respond_to?(:ext_management_system) ? t.ext_management_system : t
+        ems = case
+              when t.respond_to?(:ext_management_system) then t.ext_management_system
+              when t.respond_to?(:manager)               then t.manager
+              else                                            t
+              end
         if ems.nil?
           $log.warn "MIQ(#{self.class.name}.group_targets_by_ems) Unable to perform refresh for #{t.class} [#{t.name}] id [#{t.id}], since it is not on an EMS."
           next


### PR DESCRIPTION
This allows objects that don't have `ext_management_system`s, but rather `manager`s to be refreshed.

@Fryguy This will help with worker refresh as well.
Thinking maybe we should rename association "configuration_manager" to "manager" - but you're probably already looking into that.

Aside, #1698 is more focused on the refresh logic itself. This PR is more focused on the actual workings of `EmsRefresh.refresh`.

/cc @blomquisg @gmcculloug @brandondunne More foreman goodness