### PR TITLE
Update auth status when clicking validate for existing ems

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -370,7 +370,7 @@ module EmsCommon
     # validate button should say "revalidate" if the form is unchanged
     revalidating = !edit_changed?
     result, details = verify_ems.authentication_check(params[:type], :save => revalidating)
-    if result == :valid
+    if result
       add_flash(_("Credential validation was successful"))
     else
       add_flash(_("Credential validation was not successful: #{details}"), :error)

--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -259,7 +259,7 @@ module EmsCommon
   def form_field_changed
     return unless load_edit("ems_edit__#{params[:id]}")
     get_form_vars
-    changed = (@edit[:new] != @edit[:current])
+    changed = edit_changed?
 
     render :update do |page|                  # Use JS to update the display
       if params[:server_emstype]              # Server type changed
@@ -316,8 +316,12 @@ module EmsCommon
   end
   private :update_button_cancel
 
+  def edit_changed?
+    @edit[:new] != @edit[:current]
+  end
+
   def update_button_save
-    changed = (@edit[:new] != @edit[:current])
+    changed = edit_changed?
     update_ems = find_by_id_filtered(model, params[:id])
     set_record_vars(update_ems)
     if valid_record?(update_ems) && update_ems.save
@@ -362,17 +366,16 @@ module EmsCommon
     set_record_vars(verify_ems, :validate)
     @in_a_form = true
     @changed = session[:changed]
-    begin
-      result = verify_ems.verify_credentials(params[:type])
-    rescue StandardError => bang
-      add_flash("#{bang}", :error)
+
+    # validate button should say "revalidate" if the form is unchanged
+    revalidating = !edit_changed?
+    result, details = verify_ems.authentication_check(params[:type], :save => revalidating)
+    if result == :valid
+      add_flash(_("Credential validation was successful"))
     else
-      if result
-        add_flash(_("Credential validation was successful"))
-      else
-        add_flash(_("Credential validation was not successful"), :error)
-      end
+      add_flash(_("Credential validation was not successful: #{details}"), :error)
     end
+
     render_flash
   end
   private :update_button_validate

--- a/vmdb/app/models/authentication.rb
+++ b/vmdb/app/models/authentication.rb
@@ -16,6 +16,7 @@ class Authentication < ActiveRecord::Base
   before_save :set_credentials_changed_on
   after_save :after_authentication_changed
 
