### PR TITLE
Keep the GEM_PATH Variable in the environment for VixDiskLibServer

### DIFF
--- a/lib/VixDiskLib/VixDiskLib.rb
+++ b/lib/VixDiskLib/VixDiskLib.rb
@@ -90,8 +90,8 @@ class VixDiskLib
   #
   def self.setup_env
     vars_to_clear = %w(BUNDLE_BIN BUNDLE_BIN_PATH BUNDLE_GEMFILE
-                       BUNDLE_ORIG_MANPATH EVMSERVER GEM_HOME
-                       GEM_PATH MIQ_GUID RAILS_ENV RUBYOPT ORIGINAL_GEM_PATH)
+                       BUNDLE_ORIG_MANPATH EVMSERVER MIQ_GUID
+                       RAILS_ENV RUBYOPT ORIGINAL_GEM_PATH)
     my_env = ENV.to_hash
     vars_to_clear.each do |key|
       my_env.delete(key)


### PR DESCRIPTION
Older version of VixDiskLibServer did not need the GEM_PATH variable
saved in its environment when being started, however at this point with
Ruby 2.0.0, without thisvariable, among other things, the gem log4r cannot be 
found and the service will not start.

@Fryguy @roliveri @jrafanie please comment/merge/etc.  Thanks.