### PR TITLE
Default to using the openstack hostname for event monitoring.

### DIFF
--- a/vmdb/app/models/mixins/ems_openstack_mixin.rb
+++ b/vmdb/app/models/mixins/ems_openstack_mixin.rb
@@ -52,7 +52,7 @@ module EmsOpenstackMixin
 
   def event_monitor_options
     @event_monitor_options ||= begin
-      opts = {:hostname => self.ipaddress}
+      opts = {:hostname => self.hostname}
       opts[:port] = MiqEventCatcherOpenstack.worker_settings[:amqp_port]
       if self.has_authentication_type? :amqp
         # authentication_userid/password will happily return the "default"

--- a/vmdb/spec/models/ems_openstack_spec.rb
+++ b/vmdb/spec/models/ems_openstack_spec.rb
@@ -44,4 +44,11 @@ describe EmsOpenstack do
     end
   end
 
+  it "event_monitor_options" do
+    MiqEventCatcherOpenstack.stub(:worker_settings => {:amqp_port => 1234})
+    @ems = FactoryGirl.build(:ems_openstack, :hostname => "host", :ipaddress => "::1")
+    require 'openstack/openstack_event_monitor'
+
+    @ems.event_monitor_options.should == {:hostname => "host", :port => 1234}
+  end
 end


### PR DESCRIPTION
Related to #1936 and #1800

We need to use the hostname column and not the ipaddress.  Users can specify an ipv4/ipv6 address in the hostname column if they need to get around DNS issues or other issues.

We originally defaulted to ipaddress with this code in 99d6c2dd8f6:

```ruby
  def event_monitor_available?
    begin
      require 'openstack/openstack_event_monitor'
      options = {}
      options[:username] = self.authentication_userid(:amqp)
      options[:password] = self.authentication_password(:amqp)
      options[:hostname] = self.ipaddress
      OpenstackEventMonitor.available?(options)
    rescue => e
    end
  end
```

cc @blomquisg, thanks @himdel!