### PR TITLE
UI for editing orchestration templates

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -15,26 +15,28 @@ class CatalogController < ApplicationController
   end
 
   CATALOG_X_BUTTON_ALLOWED_ACTIONS = {
-    'ab_button_new'           => :ab_button_new,
-    'ab_button_edit'          => :ab_button_edit,
-    'ab_button_delete'        => :ab_button_delete,
-    'ab_group_delete'         => :ab_group_delete,
-    'ab_group_edit'           => :ab_group_edit,
-    'ab_group_new'            => :ab_group_new,
-    'ab_group_reorder'        => :ab_group_reorder,
-    'svc_catalog_provision'   => :svc_catalog_provision,
-    'st_catalog_delete'       => :st_catalog_delete,
+    'ab_button_new'                 => :ab_button_new,
+    'ab_button_edit'                => :ab_button_edit,
+    'ab_button_delete'              => :ab_button_delete,
+    'ab_group_delete'               => :ab_group_delete,
+    'ab_group_edit'                 => :ab_group_edit,
+    'ab_group_new'                  => :ab_group_new,
+    'ab_group_reorder'              => :ab_group_reorder,
+    'svc_catalog_provision'         => :svc_catalog_provision,
+    'st_catalog_delete'             => :st_catalog_delete,
 
-    'atomic_catalogitem_edit' => :servicetemplate_edit,
-    'atomic_catalogitem_new'  => :servicetemplate_edit,
-    'catalogitem_edit'        => :servicetemplate_edit,
-    'catalogitem_new'         => :servicetemplate_edit,
+    'atomic_catalogitem_edit'       => :servicetemplate_edit,
+    'atomic_catalogitem_new'        => :servicetemplate_edit,
+    'catalogitem_edit'              => :servicetemplate_edit,
+    'catalogitem_new'               => :servicetemplate_edit,
 
-    'catalogitem_delete'      => :st_delete,
-    'catalogitem_tag'         => :st_tags_edit,
+    'catalogitem_delete'            => :st_delete,
+    'catalogitem_tag'               => :st_tags_edit,
 
-    'st_catalog_edit'         => :st_catalog_edit,
-    'st_catalog_new'          => :st_catalog_edit,
+    'orchestration_templates_admin' => :ot_edit,
+    'ot_edit_submit'                => :ot_edit_submit,
+    'st_catalog_edit'               => :st_catalog_edit,
+    'st_catalog_new'                => :st_catalog_edit,
   }.freeze
 
   def x_button
@@ -667,6 +669,51 @@ class CatalogController < ApplicationController
   end
   hide_action :process_sts
 
+  def ot_edit
+    assert_privileges("orchestration_templates_admin")
+    ot_edit_set_form_vars
+    replace_right_cell("ot_edit")
+  end
+
+  def ot_edit_submit
+    self.x_active_tree = 'ot_tree'
+    case params[:button]
+    when "cancel"
+      ot_edit_submit_cancel
+    when "save"
+      ot_edit_submit_save
+    when "reset"
+      ot_edit_submit_reset
+    end
+  end
+
+  def ot_form_field_changed
+    id = session[:edit][:rec_id]
+    return unless load_edit("ot_edit__#{id}", "replace_cell__explorer")
+    ot_edit_get_form_vars
+    changed = (@edit[:new] != @edit[:current])
+    render :update do |page|
+      page << javascript_for_miq_button_visibility(changed)
+      page << "miqSparkle(false);"
+    end
+  end
+
+  def ot_content_changed
+    render :update do |page|
+      page << javascript_hide("buttons_off")
+      page << javascript_show("buttons_on")
+    end
+  end
+
+  def ot_content_submit
+    case params[:button]
+    when "reset"
+      ot_content_submit_reset
+    when "save"
+      ot_content_submit_save
+    end
+  end
+
   private      #######################
 
   def class_service_template(prov_type)
@@ -757,6 +804,96 @@ class CatalogController < ApplicationController
     options[:model] = "ServiceCatalog" if !options[:model]
     options[:where_clause] = condition
     process_show_list(options)
