### PR TITLE
Fix auth v2

### DIFF
--- a/vmdb/spec/tools/fix_auth/cli_spec.rb
+++ b/vmdb/spec/tools/fix_auth/cli_spec.rb
@@ -39,4 +39,28 @@ describe FixAuth::Cli do
       :databases => %w(vmdb_production),
       :hardcode  => "hardcoded")
   end
+
+  it "defaults to updating the database" do
+    options = described_class.new.parse(%w())
+      .options.slice(:db, :databaseyml, :key)
+    expect(options).to eq(:db => true)
+  end
+
+  it "doesnt default to database if running another task" do
+    options = described_class.new.parse(%w(--databaseyml))
+      .options.slice(:db, :databaseyml, :key)
+    expect(options).to eq(:databaseyml => true)
+  end
+
+  it "doesnt default to database if running another task 2" do
+    options = described_class.new.parse(%w(--key))
+      .options.slice(:db, :databaseyml, :key)
+    expect(options).to eq(:key => true)
+  end
+
+  it "can run all 3 tasks" do
+    options = described_class.new.parse(%w(--key --db --databaseyml))
+      .options.slice(:db, :databaseyml, :key)
+    expect(options).to eq(:db => true, :databaseyml => true, :key => true)
+  end
 end

--- a/vmdb/spec/tools/fix_auth/cli_spec.rb
+++ b/vmdb/spec/tools/fix_auth/cli_spec.rb
@@ -5,62 +5,64 @@ $LOAD_PATH << Rails.root.join("tools")
 require "fix_auth/cli"
 
 describe FixAuth::Cli do
-  it "should assign defaults" do
-    options = described_class.new.parse([], {})
-              .options.slice(:hostname, :username, :password, :hardcode, :databases)
-    expect(options).to eq(
-      :username  => "root",
-      :databases => %w(vmdb_production))
-  end
+  describe "#parse" do
+    it "should assign defaults" do
+      opts = described_class.new.parse([], {})
+             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+      expect(opts).to eq(
+        :username  => "root",
+        :databases => %w(vmdb_production))
+    end
 
-  it "should pickup env variables" do
-    options = described_class.new.parse([], "PGUSER" => "envuser", "PGPASSWORD" => "envpass", "PGHOST" => "envhost")
-              .options.slice(:hostname, :username, :password, :hardcode, :databases)
-    expect(options).to eq(
-      :username  => "envuser",
-      :databases => %w(vmdb_production),
-      :password  => "envpass",
-      :hostname  => "envhost")
-  end
+    it "should pickup env variables" do
+      opts = described_class.new.parse([], "PGUSER" => "envuser", "PGPASSWORD" => "envpass", "PGHOST" => "envhost")
+             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+      expect(opts).to eq(
+        :username  => "envuser",
+        :databases => %w(vmdb_production),
+        :password  => "envpass",
+        :hostname  => "envhost")
+    end
 
-  it "should parse database names" do
-    options = described_class.new.parse(%w(DB1 DB2))
-              .options.slice(:hostname, :username, :password, :hardcode, :databases)
-    expect(options).to eq(
-      :username  => "root",
-      :databases => %w(DB1 DB2))
-  end
+    it "should parse database names" do
+      opts = described_class.new.parse(%w(DB1 DB2))
+             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+      expect(opts).to eq(
+        :username  => "root",
+        :databases => %w(DB1 DB2))
+    end
 
-  it "should parse hardcoded password" do
-    options = described_class.new.parse(%w(-P hardcoded))
-              .options.slice(:hostname, :username, :password, :hardcode, :databases)
-    expect(options).to eq(
-      :username  => "root",
-      :databases => %w(vmdb_production),
-      :hardcode  => "hardcoded")
-  end
+    it "should parse hardcoded password" do
+      opts = described_class.new.parse(%w(-P hardcoded))
+             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+      expect(opts).to eq(
+        :username  => "root",
+        :databases => %w(vmdb_production),
+        :hardcode  => "hardcoded")
+    end
 
-  it "defaults to updating the database" do
-    options = described_class.new.parse(%w())
-              .options.slice(:db, :databaseyml, :key)
-    expect(options).to eq(:db => true)
-  end
+    it "defaults to updating the database" do
+      opts = described_class.new.parse(%w())
+             .options.slice(:db, :databaseyml, :key)
+      expect(opts).to eq(:db => true)
+    end
 
-  it "doesnt default to database if running another task" do
-    options = described_class.new.parse(%w(--databaseyml))
-              .options.slice(:db, :databaseyml, :key)
-    expect(options).to eq(:databaseyml => true)
-  end
+    it "doesnt default to database if running another task" do
+      opts = described_class.new.parse(%w(--databaseyml))
+             .options.slice(:db, :databaseyml, :key)
+      expect(opts).to eq(:databaseyml => true)
+    end
 
