### PR TITLE
Hide xml deprecation warning when running specs

### DIFF
--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
@@ -20,6 +20,8 @@ module MiqAeServiceServiceReconfigureRequestSpec
       </MiqAeDatastore>
       XML
 
+      # hide deprecation warning
+      expect(MiqAeDatastore).to receive(:xml_deprecated_warning)
       MiqAeDatastore::Import.load_xml(xml)
       FactoryGirl.create(:ui_task_set_approver)
     end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
@@ -20,6 +20,8 @@ module MiqAeServiceServiceReconfigureTaskSpec
       </MiqAeDatastore>
       XML
 
+      # hide deprecation warning
+      expect(MiqAeDatastore).to receive(:xml_deprecated_warning)
       MiqAeDatastore::Import.load_xml(xml)
       FactoryGirl.create(:ui_task_set_approver)
     end


### PR DESCRIPTION
Remove 3 deprecations of the form:

```
[DEPRECATION] xml export/import is deprecated. Please use the YAML format instead.  At /home/travis/build/ManageIQ/manageiq/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb:23:in `block (2 levels) in <module:MiqAeServiceServiceReconfigureRequestSpec>'
```