### PR TITLE
Fixed bug in expression editor

### DIFF
--- a/vmdb/app/controllers/application_controller/filter.rb
+++ b/vmdb/app/controllers/application_controller/filter.rb
@@ -274,8 +274,8 @@ module ApplicationController::Filter
             @edit[@expkey][:exp_field] = nil
             @edit[@expkey][:exp_skey] = nil
           end
-          if @edit[@expkey][:exp_cfield] != nil &&  # Clear expression check portion
-              (@edit[@expkey][:exp_field] == @edit[@expkey][:exp_cfield] || # if find field matches check field
+          if (@edit[@expkey][:exp_cfield].present? && @edit[@expkey][:exp_field].present?) &&  # Clear expression check portion
+             (@edit[@expkey][:exp_field] == @edit[@expkey][:exp_cfield] || # if find field matches check field
               @edit[@expkey][:exp_cfield].split("-").first != @edit[@expkey][:exp_field].split("-").first)  # or user chose a different table field
             @edit[@expkey][:exp_check] = "checkall"
             @edit[@expkey][:exp_cfield] = nil
@@ -392,15 +392,17 @@ module ApplicationController::Filter
     end
 
     # Check for changes in date format
-    if params[:date_format_1]
-      @edit[@expkey][:val1][:date_format] = params[:date_format_1]
-      @edit[@expkey][:exp_value].collect!{|v| v = params[:date_format_1] == "s" ? nil : EXP_TODAY}
-      @edit[@expkey][:val1][:through_choices] = exp_through_choices(@edit[@expkey][:exp_value][0]) if params[:date_format_1] == "r"
-    end
-    if params[:date_format_2]
-      @edit[@expkey][:val2][:date_format] = params[:date_format_2]
-      @edit[@expkey][:exp_cvalue].collect!{|v| v = params[:date_format_2] == "s" ? nil : EXP_TODAY}
-      @edit[@expkey][:val2][:through_choices] = exp_through_choices(@edit[@expkey][:exp_cvalue][0]) if params[:date_format_2] == "r"
+    if @edit[@expkey][:exp_value].present? && @edit[@expkey][:exp_cvalue].present?
+      if params[:date_format_1]
+        @edit[@expkey][:val1][:date_format] = params[:date_format_1]
+        @edit[@expkey][:exp_value].collect! { |_| params[:date_format_1] == "s" ? nil : EXP_TODAY }
+        @edit[@expkey][:val1][:through_choices] = exp_through_choices(@edit[@expkey][:exp_value][0]) if params[:date_format_1] == "r"
+      end
+      if params[:date_format_2]
+        @edit[@expkey][:val2][:date_format] = params[:date_format_2]
+        @edit[@expkey][:exp_cvalue].collect! { |_| params[:date_format_2] == "s" ? nil : EXP_TODAY }
+        @edit[@expkey][:val2][:through_choices] = exp_through_choices(@edit[@expkey][:exp_cvalue][0]) if params[:date_format_2] == "r"
+      end
     end
 
     # Check for suffixes changed


### PR DESCRIPTION
Fixed bug described in #1767 and other one discovered when fixing first one, causing

    [----] F, [2015-03-06T14:13:37.642954 #4333:3f96756b5e90] FATAL -- : Error caught: [NoMethodError] undefined method \`collect!' for nil:NilClass
    /home/rblanco/manageiq/vmdb/app/controllers/application_controller/filter.rb:397:in `exp_changed'

after clicking on image in expression editor (as seen on screenshot)
![screenshot-localhost 3000 2015-03-06 14-15-55](https://cloud.githubusercontent.com/assets/1187051/6525918/fc2c8abe-c40b-11e4-9f5f-82853bfab32d.png)