-  it "doesnt default to database if running another task 2" do
-    options = described_class.new.parse(%w(--key))
-              .options.slice(:db, :databaseyml, :key)
-    expect(options).to eq(:key => true)
-  end
+    it "doesnt default to database if running another task 2" do
+      opts = described_class.new.parse(%w(--key))
+             .options.slice(:db, :databaseyml, :key)
+      expect(opts).to eq(:key => true)
+    end
 
-  it "can run all 3 tasks" do
-    options = described_class.new.parse(%w(--key --db --databaseyml))
-              .options.slice(:db, :databaseyml, :key)
-    expect(options).to eq(:db => true, :databaseyml => true, :key => true)
+    it "can run all 3 tasks" do
+      opts = described_class.new.parse(%w(--key --db --databaseyml))
+             .options.slice(:db, :databaseyml, :key)
+      expect(opts).to eq(:db => true, :databaseyml => true, :key => true)
+    end
   end
 end

--- a/vmdb/spec/tools/fix_auth/cli_spec.rb
+++ b/vmdb/spec/tools/fix_auth/cli_spec.rb
@@ -7,7 +7,7 @@ require "fix_auth/cli"
 describe FixAuth::Cli do
   it "should assign defaults" do
     options = described_class.new.parse([], {})
-      .options.slice(:hostname, :username, :password, :hardcode, :databases)
+              .options.slice(:hostname, :username, :password, :hardcode, :databases)
     expect(options).to eq(
       :username  => "root",
       :databases => %w(vmdb_production))
@@ -15,7 +15,7 @@ describe FixAuth::Cli do
 
   it "should pickup env variables" do
     options = described_class.new.parse([], "PGUSER" => "envuser", "PGPASSWORD" => "envpass", "PGHOST" => "envhost")
