### PR TITLE
Remove unnecessary and incorrect type check

### DIFF
--- a/vmdb/app/controllers/application_controller/miq_request_methods.rb
+++ b/vmdb/app/controllers/application_controller/miq_request_methods.rb
@@ -348,7 +348,7 @@ module ApplicationController::MiqRequestMethods
   def build_grid
     if @edit[:wf].kind_of?(MiqProvisionWorkflow)
       if @edit[:new][:current_tab_key] == :service
-        if @edit[:wf].class.kind_of?(MiqProvisionWorkflow) || @edit[:new][:st_prov_type]
+        if @edit[:new][:st_prov_type]
           build_vm_grid(@edit[:wf].get_field(:src_vm_id,:service)[:values],@edit[:vm_sortdir],@edit[:vm_sortcol])
         else
           @temp[:vm] = VmOrTemplate.find_by_id(@edit[:new][:src_vm_id] && @edit[:new][:src_vm_id][0])


### PR DESCRIPTION
irb(main):001:0> s = String.new
=> ""
irb(main):002:0> s.class.kind_of?(String)
=> false

This is also confusing because two lines above we only enter this logic if
it's a MiqProvisionRequest, if this was fixed, the else to this if wouldn't
make any sense.