### PR TITLE
split save_inventory to reduce conditionals

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -215,7 +215,7 @@ module EmsRefresh::SaveInventory
       saved_hashes, new_hashes = hashes.partition { |h| h[:id] }
       saved_hashes.each { |h| deletes.delete_if { |d| d.id == h[:id] } } unless deletes.empty? || saved_hashes.empty?
 
-      save_inventory_multi(:networks, hardware, new_hashes, deletes, :ipaddress, nil, :guest_device)
+      save_inventory_multi(:networks, hardware, new_hashes, deletes, [:ipaddress], nil, :guest_device)
     when :scan
       save_inventory_multi(:networks, hardware, hashes, deletes, [:description, :guid])
     end
@@ -239,17 +239,17 @@ module EmsRefresh::SaveInventory
 
   def save_advanced_settings_inventory(parent, hashes)
     deletes = parent.advanced_settings(true).dup
-    save_inventory_multi(:advanced_settings, parent, hashes, deletes, :name)
+    save_inventory_multi(:advanced_settings, parent, hashes, deletes, [:name])
   end
 
   def save_patches_inventory(parent, hashes)
     deletes = parent.patches(true).dup
-    save_inventory_multi(:patches, parent, hashes, deletes, :name)
+    save_inventory_multi(:patches, parent, hashes, deletes, [:name])
   end
 
   def save_os_processes_inventory(os, hashes)
     deletes = os.processes(true).dup
-    save_inventory_multi(:processes, os, hashes, deletes, :pid)
+    save_inventory_multi(:processes, os, hashes, deletes, [:pid])
   end
 
   def save_firewall_rules_inventory(parent, hashes, mode = :refresh)
@@ -261,12 +261,12 @@ module EmsRefresh::SaveInventory
         # Leaves out the source_security_group_id, as we will set that later
         #   after all security_groups have been saved and ids obtained.
         if parent.kind_of?(SecurityGroupOpenstack)
-          :ems_ref
+          [:ems_ref]
         else
           [:direction, :host_protocol, :port, :end_port, :source_ip_range]
         end
       when :scan
-        :name
+        [:name]
       end
 
     deletes = parent.firewall_rules(true).dup
@@ -284,7 +284,7 @@ module EmsRefresh::SaveInventory
 
   def save_filesystems_inventory(parent, hashes)
     deletes = parent.filesystems(true).dup
-    save_inventory_multi(:filesystems, parent, hashes, deletes, :name)
+    save_inventory_multi(:filesystems, parent, hashes, deletes, [:name])
   end
 
   def save_snapshots_inventory(vm, hashes)
@@ -293,7 +293,7 @@ module EmsRefresh::SaveInventory
     hashes.each { |h| h[:parent_id] = nil } # Delink all snapshots
 
     deletes = vm.snapshots(true).dup
-    save_inventory_multi(:snapshots, vm, hashes, deletes, :uid)
+    save_inventory_multi(:snapshots, vm, hashes, deletes, [:uid])
 
     # Reset the relationship tree for the snapshots
     vm.snapshots.each do |s|
@@ -306,6 +306,6 @@ module EmsRefresh::SaveInventory
 
   def save_event_logs_inventory(os, hashes)
     deletes = os.event_logs(true).dup
-    save_inventory_multi(:event_logs, os, hashes, deletes, :uid)
+    save_inventory_multi(:event_logs, os, hashes, deletes, [:uid])
   end
 end

--- a/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_cloud.rb
@@ -85,7 +85,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    save_inventory_multi(:flavors, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:flavors, ems, hashes, deletes, [:ems_ref])
     self.store_ids_for_new_records(ems.flavors, hashes, :ems_ref)
   end
 
@@ -99,7 +99,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    save_inventory_multi(:availability_zones, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:availability_zones, ems, hashes, deletes, [:ems_ref])
     self.store_ids_for_new_records(ems.availability_zones, hashes, :ems_ref)
   end
 
@@ -113,7 +113,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    save_inventory_multi(:cloud_tenants, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:cloud_tenants, ems, hashes, deletes, [:ems_ref])
     self.store_ids_for_new_records(ems.cloud_tenants, hashes, :ems_ref)
   end
 
@@ -145,7 +145,7 @@ module EmsRefresh::SaveInventoryCloud
       []
     end
 
-    save_inventory_multi(:key_pairs, ems, hashes, deletes, :name)
+    save_inventory_multi(:key_pairs, ems, hashes, deletes, [:name])
     self.store_ids_for_new_records(ems.key_pairs, hashes, :name)
   end
 
@@ -169,7 +169,7 @@ module EmsRefresh::SaveInventoryCloud
                          ems,
                          hashes,
                          deletes,
-                         :ems_ref,
+                         [:ems_ref],
                          :cloud_subnets,
                          [:cloud_tenant, :orchestration_stack])
     store_ids_for_new_records(ems.cloud_networks, hashes, :ems_ref)
