### PR TITLE
Ensure contents of temporary image file are written.

### DIFF
--- a/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
+++ b/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
@@ -70,9 +70,17 @@ class MiqOpenStackImage
       :response_block => response_block
     )
 
+    tf.close
+
     checksum = rv.headers['X-Image-Meta-Checksum']
     $log.debug "#{log_pref}: Checksum: #{checksum}" if $log.debug?
     $log.debug "#{log_pref}: #{`ls -l #{tf.path}`}" if $log.debug?
+
+    if tf.size != isize
+      $log.error "#{log_pref}: Error downloading image #{iname}"
+      $log.error "#{log_pref}: Downloaded size does not match image size #{tf.size} != #{isize}"
+      raise "Image download failed"
+    end
 
     return tf
   end


### PR DESCRIPTION
Ensure the contents of the downloaded image file are flushed
to disk before opening the file for fleecing.

https://bugzilla.redhat.com/show_bug.cgi?id=1199240
https://bugzilla.redhat.com/show_bug.cgi?id=1199241