### PR TITLE
Ensure that AMQP credential validation fails when appropriate

### DIFF
--- a/lib/openstack/amqp/openstack_qpid_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_qpid_event_monitor.rb
@@ -34,8 +34,7 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
   end
 
   def initialize(options = {})
-    @options = options
-    @options[:port] ||= DEFAULT_AMQP_PORT
+    parse_options(options)
     @receiver_options = options.slice(:duration, :capacity)
     @collecting_events = false
   end

--- a/lib/openstack/amqp/openstack_qpid_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_qpid_event_monitor.rb
@@ -24,9 +24,9 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
       connection.open
       connection.open?
     rescue => e
-      log_prefix = "MIQ(#{self.name}.#{__method__}) Failed testing qpid amqp connection for #{options[:hostname]}. "
-      $log.info("#{log_prefix} The Openstack AMQP service may be using a different provider.  Enable debug logging to see connection exception.") if $log
-      $log.debug("#{log_prefix} Exception: #{e}") if $log
+      log_prefix = "MIQ(#{self.name}.#{__method__}) Failed testing QPid AMQP connection for #{options[:hostname]}. "
+      $log.info("#{log_prefix} The Openstack AMQP service may be using a different provider.") if $log
+      $log.info("#{log_prefix} Exception: #{e}") if $log
       return false
     ensure
       connection.close if connection.respond_to? :close

--- a/lib/openstack/amqp/openstack_qpid_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_qpid_event_monitor.rb
@@ -13,6 +13,10 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
     OpenstackQpidConnection.available? && test_connection(options)
   end
 
+  def self.plugin_priority
+    PLUGIN_PRIORITY_MED
+  end
+
   def self.test_connection(options = {})
     connection = nil
     begin

--- a/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -44,8 +44,7 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
   end
 
   def initialize(options = {})
-    @options = options
-    @options[:port] ||= DEFAULT_AMQP_PORT
+    parse_options(options)
     @collecting_events = false
     @events = []
     #protect threaded access to the events array

--- a/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -12,7 +12,7 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
   end
 
   def self.plugin_priority
-    1
+    PLUGIN_PRIORITY_HIGH
   end
 
   # Why not inline this?

--- a/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -34,9 +34,9 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
       connection.start
       return true
     rescue => e
-      log_prefix = "MIQ(#{self.name}.#{__method__}) Failed testing rabbit amqp connection for #{options[:hostname]}. "
-      $log.info("#{log_prefix} The Openstack AMQP service may be using a different provider.  Enable debug logging to see connection exception.") if $log
-      $log.debug("#{log_prefix} Exception: #{e}") if $log
+      log_prefix = "MIQ(#{self.name}.#{__method__}) Failed testing Rabbit AMQP connection for #{options[:hostname]}. "
+      $log.info("#{log_prefix} The Openstack AMQP service may be using a different provider.") if $log
+      $log.info("#{log_prefix} Exception: #{e}") if $log
       return false
     ensure
       connection.close if connection.respond_to? :close

--- a/lib/openstack/openstack_event_monitor.rb
+++ b/lib/openstack/openstack_event_monitor.rb
@@ -15,7 +15,10 @@ class OpenstackEventMonitor
     !select_event_monitor_class(options).kind_of? OpenstackNullEventMonitor
   end
 
-  DEFAULT_PLUGIN_PRIORITY = 0
+  PLUGIN_PRIORITY_HIGH    = 0
+  PLUGIN_PRIORITY_MED     = 50
+  PLUGIN_PRIORITY_LOW     = 100
+  DEFAULT_PLUGIN_PRIORITY = PLUGIN_PRIORITY_LOW
   # Subclasses can override plugin priority to receive preferential treatment.
   # The higher the plugin_priority, the ealier the plugin will be tested for
   # availability.

--- a/lib/openstack/openstack_event_monitor.rb
+++ b/lib/openstack/openstack_event_monitor.rb
@@ -60,6 +60,12 @@ class OpenstackEventMonitor
     raise NotImplementedError, "must be implemented in subclass"
   end
 
+  def parse_options(options = {})
+    @options = options
+    @options[:port] = options[:port].presence.try(:to_i) || DEFAULT_AMQP_PORT
+    @options
+  end
+
   def each
     each_batch do |events|
       events.each {|e| yield e}

--- a/lib/openstack/openstack_event_monitor.rb
+++ b/lib/openstack/openstack_event_monitor.rb
@@ -12,7 +12,7 @@ class OpenstackEventMonitor
   end
 
   def self.available?(options)
-    !select_event_monitor_class(options).kind_of? OpenstackNullEventMonitor
+    select_event_monitor_class(options) != OpenstackNullEventMonitor
   end
 
   PLUGIN_PRIORITY_HIGH    = 0

--- a/lib/spec/openstack/openstack_event_monitor_spec.rb
+++ b/lib/spec/openstack/openstack_event_monitor_spec.rb
@@ -16,7 +16,14 @@ describe OpenstackEventMonitor do
     @qpid_host = {:hostname => "qpid_host", :username => "qpid_user", :password => "qpid_pass"}
     @bad_host = {:hostname => "bad_host", :username => "bad_user", :password => "bad_pass"}
 
+    @orig_log = $log
+    $log = double.as_null_object
+
     OpenstackQpidConnection.stub(:available?).and_return(true)
+  end
+
+  after :each do
+    $log = @orig_log
   end
 
   it "selects rabbit when qpid is unavailable" do


### PR DESCRIPTION
The bug in question was fixed originally for the API credential validation, but missed the AMQP credential validation logic.

The problem with the AMQP credential validation logic was in the way it compared the selected OpenStack event monitor to the `OpenstackNullEventMonitor`.  It was using `kind_of?` previously, however, the returned value was not an instance of `OpenstackNullEventMonitor`.  It was a class called `OpenstackNullEventMonitor`.  Changing this comparison to a direct equality check fixed that logic.

Additionally

* better logging was added for the event monitor selection (and failure) process

    When no suitable event monitors can be found, the system explicitly logs that no events will be captured for that OpenStack system.

* the ordering of event monitor plugins was fixed

    Previously, the sorting of event monitor plugins was in ascending order, which meant that the least important event monitor was attempted first.  This logic was changed to select the most important event monitor.  Additionally, the `OpenstackNullEventMonitor` is not considered during the selection process, and is simply used as a fallback when selection fails.

**UPDATE:** Changed `subclasses` method back so it doesn't violate the contract and updated the specs to use a fake `$log` object.

**UPDATE:** Change `connection_url` method to use the `URI` module to build ipv6-safe parameters for the qpid connection.

https://bugzilla.redhat.com/show_bug.cgi?id=1136289