### PR TITLE
don’t connect to database for asset precompile

### DIFF
--- a/system/cfme-setup.sh
+++ b/system/cfme-setup.sh
@@ -10,7 +10,8 @@ pushd /var/www/miq/vmdb
   popd
 
   # rails compile tasks loads environment which needs above shared objects
-  RAILS_ENV=production rake evm:compile_assets
+  # There is no database.yml. Bogus database parameters appeases rails.
+  RAILS_ENV=production DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname rake evm:compile_assets
 popd
 
 #this is for the black console


### PR DESCRIPTION
NOTE: This is rails 3.x only

But this does allow us to build assets before there is a database.

Not sure if @tenderlove has any alternatives.

This is related to #1823

/cc @Fryguy @jrafanie 