### PR TITLE
Openstack infra connect undercloud and overcloud

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -598,15 +598,20 @@ module EmsCommon
     @edit[:new][:emstype] = @ems.emstype
     @edit[:amazon_regions] = get_amazon_regions if @ems.kind_of?(EmsAmazon)
     @edit[:new][:port] = @ems.port
+    @edit[:new][:provider_id] = @ems.provider_id
     if @ems.zone.nil? || @ems.my_zone == ""
       @edit[:new][:zone] = "default"
     else
       @edit[:new][:zone] = @ems.my_zone
     end
-    @edit[:server_zones] = Array.new
+    @edit[:server_zones] = []
     zones = Zone.order('lower(description)')
     zones.each do |zone|
       @edit[:server_zones].push([zone.description, zone.name])
+    end
+    
+    @edit[:openstack_infra_providers] = ProviderOpenstack.order('lower(name)').each_with_object([["---", nil]]) do |openstack_infra_provider, x|
+      x.push([openstack_infra_provider.name, openstack_infra_provider.id])
     end
 
     @edit[:new][:default_userid] = @ems.authentication_userid
@@ -661,6 +666,7 @@ module EmsCommon
       end
     end
     @edit[:new][:port] = params[:port] if params[:port]
+    @edit[:new][:provider_id] = params[:provider_id] if params[:provider_id]
     @edit[:new][:zone] = params[:server_zone] if params[:server_zone]
 
     @edit[:new][:default_userid] = params[:default_userid] if params[:default_userid]
@@ -688,6 +694,7 @@ module EmsCommon
     ems.hostname = @edit[:new][:hostname]
     ems.ipaddress = @edit[:new][:ipaddress]
     ems.port = @edit[:new][:port] if ems.supports_port?
+    ems.provider_id = @edit[:new][:provider_id] if ems.supports_provider_id?
     ems.zone = Zone.find_by_name(@edit[:new][:zone])
 
     if ems.is_a?(EmsVmware)

--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -17,6 +17,10 @@ class EmsOpenstack < EmsCloud
     %w(default amqp)
   end
 
+  def supports_provider_id?
+    true
+  end
+
   def supports_authentication?(authtype)
     supported_auth_types.include?(authtype.to_s)
   end

--- a/vmdb/app/models/ems_openstack_infra.rb
+++ b/vmdb/app/models/ems_openstack_infra.rb
@@ -1,7 +1,25 @@
 class EmsOpenstackInfra < EmsInfra
   include EmsOpenstackMixin
 
+  before_save :ensure_parent_provider
+
   has_many :orchestration_stacks, :foreign_key => :ems_id, :dependent => :destroy
+
+  def ensure_parent_provider
+    # TODO(lsmola) this might move to a general management of Providers, but for now, we will ensure, every
+    # EmsOpenstackInfra has associated a Provider. This relation will serve for relating EmsOpenstackInfra
+    # to possible many EmsOpenstacks deployed through EmsOpenstackInfra
+
+    # Name of the provider needs to be unique, get provider if there is one like that
+    self.provider = ProviderOpenstack.find_by_name(name) unless self.provider
+
+    attributes = {:name => name, :zone => zone}
+    if self.provider
+      self.provider.update_attributes!(attributes)
+    else
+      self.provider = ProviderOpenstack.create!(attributes)
+    end
+  end
 
   def self.ems_type
     @ems_type ||= "openstack_infra".freeze

--- a/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
@@ -141,20 +141,21 @@ module EmsRefresh
         host_name = identify_host_name(indexed_resources, host.instance_uuid, uid)
 
         new_result = {
-          :name             => host_name,
-          :type             => 'HostOpenstackInfra',
-          :uid_ems          => uid,
-          :ems_ref          => uid,
-          :ems_ref_obj      => host.instance_uuid,
-          :operating_system => {:product_name => 'linux'},
-          :vmm_vendor       => 'RedHat',
-          :vmm_product      => identify_product(indexed_resources, host.instance_uuid),
-          :ipaddress        => identify_primary_ip_address(host, indexed_servers),
-          :mac_address      => identify_primary_mac_address(host, indexed_servers),
-          :ipmi_address     => identify_ipmi_address(host),
-          :power_state      => lookup_power_state(host.power_state),
-          :connection_state => lookup_connection_state(host.power_state),
-          :hardware         => process_host_hardware(host)
+          :name                => host_name,
+          :type                => 'HostOpenstackInfra',
+          :uid_ems             => uid,
+          :ems_ref             => uid,
+          :ems_ref_obj         => host.instance_uuid,
+          :operating_system    => {:product_name => 'linux'},
+          :vmm_vendor          => 'RedHat',
+          :vmm_product         => identify_product(indexed_resources, host.instance_uuid),
+          :ipaddress           => identify_primary_ip_address(host, indexed_servers),
+          :mac_address         => identify_primary_mac_address(host, indexed_servers),
+          :ipmi_address        => identify_ipmi_address(host),
+          :power_state         => lookup_power_state(host.power_state),
+          :connection_state    => lookup_connection_state(host.power_state),
+          :hardware            => process_host_hardware(host),
+          :hypervisor_hostname => identify_hypervisor_hostname(host, indexed_servers)
         }
 
         return uid, new_result
