### PR TITLE
Save inventory consistency

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -1,7 +1,8 @@
 module EmsRefresh::SaveInventoryHelper
   def save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys = [], extra_keys = [])
     deletes = deletes.to_a # make sure to load the association if it's an association
-    child_keys, extra_keys, remove_keys = self.save_inventory_prep(child_keys, extra_keys)
+    child_keys = Array.wrap(child_keys)
+    remove_keys = Array.wrap(extra_keys) + child_keys
 
     record_index, record_index_columns = self.save_inventory_prep_record_index(parent.send(type), find_key)
 
@@ -22,21 +23,14 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def save_inventory_single(type, parent, hash, child_keys = [], extra_keys = [])
-    child_keys, extra_keys, remove_keys = self.save_inventory_prep(child_keys, extra_keys)
+    child_keys = Array.wrap(child_keys)
+    remove_keys = Array.wrap(extra_keys) + child_keys
     if hash.blank?
       parent.send(type).try(:destroy)
     else
       save_inventory(type, parent, hash.except(*remove_keys))
       save_child_inventory(parent.send(type), hash, child_keys)
     end
-  end
-
-  def save_inventory_prep(child_keys, extra_keys)
-    # Normalize the keys for different types on inputs
-    child_keys = [child_keys].compact unless child_keys.kind_of?(Array)
-    extra_keys = [extra_keys].compact unless extra_keys.kind_of?(Array)
-    remove_keys = child_keys + extra_keys
-    return child_keys, extra_keys, remove_keys
   end
 
   def save_inventory(type, parent, hash)


### PR DESCRIPTION
~~Really want to get the number of args into `save_inventory_with_findkey` down.~~
~~Pulling out the find functionality from the save functionality cuts it down.~~

removed `save_inventory_prep` since it has really reduced in scope (thanks @tenderlove / #2161 )

This is basically just `s/save_inventory_prep/Array.wrap/g`

/cc @Fryguy 