### PR TITLE
[WIP] SCVMM: User tries to directly add a Hyper-V server as a provider

### DIFF
--- a/vmdb/app/models/ems_microsoft/scvmm_error_handling.rb
+++ b/vmdb/app/models/ems_microsoft/scvmm_error_handling.rb
@@ -1,0 +1,18 @@
+class EmsMicrosoft
+  module ScvmmErrorHandling
+    class ScvmmNotInstalled < RuntimeError; end
+
+    NOT_SCVMM_SVR_ERR = "the specified module 'virtualmachinemanager' was not loaded"
+    NOT_SCVMM_SVR_DBG = "SCVMM is not running on this server"
+
+    @scvmm_errors_hash = {
+      NOT_SCVMM_SVR_ERR => [ScvmmNotInstalled, NOT_SCVMM_SVR_DBG],
+    }
+
+    def self.raise_error_condition(error_str)
+      @scvmm_errors_hash.keys.each do |e|
+        raise @scvmm_errors_hash[e].first, @scvmm_errors_hash[e].last if error_str.downcase.include? e
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the user adds a Hyper-V server as a provider no inventory will be collected and the logs will be filled with errors, this is because we do not offer direct Hyper-V support.
This PR gracefully handles this by enhancing the credentials verification step to ensure a VMM server is actually installed and running on the server. An error is displayed in the UI and written to the logs as appropriate.

https://bugzilla.redhat.com/show_bug.cgi?id=1149113
