### PR TITLE
Hash containing default_proc cannot by dumped by DRb

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_mixin.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_mixin.rb
@@ -33,7 +33,7 @@ module MiqAeServiceMiqProvisionMixin
   end
 
   def check_quota(quota_type, options={})
-    object_send(:check_quota, quota_type, options)
+    drb_return(object_send(:check_quota, quota_type, options))
   end
 
   def eligible_resources(rsc_type)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1202427

check_quota should be using drb_return when sending back hashes that have default_proc