### PR TITLE
Move Foreman managers into ExtManagementSystems.

### DIFF
--- a/vmdb/app/models/configuration_manager.rb
+++ b/vmdb/app/models/configuration_manager.rb
@@ -6,3 +6,7 @@ class ConfigurationManager < ExtManagementSystem
     false
   end
 end
+
+# Preload any subclasses of this class, so that they will be part of the
+#   conditions that are generated on queries against this class.
+VMDB::Util.eager_load_subclasses('ConfigurationManager')

--- a/vmdb/app/models/configuration_manager.rb
+++ b/vmdb/app/models/configuration_manager.rb
@@ -1,15 +1,8 @@
-class ConfigurationManager < ActiveRecord::Base
-  include NewWithTypeStiMixin
-  include EmsRefresh::Manager
-  include ReportableMixin
-
-  acts_as_miq_taggable
-  belongs_to :provider
-
+class ConfigurationManager < ExtManagementSystem
   has_many :configured_systems,     :dependent => :destroy
   has_many :configuration_profiles, :dependent => :destroy
 
-  delegate :zone, :my_zone, :zone_name, :to => :provider
-
-  virtual_column :name,                :type => :string,      :uses => :provider
+  def hostname_ipaddress_required?
+    false
+  end
 end

--- a/vmdb/app/models/configuration_manager_foreman.rb
+++ b/vmdb/app/models/configuration_manager_foreman.rb
@@ -1,5 +1,5 @@
 class ConfigurationManagerForeman < ConfigurationManager
-  delegate :raw_connect, :connection_attrs, :name, :to => :provider
+  delegate :raw_connect, :connection_attrs, :to => :provider
 
   def self.ems_type
     "foreman_configuration".freeze

--- a/vmdb/app/models/ems_cloud.rb
+++ b/vmdb/app/models/ems_cloud.rb
@@ -4,10 +4,6 @@ class EmsCloud < ExtManagementSystem
     EmsOpenstack
   }
 
-  def self.supported_subclasses
-    subclasses
-  end
-
   has_many :availability_zones,            :foreign_key => :ems_id, :dependent => :destroy
   has_many :flavors,                       :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_tenants,                 :foreign_key => :ems_id, :dependent => :destroy

--- a/vmdb/app/models/ems_container.rb
+++ b/vmdb/app/models/ems_container.rb
@@ -2,10 +2,6 @@ class EmsContainer < ExtManagementSystem
   SUBCLASSES = %w(
     EmsKubernetes
   )
-
-  def self.supported_subclasses
-    subclasses
-  end
 end
 
 # Preload any subclasses of this class, so that they will be part of the

--- a/vmdb/app/models/ems_infra.rb
+++ b/vmdb/app/models/ems_infra.rb
@@ -6,10 +6,6 @@ class EmsInfra < ExtManagementSystem
     EmsVmware
   }
 
-  def self.supported_subclasses
-    subclasses
-  end
-
   #
   # ems_timeouts is a general purpose proc for obtaining
   # read and open timeouts for any ems type and optional service.

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -1,8 +1,10 @@
 class ExtManagementSystem < ActiveRecord::Base
   SUBCLASSES = %w(
+    ConfigurationManager
     EmsInfra
     EmsCloud
     EmsContainer
+    ProvisioningManager
   )
 
   def self.types
@@ -18,7 +20,9 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def self.supported_subclasses
-    subclasses.flat_map(&:supported_subclasses)
+    subclasses.flat_map do |s|
+      s.subclasses.empty? ? s : s.supported_subclasses
+    end
   end
 
   def self.supported_types_and_descriptions_hash

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -5,8 +5,6 @@ class ExtManagementSystem < ActiveRecord::Base
     EmsContainer
   )
 
-  include EmsRefresh::Manager
-
   def self.types
     leaf_subclasses.collect(&:ems_type)
   end
@@ -28,6 +26,8 @@ class ExtManagementSystem < ActiveRecord::Base
       hash[klass.ems_type] = klass.description
     end
   end
