### PR TITLE
add back sortable method to fix ops controller spec

### DIFF
--- a/vmdb/app/models/vmdb_database_connection.rb
+++ b/vmdb/app/models/vmdb_database_connection.rb
@@ -33,6 +33,10 @@ class VmdbDatabaseConnection < ActiveRecord::Base
 
   attr_reader :vmdb_database_id
 
+  def self.sortable?
+    false
+  end
+
   def vmdb_database_id
     @vmdb_database_id ||= self.class.vmdb_database.id
   end


### PR DESCRIPTION
I think this method went away because of a bad merge