### PR TITLE
only parse time once

### DIFF
--- a/vmdb/app/controllers/api_controller/vms.rb
+++ b/vmdb/app/controllers/api_controller/vms.rb
@@ -180,7 +180,7 @@ class ApiController
 
     def vm_event(vm, event_type, event_message, event_time)
       desc = "Adding Event type=#{event_type} message=#{event_message}"
-      event_timestamp = event_time.blank? ? Time.now.utc.iso8601 : Time.parse(event_time).utc.iso8601
+      event_timestamp = event_time.blank? ? Time.now.utc : event_time.to_time(:utc)
 
       vm.add_ems_event(event_type, event_message, event_timestamp)
       action_result(true, desc)

--- a/vmdb/app/models/ems_event.rb
+++ b/vmdb/app/models/ems_event.rb
@@ -261,7 +261,7 @@ class EmsEvent < ActiveRecord::Base
     new_event = EmsEvent.create(event) unless EmsEvent.exists?(
       {
         :event_type => event[:event_type],
-        :timestamp => event[:timestamp].to_time,
+        :timestamp => event[:timestamp],
         :chain_id => event[:chain_id],
         :ems_id => event[:ems_id]
       }

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1840,7 +1840,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   def self.event_by_property(property, value, event_type, event_message, event_time=nil, options={})
     $log.info "MIQ(#{self.name}.event_by_property) event_vm_by_property called with property:[#{property}] value:[#{value}] type:[#{event_type}] message:[#{event_message}] event_time:[#{event_time}]"
-    event_timestamp = event_time.blank? ? Time.now.utc.iso8601 : Time.parse(event_time).utc.iso8601
+    event_timestamp = event_time.blank? ? Time.now.utc : event_time.to_time(:utc)
 
     case property
     when "ipaddress"

--- a/vmdb/spec/models/vm_or_template_spec.rb
+++ b/vmdb/spec/models/vm_or_template_spec.rb
@@ -12,7 +12,7 @@ describe VmOrTemplate do
         @vm              = FactoryGirl.create(:vm_vmware, :host  => @host, :name => "vm", :uid_ems => "1", :ems_id => 101)
 
         @event_type      = "foo"
-        @event_timestamp = Time.now.utc.iso8601
+        @event_timestamp = Time.now.utc
       end
 
       after(:each) do


### PR DESCRIPTION
This code will potentially parse time twice.  We should parse it once,
when it is input, and parse it with respect to utc.  This cleans the
code a little and makes it compatible with Rails 4 by removing some
to_time warnings