+  # TODO: DELETE ME!!!!
   ERRORS = {
     :incomplete => "Incomplete credentials",
     :invalid => "Invalid credentials",

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -40,7 +40,7 @@ class EmsKubernetes < EmsContainer
 
   def authentication_check
     # TODO: support real authentication using certificates
-    true
+    [:valid, ""]
   end
 
   def verify_credentials(_auth_type = nil, _options = {})

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -40,7 +40,7 @@ class EmsKubernetes < EmsContainer
 
   def authentication_check
     # TODO: support real authentication using certificates
-    [:valid, ""]
+    [true, ""]
   end
 
   def verify_credentials(_auth_type = nil, _options = {})

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1122,6 +1122,10 @@ class Host < ActiveRecord::Base
     return true
   end
 
+  def verify_credentials_with_ws(_auth_type = nil, _options = {})
+    raise NotImplementedError, "#{__method__} not implemented in #{self.class.name}"
+  end
+
   def verify_credentials_with_ssh(auth_type=nil, options={})
     raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
     raise MiqException::MiqHostError, "Logon to platform [#{self.os_image_name}] not supported" unless self.os_image_name =~ /linux_*/

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -219,6 +219,8 @@ module AuthenticationMixin
     return status == :valid, details
   end
 
+  private
+
   def authentication_check_no_validation(type, options)
     header  = "MIQ(#{self.class.name}.#{__method__}) type: [#{type.inspect}] for [#{self.id}] [#{self.name}]"
     verify_args = self.is_a?(Host) ? [type, options] : type
@@ -243,8 +245,6 @@ module AuthenticationMixin
     $log.warn("#{header} Validation failed: #{status}, #{details}") unless status == :valid
     return status, details
   end
-
-  private
 
   def authentication_best_fit(type = nil)
     # Look for the supplied type and if that is not found return the default credentials

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -203,7 +203,7 @@ module AuthenticationMixin
       status == :valid ? auth.validation_successful : auth.validation_failed(status, details)
     end
 
-    return status, details
+    return status == :valid, details
   end
 
   def authentication_check_no_validation(type, options)

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -191,6 +191,19 @@ module AuthenticationMixin
     types.to_miq_a.each { |t| self.authentication_check(t, options)}
   end
 
+  # Returns [boolean check_result, string details]
+  # check_result is true if and only if:
+  #   * the system is reachable
+  #   * AND we have the required authentication information
+  #   * AND we successfully connected using the authentication
+  #
+  # details is a UI friendly message
+  #
+  # By default, the authentication's status is updated by the
+  # validation_successful or validation_failed callbacks.
+  #
+  # An optional :save => false can be passed to bypass these callbacks.
+  #
   # TODO: :valid, :incomplete, and friends shouldn't be littered in here and authentication
   def authentication_check(*args)
     options         = args.last.kind_of?(Hash) ? args.last : {}

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -192,7 +192,6 @@ module AuthenticationMixin
   end
 
   # TODO: :valid, :incomplete, and friends shouldn't be littered in here and authentication
-  # Check callers of authentication_check
   def authentication_check(*args)
     options         = args.last.kind_of?(Hash) ? args.last : {}
     save            = options.fetch(:save, true)

--- a/vmdb/lib/workers/ems_refresh_core_worker.rb
+++ b/vmdb/lib/workers/ems_refresh_core_worker.rb
@@ -13,7 +13,7 @@ class EmsRefreshCoreWorker < WorkerBase
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if @ems.nil?
-    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first == :valid
+    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
 
     # Global Work Queue
     @queue = Queue.new

--- a/vmdb/lib/workers/ems_refresh_core_worker.rb
+++ b/vmdb/lib/workers/ems_refresh_core_worker.rb
@@ -13,7 +13,7 @@ class EmsRefreshCoreWorker < WorkerBase
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if @ems.nil?
-    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check
+    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first == :valid
 
     # Global Work Queue
     @queue = Queue.new

--- a/vmdb/lib/workers/ems_refresh_worker.rb
+++ b/vmdb/lib/workers/ems_refresh_worker.rb
@@ -12,7 +12,7 @@ class EmsRefreshWorker < QueueWorkerBase
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if @ems.nil?
-    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check
+    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first == :valid
   end
 
   def do_before_work_loop

--- a/vmdb/lib/workers/ems_refresh_worker.rb
+++ b/vmdb/lib/workers/ems_refresh_worker.rb
@@ -12,7 +12,7 @@ class EmsRefreshWorker < QueueWorkerBase
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if @ems.nil?
-    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first == :valid
+    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
   end
 
   def do_before_work_loop

--- a/vmdb/lib/workers/event_catcher.rb
+++ b/vmdb/lib/workers/event_catcher.rb
@@ -14,7 +14,7 @@ class EventCatcher < WorkerBase
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?
-    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check
+    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first == :valid
 
     # Get the filtered events from the event_handling config
     @filtered_events = VMDB::Config.new("event_handling").config[:filtered_events]

--- a/vmdb/lib/workers/event_catcher.rb
+++ b/vmdb/lib/workers/event_catcher.rb
@@ -14,7 +14,7 @@ class EventCatcher < WorkerBase
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?
-    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first == :valid
+    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
 
     # Get the filtered events from the event_handling config
     @filtered_events = VMDB::Config.new("event_handling").config[:filtered_events]

--- a/vmdb/lib/workers/vim_broker_worker.rb
+++ b/vmdb/lib/workers/vim_broker_worker.rb
@@ -9,7 +9,7 @@ class VimBrokerWorker < WorkerBase
     # Global Work Queue
     @queue = Queue.new
 
-    @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition {|e| e.authentication_check.first == :valid }
+    @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition { |e| e.authentication_check.first }
     start_broker_server(@initial_emses_to_monitor)
     @worker.update_attributes(:uri => DRb.uri)
     $log.info("#{self.log_prefix} DRb URI: #{DRb.uri}")

--- a/vmdb/lib/workers/vim_broker_worker.rb
+++ b/vmdb/lib/workers/vim_broker_worker.rb
@@ -9,7 +9,7 @@ class VimBrokerWorker < WorkerBase
     # Global Work Queue
     @queue = Queue.new
 
-    @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition(&:authentication_check)
+    @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition {|e| e.authentication_check.first == :valid }
     start_broker_server(@initial_emses_to_monitor)
     @worker.update_attributes(:uri => DRb.uri)
     $log.info("#{self.log_prefix} DRb URI: #{DRb.uri}")

--- a/vmdb/spec/controllers/ems_common_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_common_controller_spec.rb
@@ -76,7 +76,7 @@ describe EmsCloudController do
 
         it "successful flash message (unchanged)" do
           controller.stub(:edit_changed? => false)
-          mocked_ems_cloud.should_receive(:authentication_check).with("amqp", :save => true).and_return([:valid, ""])
+          mocked_ems_cloud.should_receive(:authentication_check).with("amqp", :save => true).and_return([true, ""])
           controller.should_receive(:add_flash).with(_("Credential validation was successful"))
           controller.should_receive(:render_flash)
           controller.send(:update_button_validate)
@@ -84,7 +84,7 @@ describe EmsCloudController do
 
         it "unsuccessful flash message (changed)" do
           controller.stub(:edit_changed? => true)
-          mocked_ems_cloud.should_receive(:authentication_check).with("amqp", :save => false).and_return([:invalid, "Invalid"])
+          mocked_ems_cloud.should_receive(:authentication_check).with("amqp", :save => false).and_return([false, "Invalid"])
           controller.should_receive(:add_flash).with(_("Credential validation was not successful: Invalid"), :error)
           controller.should_receive(:render_flash)
           controller.send(:update_button_validate)

--- a/vmdb/spec/controllers/ems_common_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_common_controller_spec.rb
@@ -66,36 +66,28 @@ describe EmsCloudController do
     end
 
     context "#update_button_validate" do
-      context "when verify_credentials" do
+      context "when authentication_check" do
         let(:mocked_ems_cloud) { mock_model(EmsCloud) }
         before(:each) do
           controller.instance_variable_set(:@_params, :id => "42", :type => "amqp")
           controller.should_receive(:find_by_id_filtered).with(EmsCloud, "42").and_return(mocked_ems_cloud)
           controller.should_receive(:set_record_vars).with(mocked_ems_cloud, :validate).and_return(mocked_ems_cloud)
         end
-        context "returns true" do
-          it "renders successful flash message" do
-            mocked_ems_cloud.should_receive(:verify_credentials).with("amqp").and_return(true)
-            controller.should_receive(:add_flash).with(_("Credential validation was successful"))
-            controller.should_receive(:render_flash)
-            controller.send(:update_button_validate)
-          end
+
+        it "successful flash message (unchanged)" do
+          controller.stub(:edit_changed? => false)
+          mocked_ems_cloud.should_receive(:authentication_check).with("amqp", :save => true).and_return([:valid, ""])
+          controller.should_receive(:add_flash).with(_("Credential validation was successful"))
+          controller.should_receive(:render_flash)
+          controller.send(:update_button_validate)
         end
-        context "returns false" do
-          it "renders unsuccessful flash message" do
-            mocked_ems_cloud.should_receive(:verify_credentials).with("amqp").and_return(false)
-            controller.should_receive(:add_flash).with(_("Credential validation was not successful"), :error)
-            controller.should_receive(:render_flash)
-            controller.send(:update_button_validate)
-          end
-        end
-        context "raises StandardError" do
-          it "renders error flash message with StandardError" do
-            mocked_ems_cloud.should_receive(:verify_credentials).with("amqp").and_raise(StandardError)
-            controller.should_receive(:add_flash).with(_("StandardError"), :error)
-            controller.should_receive(:render_flash)
-            controller.send(:update_button_validate)
-          end
+
+        it "unsuccessful flash message (changed)" do
+          controller.stub(:edit_changed? => true)
+          mocked_ems_cloud.should_receive(:authentication_check).with("amqp", :save => false).and_return([:invalid, "Invalid"])
+          controller.should_receive(:add_flash).with(_("Credential validation was not successful: Invalid"), :error)
+          controller.should_receive(:render_flash)
+          controller.send(:update_button_validate)
         end
       end
     end

--- a/vmdb/spec/factories/host.rb
+++ b/vmdb/spec/factories/host.rb
@@ -19,6 +19,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :host_vmware_esx_with_authentication, :parent => :host_vmware_esx do
+    after(:create) do |x|
+      x.authentications = [FactoryGirl.build(:authentication, :resource => x)]
+    end
+  end
+
   # Factories for perf_capture_timer and perf_capture_gap testing
   factory :host_target_vmware, :parent => :host do
     after(:create) do |x|

--- a/vmdb/spec/lib/workers/ems_refresh_core_worker_spec.rb
+++ b/vmdb/spec/lib/workers/ems_refresh_core_worker_spec.rb
@@ -13,7 +13,7 @@ describe EmsRefreshCoreWorker do
     described_class.any_instance.stub(:sync_config)
     described_class.any_instance.stub(:set_connection_pool_size)
     described_class.any_instance.stub(:heartbeat_using_drb?).and_return(false)
-    EmsVmware.any_instance.stub(:authentication_check).and_return([:valid, ""])
+    EmsVmware.any_instance.stub(:authentication_check).and_return([true, ""])
 
     @worker = EmsRefreshCoreWorker.new({:guid => @worker_record.guid, :ems_id => @ems.id})
   end

--- a/vmdb/spec/lib/workers/ems_refresh_core_worker_spec.rb
+++ b/vmdb/spec/lib/workers/ems_refresh_core_worker_spec.rb
@@ -13,7 +13,7 @@ describe EmsRefreshCoreWorker do
     described_class.any_instance.stub(:sync_config)
     described_class.any_instance.stub(:set_connection_pool_size)
     described_class.any_instance.stub(:heartbeat_using_drb?).and_return(false)
-    EmsVmware.any_instance.stub(:authentication_check).and_return(true)
+    EmsVmware.any_instance.stub(:authentication_check).and_return([:valid, ""])
 
     @worker = EmsRefreshCoreWorker.new({:guid => @worker_record.guid, :ems_id => @ems.id})
   end

--- a/vmdb/spec/lib/workers/event_catcher_redhat_spec.rb
+++ b/vmdb/spec/lib/workers/event_catcher_redhat_spec.rb
@@ -8,7 +8,7 @@ describe EventCatcherRedhat do
     let(:catcher) { described_class.new(:ems_id => ems) }
 
     before do
-      EmsRedhat.any_instance.stub(:authentication_check => true)
+      EmsRedhat.any_instance.stub(:authentication_check => [true, ""])
       WorkerBase.any_instance.stub(:worker_initialization)
     end
 

--- a/vmdb/spec/lib/workers/vim_broker_worker_spec.rb
+++ b/vmdb/spec/lib/workers/vim_broker_worker_spec.rb
@@ -18,7 +18,7 @@ describe VimBrokerWorker do
     described_class.any_instance.stub(:sync_active_roles)
     described_class.any_instance.stub(:sync_config)
     described_class.any_instance.stub(:set_connection_pool_size)
-    EmsVmware.any_instance.stub(:authentication_check).and_return([:valid, ""])
+    EmsVmware.any_instance.stub(:authentication_check).and_return([true, ""])
     EmsVmware.any_instance.stub(:authentication_status_ok?).and_return(true)
   end
 

--- a/vmdb/spec/lib/workers/vim_broker_worker_spec.rb
+++ b/vmdb/spec/lib/workers/vim_broker_worker_spec.rb
@@ -18,7 +18,7 @@ describe VimBrokerWorker do
     described_class.any_instance.stub(:sync_active_roles)
     described_class.any_instance.stub(:sync_config)
     described_class.any_instance.stub(:set_connection_pool_size)
-    EmsVmware.any_instance.stub(:authentication_check).and_return(true)
+    EmsVmware.any_instance.stub(:authentication_check).and_return([:valid, ""])
     EmsVmware.any_instance.stub(:authentication_status_ok?).and_return(true)
   end
 

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -328,267 +328,50 @@ describe AuthenticationMixin do
         queued_auth_checks.first.deliver
       end
 
-      context "with host missing credentials due to no authentication row or incomplete userid" do
-        before(:each) do
+      context "#authentication_check" do
+        it "updates status" do
           @host.stub(:has_credentials?).and_return(false)
-        end
-
-        it "should return false when calling authentication_check" do
-          @host.authentication_check.should_not be_true
-        end
-
-        it "should set the host's authentication as 'Incomplete' when doing authentication_check" do
           @host.authentication_check
           @host.authentication_type(:default).status.should == 'Incomplete'
         end
 
-        it "should queue a raise authentication incomplete event when doing authentication_check" do
+        it "raises auth event" do
+          @host.stub(:has_credentials?).and_return(false)
           @host.authentication_check
+
           events = MiqQueue.find(:all, :conditions => {:class_name => "MiqEvent", :method_name => "raise_evm_event" })
           args = [ [@host.class.name, @host.id], 'host_auth_incomplete', {}]
           events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
         end
-      end
 
-      context "with ems missing credentials due to no authentication row or incomplete userid" do
-        before(:each) do
-          @ems.stub(:has_credentials?).and_return(false)
-        end
-
-        it "should return false when calling authentication_check" do
-          @ems.authentication_check.should_not be_true
-        end
-
-        it "should set the ems's authentication as 'Incomplete' when doing authentication_check" do
-          @ems.authentication_check
-          @ems.authentication_type(:default).status.should == 'Incomplete'
-        end
-
-        it "should queue a raise authentication incomplete event when doing authentication_check" do
-          @ems.authentication_check
-          events = MiqQueue.find(:all, :conditions => {:class_name => "MiqEvent", :method_name => "raise_evm_event" })
-          args = [ [@ems.class.name, @ems.id], 'ems_auth_incomplete', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with host verify_credentials failing due to invalid credentials" do
-        before(:each) do
-          @host.stub(:verify_credentials).and_return(false)
-        end
-
-        it "should return false when calling authentication_check" do
+        it "missing credentials" do
+          @host.stub(:has_credentials?).and_return(false)
           @host.authentication_check.should_not be_true
         end
 
-        it "should set the host's authentication as 'Invalid' when doing authentication_check" do
-          @host.authentication_check
-          @host.authentication_type(:default).status.should == 'Invalid'
+        it "verify_credentials fails" do
+          @host.stub(:verify_credentials).and_return(false)
+          @host.authentication_check.should_not be_true
         end
 
-        it "should queue a raise authentication invalid event when doing authentication_check" do
-          @host.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@host.class.name, @host.id], 'host_auth_invalid', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with ems verify_credentials failing due to invalid credentials" do
-        before(:each) do
-          @ems.stub(:verify_credentials).and_return(false)
-        end
-
-        it "should return false when calling authentication_check" do
-          @ems.authentication_check.should_not be_true
-        end
-
-        it "should set the ems's authentication as 'Invalid' when doing authentication_check" do
-          @ems.authentication_check
-          @ems.authentication_type(:default).status.should == 'Invalid'
-        end
-
-        it "should queue a raise authentication invalid event when doing authentication_check" do
-          @ems.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@ems.class.name, @ems.id], 'ems_auth_invalid', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with host verify_credentials successful" do
-        before(:each) do
+        it "verify_credentials successful" do
           @host.stub(:verify_credentials).and_return(true)
