### PR TITLE
Console: open ports for websocket proxy.

### DIFF
--- a/system/COPY/etc/sysconfig/iptables
+++ b/system/COPY/etc/sysconfig/iptables
@@ -12,6 +12,7 @@
 -A INPUT -p tcp -m tcp --dport 8443 -j ACCEPT
 -A INPUT -p udp -m udp --dport 443 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 5432 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 5900:5999 -j ACCEPT
 -A INPUT -p icmp -j ACCEPT
 -A INPUT -m limit --limit 5/min --limit-burst 7 -j LOG --log-prefix "**iptables drop**"
 -A INPUT -j DROP


### PR DESCRIPTION
Need these ports to run websocket proxy for the VNC and SPICE consoles.

In the future we would prefer to open the ports on request as part of the console launch and also close them when the proxy process is gone.