+  end
+
+  def ot_edit_get_form_vars
+    @edit[:new][:name] = params[:name] if params[:name]
+    @edit[:new][:description] = params[:description] if params[:description]
+  end
+
+  def ot_edit_set_form_vars
+    @record = OrchestrationTemplate.find_by_id(from_cid(params[:id]))
+    @edit = {:current => {:name        => @record.name,
+                          :description => @record.description,
+                          :content     => @record.content},
+             :rec_id  => @record.id}
+    @edit[:new] = @edit[:current].dup
+    @edit[:key] = "ot_edit__#{@record.id}"
+    @right_cell_text = _("Editing %s") % @record.name
+    @in_a_form = true
+  end
+
+  def ot_edit_submit_cancel
+    add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
+      {:model => "Orchestration Template", :name => session[:edit][:new][:name]})
+    @in_a_form = false
+    @edit = @record = nil
+    replace_right_cell
+  end
+
+  def ot_edit_submit_save
+    assert_privileges("orchestration_templates_admin")
+    id = session[:edit][:rec_id]
+    return unless load_edit("ot_edit__#{id}", "replace_cell__explorer")
+    ot = OrchestrationTemplate.find_by_id(@edit[:rec_id])
+    ot.name = @edit[:new][:name]
+    ot.description = @edit[:new][:description]
+    begin
+      ot.save
+    rescue StandardError => bang
+      add_flash(_("Error during '%s': ") % "Orchestration Template Edit" << bang.message, :error)
+    else
+      add_flash(_("%{model} \"%{name}\" was saved") %
+                {:model => ui_lookup(:model => 'OrchestrationTemplate'),
+                 :name  => @edit[:new][:name]})
+    end
+    if @flash_array
+      render :update do |page|
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      end
+    end
+    @changed = session[:changed] = false
+    @in_a_form = false
+    @edit = session[:edit] = nil
+    replace_right_cell(nil, trees_to_replace([:ot]))
+  end
+
+  def ot_edit_submit_reset
+    add_flash(_("All changes have been reset"), :warning)
+    ot_edit_set_form_vars
+    @changed = session[:changed] = false
+    replace_right_cell("ot_edit")
+  end
+
+  def ot_content_submit_reset
+    add_flash(_("All changes have been reset"), :warning)
+    replace_right_cell
+  end
+
+  def ot_content_submit_save
+    assert_privileges("orchestration_templates_admin")
+    ot = OrchestrationTemplate.find_by_id(params[:id])
+    if ot.stacks.length > 0
+      add_flash(_("The Orchestration Template \"%s\" is read-only.") % ot.name, :error)
+    else
+      ot.content = params['template_content']
+      begin
+        ot.save
+      rescue StandardError => bang
+        add_flash(_("Error during '%s': ") % "Orchestration Template Content Edit" << bang.message, :error)
+      else
+        add_flash(_("%{model} \"%{name}\" was saved") %
+                  {:model => ui_lookup(:model => 'OrchestrationTemplate'),
+                   :name  => ot.name})
+      end
+    end
+    render :update do |page|
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+    end
+    @changed = session[:changed] = false
+    @in_a_form = false
+    @edit = session[:edit] = nil
+    replace_right_cell
   end
 
   def st_catalog_get_form_vars
@@ -1431,6 +1568,8 @@ class CatalogController < ApplicationController
         r[:partial=>"stcat_form"]
       elsif action == "dialog_provision"
         r[:partial=>"shared/dialogs/dialog_provision"]
+      elsif action == "ot_edit"
+        r[:partial => "ot_edit"]
       elsif record_showing
         if TreeBuilder.get_model_for_prefix(@nodetype) == "MiqTemplate"
           r[:partial=>"vm_common/main", :locals=>{:controller=>"vm"}]
@@ -1502,6 +1641,14 @@ class CatalogController < ApplicationController
           end
         end
         presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_dialog_buttons", :locals => {:action_url =>"dialog_form_button_pressed", :record_id => @edit[:rec_id]}]
+      elsif action == "ot_edit"
+        presenter[:expand_collapse_cells][:a] = 'collapse'
+        presenter[:expand_collapse_cells][:c] = 'expand'
+        presenter[:set_visible_elements][:form_buttons_div] = true
+        presenter[:set_visible_elements][:pc_div_1] = false
+        locals = {:record_id  => @edit[:rec_id],
+                  :action_url => "ot_edit_submit"}
+        presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_edit_buttons", :locals => locals]
       else
         # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record
         presenter[:set_visible_elements][:buttons_on] = false
@@ -1525,6 +1672,22 @@ class CatalogController < ApplicationController
     presenter[:miq_record_id] = @record && !@in_a_form ? @record.id : @edit && @edit[:rec_id] && @in_a_form ? @edit[:rec_id] : nil
 
     presenter[:lock_unlock_trees][x_active_tree] = @edit && @edit[:current]
+
+    # Render Orchestration Template content edit form buttons (for templates without stacks only)
+    if @record && !@in_a_form && x_active_tree == :ot_tree && @record.stacks.length == 0
+      locals = {
+        :record_id         => @record.id,
+        :action_url        => "ot_content_submit",
+        :save_confirm_text => _("Are you sure you want to save the modified content?"),
+        :no_cancel         => true,
+        :serialize         => true,
+      }
+      presenter[:set_visible_elements][:form_buttons_div] = true
+      presenter[:set_visible_elements][:pc_div_1] = false
+      presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_edit_buttons", :locals => locals]
+      presenter[:expand_collapse_cells][:a] = 'expand'
+      presenter[:expand_collapse_cells][:c] = 'expand'
+    end
 
     # Save open nodes, if any were added
     presenter[:save_open_states_trees] = [@sb[:active_tree].to_s] if add_nodes

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1015,6 +1015,11 @@ module ApplicationHelper
       when "miq_template_refresh", "miq_template_reload"
         return true unless @perf_options[:typ] == "realtime"
       end