-        end
-
-        it "should return true when calling authentication_check" do
           @host.authentication_check.should be_true
         end
 
-        it "should set the host's authentication as 'Valid' when doing authentication_check" do
-          @host.authentication_check
-          @host.authentication_type(:default).status.should == 'Valid'
-        end
-
-        it "should queue a raise authentication valid event when doing authentication_check" do
-          @host.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@host.class.name, @host.id], 'host_auth_valid', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with ems verify_credentials successful" do
-        before(:each) do
-          @ems.stub(:verify_credentials).and_return(true)
-        end
-
-        it "should return true when calling authentication_check" do
-          @ems.authentication_check.should be_true
-        end
-
-        it "should set the ems's authentication as 'Valid' when doing authentication_check" do
-          @ems.authentication_check
-          @ems.authentication_type(:default).status.should == 'Valid'
-        end
-
-        it "should queue a raise authentication valid event when doing authentication_check" do
-          @ems.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@ems.class.name, @ems.id], 'ems_auth_valid', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with host verify_credentials raising a known 'Unreachable' error" do
-        before(:each) do
+        it "verify_credentials raising 'Unreachable' error" do
           @host.stub(:verify_credentials).and_raise(MiqException::MiqUnreachableError)
-        end
-
-        it "should return false when calling host authentication_check" do
           @host.authentication_check.should_not be_true
         end
 
