### PR TITLE
dont build vmdb on ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ env:
   - "TEST_SUITE=automation  TEST_ROOT=vmdb"
   - "TEST_SUITE=javascript  TEST_ROOT=vmdb"
 matrix:
-  allow_failures:
-  - rvm: "2.1"
-    env: "TEST_SUITE=vmdb        TEST_ROOT=vmdb"
-  fast_finish: true
+  exclude:
+    - rvm: "2.1"
+      env: "TEST_SUITE=vmdb        TEST_ROOT=vmdb"
 addons:
   postgresql: '9.3'
 before_install:


### PR DESCRIPTION
vmdb is our longest running test task, and our current bottleneck for having a successful build.

It is not passing on ruby 2.1 due to `$SAFE = 4`, and it is currently not a priority to fix it.

Instead of spending those cycles to run a failing environment, free up those cycles. This will run the next PR that much sooner.

/cc @jrafanie @tenderlove @Fryguy 