### PR TITLE
Wrong formatting string in _policy_details partial

### DIFF
--- a/vmdb/app/views/miq_policy/_policy_details.html.haml
+++ b/vmdb/app/views/miq_policy/_policy_details.html.haml
@@ -73,7 +73,7 @@
                 %td
                   %table#formtest.form{:width => "100%"}
                     %tr
-                      %td{:align => "left"}=_("Available % Conditions:") % ui_lookup(:model => @edit[:new][:towhat])
+                      %td{:align => "left"}=_("Available %s Conditions:") % ui_lookup(:model => @edit[:new][:towhat])
                       %td
                       %td.widthed{align => "left"}=_("Policy Conditions:")
                     %tr


### PR DESCRIPTION
This was raising

```
[ArgumentError] malformed format string - %C
```