### PR TITLE
[WIP] Allow IPv6 address in forms

### DIFF
--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -21,6 +21,9 @@ module UiConstants
   MAX_DESC_LEN = 255        # Default maximum description length
   MAX_HOSTNAME_LEN = 255    # Default maximum host name length
 
+  # Max length of ipv6 is 45: http://stackoverflow.com/a/1076755
+  MAX_IPADDRESS_LEN = 45
+
   MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group
 
   REPORTS_FOLDER = File.join(Rails.root, "product/reports")

--- a/vmdb/app/views/ems_cloud/_form_fields.html.haml
+++ b/vmdb/app/views/ems_cloud/_form_fields.html.haml
@@ -19,5 +19,5 @@
     %td.wide
       = text_field_tag("ipaddress",
                        @edit[:new][:ipaddress],
-                       :maxlength => 15,
+                       :maxlength => MAX_IPADDRESS_LEN,
                        "data-miq_observe" => {:interval => ".5", :url => url}.to_json)

--- a/vmdb/app/views/ems_infra/_form_fields.html.haml
+++ b/vmdb/app/views/ems_infra/_form_fields.html.haml
@@ -11,5 +11,5 @@
     %td.wide
       = text_field_tag("ipaddress",
         @edit[:new][:ipaddress],
-        :maxlength => 15,
+        :maxlength => MAX_IPADDRESS_LEN,
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/vmdb/app/views/host/_form.html.haml
+++ b/vmdb/app/views/host/_form.html.haml
@@ -25,7 +25,7 @@
         %td.wide
           = text_field_tag("ipaddress",
             @edit[:new][:ipaddress],
-            :maxlength => 15,
+            :maxlength => MAX_IPADDRESS_LEN,
             "data-miq_observe" => observe)
       %tr
         %td.key=_('Custom Identifier')
@@ -47,7 +47,7 @@
         %td.wide
           = text_field_tag("ipmi_address",
             @edit[:new][:ipmi_address],
-            :maxlength => 15,
+            :maxlength => MAX_IPADDRESS_LEN,
             "data-miq_observe" => observe)
       %tr
         %td.key=_('MAC Address')

--- a/vmdb/app/views/storage_manager/_form.html.haml
+++ b/vmdb/app/views/storage_manager/_form.html.haml
@@ -34,7 +34,7 @@
       %td.wide
         = text_field_tag("ipaddress",
           @edit[:new][:ipaddress],
-          :maxlength => 15,
+          :maxlength => MAX_IPADDRESS_LEN,
           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     %tr
       %td.key=_('Port')


### PR DESCRIPTION
Remove hardcoded 15 length, use a constant defaulted to 45.
Max length of ipv6 is 45: http://stackoverflow.com/a/1076755