### PR TITLE
Fix issue where destroying a Foreman provider would fail on cascade.

### DIFF
--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -7,7 +7,7 @@ class ConfiguredSystem < ActiveRecord::Base
   belongs_to :configuration_profile
   belongs_to :operating_system_flavor
 
-  has_one    :computer_system, :dependent => :destroy
+  has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
 
   alias_method :manager, :configuration_manager
 

--- a/vmdb/spec/factories/computer_system.rb
+++ b/vmdb/spec/factories/computer_system.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :computer_system do
+  end
+end

--- a/vmdb/spec/factories/configuration_profile.rb
+++ b/vmdb/spec/factories/configuration_profile.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :configuration_profile do
+  end
+end

--- a/vmdb/spec/factories/configured_system.rb
+++ b/vmdb/spec/factories/configured_system.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :configured_system do
+  end
+end

--- a/vmdb/spec/factories/customization_script.rb
+++ b/vmdb/spec/factories/customization_script.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :customization_script do
+  end
+end

--- a/vmdb/spec/factories/operating_system_flavor.rb
+++ b/vmdb/spec/factories/operating_system_flavor.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :operating_system_flavor do
+  end
+end

--- a/vmdb/spec/models/provider_foreman_spec.rb
+++ b/vmdb/spec/models/provider_foreman_spec.rb
@@ -20,4 +20,36 @@ describe ProviderForeman do
       end
     end
   end
+
+  describe "#destroy" do
+    it "will remove all child objects" do
+      provider = FactoryGirl.create(:provider_foreman, :zone => FactoryGirl.create(:zone))
+
+      provider.configuration_manager.configured_systems = [
+        FactoryGirl.create(:configured_system, :computer_system =>
+          FactoryGirl.create(:computer_system,
+            :operating_system => FactoryGirl.create(:operating_system),
+            :hardware         => FactoryGirl.create(:hardware),
+          )
+        )
+      ]
+      provider.configuration_manager.configuration_profiles =
+        [FactoryGirl.create(:configuration_profile)]
+      provider.provisioning_manager.operating_system_flavors =
+        [FactoryGirl.create(:operating_system_flavor)]
+      provider.provisioning_manager.customization_scripts =
+        [FactoryGirl.create(:customization_script)]
+
+      provider.destroy
+
+      expect(Provider.count).to              eq(0)
+      expect(ConfiguredSystem.count).to      eq(0)
+      expect(ComputerSystem.count).to        eq(0)
+      expect(OperatingSystem.count).to       eq(0)
+      expect(Hardware.count).to              eq(0)
+      expect(ConfigurationProfile.count).to  eq(0)
+      expect(OperatingSystemFlavor.count).to eq(0)
+      expect(CustomizationScript.count).to   eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Specifically, configured_system failed to destroy its computer_system
because the polymorphic reference was not correct.

@kbrock @brandondunne Please review.