### PR TITLE
[WIP] Show "Red Hat" not "RedHat"

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
@@ -2,7 +2,7 @@ module EmsRefresh
   module Parsers
     class OpenstackInfra < Infra
       include EmsRefresh::Parsers::OpenstackCommon::Images
-      
+
       def self.ems_inv_to_hashes(ems, options = nil)
         new(ems, options).ems_inv_to_hashes
       end
@@ -147,7 +147,7 @@ module EmsRefresh
           :ems_ref          => uid,
           :ems_ref_obj      => host.instance_uuid,
           :operating_system => {:product_name => 'linux'},
-          :vmm_vendor       => 'RedHat',
+          :vmm_vendor       => 'Red Hat',
           :vmm_product      => identify_product(indexed_resources, host.instance_uuid),
           :ipaddress        => identify_primary_ip_address(host, indexed_servers),
           :mac_address      => identify_primary_mac_address(host, indexed_servers),

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -18,7 +18,7 @@ class Host < ActiveRecord::Base
   VENDOR_TYPES = {
     # DB            Displayed
     "microsoft"       => "Microsoft",
-    "redhat"          => "RedHat",
+    "redhat"          => "Red Hat",
     "vmware"          => "VMware",
     "openstack_infra" => "OpenStack Infrastructure",
     "unknown"         => "Unknown",
@@ -631,7 +631,7 @@ class Host < ActiveRecord::Base
     begin
       if data.is_a?(Hash) && data[:type] == :ems_events
         $log.info("MIQ(host-add_elements): Adding HASH elements for Host id:[#{self.id}]-[#{self.name}] from [#{data[:type]}]")
-        add_ems_events(data) 
+        add_ems_events(data)
       end
     rescue => err
       $log.log_backtrace(err)

--- a/vmdb/app/models/miq_server/server_smart_proxy.rb
+++ b/vmdb/app/models/miq_server/server_smart_proxy.rb
@@ -116,7 +116,7 @@ module MiqServer::ServerSmartProxy
         temp_args['ems'][:use_vim_broker]      = MiqServer.use_broker_for_embedded_proxy?(temp_args['ems']['connect_to'])
         temp_args['ems'][:vim_broker_drb_port] = MiqVimBrokerWorker.drb_port if temp_args['ems'][:use_vim_broker]
         # RHEV-M setup
-        if v.vendor.to_s == 'RedHat'
+        if v.vendor.to_s == 'Red Hat'
           temp_args[:mount] = v.ext_management_system.storage_mounts_for_vm(v, ost.taskid)
           temp_args['ems']['connect'] = true if temp_args[:mount].blank?
         end

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -35,7 +35,7 @@ class VmOrTemplate < ActiveRecord::Base
     "xen"       => "XenSource",
     "parallels" => "Parallels",
     "amazon"    => "Amazon",
-    "redhat"    => "RedHat",
+    "redhat"    => "Red Hat",
     "openstack" => "OpenStack",
     "unknown"   => "Unknown"
   }
@@ -1095,7 +1095,7 @@ class VmOrTemplate < ActiveRecord::Base
     when 'VMware'
       # VM cannot be scanned by server if they are on a repository
       return [] if self.storage_id.blank? || self.repository_vm?
-    when 'RedHat'
+    when 'Red Hat'
       return [] if self.storage_id.blank?
     else
       return []
@@ -1112,9 +1112,9 @@ class VmOrTemplate < ActiveRecord::Base
     miq_servers.select do |svr|
       result = svr.status == "started" && svr.has_zone?(self.my_zone)
       result = result && svr.is_vix_disk? if vm_vendor == 'VMware'
-      # RedHat VMs must be scanned from an EVM server who's host is attached to the same
+      # Red Hat VMs must be scanned from an EVM server who's host is attached to the same
       # storage as the VM unless overridden via SmartProxy affinity
-      if vm_vendor == 'RedHat' && !svr.vm_scan_host_affinity? && !svr.vm_scan_storage_affinity?
+      if vm_vendor == 'Red Hat' && !svr.vm_scan_host_affinity? && !svr.vm_scan_storage_affinity?
         svr_vm = svr.vm
         if svr_vm && svr_vm.host
           missing_storage_ids = storages.collect(&:id) - svr_vm.host.storages.collect(&:id)
@@ -1294,7 +1294,7 @@ class VmOrTemplate < ActiveRecord::Base
     # Return location if it contains a fully-qualified file URI
     return self.location if self.location.starts_with?('file://')
     # Return location for RHEV-M VMs