-        it "should set the host's authentication as 'Unreachable' when doing authentication_check" do
-          @host.authentication_check
-          @host.authentication_type(:default).status.should == 'Unreachable'
-        end
-
-        it "should queue a raise host authentication unreachable event when doing authentication_check" do
-          @host.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@host.class.name, @host.id], 'host_auth_unreachable', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with ems verify_credentials raising a known 'Unreachable' error" do
-        before(:each) do
-          @ems.stub(:verify_credentials).and_raise(MiqException::MiqUnreachableError)
-        end
-
-        it "should return false when calling ems authentication_check" do
-          @ems.authentication_check.should_not be_true
-        end
-
-        it "should set the ems's authentication as 'Unreachable' when doing authentication_check" do
-          @ems.authentication_check
-          @ems.authentication_type(:default).status.should == 'Unreachable'
-        end
-
-        it "should queue a raise ems authentication unreachable event when doing authentication_check" do
-          @ems.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@ems.class.name, @ems.id], 'ems_auth_unreachable', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with host verify_credentials raising invalid credentials" do
-        before(:each) do
+        it "verify_credentials raising invalid credentials" do
           @host.stub(:verify_credentials).and_raise(MiqException::MiqInvalidCredentialsError)
-        end
-
-        it "should return false when calling host authentication_check" do
           @host.authentication_check.should_not be_true
         end
 
