### PR TITLE
Support for collecting images, flavors, and networks with OpenStack infra

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
@@ -1,6 +1,8 @@
 module EmsRefresh
   module Parsers
     class OpenstackInfra < Infra
+      include OpenstackMixin
+      
       def self.ems_inv_to_hashes(ems, options = nil)
         new(ems, options).ems_inv_to_hashes
       end
@@ -18,6 +20,10 @@ module EmsRefresh
         @compute_service        = @connection # for consistency
         @baremetal_service      = @os_handle.detect_baremetal_service
         @baremetal_service_name = @os_handle.baremetal_service_name
+        @image_service        = @os_handle.detect_image_service
+        @image_service_name   = @os_handle.image_service_name
+        @network_service      = @os_handle.detect_network_service
+        @network_service_name = @os_handle.network_service_name
       end
 
       def ems_inv_to_hashes
@@ -26,8 +32,12 @@ module EmsRefresh
         $fog_log.info("#{log_header}...")
 
         load_hosts
+        get_flavors
+        get_images
+        get_networks
 
         $fog_log.info("#{log_header}...Complete")
+
         @data
       end
 

--- a/vmdb/app/models/ems_refresh/parsers/openstack_mixin.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_mixin.rb
@@ -1,0 +1,111 @@
+module EmsRefresh::Parsers
+  module OpenstackMixin
+
+    def networks
+      @networks ||= @network_service.networks
+    end
+
+    def get_flavors
+      flavors = @connection.flavors
+      process_collection(flavors, :flavors) { |flavor| parse_flavor(flavor) }
+    end
+
+    def get_private_flavor(id)
+      private_flavor = @connection.flavors.get(id)
+      process_collection([private_flavor], :flavors) { |flavor| parse_flavor(flavor) }
+    end
+
+    def get_images
+      images = @image_service.images_for_accessible_tenants
+      process_collection(images, :vms) { |image| parse_image(image) }
+    end
+
+    def get_networks
+      return unless @network_service_name == :neutron
+      process_collection(networks, :cloud_networks) { |n| parse_network(n) }
+      get_subnets
+    end
+
+    def get_subnets
+      return unless @network_service_name == :neutron
+
+      networks.each do |n|
+        new_net = @data_index.fetch_path(:cloud_networks, n.id)
+        new_net[:cloud_subnets] = n.subnets.collect { |s| parse_subnet(s) }
+      end
+    end
+
+    def parse_flavor(flavor)
+      uid = flavor.id
+
+      new_result = {
+        :type    => "FlavorOpenstack",
+        :ems_ref => uid,
+        :name    => flavor.name,
+        :enabled => !flavor.disabled,
+        :cpus    => flavor.vcpus,
+        :memory  => flavor.ram.megabytes,
+
+        # Extra keys
+        :root_disk      => flavor.disk.to_i.gigabytes,
+        :ephemeral_disk => flavor.ephemeral.to_i.gigabytes,
+        :swap_disk      => flavor.swap.to_i.megabytes
+      }
+
+      return uid, new_result
+    end
+
+    def parse_image(image)
+      uid = image.id
+
+      parent_server_uid = parse_image_parent_id(image)
+
+      new_result = {
+        :type            => "TemplateOpenstack",
+        :uid_ems         => uid,
+        :ems_ref         => uid,
+        :name            => image.name,
+        :vendor          => "openstack",
+        :raw_power_state => "never",
+        :template        => true,
+        :publicly_available => image.is_public
+      }
+      new_result[:parent_vm_uid] = parent_server_uid unless parent_server_uid.nil?
+      new_result[:cloud_tenant]  = @data_index.fetch_path(:cloud_tenants, image.owner) if image.owner
+
+      return uid, new_result
+    end
+
+    def parse_image_parent_id(image)
+      image_parent = @image_service_name == :glance ? image.copy_from : image.server
+      image_parent["id"] if image_parent
+    end
+
+    def parse_network(network)
+      uid     = network.id
+      status  = (network.status.to_s.downcase == "active") ? "active" : "inactive"
+
+      new_result = {
+        :name            => network.name,
+        :ems_ref         => uid,
+        :status          => status,
+        :enabled         => network.admin_state_up,
+        :external_facing => network.router_external,
+        :cloud_tenant    => @data_index.fetch_path(:cloud_tenants, network.tenant_id)
+      }
+      return uid, new_result
+    end
+
+    def parse_subnet(subnet)
+      {
+        :name             => subnet.name,
+        :ems_ref          => subnet.id,
+        :cidr             => subnet.cidr,
+        :network_protocol => "ipv#{subnet.ip_version}",
+        :gateway          => subnet.gateway_ip,
+        :dhcp_enabled     => subnet.enable_dhcp,
+      }
+    end
+
+  end
+end  

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno_spec.rb
@@ -29,6 +29,7 @@ describe EmsRefresh::Refreshers::OpenstackInfraRefresher do
       assert_table_counts
       assert_ems
       assert_specific_host
