### PR TITLE
Console: support for OpenStack VNC consoles.

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1447,10 +1447,7 @@ module VmCommon
         page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
         page << "miqSparkle(false);"
       else # open a window to show a VNC or VMWare console
-        console_action = case console_type
-                         when 'html5' then 'launch_html5_console'
-                         else 'launch_vmware_console'
-                         end
+        console_action = console_type == 'html5' ? 'launch_html5_console' : 'launch_vmware_console'
         page << "miqSparkle(false);"
         page << "window.open('#{url_for :controller => controller_name, :action => console_action, :id => @record.id}');"
       end

--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -123,6 +123,16 @@ module VmCommon
     password, host_address, host_port, _proxy_address, _proxy_port, protocol, ssl = @sb[:html5]
     encrypt = get_vmdb_config.fetch_path(:server, :websocket_encrypt)
 
+    case protocol
+    when 'spice'     # spice, vnc - from rhevm
+      view = "vm_common/console_spice"
+    when nil, 'vnc'  # nil - from vmware
+      view = "vm_common/console_vnc"
+    when 'novnc_url' # from OpenStack
+      redirect_to host_address
+      return
+    end
+
     proxy_options = WsProxy.start(
       :host       => host_address,
       :host_port  => host_port,
@@ -131,13 +141,6 @@ module VmCommon
       :encrypt    => encrypt    # ssl on web client side
     )
     raise _("Console access failed: proxy errror") if proxy_options.nil?
-
-    view = case protocol   # spice, vnc - from rhevm
-           when 'spice'
-             "vm_common/console_spice"
-           when nil, 'vnc' # nil - from vmware
-             "vm_common/console_vnc"
-           end
 
     render :template => view,
            :layout   => false,
@@ -1444,7 +1447,10 @@ module VmCommon
         page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
         page << "miqSparkle(false);"
       else # open a window to show a VNC or VMWare console
-        console_action = console_type == 'html5' ? 'launch_html5_console' : 'launch_vmware_console'
+        console_action = case console_type
+                         when 'html5' then 'launch_html5_console'
+                         else 'launch_vmware_console'
+                         end
         page << "miqSparkle(false);"
         page << "window.open('#{url_for :controller => controller_name, :action => console_action, :id => @record.id}');"
       end

--- a/vmdb/app/models/vm_openstack.rb
+++ b/vmdb/app/models/vm_openstack.rb
@@ -1,5 +1,6 @@
 class VmOpenstack < VmCloud
   include_concern 'Operations'
+  include_concern 'RemoteConsole'
 
   belongs_to :cloud_tenant
 

--- a/vmdb/app/models/vm_openstack/remote_console.rb
+++ b/vmdb/app/models/vm_openstack/remote_console.rb
@@ -24,7 +24,7 @@ class VmOpenstack
         :instance_id => id,
         :method_name => 'remote_console_acquire_ticket',
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',  # FIXME
+        :role        => 'ems_operations',
         :zone        => my_zone,
         :args        => [protocol, proxy_miq_server]
       }

--- a/vmdb/app/models/vm_openstack/remote_console.rb
+++ b/vmdb/app/models/vm_openstack/remote_console.rb
@@ -1,0 +1,35 @@
+class VmOpenstack
+  module RemoteConsole
+    def console_supported?(type)
+      %w(SPICE VNC).include?(type.upcase)
+    end
+
+    def remote_console_acquire_ticket(console_type, _proxy_miq_server = nil)
+      url = ext_management_system.with_provider_connection(:service => "Compute") do |con|
+        response = con.get_vnc_console(self.ems_ref, 'novnc')
+        return nil if response.body.fetch_path('console', 'type') != 'novnc'
+        response.body.fetch_path('console', 'url')
+      end
+      return nil, url, nil, nil, nil, 'novnc_url', nil
+    end
+
+    def remote_console_acquire_ticket_queue(protocol, userid, proxy_miq_server = nil)
+      task_opts = {
+        :action => "acquiring Instance #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}",
+        :userid => userid
+      }
+
+      queue_opts = {
+        :class_name  => self.class.name,
+        :instance_id => id,
+        :method_name => 'remote_console_acquire_ticket',
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',  # FIXME
+        :zone        => my_zone,
+        :args        => [protocol, proxy_miq_server]
+      }
+
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+  end
+end

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1589,6 +1589,7 @@ Vmdb::Application.routes.draw do
         drift_to_pdf
         drift_to_txt
         explorer
+        launch_html5_console
         perf_chart_chooser
         protect
         show
@@ -1602,11 +1603,13 @@ Vmdb::Application.routes.draw do
         edit_vm
         event_logs
         explorer
+        launch_html5_console
         filesystems
         filesystem_drivers
         form_field_changed
         guest_applications
         groups
+        html5_console
         kernel_drivers
         linux_initprocesses
         ownership_field_changed

--- a/vmdb/product/toolbars/x_vm_cloud_center_tb.yaml
+++ b/vmdb/product/toolbars/x_vm_cloud_center_tb.yaml
@@ -141,3 +141,8 @@
       :text: "Terminate"
       :title: "Terminate this Instance"
       :confirm: "Terminate this Instance?"
+  - :button: vm_vnc_console
+    :image: console
+    :url: 'html5_console'
+    :title: "Open a web-based VNC or SPICE console for this VM"
+    :confirm: "Opening a web-based VM VNC or SPICE console requires that the Provider is pre-configured to allow VNC connections.  Are you sure?"


### PR DESCRIPTION
OpenStack noVNC consoles is different from RHVM or VMware. In case of OpenStack we use OpenStack Nova API for a console and we get back an URL that we present to the user.

Websocket VNC console is in this case implemented on OpenStack side and does not run on the ManageIQ appliance. Sysadmins are required to do the necessary steps according to OpenStack manual to allow access to the IP address wheren the OpenStack VNC websocket proxy runs. http://docs.openstack.org/developer/nova/man/nova-novncproxy.html

