### PR TITLE
purge backup_keys/restore_keys

### DIFF
--- a/vmdb/app/models/ems_refresh.rb
+++ b/vmdb/app/models/ems_refresh.rb
@@ -181,17 +181,13 @@ module EmsRefresh
     child_keys = [:operating_system, :hardware]
     remove_keys = child_keys
 
-    # Backup keys that cannot be written directly to the database
-    key_backup = hash.slice(*child_keys)
-    tmp_hash   = hash.except(*remove_keys)
-
     begin
       raise MiqException::MiqIncompleteData if hash[:invalid]
 
       $log.info("#{log_header} Updating Vm [#{vm.name}] id: [#{vm.id}] location: [#{vm.location}] storage id: [#{vm.storage_id}] uid_ems: [#{vm.uid_ems}]")
-      vm.update_attributes!(tmp_hash)
+      vm.update_attributes!(hash.except(*remove_keys))
 
-      save_child_inventory(vm, key_backup, child_keys)
+      save_child_inventory(vm, hash.slice(*child_keys), child_keys)
 
       vm.save!
       hash[:id] = vm.id

--- a/vmdb/app/models/ems_refresh.rb
+++ b/vmdb/app/models/ems_refresh.rb
@@ -186,9 +186,7 @@ module EmsRefresh
 
       $log.info("#{log_header} Updating Vm [#{vm.name}] id: [#{vm.id}] location: [#{vm.location}] storage id: [#{vm.storage_id}] uid_ems: [#{vm.uid_ems}]")
       vm.update_attributes!(hash.except(*remove_keys))
-
-      save_child_inventory(vm, hash.slice(*child_keys), child_keys)
-
+      save_child_inventory(vm, hash, child_keys)
       vm.save!
       hash[:id] = vm.id
     rescue => err


### PR DESCRIPTION
No reason to remove and then add to the hash.
This is handles by hash#except

(2 more after this before this method is removed)