### PR TITLE
MiqReportable.records2table - pass :column_names to Ruport instead of empty array

### DIFF
--- a/vmdb/app/models/miq_reportable.rb
+++ b/vmdb/app/models/miq_reportable.rb
@@ -13,8 +13,9 @@ module MiqReportable
     }.flatten
 
     data = data[0..options[:limit] - 1] if options[:limit] # apply limit after includes are processed
+
     Ruport::Data::Table.new(:data => data,
-                            :column_names => [],
+                            :column_names => options[:only],
                             :record_class => options[:record_class],
                             :filters => options[:filters])
   end


### PR DESCRIPTION
Ruport with a hash and empty column_names doesn't work as needed, the Hash gets converted to a proper Record, but then, gets normalized using only column_names, which is an empty array.

This uses the :only parameter as :column_names.

https://bugzilla.redhat.com/show_bug.cgi?id=1201684