### PR TITLE
HACK URI::Generic.build to allow a IPv6 host value.

### DIFF
--- a/lib/spec/util/extensions/miq-uri_spec.rb
+++ b/lib/spec/util/extensions/miq-uri_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+require 'util/extensions/miq-uri'
+
+describe URI::Generic do
+  it "hash" do
+    expect(described_class.build(
+      :host => "::1",
+      :scheme => "http",
+      :port => 123,
+      :path => "/api"
+    ).to_s).to eq "http://[::1]:123/api"
+  end
+
+  it "array" do
+    expect(described_class.build(
+      # [scheme, userinfo, host, port, registry, path, opaque, query, fragment]
+      ["http", nil, "::1", 123, nil, "/api", nil,  nil, nil]
+    ).to_s).to eq "http://[::1]:123/api"
+  end
+end
+
+describe URI::HTTPS do
+  it "hash" do
+    expect(described_class.build(
+      :host => "::1",
+      :port => 123,
+      :path => "/api"
+    ).to_s).to eq "https://[::1]:123/api"
+  end
+
+  it "array" do
+    expect(described_class.build(
+      # [userinfo, host, port, path, query, fragment]
+      [nil, "::1", 123, "/api", nil, nil]
+    ).to_s).to eq "https://[::1]:123/api"
+  end
+end

--- a/lib/util/extensions/miq-uri.rb
+++ b/lib/util/extensions/miq-uri.rb
@@ -1,0 +1,70 @@
+require 'uri'
+
+# HACK URI::Generic.build to allow a IPv6 host value.
+#
+# It's a temporary workaround until https://github.com/ruby/ruby/pull/765 is
+# readily available.  As of this writing, ruby 2.0.0p643 and ruby 2.2.0 have this fixed.
+# Ruby 2.1.5, and ruby 2.0.0p598 and lower don't have this fixed and NEED this hack.
+# Ruby 2.0: https://bugs.ruby-lang.org/issues/10873 (backported and in p643)
+# Ruby 2.1: https://bugs.ruby-lang.org/issues/10875 (backported and not released yet)
+# Ruby 2.2: https://bugs.ruby-lang.org/issues/10874 (backported and in 2.2.0)
+#
+# Workaround before this hack:
+#  # Don't pass :host => "::1" to .build as it throws URI::InvalidComponentError
+#  uri = URI::HTTPS.build(:path => "/sdk")
+#  uri.hostname = "::1"
+#  uri.to_s # => "https://[::1]/sdk"
+#
+# After this hack the caller doesn't need to know to use [::1] or hostname= method:
+#  uri = URI::HTTPS.build(:host => "::1", :path => "/sdk")
+#  uri.to_s # => "https://[::1]/sdk"
+#
+def uri_supports_ipv6_on_build?
+  URI::HTTPS.build(:host => "::1", :path => "/sdk")
+rescue URI::InvalidComponentError
+  false
+end
+
+unless uri_supports_ipv6_on_build?
+  module MiqURI
+    module ClassMethods
+      def build(args)
+        host, args = _delete_host(args)
+
+        # Call .new without the host
+        u = super(args)
+
+        # Use IPv6 friendly hostname=
+        u.hostname = host if host
+        u
+      end
+
+      private
+      def _delete_host(args)
+        args = args.dup
+
+        # Save off and remove the host arg
+        if args.kind_of?(Array)
+          # host is the 3rd item in the Array:
+          # scheme, userinfo, host, port, registry, path, opaque, query and fragment
+          host, args[2] = args[2], nil
+        elsif args.kind_of?(Hash)
+          host = args.delete(:host)
+        end
+        return host, args
+      end
+    end
+
+    def self.prepended(base)
+      class << base
+        prepend ClassMethods
+      end
+    end
+  end
+
+  module URI
+    class Generic
+      prepend MiqURI
+    end
+  end
+end


### PR DESCRIPTION
It's a temporary workaround until ruby/ruby#765 is
readily available.  As of this writing, ruby 2.0.0p643 and ruby 2.2.0 have this fixed.
Ruby 2.1.5, and ruby 2.0.0p598 and lower don't have this fixed and NEED this hack.
Ruby 2.0: https://bugs.ruby-lang.org/issues/10873 (backported and in p643)
Ruby 2.1: https://bugs.ruby-lang.org/issues/10875 (backported and not released yet)
Ruby 2.2: https://bugs.ruby-lang.org/issues/10874 (backported and in 2.2.0)

Workaround before this hack:
```ruby
 # Don't pass :host => "::1" to .build as it throws URI::InvalidComponentError
 uri = URI::HTTPS.build(:path => "/sdk")
 uri.hostname = "::1"
 uri.to_s # => "https://[::1]/sdk"
```

After this hack the caller doesn't need to know to use [::1] or hostname= method:
```ruby
 uri = URI::HTTPS.build(:host => "::1", :path => "/sdk")
 uri.to_s # => "https://[::1]/sdk"
```

This enables us to use the fixed URI::Generic.build API now and  clean up 60c8f7f58b38648492a68399db16f31f71edd15a, 01cb19a7f2d4f97ee2a275798692f9d517913d64, 5cf1f3042fd343ea20f676772470f65359d1c6c4, e806c461bf744c025067698f9007a5d613186b06 and any other place we may do this in the future.

cc @matthewd @tenderlove @Fryguy @blomquisg @abonas 