### PR TITLE
ask the user to verify their database password

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -490,7 +490,13 @@ Date and Time Configuration
 
           ApplianceConsole::Logging.logger = VMDBLogger.new(LOGFILE)
           database_configuration = ApplianceConsole.const_get("#{loc_selection}DatabaseConfiguration").new
-          database_configuration.ask_questions
+          begin
+            database_configuration.ask_questions
+          rescue ArgumentError => e
+            say("\nConfiguration failed: #{e.message}\n")
+            press_any_key
+            raise MiqSignalError
+          end
 
           clear_screen
           say "Activating the configuration using the following settings...\n"

--- a/lib/appliance_console/database_configuration.rb
+++ b/lib/appliance_console/database_configuration.rb
@@ -118,7 +118,18 @@ module ApplianceConsole
       self.host     = ask_for_ip_or_hostname("database hostname or IP address", host) if host.blank? || !local?
       self.database = just_ask("name of the database on #{host}", database) unless local?
       self.username = just_ask("username", username) unless local?
-      self.password = ask_for_password_or_none("database password on #{host}", password)
+      loop do
+        password1   = ask_for_password_or_none("database password on #{host}", password)
+        # if they took the default, just bail
+        break if (password1 == password)
+        password2   = ask_for_password("database password again")
+        if password1 == password2
+          self.password = password1
+          break
+        else
+          say("\nThe passwords did not match, please try again")
+        end
+      end
     end
 
     def friendly_inspect

--- a/lib/appliance_console/database_configuration.rb
+++ b/lib/appliance_console/database_configuration.rb
@@ -118,7 +118,9 @@ module ApplianceConsole
       self.host     = ask_for_ip_or_hostname("database hostname or IP address", host) if host.blank? || !local?
       self.database = just_ask("name of the database on #{host}", database) unless local?
       self.username = just_ask("username", username) unless local?
+      count = 0
       loop do
+        count += 1
         password1   = ask_for_password_or_none("database password on #{host}", password)
         # if they took the default, just bail
         break if (password1 == password)
@@ -126,6 +128,8 @@ module ApplianceConsole
         if password1 == password2
           self.password = password1
           break
+        elsif count > 1 # only reprompt password once
+          raise ArgumentError, "passwords did not match"
         else
           say("\nThe passwords did not match, please try again")
         end

--- a/lib/spec/appliance_console/database_configuration_spec.rb
+++ b/lib/spec/appliance_console/database_configuration_spec.rb
@@ -202,6 +202,12 @@ describe ApplianceConsole::DatabaseConfiguration do
       subject.ask_for_database_credentials
       expect(subject.password).to eq("pass3")
     end
+
+    it "should raise an error if passwords do not match twice" do
+      subject.should_receive(:just_ask).with(/password/i, anything).twice.and_return(*%w(pass1 pass2 pass3 pass4))
+
+      expect { subject.ask_for_database_credentials }.to raise_error(ArgumentError, "passwords did not match")
+    end
   end
 
   context "#create_or_join_region" do
@@ -370,8 +376,8 @@ describe ApplianceConsole::DatabaseConfiguration do
   def stubbed_say(clazz)
     Class.new(clazz) do
       include ApplianceConsole::Prompts
-      # global variable
-      def say(*args)
+      # don't display the messages prompted to the end user
+      def say(*_args)
       end
     end.new
   end

--- a/lib/spec/appliance_console/database_configuration_spec.rb
+++ b/lib/spec/appliance_console/database_configuration_spec.rb
@@ -134,12 +134,7 @@ describe ApplianceConsole::DatabaseConfiguration do
   context "#ask_for_database_credentials" do
     subject do
       # Note: this will move from External to DatabaseConfiguration
-      Class.new(ApplianceConsole::ExternalDatabaseConfiguration) do
-        include ApplianceConsole::Prompts
-        # global variable
-        def say(*args)
-        end
-      end.new
+      stubbed_say(ApplianceConsole::ExternalDatabaseConfiguration)
     end
 
     it "should default prompts based upon previous values (no password)" do
@@ -192,6 +187,7 @@ describe ApplianceConsole::DatabaseConfiguration do
         def say(*_args)
         end
       end.new
+      stubbed_say(ApplianceConsole::InternalDatabaseConfiguration)
     end
 
     it "should ask for password if local" do
@@ -362,5 +358,14 @@ describe ApplianceConsole::DatabaseConfiguration do
         end
       end
     end
+  end
+
+  def stubbed_say(clazz)
+    Class.new(clazz) do
+      include ApplianceConsole::Prompts
+      # global variable
+      def say(*args)
+      end
+    end.new
   end
 end


### PR DESCRIPTION
When a user is configuring the database, as a second time for the database password

https://bugzilla.redhat.com/show_bug.cgi?id=1134978

If the passwords do not match, it will prompt again.

/cc @jrafanie 