### PR TITLE
[api] Supporting /api/providers actions

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -41,6 +41,7 @@ class ApiController < ApplicationController
   include_concern 'Conditions'
   include_concern 'Policies'
   include_concern 'PolicyActions'
+  include_concern 'Providers'
   include_concern 'Events'
   include_concern 'ProvisionRequests'
   include_concern 'RequestTasks'

--- a/vmdb/app/controllers/api_controller/parser.rb
+++ b/vmdb/app/controllers/api_controller/parser.rb
@@ -108,6 +108,15 @@ class ApiController
       subcollection ? [subcollection.to_sym, s_id] : [collection.to_sym, c_id]
     end
 
+    def parse_id(resource, collection)
+      return nil if resource.blank?
+
+      href = resource["href"]
+      return href.match(%r{^.*/#{collection}/([0-9]+)$}) && Regexp.last_match(1) if href.present?
+
+      resource["id"].kind_of?(Integer) ? resource["id"] : nil
+    end
+
     private
 
     #

--- a/vmdb/app/controllers/api_controller/providers.rb
+++ b/vmdb/app/controllers/api_controller/providers.rb
@@ -1,7 +1,11 @@
 class ApiController
   module Providers
-    CREDENTIAL_ATTRS = %w(userid password)
-    RESTRICTED_ATTRS  = %w(type zone) + CREDENTIAL_ATTRS
+    TYPE_ATTR         = "type"
+    ZONE_ATTR         = "zone"
+    CREDENTIALS_ATTR  = "credentials"
+    AUTH_TYPE_ATTR    = "auth_type"
+    DEFAULT_AUTH_TYPE = "default"
+    RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"]
 
     def create_resource_providers(type, _id, data = {})
       if data.key?("id") || data.key?("href")
@@ -14,7 +18,7 @@ class ApiController
 
     def edit_resource_providers(type, id = nil, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
-      raise BadRequestError, "Provider type cannot be updated" if data.key?("type")
+      raise BadRequestError, "Provider type cannot be updated" if data.key?(TYPE_ATTR)
 
       klass = collection_config[:providers][:klass].constantize
       provider = resource_search(id, type, klass)
@@ -50,22 +54,24 @@ class ApiController
     end
 
     def fetch_provider_klass(klass, data)
-      supported_types = klass.supported_types.join(", ")
+      supported_types = klass.supported_subclasses.collect(&:name)
+      types_string    = supported_types.join(", ")
+      unless data.key?(TYPE_ATTR)
+        raise BadRequestError, "Must specify a provider type, supported types are: #{types_string}"
+      end
 
-      unless data.key?("type")
-        raise BadRequestError, "Must specify a provider type, supported types are: #{supported_types}"
+      type = data[TYPE_ATTR]
+      unless supported_types.include?(type)
+        raise BadRequestError, "Invalid provider type #{type} specified, supported types are: #{types_string}"
       end
-      type = data["type"]
-      unless klass.supported_types.include?(type)
-        raise BadRequestError, "Invalid provider type #{type} specified, supported types are: #{supported_types}"
-      end
-      klass.supported_subclasses.detect { |p| p.ems_type == data["type"] }
+      klass.supported_subclasses.detect { |p| p.name == data[TYPE_ATTR] }
     end
 
     def create_provider(data)
       klass = collection_config[:providers][:klass].constantize
-      provider_data = data.except(*RESTRICTED_ATTRS).merge(:zone => Zone.default_zone)
-      provider = fetch_provider_klass(klass, data).create!(provider_data)
+      provider_klass = fetch_provider_klass(klass, data)
+      create_data    = fetch_provider_data(provider_klass, data, :requires_zone => true)
+      provider       = provider_klass.create!(create_data)
       update_provider_authentication(provider, data)
       provider
     rescue => err
@@ -74,7 +80,7 @@ class ApiController
     end
 
     def edit_provider(provider, data)
-      update_data = data.except(*RESTRICTED_ATTRS)
+      update_data = fetch_provider_data(provider.class, data)
       provider.update_attributes(update_data) if update_data.present?
       update_provider_authentication(provider, data)
       provider
@@ -99,8 +105,57 @@ class ApiController
     end
 
     def update_provider_authentication(provider, data)
-      credentials = data.slice(*CREDENTIAL_ATTRS)
-      provider.update_authentication(:default => credentials.symbolize_keys!) if credentials.present?
+      credentials = data[CREDENTIALS_ATTR]
+      return if credentials.blank?
+      all_credentials = Array.wrap(credentials).each_with_object({}) do |creds, hash|
+        auth_type, creds = validate_auth_type(provider, creds)
+        validate_credential_attributes(provider, creds)
+        hash[auth_type.to_sym] = creds.symbolize_keys!
+      end
+      provider.update_authentication(all_credentials) if all_credentials.present?
+    end
+
+    def validate_auth_type(provider, creds)
+      auth_type  = creds.delete(AUTH_TYPE_ATTR) || DEFAULT_AUTH_TYPE
+      auth_types = provider.respond_to?(:supported_auth_types) ? provider.supported_auth_types : [DEFAULT_AUTH_TYPE]
+      unless auth_types.include?(auth_type)
+        raise BadRequestError, format("Unsupported authentication type %s specified, %s supports: %s",
+                                      auth_type, provider.class.name, auth_types.join(", "))
+      end
+      [auth_type, creds]
+    end
+
+    def validate_credential_attributes(provider, creds)
+      auth_attrs    = provider.supported_auth_attributes
+      invalid_attrs = creds.keys - auth_attrs
+      return if invalid_attrs.blank?
+      raise BadRequestError, format("Unsupported credential attributes %s specified, %s supports: %s",
+                                    invalid_attrs.join(', '), provider.class.name, auth_attrs.join(", "))
+    end
+
+    def fetch_provider_data(provider_klass, data, options = {})
+      provider_data = data.except(*RESTRICTED_ATTRS)
+      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys
+      raise BadRequestError, "Invalid Provider attributes #{invalid_keys.join(', ')} specified" if invalid_keys.present?
+
+      specify_zone(provider_data, data, options)
+      provider_data
+    end
+
+    def specify_zone(provider_data, data, options)
+      if data[ZONE_ATTR].present?
+        provider_data[ZONE_ATTR] = fetch_zone(data)
+      elsif options[:requires_zone]
+        provider_data[ZONE_ATTR] = Zone.default_zone
+      end
+    end
+
+    def fetch_zone(data)
+      return unless data[ZONE_ATTR].present?
+
+      zone_id = parse_id(data[ZONE_ATTR], :zone)
+      raise BadRequestError, "Missing zone href or id" if zone_id.nil?
+      resource_search(zone_id, :zone, Zone)   # Only support Rbac allowed zone
     end
   end
 end

--- a/vmdb/app/controllers/api_controller/providers.rb
+++ b/vmdb/app/controllers/api_controller/providers.rb
@@ -1,0 +1,106 @@
+class ApiController
+  module Providers
+    CREDENTIAL_ATTRS = %w(userid password)
+    RESTRICTED_ATTRS  = %w(type zone) + CREDENTIAL_ATTRS
+
+    def create_resource_providers(type, _id, data = {})
+      if data.key?("id") || data.key?("href")
+        raise BadRequestError,
+              "Resource id or href should not be specified for creating a new #{type}"
+      end
+
+      create_provider(data)
+    end
+
+    def edit_resource_providers(type, id = nil, data = {})
+      raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
+      raise BadRequestError, "Provider type cannot be updated" if data.key?("type")
+
+      klass = collection_config[:providers][:klass].constantize
+      provider = resource_search(id, type, klass)
+      edit_provider(provider, data)
+    end
+
+    def refresh_resource_providers(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for refreshing a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        provider = resource_search(id, type, klass)
+        api_log_info("Refreshing #{provider_ident(provider)}")
+
+        refresh_provider(provider)
+      end
+    end
+
+    def delete_resource_providers(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        provider = resource_search(id, type, klass)
+        api_log_info("Deleting #{provider_ident(provider)}")
+
+        destroy_provider(provider)
+      end
+    end
+
+    private
+
+    def provider_ident(provider)
+      "Provider id:#{provider.id} name:'#{provider.name}'"
+    end
+
+    def fetch_provider_klass(klass, data)
+      supported_types = klass.supported_types.join(", ")
+
+      unless data.key?("type")
+        raise BadRequestError, "Must specify a provider type, supported types are: #{supported_types}"
+      end
+      type = data["type"]
+      unless klass.supported_types.include?(type)
+        raise BadRequestError, "Invalid provider type #{type} specified, supported types are: #{supported_types}"
+      end
+      klass.supported_subclasses.detect { |p| p.ems_type == data["type"] }
+    end
+
+    def create_provider(data)
+      klass = collection_config[:providers][:klass].constantize
+      provider_data = data.except(*RESTRICTED_ATTRS).merge(:zone => Zone.default_zone)
+      provider = fetch_provider_klass(klass, data).create!(provider_data)
+      update_provider_authentication(provider, data)
+      provider
+    rescue => err
+      provider.destroy if provider
+      raise BadRequestError, "Could not create the new provider - #{err}"
+    end
+
+    def edit_provider(provider, data)
+      update_data = data.except(*RESTRICTED_ATTRS)
+      provider.update_attributes(update_data) if update_data.present?
+      update_provider_authentication(provider, data)
+      provider
+    rescue => err
+      raise BadRequestError, "Could not update the provider - #{err}"
+    end
+
+    def refresh_provider(provider)
+      desc = "#{provider_ident(provider)} refreshing"
+      provider.refresh_ems
+      action_result(true, desc)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def destroy_provider(provider)
+      desc = "#{provider_ident(provider)} deleting"
+      task_id = queue_object_action(provider, desc, :method_name => "destroy")
+      action_result(true, desc, :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def update_provider_authentication(provider, data)
+      credentials = data.slice(*CREDENTIAL_ATTRS)
+      provider.update_authentication(:default => credentials.symbolize_keys!) if credentials.present?
+    end
+  end
+end

--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -13,8 +13,12 @@ class EmsOpenstack < EmsCloud
     true
   end
 
+  def supported_auth_types
+    %w(default amqp)
+  end
+
   def supports_authentication?(authtype)
-    %w(default amqp).include?(authtype.to_s)
+    supported_auth_types.include?(authtype.to_s)
   end
 
   #

--- a/vmdb/app/models/ems_openstack_infra.rb
+++ b/vmdb/app/models/ems_openstack_infra.rb
@@ -15,8 +15,12 @@ class EmsOpenstackInfra < EmsInfra
     true
   end
 
+  def supported_auth_types
+    %w(default amqp)
+  end
+
   def supports_authentication?(authtype)
-    %w(default amqp).include?(authtype.to_s)
+    supported_auth_types.include?(authtype.to_s)
   end
 
   def self.event_monitor_class

--- a/vmdb/app/models/ems_redhat.rb
+++ b/vmdb/app/models/ems_redhat.rb
@@ -11,8 +11,12 @@ class EmsRedhat < EmsInfra
     true
   end
 
+  def supported_auth_types
+    %w(default metrics)
+  end
+
   def supports_authentication?(authtype)
-    %w(default metrics).include?(authtype.to_s)
+    supported_auth_types.include?(authtype.to_s)
   end
 
   def self.raw_connect(server, port, username, password, service = "Service")

--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -14,6 +14,10 @@ module AuthenticationMixin
     end
   end
 
+  def supported_auth_attributes
+    %w(userid password)
+  end
+
   def authentication_userid_passwords
     authentications.select { |a| a.kind_of?(AuthUseridPassword) }
   end

--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -351,7 +351,7 @@
     :description: Providers
     :options:
     - :collection
-    :methods: *70174834085860
+    :methods: *70174834085620
     :klass: ExtManagementSystem
     :subcollections:
     - :tags
@@ -359,26 +359,22 @@
     - :policy_profiles
     :collection_actions:
       :post:
-      - :name: add
+      - :name: create
         :identifier: ems_infra_new
-        :disabled: true
       - :name: edit
         :identifier: ems_infra_edit
-        :disabled: true
       - :name: refresh
         :identifier: ems_infra_refresh
-        :disabled: true
       - :name: delete
         :identifier: ems_infra_delete
-        :disabled: true
     :resource_actions:
       :post:
       - :name: edit
         :identifier: ems_infra_edit
-        :disabled: true
       - :name: refresh
+        :identifier: ems_infra_refresh
+      - :name: delete
         :identifier: ems_infra_delete
-        :disabled: true
       :delete:
       - :name: delete
         :identifier: ems_infra_delete


### PR DESCRIPTION
- Enabling POST & DELETE verbs
- supporting provider "create" action
- renaming "add" to "create" method, supporting non action based POSTS.
- supporting provider "edit" action
- supporting provider "refresh" action
- supporting provider "delete" action in async mode