### PR TITLE
Fixes 1902 nil K8 ports spec on kubernetes refresh

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -136,10 +136,8 @@ module EmsRefresh::Parsers
         :cpu_cores         => container_def["cpu"].to_f / 1000
       }
       ports = container_def["ports"]
-      unless ports.nil?
-        new_result[:container_port_configs] = ports.collect do |port_entry|
+      new_result[:container_port_configs] = Array(ports).collect do |port_entry|
           parse_container_port_config(port_entry, pod_id, container_def["name"])
-        end
       end
       new_result
     end

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -136,8 +136,10 @@ module EmsRefresh::Parsers
         :cpu_cores         => container_def["cpu"].to_f / 1000
       }
       ports = container_def["ports"]
-      new_result[:container_port_configs] = ports.collect do |port_entry|
-        parse_container_port_config(port_entry, pod_id, container_def["name"])
+      unless ports.nil?
+        new_result[:container_port_configs] = ports.collect do |port_entry|
+          parse_container_port_config(port_entry, pod_id, container_def["name"])
+        end
       end
       new_result
     end

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -137,7 +137,7 @@ module EmsRefresh::Parsers
       }
       ports = container_def["ports"]
       new_result[:container_port_configs] = Array(ports).collect do |port_entry|
-          parse_container_port_config(port_entry, pod_id, container_def["name"])
+        parse_container_port_config(port_entry, pod_id, container_def["name"])
       end
       new_result
     end


### PR DESCRIPTION
Fixes #1902 - checks if ports spec is defined in the containers_def for K8