+      assert_specific_public_template
     end
   end
 
@@ -39,7 +40,7 @@ describe EmsRefresh::Refreshers::OpenstackInfraRefresher do
     Host.count.should                == 7
     ResourcePool.count.should        == 0
     Vm.count.should                  == 0
-    VmOrTemplate.count.should        == 0
+    VmOrTemplate.count.should        == 16
     CustomAttribute.count.should     == 0
     CustomizationSpec.count.should   == 0
     Disk.count.should                == 0
@@ -48,15 +49,16 @@ describe EmsRefresh::Refreshers::OpenstackInfraRefresher do
     Lan.count.should                 == 0
     MiqScsiLun.count.should          == 0
     MiqScsiTarget.count.should       == 0
-    Network.count.should             == 0
+#    Network.count.should             == 1
     OperatingSystem.count.should     == 0
     Snapshot.count.should            == 0
     Switch.count.should              == 0
     SystemService.count.should       == 0
     Relationship.count.should        == 0
 
-    MiqQueue.count.should            == 3
+    MiqQueue.count.should            == 19
     Storage.count.should             == 0
+#    Flavor.count.should              == 1
   end
 
   def assert_ems
@@ -70,9 +72,9 @@ describe EmsRefresh::Refreshers::OpenstackInfraRefresher do
 
     @ems.storages.size.should            == 0
     @ems.hosts.size.should               == 7
-    @ems.vms_and_templates.size.should   == 0
+    @ems.vms_and_templates.size.should   == 16
     @ems.vms.size.should                 == 0
-    @ems.miq_templates.size.should       == 0
+    @ems.miq_templates.size.should       == 16
     @ems.customization_specs.size.should == 0
   end
 
@@ -109,5 +111,47 @@ describe EmsRefresh::Refreshers::OpenstackInfraRefresher do
       :cpu_usage          => nil,
       :memory_usage       => nil
     )
+  end
+
+  def assert_specific_public_template
+    assert_specific_template("overcloud-control", "1734551c-dff7-472c-9925-f713e7af5a52", true)
+  end
+
+  def assert_specific_template(name, uid, is_public = false)
+    template = TemplateOpenstack.where(:name => name).first
+    template.should have_attributes(
+      :template              => true,
+      :publicly_available    => is_public,
+      :ems_ref_obj           => nil,
+      :uid_ems               => uid,
+      :vendor                => "OpenStack",
+      :power_state           => "never",
+      :location              => "unknown",
+      :tools_status          => nil,
+      :boot_time             => nil,
+      :standby_action        => nil,
+      :connection_state      => nil,
+      :cpu_affinity          => nil,
+      :memory_reserve        => nil,
+      :memory_reserve_expand => nil,
+      :memory_limit          => nil,
+      :memory_shares         => nil,
+      :memory_shares_level   => nil,
+      :cpu_reserve           => nil,
+      :cpu_reserve_expand    => nil,
+      :cpu_limit             => nil,
+      :cpu_shares            => nil,
+      :cpu_shares_level      => nil
+    )
+    template.ems_ref.should be_guid
+
+    template.ext_management_system.should  == @ems
+    template.operating_system.should       be_nil # TODO: This should probably not be nil
+    template.custom_attributes.size.should == 0
+    template.snapshots.size.should         == 0
+    template.hardware.should               be_nil
+
+    template.parent.should                 be_nil
+    template
   end
 end

