### PR TITLE
Removed extra "Provisioning Entry Point" field from summary screen

### DIFF
--- a/vmdb/app/views/catalog/_sandt_tree_show.html.haml
+++ b/vmdb/app/views/catalog/_sandt_tree_show.html.haml
@@ -40,8 +40,7 @@
             %td= h(@record.orchestration_manager.name)
       - entry_points = [[_("Provisioning"), :fqname]]
       - unless @record.prov_type == "generic_orchestration"
-        - entry_points.push([_("Provisioning"), :fqname],
-           [_("Reconfigure"),  :reconfigure_fqname],
+        - entry_points.push([_("Reconfigure"),  :reconfigure_fqname],
            [_("Retirement"),   :retire_fqname])
       - entry_points.each do |entry_points_op|
         %tr


### PR DESCRIPTION
@mkanoor please test.

@dclarizio please review/merge.

Before fix:
![catalog_item_before_fix](https://cloud.githubusercontent.com/assets/3450808/6536056/2453bc68-c418-11e4-9e8c-647304bafa03.png)

After fix:
![catalog_item_after](https://cloud.githubusercontent.com/assets/3450808/6536058/265a60de-c418-11e4-9b78-30bf61d6f7f2.png)
