### PR TITLE
keep `get_connection` alive until the main thread has made assertions

### DIFF
--- a/vmdb/spec/models/vmdb_database_connection_spec.rb
+++ b/vmdb/spec/models/vmdb_database_connection_spec.rb
@@ -16,9 +16,10 @@ describe VmdbDatabaseConnection do
 
     get_connection = Thread.new do
       VmdbDatabaseConnection.connection.transaction do
-        made_connection.release
-        continue.release
+        # make an empty txn to ensure we've sent something to the db
       end
+      made_connection.release
+      continue.await # block until the main thread has found this connection.
     end
 
     made_connection.await # wait until the thread has made a db connection


### PR DESCRIPTION
the code should have said `continue.await` in order to keep the thread
alive until the main thread has made assertions.  If the thread wasn't
alive, the connection could get garbage collected which would cause
sporadic failures.

fixes #2108