### PR TITLE
Require the hash extensions where we need fetch_path.

### DIFF
--- a/lib/openstack/openstack_event_monitor.rb
+++ b/lib/openstack/openstack_event_monitor.rb
@@ -1,6 +1,8 @@
 # The OpentstackEventMonitor uses a plugin pattern to instantiate the correct
 # subclass as a plugin based on the #available? class method implemented in each
 # subclass
+require 'more_core_extensions/core_ext/hash'
+
 class OpenstackEventMonitor
   DEFAULT_AMQP_PORT = 5672
 


### PR DESCRIPTION
Fixes the following error when you run only part of the suite:
`bundle exec rspec spec/openstack`

```
  Failure/Error: OpenstackEventMonitor.new(opts).class.should eq
    OpenstackRabbitEventMonitor
  NoMethodError:
   undefined method `fetch_path' for {}:Hash
```

cc @blomquisg 