### PR TITLE
No need to resizetaskbar on replace right cell.

### DIFF
--- a/vmdb/app/presenters/explorer_presenter.rb
+++ b/vmdb/app/presenters/explorer_presenter.rb
@@ -213,9 +213,7 @@ class ExplorerPresenter
     @out << @options[:extra_js].join("\n")
 
     # Position the clear_search link
-    @out << "
-      $('.dhtmlxInfoBarLabel').filter(':visible').append($('#clear_search')[0]);
-      miqResizeTaskbarCell();"
+    @out << "$('.dhtmlxInfoBarLabel').filter(':visible').append($('#clear_search')[0]);"
 
     @out << "if (typeof show_clear_search != 'undefined') $('#clear_search').show();"
 


### PR DESCRIPTION
This only needs to be done when resizing browser window or layouts panel to adjust taskbar depending upon div positioning. This was causing right cell header to move down in all explorers when right cell was replaced.

@dclarizio please review/verify