### PR TITLE
Cleanup region spec to fix sporadic failure

### DIFF
--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -69,18 +69,6 @@ describe MiqRegion do
       @other_region = FactoryGirl.create(:miq_region)
     end
 
-    it "finds record with original region number" do
-      MiqRegion.exists?(:region => @orig_region).should be_true
-    end
-
-    it "should have different region values" do
-      @region.region.should_not == @other_region.region
-    end
-
-    it "should have 2 records in the miq_regions table" do
-      MiqRegion.count.should == 2
-    end
-
     context "after seeding" do
       before(:each) do
         MiqRegion.seed

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -12,11 +12,20 @@ describe MiqRegion do
 
   context "after seeding" do
     before(:each) do
+      @region_number = 99
+      MiqRegion.stub(:my_region_number => @region_number)
       MiqRegion.seed
     end
 
-    it "should have 1 record in the miq_regions table" do
+    it "seeds 1 record in the miq_regions" do
       MiqRegion.count.should == 1
+      MiqRegion.first.region.should == @region_number
+    end
+
+    it "skips seeding if one exists" do
+      MiqRegion.seed
+      MiqRegion.count.should == 1
+      MiqRegion.first.region.should == @region_number
     end
 
     it "should increment naming sequence number after each call" do

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -84,36 +84,6 @@ describe MiqRegion do
         @other_region = FactoryGirl.create(:miq_region, :region => @region_number + 1)
       end
 
-      context "after seeding" do
-        before(:each) do
-          MiqRegion.seed
-        end
-
-        it "should find region" do
-          MiqRegion.exists?(:region => @region_number).should be_true
-        end
-      end
-
-      context "then original destroyed" do
-        before(:each) do
-          @region.destroy
-        end
-
-        it "should not find region" do
-          MiqRegion.exists?(:region => @region_number).should_not be_true
-        end
-
-        context "after seeding" do
-          before(:each) do
-            MiqRegion.seed
-          end
-
-          it "should find region" do
-            MiqRegion.exists?(:region => @region_number).should be_true
-          end
-        end
-      end
-
       context "with MiqDatabase" do
         before(:each) do
           @db = FactoryGirl.create(:miq_database)

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -78,23 +78,11 @@ describe MiqRegion do
       end
     end
 
-    context "existing region" do
-      before(:each) do
-        @region = FactoryGirl.create(:miq_region, :region => @region_number)
-        @other_region = FactoryGirl.create(:miq_region, :region => @region_number + 1)
-      end
-
-      context "with MiqDatabase" do
-        before(:each) do
-          @db = FactoryGirl.create(:miq_database)
-        end
-
-        it "will raise Exception if my_region_number is not the db region" do
-          MiqRegion.stub(:my_region_number).and_return(@other_region.region)
-          MiqRegion.my_region_number.should_not == @db.region_id
-          lambda { MiqRegion.seed }.should raise_error(Exception)
-        end
-      end
+    it "raises Exception if db region_id doesn't match my_region_number" do
+      FactoryGirl.create(:miq_region, :region => @region_number)
+      @db = FactoryGirl.create(:miq_database)
+      MiqRegion.stub(:my_region_number => @region_number + 1)
+      lambda { MiqRegion.seed }.should raise_error(Exception)
     end
   end
 end

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -46,7 +46,7 @@ describe MiqRegion do
       MiqRegion.seed
     end
 
-    it "seeds 1 record in the miq_regions" do
+    it "seeds 1 row in miq_regions" do
       MiqRegion.count.should == 1
       MiqRegion.first.region.should == @region_number
     end

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -69,6 +69,13 @@ describe MiqRegion do
         MiqRegion.count.should == 1
         MiqRegion.first.region.should == @region_number
       end
+
+      it "replaces deleted current region" do
+        MiqRegion.where(:region => @region_number).destroy_all
+        MiqRegion.count.should == 0
+        MiqRegion.seed
+        MiqRegion.first.region.should == @region_number
+      end
     end
 
     context "existing region" do

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -43,34 +43,28 @@ describe MiqRegion do
     before do
       @region_number = 99
       MiqRegion.stub(:my_region_number => @region_number)
+      MiqRegion.seed
     end
 
-    context "no regions" do
-      before(:each) do
-        MiqRegion.seed
-      end
+    it "seeds 1 record in the miq_regions" do
+      MiqRegion.count.should == 1
+      MiqRegion.first.region.should == @region_number
+    end
 
-      it "seeds 1 record in the miq_regions" do
-        MiqRegion.count.should == 1
-        MiqRegion.first.region.should == @region_number
-      end
+    it "skips seeding if one exists" do
+      MiqRegion.seed
+      MiqRegion.count.should == 1
+      MiqRegion.first.region.should == @region_number
+    end
 
