### PR TITLE
Use Datastore VM Path if scan_via_host is true

### DIFF
--- a/lib/MiqVm/MiqVm.rb
+++ b/lib/MiqVm/MiqVm.rb
@@ -80,13 +80,12 @@ class MiqVm
             
             if @ost.miqVim
                 dInfo.vixDiskInfo = Hash.new
+                dInfo.vixDiskInfo[:fileName]    = @ost.miqVim.datastorePath(df)
                 if @ost.miqVimVm && @ost.miqVim.isVirtualCenter?
                     @vdlConnection = @ost.miqVimVm.vdlVcConnection if !@vdlConnection
-                    dInfo.vixDiskInfo[:fileName]    = @ost.miqVim.datastorePath(df)
                     $log.debug "openDisks (VC): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
                 else
                     @vdlConnection = @ost.miqVim.vdlConnection if !@vdlConnection
-                    dInfo.vixDiskInfo[:fileName]    = @ost.miqVim.localVmPath(df)
                     $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
                 end
                 dInfo.vixDiskInfo[:connection]  = @vdlConnection


### PR DESCRIPTION
Use the datastore vm path if regardless of whether or
not scan_via_host is true.  Previously if it was
true then the host path was used, and only if it
was false (and the scan was via the vCenter host)
was the datastore path used.

@roliveri @Fryguy @chessbyte please review.