### PR TITLE
Microsoft VM power function fix.

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -96,7 +96,7 @@ class EmsMicrosoft < EmsInfra
     return unless vm_uid_ems.guid?
 
     params  = parameters.join(" ")
-    
+
     # TODO: If localhost could feasibly be changed to an IPv6 address such as "::1", we need to
     # wrap the IPv6 address in square brackets,  similar to the a URIs's host field, "[::1]".
     command = "powershell Import-Module VirtualMachineManager; Get-SCVMMServer localhost;\

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -96,8 +96,8 @@ class EmsMicrosoft < EmsInfra
     return unless vm_uid_ems.guid?
 
     params  = parameters.join(" ")
-    command = "powershell Import-Module VirtualMachineManager; Get-VMMServer #{ipaddress}; "
-    command += "#{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
+    command = "powershell Import-Module VirtualMachineManager; Get-SCVMMServer localhost;\
+    #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
     run_dos_command(command)
   end
 end

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -96,8 +96,11 @@ class EmsMicrosoft < EmsInfra
     return unless vm_uid_ems.guid?
 
     params  = parameters.join(" ")
+    
+    # TODO: If localhost could feasibly be changed to an IPv6 address such as "::1", we need to
+    # wrap the IPv6 address in square brackets,  similar to the a URIs's host field, "[::1]".
     command = "powershell Import-Module VirtualMachineManager; Get-SCVMMServer localhost;\
-    #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
+        #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
     run_dos_command(command)
   end
 end

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -96,7 +96,7 @@ class EmsMicrosoft < EmsInfra
     return unless vm_uid_ems.guid?
 
     params  = parameters.join(" ")
-    command = "powershell #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
+    command = "powershell Import-Module VirtualMachineManager; Get-VMMServer #{ipaddress}; #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
     run_dos_command(command)
   end
 end

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -96,7 +96,8 @@ class EmsMicrosoft < EmsInfra
     return unless vm_uid_ems.guid?
 
     params  = parameters.join(" ")
-    command = "powershell Import-Module VirtualMachineManager; Get-VMMServer #{ipaddress}; #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
+    command = "powershell Import-Module VirtualMachineManager; Get-VMMServer #{ipaddress}; "
+    command += "#{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
     run_dos_command(command)
   end
 end

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -100,7 +100,7 @@ class EmsMicrosoft < EmsInfra
     # TODO: If localhost could feasibly be changed to an IPv6 address such as "::1", we need to
     # wrap the IPv6 address in square brackets,  similar to the a URIs's host field, "[::1]".
     command = "powershell Import-Module VirtualMachineManager; Get-SCVMMServer localhost;\
-        #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
+      #{cmdlet}-SCVirtualMachine -VM (Get-SCVirtualMachine -ID #{vm_uid_ems}) #{params}"
     run_dos_command(command)
   end
 end


### PR DESCRIPTION
VM power operations failing on SCVMM 2012 SP1 provider with
‘unrecognised cmdlet’ error. PowerShell command amended to include
snap-in load and connection to provider.