### PR TITLE
Fix method name not start with 'get' following kubeclient change 

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -32,7 +32,7 @@ gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
 gem "ovirt",                "~>0.3.0",       :require => false
-gem "kubeclient",           ">=0.1.1",       :require => false
+gem "kubeclient",           ">=0.1.3",       :require => false
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false
 gem "rubyzip",              "=0.9.5",        :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646

--- a/vmdb/app/models/ems_refresh/refreshers/kubernetes_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/kubernetes_refresher.rb
@@ -3,7 +3,7 @@ module EmsRefresh::Refreshers
     include EmsRefresherMixin
 
     def parse_inventory(ems, _targets = nil)
-      all_entities = ems.with_provider_connection(&:get_all_entities)
+      all_entities = ems.with_provider_connection(&:all_entities)
       EmsRefresh.log_inv_debug_trace(all_entities, "inv_hash:")
       EmsRefresh::Parsers::Kubernetes.ems_inv_to_hashes(all_entities)
     end


### PR DESCRIPTION
and bump kubeclient version