### PR TITLE
ask the class if it is reportable before getting info

### DIFF
--- a/vmdb/app/models/cim_base_storage_extent.rb
+++ b/vmdb/app/models/cim_base_storage_extent.rb
@@ -29,5 +29,8 @@ class CimBaseStorageExtent < ActsAsArModel
     CimStorageExtent.table_name
   end
 
+  def self.sortable?
+    true
+  end
 
 end

--- a/vmdb/app/models/miq_report/search.rb
+++ b/vmdb/app/models/miq_report/search.rb
@@ -33,7 +33,7 @@ module MiqReport::Search
 
   def get_order_info
     order = nil
-    apply_sortby_in_search = !self.db_class.table_name.nil?
+    apply_sortby_in_search = db_class.sortable?
     if apply_sortby_in_search && !self.sortby.nil?
       # Convert sort cols from sub-tables from the form of assoc_name.column to the form of table_name.column
       order = self.sortby.to_miq_a.collect do |c|

--- a/vmdb/app/models/mixins/reportable_mixin.rb
+++ b/vmdb/app/models/mixins/reportable_mixin.rb
@@ -5,6 +5,10 @@ module ReportableMixin
   end
 
   module ClassMethods
+    def sortable?
+      true
+    end
+
     def report_table(number = :all, options = {})
       only = options.delete(:only).collect {|c| "category." == c[0..8] ? nil : c}.compact
       except = options.delete(:except)

--- a/vmdb/app/models/vmdb_database_setting.rb
+++ b/vmdb/app/models/vmdb_database_setting.rb
@@ -7,6 +7,10 @@ class VmdbDatabaseSetting < ActiveRecord::Base
   self.table_name = 'pg_settings'
   self.primary_key = nil
 
+  def self.sortable?
+    false
+  end
+
   virtual_belongs_to :vmdb_database
   virtual_column :description,      :type => :string
   virtual_column :minimum_value,    :type => :integer

--- a/vmdb/lib/acts_as_ar_model.rb
+++ b/vmdb/lib/acts_as_ar_model.rb
@@ -16,6 +16,10 @@ class ActsAsArModel
     ActiveRecord::Base.connection
   end
 
+  def self.sortable?
+    false
+  end
+
   def connection
     self.class.connection
   end


### PR DESCRIPTION
This decouples getting the order info from whether or not the model has
a table name.  Changing this will allow us to turn ActsAsArModel models
in to regular models and maintain backwards compatibility