### PR TITLE
Appliance postgres selabel

### DIFF
--- a/lib/appliance_console/internal_database_configuration.rb
+++ b/lib/appliance_console/internal_database_configuration.rb
@@ -64,7 +64,7 @@ module ApplianceConsole
       log_and_feedback(__method__) do
         prep_database_mount_point
         run_initdb
-        relabel_postgresql_log_dir
+        relabel_postgresql_dir
         configure_postgres
         start_postgres
         create_postgres_root_user
@@ -183,8 +183,8 @@ module ApplianceConsole
       AwesomeSpawn.run("su", :params => {"-" => nil, nil => "postgres", "-c" => "#{SCL_ENABLE_PREFIX} \"#{cmd}\""})
     end
 
-    def relabel_postgresql_log_dir
-      LinuxAdmin.run!("/sbin/restorecon -R -v #{DATABASE_DISK_MOUNT_POINT.join('pg_log')}")
+    def relabel_postgresql_dir
+      LinuxAdmin.run!("/sbin/restorecon -R -v #{DATABASE_DISK_MOUNT_POINT}")
     end
   end
 end


### PR DESCRIPTION
The selinux labels have been fixed for the collections version of postgres.
We needed to remove one of the labels, thinking we should just remove the second.

1. After mounting the postgres volume, relabel all of the postgres, not just the log directory.
2. ~~Setup the selinux labels to match the suggested install.~~

~~@jrafanie do you remember why we have the selinux label on `pg_log`? Is this to support log rotation or something else?~~ answer: Yes, for `logrotate`

[skip ci]

**UPDATE:** not changing label, just changing directory that is relabeled (will change log directory later)