### PR TITLE
Consolidate owner and requester in Workflows

### DIFF
--- a/vmdb/app/models/resource_action_workflow.rb
+++ b/vmdb/app/models/resource_action_workflow.rb
@@ -7,8 +7,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
 
   def initialize(values, requester, resource_action, options={})
     @settings        = {}
-    @requester       = @owner    = MiqLdap.using_ldap? ? User.find_or_create_by_ldap_upn(requester) : User.find_by_userid(requester)
-    @requester_id    = @owner_id = @requester.userid
+    @requester       = MiqLdap.using_ldap? ? User.find_or_create_by_ldap_upn(requester) : User.find_by_userid(requester)
     @target          = options[:target]
     @dialog          = load_dialog(resource_action, values)
 


### PR DESCRIPTION
Making changes to owners in workflow to help us with [bz 1187777](https://bugzilla.redhat.com/show_bug.cgi?id=1187777)

Workflows only have requesters (assigned to `@owner` and `@requester`)
But `@owner` and `@requester` were then never assigned after the initializer.
This consolidates the two variables together.

Also, the `@{requester,owner}_id` is derived from the `@requester.userid`,
No need for these variables.

Finally, `user` was looked up from `@requester.userid`.
No need to look this up, already have a user object in `@requester`.

/cc @gmcculloug 