### PR TITLE
Remove useless 'VM and Instance Items' (:vmitem) Default Views setting; and :storageitem which has no setting

### DIFF
--- a/vmdb/app/controllers/storage_controller.rb
+++ b/vmdb/app/controllers/storage_controller.rb
@@ -266,11 +266,9 @@ class StorageController < ApplicationController
     @showlinks = true
 
     @view, @pages = get_view(db,
-                            :parent=>@storage,
-                            :association=>association,
-                            :conditions=>condition,
-                            :dbname=>"storageitem") # Get the records into a view & paginator
-
+                            :parent => @storage,
+                            :association => association,
+                            :conditions => condition) # Get the records into a view & paginator
 
     # Came in from outside, use RJS to redraw gtl partial
     if params[:ppsetting]  || params[:searchtag] || params[:entry] || params[:sort_choice]

--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -226,7 +226,6 @@ module UiConstants
       :scanhistory           => "list",
       :snialocalfilesystem   => "list",
       :storage_files         => "list",
-      :storageitem           => "list",
       :registryitems         => "list",
       :repo                  => "grid",
       :serverbuild           => "list",
@@ -240,7 +239,6 @@ module UiConstants
       :vminfra               => "grid",
       :vmortemplate          => "grid",
       :vmcompare             => "compressed",
-      :vmitem                => "list"
     },
     :perpage => { # Items per page, by view setting
       :grid => 20,

--- a/vmdb/app/views/configuration/_ui_2.html.haml
+++ b/vmdb/app/views/configuration/_ui_2.html.haml
@@ -11,8 +11,7 @@
                       :compare      => _('Compare'),
                       :compare_mode => _('Compare Mode'),
                       :drift        => _('Drift'),
-                      :drift_mode   => _('Drift Mode'),
-                      :vmitem       => _('VM and Instance Items')}
+                      :drift_mode   => _('Drift Mode')}
             - keys.each do |resource, view_name|
               %tr
                 %td.key #{view_name}


### PR DESCRIPTION
This is related to PR #1859 in that it deals with the same kind of items, except for gtl, not quadicon.

But I'm doing a separate PR because a) this is is not related to any bugzilla tickets I'm aware of, and b) it needs more eyes to be sure.

From what I can figure out, :vmitem should never happen because it's always :vminfra_item and :vmcloud_item. (No mentions of neither in code, these names come into existence in ci_processing by means of `"#{@db}item"`.) Either way, these are always list so the setting is never used and in fact useless now.

But as I said, I'd realy like some more eyes on this one.