@@ -182,7 +182,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:availability_zone_id] = h.fetch_path(:availability_zone, :id)
     end
 
-    save_inventory_multi(:cloud_subnets, cloud_network, hashes, deletes, :ems_ref, nil, :availability_zone)
+    save_inventory_multi(:cloud_subnets, cloud_network, hashes, deletes, [:ems_ref], nil, :availability_zone)
 
     cloud_network.save!
     self.store_ids_for_new_records(cloud_network.cloud_subnets, hashes, :ems_ref)
@@ -207,7 +207,7 @@ module EmsRefresh::SaveInventoryCloud
     save_inventory_multi(:security_groups,
                          ems, hashes,
                          deletes,
-                         :ems_ref,
+                         [:ems_ref],
                          :firewall_rules,
                          [:cloud_network, :cloud_tenant, :orchestration_stack])
     store_ids_for_new_records(ems.security_groups, hashes, :ems_ref)
@@ -239,7 +239,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:cloud_tenant, :id) if h.key?(:cloud_tenant)
     end
 
-    save_inventory_multi(:floating_ips, ems, hashes, deletes, :ems_ref, nil, [:vm, :cloud_tenant])
+    save_inventory_multi(:floating_ips, ems, hashes, deletes, [:ems_ref], nil, [:vm, :cloud_tenant])
     self.store_ids_for_new_records(ems.floating_ips, hashes, :ems_ref)
   end
 
@@ -268,7 +268,7 @@ module EmsRefresh::SaveInventoryCloud
                                   ems,
                                   hashes,
                                   deletes,
-                                  :ems_ref,
+                                  [:ems_ref],
                                   [:parameters, :outputs, :resources],
                                   [:parent, :orchestration_template])
     store_ids_for_new_records(ems.orchestration_stacks, hashes, :ems_ref)
@@ -290,7 +290,7 @@ module EmsRefresh::SaveInventoryCloud
                          orchestration_stack,
                          hashes,
                          deletes,
-                         :ems_ref)
+                         [:ems_ref])
   end
 
   def save_outputs_inventory(orchestration_stack, hashes)
@@ -300,7 +300,7 @@ module EmsRefresh::SaveInventoryCloud
                          orchestration_stack,
                          hashes,
                          deletes,
-                         :ems_ref)
+                         [:ems_ref])
   end
 
   def save_resources_inventory(orchestration_stack, hashes)
@@ -310,7 +310,7 @@ module EmsRefresh::SaveInventoryCloud
                          orchestration_stack,
                          hashes,
                          deletes,
-                         :ems_ref)
+                         [:ems_ref])
   end
 
   def save_cloud_volumes_inventory(ems, hashes, target = nil)
@@ -330,7 +330,7 @@ module EmsRefresh::SaveInventoryCloud
       # Defer setting :cloud_volume_snapshot_id until after snapshots are saved.
     end
 
-    save_inventory_multi(:cloud_volumes, ems, hashes, deletes, :ems_ref, nil, [:tenant, :availability_zone, :base_snapshot])
+    save_inventory_multi(:cloud_volumes, ems, hashes, deletes, [:ems_ref], nil, [:tenant, :availability_zone, :base_snapshot])
     self.store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 
@@ -350,7 +350,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_volume_id] = h.fetch_path(:volume, :id)
     end
 
-    save_inventory_multi(:cloud_volume_snapshots, ems, hashes, deletes, :ems_ref, nil, [:tenant, :volume])
+    save_inventory_multi(:cloud_volume_snapshots, ems, hashes, deletes, [:ems_ref], nil, [:tenant, :volume])
     self.store_ids_for_new_records(ems.cloud_volume_snapshots, hashes, :ems_ref)
   end
 
@@ -380,7 +380,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:tenant, :id)
     end
 
-    save_inventory_multi(:cloud_object_store_containers, ems, hashes, deletes, :ems_ref, nil, :tenant)
+    save_inventory_multi(:cloud_object_store_containers, ems, hashes, deletes, [:ems_ref], nil, :tenant)
     self.store_ids_for_new_records(ems.cloud_object_store_containers, hashes, :ems_ref)
   end
 
@@ -400,7 +400,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_object_store_container_id] = h.fetch_path(:container, :id)
     end
 
-    save_inventory_multi(:cloud_object_store_objects, ems, hashes, deletes, :ems_ref, nil, [:tenant, :container])
+    save_inventory_multi(:cloud_object_store_objects, ems, hashes, deletes, [:ems_ref], nil, [:tenant, :container])
     self.store_ids_for_new_records(ems.cloud_object_store_objects, hashes, :ems_ref)
   end
 end

