### PR TITLE
Fix unhelpful "Unexpected response" toast when verifying new cloud provider and password empty

### DIFF
--- a/vmdb/app/models/ems_amazon.rb
+++ b/vmdb/app/models/ems_amazon.rb
@@ -44,7 +44,7 @@ class EmsAmazon < EmsCloud
   end
 
   def translate_exception(err)
-    case err.class
+    case err
     when AWS::EC2::Errors::SignatureDoesNotMatch
       MiqException::MiqHostError.new "SignatureMismatch - check your AWS Secret Access Key and signing method"
     when AWS::EC2::Errors::AuthFailure

--- a/vmdb/app/models/ems_amazon.rb
+++ b/vmdb/app/models/ems_amazon.rb
@@ -49,13 +49,18 @@ class EmsAmazon < EmsCloud
     begin
       # EC2 does Lazy Connections, so call a cheap function
       with_provider_connection(options.merge(:auth_type => auth_type)) { |ec2| ec2.regions.map(&:name) }
-    rescue AWS::EC2::Errors::SignatureDoesNotMatch
+    rescue AWS::EC2::Errors::SignatureDoesNotMatch => err
+      $log.error("MIQ(#{self.class.name}.verify_credentials) Error Class=#{err.class.name}, Message=#{err.message}")
       raise MiqException::MiqHostError, "SignatureMismatch - check your AWS Secret Access Key and signing method"
-    rescue AWS::EC2::Errors::AuthFailure
+    rescue AWS::EC2::Errors::AuthFailure => err
+      $log.error("MIQ(#{self.class.name}.verify_credentials) Error Class=#{err.class.name}, Message=#{err.message}")
       raise MiqException::MiqHostError, "Login failed due to a bad username or password."
+    rescue AWS::Errors::MissingCredentialsError => err
+      $log.error("MIQ(#{self.class.name}.verify_credentials) Error Class=#{err.class.name}, Message=#{err.message}")
+      raise MiqException::MiqHostError, "Missing credentials"
     rescue Exception => err
       $log.error("MIQ(#{self.class.name}.verify_credentials) Error Class=#{err.class.name}, Message=#{err.message}")
-      raise MiqException::MiqHostError, "Unexpected response returned from system, see log for details"
+      raise MiqException::MiqHostError, "Unexpected response returned from system: #{err.message}"
     end
 
     return true

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -46,8 +46,12 @@ module AuthenticationMixin
     authentication_component(type, :password_encrypted)
   end
 
+  def required_credential_fields(_type)
+    [:userid]
+  end
+
   def has_credentials?(type = nil)
-    !!authentication_component(type, :userid)
+    required_credential_fields(type).all? { |field| authentication_component(type, field) }
   end
 
   def missing_credentials?(type = nil)

--- a/vmdb/app/models/mixins/ems_openstack_mixin.rb
+++ b/vmdb/app/models/mixins/ems_openstack_mixin.rb
@@ -74,7 +74,7 @@ module EmsOpenstackMixin
   end
 
   def translate_exception(err)
-    case err.class
+    case err
     when Excon::Errors::Unauthorized
       MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
     when Excon::Errors::Timeout

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -160,6 +160,10 @@ describe EmsAmazon do
   end
 
   context "translate_exception" do
+    before :all do
+      require 'aws-sdk'
+    end
+
     before :each do
       @ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
 

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -162,10 +162,13 @@ describe EmsAmazon do
   context "translate_exception" do
     it "preserves and logs message for unknown exceptions" do
       ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
-      ems.stub(:with_provider_connection).and_raise(Exception, "unlikely")
 
-      $log.should_receive(:warn).with(/unlikely/)
+      creds = {:default => {:userid => "fake_user", :password => "fake_password"}}
+      ems.update_authentication(creds, :save => false)
 
+      ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
+
+      $log.should_receive(:error).with(/unlikely/)
       expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
     end
 

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -158,4 +158,33 @@ describe EmsAmazon do
       expect { FactoryGirl.create(:ems_amazon, :name => "ems_2", :provider_region => "us-east-1") }.to_not raise_error
     end
   end
+
+  context "translate_exception" do
+    it "preserves and logs message for unknown exceptions" do
+      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
+      ems.stub(:with_provider_connection).and_raise(Exception, "unlikely")
+
+      $log.should_receive(:warn).with(/unlikely/)
+
+      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
+    end
+
+    it "handles SignatureDoesNotMatch" do
+      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
+      ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::SignatureDoesNotMatch)
+      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /SignatureMismatch/)
+    end
+
+    it "handles AuthFailure" do
+      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
+      ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::AuthFailure)
+      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Login failed/)
+    end
+
+    it "handles MissingCredentialsErrror" do
+      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
+      ems.stub(:with_provider_connection).and_raise(AWS::Errors::MissingCredentialsError)
+      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Missing credentials/)
+    end
+  end
 end

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -174,22 +174,22 @@ describe EmsAmazon do
     it "preserves and logs message for unknown exceptions" do
       @ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
       $log.should_receive(:error).with(/unlikely/)
