### PR TITLE
[api] Improve query performance

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -72,7 +72,7 @@ class ApiController < ApplicationController
   #
   # Attributes used for identification
   #
-  ID_ATTRS = %w(id href)
+  ID_ATTRS = %w(href id)
 
   #
   # To skip CSRF token verification as API clients would

--- a/vmdb/app/helpers/api_helper/normalizer.rb
+++ b/vmdb/app/helpers/api_helper/normalizer.rb
@@ -8,11 +8,14 @@ module ApiHelper
     # virtual subcollections is added.
 
     def normalize_hash(type, obj, opts = {})
-      attrs = (obj.respond_to?(:attributes) ? obj.attributes.keys : obj.keys)
+      attrs = normalize_select_attributes(obj, opts)
       result = {}
 
       href = new_href(type, obj["id"], obj["href"], opts)
-      result["href"] = href if href.present?
+      if href.present?
+        result["href"] = href
+        attrs -= ["href"]
+      end
 
       attrs.each { |k| result[k] = normalize_direct(type, k, obj[k]) }
       result
@@ -89,6 +92,14 @@ module ApiHelper
     end
 
     private
+
+    def normalize_select_attributes(obj, opts)
+      if opts[:render_attributes].present?
+        opts[:render_attributes]
+      else
+        obj.respond_to?(:attributes) ? obj.attributes.keys : obj.keys
+      end
+    end
 
     def normalize_direct(type, name, obj)
       return normalize_direct_array(type, name, obj) if obj.kind_of?(Array)


### PR DESCRIPTION
With the introduction of the virtual attributes, querying with
expanded resources and specific attributes (physical or virtual) has
been crawling terribly, i.e. querying 360 vms with details slowed
down from ~1sec to ~22sec.

Issue with the api was two-fold:
* attr_virtual? was getting called for each physical attribute of each resource being expanded/returned instead of simply the asked for attributes.
* Inefficient key lookup of reflections and columns