### PR TITLE
auto fix double encoded config columns

### DIFF
--- a/vmdb/lib/vmdb/configuration_encoder.rb
+++ b/vmdb/lib/vmdb/configuration_encoder.rb
@@ -28,6 +28,9 @@ module Vmdb
       end
 
       hash = YAML.load(data)
+      # shouldn't be necessary: fixes issue when data was double encoded
+      hash = YAML.load(hash) if hash.kind_of?(String)
+
       symbolize!(stringify!(hash)) if symbolize_keys
 
       if block_given?


### PR DESCRIPTION
`fix_auth.rb` re-encodes all passwords in the database. Since it is reading all records, it is more sensitive to bad data than other processes.

It just got snagged by a configurations record that had double encoded yaml:

```
/Users/kbrock/src/manageiq/vmdb/lib/vmdb/configuration_encoder.rb:11:in `stringify!': undefined method `each_key' for #<String:0x007fd9e1dea388> (NoMethodError)
```

This problem was fixed. And @jrafanie introduced a db/migration to fix any data in the database. But here we are. And I've run into the problem yet again. Think this is the 3rd time in ~1.5 years.

I've used this code to fix my database. So it isn't a problem.
But was curious if we could just leave it in there for others.

/cc @Fryguy @jrafanie 