### PR TITLE
String#to_time changed defaults from :utc to :local

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1750,7 +1750,7 @@ module ApplicationHelper
       @edit[:new][:timer_weeks]  = schedule.run_at[:interval][:value] if schedule.run_at[:interval][:unit] == "weekly"
       @edit[:new][:timer_days]   = schedule.run_at[:interval][:value] if schedule.run_at[:interval][:unit] == "daily"
       @edit[:new][:timer_hours]  = schedule.run_at[:interval][:value] if schedule.run_at[:interval][:unit] == "hourly"
-      t                          = schedule.run_at[:start_time].to_time.in_time_zone(@edit[:tz])
+      t                          = schedule.run_at[:start_time].to_time(:utc).in_time_zone(@edit[:tz])
       @edit[:new][:start_hour]   = t.strftime("%H")
       @edit[:new][:start_min]    = t.strftime("%M")
     end

--- a/vmdb/config/initializers/as_to_time.rb
+++ b/vmdb/config/initializers/as_to_time.rb
@@ -1,0 +1,17 @@
+require 'active_support/core_ext/string/conversions'
+require 'active_support/deprecation'
+
+class String
+  alias_method :old_to_time, :to_time
+
+  OBJ = Object.new
+
+  def to_time(form = OBJ)
+    if form == OBJ
+      ActiveSupport::Deprecation.warn "Rails 4 changes the default of String#to_time to local.  Please pass the type of conversion you want, like to_time(:utc) or to_time(:local)", caller.drop(1)
+      old_to_time(:utc)
+    else
+      old_to_time(form)
+    end
+  end
+end


### PR DESCRIPTION
This commit monkey patches to_time to default back to :utc, but emits a
warning if you don't pass a value in to to_time().  Any calls to
`to_time` in the current code base should pass :utc.  This monkey patch
will make to_time backwards compatible until we find all the spots where
we don't pass the right conversion type in.

The default was changed [here](https://github.com/rails/rails/commit/b79adc4323ff289aed3f5787fdfbb9542aa4f89f).