-      .options.slice(:hostname, :username, :password, :hardcode, :databases)
+              .options.slice(:hostname, :username, :password, :hardcode, :databases)
     expect(options).to eq(
       :username  => "envuser",
       :databases => %w(vmdb_production),
@@ -25,7 +25,7 @@ describe FixAuth::Cli do
 
   it "should parse database names" do
     options = described_class.new.parse(%w(DB1 DB2))
-      .options.slice(:hostname, :username, :password, :hardcode, :databases)
+              .options.slice(:hostname, :username, :password, :hardcode, :databases)
     expect(options).to eq(
       :username  => "root",
       :databases => %w(DB1 DB2))
@@ -33,7 +33,7 @@ describe FixAuth::Cli do
 
   it "should parse hardcoded password" do
     options = described_class.new.parse(%w(-P hardcoded))
-      .options.slice(:hostname, :username, :password, :hardcode, :databases)
+              .options.slice(:hostname, :username, :password, :hardcode, :databases)
     expect(options).to eq(
       :username  => "root",
       :databases => %w(vmdb_production),
@@ -42,25 +42,25 @@ describe FixAuth::Cli do
 
   it "defaults to updating the database" do
     options = described_class.new.parse(%w())
-      .options.slice(:db, :databaseyml, :key)
+              .options.slice(:db, :databaseyml, :key)
     expect(options).to eq(:db => true)
   end
 
   it "doesnt default to database if running another task" do
     options = described_class.new.parse(%w(--databaseyml))
-      .options.slice(:db, :databaseyml, :key)
+              .options.slice(:db, :databaseyml, :key)
     expect(options).to eq(:databaseyml => true)
   end
 
   it "doesnt default to database if running another task 2" do
     options = described_class.new.parse(%w(--key))
-      .options.slice(:db, :databaseyml, :key)
+              .options.slice(:db, :databaseyml, :key)
     expect(options).to eq(:key => true)
   end
 
   it "can run all 3 tasks" do
     options = described_class.new.parse(%w(--key --db --databaseyml))
-      .options.slice(:db, :databaseyml, :key)
+              .options.slice(:db, :databaseyml, :key)
     expect(options).to eq(:db => true, :databaseyml => true, :key => true)
   end
 end

--- a/vmdb/spec/tools/fix_auth/fix_auth_spec.rb
+++ b/vmdb/spec/tools/fix_auth/fix_auth_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+$LOAD_PATH << Rails.root.join("tools")
+
+require "fix_auth/fix_auth"
+require "fix_auth/models"
+
+describe FixAuth::FixAuth do
+
+  describe "#fix_database_yml" do
+    it "respects --hardcode" do
+      subject = described_class.new(:password => 'newpass', :root => '/', :databaseyml => true)
+      expect(FixAuth::FixDatabaseYml).to receive(:run).with(:hardcode => 'newpass')
+      subject.fix_database_yml
+    end
+
+    it "respects --password" do
+      subject = described_class.new(:hardcode => 'newpass', :root => '/', :databaseyml => true)
+      expect(FixAuth::FixDatabaseYml).to receive(:run).with(:hardcode => 'newpass')
+      subject.fix_database_yml
+    end
+  end
+end

--- a/vmdb/spec/tools/fix_auth/fix_auth_spec.rb
+++ b/vmdb/spec/tools/fix_auth/fix_auth_spec.rb
@@ -7,13 +7,13 @@ require "fix_auth/models"
 
 describe FixAuth::FixAuth do
   describe "#fix_database_yml" do
-    it "respects --hardcode" do
+    it "supports --hardcode" do
       subject = described_class.new(:password => 'newpass', :root => '/', :databaseyml => true)
       expect(FixAuth::FixDatabaseYml).to receive(:run).with(:hardcode => 'newpass')
       subject.fix_database_yml
     end
 
-    it "respects --password" do
+    it "supports --password as an alias of --hardcode" do
       subject = described_class.new(:hardcode => 'newpass', :root => '/', :databaseyml => true)
       expect(FixAuth::FixDatabaseYml).to receive(:run).with(:hardcode => 'newpass')
       subject.fix_database_yml

--- a/vmdb/spec/tools/fix_auth/fix_auth_spec.rb
+++ b/vmdb/spec/tools/fix_auth/fix_auth_spec.rb
@@ -6,7 +6,6 @@ require "fix_auth/fix_auth"
 require "fix_auth/models"
 
 describe FixAuth::FixAuth do
-
   describe "#fix_database_yml" do
     it "respects --hardcode" do
       subject = described_class.new(:password => 'newpass', :root => '/', :databaseyml => true)

--- a/vmdb/tools/fix_auth/auth_config_model.rb
+++ b/vmdb/tools/fix_auth/auth_config_model.rb
@@ -13,21 +13,21 @@ module FixAuth
         puts "  #{r.id}:"
       end
 
-      def display_column(r, column)
+      def display_column(r, column, options)
         puts "    #{column}:"
-        traverse_column([], YAML.load(r.send(column)))
+        traverse_column([], YAML.load(r.send(column)), options)
       end
 
       def password_field?(key)
         key.to_s.in?(password_fields) || (password_prefix && key.to_s.include?(password_prefix))
       end
 
-      def traverse_column(names, hash)
+      def traverse_column(names, hash, options)
         hash.each_pair do |n, v|
           if password_field?(n)
-            puts "      #{names.join(".")}.#{n}: #{v}"
+            puts "      #{names.join(".")}.#{n}: #{highlight_password(v, options)}"
           elsif v.is_a?(Hash)
-            traverse_column(names + [n], v)
+            traverse_column(names + [n], v, options)
           end
         end
       end

--- a/vmdb/tools/fix_auth/cli.rb
+++ b/vmdb/tools/fix_auth/cli.rb
@@ -21,7 +21,7 @@ module FixAuth
         opt :v2,       "Fix V2 passwords also", :type => :boolean, :short => "f", :default => true
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
-        opt :databaseyml, "rewrite databaseyml", :type => :boolean, :short => "y", :default => false
+        opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false
         opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
       end
 

--- a/vmdb/tools/fix_auth/cli.rb
+++ b/vmdb/tools/fix_auth/cli.rb
@@ -22,9 +22,12 @@ module FixAuth
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
         opt :databaseyml, "rewrite databaseyml", :type => :boolean, :short => "y", :default => false
+        opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
       end
 
       options[:databases] = args.presence || %w(vmdb_production)
+      # default to updating the db
+      options[:db] = true if !options[:key] && !options[:databaseyml]
       self.options = options.delete_if { |n, v| v.blank? }
       self
     end

--- a/vmdb/tools/fix_auth/cli.rb
+++ b/vmdb/tools/fix_auth/cli.rb
@@ -18,7 +18,7 @@ module FixAuth
         opt :hardcode, "Password to use for all passwords",     :type => :string, :short => "P"
         opt :invalid,  "Password to use for invalid passwords", :type => :string, :short => "i"
         opt :key,      "Generate key",      :type => :boolean, :short => "k"
-        opt :v2,       "Fix V2 passwords also", :type => :boolean, :short => "f", :default => false
+        opt :v2,       "Fix V2 passwords also", :type => :boolean, :short => "f", :default => true
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
         opt :databaseyml, "rewrite databaseyml", :type => :boolean, :short => "y", :default => false

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -81,7 +81,7 @@ module FixAuth
 
       generate_password if options[:key]
       fix_database_yml if options[:databaseyml]
-      fix_database_passwords if !options[:key] && !options[:databaseyml]
+      fix_database_passwords if options[:db]
     end
   end
 end

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -73,7 +73,7 @@ module FixAuth
 
     def fix_database_yml
       FixDatabaseYml.file_name = "#{options[:root]}/config/database.yml"
-      FixDatabaseYml.run(run_options.merge(:hardcode => options[:password]))
+      FixDatabaseYml.run({:hardcode => options[:password]}.merge(run_options))
     end
 
     def run


### PR DESCRIPTION
While working through helping a customer upgrade their database, the command line was a little confusing for them. Also found a few bugs.

1. Always told users to pass in `--v2` when having key issues. It was an optimization added before and to be honest, doesn't really buy us enough. Turning this off by default. Potentially want to tear this option out.
2. With `--databaseyml`, either `--hardcode` or `--password` should work. I never remember the syntax so fixed code for either to work.
3. When explaining `fix_auth.rb` to the customer, it is confusing to explain the difference between the action flags. And to make matters worse, passing in no flag actually meant something. To stay backwards compatible, this still supports no flag, but now `--db` will upgrade the database. This helps them understand what they are doing.
4. Never knew whether a `Configuration` table hash was updated or not. Now it is easier to spot when a key was replaces via the `--invalid` option.

Hope that will begin to make things easier to understand for our users.
/cc @jrafanie @abellotti 

related to https://bugzilla.redhat.com/show_bug.cgi?id=1200424

---
**UPDATE:**

Running 2 commands
a) update `database.yml` with new encryption keys.
b) update database with new encryption keys.