-      it "skips seeding if one exists" do
-        MiqRegion.seed
-        MiqRegion.count.should == 1
-        MiqRegion.first.region.should == @region_number
-      end
-
-      it "replaces deleted current region" do
-        MiqRegion.where(:region => @region_number).destroy_all
-        MiqRegion.count.should == 0
-        MiqRegion.seed
-        MiqRegion.first.region.should == @region_number
-      end
+    it "replaces deleted current region" do
+      MiqRegion.where(:region => @region_number).destroy_all
+      MiqRegion.count.should == 0
+      MiqRegion.seed
+      MiqRegion.first.region.should == @region_number
     end
 
     it "raises Exception if db region_id doesn't match my_region_number" do
-      FactoryGirl.create(:miq_region, :region => @region_number)
       @db = FactoryGirl.create(:miq_database)
       MiqRegion.stub(:my_region_number => @region_number + 1)
       lambda { MiqRegion.seed }.should raise_error(Exception)

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -1,15 +1,6 @@
 require "spec_helper"
 
 describe MiqRegion do
-  REGION_FILE = File.join(Rails.root, "REGION")
-  def read_region
-    (File.open(REGION_FILE, 'r') {|f| f.read }).chomp if File.exist?(REGION_FILE)
-  end
-
-  def write_region(number)
-    File.open(REGION_FILE, 'w') {|f| f.write(number) } if File.exist?(REGION_FILE)
-  end
-
   context "after seeding" do
     before(:each) do
       MiqRegion.seed

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -49,10 +49,13 @@ describe MiqRegion do
   end
 
   context ".seed" do
+    before do
+      @region_number = 99
+      MiqRegion.stub(:my_region_number => @region_number)
+    end
+
     context "no regions" do
       before(:each) do
-        @region_number = 99
-        MiqRegion.stub(:my_region_number => @region_number)
         MiqRegion.seed
       end
 
@@ -70,10 +73,8 @@ describe MiqRegion do
 
     context "existing region" do
       before(:each) do
-        @orig_region = self.read_region if File.exist?(REGION_FILE)
-        @orig_region ||= 0
-        @region = FactoryGirl.create(:miq_region, :region => @orig_region)
-        @other_region = FactoryGirl.create(:miq_region)
+        @region = FactoryGirl.create(:miq_region, :region => @region_number)
+        @other_region = FactoryGirl.create(:miq_region, :region => @region_number + 1)
       end
 
       context "after seeding" do
@@ -82,7 +83,7 @@ describe MiqRegion do
         end
 
         it "should find region" do
-          MiqRegion.exists?(:region => @orig_region).should be_true
+          MiqRegion.exists?(:region => @region_number).should be_true
         end
       end
 
@@ -92,7 +93,7 @@ describe MiqRegion do
         end
 
         it "should not find region" do
-          MiqRegion.exists?(:region => @orig_region).should_not be_true
+          MiqRegion.exists?(:region => @region_number).should_not be_true
         end
 
         context "after seeding" do
@@ -101,7 +102,7 @@ describe MiqRegion do
           end
 
           it "should find region" do
-            MiqRegion.exists?(:region => @orig_region).should be_true
+            MiqRegion.exists?(:region => @region_number).should be_true
           end
         end
       end

--- a/vmdb/spec/models/miq_region_spec.rb
+++ b/vmdb/spec/models/miq_region_spec.rb
@@ -10,14 +10,6 @@ describe MiqRegion do
     File.open(REGION_FILE, 'w') {|f| f.write(number) } if File.exist?(REGION_FILE)
   end
 
-  before(:each) do
-    MiqRegion.delete_all
-  end
-
-  it "should have 0 records in the miq_regions table" do
-    MiqRegion.count.should == 0
-  end
-
   context "after seeding" do
     before(:each) do
       MiqRegion.seed


### PR DESCRIPTION
There was a sporadic test failure that was occurring on travis.

```
  1) MiqRegion with two regions should have different region values
     Failure/Error: @region.region.should_not == @other_region.region
       expected not: == 1
                got:    1
     # ./spec/models/miq_region_spec.rb:76:in `block (3 levels) in <top (required)>'
```

Travis has a **REGION file populated with 1**, see [here](https://github.com/ManageIQ/manageiq/blob/1249d1b7d321ff2e6dca6d42f7e3d8372432f6dc/.travis.yml#L27).

Additionally, the **:miq_region factory uses a sequence to determine the `region`** value
```ruby
sequence(:region)  { |reg| reg }
``` 
See [here](https://github.com/ManageIQ/manageiq/blob/1249d1b7d321ff2e6dca6d42f7e3d8372432f6dc/vmdb/spec/factories/miq_region.rb#L3)

This would cause travis to randomly fail since this example would have to be run in a specific order so that the `sequence` matched the REGION file, 1.

Most of this spec is testing Rails/FactoryGirl instead of the logic of MiqRegion.  The only solution was to refactor it and remove the dead/useless tests.