### PR TITLE
Change default RHEV-M provision type from ISO to native_clone

### DIFF
--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -295,7 +295,7 @@
           :description: Provision Type
           :required: true
           :display: :edit
-          :default: iso
+          :default: native_clone
           :data_type: :string
         :linked_clone:
           :values:


### PR DESCRIPTION
When the dialogs were first created the product did not support native cloning through RHEV-M.  Now that native cloning is supported it is a better out-of-the-box default provisioning type.