### PR TITLE
remove new records from the `deletes` list.

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -12,7 +12,7 @@ module EmsRefresh::SaveInventoryHelper
     # Delete the items no longer found
     unless deletes.blank?
       $log.info("MIQ(#{self.name}.save_#{type}_inventory) Deleting #{self.log_format_deletes(deletes)}")
-      parent.send(type).delete(deletes)
+      parent.send(type).delete(deletes - new_records)
     end
 
     # Add the new items


### PR DESCRIPTION
In Rails 4, calling `delete` will immediately delete and freeze the
records.  Those frozen records can't be saved.  The `deletes` list has
some records from `new_records` that it deletes, then attempts to save
again.  This is causing test failures on the Rails 4 branch.

Specifically:

  spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb