### PR TITLE
Only show console url / region after configured

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -170,7 +170,8 @@ loop do
 
     clear_screen
 
-    say("#{I18n.t("product.name")} Virtual Appliance\n\nTo administer this appliance, browse to https://#{ip}\n")
+    say("#{I18n.t("product.name")} Virtual Appliance\n")
+    say("To administer this appliance, browse to https://#{ip}\n") if ApplianceConsole::DatabaseConfiguration.configured?
     if $MIQDEBUG
       $MIQDEBUG_FILES.each { |f| puts "Modified #{(Time.now - File.mtime(f)).to_i / 60} minutes ago - #{f}" }
     end
@@ -201,6 +202,7 @@ loop do
         timezone = Env["TIMEZONE"]
         region   = File.read(REGION_FILE).chomp  if File.exist?(REGION_FILE)
         version  = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
+        configured = ApplianceConsole::DatabaseConfiguration.configured?
 
         clear_screen
 
@@ -219,11 +221,11 @@ To modify the configuration, use a web browser to access the management page.
         MAC Address:       #{mac}
         Timezone:          #{timezone}
         Local Database:    #{ApplianceConsole::Utilities.pg_status}
-        EVM Database:      #{dbtype} @ #{dbhost}
-        Database/Region:   #{database} / #{region || 0}
+        EVM Database:      #{configured ? "#{dbtype} @ #{dbhost}" : "not configured"}
+        Database/Region:   #{configured ? "#{database} / #{region || 0}" : "not configured"}
         External Auth:     #{ExternalHttpdAuthentication.config_status}
         EVM Version:       #{version}
-        EVM Console:       https://#{ip}
+        EVM Console:       #{configured ? "https://#{ip}" : "not configured"}
         EOL
 
         say("Note: Use the Ctrl-Alt-Del to exit out of any screen and return to the summary screen.")
@@ -428,7 +430,7 @@ Date and Time Configuration
 
         when I18n.t("advanced_settings.dbregion_setup")
           say("#{selection}\n\n")
-          unless DatabaseConfiguration.configured?
+          unless configured
             say("There is no database configured yet, please choose #{I18n.t("advanced_settings.db_config")} instead.")
             press_any_key
             raise MiqSignalError

--- a/lib/appliance_console/utilities.rb
+++ b/lib/appliance_console/utilities.rb
@@ -21,7 +21,7 @@ module ApplianceConsole
       require 'open4'
       out = nil
       err = nil
-      Open4::popen4("cd #{RAILS_ROOT} && script/rails runner 'puts MiqDbConfig.current.options[:host]; puts MiqDbConfig.current.options[:name]; puts MiqDbConfig.current.options[:database]'") do |pid, stdin, stdout, stderr|
+      Open4::popen4("cd #{RAILS_ROOT} && script/rails runner 'puts MiqDbConfig.current.options[:host]|| \"localhost\"; puts MiqDbConfig.current.options[:name]; puts MiqDbConfig.current.options[:database]'") do |pid, stdin, stdout, stderr|
         out = stdout.read
         err = stderr.read
       end


### PR DESCRIPTION
- In the login prompt, don't show link to unconfigured console.
- In the summary screen, don't show link to unconfigured appliance.
- If the database is not configured, don't show configuration info
- If the database is not configured, don't show region

https://bugzilla.redhat.com/show_bug.cgi?id=1095558

Extra credit:
- For localhost, was showing blank database hostname, now show localhost.

No database configured

![ac_not_configured_login](https://cloud.githubusercontent.com/assets/1930/6449308/e3c55c4c-c0ed-11e4-8341-97f835bf8926.png)
![ac_not_configured_summary](https://cloud.githubusercontent.com/assets/1930/6449313/e72e9d62-c0ed-11e4-8b3e-74f74becb768.png)

Database configured

![ac_configured_login](https://cloud.githubusercontent.com/assets/1930/6449316/ec876744-c0ed-11e4-9f48-f50675e934bc.png)

![ac_configured_summary](https://cloud.githubusercontent.com/assets/1930/6449318/f10ded56-c0ed-11e4-96c7-5b55e0250a0c.png)

/cc @jrafanie 