+
+  belongs_to :provider
 
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate"
@@ -60,7 +60,7 @@ class ExtManagementSystem < ActiveRecord::Base
   include NewWithTypeStiMixin
   include UuidMixin
   include WebServiceAttributeMixin
-
+  include EmsRefresh::Manager
 
   after_destroy { |record| $log.info "MIQ(ExtManagementSystem.after_destroy) Removed EMS [#{record.name}] id [#{record.id}]" }
 

--- a/vmdb/app/models/provider.rb
+++ b/vmdb/app/models/provider.rb
@@ -1,4 +1,5 @@
 class Provider < ActiveRecord::Base
+  include NewWithTypeStiMixin
   include AuthenticationMixin
   include EmsRefresh::Manager
 

--- a/vmdb/app/models/provider_foreman.rb
+++ b/vmdb/app/models/provider_foreman.rb
@@ -1,15 +1,20 @@
 require 'manageiq_foreman'
+
 class ProviderForeman < Provider
   has_one :configuration_manager,
           :foreign_key => "provider_id",
           :class_name  => "ConfigurationManagerForeman",
-          :dependent   => :destroy
+          :dependent   => :destroy,
+          :autosave    => true
   has_one :provisioning_manager,
           :foreign_key => "provider_id",
           :class_name  => "ProvisioningManagerForeman",
-          :dependent   => :destroy
+          :dependent   => :destroy,
+          :autosave    => true
 
