### PR TITLE
Force encoding of Qcow magic.

### DIFF
--- a/lib/disk/modules/MSVSDiskProbe.rb
+++ b/lib/disk/modules/MSVSDiskProbe.rb
@@ -1,3 +1,4 @@
+# encoding: US-ASCII
 require 'MiqLargeFile'
 require 'MSCommon'
 

--- a/lib/disk/modules/QcowDiskProbe.rb
+++ b/lib/disk/modules/QcowDiskProbe.rb
@@ -1,5 +1,6 @@
+# encoding: US-ASCII
 module QcowDiskProbe
-  QCOW_MAGIC   = "QFI\xfb".force_encoding("ASCII-8BIT")
+  QCOW_MAGIC   = "QFI\xfb"
   QCOW_DISK    = "QcowDisk"
 
   def QcowDiskProbe.probe(ostruct)

--- a/lib/disk/modules/QcowDiskProbe.rb
+++ b/lib/disk/modules/QcowDiskProbe.rb
@@ -1,5 +1,5 @@
 module QcowDiskProbe
-  QCOW_MAGIC   = "QFI\xfb"
+  QCOW_MAGIC   = "QFI\xfb".force_encoding("ASCII-8BIT")
   QCOW_DISK    = "QcowDisk"
 
   def QcowDiskProbe.probe(ostruct)


### PR DESCRIPTION
Account for new default string encoding in Ruby 2, by
forcing the encoding of the qcow magic string.

https://bugzilla.redhat.com/show_bug.cgi?id=1198814
https://bugzilla.redhat.com/show_bug.cgi?id=1199224