### PR TITLE
Bump appliances to LAST bugfix release of ruby 2.0.0, p643.

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -221,7 +221,7 @@ make install
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-/usr/local/bin/ruby-install ruby 2.0.0-p598 -- --disable-install-doc --enable-shared
+/usr/local/bin/ruby-install ruby 2.0.0-p643 -- --disable-install-doc --enable-shared
 
 # Add the ruby binaries path to the PATH so we can find bundle and friends:
 ruby_bin_path=(/opt/rubies/ruby-2.0.0*/bin)


### PR DESCRIPTION
```
"We are pleased to announce the release of Ruby 2.0.0-p643.

This is the last ordinal release of Ruby 2.0.0. Ruby 2.0.0 goes into the state
of the security maintenance phase, and will never be released unless any
critical regressions or security issues are found. This phase is planned to be
maintained for 1 year. Then, maintenance of Ruby 2.0.0 will be ended at Feb.
24th, 2016. We recommend to start planning to migrate to newer versions of Ruby,
such as 2.1 or 2.2."
```
  -- https://www.ruby-lang.org/en/news/2015/02/25/ruby-2-0-0-p643-is-released/