### PR TITLE
Shorten "name" for foreman managers

### DIFF
--- a/vmdb/app/models/provider_foreman.rb
+++ b/vmdb/app/models/provider_foreman.rb
@@ -54,11 +54,11 @@ class ProviderForeman < Provider
 
   def ensure_managers
     build_provisioning_manager unless provisioning_manager
-    provisioning_manager.name    = "Configuration Manager for Foreman Provider '#{name}'"
+    provisioning_manager.name    = "#{name} Provisioning Manager"
     provisioning_manager.zone_id = zone_id
 
     build_configuration_manager unless configuration_manager
-    configuration_manager.name    = "Provisioning Manager for Foreman Provider '#{name}'"
+    configuration_manager.name    = "#{name} Configuration Manager"
     configuration_manager.zone_id = zone_id
   end
 end


### PR DESCRIPTION
Looks like the names for foreman providers are swapped.

I shortened the names while I was at it. (since it is displayed in the UI)
Let me know if you want other names.

Alt: `configuration_manager.name = name` since that is the one that is actually displayed in the UI.

/cc @AparnaKarve @Fryguy 