### PR TITLE
Filter events on the base class, because that's how they're defined

### DIFF
--- a/vmdb/app/models/bottleneck_event.rb
+++ b/vmdb/app/models/bottleneck_event.rb
@@ -50,7 +50,8 @@ class BottleneckEvent < ActiveRecord::Base
   end
 
   def self.future_event_definitions_for_obj(obj)
-    self.event_definitions("projected").find_all {|e| e[:definition][:applies_to].include?(obj.class.name.to_sym)}
+    search_type = obj.class.base_class.name.to_sym
+    event_definitions("projected").find_all { |e| e[:definition][:applies_to].include?(search_type) }
   end
 
   def self.delete_future_events_for_obj(obj)

--- a/vmdb/spec/models/bottleneck_event_spec.rb
+++ b/vmdb/spec/models/bottleneck_event_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe BottleneckEvent do
+  describe ".future_event_definitions_for_obj" do
+    it "contains things" do
+      MiqEvent.seed_default_definitions
+      expect(BottleneckEvent.future_event_definitions_for_obj(HostVmware.new)).not_to be_empty
+    end
+  end
+end

--- a/vmdb/spec/support/evm_spec_helper.rb
+++ b/vmdb/spec/support/evm_spec_helper.rb
@@ -24,6 +24,7 @@ module EvmSpecHelper
 
     clear_instance_variables(MiqEnvironment::Command)
     clear_instance_variable(MiqProductFeature, :@feature_cache)
+    clear_instance_variable(BottleneckEvent, :@event_definitions)
 
     # Clear the thread local variable to prevent test contamination
     User.current_userid = nil if defined?(User) && User.respond_to?(:current_userid=)


### PR DESCRIPTION
There don't seem to be any nearby tests, so I've just added one to address this particular change; the resulting coverage, even of that particular method, remains... less than comprehensive.

https://bugzilla.redhat.com/show_bug.cgi?id=1181340