### PR TITLE
Thin server should bind on 0.0.0.0 in dev mode.

### DIFF
--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -2,7 +2,7 @@ require 'miq_apache'
 module WebServerWorkerMixin
   extend ActiveSupport::Concern
 
-  BINDING_ADDRESS = "127.0.0.1"
+  BINDING_ADDRESS = Rails.env.production? ? "127.0.0.1" : "0.0.0.0"
 
   included do
     class << self


### PR DESCRIPTION
Followup to #1853

We should be able to make rails development environments easier to setup
while also making production abide by the STIG requirement:
"The web server must be configured to listen on a specific IP address and port"

http://www.stigviewer.com/stig/apache_server_2.2unix/2014-04-03/finding/V-26326

https://bugzilla.redhat.com/show_bug.cgi?id=1182330