### PR TITLE
Change retirement state machine order.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -294,30 +294,10 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: DeleteFromVMDB
-      display_name: 
-      datatype: string
-      priority: 15
-      owner: 
-      default_value: "/Cloud/VM/Retirement/StateMachines/Methods/DeleteFromVMDB"
-      substitute: true
-      message: create
-      visibility: 
-      collect: 
-      scope: 
-      description: 
-      condition: 
-      on_entry: update_retirement_status(status => 'Removing from VMDB')
-      on_exit: update_retirement_status(status => 'Removed from VMDB')
-      on_error: update_retirement_status(status => 'Error Removing from VMDB')
-      max_retries: '100'
-      max_time: 
-  - field:
-      aetype: state
       name: FinishRetirement
       display_name: 
       datatype: string
-      priority: 16
+      priority: 15
       owner: 
       default_value: "/Cloud/VM/Retirement/StateMachines/Methods/FinishRetirement"
       substitute: true
@@ -330,5 +310,25 @@ object:
       on_entry: update_retirement_status(status => 'Finishing Retirement')
       on_exit: update_retirement_status(status => 'Finished Retirement')
       on_error: update_retirement_status(status => 'Error Finishing Retirement')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: DeleteFromVMDB
+      display_name: 
+      datatype: string
+      priority: 16
+      owner: 
+      default_value: "/Cloud/VM/Retirement/StateMachines/Methods/DeleteFromVMDB"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_retirement_status(status => 'Removing from VMDB')
+      on_exit: update_retirement_status(status => 'Removed from VMDB')
+      on_error: update_retirement_status(status => 'Error Removing from VMDB')
       max_retries: '100'
       max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/default.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/default.yaml
@@ -14,5 +14,3 @@ object:
       value: "/Cloud/VM/Retirement/StateMachines/Methods/CheckRemovedFromProvider"
   - DeleteFromVMDB:
       value: "/Cloud/VM/Retirement/StateMachines/Methods/DeleteFromVMDB"
-  - FinishRetirement:
-      value: "#"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -294,30 +294,10 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: DeleteFromVMDB
-      display_name: 
-      datatype: string
-      priority: 15
-      owner: 
-      default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/DeleteFromVMDB"
-      substitute: true
-      message: create
-      visibility: 
-      collect: 
-      scope: 
-      description: 
-      condition: 
-      on_entry: update_retirement_status(status => 'Removing from VMDB')
-      on_exit: update_retirement_status(status => 'Removed from VMDB')
-      on_error: update_retirement_status(status => 'Error Removing from VMDB')
-      max_retries: '100'
-      max_time: 
-  - field:
-      aetype: state
       name: FinishRetirement
       display_name: 
       datatype: string
-      priority: 16
+      priority: 15
       owner: 
       default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/FinishRetirement"
       substitute: true
@@ -330,5 +310,25 @@ object:
       on_entry: update_retirement_status(status => 'Finishing Retirement')
       on_exit: update_retirement_status(status => 'Finished Retirement')
       on_error: update_retirement_status(status => 'Error Finishing Retirement')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: DeleteFromVMDB
+      display_name: 
+      datatype: string
+      priority: 16
+      owner: 
+      default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/DeleteFromVMDB"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_retirement_status(status => 'Removing from VMDB')
+      on_exit: update_retirement_status(status => 'Removed from VMDB')
+      on_error: update_retirement_status(status => 'Error Removing from VMDB')
       max_retries: '100'
       max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__class__.yaml
@@ -158,10 +158,30 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: DeleteServiceFromVMDB
+      name: FinishRetirement
       display_name: 
       datatype: string
       priority: 8
+      owner: 
+      default_value: "/Service/Retirement/StateMachines/Methods/FinishRetirement"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_service_retirement_status(status => 'Finishing Retirement')
+      on_exit: update_service_retirement_status(status => 'Finished Retirement')
+      on_error: update_service_retirement_status(status => 'Error Finishing Retirement')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: DeleteServiceFromVMDB
+      display_name: 
+      datatype: string
+      priority: 9
       owner: 
       default_value: "/Service/Retirement/StateMachines/Methods/DeleteServiceFromVMDB"
       substitute: true
@@ -177,25 +197,5 @@ object:
         from VMDB')
       on_error: update_service_retirement_status(status => 'Error Deleting Retired
         Service from VMDB')
-      max_retries: '100'
-      max_time: 
-  - field:
-      aetype: state
-      name: FinishRetirement
-      display_name: 
-      datatype: string
-      priority: 9
-      owner: 
-      default_value: "/Service/Retirement/StateMachines/Methods/FinishRetirement"
-      substitute: true
-      message: create
-      visibility: 
-      collect: 
-      scope: 
-      description: 
-      condition: 
-      on_entry: update_service_retirement_status(status => 'Finishing Retirement')
-      on_exit: update_service_retirement_status(status => 'Finished Retirement')
-      on_error: update_service_retirement_status(status => 'Error Finishing Retirement')
       max_retries: '100'
       max_time: 


### PR DESCRIPTION
Execute FinishRetirement state prior to DeleteFromVMDB for cloud, infra
and services so the audit event will get raised.
