### PR TITLE
Add QCOW 3 support

### DIFF
--- a/lib/disk/modules/QcowDisk.rb
+++ b/lib/disk/modules/QcowDisk.rb
@@ -187,7 +187,7 @@ module QcowDisk
       case version
       when 1
         header['l2bits']
-      when 2
+      when 2, 3
         cluster_bits - 3
       else
         raise "Unknown QCOW Version: #{version}"
@@ -221,7 +221,7 @@ module QcowDisk
       when 1
        shift = cluster_bits + l2_bits
        (size + (1 << shift) - 1) >> shift
-      when 2
+      when 2, 3
         header['l1_size']
       else
         raise "Unknown QCOW Version: #{version}"
@@ -441,7 +441,7 @@ module QcowDisk
       when 1
         raise "QCOW Version 1 is not supported"
         QCOW_HEADER_V1.decode(file_handle.read(SIZEOF_QCOW_HEADER_V1))
-      when 2
+      when 2, 3
         h = QCOW_HEADER_V2.decode(file_handle.read(SIZEOF_QCOW_HEADER_V2))
         # TODO: Handle Encryption
         raise "QCOW Encryption is not supported" if h['crypt_method'] == 1
@@ -495,7 +495,7 @@ module QcowDisk
       case version
       when 1
         0
-      when 2
+      when 2, 3
         1 << 63
       else
         raise "Unknown QCOW Version: #{version}"
@@ -508,7 +508,7 @@ module QcowDisk
       case version
       when 1
         1 << 63
-      when 2
+      when 2, 3
         1 << 62
       else
         raise "Unknown QCOW Version: #{version}"

--- a/lib/disk/modules/QcowDisk.rb
+++ b/lib/disk/modules/QcowDisk.rb
@@ -83,6 +83,8 @@ module QcowDisk
     :corrupt => 0x2
   }
 
+  KNOWN_INCOMPATIBLE_FEATURES_MASK = 0x3
+
   COMPATIBLE_FEATURES_MASK = {
     :lazy_refcounts => 0x1
   }
@@ -491,9 +493,9 @@ module QcowDisk
         h
       when 3
         h = QCOW_HEADER_V3.decode(file_handle.read(SIZEOF_QCOW_HEADER_V3))
-        # TODO raise error if unknown incompatible bits set
-        # TODO warning if dirty or corrupt
+        # TODO: warning if dirty or corrupt (?)
         raise "QCOW Encryption is not supported" if h['crypt_method'] == 1
+        raise "Unknown QCOW incompatible features" if h['incompatible_features'] & ~KNOWN_INCOMPATIBLE_FEATURES_MASK > 0
         h
       else
         raise "Uknown Version: #{partial_header['version'].inspect}"

--- a/lib/disk/modules/QcowDisk.rb
+++ b/lib/disk/modules/QcowDisk.rb
@@ -100,7 +100,6 @@ module QcowDisk
     :feature_table_name           => 0x6803f857
   }
 
-
   def d_init
     self.diskType = "QCOW"
     self.blockSize = SECTOR_SIZE
@@ -286,10 +285,12 @@ module QcowDisk
   end
 
   def refcount_order
+    # https://github.com/qemu/qemu/blob/v2.2.0/docs/specs/qcow2.txt#L108
     version < 3 ? 4 : @header['refcount_order']
   end
 
   def header_length
+    # https://github.com/qemu/qemu/blob/v2.2.0/docs/specs/qcow2.txt#L115
     version < 3 ? SIZEOF_QCOW_HEADER_V2 : @header['header_length']
   end
 
@@ -642,15 +643,15 @@ module QcowDisk
     version < 3 ? 0 : @header['autoclear_features']
   end
 
-  def dirty
+  def dirty?
     (incompatible_features & INCOMPATIBLE_FEATURES_MASK[:dirty]) == INCOMPATIBLE_FEATURES_MASK[:dirty]
   end
 
-  def corrupt
+  def corrupt?
     (incompatible_features & INCOMPATIBLE_FEATURES_MASK[:corrupt]) == INCOMPATIBLE_FEATURES_MASK[:corrupt] 
   end
 
-  def lazy_refcounts
+  def lazy_refcounts?
     compatible_features & COMPATIBLE_FEATURES_MASK[:lazy_refcounts]
   end
 
@@ -680,8 +681,8 @@ module QcowDisk
     out << "Incompatible Features    : #{incompatible_features}\n"
     out << "Compatible Features      : #{compatible_features}\n"
     out << "Autoclear Features       : #{autoclear_features}\n"
-    out << "Dirty                    : #{dirty}\n"
-    out << "Corrupt                  : #{corrupt}\n"
+    out << "Dirty                    : #{dirty?}\n"
+    out << "Corrupt                  : #{corrupt?}\n"
     return out
   end
 


### PR DESCRIPTION
Adds support for latest version of qcow spec to vm parsing code. Confirmed a qcow3 disk fails parsing before patch and succeeds after. Does not add any additional parsing logic for new qcow3 features (compatibilty bits and such) which can be added at a later date.