### PR TITLE
Listen on loopback in dev mode / Build URI with binding_address

### DIFF
--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -57,6 +57,14 @@ module WebServerWorkerMixin
       self.server_scope.all.collect { |w| w.port unless w.is_stopped? && !MiqProcess.is_worker?(w.pid)}.compact
     end
 
+    # Utilize URI::Generic#hostname to add support for IPv6 literals
+    # TODO: simplify this once https://github.com/ruby/ruby/pull/765 lands in our ruby
+    def self.build_uri(port)
+      uri = URI::HTTP.build(:port => port)
+      uri.hostname = binding_address
+      uri.to_s
+    end
+
     def self.sync_workers
       #TODO: add an at_exit to remove all registered ports and gracefully stop apache
       self.registered_ports ||= []
@@ -75,7 +83,7 @@ module WebServerWorkerMixin
             port = self.reserve_port(ports)
             $log.info("MIQ(#{self.name}.sync_workers) Reserved port=#{port}, Current ports in use: #{ports.inspect}")
             ports << port
-            w = self.start_worker(:uri => "http://0.0.0.0:#{port}")
+            w = self.start_worker(:uri => build_uri(port))
             result[:adds] << w.pid
           end
         elsif desired < current

--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -18,7 +18,7 @@ module WebServerWorkerMixin
 
       defaults = {
         :port         => 3000,
-        :binding      => Rails.env.production? ? "127.0.0.1" : "0.0.0.0",
+        :binding      => "127.0.0.1",
         :environment  => Rails.env.to_s,
         :config       => Rails.root.join("config.ru")
       }

--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -2,9 +2,15 @@ require 'miq_apache'
 module WebServerWorkerMixin
   extend ActiveSupport::Concern
 
+  BINDING_ADDRESS = "127.0.0.1"
+
   included do
     class << self
       attr_accessor :registered_ports
+    end
+
+    def self.binding_address
+      BINDING_ADDRESS
     end
 
     def self.rails_server_command_line
@@ -18,7 +24,7 @@ module WebServerWorkerMixin
 
       defaults = {
         :port         => 3000,
-        :binding      => "127.0.0.1",
+        :binding      => binding_address,
         :environment  => Rails.env.to_s,
         :config       => Rails.root.join("config.ru")
       }


### PR DESCRIPTION
Followup to #1832 

* listen on 127.0.0.1 in dev mode also (developers will have to use 127.0.0.1/localhost to access the rails server)
* the worker's uri column was hardcoded with 0.0.0.0.   Change to use binding_address and proper URI building

https://bugzilla.redhat.com/show_bug.cgi?id=1182330