### PR TITLE
pass utc to to_time

### DIFF
--- a/vmdb/app/models/miq_expression.rb
+++ b/vmdb/app/models/miq_expression.rb
@@ -1215,7 +1215,7 @@ class MiqExpression
       return mode == :sql ? ActiveRecord::Base.connection.quote(val) : "\'#{val}\'.to_date"
     when "datetime"
       return "nil" if val.blank? # treat nil value as empty string
-      return mode == :sql ? ActiveRecord::Base.connection.quote(val.iso8601) : "\'#{val.iso8601}\'.to_time"
+      return mode == :sql ? ActiveRecord::Base.connection.quote(val.iso8601) : "\'#{val.iso8601}\'.to_time(:utc)"
     when "integer", "decimal", "fixnum"
       return val.to_s.to_i_with_method
     when "float"

--- a/vmdb/app/models/miq_schedule.rb
+++ b/vmdb/app/models/miq_schedule.rb
@@ -45,7 +45,9 @@ class MiqSchedule < ActiveRecord::Base
     val = read_attribute(:run_at)
     if val.kind_of?(Hash)
       st = val[:start_time]
-      val[:start_time] = st.to_time.utc if st
+      if st && String === st
+        val[:start_time] = st.to_time(:utc).utc
+      end
     end
     return val
   end

--- a/vmdb/app/models/miq_widget.rb
+++ b/vmdb/app/models/miq_widget.rb
@@ -559,7 +559,7 @@ class MiqWidget < ActiveRecord::Base
     elsif unit == "hourly"
       ts = (Time.now.utc + 1.hour).iso8601
       ts[14..18] = "00:00"
-      sched_time = ts.to_time.in_time_zone(server_tz)
+      sched_time = ts.to_time(:utc).in_time_zone(server_tz)
     else
       raise "Unsupported interval '#{interval}'"
     end

--- a/vmdb/lib/workers/schedule_worker.rb
+++ b/vmdb/lib/workers/schedule_worker.rb
@@ -224,10 +224,10 @@ class ScheduleWorker < WorkerBase
 
     # Schedule every 24 hours
     at = worker_setting_or_default(:storage_file_collection_time_utc)
-    if Time.now.strftime("%Y-%m-%d #{at}").to_time < Time.now.utc
-      time_at = 1.day.from_now.utc.strftime("%Y-%m-%d #{at}").to_time
+    if Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc) < Time.now.utc
+      time_at = 1.day.from_now.utc.strftime("%Y-%m-%d #{at}").to_time(:utc)
     else
-      time_at = Time.now.strftime("%Y-%m-%d #{at}").to_time
+      time_at = Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc)
     end
     @schedules[:scheduler] << self.system_schedule_every(worker_setting_or_default(:storage_file_collection_interval), :first_at => time_at) do |rufus_job|
       @queue.enq :storage_scan_timer

--- a/vmdb/spec/models/miq_expression/miq_expression_spec.rb
+++ b/vmdb/spec/models/miq_expression/miq_expression_spec.rb
@@ -496,16 +496,16 @@ describe MiqExpression do
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time && val.to_time <= '2011-01-10T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T23:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]}})
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
@@ -514,10 +514,10 @@ describe MiqExpression do
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T08:00:00Z'.to_time && val.to_time <= '2011-01-10T17:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T08:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T17:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time && val.to_time <= '2011-01-10T00:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T00:00:00Z'.to_time(:utc)"
       end
 
       it "should generate the correct ruby expression running to_ruby with an expression having static dates and times with a time zone" do
@@ -542,10 +542,10 @@ describe MiqExpression do
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"}})
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date"
@@ -554,10 +554,10 @@ describe MiqExpression do
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T13:00:00Z'.to_time && val.to_time <= '2011-01-10T22:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T13:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T22:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time && val.to_time <= '2011-01-10T05:00:00Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T05:00:00Z'.to_time(:utc)"
       end
 
       it "should generate the correct SQL query running to_sql with an expression having static dates and times with no time zone" do
@@ -745,28 +745,28 @@ describe MiqExpression do
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"}})
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time && val.to_time <= '2011-01-11T17:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T17:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]}})
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time && val.to_time <= '2011-01-09T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T00:00:00Z'.to_time && val.to_time <= '2010-12-31T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T00:00:00Z'.to_time(:utc) && val.to_time <= '2010-12-31T23:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-last_scan_on", "value" => "Last Week"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time && val.to_time <= '2011-01-09T23:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-retires_on", "value" => "Last Week"}})
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
@@ -778,26 +778,26 @@ describe MiqExpression do
         exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"}})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time && val.to_time <= '2011-01-11T14:59:59Z'.to_time"
+        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)"
       end
 
       it "should generate the correct ruby expression running to_ruby with an expression having relative time with a time zone" do
         tz = "Hawaii"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time && val.to_time <= '2011-01-11T17:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T17:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]}})
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time && val.to_time <= '2011-01-10T09:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T10:00:00Z'.to_time && val.to_time <= '2011-01-01T09:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-01T09:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-last_scan_on", "value" => "Last Week"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time && val.to_time <= '2011-01-10T09:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-retires_on", "value" => "Last Week"}})
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
@@ -809,7 +809,7 @@ describe MiqExpression do
         exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date"
 
         exp = MiqExpression.new({"IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"}})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time && val.to_time <= '2011-01-11T14:59:59Z'.to_time"
+        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)"
       end
 
       it "should generate the correct SQL query running to_sql with an expression having relative dates with no time zone" do


### PR DESCRIPTION
we need to pass the conversion value to to_time since newer versions of
to_time assume the conversion is `local` rather than `utc`