### PR TITLE
fix foreman connection build_state

### DIFF
--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -2,7 +2,7 @@ class ConfiguredSystemForeman < ConfiguredSystem
   include ProviderObjectMixin
 
   def provider_object(connection = nil)
-    (connection || raw_connect).host(manager_ref)
+    (connection || connection_source.raw_connect).host(manager_ref)
   end
 
   private

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -93,7 +93,7 @@ module EmsRefresh
             :configuration_profile      => id_lookup(profiles, cs, "hostgroup_id"),
             :operating_system_flavor_id => id_lookup(operatingsystems, cs, "operatingsystem_id"),
             :last_checkin               => cs["last_compile"],
-            :build_state                => cs["build"] == "true" ? "pending" : nil,
+            :build_state                => cs["build"] ? "pending" : nil,
           }
         end
       end

--- a/vmdb/app/models/provider_foreman.rb
+++ b/vmdb/app/models/provider_foreman.rb
@@ -1,3 +1,4 @@
+require 'manageiq_foreman'
 class ProviderForeman < Provider
   has_one :configuration_manager,
           :foreign_key => "provider_id",

--- a/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
+++ b/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
@@ -35,7 +35,7 @@ describe EmsRefresh::Parsers::Foreman do
         "medium_id"          => 10,
         "ptable_id"          => 30,
         "last_compile"       => nil,
-        "build"              => ""
+        "build"              => false
       },
       {
         "id"                 => 2,
@@ -45,7 +45,7 @@ describe EmsRefresh::Parsers::Foreman do
         "medium_id"          => 20,
         "ptable_id"          => 10,
         "last_compile"       => date1,
-        "build"              => "true"
+        "build"              => true
       },
     ]
   end


### PR DESCRIPTION
Minor tweaks for foreman

1. `configured_system` now properly creates `provider_object` for a nil connection.
2. now properly parse `build_state` as a boolean not a String.

/cc @brandondunne @gmcculloug 