### PR TITLE
Add javascript to execute calendar building for date/datetime fields

### DIFF
--- a/vmdb/app/controllers/service_controller.rb
+++ b/vmdb/app/controllers/service_controller.rb
@@ -477,6 +477,17 @@ class ServiceController < ApplicationController
         page << "miq_record_id = undefined;"  # reset this, otherwise it remembers previously selected id and sends up from list view when add button is pressed
       end
 
+      if @record.kind_of?(Dialog)
+        @record.dialog_fields.each do |field|
+          if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
+            date_from = field.show_past_dates ? nil : Time.now.in_time_zone(session[:user_tz]).to_i * 1000
+            page << "miq_cal_dateFrom = new Date(#{date_from});"
+
+            page << 'miqBuildCalendar();'
+          end
+        end
+      end
+
       page << "cfmeDynatree_activateNodeSilently('#{x_active_tree}','#{x_node}');" if params[:id]
       page << "$('##{x_active_tree}box').dynatree('#{@in_a_form && @edit ? 'disable' : 'enable'}');"
       dim_div = @in_a_form && @edit && @edit[:current] ? true : false

--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1648,6 +1648,16 @@ module VmCommon
         locals[:create_button] = true
       end
 
+      if @record.kind_of?(Dialog)
+        @record.dialog_fields.each do |field|
+          if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
+            presenter[:build_calendar]  = {
+              :date_from => field.show_past_dates ? nil : Time.now.in_time_zone(session[:user_tz]).to_i * 1000
+            }
+          end
+        end
+      end
+
       if %w(ownership protect reconfigure retire tag).include?(@sb[:action])
         locals[:multi_record] = true    # need save/cancel buttons on edit screen even tho @record.id is not there
         locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids][0] if @sb[:action] == "tag"


### PR DESCRIPTION
This fix simply adds the necessary javascript to execute calendar building when there are date and datetime dialog fields present when pressing a custom button.

https://bugzilla.redhat.com/show_bug.cgi?id=1195877