### PR TITLE
Added support to manage Catalog Items based on Orchestration Templates

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2643,4 +2643,8 @@ module ApplicationHelper
     (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
       (@explorer && x_tree && [:filter, :images, :instances, :vandt].include?(x_tree[:type]) && !@record)
   end
+
+  def need_prov_dialogs?(type)
+    !type.starts_with?("generic")
+  end
 end

--- a/vmdb/app/views/catalog/_form.html.haml
+++ b/vmdb/app/views/catalog/_form.html.haml
@@ -2,27 +2,29 @@
   %ul.tab
     %li#li_basic
       %a{:href => "#basic"}=_('Basic Info')
-    %li#li_details
-      %a{:href => "#details"}=_('Details')
-    - if @edit[:new][:service_type] == "composite"
-      %li#li_resources
-        %a{:href => "#resources"}=_('Resources')
-    - else
-      - if @edit[:new][:service_type] == "atomic" && @edit[:new][:st_prov_type] != "generic"
-        %li#li_request
-          %a{:href => "#request"}=_('Request Info')
+    - unless @edit[:new][:st_prov_type] == "generic_orchestration"
+      %li#li_details
+        %a{:href => "#details"}=_('Details')
+      - if @edit[:new][:service_type] == "composite"
+        %li#li_resources
+          %a{:href => "#resources"}=_('Resources')
+      - else
+        - if @edit[:new][:service_type] == "atomic" && need_prov_dialogs?(@edit[:new][:st_prov_type])
+          %li#li_request
+            %a{:href => "#request"}=_('Request Info')
 
   #basic{:name => "basic", :width => "80px;"}
     = render :partial => "form_basic_info"
-  #details{:name => "details", :width => "80px"}
-    = render :partial => "form_details_info"
-  - if @edit[:new][:service_type] == "composite"
-    #resources{:name => "resources", :width => "80px"}
-      = render :partial => "form_resources_info"
-  - else
-    - if @edit[:new][:service_type] == "atomic" && @edit[:new][:st_prov_type] != "generic"
-      #request{:name => "request", :width => "80px"}
-        = render :partial => "form_request_info"
+  - unless @edit[:new][:st_prov_type] == "generic_orchestration"
+    #details{:name => "details", :width => "80px"}
+      = render :partial => "form_details_info"
+    - if @edit[:new][:service_type] == "composite"
+      #resources{:name => "resources", :width => "80px"}
+        = render :partial => "form_resources_info"
+    - else
+      - if @edit[:new][:service_type] == "atomic" && need_prov_dialogs?(@edit[:new][:st_prov_type])
+        #request{:name => "request", :width => "80px"}
+          = render :partial => "form_request_info"
 
 :javascript
   //method takes hash that can have 4 keys: tabs div id, active_tab label,

--- a/vmdb/app/views/catalog/_form_basic_info.html.haml
+++ b/vmdb/app/views/catalog/_form_basic_info.html.haml
@@ -40,6 +40,25 @@
           = select_tag('dialog_id',
             options_for_select(options, @edit[:new][:dialog_id]),
             "data-miq_sparkle_on" => true, "data-miq_observe" => {:url => url}.to_json)
+
+      - if @edit[:new][:st_prov_type] == "generic_orchestration"
+        - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
+        %tr
+          %td.key=_('Orchestration Template')
+          %td.wide
+            = select_tag('template_id',
+                    options_for_select(opts, @edit[:new][:template_id]),
+                    "data-miq_sparkle_on" => true,
+                    "data-miq_observe" => {:url => url}.to_json)
+        - if @edit[:new][:template_id]
+        - opts = [["<Choose>",nil]] + @edit[:new][:available_managers]
+          %tr
+            %td.key=_('Provider')
+            %td.wide
+              = select_tag('manager_id',
+                          options_for_select(opts, @edit[:new][:manager_id]),
+                          "data-miq_sparkle_on" => true,
+                          "data-miq_observe" => {:url => url}.to_json)
       %tr
         %td.key{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
           =_('Provisioning Entry Point')
@@ -61,48 +80,49 @@
                     "data-confirm" => _("Are you sure you want to remove this Provisioning Entry Point?"),
                     :remote => true,
                     :title => _("Remove this Provisioning Entry Point"))
-      %tr
-        %td.key{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
-          =_('Reconfigure Entry Point')
-          %br
-          =_('(NS/Cls/Inst)')
-        %td.wider{:title => @edit[:new][:reconfigure_fqname]}
-          %table
-            %tr
-              %td
-                = text_field_tag("reconfigure_fqname",
-                  @edit[:new][:reconfigure_fqname],
-                  :onFocus => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
-                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-              %td
-                #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
-                  = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => "Remove this Reconfigure Entry Point"),
-                    {:action => 'ae_tree_select_discard', :typ => "reconfigure"},
-                    "data-miq_sparkle_on" => true,
-                    "data-miq_sparkle_off" => true,
-                    "data-confirm" => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                    :remote => true,
-                    :title => _("Remove this Reconfigure Entry Point"))
-      %tr
-        %td.key{:title => "Retirement Entry Point (NameSpace/Class/Instance)"}
-          =_('Retirement Entry Point')
-          %br
-          =_('(NS/Cls/Inst)')
-        %td.wider{:title => @edit[:new][:retire_fqname]}
-          %table
-            %tr
-              %td
-                = text_field_tag("retire_fqname", @edit[:new][:retire_fqname],
-                  :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
-              %td
-                #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
-                  = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => "Remove this Retirement Entry Point"),
-                    {:action => 'ae_tree_select_discard', :typ => "retirement"},
-                    "data-miq_sparkle_on" => true,
-                    "data-miq_sparkle_off" => true,
-                    "data-confirm" => _("Are you sure you want to remove this Retirement Entry Point?"),
-                    :remote => true,
-                    :title => _("Remove this Retirement Entry Point"))
+      - unless @edit[:new][:st_prov_type] == "generic_orchestration"
+        %tr
+          %td.key{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
+            =_('Reconfigure Entry Point')
+            %br
+            =_('(NS/Cls/Inst)')
+          %td.wider{:title => @edit[:new][:reconfigure_fqname]}
+            %table
+              %tr
+                %td
+                  = text_field_tag("reconfigure_fqname",
+                    @edit[:new][:reconfigure_fqname],
+                    :onFocus => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
+                    "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                %td
+                  #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
+                    = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => "Remove this Reconfigure Entry Point"),
+                      {:action => 'ae_tree_select_discard', :typ => "reconfigure"},
+                      "data-miq_sparkle_on" => true,
+                      "data-miq_sparkle_off" => true,
+                      "data-confirm" => _("Are you sure you want to remove this Reconfigure Entry Point?"),
+                      :remote => true,
+                      :title => _("Remove this Reconfigure Entry Point"))
+        %tr
+          %td.key{:title => "Retirement Entry Point (NameSpace/Class/Instance)"}
+            =_('Retirement Entry Point')
+            %br
+            =_('(NS/Cls/Inst)')
+          %td.wider{:title => @edit[:new][:retire_fqname]}
+            %table
+              %tr
+                %td
+                  = text_field_tag("retire_fqname", @edit[:new][:retire_fqname],
+                    :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
+                %td
+                  #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
+                    = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => "Remove this Retirement Entry Point"),
+                      {:action => 'ae_tree_select_discard', :typ => "retirement"},
+                      "data-miq_sparkle_on" => true,
+                      "data-miq_sparkle_off" => true,
+                      "data-confirm" => _("Are you sure you want to remove this Retirement Entry Point?"),
+                      :remote => true,
+                      :title => _("Remove this Retirement Entry Point"))
     /
       %tr
         %td.key Cost

