### PR TITLE
Add support for verifying the Kubernetes connection

### DIFF
--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -3,6 +3,9 @@ class EmsKubernetes < EmsContainer
   has_many :container_groups,                     :foreign_key => :ems_id, :dependent => :destroy
   has_many :container_services,                   :foreign_key => :ems_id, :dependent => :destroy
 
+  # TODO: support real authentication using certificates
+  before_validation :ensure_authentications_record
+
   default_value_for :port, 6443
 
   def self.ems_type
@@ -11,6 +14,10 @@ class EmsKubernetes < EmsContainer
 
   def self.description
     @description ||= "Kubernetes".freeze
+  end
+
+  def self.event_monitor_class
+    MiqEventCatcherKubernetes
   end
 
   def self.raw_connect(hostname, port)
@@ -23,7 +30,7 @@ class EmsKubernetes < EmsContainer
   end
 
   def self.raw_api_endpoint(hostname, port)
-    URI::HTTPS.build(:host => hostname, :port => port.to_i)
+    URI::HTTPS.build(:host => hostname, :port => port.presence.try(:to_i))
   end
 
   # UI methods for determining availability of fields
@@ -35,27 +42,33 @@ class EmsKubernetes < EmsContainer
     self.class.raw_api_endpoint(hostname, port)
   end
 
-  def connect(_options = {})
+  def connect(options = {})
+    hostname = options[:hostname] || self.address
+    port     = options[:port]     || self.port
+
     self.class.raw_connect(hostname, port)
   end
 
-  def self.event_monitor_class
-    MiqEventCatcherKubernetes
+  def verify_credentials(auth_type = nil, options = {})
+    # TODO: support real authentication using certificates
+    options = options.merge(:auth_type => auth_type)
+
+    with_provider_connection(options, &:api_valid?)
+  rescue SocketError,
+         Errno::ECONNREFUSED,
+         RestClient::ResourceNotFound,
+         RestClient::InternalServerError => err
+    raise MiqException::MiqUnreachableError, err.message, err.backtrace
+  rescue RestClient::Unauthorized => err
+    raise MiqException::MiqInvalidCredentialsError, err.message, err.backtrace
   end
 
-  def authentication_check
-    # TODO: support real authentication using certificates
-    [true, ""]
-  end
+  private
 
-  def verify_credentials(_auth_type = nil, _options = {})
+  def ensure_authentications_record
     # TODO: support real authentication using certificates
-    true
-  end
-
-  def authentication_status_ok?(_type = nil)
-    # TODO: support real authentication using certificates
-    true
+    return if authentications.present?
+    update_authentication(:default => {:userid => "_", :save => false})
   end
 
   # required by aggregate_hardware

--- a/vmdb/spec/models/ext_management_system_spec.rb
+++ b/vmdb/spec/models/ext_management_system_spec.rb
@@ -112,26 +112,29 @@ describe ExtManagementSystem do
       t = ems.name.underscore
 
       context "for #{ems}" do
+        before do
+          _, _, @zone = EvmSpecHelper.create_guid_miq_server_zone
+        end
 
         it "name" do
-          expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
-          expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "2.2.2.2", :hostname => "ems_2") }.to     raise_error
+          expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "1.1.1.1", :hostname => "ems_1", :zone => @zone) }.to_not raise_error
+          expect { FactoryGirl.create(t, :name => "ems_1", :ipaddress => "2.2.2.2", :hostname => "ems_2", :zone => @zone) }.to     raise_error
         end
 
         if ems.new.hostname_required?
           context "hostname" do
             it "duplicate hostname" do
-              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1") }.to_not raise_error
-              expect { FactoryGirl.create(t, :ipaddress => "2.2.2.2", :hostname => "ems_1") }.to     raise_error
-              expect { FactoryGirl.create(t, :ipaddress => "3.3.3.3", :hostname => "EMS_1") }.to     raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "ems_1", :zone => @zone) }.to_not raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "2.2.2.2", :hostname => "ems_1", :zone => @zone) }.to     raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "3.3.3.3", :hostname => "EMS_1", :zone => @zone) }.to     raise_error
             end
 
             it "blank hostname" do
-              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "") }.to raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => "", :zone => @zone) }.to raise_error
             end
 
             it "nil hostname" do
-              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => nil) }.to raise_error
+              expect { FactoryGirl.create(t, :ipaddress => "1.1.1.1", :hostname => nil, :zone => @zone) }.to raise_error
             end
           end
         end


### PR DESCRIPTION
This will prevent worker cycling when the Kubernetes endpoint is not
available.

---
@abonas Please review.

Even though there are no credentials I need an authentications record to keep track of the verification status.  So, I created a dummy record for now.  I figure we can change that record into a certificate based record when we get to certificates.

@h-kataria This brings up the question of "verifying" the connection in the UI, which will now be needed, in case the connection goes bad.  The user will want to go into the EMS and "revalidate" it to make it active again.  However since there are no credentials, I'm not sure how you want to present this in the UI.  cc @jrafanie 

@abonas I this this PR would be better served with a method on Kubeclient called `verify?` or something similar.  You can see what I did for Foreman [here](https://github.com/ManageIQ/manageiq/blob/master/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb#L20-L23).  What do you think?  Basically, the method tries to connect and does a lightweight action.  Additionally it verifies that the content it gets back is what is expected.  This is important since you could technically hit *any* https://example.com/api and it could come back ok, so we want to verify it's the *right* one.