### PR TITLE
In development, raise ems refresh failures

### DIFF
--- a/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -39,6 +39,7 @@ module EmsRefresh
 
             # record the failed status and skip post-processing
             ems.update_attributes(:last_refresh_error => e.to_s, :last_refresh_date => Time.now.utc)
+            raise if Rails.env.development?
             next
           ensure
             post_refresh_ems_cleanup(ems, targets)


### PR DESCRIPTION
When an ems fails refreshing, a comment goes to the log. But in development, this causes me issues and I always comment out this rescue block.

I want to see errors as they occur. Otherwise a failure sneaks by and shows itself in strange ways. Does this work for others? @dclarizio @Fryguy @blomquisg @gmcculloug 

/cc @jrafanie @brandondunne @AparnaKarve (not sure if you care)