### PR TITLE
Fixed if condition.

### DIFF
--- a/vmdb/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -15,7 +15,7 @@
       - wf.dialog.dialog_tabs.each do |tab|
         = render :partial => "shared/dialogs/dialog_tab", 
                  :locals => {:wf => wf, :tab => tab}
-  - unless @edit[:explorer]
+  - if @edit && !@edit[:explorer]
     = render :partial => "layouts/x_dialog_buttons",
              :locals  => {:action_url => 'dialog_form_button_pressed',
                           :record_id  => @edit[:rec_id]}


### PR DESCRIPTION
- Render x_dialog_buttons only when @edit is present and @edit[:explorer] is not set, no need to render buttons on show screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1194479

@bmclaughlin please test