### PR TITLE
Fix issue where media and ptables might overwrite each other.

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
@@ -14,7 +14,7 @@ module EmsRefresh
 
     def save_customization_scripts_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:customization_scripts, manager, hashes, delete_missing_records, :manager_ref)
+      save_inventory_assoc(:customization_scripts, manager, hashes, delete_missing_records, [:type, :manager_ref])
     end
 
     def save_operating_system_flavors_inventory(manager, hashes, target)


### PR DESCRIPTION
media and ptable may share manager_ref ids, but both write into the same
customization_scripts table, so we need to qualify them by type when
saving.

If we don't do this we either
- Completely don't get media entries.
- If we happen to have a database with both, from old refreshes, then
  we get record thrashing as it tries to update as media, then update
  again as ptable.

--- 

@kbrock Please review.