### PR TITLE
Backport "Regression in support for IPv6 literals in URIs with Net::HTTP"

### DIFF
--- a/lib/util/extensions/miq-net-http.rb
+++ b/lib/util/extensions/miq-net-http.rb
@@ -1,0 +1,18 @@
+require 'net/http'
+
+# Monkey patch to fix a IPv6 regression in Net::HTTP
+# https://bugs.ruby-lang.org/issues/9129  (trunk, 2.2.0+)
+# https://bugs.ruby-lang.org/issues/10530 (2.0.0-p643)
+# https://bugs.ruby-lang.org/issues/10531 (2.1 not yet released)
+# TODO: Delete me when it's reasonable that most rubies have this fix
+if RUBY_VERSION.start_with?("2.1") || (RUBY_VERSION == "2.0.0" && RUBY_PATCHLEVEL < 643)
+  module Net
+    class HTTP < Protocol
+      def proxy_uri # :nodoc:
+        @proxy_uri ||= URI::HTTP.new(
+          "http".freeze, nil, address, port, nil, nil, nil, nil, nil
+        ).find_proxy
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/f01485b4ec97d6bbc462f6c7210b2499a97ce398
https://bugs.ruby-lang.org/issues/9129  (trunk, 2.2.0+)
https://bugs.ruby-lang.org/issues/10530 (2.0.0-p643)
https://bugs.ruby-lang.org/issues/10531 (2.1 not yet released)

This is used by ovirt through rest-client.