### PR TITLE
Corrected validation message in dialog editor

### DIFF
--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -685,7 +685,7 @@ module MiqAeCustomizationController::Dialogs
         res = false
       end
       if needs_entry_point?
-        add_flash(_("Entry Point must be given for field \"%s\".") %  @edit[:field_name], :error)
+        add_flash(_("Entry Point must be given."), :error)
         res = false
       end
       if @edit[:field_name].to_s !~ %r{^[a-z0-9_]+$}i


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1132125

Corrected validation message in dialog editor as described in bugzilla ticket.

I was also thinking about modifying message like
*Entry point must be given for element "`@edit[:field_label]`".*,
to specify which element is missing `Entry point`, but since user is not able to change element in editor, until he give some Entry point, I think there is no need for it.