### PR TITLE
Fixed correct buttons to show on VM Snapshots screen.

### DIFF
--- a/vmdb/app/views/vm_common/_snapshots_tree.html.haml
+++ b/vmdb/app/views/vm_common/_snapshots_tree.html.haml
@@ -14,5 +14,5 @@
           :icon_size => 24,
           :open_close_all_on_dbl_click => true})
 
-:javascript
-  cfmeDynatree_activateNodeSilently('snapshots_tree', '<%= session[:snap_selected] %>');
+    :javascript
+      cfmeDynatree_activateNodeSilently('snapshots_tree', '<%= session[:snap_selected] %>');


### PR DESCRIPTION
Need to only set active node in tree when there are any snapshot for a VM.

Issue #1911 

@bmclaughlin can you test/review this. To recreate go to VM snapshots screen that with no snapshots.