### PR TITLE
Upper case "VM" for Add VM conditions selection

### DIFF
--- a/vmdb/product/toolbars/conditions_center_tb.yaml
+++ b/vmdb/product/toolbars/conditions_center_tb.yaml
@@ -13,5 +13,5 @@
     :items:
     - :button: condition_new
       :image: new
-      :text: 'Add a New #{ui_lookup(:model=>@sb[:folder])} Condition'
-      :title: 'Add a New #{ui_lookup(:model=>@sb[:folder])} Condition'
+      :text: 'Add a New #{@sb[:folder].upcase == "VM" ? "VM" : ui_lookup(:model=>@sb[:folder])} Condition'
+      :title: 'Add a New #{@sb[:folder].upcase == "VM" ? "VM" : ui_lookup(:model=>@sb[:folder])} Condition'


### PR DESCRIPTION
Substituted proper conversion to upper case "VM" when adding VM conditions

https://bugzilla.redhat.com/show_bug.cgi?id=1110656