-      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
+      expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
     end
 
     it "handles SignatureDoesNotMatch" do
       @ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::SignatureDoesNotMatch)
-      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Signature.*match/)
+      expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Signature.*match/)
     end
 
     it "handles AuthFailure" do
       @ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::AuthFailure)
-      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Login failed/)
+      expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Login failed/)
     end
 
     it "handles MissingCredentialsErrror" do
       @ems.stub(:with_provider_connection).and_raise(AWS::Errors::MissingCredentialsError)
-      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Missing credentials/i)
+      expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Missing credentials/i)
     end
   end
 end

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -160,34 +160,32 @@ describe EmsAmazon do
   end
 
   context "translate_exception" do
-    it "preserves and logs message for unknown exceptions" do
-      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
+    before :each do
+      @ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
 
       creds = {:default => {:userid => "fake_user", :password => "fake_password"}}
-      ems.update_authentication(creds, :save => false)
+      @ems.update_authentication(creds, :save => false)
+    end
 
-      ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
-
+    it "preserves and logs message for unknown exceptions" do
+      @ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
       $log.should_receive(:error).with(/unlikely/)
-      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
+      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
     end
 
     it "handles SignatureDoesNotMatch" do
-      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
-      ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::SignatureDoesNotMatch)
-      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /SignatureMismatch/)
+      @ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::SignatureDoesNotMatch)
+      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Signature.*match/)
     end
 
     it "handles AuthFailure" do
-      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
-      ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::AuthFailure)
-      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Login failed/)
+      @ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::AuthFailure)
+      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Login failed/)
     end
 
     it "handles MissingCredentialsErrror" do
-      ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
-      ems.stub(:with_provider_connection).and_raise(AWS::Errors::MissingCredentialsError)
-      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Missing credentials/)
+      @ems.stub(:with_provider_connection).and_raise(AWS::Errors::MissingCredentialsError)
+      expect { @ems.verify_credentials() }.to raise_error(MiqException::MiqHostError, /Missing credentials/i)
     end
   end
 end

--- a/vmdb/spec/models/ems_openstack_spec.rb
+++ b/vmdb/spec/models/ems_openstack_spec.rb
@@ -62,7 +62,7 @@ describe EmsOpenstack do
       ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
 
       $log.should_receive(:error).with(/unlikely/)
-      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqEVMLoginError, /Unexpected.*unlikely/)
+      expect { ems.verify_credentials }.to raise_error(MiqException::MiqEVMLoginError, /Unexpected.*unlikely/)
     end
   end
 end

--- a/vmdb/spec/models/ems_openstack_spec.rb
+++ b/vmdb/spec/models/ems_openstack_spec.rb
@@ -51,4 +51,15 @@ describe EmsOpenstack do
 
     @ems.event_monitor_options.should == {:hostname => "host", :port => 1234}
   end
+
+  context "translate_exception" do
+    it "preserves and logs message for unknown exceptions" do
+      ems = FactoryGirl.build(:ems_openstack, :hostname => "host", :ipaddress => "::1")
+      ems.stub(:with_provider_connection).and_raise(Exception, "unlikely")
+
+      $log.should_receive(:warn).with(/unlikely/)
+
+      expect { ems.verify_credentials() }.to raise_error(MiqException::MiqEVMLoginError, /Unexpected.*unlikely/)
+    end
+  end
 end

--- a/vmdb/spec/models/ems_openstack_spec.rb
+++ b/vmdb/spec/models/ems_openstack_spec.rb
@@ -55,10 +55,13 @@ describe EmsOpenstack do
   context "translate_exception" do
     it "preserves and logs message for unknown exceptions" do
       ems = FactoryGirl.build(:ems_openstack, :hostname => "host", :ipaddress => "::1")
-      ems.stub(:with_provider_connection).and_raise(Exception, "unlikely")
 
-      $log.should_receive(:warn).with(/unlikely/)
+      creds = {:default => {:userid => "fake_user", :password => "fake_password"}}
+      ems.update_authentication(creds, :save => false)
 
+      ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
+
+      $log.should_receive(:error).with(/unlikely/)
       expect { ems.verify_credentials() }.to raise_error(MiqException::MiqEVMLoginError, /Unexpected.*unlikely/)
     end
   end


### PR DESCRIPTION
Only affects the cloud providers (and openstack in infra), the rest of infra providers pass on the actual exception message

For Amazon, there's a MissingCredentials exception so we're explicitly catching that one

For OpenStack, OpenStackHandle::Handle#connect throws a rather unhelpful ArgumentError when the password is nil, but not when empty, so ||ing an empty string

Also added a Timeout rescue for OpenStack

https://bugzilla.redhat.com/show_bug.cgi?id=1083773