### PR TITLE
Cleanup profile_build methods.

### DIFF
--- a/vmdb/app/controllers/application_controller/policy_support.rb
+++ b/vmdb/app/controllers/application_controller/policy_support.rb
@@ -124,13 +124,11 @@ module ApplicationController::PolicySupport
   end
 
   def profile_build
+    @catinfo ||= {}
     session[:assignments] = session[:protect_item].get_policies
-    session[:assignments].sort_by { |a| a["description"] }.each do |policy|
-      @catinfo ||= Hash.new                               # Hash to hold category squashed states
+    session[:assignments].each do |policy|
       cat = policy["description"]
-      if @catinfo[cat] ==  nil
-        @catinfo[cat] = true                                # Set compressed if no entry present yet
-      end
+      @catinfo[cat] = true unless @catinfo.key?(cat)
     end
   end
 

--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1090,15 +1090,10 @@ module VmCommon
   end
 
   def profile_build
-   session[:vm].resolve_profiles(session[:policies].keys).sort_by { |p| p["description"] }.each do | policy |
-      @catinfo ||= Hash.new                               # Hash to hold category squashed states
-      policy.each do | key, cat|
-       if key == "description"
-        if @catinfo[cat] ==  nil
-          @catinfo[cat] = true                                # Set compressed if no entry present yet
-        end
-       end
-      end
+    @catinfo ||= {}
+    session[:vm].resolve_profiles(session[:policies].keys).each do |policy|
+      cat = policy["description"]
+      @catinfo[cat] = true unless @catinfo.key?(cat)
     end
   end
 


### PR DESCRIPTION
@dclarizio @h-kataria @martinpovolny  Please review.

This started as just a cleanup of the whitespace for the one profile_build method in vm_common.rb, and then I realized this is doing all kinds of useless stuff.

- The sorting is not needed because the `@catinfo` is not used for doing anything for sorting.
- The `policy` variable is a hash of *all* the attributes of a policy, but the code skips every attribute except "description".  So, in effect, all you have to do is just get the description. 
- The nil check is really just checking if we've ever seen that key before, so switch to `.key?` instead.
- The nearly exact same code from vm_common is in policy_support, and that one already did bullet 2 above.  I made the code the same.  I think these two methods should be shared somewhere, but I have no idea where to put it...maybe application_controller/policy_support.rb in a new method?