### PR TITLE
Fixed value of type parameter being sent upto server

### DIFF
--- a/vmdb/app/views/catalog/_form_basic_info.html.haml
+++ b/vmdb/app/views/catalog/_form_basic_info.html.haml
@@ -117,7 +117,7 @@
                 %td
                   #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
                     = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => "Remove this Retirement Entry Point"),
-                      {:action => 'ae_tree_select_discard', :typ => "retirement"},
+                      {:action => 'ae_tree_select_discard', :typ => "retire"},
                       "data-miq_sparkle_on" => true,
                       "data-miq_sparkle_off" => true,
                       "data-confirm" => _("Are you sure you want to remove this Retirement Entry Point?"),


### PR DESCRIPTION
Fixed value of type parameter being sent upto server in the "Remove this Retirement Entry Point" link, this was preventing user from removing previously saved Retirement Entry point value while editing Catalog Item.

@mkanoor can you please test.
@dclarizio please review/test.