### PR TITLE
Ipaddress is no longer required on host/ems

### DIFF
--- a/vmdb/app/models/configuration_manager.rb
+++ b/vmdb/app/models/configuration_manager.rb
@@ -2,7 +2,7 @@ class ConfigurationManager < ExtManagementSystem
   has_many :configured_systems,     :dependent => :destroy
   has_many :configuration_profiles, :dependent => :destroy
 
-  def hostname_ipaddress_required?
+  def hostname_required?
     false
   end
 end

--- a/vmdb/app/models/configuration_manager.rb
+++ b/vmdb/app/models/configuration_manager.rb
@@ -2,7 +2,7 @@ class ConfigurationManager < ExtManagementSystem
   has_many :configured_systems,     :dependent => :destroy
   has_many :configuration_profiles, :dependent => :destroy
 
-  def hostname_required?
+  def self.hostname_required?
     false
   end
 end

--- a/vmdb/app/models/ems_amazon.rb
+++ b/vmdb/app/models/ems_amazon.rb
@@ -10,7 +10,7 @@ class EmsAmazon < EmsCloud
     @description ||= "Amazon EC2".freeze
   end
 
-  def hostname_ipaddress_required?
+  def hostname_required?
     false
   end
 

--- a/vmdb/app/models/ems_amazon.rb
+++ b/vmdb/app/models/ems_amazon.rb
@@ -10,7 +10,7 @@ class EmsAmazon < EmsCloud
     @description ||= "Amazon EC2".freeze
   end
 
-  def hostname_required?
+  def self.hostname_required?
     false
   end
 

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -55,8 +55,8 @@ class ExtManagementSystem < ActiveRecord::Base
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource  # Destroy will be handled by purger
 
-  validates :name,                 :presence => true, :uniqueness => true
-  validates :hostname, :ipaddress, :presence => true, :uniqueness => {:case_sensitive => false}, :if => :hostname_ipaddress_required?
+  validates :name,     :presence => true, :uniqueness => true
+  validates :hostname, :presence => true, :uniqueness => {:case_sensitive => false}, :if => :hostname_required?
 
   # TODO: Remove all callers of address
   alias_attribute :address, :hostname
@@ -173,7 +173,7 @@ class ExtManagementSystem < ActiveRecord::Base
     self.name
   end
 
-  def hostname_ipaddress_required?
+  def hostname_required?
     true
   end
 

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -174,6 +174,10 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def hostname_required?
+    self.class.hostname_required?
+  end
+
+  def self.hostname_required?
     true
   end
 

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -36,7 +36,7 @@ class Host < ActiveRecord::Base
   }
 
   validates_presence_of     :name
-  validates_presence_of     :hostname, :ipaddress, :if => :hostname_ipaddress_required?
+  validates_presence_of     :hostname, :if => :hostname_required?
   validates_uniqueness_of   :name
   validates_inclusion_of    :user_assigned_os, :in => ["linux_generic", "windows_generic", nil]
   validates_inclusion_of    :vmm_vendor, :in => VENDOR_TYPES.values
@@ -184,7 +184,7 @@ class Host < ActiveRecord::Base
     self.hardware.annotation
   end
 
-  def hostname_ipaddress_required?
+  def hostname_required?
     self.vmm_vendor == "vmware"
   end
 

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -4,7 +4,7 @@ class ProvisioningManager < ExtManagementSystem
   has_many :customization_script_ptables
   has_many :customization_script_media
 
-  def hostname_ipaddress_required?
+  def hostname_required?
     false
   end
 end

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -4,7 +4,7 @@ class ProvisioningManager < ExtManagementSystem
   has_many :customization_script_ptables
   has_many :customization_script_media
 
-  def hostname_required?
+  def self.hostname_required?
     false
   end
 end

--- a/vmdb/spec/models/ext_management_system_spec.rb
+++ b/vmdb/spec/models/ext_management_system_spec.rb
@@ -118,22 +118,7 @@ describe ExtManagementSystem do
           expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "2.2.2.2", :hostname => "ems_2") }.to     raise_error
         end
 
-        if ems.new.hostname_ipaddress_required?
-          context "ipaddress" do
-            it "duplicate ipaddress" do
-              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
-              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_2") }.to     raise_error
-            end
-
-            it "blank ipaddress" do
-              expect { FactoryGirl.create(t, :ipaddress => "", :hostname => "ems_1") }.to raise_error
-            end
-
-            it "nil ipaddress" do
-              expect { FactoryGirl.create(t, :ipaddress => nil, :hostname => "ems_1") }.to raise_error
-            end
-          end
-
+        if ems.new.hostname_required?
           context "hostname" do
             it "duplicate hostname" do
               expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
@@ -166,24 +151,11 @@ describe ExtManagementSystem do
         end
       end
 
-      it "duplicate ipaddress" do
-        described_class.leaf_subclasses.collect{|ems| ems.name.underscore.to_sym}.each do |t|
-          provider = FactoryGirl.build(t, :ipaddress => @ems.ipaddress, :hostname => @different_host_name)
-
-          if provider.hostname_ipaddress_required?
-            expect { provider.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: IP Address has already been taken")
-          else
-            expect { provider.save! }.to_not raise_error
-            provider.destroy
-          end
-        end
-      end
-
       it "duplicate hostname" do
         described_class.leaf_subclasses.collect{|ems| ems.name.underscore.to_sym}.each do |t|
           provider = FactoryGirl.build(t, :hostname => @same_host_name)
 
-          if provider.hostname_ipaddress_required?
+          if provider.hostname_required?
             expect { provider.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Host Name has already been taken")
           else
             expect { provider.save! }.to_not raise_error


### PR DESCRIPTION
As of #1800, #2063, #2064 we use hostname exclusively for communication so ipaddress is merely informational.

* Rename hostname_ipaddress_required? to hostname_required?
  * Remove tests requiring IP Address and IP uniqueness.
* hostname_required? knowledge moved to the class level.
  * Instance methods are delegated through the class method.
  * Subclasses now need to override the class method.

Existing tests already test all new behavior.

cc @Fryguy @himdel is this what was mentioned in #2011?