### PR TITLE
Flash message was not contained in flash_div on login page

### DIFF
--- a/vmdb/app/views/dashboard/login.html.haml
+++ b/vmdb/app/views/dashboard/login.html.haml
@@ -9,8 +9,8 @@
       .form-horizontal#login_div
         = render(:partial => "layouts/spinner", 
                  :locals  => {:login => true})
-        #flash_div{:style =>"#{flash[:notice] ? "" : "display:none"}"}
-        #{flash[:notice]}
+        #flash_div{:style => flash[:notice] ? "" : "display: none;"}
+          = flash[:notice]
         .form-group
           %label.col-sm-3.col-md-3.control-label=_('Username')
           .col-sm-9.col-md-9


### PR DESCRIPTION
I noticed this when writing test on session timeout, I could not match the flash message because the text was outside of the `flash_div` :)
![](http://i57.tinypic.com/987r74.png)

And it also gets no style assigned so it does not look like a proper flash message but I am leaving this to someone else since I don't know what classes are used there exactly.