+    when "OrchestrationTemplate", "OrchestrationTemplateCfn", "OrchestrationTemplateHot"
+      case id
+      when "orchestration_templates_admin"
+        return true unless role_allows(:feature => "orchestration_templates_admin")
+      end
     when "NilClass"
       case id
       when "action_new"
@@ -1033,6 +1038,8 @@ module ApplicationHelper
         return true if ["workers", "download_logs"].include?(@lastaction)
       when "logdepot_edit"
         return true if ["workers", "evm_logs", "audit_logs"].include?(@lastaction)
+      when "orchestration_templates_admin"
+        return true unless @report
       when "policy_new"
         return true unless role_allows(:feature => "policy_new")
       when "profile_new"
@@ -1926,7 +1933,7 @@ module ApplicationHelper
       else
         if x_active_tree == :ae_tree
           return center_toolbar_filename_automate
-        elsif [:sandt_tree, :svccat_tree, :stcat_tree, :svcs_tree].include?(x_active_tree)
+        elsif [:sandt_tree, :svccat_tree, :stcat_tree, :svcs_tree, :ot_tree].include?(x_active_tree)
           return center_toolbar_filename_services
         elsif @layout == "chargeback"
           return center_toolbar_filename_chargeback
@@ -2036,6 +2043,8 @@ module ApplicationHelper
       else
         return "services_center_tb"
       end
+    elsif x_active_tree == :ot_tree
+      return "ot_center_tb"
     end
   end
 

--- a/vmdb/app/views/catalog/_ot_edit.html.haml
+++ b/vmdb/app/views/catalog/_ot_edit.html.haml
@@ -1,0 +1,30 @@
+#form_div
+  #basic_info_div
+    = render :partial => "layouts/flash_msg"
+    - url = url_for(:action => "ot_form_field_changed", :id => @edit[:rec_id])
+    %p.legend= _("Orchestration Template Information")
+    %table
+      %td{:valign => "top"}
+        %table.style1
+          %tr
+            %td.key=_('Name')
+            %td
+              = text_field_tag("name",
+                               @edit[:current][:name],
+                               :autocomplete => 'off',
+                               :diabled => false,
+                               :size => 80,
+                               :maxlength => 255,
+                               "data-miq_observe" => {:interval => '.5',
+                                                      :url      => url}.to_json)
+          %tr
+            %td.key=_('Description')
+            %td
+              = text_area_tag("description",
+                              @edit[:current][:description],
+                              :autocomplete => 'off',
+                              :disabled => false,
+                              :rows => 15,
+                              :cols => 80,
+                              "data-miq_observe" => {:interval => '.5',
+                                                     :url      => url}.to_json)

--- a/vmdb/app/views/catalog/_ot_tree_show.html.haml
+++ b/vmdb/app/views/catalog/_ot_tree_show.html.haml
@@ -1,30 +1,38 @@
-.maincontent{:xmlns => "http://www.w3.org/1999/html"}
+#main_div
   = render :partial => "layouts/flash_msg"
+  - read_only = @record.stacks.length > 0
+  %p.legend= _("Orchestration Template Information")
   %table
     %td{:valign => "top"}
       %table.style1
         %tr
           %td.key=_('Name')
-          %td.notwide= @record.name
+          %td= @record.name
         %tr
           %td.key=_('Description')
-          %td.notwide= @record.description
-        %tr
-          %td.key=_('Created On')
-          %td.notwide= @record.created_at
-        %tr
-          %td.key=_('Updated On')
-          %td.notwide= @record.updated_at
+          %td=@record.description
+        - unless @edit
+          %tr
+            %td.key=_('Read Only')
+            %td= read_only ? _("True") : _("False")
+          %tr
+            %td.key=_('Created On')
+            %td= @record.created_at
+          %tr
+            %td.key=_('Updated On')
+            %td= @record.updated_at
 
   %hr
-  - if @record.content
+  #form_div
     = text_area_tag("template_content", @record.content, :style => "display:none;")
     - if params[:action] != "explorer"
+      - url = url_for(:action => "ot_content_changed", :id => "#{@record[:id]}")
       = render :partial => "/layouts/my_code_mirror",
         :locals       => {:text_area_id => "template_content",
         :mode         => "yaml",
-        :line_numbers => false,
-        :read_only    => true}
+        :line_numbers => !read_only,
+        :read_only    => read_only,
+        :url          => url}
 
-:javascript
-  miqEditor.refresh();
+    :javascript
+      miqEditor.refresh();

