### PR TITLE
Parameters starting such as reg_ in url are being converted to %C2%AE

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/vmdb/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -111,9 +111,9 @@ module OpsController::Settings::AnalysisProfiles
   def ap_ce_delete
     return unless load_edit("ap_edit__#{params[:id]}","replace_cell__explorer")
     ap_get_form_vars
-    if params[:item1] == "registry"
+    if params[:item2] == "registry"
       session[:reg_entries].each do | reg |
-        if reg.has_value?(params[:reg_key]) && reg.has_value?(params[:reg_value])
+        if reg.value?(params[:reg_key]) && reg.value?(params[:reg_value])
           session[:reg_entries].delete(reg)
         end
       end

--- a/vmdb/app/views/ops/_ap_form_registry.html.haml
+++ b/vmdb/app/views/ops/_ap_form_registry.html.haml
@@ -48,10 +48,23 @@
           - else
             %tr{:id => "#{i}_tr"}
               %td{:onclick => remote_function(:url=>{:action=>'ap_ce_delete', :entry_id=>i,:item1=>"registry", :reg_key=>reg["key"], :reg_value=>reg["value"], :id=>"#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
-                = image_tag("/images/toolbars/delete.png", :class=>"rollover small")
-              %td{:onclick => remote_function(:url=>{:action=>'ap_ce_select', :entry_id=>i,:item2=>"registry", :reg_key=>reg["key"], :reg_value=>reg["value"], :edit_entry=>'edit_registry', :field=>"kname", :id=>"#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+            %tr{:id => "#{i}_tr"}
+              - url = {:action     => 'ap_ce_delete',
+                       :entry_id   => i,
+                       :item2      => "registry",
+                       :reg_key    => reg["key"],
+                       :reg_value  => reg["value"],
+                       :edit_entry => 'edit_registry',
+                       :field      => "kname",
+                       :id         => "#{@scan.id || "new"}"}
+              - remote_link = remote_function(:url => url).to_str
+              %td{:onclick => remote_link, :title => _("Click to delete this entry")}
+                = image_tag("/images/toolbars/delete.png")
+              - url[:action] = "ap_ce_select"
+              - remote_link = remote_function(:url => url).to_str
+              %td{:onclick => remote_link, :title => _("Click to update this entry")}
                 =_("HKLM")
-              %td{:onclick => remote_function(:url=>{:action=>'ap_ce_select', :entry_id=>i,:item2=>"registry", :reg_key=>reg["key"], :reg_value=>reg["value"], :edit_entry=>'edit_registry', :field=>"kname", :id=>"#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              %td{:onclick => remote_link, :title => _("Click to update this entry")}
                 = h(reg["key"])
-              %td{:onclick => remote_function(:url=>{:action=>'ap_ce_select', :entry_id=>i,:item2=>"registry", :reg_key=>reg["key"], :reg_value=>reg["value"], :edit_entry=>'edit_registry', :field=>"value", :id=>"#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              %td{:onclick => remote_link, :title => _("Click to update this entry")}
                 = h(reg["value"])


### PR DESCRIPTION
Parameters being passed in to remote_function call to build a url that start with reg_ in url are being converted to %C2%AE, as url should have been &reg_key=some_key&reg_value=some_value but instead it is being nuilt as %C2%AE_key=some_key%C2%AE_value=some_value. To fix this issue changed variable names to registry_key, registry_value

Issue #1920
Issue #1921 

@Fryguy @tenderlove i am not sure if this issue was introduced with Ruby 2.0 or could it be jquery, please review.