### PR TITLE
Make memcached listen on loopback address, not all addresses.

### DIFF
--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -204,7 +204,7 @@ server:
 session:
   interval: 60
   memcache_server: 127.0.0.1:11211
-  memcache_server_opts:
+  memcache_server_opts: '-l 127.0.0.1'
   show_login_info: true
   timeout: 3600
 smartproxy_deploy:

--- a/vmdb/lib/miq_memcached.rb
+++ b/vmdb/lib/miq_memcached.rb
@@ -9,7 +9,7 @@ module MiqMemcached
     DEFAULT_USER = 'memcached'
     DEFAULT_MEMORY = 64
     DEFAULT_MAXCONN = 1024
-    DEFAULT_OPTIONS = ""
+    DEFAULT_OPTIONS = "-l 127.0.0.1"
 
     def initialize(opts = {})
       self.update(opts)


### PR DESCRIPTION
In other words, listen on 127.0.0.1, not 0.0.0.0.

We don't actually share memcached between appliances so our default iptables
blocks incoming requests on port 11211 already so let's only listen on the
loopback address used by the UI/Web Service workers.

Note, since existing appliance configurations contain memcache_server_opts in
the session section, users will have to update their current configuration if they
want to limit memcached to 127.0.0.1.

In other words, change the configuration in the user interface as below:

Configure, Configuration, Select the correct server, Advanced tab.

From:
```
session:
  interval: 60
  memcache_server: 127.0.0.1:11211
  memcache_server_opts:
```

To:
```
session:
  interval: 60
  memcache_server: 127.0.0.1:11211
  memcache_server_opts: "-l 127.0.0.1"
```
https://bugzilla.redhat.com/show_bug.cgi?id=1182330