### PR TITLE
HAML conversion fixes - syntax error in js, td in a td

### DIFF
--- a/vmdb/app/views/layouts/_show_statistics.html.haml
+++ b/vmdb/app/views/layouts/_show_statistics.html.haml
@@ -10,9 +10,9 @@
       %tr{:class => cycle('row0', 'row1')}
         %td
           = h(format_timezone(stat.statistic_time, Time.zone, "compare_hdr"))
-          - %i(k_bytes_read_per_sec k_bytes_written_per_sec k_bytes_transferred_per_sec read_ios_per_sec read_hit_ios_per_sec write_ios_per_sec write_hit_ios_per_sec total_ios_per_sec avg_read_size avg_write_size pct_read pct_write pct_hit utilization response_time_sec queue_depth service_time_sec wait_time_sec).each do |e|
-            %td{:align => "right"}
-              = h(number_with_precision(stat.send(e), :precision => 2))
+      - %i(k_bytes_read_per_sec k_bytes_written_per_sec k_bytes_transferred_per_sec read_ios_per_sec read_hit_ios_per_sec write_ios_per_sec write_hit_ios_per_sec total_ios_per_sec avg_read_size avg_write_size pct_read pct_write pct_hit utilization response_time_sec queue_depth service_time_sec wait_time_sec).each do |e|
+        %td{:align => "right"}
+          = h(number_with_precision(stat.send(e), :precision => 2))
   %tfoot
     %tr
       %td{:colspan => "40"}

--- a/vmdb/app/views/layouts/_timeline.html.haml
+++ b/vmdb/app/views/layouts/_timeline.html.haml
@@ -3,7 +3,7 @@
   - # commented this to, for a workaround to close any open bubble from previous timeline when switching between timelines
   - # var tl;
   - load_tl_now ||= false
-  var miq_timeline_filter = #{@timeline_filter}
+  var miq_timeline_filter = #{!! @timeline_filter};
   function miqLoadTL() {
   var eventSource = new Timeline.DefaultEventSource();
   - # Following works around a issue that causes timeline to not show any events in IE


### PR DESCRIPTION
Closes #1916 - `var miq_timeline_filter = ;` is not valid JS, happened when `@timeline_filter.to_s = ''`
The original code did an if ... =true / =false, so reintroduced boolification.

The change in _show_statistics puts the tds outside the first one, that's it.