--- a/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno.yml
+++ b/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno.yml
@@ -242,6 +242,213 @@ http_interactions:
     http_version: 
   recorded_at: Mon, 19 Jan 2015 12:16:23 GMT
 - request:
+    method: post
+    uri: http://192.0.2.1:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"f593665c68a605c4728d91a112b4513143f16a7d"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Vary:
+      - X-Auth-Token
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3484'
+      Date:
+      - Tue, 03 Feb 2015 23:11:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"access": {"token": {"issued_at": "2015-02-03T23:11:04.239968", "expires":
+        "2015-02-04T03:11:04Z", "id": "f04739b65cca4658b1fd02104de9bc33", "tenant":
+        {"description": null, "enabled": true, "id": "51bcb84d79174b6680284bfbd44c23a8",
+        "name": "admin"}, "audit_ids": ["OqTCXcM9T8uZ88uzD428vg"]}, "serviceCatalog":
+        [{"endpoints": [{"adminURL": "http://192.0.2.1:8585/", "region": "regionOne",
+        "internalURL": "http://192.0.2.1:8585/", "id": "24ffdec8d8554612a3c80868fc2c7e33",
+        "publicURL": "http://192.0.2.1:8585/"}], "endpoints_links": [], "type": "management",
+        "name": "tuskar"}, {"endpoints": [{"adminURL": "http://192.0.2.1:8774/v2/51bcb84d79174b6680284bfbd44c23a8",
+        "region": "regionOne", "internalURL": "http://192.0.2.1:8774/v2/51bcb84d79174b6680284bfbd44c23a8",
+        "id": "5f7b874fc7794ffeba97959e88a696ca", "publicURL": "http://192.0.2.1:8774/v2/51bcb84d79174b6680284bfbd44c23a8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://192.0.2.1:9696/", "region": "regionOne", "internalURL": "http://192.0.2.1:9696/",
+        "id": "548693814a5a4dc3b456818a8109065b", "publicURL": "http://192.0.2.1:9696/"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://192.0.2.1:8774/v3", "region": "regionOne", "internalURL":
+        "http://192.0.2.1:8774/v3", "id": "1ef9abaabe034f57a575e86d12646ed3", "publicURL":
+        "http://192.0.2.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "nova"}, {"endpoints": [{"adminURL": "http://192.0.2.1:9292/", "region":
+        "regionOne", "internalURL": "http://192.0.2.1:9292/", "id": "04058e401124416fa4afaf29246e897f",
+        "publicURL": "http://192.0.2.1:9292/"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://192.0.2.1:8777/", "region":
+        "regionOne", "internalURL": "http://192.0.2.1:8777/", "id": "4fb7ca88434b4b2993fabd4c8dfd3ac4",
+        "publicURL": "http://192.0.2.1:8777/"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://192.0.2.1:6385/",
+        "region": "regionOne", "internalURL": "http://192.0.2.1:6385/", "id": "00e46e4c1cae42d2a7b1fc243d6c9ab7",
+        "publicURL": "http://192.0.2.1:6385/"}], "endpoints_links": [], "type": "baremetal",
+        "name": "ironic"}, {"endpoints": [{"adminURL": "http://192.0.2.1:8773/services/Admin",
+        "region": "regionOne", "internalURL": "http://192.0.2.1:8773/services/Cloud",
+        "id": "4c89f8e5eaae41758c4bcfac98936307", "publicURL": "http://192.0.2.1:8773/services/Cloud"}],
+        "endpoints_links": [], "type": "ec2", "name": "ec2"}, {"endpoints": [{"adminURL":
+        "http://192.0.2.1:8004/v1/51bcb84d79174b6680284bfbd44c23a8", "region": "regionOne",
+        "internalURL": "http://192.0.2.1:8004/v1/51bcb84d79174b6680284bfbd44c23a8",
+        "id": "66fdcf06f2914da4a976e805f2fd55bb", "publicURL": "http://192.0.2.1:8004/v1/51bcb84d79174b6680284bfbd44c23a8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://192.0.2.1:35357/v2.0", "region": "regionOne", "internalURL":
+        "http://192.0.2.1:5000/v2.0", "id": "8fc1c2cec4c9456aa67bf92172f941dc", "publicURL":
+        "http://192.0.2.1:5000/v2.0"}], "endpoints_links": [], "type": "identity",
+        "name": "keystone"}], "user": {"username": "admin", "roles_links": [], "id":
+        "82e74051c5b440e0859d358affa643da", "roles": [{"name": "_member_"}, {"name":
+        "admin"}], "name": "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
+        "e85e029eb267481c9331c21ab8e23f7c"]}}}'
+    http_version: 
+  recorded_at: Tue, 03 Feb 2015 23:11:04 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:9292/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 10da4d149bc14131b27fdd0b2e1d2e91
+  response:
+    status:
+      code: 300
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '530'
+      Date:
+      - Tue, 03 Feb 2015 23:11:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"versions": [{"status": "CURRENT", "id": "v2.2", "links": [{"href":
+        "http://192.0.2.1:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
+        "v2.1", "links": [{"href": "http://192.0.2.1:9292/v2/", "rel": "self"}]},
+        {"status": "SUPPORTED", "id": "v2.0", "links": [{"href": "http://192.0.2.1:9292/v2/",
+        "rel": "self"}]}, {"status": "CURRENT", "id": "v1.1", "links": [{"href": "http://192.0.2.1:9292/v1/",
+        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v1.0", "links": [{"href":
+        "http://192.0.2.1:9292/v1/", "rel": "self"}]}]}'
+    http_version: 
+  recorded_at: Tue, 03 Feb 2015 23:11:04 GMT
+- request:
+    method: post
+    uri: http://192.0.2.1:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"f593665c68a605c4728d91a112b4513143f16a7d"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Vary:
+      - X-Auth-Token
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3484'
+      Date:
+      - Thu, 05 Feb 2015 18:12:38 GMT
+    body:
+      encoding: UTF-8
+      string: '{"access": {"token": {"issued_at": "2015-02-05T18:12:38.060164", "expires":
+        "2015-02-05T22:12:38Z", "id": "c499aa1aa3864fa2ae05fe2a327fb883", "tenant":
+        {"description": null, "enabled": true, "id": "51bcb84d79174b6680284bfbd44c23a8",
+        "name": "admin"}, "audit_ids": ["b1nvTMtmTcSsvg1BWlIqiw"]}, "serviceCatalog":
+        [{"endpoints": [{"adminURL": "http://192.0.2.1:8585/", "region": "regionOne",
+        "internalURL": "http://192.0.2.1:8585/", "id": "24ffdec8d8554612a3c80868fc2c7e33",
+        "publicURL": "http://192.0.2.1:8585/"}], "endpoints_links": [], "type": "management",
+        "name": "tuskar"}, {"endpoints": [{"adminURL": "http://192.0.2.1:8774/v2/51bcb84d79174b6680284bfbd44c23a8",
+        "region": "regionOne", "internalURL": "http://192.0.2.1:8774/v2/51bcb84d79174b6680284bfbd44c23a8",
+        "id": "5f7b874fc7794ffeba97959e88a696ca", "publicURL": "http://192.0.2.1:8774/v2/51bcb84d79174b6680284bfbd44c23a8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://192.0.2.1:9696/", "region": "regionOne", "internalURL": "http://192.0.2.1:9696/",
+        "id": "548693814a5a4dc3b456818a8109065b", "publicURL": "http://192.0.2.1:9696/"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://192.0.2.1:8774/v3", "region": "regionOne", "internalURL":
+        "http://192.0.2.1:8774/v3", "id": "1ef9abaabe034f57a575e86d12646ed3", "publicURL":
+        "http://192.0.2.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "nova"}, {"endpoints": [{"adminURL": "http://192.0.2.1:9292/", "region":
+        "regionOne", "internalURL": "http://192.0.2.1:9292/", "id": "04058e401124416fa4afaf29246e897f",
+        "publicURL": "http://192.0.2.1:9292/"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://192.0.2.1:8777/", "region":
+        "regionOne", "internalURL": "http://192.0.2.1:8777/", "id": "4fb7ca88434b4b2993fabd4c8dfd3ac4",
+        "publicURL": "http://192.0.2.1:8777/"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://192.0.2.1:6385/",
+        "region": "regionOne", "internalURL": "http://192.0.2.1:6385/", "id": "00e46e4c1cae42d2a7b1fc243d6c9ab7",
+        "publicURL": "http://192.0.2.1:6385/"}], "endpoints_links": [], "type": "baremetal",
+        "name": "ironic"}, {"endpoints": [{"adminURL": "http://192.0.2.1:8773/services/Admin",
+        "region": "regionOne", "internalURL": "http://192.0.2.1:8773/services/Cloud",
+        "id": "4c89f8e5eaae41758c4bcfac98936307", "publicURL": "http://192.0.2.1:8773/services/Cloud"}],
+        "endpoints_links": [], "type": "ec2", "name": "ec2"}, {"endpoints": [{"adminURL":
+        "http://192.0.2.1:8004/v1/51bcb84d79174b6680284bfbd44c23a8", "region": "regionOne",
+        "internalURL": "http://192.0.2.1:8004/v1/51bcb84d79174b6680284bfbd44c23a8",
+        "id": "66fdcf06f2914da4a976e805f2fd55bb", "publicURL": "http://192.0.2.1:8004/v1/51bcb84d79174b6680284bfbd44c23a8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://192.0.2.1:35357/v2.0", "region": "regionOne", "internalURL":
+        "http://192.0.2.1:5000/v2.0", "id": "8fc1c2cec4c9456aa67bf92172f941dc", "publicURL":
+        "http://192.0.2.1:5000/v2.0"}], "endpoints_links": [], "type": "identity",
+        "name": "keystone"}], "user": {"username": "admin", "roles_links": [], "id":
+        "82e74051c5b440e0859d358affa643da", "roles": [{"name": "_member_"}, {"name":
+        "admin"}], "name": "admin"}, "metadata": {"is_admin": 0, "roles": ["9fe2ff9ee4384b1894a90878d3e92bab",
+        "e85e029eb267481c9331c21ab8e23f7c"]}}}'
+    http_version: 
+  recorded_at: Thu, 05 Feb 2015 18:12:38 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:9696/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c499aa1aa3864fa2ae05fe2a327fb883
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '117'
+      Date:
+      - Thu, 05 Feb 2015 18:12:38 GMT
+    body:
+      encoding: UTF-8
+      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
+        "http://192.0.2.1:9696/v2.0", "rel": "self"}]}]}'
+    http_version: 
+  recorded_at: Thu, 05 Feb 2015 18:12:38 GMT
+- request:
     method: get
     uri: http://192.0.2.1:8774/v2/23e55ecf26c54fb4b15fa2bc12323bfa/servers/detail.json
     body:
