### PR TITLE
Use rest-client master branch at ipv6 fixes.

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -32,8 +32,9 @@ gem "log4r",                "=1.1.8",        :require => false
 gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
-gem "ovirt",                "~>0.3.0",       :require => false
+gem "ovirt",                "~>0.4.0",       :require => false
 gem "kubeclient",           ">=0.1.4",       :require => false
+gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false
 gem "rubyzip",              "=0.9.5",        :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646


### PR DESCRIPTION
Upgrade ovirt to be able to use this rest-client.

https://github.com/rest-client/rest-client/pull/332
https://github.com/rest-client/rest-client/pull/333

Note, I'm using rest-client on the master branch's commit that contains the above ipv6 merged pull requests.

The goal is to use a rest-client release when it's released with those fixes, otherwise we'll have to fork rest-client again.

cc @brandondunne @kbrock  (I know you use rest-client elsewhere)

I was able to re-verify ipv6 based rhevm inventory and eventing with this branch.  cc @dajohnso 