### PR TITLE
don't depend on the side-effects of `reportable_data`

### DIFF
--- a/vmdb/app/models/miq_reportable.rb
+++ b/vmdb/app/models/miq_reportable.rb
@@ -3,6 +3,9 @@ module MiqReportable
   def self.records2table(records, options)
     return Ruport::Data::Table.new if records.blank?
 
+    db = records.first.class
+    db.aar_columns = []
+
     data = records.map {|r|
       options[:include]["categories"] = options[:include_categories] if options[:include] && options[:include_categories]
       r.reportable_data(:include => options[:include],
@@ -14,7 +17,7 @@ module MiqReportable
 
     data = data[0..options[:limit] - 1] if options[:limit] # apply limit after includes are processed
     Ruport::Data::Table.new(:data => data,
-                            :column_names => [],
+                            :column_names => db.aar_columns,
                             :record_class => options[:record_class],
                             :filters => options[:filters])
   end

--- a/vmdb/app/models/miq_reportable.rb
+++ b/vmdb/app/models/miq_reportable.rb
@@ -3,23 +3,20 @@ module MiqReportable
   def self.records2table(records, options)
     return Ruport::Data::Table.new if records.blank?
 
-    db = records.first.class
-    db.aar_columns = []
-
     data = records.map {|r|
       options[:include]["categories"] = options[:include_categories] if options[:include] && options[:include_categories]
-      r.reportable_data(:include => options[:include],
-                             :only => options[:only],
-                             :except => options[:except],
-                             :tag_filters => options[:tag_filters],
-                             :methods => options[:methods])
-    }.flatten
+      r.reportable_data_with_columns(:include     => options[:include],
+                                     :only        => options[:only],
+                                     :except      => options[:except],
+                                     :tag_filters => options[:tag_filters],
+                                     :methods     => options[:methods])
+    }
 
     data = data[0..options[:limit] - 1] if options[:limit] # apply limit after includes are processed
-    Ruport::Data::Table.new(:data => data,
-                            :column_names => db.aar_columns,
+    Ruport::Data::Table.new(:data         => data.collect(&:last).flatten,
+                            :column_names => data.collect(&:first).flatten.uniq,
                             :record_class => options[:record_class],
-                            :filters => options[:filters])
+                            :filters      => options[:filters])
   end
 
   # generate a ruport table from an array of hashes where the keys are the column names

--- a/vmdb/app/models/mixins/reportable_mixin.rb
+++ b/vmdb/app/models/mixins/reportable_mixin.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 module ReportableMixin
   extend ActiveSupport::Concern
   included do
@@ -115,12 +117,19 @@ module ReportableMixin
     end
   end
 
-  def reportable_data(options = {})
+  def reportable_data_with_columns(options = {})
     data_records = [get_attributes_with_options(options)]
-    self.class.aar_columns |= data_records.first.keys
+    columns = data_records.first.keys
 
     data_records =
       add_includes(data_records, options) if options[:include]
+    [columns, data_records]
+  end
+
+  def reportable_data(options = {})
+    ActiveSupport::Deprecation.warn "`reportable_data` is deprecated, use `reportable_data_with_columns` instead"
+    columns, data_records = reportable_data_with_columns(options)
+    self.class.aar_columns |= columns
     data_records
   end
 

--- a/vmdb/spec/controllers/host_controller_spec.rb
+++ b/vmdb/spec/controllers/host_controller_spec.rb
@@ -2,6 +2,20 @@ require "spec_helper"
 
 describe HostController do
   context "#button" do
+    render_views
+
+    it "doesn't break" do
+      set_user_privileges
+      h1 = FactoryGirl.create(:host)
+      h2 = FactoryGirl.create(:host)
+      session[:host_items] = [h1.id, h2.id]
+      session[:settings] = {:views     => {:host => 'grid'},
+                            :display   => {:quad_truncate => 'f'},
+                            :quadicons => {:host => 'foo'}}
+      get :edit
+      expect(response.status).to eq(200)
+    end
+
     it "when VM Right Size Recommendations is pressed" do
       controller.instance_variable_set(:@_params, {:pressed => "vm_right_size"})
       controller.should_receive(:vm_right_size)


### PR DESCRIPTION
This removes depending on the global side effects of `reportable_data`
 by passing the columns back with the report data.