### PR TITLE
do not store hashes in the lookup table

### DIFF
--- a/lib/util/extensions/miq-yaml.rb
+++ b/lib/util/extensions/miq-yaml.rb
@@ -7,8 +7,6 @@ module Psych
   module Visitors
     class ToRuby
       def revive_hash hash, o
-        @st[o.anchor] = hash if o.anchor
-
           o.children.each_slice(2) { |k,v|
           key = accept(k)
 


### PR DESCRIPTION
The [method we are monkey patching doesn't do it](https://github.com/tenderlove/psych/blob/22589e504eb32388b23dd9c22ed7e95cd11c845a/lib/psych/visitors/to_ruby.rb#L333-365), so we shouldn't either.  This can cause incorrect objects to be deserialized (hashes instead of objects)