### PR TITLE
Fixed typo caused by Haml conversion

### DIFF
--- a/vmdb/app/views/layouts/_form_buttons_verify.html.haml
+++ b/vmdb/app/views/layouts/_form_buttons_verify.html.haml
@@ -5,7 +5,7 @@
 - ujs_button ||= nil
 - serialize  ||= false
 - if record
-  - id = record.id.blank? ? "new" : record_id
+  - id = record.id.blank? ? "new" : record.id
 - else
   - id = record_id ? record_id : nil
 
@@ -20,7 +20,7 @@
   - if serialize
     = button_tag(_("Validate"),
                  :class   => "btn btn-primary btn-xs",
-                 :alt     => verify_title_on, 
+                 :alt     => verify_title_on,
                  :title   => verify_title_on,
                  :onclick => "miqAjaxButton('#{url_for(:action => validate_url,
                                                        :id     => id,
@@ -29,17 +29,17 @@
     = link_to(button_tag(_("Validate"),
                          :class  => "btn btn-primary btn-xs",
                          :alt    => verify_title_on),
-              {:action => validate_url, 
-               :button => "validate", 
-               :type   => valtype, 
+              {:action => validate_url,
+               :button => "validate",
+               :type   => valtype,
                :id     => id},
-              :title                 => verify_title_on, 
+              :title                 => verify_title_on,
               :id                    => "val",
-              "data-miq_sparkle_on"  => true, 
+              "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true,
               :remote                => true)
 
 %div{:id => "#{valtype}_validate_buttons_off", :style => ("display:none" if @edit[statuskey])}
-  = button_tag(_("Validate"), 
+  = button_tag(_("Validate"),
                :class    => "btn btn-primary btn-xs btn-disabled",
-               :disabled => true) 
+               :disabled => true)


### PR DESCRIPTION
Typo introduced by Haml conversion causing that record id was not set properly