### PR TITLE
Remove unused :storageitem and :vmitem quadicon settings

### DIFF
--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -818,8 +818,6 @@ class ConfigurationController < ApplicationController
       if get_vmdb_config[:product][:proto] # Hide behind proto setting - Sprint 34
         @edit[:new][:quadicons][:service] = params[:quadicons_service] == "1" if params[:quadicons_service]
       end
-      @edit[:new][:quadicons][:vmitem] = params[:quadicons_vmitem] == "1" if params[:quadicons_vmitem]
-      @edit[:new][:quadicons][:storageitem] = params[:quadicons_storageitem] == "1" if params[:quadicons_storageitem]
       @edit[:new][:quadicons][:storage] = params[:quadicons_storage] == "1" if params[:quadicons_storage]
       @edit[:new][:perpage][:grid] = params[:perpage_grid].to_i if params[:perpage_grid]
       @edit[:new][:perpage][:tile] = params[:perpage_tile].to_i if params[:perpage_tile]

--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -174,9 +174,7 @@ module UiConstants
       :miq_template   =>  true,
       :storage        =>  true,
       :vm             =>  true,
-      :vmitem         =>  true,
       :hostitem       =>  true,
-      :storageitem    =>  true
     },
     :views => { # List view setting, by resource type
       :availabilityzone      => "list",

--- a/vmdb/app/views/configuration/_ui_1.html.haml
+++ b/vmdb/app/views/configuration/_ui_1.html.haml
@@ -16,9 +16,7 @@
                [role_allows(:feature => "host_show_list"),      _("Host"),                                 "host"],
                [false,                                          _("Host Item"),                            "hostitem"],
                [role_allows(:feature => "storage_show_list"),   ui_lookup(:table => "storages"),           "storage"],
-               [role_allows(:feature => "storage_show_list"),   "#{ui_lookup(:table => "storages")} Item", "storageitem"],
                [true,                                           _("VM"),                                   "vm"],
-               [true,                                           _("VM Item"),                              "vmitem"],
                [true,                                           _("Template"),                             "miq_template"]].each do |icons_checkbox|
               - if icons_checkbox[0]
                 %tr


### PR DESCRIPTION
This removes Configuration > My Settings: "Show Datastore Item Quadrants" and "Show VM Item Quadrants"

These were no longer used because there's only the list view available for these items.

https://bugzilla.redhat.com/show_bug.cgi?id=1195407