### PR TITLE
Allow access for EvmRole-vm_user to Infrastructure/Virtual Machines

### DIFF
--- a/vmdb/db/fixtures/miq_user_roles.yml
+++ b/vmdb/db/fixtures/miq_user_roles.yml
@@ -1,4 +1,4 @@
---- 
+---
 
 - :name: EvmRole-super_administrator
   :read_only: true

--- a/vmdb/db/fixtures/miq_user_roles.yml
+++ b/vmdb/db/fixtures/miq_user_roles.yml
@@ -875,6 +875,7 @@
   - vm_explorer
   - vm_guest_restart
   - vm_guest_shutdown
+  - vm_infra_explorer
   - vm_miq_request_new
   - vm_perf
   - vm_policy_sim


### PR DESCRIPTION
We had defined access to product features under Infrastructure -> Virtual Machines - VM Access Rules/Template Access Rules, but the users with that role didn't see the tab in UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1171577