### PR TITLE
Added the params[:id] check for correct functioning of checked schedules

### DIFF
--- a/vmdb/app/controllers/report_controller/schedules.rb
+++ b/vmdb/app/controllers/report_controller/schedules.rb
@@ -101,7 +101,7 @@ module ReportController::Schedules
       render :update do |page|
         page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
       end
-    else
+    elsif params[:id]
       if MiqSchedule.exists?(from_cid(params[:id]))
         scheds.push(from_cid(params[:id]))
       else


### PR DESCRIPTION
Checked schedules were getting ignored in the absence of the params[:id] check, giving the user the following error - "Schedule no longer exists".

https://bugzilla.redhat.com/show_bug.cgi?id=1192198