### PR TITLE
Migrate empty memcache_server_opts to bind on localhost by default.

### DIFF
--- a/vmdb/db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration.rb
+++ b/vmdb/db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration.rb
@@ -1,0 +1,27 @@
+class AddLoopbackToMemcacheServerOptsInConfiguration < ActiveRecord::Migration
+  class Configuration < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    default_binding_address = "-l 127.0.0.1"
+    Configuration.where(:typ => "vmdb").each do |config|
+      options = config.settings.fetch_path("session", "memcache_server_opts")
+      next if options.present?
+
+      config.settings.store_path("session", "memcache_server_opts", default_binding_address)
+      config.save
+    end
+  end
+
+  def down
+    default_binding_address = "-l 127.0.0.1"
+    Configuration.where(:typ => "vmdb").each do |config|
+      options = config.settings.fetch_path("session", "memcache_server_opts")
+      next unless options == default_binding_address
+
+      config.settings.store_path("session", "memcache_server_opts", "")
+      config.save
+    end
+  end
+end

--- a/vmdb/spec/migrations/20150224164512_add_loopback_to_memcache_server_opts_in_configuration_spec.rb
+++ b/vmdb/spec/migrations/20150224164512_add_loopback_to_memcache_server_opts_in_configuration_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration")
+
+describe AddLoopbackToMemcacheServerOptsInConfiguration do
+  let(:configuration_stub) { migration_stub(:Configuration) }
+
+  migration_context :up do
+    it "leaves custom memcache_server_opts" do
+      custom_binding = "-l 0.0.0.0"
+      with_custom = {"session" => {"memcache_server_opts" => custom_binding}}
+      config = configuration_stub.create!(:typ => 'vmdb', :settings => with_custom)
+
+      migrate
+
+      config.reload.settings.fetch_path("session", "memcache_server_opts").should == custom_binding
+    end
+
+    it "adds listen on localhost binding to memcache_server_opts" do
+      default_binding = "-l 127.0.0.1"
+      with_blank = {"session" => {"memcache_server_opts" => ""}}
+      config = configuration_stub.create!(:typ => 'vmdb', :settings => with_blank)
+
+      migrate
+
+      config.reload.settings.fetch_path("session", "memcache_server_opts").should == default_binding
+    end
+  end
+
+  migration_context :down do
+    it "leaves custom memcache_server_opts" do
+      custom_binding = "-l 0.0.0.0"
+      with_custom = {"session" => {"memcache_server_opts" => custom_binding}}
+      config = configuration_stub.create!(:typ => 'vmdb', :settings => with_custom)
+
+      migrate
+
+      config.reload.settings.fetch_path("session", "memcache_server_opts").should == custom_binding
+    end
+
+    it "reverts listen on localhost binding to blank option" do
+      default_binding = "-l 127.0.0.1"
+      with_blank = {"session" => {"memcache_server_opts" => default_binding}}
+      config = configuration_stub.create!(:typ => 'vmdb', :settings => with_blank)
+
+      migrate
+
+      config.reload.settings.fetch_path("session", "memcache_server_opts").should == ""
+    end
+  end
+
+end


### PR DESCRIPTION
Instead of having memcached bind on 0.0.0.0, we want 127.0.0.1 by default.
If a user configured their own options, it is left intact.
Followup to #1834

https://bugzilla.redhat.com/show_bug.cgi?id=1182330