### PR TITLE
eagerly load `deletes` collection proxy

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -1,6 +1,8 @@
 module EmsRefresh::SaveInventoryHelper
   def save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys = [], extra_keys = [])
+    deletes = deletes.to_a # make sure to load the association if it's an association
     child_keys, extra_keys, remove_keys = self.save_inventory_prep(child_keys, extra_keys)
+
     record_index, record_index_columns = self.save_inventory_prep_record_index(parent.send(type), find_key)
 
     new_records = []


### PR DESCRIPTION
`deletes` seems to typically be a collection proxy.  The methods that
save_inventory_multi call may impact the results of that query, so we
should eagerly load the collection.

This fixes:

  spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb