### PR TITLE
Rename orchestration template ems_ref to md5

### DIFF
--- a/vmdb/db/migrate/20150311182221_orchestration_template_rename_ems_ref_to_md5_and_drop_unique.rb
+++ b/vmdb/db/migrate/20150311182221_orchestration_template_rename_ems_ref_to_md5_and_drop_unique.rb
@@ -1,0 +1,13 @@
+class OrchestrationTemplateRenameEmsRefToMd5AndDropUnique < ActiveRecord::Migration
+  def up
+    remove_index  :orchestration_templates, :ems_ref
+    rename_column :orchestration_templates, :ems_ref, :md5
+    add_index     :orchestration_templates, :md5
+  end
+
+  def down
+    remove_index  :orchestration_templates, :md5
+    rename_column :orchestration_templates, :md5, :ems_ref
+    add_index     :orchestration_templates, :ems_ref, :unique => true
+  end
+end

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -436,7 +436,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   def assert_specific_orchestration_template
     @orch_template = OrchestrationTemplateCfn.where(:name => "cloudformation-spec-WebServerInstance-QS899ZNAHZU6").first
     @orch_template.should have_attributes(
-      :ems_ref => "e929859521d64ac28ee29f8526d33e8f",
+      :md5 => "e929859521d64ac28ee29f8526d33e8f",
     )
     @orch_template.description.should start_with("AWS CloudFormation Sample Template WordPress_Simple:")
     @orch_template.content.should start_with("{\n  \"AWSTemplateFormatVersion\" : \"2010-09-09\",")

--- a/vmdb/spec/models/orchestration_template_spec.rb
+++ b/vmdb/spec/models/orchestration_template_spec.rb
@@ -13,7 +13,7 @@ describe OrchestrationTemplate do
         record.name.should        == query_hash[:name]
         record.content.should     == query_hash[:content]
         record.description.should == query_hash[:description]
-        record.ems_ref.should_not be_nil
+        record.md5.should_not be_nil
       end
     end
 


### PR DESCRIPTION
Rename orchestration template ems_ref to md5

@gmcculloug and @Fryguy This change is per our conversation. Please review