### PR TITLE
Removed an extra call to after_request_task_create

### DIFF
--- a/vmdb/app/models/miq_provision_request_template.rb
+++ b/vmdb/app/models/miq_provision_request_template.rb
@@ -21,7 +21,6 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
         task.options[:owner_last_name]  = user.last_name
       end
       task.save!
-      task.after_request_task_create
       service_task.miq_request.miq_request_tasks << task
 
       tasks << task


### PR DESCRIPTION
Removed an extra call to after_request_task_create since
create_request_task already calls after_request_task_create.
after_request_task_create was responsible for setting the vmname.
Since it got called twice it increments in even increments, so
the vms created via services with $n{x} notation would always start
as 002 and then increment by 2.

https://bugzilla.redhat.com/show_bug.cgi?id=1195754