@@ -172,7 +173,7 @@ module EmsRefresh
         # TODO(lsmola) Nova is missing information which address is primary now,
         # so just taking first. We need to figure out how to identify it if
         # there are multiple.
-        server.addresses.try(:[], 'ctlplane').try(:[], 0).try(:[], key) if server
+        server.addresses.fetch_path('ctlplane', 0, key) if server
       end
 
       def get_purpose(indexed_resources, instance_uuid)
@@ -207,6 +208,10 @@ module EmsRefresh
 
       def identify_ipmi_address(host)
         host.driver_info["ipmi_address"]
+      end
+
+      def identify_hypervisor_hostname(host, indexed_servers)
+        indexed_servers.fetch_path(host.instance_uuid).try(:name)
       end
 
       def lookup_power_state(power_state_input)

--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -51,7 +51,7 @@ module EmsRefresh::SaveInventory
       key_backup = backup_keys(h, remove_keys)
 
       h[:ems_id]                 = ems.id
-      h[:host_id]                = key_backup.fetch_path(:host, :id)
+      h[:host_id]                = key_backup.fetch_path(:host, :id) || key_backup.fetch_path(:host).try(:id)
       h[:ems_cluster_id]         = key_backup.fetch_path(:ems_cluster, :id)
       h[:storage_id]             = key_backup.fetch_path(:storage, :id)
       h[:flavor_id]              = key_backup.fetch_path(:flavor, :id)

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -156,6 +156,10 @@ class ExtManagementSystem < ActiveRecord::Base
     false
   end
 
+  def supports_provider_id?
+    false
+  end
+
   def supports_authentication?(authtype)
     authtype.to_s == "default"
   end

--- a/vmdb/app/models/provider_openstack.rb
+++ b/vmdb/app/models/provider_openstack.rb
@@ -1,0 +1,14 @@
+class ProviderOpenstack < Provider
+  has_one :infra_ems,
+          :foreign_key => "provider_id",
+          :class_name  => "EmsOpenstackInfra",
+          :dependent   => :destroy,
+          :autosave    => true
+  has_many :cloud_ems,
+           :foreign_key => "provider_id",
+           :class_name  => "EmsOpenstack",
+           :dependent   => :destroy,
+           :autosave    => true
+
+  validates :name, :presence => true, :uniqueness => true
+end

--- a/vmdb/app/views/shared/views/ems_common/_form.html.haml
+++ b/vmdb/app/views/shared/views/ems_common/_form.html.haml
@@ -32,6 +32,14 @@
           = text_field_tag("port", @edit[:new][:port],
             :maxlength         => 15,
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      - if @edit[:new][:emstype] && @edit[:new][:emstype] == 'openstack' && @edit[:openstack_infra_providers].length > 1
+        %tr
+          %td.key
+            = _('Openstack Infra provider')
+          %td.wide
+            = select_tag("provider_id",
+              options_for_select(@edit[:openstack_infra_providers], @edit[:new][:provider_id]),
+              "data-miq_observe" => {:url => url}.to_json)
       %tr
         %td.key
           = _('Zone')

--- a/vmdb/db/migrate/20150224102026_create_host_hypervisor_hostname.rb
+++ b/vmdb/db/migrate/20150224102026_create_host_hypervisor_hostname.rb
@@ -1,0 +1,5 @@
+class CreateHostHypervisorHostname < ActiveRecord::Migration
+  def change
+    add_column :hosts, :hypervisor_hostname, :string
+  end
+end


### PR DESCRIPTION
Connecting Undercloud and Overcloud, meaning we will be able to see Hosts for Openstack provider Vms and Vms for OpenstackInfra provider Hosts. That means we are connecting 2 providers. As a benefit we can see the same Host/Vm relations as for e.g. rhevm, VmVare, ... at least for NovaCompute hosts 