### PR TITLE
Orchestration template tree: bring back center button toolbar

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1932,7 +1932,7 @@ module ApplicationHelper
           return center_toolbar_filename_automate
         elsif x_active_tree == :containers_tree
           return center_toolbar_filename_containers
-        elsif [:sandt_tree, :svccat_tree, :stcat_tree, :svcs_tree].include?(x_active_tree)
+        elsif [:sandt_tree, :svccat_tree, :stcat_tree, :svcs_tree, :ot_tree].include?(x_active_tree)
           return center_toolbar_filename_services
         elsif @layout == "chargeback"
           return center_toolbar_filename_chargeback


### PR DESCRIPTION
The center toolbar (the one rendering center button) was mistakenly
removed from the ot_tree with commit

    bfdf9c5e05ce8b00a75bcb2b62f1e627d954ae6b