@@ -490,4 +697,278 @@ http_interactions:
         "rel": "bookmark"}]}]}'
     http_version: 
   recorded_at: Mon, 19 Jan 2015 12:16:23 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:8774/v2/23e55ecf26c54fb4b15fa2bc12323bfa/flavors/detail.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc1f6d47ef594448b1a5002b3251fcf7
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '528'
+      X-Compute-Request-Id:
+      - req-df35caca-29a9-4bf7-af76-6b97804e1d68
+      Date:
+      - Thu, 05 Feb 2015 18:12:38 GMT
+    body:
+      encoding: UTF-8
+      string: '{"flavors": [{"name": "baremetal", "links": [{"href": "http://192.0.2.1:8774/v2/23e55ecf26c54fb4b15fa2bc12323bfa/flavors/31b3804d-d24f-401f-8f50-51c6e5044abb",
+        "rel": "self"}, {"href": "http://192.0.2.1:8774/23e55ecf26c54fb4b15fa2bc12323bfa/flavors/31b3804d-d24f-401f-8f50-51c6e5044abb",
+        "rel": "bookmark"}], "ram": 4096, "OS-FLV-DISABLED:disabled": false, "vcpus":
+        1, "swap": "", "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
+        0, "disk": 30, "id": "31b3804d-d24f-401f-8f50-51c6e5044abb"}]}'
+    http_version: 
+  recorded_at: Thu, 05 Feb 2015 18:12:38 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:9292/v1.1/images/detail
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      X-Auth-Token:
+      - 10da4d149bc14131b27fdd0b2e1d2e91
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8724'
+      X-Openstack-Request-Id:
+      - req-987d3199-a954-41d2-a4fc-0523fc96f579
+      Date:
+      - Tue, 03 Feb 2015 23:11:05 GMT
+    body:
+      encoding: UTF-8
+      string: '{"images": [{"status": "active", "deleted_at": null, "name": "discovery-ramdisk",
+        "deleted": false, "container_format": "ari", "created_at": "2015-01-31T00:55:41",
+        "disk_format": "ari", "updated_at": "2015-01-31T00:55:42", "min_disk": 0,
+        "protected": false, "id": "7634252f-5332-4b5e-bac6-636762113045", "min_ram":
+        0, "checksum": "b88c84888a00f1c12583b4916ab5bc85", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": false, "virtual_size": null, "properties": {"type": "discovery
+        ramdisk"}, "size": 34093840}, {"status": "active", "deleted_at": null, "name":
+        "discovery-kernel", "deleted": false, "container_format": "aki", "created_at":
+        "2015-01-31T00:55:40", "disk_format": "aki", "updated_at": "2015-01-31T00:55:42",
+        "min_disk": 0, "protected": false, "id": "29cd688d-b8de-4f07-90f5-776c3f0f819e",
+        "min_ram": 0, "checksum": "6c73db790b2c8caeddb20a8cc00d63d1", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": false, "virtual_size": null, "properties": {"type": "discovery
+        kernel"}, "size": 5707784}, {"status": "active", "deleted_at": null, "name":
+        "bm-deploy-ramdisk", "deleted": false, "container_format": "ari", "created_at":
+        "2015-01-31T00:55:38", "disk_format": "ari", "updated_at": "2015-01-31T00:55:43",
+        "min_disk": 0, "protected": false, "id": "54251916-9c21-46d0-bfa8-e0b3e8ce9a25",
+        "min_ram": 0, "checksum": "5452d492ce20587153ebc9108e3c56c4", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": false, "virtual_size": null, "properties": {"type": "deploy ramdisk"},
+        "size": 33731827}, {"status": "active", "deleted_at": null, "name": "bm-deploy-kernel",
+        "deleted": false, "container_format": "aki", "created_at": "2015-01-31T00:55:37",
+        "disk_format": "aki", "updated_at": "2015-01-31T00:55:43", "min_disk": 0,
+        "protected": false, "id": "976f1154-2ca0-41a2-9d44-277cd6538122", "min_ram":
+        0, "checksum": "ec468d5114f00be727b7725bd2028467", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": false, "virtual_size": null, "properties": {"type": "deploy kernel"},
+        "size": 5594840}, {"status": "active", "deleted_at": null, "name": "overcloud-swift-storage",
+        "deleted": false, "container_format": "bare", "created_at": "2015-01-31T00:55:33",
+        "disk_format": "qcow2", "updated_at": "2015-01-31T00:55:48", "min_disk": 0,
+        "protected": false, "id": "3e0f048d-78b1-4c49-aa37-93db49501781", "min_ram":
+        0, "checksum": "cae1cbdde93f29ca3da6480bbb73b02d", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"kernel_id": "44d25747-4d88-4621-9de8-dfe498b4f1db",
+        "ramdisk_id": "4a667392-b772-4212-af1a-209d13179952", "type": "overcloud provisioning"},
+        "size": 579076096}, {"status": "active", "deleted_at": null, "name": "overcloud-swift-storage-initrd",
+        "deleted": false, "container_format": "ari", "created_at": "2015-01-31T00:55:32",
+        "disk_format": "ari", "updated_at": "2015-01-31T00:55:49", "min_disk": 0,
+        "protected": false, "id": "4a667392-b772-4212-af1a-209d13179952", "min_ram":
+        0, "checksum": "0f36fbee1a1b1c51af2c1cb5e4411940", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning ramdisk"}, "size": 22762033}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-swift-storage-vmlinuz", "deleted": false, "container_format":
+        "aki", "created_at": "2015-01-31T00:55:32", "disk_format": "aki", "updated_at":
+        "2015-01-31T00:55:49", "min_disk": 0, "protected": false, "id": "44d25747-4d88-4621-9de8-dfe498b4f1db",
+        "min_ram": 0, "checksum": "ec468d5114f00be727b7725bd2028467", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning kernel"}, "size": 5594840}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-cinder-volume", "deleted": false, "container_format":
+        "bare", "created_at": "2015-01-31T00:55:19", "disk_format": "qcow2", "updated_at":
+        "2015-01-31T00:55:47", "min_disk": 0, "protected": false, "id": "336a9a6b-e094-447c-b6f2-43ea2f2303cf",
+        "min_ram": 0, "checksum": "9f6733467f8e5604847babba6f236125", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"kernel_id": "cf7f6c3c-8e51-4d18-b01d-996099e71c06",
+        "ramdisk_id": "7789dc3c-6a75-4348-abf0-101aef40ac28", "type": "overcloud provisioning"},
+        "size": 656744448}, {"status": "active", "deleted_at": null, "name": "overcloud-cinder-volume-initrd",
+        "deleted": false, "container_format": "ari", "created_at": "2015-01-31T00:55:18",
+        "disk_format": "ari", "updated_at": "2015-01-31T00:55:47", "min_disk": 0,
+        "protected": false, "id": "7789dc3c-6a75-4348-abf0-101aef40ac28", "min_ram":
+        0, "checksum": "443787c875bed4a574341c192313a266", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning ramdisk"}, "size": 26741363}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-cinder-volume-vmlinuz", "deleted": false, "container_format":
+        "aki", "created_at": "2015-01-31T00:55:17", "disk_format": "aki", "updated_at":
+        "2015-01-31T00:55:48", "min_disk": 0, "protected": false, "id": "cf7f6c3c-8e51-4d18-b01d-996099e71c06",
+        "min_ram": 0, "checksum": "ec468d5114f00be727b7725bd2028467", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning kernel"}, "size": 5594840}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-compute", "deleted": false, "container_format": "bare",
+        "created_at": "2015-01-31T00:54:50", "disk_format": "qcow2", "updated_at":
+        "2015-01-31T00:55:45", "min_disk": 0, "protected": false, "id": "e3a47c76-a69a-4126-95b5-1213369a9155",
+        "min_ram": 0, "checksum": "b97ef8c71484ad9a827ee13f3f7730b7", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"kernel_id": "0b4ebca8-eea9-491e-9582-9e408d92a6ed",
+        "ramdisk_id": "ae0c3aee-1342-4fea-b4d8-3602094ac706", "type": "overcloud provisioning"},
+        "size": 683976192}, {"status": "active", "deleted_at": null, "name": "overcloud-compute-initrd",
+        "deleted": false, "container_format": "ari", "created_at": "2015-01-31T00:54:50",
+        "disk_format": "ari", "updated_at": "2015-01-31T00:55:46", "min_disk": 0,
+        "protected": false, "id": "ae0c3aee-1342-4fea-b4d8-3602094ac706", "min_ram":
+        0, "checksum": "a27089af7c80663db9e1f35e56bc8195", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning ramdisk"}, "size": 20692263}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-compute-vmlinuz", "deleted": false, "container_format":
+        "aki", "created_at": "2015-01-31T00:54:49", "disk_format": "aki", "updated_at":
+        "2015-01-31T00:55:46", "min_disk": 0, "protected": false, "id": "0b4ebca8-eea9-491e-9582-9e408d92a6ed",
+        "min_ram": 0, "checksum": "ec468d5114f00be727b7725bd2028467", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning kernel"}, "size": 5594840}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-control", "deleted": false, "container_format": "bare",
+        "created_at": "2015-01-31T00:54:41", "disk_format": "qcow2", "updated_at":
+        "2015-01-31T00:55:44", "min_disk": 0, "protected": false, "id": "1734551c-dff7-472c-9925-f713e7af5a52",
+        "min_ram": 0, "checksum": "5f886f0ddc38ce8e16aa66b57d7c8b61", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"kernel_id": "aaa7b6f9-b1ba-4907-96c7-a213cd2e0901",
+        "ramdisk_id": "7cbea504-473e-49bf-aad5-5b8e1a50194b", "type": "overcloud provisioning"},
+        "size": 795477504}, {"status": "active", "deleted_at": null, "name": "overcloud-control-initrd",
+        "deleted": false, "container_format": "ari", "created_at": "2015-01-31T00:54:40",
+        "disk_format": "ari", "updated_at": "2015-01-31T00:55:44", "min_disk": 0,
+        "protected": false, "id": "7cbea504-473e-49bf-aad5-5b8e1a50194b", "min_ram":
+        0, "checksum": "b94813b3ac7ae81b19f8cc9941667671", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning ramdisk"}, "size": 20673913}, {"status": "active", "deleted_at":
+        null, "name": "overcloud-control-vmlinuz", "deleted": false, "container_format":
+        "aki", "created_at": "2015-01-31T00:54:39", "disk_format": "aki", "updated_at":
+        "2015-01-31T00:55:45", "min_disk": 0, "protected": false, "id": "aaa7b6f9-b1ba-4907-96c7-a213cd2e0901",
+        "min_ram": 0, "checksum": "ec468d5114f00be727b7725bd2028467", "owner": "51bcb84d79174b6680284bfbd44c23a8",
+        "is_public": true, "virtual_size": null, "properties": {"type": "overcloud
+        provisioning kernel"}, "size": 5594840}]}'
+    http_version: 
+  recorded_at: Tue, 03 Feb 2015 23:11:05 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:9292/v1.1/images/detail?marker=aaa7b6f9-b1ba-4907-96c7-a213cd2e0901
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      X-Auth-Token:
+      - 10da4d149bc14131b27fdd0b2e1d2e91
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '14'
+      X-Openstack-Request-Id:
+      - req-29383ed6-8e46-4d0a-9ea1-0b4967e25976
+      Date:
+      - Tue, 03 Feb 2015 23:11:05 GMT
+    body:
+      encoding: UTF-8
+      string: '{"images": []}'
+    http_version: 
+  recorded_at: Tue, 03 Feb 2015 23:11:05 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:9696/v2.0/networks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c499aa1aa3864fa2ae05fe2a327fb883
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '379'
+      X-Openstack-Request-Id:
+      - req-4d32e18f-e40e-4d92-b27f-039edd0a0284
+      Date:
+      - Thu, 05 Feb 2015 18:12:38 GMT
+    body:
+      encoding: UTF-8
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["8402db3a-23e8-472d-82bc-047b44ac1537"],
+        "name": "ctlplane", "provider:physical_network": "ctlplane", "admin_state_up":
+        true, "tenant_id": "51bcb84d79174b6680284bfbd44c23a8", "provider:network_type":
+        "flat", "router:external": false, "shared": false, "id": "b2b51fc1-5c3a-46d2-b979-5663f4fd29f6",
+        "provider:segmentation_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 05 Feb 2015 18:12:38 GMT
+- request:
+    method: get
+    uri: http://192.0.2.1:9696/v2.0/subnets
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog/1.26.0 fog-core/1.27.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c499aa1aa3864fa2ae05fe2a327fb883
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '499'
+      X-Openstack-Request-Id:
+      - req-391df3f4-b94e-4a53-9442-858a1fcff7c9
+      Date:
+      - Thu, 05 Feb 2015 18:12:38 GMT
+    body:
+      encoding: UTF-8
+      string: '{"subnets": [{"name": "", "enable_dhcp": true, "network_id": "b2b51fc1-5c3a-46d2-b979-5663f4fd29f6",
+        "tenant_id": "51bcb84d79174b6680284bfbd44c23a8", "dns_nameservers": ["192.168.122.1"],
+        "gateway_ip": "192.0.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.0.2.5", "end": "192.0.2.24"}], "host_routes": [{"nexthop": "192.0.2.1",
+        "destination": "169.254.169.254/32"}], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.0.2.0/24", "id": "8402db3a-23e8-472d-82bc-047b44ac1537"}]}'
+    http_version: 
+  recorded_at: Thu, 05 Feb 2015 18:12:38 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Refactored common code out of OpenStack cloud parser into a mixin
so that it can be shared with the infra provider.

Flavors and networks collection does not work at the moment.
They depend on modeling changes to EmsOpenstackInfra which will
be done in other patches.