--- a/vmdb/app/models/ems_refresh/save_inventory_configuration.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_configuration.rb
@@ -19,7 +19,7 @@ module EmsRefresh
 
     def save_configuration_profiles_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:configuration_profiles, manager, hashes, delete_missing_records, :manager_ref)
+      save_inventory_assoc(:configuration_profiles, manager, hashes, delete_missing_records, [:manager_ref])
     end
 
     def save_configured_systems_inventory(manager, hashes, target)
@@ -27,7 +27,7 @@ module EmsRefresh
       hashes.each do |hash|
         hash[:configuration_profile_id] = hash.fetch_path(:configuration_profile, :id)
       end
-      save_inventory_assoc(:configured_systems, manager, hashes, delete_missing_records, :manager_ref, nil,
+      save_inventory_assoc(:configured_systems, manager, hashes, delete_missing_records, [:manager_ref], nil,
                            [:configuration_profile])
     end
   end

--- a/vmdb/app/models/ems_refresh/save_inventory_container.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_container.rb
@@ -21,7 +21,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_nodes, ems, hashes, deletes, :ems_ref)
+    save_inventory_multi(:container_nodes, ems, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.container_nodes, hashes, :ems_ref)
   end
 
@@ -36,7 +36,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_services, ems, hashes, deletes, :ems_ref, [:labels, :selector_parts])
+    save_inventory_multi(:container_services, ems, hashes, deletes, [:ems_ref], [:labels, :selector_parts])
     store_ids_for_new_records(ems.container_services, hashes, :ems_ref)
   end
 
@@ -51,7 +51,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_groups, ems, hashes, deletes, :ems_ref, [:container_definitions, :containers, :labels])
+    save_inventory_multi(:container_groups, ems, hashes, deletes, [:ems_ref], [:container_definitions, :containers, :labels])
     store_ids_for_new_records(ems.container_groups, hashes, :ems_ref)
   end
 
@@ -65,7 +65,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_definitions, container_group, hashes, deletes, :ems_ref, :container_port_configs)
+    save_inventory_multi(:container_definitions, container_group, hashes, deletes, [:ems_ref], :container_port_configs)
     store_ids_for_new_records(container_group.container_definitions, hashes, :ems_ref)
   end
 
@@ -79,7 +79,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_port_configs, container_definition, hashes, deletes, :ems_ref)
+    save_inventory_multi(:container_port_configs, container_definition, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(container_definition.container_port_configs, hashes, :ems_ref)
   end
 
@@ -93,7 +93,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:containers, container_group, hashes, deletes, :ems_ref)
+    save_inventory_multi(:containers, container_group, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(container_group.containers, hashes, :ems_ref)
   end
 

--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -1,11 +1,11 @@
 module EmsRefresh::SaveInventoryHelper
   def save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys = [], extra_keys = [])
-    find_key, child_keys, extra_keys, remove_keys = self.save_inventory_prep(find_key, child_keys, extra_keys)
+    child_keys, extra_keys, remove_keys = self.save_inventory_prep(child_keys, extra_keys)
     record_index, record_index_columns = self.save_inventory_prep_record_index(parent.send(type), find_key)
 
     new_records = []
     hashes.each do |h|
-      found = save_inventory(type, parent, h.except(*remove_keys), deletes, new_records, record_index, record_index_columns, find_key)
+      found = save_inventory_with_findkey(type, parent, h.except(*remove_keys), deletes, new_records, record_index, record_index_columns, find_key)
       save_child_inventory(found, h, child_keys)
     end
 
@@ -20,26 +20,37 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def save_inventory_single(type, parent, hash, child_keys = [], extra_keys = [])
-    find_key, child_keys, extra_keys, remove_keys = self.save_inventory_prep(nil, child_keys, extra_keys)
+    child_keys, extra_keys, remove_keys = self.save_inventory_prep(child_keys, extra_keys)
     save_inventory(type, parent, hash.except(*remove_keys))
     save_child_inventory(parent.send(type), hash, child_keys)
   end
 
-  def save_inventory_prep(find_key, child_keys, extra_keys)
+  def save_inventory_prep(child_keys, extra_keys)
     # Normalize the keys for different types on inputs
-    find_key = [find_key].compact unless find_key.kind_of?(Array)
     child_keys = [child_keys].compact unless child_keys.kind_of?(Array)
     extra_keys = [extra_keys].compact unless extra_keys.kind_of?(Array)
     remove_keys = child_keys + extra_keys
-    return find_key, child_keys, extra_keys, remove_keys
+    return child_keys, extra_keys, remove_keys
   end
 
-  def save_inventory(type, parent, hash, deletes = nil, new_records = nil, record_index = nil, record_index_columns = nil, find_key = nil)
+  def save_inventory(type, parent, hash)
     # Find the record, and update if found, else create it
-    found = find_key.blank? ? parent.send(type) : self.save_inventory_record_index_fetch(record_index, record_index_columns, hash, find_key)
+    found = parent.send(type)
     if found.nil?
