### PR TITLE
Always update host name to new one

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -151,9 +151,6 @@ module EmsRefresh::SaveInventoryInfra
           ip_part  =  %r{[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+}
           ip_whole = %r{^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$}
 
-          #   Keep the previous name unless it's nil
-          h[:name] = found.name unless found.name.nil?
-
           # Keep the previous ip address if we don't have a new one or the new one is not an ip address
           h[:ipaddress] = found.ipaddress if h[:ipaddress].nil? || (h[:ipaddress] !~ ip_whole)
 


### PR DESCRIPTION
Host name should be updated if it changes in the provider.
Not sure what is the benefit of keeping it always the same.
Cause then we can have different name in VMDB and provider.