### PR TITLE
Delete vestigial diagnostics

### DIFF
--- a/system/LINK/bin/miqnet.sh
+++ b/system/LINK/bin/miqnet.sh
@@ -98,7 +98,7 @@ get_info () {
         echo -e $USAGETEXT >&2
         exit 1
       fi
-      echo `get_hostname` `get_mac` `get_ip` `get_netmask` `get_gateway` `get_dns1` `get_dns2` `get_timeserver`
+      echo `get_hostname` `get_mac` `get_ip` `get_netmask` `get_gateway` `get_dns1` `get_dns2`
       ;;
   esac
 }

--- a/vmdb/lib/vmdb/appliance.rb
+++ b/vmdb/lib/vmdb/appliance.rb
@@ -85,10 +85,6 @@ module Vmdb
 
         fstab = `cat /etc/fstab 2> /dev/null` rescue nil
         startup.info "fstab information:\n#{fstab}" unless fstab.blank?
-
-        vars = ""
-        ENV.each { |k, v| vars << "#{k} = #{v}\n"}
-        startup.info "Environment Variables: \n#{vars}" unless vars.blank?
       ensure
         startup.close rescue nil
       end
@@ -98,12 +94,6 @@ module Vmdb
       return unless MiqEnvironment::Command.is_appliance?
 
       init_diagnostics
-      # TODO:  Add pinging of gateways and Database
-      #      pings =""
-      #      gateways = `/sbin/route -n | awk '{ if ($4 ~ /G/) print $2; }'`.split("\n").collect {|g| pings << `ping -c 5 #{g}`}
-      # TODO: Make this method executable as a scheduled queue item
-
-      # execute or evaluate each diagnostic command
       @diags.each do |diag|
         begin
           if diag[:evaluate?]
@@ -117,10 +107,6 @@ module Vmdb
         end
         $log.info("Diagnostics: [#{diag[:msg]}]\n#{res}") unless res.blank?
       end
-
-      vars = ""
-      ENV.each { |k, v| vars << "#{k} = #{v}\n"}
-      $log.info "Environment Variables: \n#{vars}" unless vars.blank?
     end
 
     private

--- a/vmdb/lib/vmdb/appliance.rb
+++ b/vmdb/lib/vmdb/appliance.rb
@@ -147,9 +147,7 @@ module Vmdb
     def self.init_diagnostics
       log_dir = "/var/www/miq/vmdb/log"
       gem_log = File.join(log_dir, "gem_list.txt")
-      ven_gem_log = File.join(log_dir, "vendor_gems.txt")
       rpm_log = File.join(log_dir, "package_list_rpm.txt")
-      dpkg_log = File.join(log_dir, "package_list_dpkg.txt")
 
       @diags ||= [
         {:cmd => "top -b -n 1", :msg =>"Uptime, top processes, and memory usage"}, # batch mode - once
@@ -163,9 +161,7 @@ module Vmdb
         {:cmd => "File.open('/etc/hosts','r'){|f| f.read} if File.exist?('/etc/hosts')", :evaluate? => true, :msg => "Hosts file contents"},
         {:cmd => "File.open('/etc/fstab','r'){|f| f.read} if File.exist?('/etc/fstab')", :evaluate? => true, :msg => "Fstab file contents"},
         {:cmd => "echo start: date time is: #{Time.now.utc} >> #{gem_log}; gem list > #{gem_log}"},
-        {:cmd => "echo start: date time is: #{Time.now.utc} >> #{ven_gem_log}; ls -1 vendor/gems > #{ven_gem_log}"},
         {:cmd => "echo start: date time is: #{Time.now.utc} >> #{rpm_log}; rpm -qa --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' |sort -k 1  > #{rpm_log} 2> /dev/null"},
-        {:cmd => "echo start: date time is: #{Time.now.utc} >> #{dpkg_log}; dpkg -l > #{dpkg_log} 2> /dev/null"}
       ]
     end
   end


### PR DESCRIPTION
I noticed these errors in the appliance logs while testing some ipv6 stuff.

This PR removes some of most annoying and useless log lines.

log/evm.log-20150219:cat: /etc/default/ntpdate: No such file or directory
log/evm.log-20150219:ls: cannot access vendor/gems: No such file or directory