### PR TITLE
Introduce foreman Host (via connection.host)

### DIFF
--- a/lib/manageiq_foreman/lib/manageiq_foreman.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman.rb
@@ -5,6 +5,7 @@ require 'foreman_api'
 require "manageiq_foreman/paged_response"
 require "manageiq_foreman/connection"
 require "manageiq_foreman/inventory"
+require "manageiq_foreman/host"
 
 module ManageiqForeman
 end

--- a/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
@@ -35,10 +35,6 @@ module ManageiqForeman
       fetch(:hosts, :index, filter)
     end
 
-    def denormalized_hostgroups(filter = {})
-      denormalize_ancestors!(all(:hostgroups, filter))
-    end
-
     def hostgroups(filter = {})
       fetch(:hostgroups, :index, filter)
     end
@@ -76,20 +72,6 @@ module ManageiqForeman
 
     def fetch(resource, action = :index, filter = {})
       PagedResponse.new(raw(resource).send(action, filter).first)
-    end
-
-    def denormalize_ancestors!(records)
-      records.each do |record|
-        ancestor_ids(record["ancestry"]).reverse.each do |ancestor_id|
-          ancestor = records.detect { |r| r["id"] == ancestor_id }
-          ancestor.each_pair { |n, v| record[n] ||= v unless v.nil? } if ancestor
-        end
-      end
-      records
-    end
-
-    def ancestor_ids(str)
-      (str || "").split("/").collect(&:to_i)
     end
 
     def raw(resource)

--- a/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
@@ -41,6 +41,10 @@ module ManageiqForeman
       PagedResponse.new(raw(resource).send(action, filter).first)
     end
 
+    def host(manager_ref)
+      ::ManageiqForeman::Host.new(self, manager_ref)
+    end
+
     private
 
     def raw(resource)

--- a/lib/manageiq_foreman/lib/manageiq_foreman/host.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/host.rb
@@ -1,0 +1,36 @@
+module ManageiqForeman
+  class Host
+    attr_accessor :manager_ref
+    attr_accessor :connection
+
+    def initialize(connection, manager_ref)
+      @connection = connection
+      @manager_ref = manager_ref
+    end
+
+    def start
+      power_state("on")
+    end
+
+    def stop
+      power_state("off")
+    end
+
+    # valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)
+    def power_state(action = "status")
+      connection.fetch(:hosts, :power, "id" => manager_ref, "power_action" => action).first["power"]
+    end
+
+    def powered_on?
+      power_state == "on"
+    end
+
+    def reboot(mode = "pxe")
+      connection.fetch(:hosts, :boot, "id" => manager_ref, "device" => mode)
+    end
+
+    def update(params)
+      connection.fetch(:hosts, :update, params.merge("id" => manager_ref))
+    end
+  end
+end

--- a/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
@@ -22,7 +22,7 @@ module ManageiqForeman
 
     def refresh_provisioning(_target = nil)
       {
-        :operating_systems => connection.all(:operating_system_details),
+        :operating_systems => connection.all_with_details(:operating_systems),
         :media             => connection.all(:media),
         :ptables           => connection.all(:ptables),
       }

--- a/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
@@ -16,7 +16,7 @@ module ManageiqForeman
     def refresh_configuration(_target = nil)
       {
         :hosts      => connection.all(:hosts),
-        :hostgroups => connection.denormalized_hostgroups,
+        :hostgroups => connection.all(:hostgroups).denormalize,
       }
     end
 

--- a/lib/manageiq_foreman/lib/manageiq_foreman/paged_response.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/paged_response.rb
@@ -32,5 +32,21 @@ module ManageiqForeman
     def ==(other)
       results == other.results
     end
+
+    def denormalize
+      self.class.new(
+        results.collect do |record|
+          ancestors(results, record["ancestry"]).each_with_object({}) do |ancestor, h|
+            h.merge!(ancestor.select { |_n, v| !v.nil? && v != "" })
+          end.merge!(record.select { |_n, v| !v.nil? && v != "" })
+        end
+      )
+    end
+
+    private
+
+    def ancestors(records, ancestry)
+      (ancestry || "").split("/").collect(&:to_i).collect { |id| records.detect { |r| r["id"] == id } }
+    end
   end
 end

--- a/lib/manageiq_foreman/spec/connection_spec.rb
+++ b/lib/manageiq_foreman/spec/connection_spec.rb
@@ -5,9 +5,9 @@ describe ManageiqForeman::Connection do
     described_class.new(:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => nil)
   end
 
-  describe "#host" do
+  describe "#fetch" do
     context "with 2 hosts" do
-      let(:results) { connection.hosts("per_page" => 2) }
+      let(:results) { connection.fetch(:hosts, "per_page" => 2) }
 
       it "fetches 2 hosts" do
         with_vcr("_2_hosts") do
@@ -26,10 +26,10 @@ describe ManageiqForeman::Connection do
   end
 
   describe "#operating_system_detail" do
-    context "with 2 operating_system_details" do
-      let(:results) { connection.operating_system_details("per_page" => 2) }
+    context "with 2 operating_system details" do
+      let(:results) { connection.all_with_details(:operating_systems, "per_page" => 2) }
 
-      it "fetches 2 operating_system_details" do
+      it "fetches 2 operating_system details" do
         with_vcr("_2_operating_systems") do
           expect(results.size).to eq(2)
         end
@@ -40,13 +40,13 @@ describe ManageiqForeman::Connection do
   describe "simple accessor methods" do
     it "works" do
       with_vcr("_all_methods") do
-        expect(connection.hosts(:per_page => 2).size).to eq(2)
-        expect(connection.hostgroups(:per_page => 2).size).to eq(2)
-        expect(connection.operating_systems(:per_page => 2).size).to eq(2)
-        expect(connection.media(:per_page => 2).size).to eq(2)
-        expect(connection.ptables(:per_page => 2).size).to eq(2)
-        expect(connection.config_templates(:per_page => 2).size).to eq(2)
-        expect(connection.subnets(:per_page => 2).size).to eq(2)
+        expect(connection.fetch(:hosts, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:hostgroups, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:operating_systems, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:media, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:ptables, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:config_templates, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:subnets, :per_page => 2).size).to eq(2)
       end
     end
   end

--- a/lib/spec/vcr_cassettes/ManageiqForeman_Connection_2_operating_systems.yml
+++ b/lib/spec/vcr_cassettes/ManageiqForeman_Connection_2_operating_systems.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://admin:smartvm@example.com/api/operatingsystems?per_page=2
+    uri: http://admin:smartvm@example.com/api/operatingsystems?page=1&per_page=2
     body:
       encoding: US-ASCII
       string: ''
@@ -58,7 +58,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-          "total": 5,
+          "total": 2,
           "subtotal": 5,
           "page": 1,
           "per_page": 2,


### PR DESCRIPTION
Change foreman connection to reduce the number of methods available.

This is pulling out these changes for #1783

- removed foreman methods that were simply rest wrappers
- introduce host object

/cc @gmcculloug @brandondunne