-        it "should set the host's authentication as :error when doing authentication_check" do
-          @host.authentication_check
-          @host.authentication_type(:default).status.should == 'Invalid'
-        end
-
-        it "should queue a raise host authentication error event when doing authentication_check" do
-          @host.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@host.class.name, @host.id], 'host_auth_invalid', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with ems verify_credentials raising invalid credentials" do
-        before(:each) do
-          @ems.stub(:verify_credentials).and_raise(MiqException::MiqInvalidCredentialsError)
-        end
-
-        it "should return false when calling authentication_check" do
-          @ems.authentication_check.should_not be_true
-        end
-
-        it "should set the ems's authentication as :error when doing authentication_check" do
-          @ems.authentication_check
-          @ems.authentication_type(:default).status.should == 'Invalid'
-        end
-
-        it "should queue a raise ems authentication error event when doing authentication_check" do
-          @ems.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@ems.class.name, @ems.id], 'ems_auth_invalid', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with host verify_credentials raising an unexpected error" do
-        before(:each) do
+        it "verify_credentials raising an unexpected error" do
           @host.stub(:verify_credentials).and_raise(RuntimeError)
-        end
-
-        it "should return false when calling host authentication_check" do
           @host.authentication_check.should_not be_true
-        end
-
-        it "should set the host's authentication as :error when doing authentication_check" do
-          @host.authentication_check
-          @host.authentication_type(:default).status.should == 'Error'
-        end
-
-        it "should queue a raise host authentication error event when doing authentication_check" do
-          @host.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@host.class.name, @host.id], 'host_auth_error', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
-        end
-      end
-
-      context "with ems verify_credentials raising an unexpected error" do
-        before(:each) do
-          @ems.stub(:verify_credentials).and_raise(RuntimeError)
-        end
-
-        it "should return false when calling authentication_check" do
-          @ems.authentication_check.should_not be_true
-        end
-
-        it "should set the ems's authentication as :error when doing authentication_check" do
-          @ems.authentication_check
-          @ems.authentication_type(:default).status.should == 'Error'
-        end
-
-        it "should queue a raise ems authentication error event when doing authentication_check" do
-          @ems.authentication_check
-          events = MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event")
-          args = [ [@ems.class.name, @ems.id], 'ems_auth_error', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
         end
       end
 

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -330,13 +330,13 @@ describe AuthenticationMixin do
 
       context "#authentication_check" do
         it "updates status by default" do
-          @host.stub(:has_credentials?).and_return(false)
+          @host.stub(:missing_credentials?).and_return(true)
           @host.authentication_check
           @host.authentication_type(:default).status.should == 'Incomplete'
         end
 
         it "raises auth event" do
-          @host.stub(:has_credentials?).and_return(false)
+          @host.stub(:missing_credentials?).and_return(true)
           @host.authentication_check
 
           event = MiqQueue.where(:class_name => "MiqEvent").where(:method_name => "raise_evm_event").first
@@ -352,14 +352,14 @@ describe AuthenticationMixin do
         end
 
         it "(:save => false) does not update status" do
-          @host.stub(:verify_credentials).and_return(true)
+          @host.stub(:missing_credentials?).and_return(false)
           @host.authentication_check(:save => false)
           @host.authentication_type(:default).status.should be_nil
           MiqQueue.where(:class_name => "MiqEvent").where(:method_name => "raise_evm_event").count.should == 0
         end
 
         it "missing credentials" do
-          @host.stub(:has_credentials?).and_return(false)
+          @host.stub(:missing_credentials?).and_return(true)
           @host.authentication_check.should == [false, "Missing credentials"]
         end
 

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -153,7 +153,7 @@ describe AuthenticationMixin do
 
     context "with a host and ems" do
       before(:each) do
-        @host = FactoryGirl.create(:host_with_authentication)
+        @host = FactoryGirl.create(:host_vmware_esx_with_authentication)
         @ems  = FactoryGirl.create(:ems_vmware_with_authentication)
         MiqQueue.destroy_all
         @auth = @ems.authentication_type(:default)
@@ -311,7 +311,7 @@ describe AuthenticationMixin do
 
       it "Host#authentication_check_types_queue with [:ssh, :default], :remember_host => true is passed down to verify_credentials" do
         @host.authentication_check_types_queue([:ssh, :default], :remember_host => true)
-        conditions = {:class_name => @host.class.name, :instance_id => @host.id, :method_name => 'authentication_check_types', :role => @host.authentication_check_role}
+        conditions = {:class_name => @host.class.base_class.name, :instance_id => @host.id, :method_name => 'authentication_check_types', :role => @host.authentication_check_role}
         queued_auth_checks = MiqQueue.where(conditions)
         queued_auth_checks.length.should == 1
         Host.any_instance.should_receive(:verify_credentials).with(:default, :remember_host => true)
@@ -339,9 +339,9 @@ describe AuthenticationMixin do
           @host.stub(:has_credentials?).and_return(false)
           @host.authentication_check
 
-          events = MiqQueue.where(:class_name => "MiqEvent").where(:method_name => "raise_evm_event")
-          args = [ [@host.class.name, @host.id], 'host_auth_incomplete', {}]
-          events.any? {|e| e.args == args }.should be_true, "#{events.inspect} with args: #{args.inspect} expected"
+          event = MiqQueue.where(:class_name => "MiqEvent").where(:method_name => "raise_evm_event").first
+          args = [[@host.class.name, @host.id], 'host_auth_incomplete', {}]
+          event.args.should eq args
         end
 
         it "(:save => true) updates status" do

--- a/vmdb/spec/models/mixins/authentication_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/authentication_mixin_spec.rb
@@ -329,7 +329,7 @@ describe AuthenticationMixin do
       end
 
       context "#authentication_check" do
-        it "updates status" do
+        it "updates status by default" do
           @host.stub(:has_credentials?).and_return(false)
           @host.authentication_check
           @host.authentication_type(:default).status.should == 'Incomplete'
@@ -360,32 +360,32 @@ describe AuthenticationMixin do
 
         it "missing credentials" do
           @host.stub(:has_credentials?).and_return(false)
-          @host.authentication_check.should == [:incomplete, "Missing credentials"]
+          @host.authentication_check.should == [false, "Missing credentials"]
         end
 
         it "verify_credentials fails" do
           @host.stub(:verify_credentials).and_return(false)
-          @host.authentication_check.should == [:invalid, "Unknown reason"]
+          @host.authentication_check.should == [false, "Unknown reason"]
         end
 
         it "verify_credentials successful" do
           @host.stub(:verify_credentials).and_return(true)
-          @host.authentication_check.should == [:valid, ""]
+          @host.authentication_check.should == [true, ""]
         end
 
         it "verify_credentials raising 'Unreachable' error" do
           @host.stub(:verify_credentials).and_raise(MiqException::MiqUnreachableError)
-          @host.authentication_check.should == [:unreachable, "MiqException::MiqUnreachableError"]
+          @host.authentication_check.should == [false, "MiqException::MiqUnreachableError"]
         end
 
         it "verify_credentials raising invalid credentials" do
           @host.stub(:verify_credentials).and_raise(MiqException::MiqInvalidCredentialsError)
-          @host.authentication_check.should == [:invalid, "MiqException::MiqInvalidCredentialsError"]
+          @host.authentication_check.should == [false, "MiqException::MiqInvalidCredentialsError"]
         end
 
         it "verify_credentials raising an unexpected error" do
           @host.stub(:verify_credentials).and_raise(RuntimeError)
-          @host.authentication_check.should == [:error, "RuntimeError"]
+          @host.authentication_check.should == [false, "RuntimeError"]
         end
       end
 


### PR DESCRIPTION
EDIT: 
**Issue**:  ems based workers no longer try to start if the ems's authentication was detected as previously bad, see #1691.  Finally, if the ems was unreachable and marked as bad, editing the ems in the UI and clicking "validate" doesn't "fix" the authentication's status, making it hard to make the ems's workers start.  The only **workaround** previously was to save invalid credentials, edit it again, and save the correct credentials.

https://bugzilla.redhat.com/show_bug.cgi?id=1044608

**Problem**:
The "workaround" above is horrible for users.

**Solution** validate button in UI should "revalidate" an unchanged ems (ie, when save is not enabled) and update it's authentication status so workers can start back up.

`authentication_check` defaults to verifying the credentials and saving the resulting status.

If you wanted to bypass the saving of the authentication's status, you can do this:
`authentication_check(:save => false)`.

The EMS edit UI code has been changed to no longer do error handling and instead call this method with `:save => false` or `:save => true` if the EMS's edit form has been changed or not.

This example code demonstrates how a client of this code would use these changes:
```ruby
    result, details = verify_ems.authentication_check(params[:type], :save => revalidating)
    if result
      add_flash(_("Credential validation was successful"))
    else
      add_flash(_("Credential validation was not successful: #{details}"), :error)
    end
```