### PR TITLE
embed DATABASE_URL into precompile assets

### DIFF
--- a/system/cfme-setup.sh
+++ b/system/cfme-setup.sh
@@ -11,7 +11,7 @@ pushd /var/www/miq/vmdb
 
   # rails compile tasks loads environment which needs above shared objects
   # There is no database.yml. Bogus database parameters appeases rails.
-  RAILS_ENV=production DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname rake evm:compile_assets
+  RAILS_ENV=production rake evm:compile_assets
 popd
 
 #this is for the black console

--- a/vmdb/lib/tasks/evm.rake
+++ b/vmdb/lib/tasks/evm.rake
@@ -36,7 +36,8 @@ namespace :evm do
     EvmApplication.update_stop
   end
 
-  task :compile_assets => :environment do
+  task :compile_assets do
+    ENV["DATABASE_URL"] ||= "postgresql://user:pass@127.0.0.1/dbname"
     Rake::Task["assets:clean"].invoke
     Rake::Task["assets:precompile"].invoke
   end


### PR DESCRIPTION
A few places precompile assets. This removes the onus on the
developer

followup to #1901

[skip ci]

This fixes issue @JPrause and @jvlcek are having with the downstream build too.

/cc @jrafanie @Fryguy This work for you guys?