### PR TITLE
fix_auth: use random when fixing secret_token(s)

### DIFF
--- a/lib/spec/support/custom_matchers/be_encrypted.rb
+++ b/lib/spec/support/custom_matchers/be_encrypted.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :be_encrypted do |expected|
   end
 
   failure_message_for_should_not do |actual|
-    "expected: #{actual.inspect} not to be encrypted"
+    "expected: #{actual.inspect} not to be encrypted#{ " and decrypt to #{expected}" if expected}"
   end
 
   description do

--- a/vmdb/tools/fix_auth/auth_model.rb
+++ b/vmdb/tools/fix_auth/auth_model.rb
@@ -25,15 +25,19 @@ module FixAuth
         end.join(" OR ")
       end
 
+      def hardcode(_old_value, new_value)
+        MiqPassword.encrypt(new_value)
+      end
+
       def recrypt(old_value, options = {})
         if options[:hardcode]
-          MiqPassword.encrypt(options[:hardcode])
+          hardcode(old_value, options[:hardcode])
         else
           MiqPassword.new.recrypt(old_value)
         end
       rescue
         if options[:invalid]
-          MiqPassword.encrypt(options[:invalid])
+          hardcode(old_value, options[:invalid])
         else
           raise
         end


### PR DESCRIPTION
`fix_auth` is the tool users use when they lose a `v2_key`.
After losing a `v2_key`, the passwords can't be retrieved and are thus invalid.
The option of `--invalid bogus` resets these passwords to a known value.
The user can then go into the ui and correct.

The `MiqDatabase` table is an exception here. `session_secret_token` and `csrf_secret_token` do not contain provider passwords but rather random strings. So the invalid option works a little differently for this table. If you specify invalid, it will populate with a random string and not the `bogus` value provided by the user.

Unfortunately #962 introduces a bug where `session_secret_token` and `csrf_secret_token` are populated with `bogus` value.

This PR re-introduces the `hardcode` method that was overridden by `FixMiqDatabase`.

/cc @jrafanie @abellotti

**UPDATED:** reworded. thanks @abellotti 
**UPDATED:** The bug luckily was found before going out with 5.3 or 5.4