-  before_create :build_managers
+  before_validation :ensure_managers
+
+  validates :name, :presence => true, :uniqueness => true
 
   def connection_attrs(auth_type = nil)
     {
@@ -30,8 +35,13 @@ class ProviderForeman < Provider
 
   private
 
-  def build_managers
+  def ensure_managers
     build_provisioning_manager unless provisioning_manager
+    provisioning_manager.name    = "Configuration Manager for Foreman Provider '#{name}'"
+    provisioning_manager.zone_id = zone_id
+
     build_configuration_manager unless configuration_manager
+    configuration_manager.name    = "Provisioning Manager for Foreman Provider '#{name}'"
+    configuration_manager.zone_id = zone_id
   end
 end

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -1,13 +1,10 @@
-class ProvisioningManager < ActiveRecord::Base
-  include EmsRefresh::Manager
-  belongs_to :provider
-
+class ProvisioningManager < ExtManagementSystem
   has_many :operating_system_flavors, :dependent => :destroy
   has_many :customization_scripts,    :dependent => :destroy
   has_many :customization_script_ptables
   has_many :customization_script_media
 
-  delegate :zone, :my_zone, :zone_name, :to => :provider
-
-  virtual_column :name,                :type => :string,      :uses => :provider
+  def hostname_ipaddress_required?
+    false
+  end
 end

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -8,3 +8,7 @@ class ProvisioningManager < ExtManagementSystem
     false
   end
 end
+
+# Preload any subclasses of this class, so that they will be part of the
+#   conditions that are generated on queries against this class.
+VMDB::Util.eager_load_subclasses('ProvisioningManager')

--- a/vmdb/app/models/provisioning_manager_foreman.rb
+++ b/vmdb/app/models/provisioning_manager_foreman.rb
@@ -1,5 +1,5 @@
 class ProvisioningManagerForeman < ProvisioningManager
-  delegate :raw_connect, :connection_attrs, :name, :to => :provider
+  delegate :raw_connect, :connection_attrs, :to => :provider
 
   def self.ems_type
     "foreman_provisioning".freeze

--- a/vmdb/db/migrate/20150224192447_add_provider_id_to_ems.rb
+++ b/vmdb/db/migrate/20150224192447_add_provider_id_to_ems.rb
@@ -1,0 +1,5 @@
+class AddProviderIdToEms < ActiveRecord::Migration
+  def change
+    add_column :ext_management_systems, :provider_id, :bigint
+  end
+end

--- a/vmdb/db/migrate/20150224192716_migrate_configuration_manager_to_ems.rb
+++ b/vmdb/db/migrate/20150224192716_migrate_configuration_manager_to_ems.rb
@@ -1,0 +1,67 @@
+class MigrateConfigurationManagerToEms < ActiveRecord::Migration
+  class ExtManagementSystem < ActiveRecord::Base
+    include UuidMixin
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ConfigurationManager < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ConfiguredSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ConfigurationProfile < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Migrating configuration_managers to ext_management_systems") do
+      systems  = ConfiguredSystem.all.group_by(&:configuration_manager_id)
+      profiles = ConfigurationProfile.all.group_by(&:configuration_manager_id)
+
+      ConfigurationManager.all.each do |manager|
+        attrs = manager.attributes.except("id")
+        attrs["created_on"] = attrs.delete("created_at")
+        attrs["updated_on"] = attrs.delete("updated_at")
+        ems = ExtManagementSystem.create!(attrs)
+
+        Array(systems.delete(manager.id)).each do |s|
+          s.update_attributes!(:configuration_manager_id => ems.id)
+        end
+
+        Array(profiles.delete(manager.id)).each do |p|
+          p.update_attributes!(:configuration_manager_id => ems.id)
+        end
+
+        manager.delete
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrating ext_management_systems to configuration_managers") do
+      systems  = ConfiguredSystem.all.group_by(&:configuration_manager_id)
+      profiles = ConfigurationProfile.all.group_by(&:configuration_manager_id)
+
+      ExtManagementSystem.where(:type => "ConfigurationManagerForeman").each do |ems|
+        attrs = ems.attributes
+        attrs["created_at"] = attrs.delete("created_on")
+        attrs["updated_at"] = attrs.delete("updated_on")
+        attrs = attrs.slice(*ConfigurationManager.column_names).except("id")
+        manager = ConfigurationManager.create!(attrs)
+
+        Array(systems.delete(ems.id)).each do |s|
+          s.update_attributes!(:configuration_manager_id => manager.id)
+        end
+
+        Array(profiles.delete(ems.id)).each do |p|
+          p.update_attributes!(:configuration_manager_id => manager.id)
+        end
+
+        ems.delete
+      end
+    end
+  end
+end

--- a/vmdb/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
+++ b/vmdb/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
@@ -1,0 +1,67 @@
+class MigrateProvisioningManagerToEms < ActiveRecord::Migration
+  class ExtManagementSystem < ActiveRecord::Base
+    include UuidMixin
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ProvisioningManager < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class OperatingSystemFlavor < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CustomizationScript < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Migrating provisioning_managers to ext_management_os_flavors") do
+      os_flavors = OperatingSystemFlavor.all.group_by(&:provisioning_manager_id)
+      scripts    = CustomizationScript.all.group_by(&:provisioning_manager_id)
+
+      ProvisioningManager.all.each do |manager|
+        attrs = manager.attributes.except("id")
+        attrs["created_on"] = attrs.delete("created_at")
+        attrs["updated_on"] = attrs.delete("updated_at")
+        ems = ExtManagementSystem.create!(attrs)
+
+        Array(os_flavors.delete(manager.id)).each do |f|
+          f.update_attributes!(:provisioning_manager_id => ems.id)
+        end
+
+        Array(scripts.delete(manager.id)).each do |s|
+          s.update_attributes!(:provisioning_manager_id => ems.id)
+        end
+
+        manager.delete
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrating ext_management_os_flavors to provisioning_managers") do
+      os_flavors = OperatingSystemFlavor.all.group_by(&:provisioning_manager_id)
+      scripts    = CustomizationScript.all.group_by(&:provisioning_manager_id)
+
+      ExtManagementSystem.where(:type => "ProvisioningManagerForeman").each do |ems|
+        attrs = ems.attributes
+        attrs["created_at"] = attrs.delete("created_on")
+        attrs["updated_at"] = attrs.delete("updated_on")
+        attrs = attrs.slice(*ProvisioningManager.column_names).except("id")
+        manager = ProvisioningManager.create!(attrs)
+
+        Array(os_flavors.delete(ems.id)).each do |f|
+          f.update_attributes!(:provisioning_manager_id => manager.id)
+        end
+
+        Array(scripts.delete(ems.id)).each do |s|
+          s.update_attributes!(:provisioning_manager_id => manager.id)
+        end
+
+        ems.delete
+      end
+    end
+  end
+end

--- a/vmdb/db/migrate/20150224193752_drop_configration_manager_and_provisioning_manager.rb
+++ b/vmdb/db/migrate/20150224193752_drop_configration_manager_and_provisioning_manager.rb
@@ -1,0 +1,33 @@
+class DropConfigrationManagerAndProvisioningManager < ActiveRecord::Migration
+  def up
+    remove_index :configuration_managers, :provider_id
+    drop_table   :configuration_managers
+
+    remove_index :provisioning_managers, :provider_id
+    drop_table   :provisioning_managers
+  end
+
+  def down
+    create_table :configuration_managers do |t|
+      t.string   :type
+      t.bigint   :provider_id
+      t.datetime :created_at
+      t.datetime :updated_at
+      t.text     :last_refresh_error
+      t.datetime :last_refresh_date
+    end
+
+    add_index :configuration_managers, :provider_id
+
+    create_table :provisioning_managers do |t|
+      t.string   :type
+      t.bigint   :provider_id
+      t.datetime :created_at
+      t.datetime :updated_at
+      t.text     :last_refresh_error
+      t.datetime :last_refresh_date
+    end
+
+    add_index :provisioning_managers, :provider_id
+  end
+end

--- a/vmdb/spec/factories/ext_management_system.rb
+++ b/vmdb/spec/factories/ext_management_system.rb
@@ -6,7 +6,26 @@ FactoryGirl.define do
     guid                 { MiqUUID.new_guid }
   end
 
-  factory :ems_vmware, :class => "EmsVmware", :parent => :ext_management_system do
+  # Intermediate classes
+
+  factory :ems_infra, :class => "EmsInfra", :parent => :ext_management_system do
+  end
+
+  factory :ems_cloud, :class => "EmsCloud", :parent => :ext_management_system do
+  end
+
+  factory :ems_container, :class => "EmsContainer", :parent => :ext_management_system do
+  end
+
+  factory :configuration_manager, :class => "ConfigurationManager", :parent => :ext_management_system do
+  end
+
+  factory :provisioning_manager, :class => "ProvisioningManager", :parent => :ext_management_system do
+  end
+
+  # Leaf classes for ems_infra
+
+  factory :ems_vmware, :class => "EmsVmware", :parent => :ems_infra do
   end
 
   factory :ems_vmware_with_authentication, :parent => :ems_vmware do
@@ -15,7 +34,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :ems_microsoft, :class => "EmsMicrosoft", :parent => :ext_management_system do
+  factory :ems_microsoft, :class => "EmsMicrosoft", :parent => :ems_infra do
   end
 
   factory :ems_microsoft_with_authentication, :parent => :ems_microsoft do
@@ -24,7 +43,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :ems_redhat, :class => "EmsRedhat", :parent => :ext_management_system do
+  factory :ems_redhat, :class => "EmsRedhat", :parent => :ems_infra do
   end
 
   factory :ems_redhat_with_authentication, :parent => :ems_redhat do
@@ -33,7 +52,19 @@ FactoryGirl.define do
     end
   end
 
-  factory :ems_amazon, :class => "EmsAmazon", :parent => :ext_management_system do
+  factory :ems_openstack_infra, :class => "EmsOpenstackInfra", :parent => :ems_infra do
+  end
+
+  factory :ems_openstack_infra_with_authentication, :parent => :ems_openstack_infra do
+    after :create do |x|
+      x.authentications << FactoryGirl.create(:authentication, :userid => "admin", :password => "123456789")
+      x.authentications << FactoryGirl.create(:authentication, :userid => "qpid_user", :password => "qpid_password", :authtype => "amqp")
+    end
+  end
+
+  # Leaf classes for ems_cloud
+
+  factory :ems_amazon, :class => "EmsAmazon", :parent => :ems_cloud do
     provider_region "us-east-1"
   end
 
@@ -49,7 +80,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :ems_openstack, :class => "EmsOpenstack", :parent => :ext_management_system do
+  factory :ems_openstack, :class => "EmsOpenstack", :parent => :ems_cloud do
   end
 
   factory :ems_openstack_with_authentication, :parent => :ems_openstack do
@@ -59,16 +90,30 @@ FactoryGirl.define do
     end
   end
 
-  factory :ems_openstack_infra, :class => "EmsOpenstackInfra", :parent => :ext_management_system do
+  # Leaf classes for ems_container
+
+  factory :ems_kubernetes, :class => "EmsKubernetes", :parent => :ems_container do
   end
 
-  factory :ems_openstack_infra_with_authentication, :parent => :ems_openstack_infra do
+  # Leaf classes for configuration_manager
+
+  factory :configuration_manager_foreman, :class => "ConfigurationManagerForeman", :parent => :configuration_manager do
+  end
+
+  factory :configuration_manager_foreman_with_authentication, :parent => :configuration_manager_foreman do
     after :create do |x|
-      x.authentications << FactoryGirl.create(:authentication, :userid => "admin", :password => "123456789")
-      x.authentications << FactoryGirl.create(:authentication, :userid => "qpid_user", :password => "qpid_password", :authtype => "amqp")
+      x.authentications << FactoryGirl.create(:authentication)
     end
   end
 
-  factory :ems_kubernetes, :class => "EmsKubernetes", :parent => :ext_management_system do
+  # Leaf classes for provisioning_manager
+
+  factory :provisioning_manager_foreman, :class => "ProvisioningManagerForeman", :parent => :provisioning_manager do
+  end
+
+  factory :provisioning_manager_foreman_with_authentication, :parent => :provisioning_manager_foreman do
+    after :create do |x|
+      x.authentications << FactoryGirl.create(:authentication)
+    end
   end
 end

--- a/vmdb/spec/factories/provider.rb
+++ b/vmdb/spec/factories/provider.rb
@@ -1,6 +1,12 @@
 FactoryGirl.define do
-  factory :provider_foreman do
+  factory :provider do
+    sequence(:name) { |n| "provider_#{seq_padded_for_sorting(n)}" }
+    guid            { MiqUUID.new_guid }
+  end
+
+  factory :provider_foreman, :class => "ProviderForeman", :parent => :provider do
     url "example.com"
+
     after(:build) do |provider|
       provider.authentications << FactoryGirl.build(:authentication,
                                                     :userid   => "admin",

--- a/vmdb/spec/migrations/20150224192716_migrate_configuration_manager_to_ems_spec.rb
+++ b/vmdb/spec/migrations/20150224192716_migrate_configuration_manager_to_ems_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150224192716_migrate_configuration_manager_to_ems")
+
+describe MigrateConfigurationManagerToEms do
+  let(:config_manager_stub) { migration_stub(:ConfigurationManager) }
+  let(:config_system_stub)  { migration_stub(:ConfiguredSystem) }
+  let(:config_profile_stub) { migration_stub(:ConfigurationProfile) }
+  let(:ems_stub)            { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it "migrates configuration_managers to ext_management_systems" do
+      manager = config_manager_stub.create!(
+        :type               => "ConfigurationManagerForeman",
+        :provider_id        => 99,
+        :last_refresh_error => "xxx",
+        :last_refresh_date  => Time.now.utc
+      )
+      systems = 2.times.collect do
+        config_system_stub.create!(:configuration_manager_id => manager.id)
+      end
+      profiles = 2.times.collect do
+        config_profile_stub.create!(:configuration_manager_id => manager.id)
+      end
+
+      migrate
+
+      expect(ems_stub.count).to eq(1)
+      ems = ems_stub.first
+      expect(ems).to have_attributes(
+        manager.attributes.slice(
+          "type", "provider_id", "last_refresh_error", "last_refresh_date"
+        )
+      )
+      expect(ems.guid).to_not be_nil
+
+      systems.each do |s|
+        expect(s.reload.configuration_manager_id).to eq(ems.id)
+      end
+
+      profiles.each do |p|
+        expect(p.reload.configuration_manager_id).to eq(ems.id)
+      end
+    end
+  end
+
+  migration_context :down do
+    it "migrates ext_management_systems to configuration_managers" do
+      ems = ems_stub.create!(
+        :type               => "ConfigurationManagerForeman",
+        :provider_id        => 99,
+        :last_refresh_error => "xxx",
+        :last_refresh_date  => Time.now.utc
+      )
+      systems = 2.times.collect do
+        config_system_stub.create!(:configuration_manager_id => ems.id)
+      end
+      profiles = 2.times.collect do
+        config_profile_stub.create!(:configuration_manager_id => ems.id)
+      end
+
+      migrate
+
+      expect(config_manager_stub.count).to eq(1)
+      manager = config_manager_stub.first
+      expect(manager).to have_attributes(
+        ems.attributes.slice(
+          "type", "provider_id", "last_refresh_error", "last_refresh_date"
+        )
+      )
+
+      systems.each do |s|
+        expect(s.reload.configuration_manager_id).to eq(manager.id)
+      end
+
+      profiles.each do |p|
+        expect(p.reload.configuration_manager_id).to eq(manager.id)
+      end
+    end
+  end
+end

--- a/vmdb/spec/migrations/20150224192816_migrate_provisioning_manager_to_ems_spec.rb
+++ b/vmdb/spec/migrations/20150224192816_migrate_provisioning_manager_to_ems_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150224192816_migrate_provisioning_manager_to_ems")
+
+describe MigrateProvisioningManagerToEms do
+  let(:prov_manager_stub) { migration_stub(:ProvisioningManager) }
+  let(:os_flavor_stub)    { migration_stub(:OperatingSystemFlavor) }
+  let(:cust_script_stub)  { migration_stub(:CustomizationScript) }
+  let(:ems_stub)          { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it "migrates provisioning_managers to ext_management_systems" do
+      manager = prov_manager_stub.create!(
+        :type               => "ProvisioningManagerForeman",
+        :provider_id        => 99,
+        :last_refresh_error => "xxx",
+        :last_refresh_date  => Time.now.utc
+      )
+      os_flavors = 2.times.collect do
+        os_flavor_stub.create!(:provisioning_manager_id => manager.id)
+      end
+      scripts = 2.times.collect do
+        cust_script_stub.create!(:provisioning_manager_id => manager.id)
+      end
+
+      migrate
+
+      expect(ems_stub.count).to eq(1)
+      ems = ems_stub.first
+      expect(ems).to have_attributes(
+        manager.attributes.slice(
+          "type", "provider_id", "last_refresh_error", "last_refresh_date"
+        )
+      )
+      expect(ems.guid).to_not be_nil
+
+      os_flavors.each do |f|
+        expect(f.reload.provisioning_manager_id).to eq(ems.id)
+      end
+
+      scripts.each do |s|
+        expect(s.reload.provisioning_manager_id).to eq(ems.id)
+      end
+    end
+  end
+
+  migration_context :down do
+    it "migrates ext_management_systems to provisioning_managers" do
+      ems = ems_stub.create!(
+        :type               => "ProvisioningManagerForeman",
+        :provider_id        => 99,
+        :last_refresh_error => "xxx",
+        :last_refresh_date  => Time.now.utc
+      )
+      os_flavors = 2.times.collect do
+        os_flavor_stub.create!(:provisioning_manager_id => ems.id)
+      end
+      scripts = 2.times.collect do
+        cust_script_stub.create!(:provisioning_manager_id => ems.id)
+      end
+
+      migrate
+
+      expect(prov_manager_stub.count).to eq(1)
+      manager = prov_manager_stub.first
+      expect(manager).to have_attributes(
+        ems.attributes.slice(
+          "type", "provider_id", "last_refresh_error", "last_refresh_date"
+        )
+      )
+
+      os_flavors.each do |f|
+        expect(f.reload.provisioning_manager_id).to eq(manager.id)
+      end
+
+      scripts.each do |s|
+        expect(s.reload.provisioning_manager_id).to eq(manager.id)
+      end
+    end
+  end
+end

--- a/vmdb/spec/models/ext_management_system_spec.rb
+++ b/vmdb/spec/models/ext_management_system_spec.rb
@@ -8,32 +8,26 @@ describe ExtManagementSystem do
     described_class.model_name_from_emstype('foo').should be_nil
   end
 
-  it ".types" do
-    expected_types =  [
-      "vmwarews",
-      "ec2",
-      "scvmm",
-      "rhevm",
-      "openstack",
-      "openstack_infra",
-      "kubernetes"
-    ]
+  let(:all_types) do
+    %w(
+      ec2
+      foreman_configuration
+      foreman_provisioning
+      kubernetes
+      openstack
+      openstack_infra
+      rhevm
+      scvmm
+      vmwarews
+    )
+  end
 
-    described_class.types.should match_array(expected_types)
+  it ".types" do
+    described_class.types.should match_array(all_types)
   end
 
   it ".supported_types" do
-    expected_types =  [
-      "vmwarews",
-      "ec2",
-      "rhevm",
-      "scvmm",
-      "openstack",
-      "openstack_infra",
-      "kubernetes"
-    ]
-
-    described_class.supported_types.should match_array(expected_types)
+    described_class.supported_types.should match_array(all_types)
   end
 
   it ".ems_discovery_types" do

--- a/vmdb/spec/models/ext_management_system_spec.rb
+++ b/vmdb/spec/models/ext_management_system_spec.rb
@@ -107,47 +107,49 @@ describe ExtManagementSystem do
   end
 
   context "validates" do
-    described_class.leaf_subclasses.collect{|ems| ems.name.underscore.to_sym}.each do |t|
-      next if t == :ems_amazon # Amazon is tested in ems_amazon_spec.rb
+    described_class.leaf_subclasses.each do |ems|
+      next if ems == EmsAmazon # Amazon is tested in ems_amazon_spec.rb
+      t = ems.name.underscore
 
-      context "for #{t}" do
+      context "for #{ems}" do
 
         it "name" do
           expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
           expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "2.2.2.2", :hostname => "ems_2") }.to     raise_error
         end
 
-        context "ipaddress" do
-          it "duplicate ipaddress" do
-            expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
-            expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_2") }.to     raise_error
+        if ems.new.hostname_ipaddress_required?
+          context "ipaddress" do
+            it "duplicate ipaddress" do
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_2") }.to     raise_error
+            end
+
+            it "blank ipaddress" do
+              expect { FactoryGirl.create(t, :ipaddress => "", :hostname => "ems_1") }.to raise_error
+            end
+
+            it "nil ipaddress" do
+              expect { FactoryGirl.create(t, :ipaddress => nil, :hostname => "ems_1") }.to raise_error
+            end
           end
 
-          it "blank ipaddress" do
-            expect { FactoryGirl.create(t, :ipaddress => "", :hostname => "ems_1") }.to raise_error
-          end
+          context "hostname" do
+            it "duplicate hostname" do
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "2.2.2.2", :hostname => "ems_1") }.to     raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "3.3.3.3", :hostname => "EMS_1") }.to     raise_error
+            end
 
-          it "nil ipaddress" do
-            expect { FactoryGirl.create(t, :ipaddress => nil, :hostname => "ems_1") }.to raise_error
+            it "blank hostname" do
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "") }.to raise_error
+            end
+
+            it "nil hostname" do
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => nil) }.to raise_error
+            end
           end
         end
-
-        context "hostname" do
-          it "duplicate hostname" do
-            expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
-            expect { FactoryGirl.create(t, :ipaddress => "2.2.2.2", :hostname => "ems_1") }.to     raise_error
-            expect { FactoryGirl.create(t, :ipaddress => "3.3.3.3", :hostname => "EMS_1") }.to     raise_error
-          end
-
-          it "blank hostname" do
-            expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "") }.to raise_error
-          end
-
-          it "nil hostname" do
-            expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => nil) }.to raise_error
-          end
-        end
-
       end
     end
 


### PR DESCRIPTION
This is needed because so many other things rely on EMSes that having
them separate makes the calling so much more complex.  This includes
things like workers, reporting, REST API, validations, scheduling, etc.

This commit may break reporting and/or introduce inconsistencies in
reporting, which will be fixed in follow up work.