--- a/vmdb/app/views/layouts/_x_edit_buttons.html.haml
+++ b/vmdb/app/views/layouts/_x_edit_buttons.html.haml
@@ -112,7 +112,7 @@
                   :class   => "btn btn-primary",
                   :alt     => save_text,
                   :title   => save_text,
-                  :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}');")
+                  :onclick => "if (confirm('#{save_confirm_text}')) miqAjaxButton('#{url_for(:action => action_url, :id => record_id, :button => "save")}', #{serialize});")
               - else
                 = button_tag(_('Save'),
                   :class   => "btn btn-primary",

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -173,6 +173,7 @@ Vmdb::Application.routes.draw do
       :get  => %w(
         download_data
         explorer
+        ot_edit
         show
       ),
       :post => %w(
@@ -189,6 +190,10 @@ Vmdb::Application.routes.draw do
         group_form_field_changed
         group_update
         identify_catalog
+        ot_content_changed
+        ot_content_submit
+        ot_edit_submit
+        ot_form_field_changed
         process_sts
         prov_field_changed
         reload

--- a/vmdb/product/toolbars/ot_center_tb.yaml
+++ b/vmdb/product/toolbars/ot_center_tb.yaml
@@ -1,0 +1,14 @@
+---
+:model: OrchestrationTemplate
+:button_groups:
+- :name: ot_config
+  :items:
+  - :buttonSelect: ot_config_choice
+    :image: vmdb
+    :title: Configuration
+    :text: Configuration
+    :items:
+    - :button: orchestration_templates_admin
+      :image: edit
+      :text: "Edit this Orchestration Template"
+      :title: "Edit this Orchestration Template"

--- a/vmdb/spec/controllers/catalog_controller_spec.rb
+++ b/vmdb/spec/controllers/catalog_controller_spec.rb
@@ -76,4 +76,63 @@ describe CatalogController do
       assigns(:record).should == nil
     end
   end
+
+  context "#ot_name_and_description_edit" do
+    it "Orchestration Template name and description are edited" do
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@_params, :button => "save")
+      controller.instance_variable_set(:@_response, ActionController::TestResponse.new)
+      ot = FactoryGirl.create(:orchestration_template)
+      controller.instance_variable_set(:@record, ot)
+      new_name = "New Name"
+      new_description = "New Description"
+      edit = {
+        :new    => {
+          :name        => new_name,
+          :description => new_description},
+        :key    => "ot_edit__#{ot.id}",
+        :rec_id => ot.id,
+      }
+      controller.instance_variable_set(:@edit, edit)
+      session[:edit] = edit
+      controller.stub(:replace_right_cell)
+      controller.send(:ot_edit_submit)
+      ot.reload
+      ot.name.should == new_name
+      ot.description.should == new_description
+    end
+  end
+
+  context "#ot_content_edit" do
+    it "Orchestration Template content is edited" do
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@_params, :button => "save")
+      controller.instance_variable_set(:@_response, ActionController::TestResponse.new)
+      ot = FactoryGirl.create(:orchestration_template)
+      new_content = "New Content"
+      controller.params.merge!(:id => ot.id, 'template_content' => new_content)
+      controller.stub(:replace_right_cell)
+      controller.send(:ot_content_submit)
+      ot.reload
+      ot.content.should == new_content
+    end
+  end
+
+  context "#ot_read_only_content_edit" do
+    it "Read-only Orchestration Template content cannot be edited" do
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@_params, :button => "save")
+      controller.instance_variable_set(:@_response, ActionController::TestResponse.new)
+      ot = FactoryGirl.create(:orchestration_template_with_stacks)
+      original_content = ot.content
+      new_content = "New Content"
+      controller.params.merge!(:id => ot.id, 'template_content' => new_content)
+      controller.stub(:replace_right_cell)
+      controller.send(:ot_content_submit)
+      controller.send(:flash_errors?).should be_true
+      ot.reload
+      ot.content.should == original_content
+    end
+  end
+
 end

--- a/vmdb/spec/routing/catalog_routing_spec.rb
+++ b/vmdb/spec/routing/catalog_routing_spec.rb
@@ -11,6 +11,7 @@ describe 'routes for CatalogController' do
   %w(
     download_data
     explorer
+    ot_edit
     show
   ).each do |path|
     describe "##{path}" do
@@ -36,6 +37,10 @@ describe 'routes for CatalogController' do
     group_form_field_changed
     group_update
     identify_catalog
+    ot_content_changed
+    ot_content_submit
+    ot_edit_submit
+    ot_form_field_changed
     process_sts
     prov_field_changed
     reload


### PR DESCRIPTION
This change adds the following functionality:
* show wheter or not is a template read-only
* allows for editing of name & description of every template
* allows for editing content of read-write templates

Parent issue: #1221