### PR TITLE
Add dependent and persistent options into vm_add_disk method

### DIFF
--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -721,7 +721,7 @@ class MiqVimVm
 	# If backingFile is just the datastore name, "[storage 1]" for example,
 	#    file names will be generated as appropriate.
 	#
-	def addDisk(backingFile, sizeInMB, label=nil, summary=nil, thinProvisioned=false)
+	def addDisk(backingFile, sizeInMB, label=nil, summary=nil, thinProvisioned=false, dependent=false, persistent=true)
 	    ck, un = getScsiCandU
 	    raise "addDisk: no SCSI controller found" if !ck
 
@@ -749,9 +749,12 @@ class MiqVimVm
 						    con.startConnected		= "true"
 						    con.connected			= "true"
 						end
+						mode = (dependent ? 
+							  (persistent ? VirtualDiskMode::Persistent : VirtualDiskMode::Nonpersistent ) 
+							: (persistent ? VirtualDiskMode::Independent_persistent : VirtualDiskMode::Independent_nonpersistent )
+						)
 						vDev.backing = VimHash.new("VirtualDiskFlatVer2BackingInfo") do |bck|
-							# bck.diskMode = VirtualDiskMode::Independent_nonpersistent
-							bck.diskMode		= VirtualDiskMode::Independent_persistent
+							bck.diskMode		= mode
 						    bck.split			= "false"
 						    bck.thinProvisioned	= thinProvisioned.to_s
 						    bck.writeThrough	= "false"

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -756,7 +756,6 @@ class MiqVimVm
 						    con.startConnected		= "true"
 						    con.connected			= "true"
 						end
-						mode = VirtualDiskMode::Independent_persistent
 						if dependent
 							mode = (persistent ? VirtualDiskMode::Persistent : VirtualDiskMode::Nonpersistent)
 						else

--- a/vmdb/app/models/ems_vmware.rb
+++ b/vmdb/app/models/ems_vmware.rb
@@ -351,7 +351,7 @@ class EmsVmware < EmsInfra
   end
 
   def vm_add_disk(vm, options={})
-    invoke_vim_ws(:addDisk, vm, options[:user_event], options[:diskName], options[:diskSize], nil, nil, options[:thinProvisioned])
+    invoke_vim_ws(:addDisk, vm, options[:user_event], options[:diskName], options[:diskSize], nil, nil, options[:thinProvisioned], options[:dependent], options[:persistent])
   end
 
   def vm_remove_disk_by_file(vm, options={})

--- a/vmdb/app/models/ems_vmware.rb
+++ b/vmdb/app/models/ems_vmware.rb
@@ -351,7 +351,8 @@ class EmsVmware < EmsInfra
   end
 
   def vm_add_disk(vm, options={})
-    invoke_vim_ws(:addDisk, vm, options[:user_event], options[:diskName], options[:diskSize], nil, nil, options[:thinProvisioned], options[:dependent], options[:persistent])
+    invoke_vim_ws(:addDisk, vm, options[:user_event], options[:diskName], options[:diskSize], nil, nil, 
+      thin_provisioned: options[:thinProvisioned], dependent: options[:dependent], persistent: options[:persistent])
   end
 
   def vm_remove_disk_by_file(vm, options={})

--- a/vmdb/app/models/vm_or_template/operations/configuration.rb
+++ b/vmdb/app/models/vm_or_template/operations/configuration.rb
@@ -71,14 +71,14 @@ module VmOrTemplate::Operations::Configuration
     raw_disconnect_floppies
   end
 
-  def raw_add_disk(disk_name, disk_size_mb, thin_provisioned=false, dependent=false, persistent=true)
+  def raw_add_disk(disk_name, disk_size_mb, options={})
     raise "VM has no EMS, unable to add disk" unless self.ext_management_system
     run_command_via_parent(:vm_add_disk, :diskName => disk_name, :diskSize => disk_size_mb, 
-        :thinProvisioned => thin_provisioned, :dependent => dependent, :persistent => persistent)
+        :thinProvisioned => options[:thin_provisioned], :dependent => options[:dependent], :persistent => options[:persistent])
   end
 
-  def add_disk(disk_name, disk_size_mb, thin_provisioned=false, dependent=false, persistent=true)
-    raw_add_disk(disk_name, disk_size_mb, thin_provisioned, dependent, persistent)
+  def add_disk(disk_name, disk_size_mb, options={})
+    raw_add_disk(disk_name, disk_size_mb, options)
   end
 
   def spec_reconfigure(spec)

--- a/vmdb/app/models/vm_or_template/operations/configuration.rb
+++ b/vmdb/app/models/vm_or_template/operations/configuration.rb
@@ -71,13 +71,14 @@ module VmOrTemplate::Operations::Configuration
     raw_disconnect_floppies
   end
 
-  def raw_add_disk(disk_name, disk_size_mb, thin_provisioned=false)
+  def raw_add_disk(disk_name, disk_size_mb, thin_provisioned=false, dependent=false, persistent=true)
     raise "VM has no EMS, unable to add disk" unless self.ext_management_system
-    run_command_via_parent(:vm_add_disk, :diskName => disk_name, :diskSize => disk_size_mb, :thinProvisioned => thin_provisioned)
+    run_command_via_parent(:vm_add_disk, :diskName => disk_name, :diskSize => disk_size_mb, 
+        :thinProvisioned => thin_provisioned, :dependent => dependent, :persistent => persistent)
   end
 
-  def add_disk(disk_name, disk_size_mb, thin_provisioned=false)
-    raw_add_disk(disk_name, disk_size_mb, thin_provisioned)
+  def add_disk(disk_name, disk_size_mb, thin_provisioned=false, dependent=false, persistent=true)
+    raw_add_disk(disk_name, disk_size_mb, thin_provisioned, dependent, persistent)
   end
 
   def spec_reconfigure(spec)


### PR DESCRIPTION
Hello Team. One more pull request related to disks on VMware.

Current addDisk method creates new disk as VirtualDiskMode::Independent_persistent, and it's not always good.

The major issue is that independent disks can not be shapshoted live. So, if one attaches such disk to VM, this VM can not be cloned anymore without powering it off. VMware error looks like this:
<pre>
Virtual machine is configured to use a device that prevents the operation: 
com.vmware.vim.binding.vmodl.fault.SystemError: reason = This operation is not supported with virtual disks 
in independent mode or raw disk mappings in physical compatibility mode inherited from 
com.vmware.vim.binding.vmodl.fault.SystemError: A general system error occurred: This operation is not supported 
with virtual disks in independent mode or raw disk mappings in physical compatibility mode
</pre>

New parameters allow to choose disk provisioning mode in custom scripts. Default behaviour left unchanged - without new params disk is added as VirtualDiskMode::Independent_persistent.