--- a/vmdb/app/views/catalog/_sandt_tree_show.html.haml
+++ b/vmdb/app/views/catalog/_sandt_tree_show.html.haml
@@ -3,14 +3,14 @@
   %ul.tab
     %li#li_basic
       %a{:href => "#basic"}=_('Basic Info')
-    - if @record.display
+    - if @record.display && @record.prov_type != "generic_orchestration"
       %li#li_details
         %a{:href => "#details"}=_('Details')
     - if @record.composite?
       %li#li_resources
         %a{:href => "#resources"}=_('Selected Resources')
     - else
-      - unless @record.prov_type.eql?("generic")
+      - if need_prov_dialogs?(@record.prov_type)
         %li#li_request
           %a{:href => "#request"}=_('Request Info')
   #basic{:name => "basic", :width => "80px"}
@@ -30,9 +30,20 @@
       %tr
         %td.key=_('Dialog')
         %td= h(@sb[:dialog_label])
-      - [[_("Provisioning"), :fqname],
-         [_("Reconfigure"),  :reconfigure_fqname],
-         [_("Retirement"),   :retire_fqname]].each do |entry_points_op|
+      - if @record.prov_type == "generic_orchestration"
+        %tr
+          %td.key=_('Orchestration Template')
+          %td= h(@record.try(:orchestration_template).try(:name))
+        - if @record.orchestration_manager
+          %tr
+            %td.key=_('Provider')
+            %td= h(@record.orchestration_manager.name)
+      - entry_points = [[_("Provisioning"), :fqname]]
+      - unless @record.prov_type == "generic_orchestration"
+        - entry_points.push([_("Provisioning"), :fqname],
+           [_("Reconfigure"),  :reconfigure_fqname],
+           [_("Retirement"),   :retire_fqname])
+      - entry_points.each do |entry_points_op|
         %tr
           %td.key{:title => _("%s Entry Point (NameSpace/Class/Instance)") % entry_points_op[0]}
             ="#{entry_points_op[0]} #{_('Entry Point')}"
@@ -79,7 +90,7 @@
         =_('* Requirements - Type: jpg/png  Size: 100x100')
       %script{:type => "text/javascript"} miqInitJqueryForm();
 
-  - if @record.display
+  - if @record.display && @record.prov_type != "generic_orchestration"
     #details{:name => "details", :width => "80px"}
       %p.legend=_('Basic Information')
       %table.style1
@@ -136,7 +147,7 @@
       - else
         =_('No Resources found.')
   - else
-    - if !@record.prov_type || (@record.prov_type && @record.prov_type != "generic")
+    - if !@record.prov_type || (@record.prov_type && need_prov_dialogs?(@record.prov_type))
       #request{:name => "request", :width => "80px"}
         - if @options[:wf]
           %p.legend


### PR DESCRIPTION
Added new type "Orchestration" to the Catalog Item type pull down. Added support to save orchestration_Template and orchestration_manager. In addition to above Provision Entry Point (NS/Cls/Inst) & Dialog can be saved for this type of Catalog Item.

Issue #1445 
@bzwei @gmcculloug please review/test.