### PR TITLE
Add support for IPv6 literals in microsoft hostnames. 

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -25,9 +25,9 @@ class EmsMicrosoft < EmsInfra
     WinRM::WinRMWebService.new(auth_url, :ssl, :user => username, :pass => password, :disable_sspi => true)
   end
 
-  def self.auth_url(ipaddress, port = nil)
+  def self.auth_url(hostname, port = nil)
     port ||= 5985
-    "http://#{ipaddress}:#{port}/wsman"
+    "http://#{hostname}:#{port}/wsman"
   end
 
   def connect(options = {})
@@ -35,8 +35,8 @@ class EmsMicrosoft < EmsInfra
 
     username = options[:user] || authentication_userid(options[:auth_type])
     password = options[:pass] || authentication_password(options[:auth_type])
-    ipaddress = options[:ipaddress] || self.ipaddress
-    auth_url = self.class.auth_url(ipaddress, port)
+    hostname = options[:hostname] || self.hostname
+    auth_url = self.class.auth_url(hostname, port)
     self.class.raw_connect(username, password, auth_url)
   end
 

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -25,9 +25,14 @@ class EmsMicrosoft < EmsInfra
     WinRM::WinRMWebService.new(auth_url, :ssl, :user => username, :pass => password, :disable_sspi => true)
   end
 
+  # Utilize URI::Generic#hostname to add support for IPv6 literals
+  # TODO: simplify this once https://github.com/ruby/ruby/pull/765 lands in our ruby
   def self.auth_url(hostname, port = nil)
     port ||= 5985
-    "http://#{hostname}:#{port}/wsman"
+    require 'uri'
+    uri = URI::HTTP.build(:port => port, :path => "/wsman")
+    uri.hostname = hostname
+    uri.to_s
   end
 
   def connect(options = {})

--- a/vmdb/spec/models/ems_microsoft_spec.rb
+++ b/vmdb/spec/models/ems_microsoft_spec.rb
@@ -9,6 +9,10 @@ describe EmsMicrosoft do
     described_class.description.should == 'Microsoft System Center VMM'
   end
 
+  it ".auth_url handles ipv6" do
+    described_class.auth_url("::1").should == "http://[::1]:5985/wsman"
+  end
+
   context "#connect" do
     before do
       @e = FactoryGirl.create(:ems_microsoft, :hostname => "host", :ipaddress => "127.0.0.1")

--- a/vmdb/spec/models/ems_microsoft_spec.rb
+++ b/vmdb/spec/models/ems_microsoft_spec.rb
@@ -9,4 +9,30 @@ describe EmsMicrosoft do
     described_class.description.should == 'Microsoft System Center VMM'
   end
 
+  context "#connect" do
+    before do
+      @e = FactoryGirl.create(:ems_microsoft, :hostname => "host", :ipaddress => "127.0.0.1")
+      @e.authentications << FactoryGirl.create(:authentication, :userid => "user", :password => "pass")
+    end
+
+    it "defaults" do
+      described_class.should_receive(:raw_connect).with do |u, p, url|
+        u.should == "user"
+        p.should == "pass"
+        url.should match(/host/)
+      end
+
+      @e.connect
+    end
+
+    it "accepts overrides" do
+      described_class.should_receive(:raw_connect).with do |u, p, url|
+        u.should == "user2"
+        p.should == "pass2"
+        url.should match(/host2/)
+      end
+
+      @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
+    end
+  end
 end


### PR DESCRIPTION
Please merge after #2063 since this includes a commit from that PR.