### PR TITLE
Error pages should return a 500

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -102,6 +102,7 @@ class ApplicationController < ActionController::Base
       end
       format.html do                # HTML, send error screen
         @layout = "exception"
+        response.status = 500
         render(:template => "layouts/exception", :locals => { :message => msg })
       end
       format.any { render :nothing => true, :status => 404 }  # Anything else, just send 404

--- a/vmdb/spec/controllers/container_group_controller_spec.rb
+++ b/vmdb/spec/controllers/container_group_controller_spec.rb
@@ -23,6 +23,14 @@ describe ContainerGroupController do
   end
 
   it "renders show_list" do
+    session[:settings] = {:default_search => 'foo',
+                          :views          => {:containernode => 'list'},
+                          :perpage        => {:list => 10}}
+    session[:userid] = User.current_user.userid
+    session[:eligible_groups] = []
+    FactoryGirl.create(:vmdb_database)
+    EvmSpecHelper.create_guid_miq_server_zone
+
     get :show_list
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty

--- a/vmdb/spec/controllers/container_node_controller_spec.rb
+++ b/vmdb/spec/controllers/container_node_controller_spec.rb
@@ -23,6 +23,14 @@ describe ContainerNodeController do
   end
 
   it "renders show_list" do
+    session[:settings] = {:default_search => 'foo',
+                          :views          => {:containernode => 'list'},
+                          :perpage        => {:list => 10}}
+    session[:userid] = User.current_user.userid
+    session[:eligible_groups] = []
+    FactoryGirl.create(:vmdb_database)
+    EvmSpecHelper.create_guid_miq_server_zone
+
     get :show_list
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty

--- a/vmdb/spec/controllers/container_service_controller_spec.rb
+++ b/vmdb/spec/controllers/container_service_controller_spec.rb
@@ -23,6 +23,15 @@ describe ContainerServiceController do
   end
 
   it "renders show_list" do
+    session[:settings] = {:default_search => 'foo',
+                          :views          => {:containernode => 'list'},
+                          :perpage        => {:list => 10}}
+    session[:eligible_groups] = []
+    session[:userid] = User.current_user.userid
+
+    FactoryGirl.create(:vmdb_database)
+    EvmSpecHelper.create_guid_miq_server_zone
+
     get :show_list
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty


### PR DESCRIPTION
For some reason, our exception page is setting the status to a 200.  It should be a 500.  I'm afraid this may cause tests to fail since many tests assert the response as 200, but in fact there are exceptions (IOW, the tests *are actually broken*).