### PR TITLE
Use log_depot for MiqServer#log_file_depot or Zone#log_file_depot

### DIFF
--- a/vmdb/app/models/miq_server/log_management.rb
+++ b/vmdb/app/models/miq_server/log_management.rb
@@ -62,7 +62,7 @@ module MiqServer::LogManagement
         local_file = VMDB::Util.zip_logs("evm_server_daily.zip", patterns, "admin")
 
         logfile.update_attributes(
-          :file_depot         => log_file_depot,
+          :file_depot         => log_depot,
           :local_file         => local_file,
           :logging_started_on => log_start,
           :logging_ended_on   => log_end,
@@ -169,7 +169,7 @@ module MiqServer::LogManagement
       desc = "Logs for Zone #{self.zone.name rescue nil} Server #{self.name} #{date_string}"
 
       logfile.update_attributes(
-        :file_depot         => log_file_depot,
+        :file_depot         => log_depot,
         :local_file         => local_file,
         :logging_started_on => log_start,
         :logging_ended_on   => log_end,

--- a/vmdb/spec/factories/file_depot.rb
+++ b/vmdb/spec/factories/file_depot.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :file_depot do
     name "File Depot"
+    uri  "nfs://somehost/export"
   end
 end

--- a/vmdb/spec/models/log_collection_spec.rb
+++ b/vmdb/spec/models/log_collection_spec.rb
@@ -147,7 +147,7 @@ describe "LogCollection" do
 
   context "Log Collection #synchronize_logs" do
     before do
-      depot = FactoryGirl.create(:file_depot, :uri => "nfs://server/dir")
+      depot = FactoryGirl.create(:file_depot)
       @zone.update_attributes(:log_file_depot_id => depot.id)
     end
 

--- a/vmdb/spec/models/miq_server/log_management_spec.rb
+++ b/vmdb/spec/models/miq_server/log_management_spec.rb
@@ -47,6 +47,7 @@ describe MiqServer do
     end
 
     context "#get_log_depot_settings" do
+      let(:uri)            { "smb://server/share" }
       let(:depot_hash) do
         {:uri      => uri,
          :username => "user",
@@ -56,7 +57,6 @@ describe MiqServer do
 
       let(:depot)          { FactoryGirl.create(:file_depot, :uri => uri) }
       let(:new_depot_hash) { {:uri => "nfs://server.example.com", :username => "new_user", :password => "new_pass"} }
-      let(:uri)            { "smb://server/share" }
 
       before do
         depot.update_authentication(:default => {:userid => "user", :password => "pass"})

--- a/vmdb/spec/models/miq_server/log_management_spec.rb
+++ b/vmdb/spec/models/miq_server/log_management_spec.rb
@@ -54,7 +54,7 @@ describe MiqServer do
          :name     => "File Depot"}
       end
 
-      let(:depot)          { FactoryGirl.build(:file_depot, :uri => uri) { |d| d.save(:validate => false) } }
+      let(:depot)          { FactoryGirl.create(:file_depot, :uri => uri) }
       let(:new_depot_hash) { {:uri => "nfs://server.example.com", :username => "new_user", :password => "new_pass"} }
       let(:uri)            { "smb://server/share" }
 

--- a/vmdb/spec/models/miq_server/log_management_spec.rb
+++ b/vmdb/spec/models/miq_server/log_management_spec.rb
@@ -21,6 +21,31 @@ describe MiqServer do
       end
     end
 
+    context "#log_depot" do
+      it "server log_file_depot configured" do
+        server_depot = FactoryGirl.create(:file_depot)
+        @miq_server.log_file_depot = server_depot
+
+        @miq_server.log_depot.should == server_depot
+      end
+
+      it "zone log_file_depot configured" do
+        zone_depot = FactoryGirl.create(:file_depot)
+        @zone.log_file_depot = zone_depot
+
+        @miq_server.log_depot.should == zone_depot
+      end
+
+      it "server and zone log_file_depot configured" do
+        server_depot = FactoryGirl.create(:file_depot)
+        zone_depot   = FactoryGirl.create(:file_depot)
+        @miq_server.log_file_depot = server_depot
+        @zone.log_file_depot = zone_depot
+
+        @miq_server.log_depot.should == server_depot
+      end
+    end
+
     context "#get_log_depot_settings" do
       let(:depot_hash) do
         {:uri      => uri,


### PR DESCRIPTION
When the Zone level log_file_depot is configured, but not the MiqServer, MiqServer#log_file_depot is nil, so we need to look for the Zone's depot.

Commit 4f0c1b542649bb8b4c99d8f584582aeef439cefa, changed log collection to use relationships to get the file depots but only on the server.
It missed that we can configure the depot at the server or zone or both and that we should look for the server's first, then the zone's.

https://bugzilla.redhat.com/show_bug.cgi?id=1186485

cc @brandondunne 