### PR TITLE
ensure rspec rake task is defined for tasks

### DIFF
--- a/vmdb/lib/tasks/test_automation.rake
+++ b/vmdb/lib/tasks/test_automation.rake
@@ -1,6 +1,6 @@
 require_relative "./evm_test_helper"
 
-if defined?(RSpec)
+if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :automation do
     task :setup => :setup_db

--- a/vmdb/lib/tasks/test_migrations.rake
+++ b/vmdb/lib/tasks/test_migrations.rake
@@ -1,6 +1,6 @@
 require_relative "./evm_test_helper"
 
-if defined?(RSpec)
+if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   desc "Run all migration specs"
   task :migrations => %w(

--- a/vmdb/lib/tasks/test_replication.rake
+++ b/vmdb/lib/tasks/test_replication.rake
@@ -1,6 +1,6 @@
 require_relative "./evm_test_helper"
 
-if defined?(RSpec)
+if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :replication do
     task :setup => :initialize do

--- a/vmdb/lib/tasks/test_vmdb.rake
+++ b/vmdb/lib/tasks/test_vmdb.rake
@@ -1,6 +1,6 @@
 require_relative "./evm_test_helper"
 
-if defined?(RSpec)
+if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :vmdb do
     task :setup => :setup_db


### PR DESCRIPTION
When I run asset precompile locally, it blows up on undefined rspec tasks.

**EDIT:** It happens when I do not have a database.yml locally

This is double sure that the RSpec RakeTask is defined

to reproduce:
```
git checkout master
cd vmdb
mv config/databse.yml config/databse.yml-bak
bundle exec rake assets:precompile
```

Get an error about `RSpec::Core::Task` not being defined. Apparently, `RSpec` is defined though.