-      found = find_key ? parent.send(type).build(hash) : parent.send("build_#{type}", hash)
-      new_records.nil? ? parent.send("#{type}=", found) : new_records << found
+      found = parent.send("build_#{type}", hash)
+      parent.send("#{type}=", found)
+    else
+      found.update_attributes!(hash.except(:type))
+    end
+    found
+  end
+
+  def save_inventory_with_findkey(type, parent, hash, deletes, new_records, record_index, record_index_columns, find_key)
+    # Find the record, and update if found, else create it
+    found = save_inventory_record_index_fetch(record_index, record_index_columns, hash, find_key)
+    if found.nil?
+      found = parent.send(type).build(hash)
+      new_records << found
     else
       found.update_attributes!(hash.except(:type))
       deletes.delete(found) unless deletes.blank?

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -220,7 +220,7 @@ module EmsRefresh::SaveInventoryInfra
       []
     end
 
-    save_inventory_multi(:ems_folders, ems, hashes, deletes, :uid_ems, nil, :ems_children)
+    save_inventory_multi(:ems_folders, ems, hashes, deletes, [:uid_ems], nil, :ems_children)
     self.store_ids_for_new_records(ems.ems_folders, hashes, :uid_ems)
   end
   alias_method :save_ems_folders_inventory, :save_folders_inventory
@@ -235,7 +235,7 @@ module EmsRefresh::SaveInventoryInfra
       []
     end
 
-    save_inventory_multi(:ems_clusters, ems, hashes, deletes, :uid_ems, nil, :ems_children)
+    save_inventory_multi(:ems_clusters, ems, hashes, deletes, [:uid_ems], nil, :ems_children)
     self.store_ids_for_new_records(ems.ems_clusters, hashes, :uid_ems)
   end
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
@@ -252,28 +252,28 @@ module EmsRefresh::SaveInventoryInfra
       []
     end
 
-    save_inventory_multi(:resource_pools, ems, hashes, deletes, :uid_ems, nil, :ems_children)
+    save_inventory_multi(:resource_pools, ems, hashes, deletes, [:uid_ems], nil, :ems_children)
     self.store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
   end
 
   def save_customization_specs_inventory(ems, hashes, target = nil)
     deletes = ems.customization_specs(true).dup
-    save_inventory_multi(:customization_specs, ems, hashes, deletes, :name)
+    save_inventory_multi(:customization_specs, ems, hashes, deletes, [:name])
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
     deletes = guest_device.miq_scsi_targets(true).dup
-    save_inventory_multi(:miq_scsi_targets, guest_device, hashes, deletes, :uid_ems, :miq_scsi_luns)
+    save_inventory_multi(:miq_scsi_targets, guest_device, hashes, deletes, [:uid_ems], :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
     deletes = miq_scsi_target.miq_scsi_luns(true).dup
-    save_inventory_multi(:miq_scsi_luns, miq_scsi_target, hashes, deletes, :uid_ems)
+    save_inventory_multi(:miq_scsi_luns, miq_scsi_target, hashes, deletes, [:uid_ems])
   end
 
   def save_switches_inventory(host, hashes)
     deletes = host.switches(true).dup
-    save_inventory_multi(:switches, host, hashes, deletes, :uid_ems, :lans)
+    save_inventory_multi(:switches, host, hashes, deletes, [:uid_ems], :lans)
 
     host.save!
 
@@ -292,11 +292,11 @@ module EmsRefresh::SaveInventoryInfra
 
   def save_lans_inventory(switch, hashes)
     deletes = switch.lans(true).dup
-    save_inventory_multi(:lans, switch, hashes, deletes, :uid_ems)
+    save_inventory_multi(:lans, switch, hashes, deletes, [:uid_ems])
   end
 
   def save_storage_files_inventory(storage, hashes)
     deletes = storage.storage_files(true).dup
-    save_inventory_multi(:storage_files, storage, hashes, deletes, :name)
+    save_inventory_multi(:storage_files, storage, hashes, deletes, [:name])
   end
 end

--- a/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
@@ -24,7 +24,7 @@ module EmsRefresh
           hash[:customization_script_ids] = hash[:customization_scripts].map { |cp| cp[:id] }
         end
       end
-      save_inventory_assoc(:operating_system_flavors, manager, hashes, delete_missing_records, :manager_ref, nil,
+      save_inventory_assoc(:operating_system_flavors, manager, hashes, delete_missing_records, [:manager_ref], nil,
                            [:customization_scripts])
     end
   end


### PR DESCRIPTION
This commit splits save_inventory to two methods so that we don't have
to do so many conditionals on every call.  Then changes all the callers
to ensure that `find_key` is always an array.  This allows us to not
have to guess what the type of `find_key` is.  We know that it is always
going to be a non-empty array.