### PR TITLE
Fixed E-mail column in alert editor

### DIFF
--- a/vmdb/app/views/layouts/_edit_email.html.haml
+++ b/vmdb/app/views/layouts/_edit_email.html.haml
@@ -9,10 +9,11 @@
       %tr
         %td.key
           = _("Send an E-mail")
-        = check_box_tag("send_email_cb",
-                        "1",
-                        @edit[:new][:send_email],
-                        "data-miq_observe_checkbox" => {:url => url}.to_json)
+        %td
+          = check_box_tag("send_email_cb",
+                          "1",
+                          @edit[:new][:send_email],
+                          "data-miq_observe_checkbox" => {:url => url}.to_json)
       - if @edit[:new][:send_email]
         %tr
           %td.key

--- a/vmdb/app/views/layouts/_edit_to_email.html.haml
+++ b/vmdb/app/views/layouts/_edit_to_email.html.haml
@@ -53,4 +53,4 @@
                       :style   => "width: 20px; height: 20px",
                       :alt     => t = _("Add"),
                       :title   => t,
-                      :onclick => "miqAjaxButton('#{url_for(:action > action_url, :button => "add_email", :id => "#{record.id || "new"}")}');")
+                      :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');")


### PR DESCRIPTION
Fixed 
- bug that caused `Error caught: [ArgumentError] comparison of Symbol with String failed` after checking `E-mail` checkbox in `Alert Editor` 
- missing `%td` tag in E-mail column