### PR TITLE
Add EMS Refresh worker for Kubernetes.

### DIFF
--- a/vmdb/app/models/miq_ems_refresh_worker_kubernetes.rb
+++ b/vmdb/app/models/miq_ems_refresh_worker_kubernetes.rb
@@ -1,0 +1,5 @@
+class MiqEmsRefreshWorkerKubernetes < MiqEmsRefreshWorker
+  def self.ems_class
+    EmsKubernetes
+  end
+end

--- a/vmdb/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/vmdb/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -12,6 +12,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqEmsRefreshWorkerAmazon
     MiqEmsRefreshWorkerForemanConfiguration
     MiqEmsRefreshWorkerForemanProvisioning
+    MiqEmsRefreshWorkerKubernetes
     MiqEmsRefreshWorkerMicrosoft
     MiqEmsRefreshWorkerRedhat
     MiqEmsRefreshWorkerOpenstack
@@ -58,6 +59,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqEmsRefreshWorkerAmazon
     MiqEmsRefreshWorkerForemanConfiguration
     MiqEmsRefreshWorkerForemanProvisioning
+    MiqEmsRefreshWorkerKubernetes
     MiqEmsRefreshWorkerMicrosoft
     MiqEmsRefreshWorkerRedhat
     MiqEmsRefreshWorkerOpenstack

--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -332,6 +332,7 @@ workers:
         :ems_refresh_worker_amazon: {}
         :ems_refresh_worker_foreman_configuration: {}
         :ems_refresh_worker_foreman_provisioning: {}
+        :ems_refresh_worker_kubernetes: {}
         :ems_refresh_worker_microsoft: {}
         :ems_refresh_worker_redhat: {}
         :ems_refresh_worker_openstack: {}

--- a/vmdb/lib/workers/ems_refresh_worker_kubernetes.rb
+++ b/vmdb/lib/workers/ems_refresh_worker_kubernetes.rb
@@ -1,0 +1,4 @@
+require 'workers/ems_refresh_worker'
+
+class EmsRefreshWorkerKubernetes < EmsRefreshWorker
+end


### PR DESCRIPTION
@abonas Please review.

I noticed we did not have the refresh workers in place for Kube so I added them.  I don't have an environment to test, so if you could, please do.  Simplest way to test is:

- Run `MIQ_SPARTAN=minimal:ems_inventory bundle exec rake evm:start`
- wait until workers start
- tail the evm.log
- Go into rails console
- Run `EmsRefresh.queue_refresh(EmsKubernetes.first)`
- Watch the log and see if the refresh goes through without any errors
