### PR TITLE
Report styling should respect user's time zone

### DIFF
--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -989,8 +989,8 @@ class MiqExpression
     return false
   end
 
-  def self.evaluate(expression, obj, inputs={})
-    ruby_exp = expression.is_a?(Hash) ? self.new(expression).to_ruby : expression.to_ruby
+  def self.evaluate(expression, obj, inputs = {}, tz = nil)
+    ruby_exp = expression.is_a?(Hash) ? self.new(expression).to_ruby(tz) : expression.to_ruby(tz)
     $log.debug("MIQ(Expression-evaluate) Expression before substitution: #{ruby_exp}")
     subst_expr = self.subst(ruby_exp, obj, inputs)
     $log.debug("MIQ(Expression-evaluate) Expression after substitution: #{subst_expr}")
@@ -999,8 +999,8 @@ class MiqExpression
     return result
   end
 
-  def evaluate(obj, inputs={})
-    self.class.evaluate(self, obj, inputs)
+  def evaluate(obj, inputs = {}, tz = nil)
+    self.class.evaluate(self, obj, inputs, tz)
   end
 
   def self.evaluate_atoms(exp, obj, inputs={})

--- a/vmdb/app/models/miq_report/generator/html.rb
+++ b/vmdb/app/models/miq_report/generator/html.rb
@@ -64,7 +64,7 @@ module MiqReport::Generator::Html
         row = 1 - row
 
         self.col_order.each_with_index do |c, c_idx|
-          style = self.get_style_class(c, d.data)
+          style = self.get_style_class(c, d.data, tz)
           style_class = !style.nil? ? " class='#{style}'" : nil
           if c == "resource_type"                     # Lookup models in resource_type col
             output << "<td#{style_class}>"
@@ -249,7 +249,7 @@ module MiqReport::Generator::Html
     return html_rows
   end
 
-  def get_style_class(col, row)
+  def get_style_class(col, row, tz = nil)
     atoms = self.col_options.fetch_path(col, :style) unless self.col_options.nil?
     return if atoms.nil?
 
@@ -260,7 +260,7 @@ module MiqReport::Generator::Html
       return atom[:class] if atom[:operator].downcase == "default"
 
       exp = expression_for_style_class(field, atom)
-      return atom[:class] if exp.evaluate(nh)
+      return atom[:class] if exp.evaluate(nh, {}, tz)
     end
     return nil
   end


### PR DESCRIPTION
Right now, when generating reports in non-UTC timezone, when you use "Today" in filter, it works as expected, but when "Today" is used in styling, it assumes UTC. This PR fixes that...

MiqExpression#evaluate - added optional time zone argument (so that .to_ruby doesn't have to default to UTC in this case)
MiqReport::Generator::Html#get_style_class gets time zone from #build_html_rows, passes it to exp.evaluate

https://bugzilla.redhat.com/show_bug.cgi?id=1196852