### PR TITLE
[api] Enhancements to the Token Manager

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -54,7 +54,6 @@ class ApiController < ApplicationController
   extend ApiHelper::ErrorHandler::ClassMethods
   respond_to :json
   rescue_from_api_errors
-  before_filter :auth_token_cleanup
   before_filter :require_api_user_or_token
 
   TAG_NAMESPACE = "/managed"

--- a/vmdb/app/controllers/api_controller/authentication.rb
+++ b/vmdb/app/controllers/api_controller/authentication.rb
@@ -14,14 +14,6 @@ class ApiController
     end
 
     #
-    # Supporting Methods
-    #
-
-    def auth_token_cleanup
-      @api_token_mgr.token_cleanup if defined?(@api_token_mgr)
-    end
-
-    #
     # REST APIs Authenticator and Redirector
     #
     def require_api_user_or_token
@@ -30,8 +22,6 @@ class ApiController
         @auth_token  = request.env['HTTP_X_AUTH_TOKEN']
         if !@api_token_mgr.token_valid?(@module, @auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{@auth_token} specified"
-        elsif @api_token_mgr.token_expired?(@module, @auth_token)
-          raise AuthenticationError, "Authentication Token #{@auth_token} specified expired"
         else
           @auth_user     = @api_token_mgr.token_get_info(@module, @auth_token, :userid)
           @auth_user_obj = userid_to_userobj(@auth_user)

--- a/vmdb/app/controllers/api_controller/initializer.rb
+++ b/vmdb/app/controllers/api_controller/initializer.rb
@@ -55,7 +55,7 @@ class ApiController
         $api_log.info("Static Configuration")
         base_config.each { |key, val| log_kv(key, val) }
 
-        [:token_ttl, :token_cleanup_interval, :authentication_timeout].each do |key|
+        [:token_ttl, :authentication_timeout].each do |key|
           cfg.merge_from_template_if_missing([mod.to_sym] + [key])
         end
 
@@ -76,11 +76,9 @@ class ApiController
       #
       def new_token_mgr(mod, name, api_config)
         token_ttl   = api_config[:token_ttl]
-        token_cui   = api_config[:token_cleanup_interval]
 
         options                          = {}
         options[:token_ttl]              = token_ttl.to_i_with_method if token_ttl
-        options[:token_cleanup_interval] = token_cui.to_i_with_method if token_cui
 
         $api_log.info("")
         $api_log.info("Creating new Token Manager for the #{name}")

--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -21,7 +21,6 @@
 ---
 api:
   token_ttl: 10.minutes
-  token_cleanup_interval: 2.minutes
   authentication_timeout: 30.seconds
 authentication:
   basedn:

--- a/vmdb/lib/token_manager.rb
+++ b/vmdb/lib/token_manager.rb
@@ -1,22 +1,16 @@
 require 'securerandom'
+require 'action_dispatch/middleware/session/dalli_store'
 
 #
 # Supporting class for Managing Tokens, i.e. Authentication Tokens for REST API, etc.
 #
 class TokenManager
   RESTRICTED_OPTIONS = [:expires_on]
+  DEFAULT_NS         = "default"
 
-  #
-  # Token expiration all managed in seconds from epoch (using tv_sec)
-  # Token check intervals and time-to-live are also in seconds
-  #
-  DEFAULT_NS = "default"
-  @global_token_store          = {}    # Indexed by name
-  @token_store_cleanup_lastrun = 0
-  @config = {
-    :token_ttl              => 10.minutes,
-    :token_cleanup_interval => 2.minutes
-  }
+  # Token expiration managed in seconds via token_ttl option.
+  @token_caches = {}    # Hash of memcache Dalli Clients, Keyed by namespace
+  @config       = {:token_ttl => 10.minutes}
 
   def self.new(name = DEFAULT_NS, options = {})
     class_initialize(name, options)
@@ -28,7 +22,13 @@ class TokenManager
   end
 
   def self.global_token_store(namespace)
-    @global_token_store[namespace] ||= {}
+    @token_caches[namespace] ||= begin
+      memcache_server = VMDB::Config.new("vmdb").config[:session][:memcache_server] || "127.0.0.1:11221"
+      Dalli::Client.new(memcache_server,
+                        :namespace  => "MIQ:VMDB:TOKENS:#{namespace.upcase}",
+                        :threadsafe => true,
+                        :expires_in => @config[:token_ttl])
+    end
   end
 
   def self.configure(_namespace, options = {})
@@ -36,94 +36,42 @@ class TokenManager
   end
 
   def self.gen_token(namespace, token_options = {})
-    token_cleanup
-    token = SecureRandom.hex(16)
-
     ts = global_token_store(namespace)
-    ts[token] = {:expires_on => Time.now.tv_sec + @config[:token_ttl]}
-    ts[token].merge!(prune_token_options(namespace, token, token_options))
+    token = SecureRandom.hex(16)
+    token_data = {:expires_on => Time.now.tv_sec + @config[:token_ttl]}
 
+    ts.add(token,
+           token_data.merge!(prune_token_options(token_options)),
+           @config[:token_ttl])
     token
   end
 
   def self.token_set_info(namespace, token, token_options = {})
     ts = global_token_store(namespace)
-    return {} unless ts.key?(token)
-    ts[token].merge!(prune_token_options(namespace, token, token_options))
+    token_data = ts.get(token)
+    return {} if token_data.blank?
+
+    ts.set(token, token_data.merge!(prune_token_options(token_options)))
   end
 
   def self.token_get_info(namespace, token, what = nil)
     ts = global_token_store(namespace)
-    return {} unless ts.key?(token)
-    what.nil? ? ts[token] : ts[token][what]
+    return {} unless token_valid?(namespace, token)
+
+    what.nil? ? ts.get(token) : ts.get(token)[what]
   end
 
   def self.token_valid?(namespace, token)
-    global_token_store(namespace).key?(token)
+    !global_token_store(namespace).get(token).nil?
   end
 
-  def self.token_expired?(namespace, token)
-    return true unless token_valid?(namespace, token)
-
-    ts = global_token_store(namespace)
-    if ts[token][:expires_on] < Time.now.tv_sec
-      log "#{namespace}:Expiring Token #{token}"
-      ts.delete(token)
-      return true
-    end
-    false
+  def self.prune_token_options(token_options = {})
+    token_options.except(*RESTRICTED_OPTIONS)
   end
 
-  # Method to remove expired token
-  def self.token_cleanup
-    return if @config.nil?
-    interval = @config[:token_cleanup_interval]
-    # We only run the cleanup after a certain period of time
-    thisrt = Time.now.tv_sec
-    skipit = thisrt < (@token_store_cleanup_lastrun + interval)
-
-    unless skipit
-      @token_store_cleanup_lastrun = thisrt
-
-      # Let's go over the current tokens and zap the expired ones
-      @global_token_store.keys.each do |ns|
-        ts = global_token_store(ns)
-        ts.keys.each do |token|
-          if ts[token][:expires_on] < Time.now.tv_sec
-            log "#{ns}:Deleting Token #{token}"
-            ts.delete(token)
-          end
-        end
-      end
-    end
-  end
-
-  delegate :configure, :gen_token, :token_set_info,
-           :token_get_info, :token_valid?, :token_expired?,
-           :token_cleanup, :to => self
+  delegate :configure, :gen_token, :token_set_info, :token_get_info, :token_valid?, :to => self
 
   def initialize(*args)
     self.class.class_initialize(*args)
-  end
-
-  def self.prune_token_options(namespace, token, token_options = {})
-    RESTRICTED_OPTIONS.each do |rto|
-      if token_options.key?(rto)
-        log "#{namespace}:Cannot set Restricted option #{rto} for token #{token}"
-        token_options.delete(rto)
-      end
-    end
-    token_options
-  end
-
-  def self.log(msg)
-    match  = /`(?<mname>[^']*)'/.match(caller.first)
-    method = (match ? match[:mname] : __method__).sub(/block .*in /, "")
-    log_prefix = "#{self.class.name}.#{method}"
-    if defined?($api_log.info)
-      $api_log.info("MIQ(#{log_prefix}) #{msg}")
-    else
-      puts "#{log_prefix}: #{msg}"
-    end
   end
 end


### PR DESCRIPTION
- Leveraging Memcached to make sure tokens work across workers
- Using Dalli::Client's interface and token cleanup support.
- Removing Token Manager token cleanup code
- Removing api token_cleanup_interval configuration
- Rubocop changes

https://trello.com/c/Drza2h1q