### PR TITLE
Fixed bug in Providers Policy Managing

### DIFF
--- a/vmdb/app/views/layouts/_adv_search.html.haml
+++ b/vmdb/app/views/layouts/_adv_search.html.haml
@@ -1,4 +1,4 @@
-- if show_adv_search?
+- if show_adv_search? && @edit[@expkey].present?
   - mode ||= "search"
   - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 


### PR DESCRIPTION
Fixed bug causing 
    `[----] F, [2015-02-24T14:01:28.793920 #15907:3fbcac627e94] FATAL -- : Error caught: [NoMethodError] undefined method '[]' for nil:NilClass`
 error after trying to manage Policies for any Provider

*(Infrastructure/Cloud -> Providers -> Check any -> Policy -> Manage Policies)*