### PR TITLE
Allow subclasses for per_ems_worker_mixin

### DIFF
--- a/vmdb/app/models/miq_worker.rb
+++ b/vmdb/app/models/miq_worker.rb
@@ -91,6 +91,10 @@ class MiqWorker < ActiveRecord::Base
     where(:miq_server_id => server_id)
   end
 
+  def self.no_subclasses_scope
+    where(:type => self.to_s)
+  end
+
   CONDITION_CURRENT = {:status => STATUSES_CURRENT}
   def self.find_current(server_id = nil)
     self.server_scope(server_id).where(CONDITION_CURRENT)
@@ -117,7 +121,7 @@ class MiqWorker < ActiveRecord::Base
   end
 
   def self.find_current_or_starting(server_id = nil)
-    self.server_scope(server_id).where(:status => STATUSES_CURRENT_OR_STARTING)
+    self.server_scope(server_id).no_subclasses_scope.where(:status => STATUSES_CURRENT_OR_STARTING)
   end
 
   def self.find_alive(server_id = nil)


### PR DESCRIPTION
The `PerEmsWorkerMixin.sync_workers` method calls `MiqWorker.find_current_or_starting` when determining how many workers are running of any given type.  `MiqWorker.find_current_or_starting` calls
`MiqWorker.server_scope` to find the number of workers in the database and adds a where clause to select only those that are running or starting.  However, the `MiqWorker.server_scope` method does not take into account that the worker class may have been subclassed.

This is the case with `MiqEventCatcherOpenstack` and `MiqEventCatherOpenstackInfra`.  The `MiqEventCatcherOpenstackInfra` worker is a subclass of the `MiqEventCatcherOpenstack` worker.

When the `MiqWorker.server_scope` method builds the query to find all the `MiqEventCatcherOpenstack` methods, it includes `MiqEventCatcherOpenstackInfra` because of standard ActiveRecord STI functionality.

The problem manifests itself by killing running worker subclasses.  For instance, if there is an `EmsOpenstackInfra` record (and therefore should be a `MiqEventCatcherOpenstackInfra` worker), but there is **not** an `EmsOpenstack` record (and therefore should **not** be a `MiqEventCatcherOpenstack` worker). When `MiqEventCatcherOpenstack.sync_workers` is called (during the normal course
of worker management), it will erroneously detect the `MiqEventCatcherOpenstackInfra` worker and kill it.

Changing the method to restrict by record type limits the scope to only the worker and excludes the worker's subclasses.