### PR TITLE
replace calls to reflections_with_virtual with reflection_with_virtual

### DIFF
--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -954,7 +954,7 @@ class MiqExpression
 
     parts.each do |assoc|
       assoc = assoc.to_sym
-      ref = model.reflections_with_virtual[assoc]
+      ref = model.reflection_with_virtual(assoc)
       result[:virtual_reflection] = true if ref.kind_of?(VirtualReflection)
 
       unless result[:virtual_reflection]
@@ -1685,7 +1685,7 @@ class MiqExpression
     macro = nil
     model = model_class(parts.shift)
     parts.each do |assoc|
-      ref = model.reflections_with_virtual[assoc.to_sym]
+      ref = model.reflection_with_virtual(assoc.to_sym)
       return false if ref.nil?
 
       macro = ref.macro
@@ -1840,7 +1840,7 @@ class MiqExpression
     return nil if model.nil?
 
     parts.each do |assoc|
-      ref = model.reflections_with_virtual[assoc.to_sym]
+      ref = model.reflection_with_virtual(assoc.to_sym)
       return nil if ref.nil?
       model = ref.klass
     end

--- a/vmdb/app/models/miq_report/generator.rb
+++ b/vmdb/app/models/miq_report/generator.rb
@@ -78,7 +78,7 @@ module MiqReport::Generator
       when :"<compare>"
         self.class.name
       else
-        ref = self.db_class.reflections_with_virtual[table.to_sym]
+        ref = db_class.reflection_with_virtual(table.to_sym)
         ref ? ref.class_name : table.singularize.camelize
       end
     end

--- a/vmdb/app/models/miq_report/search.rb
+++ b/vmdb/app/models/miq_report/search.rb
@@ -75,7 +75,7 @@ module MiqReport::Search
     end
     assoc = options.delete(:association) || options.delete(:parent_method)
     assoc ||= self.db_class.base_model.to_s.pluralize.underscore  # Derive association from base model
-    ref = parent.class.reflections_with_virtual[assoc.to_sym]
+    ref = parent.class.reflection_with_virtual(assoc.to_sym)
     if ref.nil? || ref.kind_of?(VirtualReflection)
       targets = parent.send(assoc).collect(&:id) # assoc is either a virtual reflection or a method so just call the association and collect the ids
     else


### PR DESCRIPTION
This avoids hash allocations and abstracts the application from whether
the keys are strings or symbols for each type