### PR TITLE
Cluster - drift_history breadcrumb fix

### DIFF
--- a/vmdb/app/controllers/application_controller/compare.rb
+++ b/vmdb/app/controllers/application_controller/compare.rb
@@ -795,7 +795,7 @@ module ApplicationController::Compare
     @timestamps = @drift_obj.drift_state_timestamps
     session[:timestamps] = @timestamps
     @showtype = "drift_history"
-    drop_breadcrumb( {:name=>"Drift History", :url=>"/#{@sb[:compare_db].downcase}/drift_history/#{@drift_obj.id}"} )
+    drop_breadcrumb({:name => "Drift History", :url => "/#{controller_name}/drift_history/#{@drift_obj.id}"})
     @lastaction = "drift_history"
     @display = "main"
     @button_group = "common_drift"


### PR DESCRIPTION
Previously, /emscluser/drift_history/[:id] got pushed to breadcrumbs instead of /ems_cluster/...
Changed to use controller_name which should always fit.

Please note that this will only work with Cluster and Host because others don't yet have GET routes for drift_history.

https://bugzilla.redhat.com/show_bug.cgi?id=1194242