-    return rhevm_config_path if self.vendor.to_s == 'RedHat'
+    return rhevm_config_path if self.vendor.to_s == 'Red Hat'
 
     case self.storage.store_type
     when "VMFS" then "[#{storage.name}] #{location}"

--- a/vmdb/app/models/vm_or_template/scanning.rb
+++ b/vmdb/app/models/vm_or_template/scanning.rb
@@ -224,7 +224,7 @@ module VmOrTemplate::Scanning
   # TODO: Vmware specfic
   def require_snapshot_for_scan?
     return false unless self.runnable?
-    return false if ['RedHat'].include?(self.vendor)
+    return false if self.vendor == 'Red Hat'
     return false if self.host && self.host.platform == "windows"
     return true
   end
@@ -393,12 +393,12 @@ module VmOrTemplate::Scanning
         bb.postSync()
         bb.close
       end
-      
+
       $log.info "#{log_pref} Starting:  Sending vm summary to server.  TaskId:[#{ost.taskid}]  VM:[#{vmName}]"
       $log.debug "#{log_pref}: xml_summary2 = #{xml_summary.class.name}"
       driver.SaveVmmetadata(vmId, xml_summary.miqEncode, "b64,zlib,xml", ost.taskid)
       $log.info "#{log_pref} Completed: Sending vm summary to server.  TaskId:[#{ost.taskid}]  VM:[#{vmName}]"
-      
+
       UpdateAgentState(driver, ost, "Synchronize", "Synchronization complete")
 
       raise syncErr if syncErr

--- a/vmdb/app/models/vm_scan.rb
+++ b/vmdb/app/models/vm_scan.rb
@@ -167,7 +167,7 @@ class VmScan < Job
 
     # Disable connecting to EMS for COS SmartProxy.  Embedded Proxy will
     # enable this if needed in the scan_sync_vm method in server_smart_proxy.rb.
-    ems_list['connect'] = false if vm.vendor.to_s == 'RedHat'
+    ems_list['connect'] = false if vm.vendor.to_s == 'Red Hat'
     ems_list
   end
 
@@ -177,7 +177,7 @@ class VmScan < Job
     # Check if Policy returned scan profiles to use, otherwise use the default profile if available.
     scan_args["vmScanProfiles"] = self.options[:scan_profiles] || vm.scan_profile_list
     scan_args['snapshot']['forceFleeceDefault'] = false if vm.scan_via_ems? && vm.template?
-    scan_args['permissions'] = { 'group' => 36 } if vm.vendor.to_s == 'RedHat'
+    scan_args['permissions'] = { 'group' => 36 } if vm.vendor.to_s == 'Red Hat'
     scan_args
   end
 

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -1,6 +1,6 @@
 ---
 :name: miq_provision_redhat_dialogs_clone_to_vm
-:description: Sample RedHat VM Clone to VM Dialog
+:description: Sample Red Hat VM Clone to VM Dialog
 :dialog_type: MiqProvisionWorkflow
 :content:
   :buttons:

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -1,6 +1,6 @@
 ---
 :name: miq_provision_redhat_dialogs_template
-:description: Sample RedHat VM Provisioning Dialog
+:description: Sample Red Hat VM Provisioning Dialog
 :dialog_type: MiqProvisionWorkflow
 :content:
   :buttons:


### PR DESCRIPTION
Updating places where the name "RedHat" shows up and attempting to replace with "Red Hat".

Questions:

1)  Are there other places I should check for?  I did a blanket grep and found that the [miq_searches](https://github.com/ManageIQ/manageiq/blob/cd428d4034b5ba070c8604d1fc08bf2c2eeb2349/vmdb/db/fixtures/miq_searches.yml) db fixture has the term "Redhat", but I'm not sure where those show up.  (search_key: _hidden_ might have something to do with them not appearing in the advanced search drop down).

2)  Should the database be migrated?  I'm guessing probably not...  I think the vendor value in the DB will be "redhat", which will be translated into "Red Hat" based on the vendor calculation in [host.rb](https://github.com/ManageIQ/manageiq/blob/1f07e39c394cf6c7e4b049c1f18418e149da9809/vmdb/app/models/host.rb) and [vm_or_template.rb](https://github.com/ManageIQ/manageiq/blob/a442fd80217106431db5652f09f402dc11d74c62/vmdb/app/models/vm_or_template.rb).

https://bugzilla.redhat.com/show_bug.cgi?id=1193249