### PR TITLE
Fix Openstack SSL Error

### DIFF
--- a/lib/spec/openstack/openstack_handle/handle_spec.rb
+++ b/lib/spec/openstack/openstack_handle/handle_spec.rb
@@ -45,7 +45,7 @@ describe OpenstackHandle::Handle do
       fog            = double('fog')
       handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address")
       auth_url_nossl = OpenstackHandle::Handle.auth_url("address")
-      auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, true)
+      auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       # setup the socket error for the initial non-ssl failure
       socket_error = double('socket_error')

--- a/vmdb/app/models/mixins/ems_openstack_mixin.rb
+++ b/vmdb/app/models/mixins/ems_openstack_mixin.rb
@@ -74,6 +74,7 @@ module EmsOpenstackMixin
 
   def verify_api_credentials(options={})
     begin
+      options[:service] = "Identity"
       with_provider_connection(options) {}
     rescue Excon::Errors::Unauthorized => err
       $log.error("MIQ(#{self.class.name}.verify_api_credentials) Error Class=#{err.class.name}, Message=#{err.message}")


### PR DESCRIPTION
All connections to OpenStack need to attempt to connect non-SSL then SSL.  There are two reasons for this:

1.  OpenStack doesn't have a set of ports designated for use with their API over SSL.  The ports are generally kept as the same number (i.e., Keystone is usually 5000 regardless of whether it is SSL protected).

2.  ManageIQ does not have a way to specify whether a Provider's endpoint is using SSL.  So, users cannot configure this for different providers.

The problem that was uncovered by this bug is that *most* connections were trying SSL.  However, connections made with an unscoped token used to retrieve the list of visible tenants was **not** trying SSL.

Additionally, this PR will allow OpenStack credential validation to altogether bypass trying to determine the user's default tenant name.

Fixes #2155
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1201920