before:
```
# bundle exec ruby ./tools/fix_auth.rb --databaseyml -v --password smartvm # A
  /Users/kbrock/src/manageiq/vmdb/config/database.yml:
      base.password: v2:{P4PLVcHJ6Sh1rG0R6CAkkA==}
# bundle exec ruby ./tools/fix_auth.rb -v --v2 --invalid bogus # B
fixing authentications.password, auth_key
  10000000000025:
    password: "v2:{/OViaBJ0Ug+RSW9n7EFGqw==}" (not changed)
  10000000000004:
    password: "v2:{I2SQ5PdmGPwN7t5goRiyaQ==}" => v2:{pm+OaUShlWLpGj5WUN+ZfQ==}
...
fixing configurations.settings
  10000000000001 (vmdb.yml):
      authentication.bind_pwd: 
      http_proxy.password: 
      log_depot.password: v2:{pm+OaUShlWLpGj5WUN+ZfQ==}
      smtp.password: v2:{pm+OaUShlWLpGj5WUN+ZfQ==}
      workers.worker_base.replication_worker.replication.destination.password: v2:{I2SQ5PdmGPwN7t5goRiyaQ==}
```
after:
```
# bundle exec ruby ./tools/fix_auth.rb --databaseyml -v --hardcode smartvm # A
  /Users/kbrock/src/manageiq/vmdb/config/database.yml:
      base.password: v2:{P4PLVcHJ6Sh1rG0R6CAkkA==} HARDCODED
# bundle exec ruby ./tools/fix_auth.rb --db -v --invalid bogus # B
fixing authentications.password, auth_key
  10000000000025:
    password: "v2:{/OViaBJ0Ug+RSW9n7EFGqw==}" (not changed)
  10000000000004:
    password: "v2:{I2SQ5PdmGPwN7t5goRiyaQ==}" => v2:{pm+OaUShlWLpGj5WUN+ZfQ==} HARDCODED (WAS INVALID)
...
fixing configurations.settings
  10000000000001 (vmdb.yml):
      authentication.bind_pwd: 
      http_proxy.password: 
      log_depot.password: v2:{pm+OaUShlWLpGj5WUN+ZfQ==} HARDCODED (WAS INVALID)
      smtp.password: v2:{pm+OaUShlWLpGj5WUN+ZfQ==} HARDCODED (WAS INVALID)
      workers.worker_base.replication_worker.replication.destination.password: v2:{I2SQ5PdmGPwN7t5goRiyaQ==}
```

Differences:
1. The second command (B) no longer needs `--v2`. Before, if the user forgot this, the database could be still invalid. even after what looked like a successful run. After, it fixes the key correctly.
2. The first command (A) works with `--password` or `--hardcode`. the database password is configured using `--password` so that may make more sense to them. On the other hand, updating the database receives `--hardcode` when you want to replace an encrypted password. It is lenient and supports either.
3. The second command (B) has `--db` which lets them know they are updating the database. First command has `--databaseyml`. It is consistent. If they skip `--db` it will still update the database to be backwards compatible.
4. The output from the commands tells you if keys were updated for a particular reason other than converting a key from a v1 to v2 key. Displaying `HARDCODED` and `HARDCODED (WAS INVALID)`.