### PR TITLE
Rails server listen on loopback in production

### DIFF
--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -18,7 +18,7 @@ module WebServerWorkerMixin
 
       defaults = {
         :port         => 3000,
-        :binding      => "0.0.0.0",
+        :binding      => Rails.env.production? ? "127.0.0.1" : "0.0.0.0",
         :environment  => (Rails.env || "development").to_s.dup,
         :config       => Rails.root.join("config.ru")
       }

--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -19,7 +19,7 @@ module WebServerWorkerMixin
       defaults = {
         :port         => 3000,
         :binding      => Rails.env.production? ? "127.0.0.1" : "0.0.0.0",
-        :environment  => (Rails.env || "development").to_s.dup,
+        :environment  => Rails.env.to_s,
         :config       => Rails.root.join("config.ru")
       }
 


### PR DESCRIPTION
Bind to loopback address in production mode. …
The appliances are already blocking ports 3000+, 4000+ as only local apache
workers communicate with the Rails "thin" server on those ports.

Let's not bind to 0.0.0.0 in production since we can't access them anyway.

https://bugzilla.redhat.com/show_bug.cgi?id=1182330

Note, if you're a developer running rake evm:start to start your workers and you're not behind apache, you won't be able to navigate to http://my_ip_address:3000 to access the UI in PRODUCTION mode.  You'll need to access http://localhost:3000 or http://127.0.0.1:3000.

cc @dclarizio @h-kataria @kbrock 