### PR TITLE
_edit_to_email template fixes

### DIFF
--- a/vmdb/app/views/layouts/_edit_to_email.html.haml
+++ b/vmdb/app/views/layouts/_edit_to_email.html.haml
@@ -12,9 +12,7 @@
             = _("None")
           - else
             - if @temp[:email_to].present?
-              - emails = @temp[:email_to]
-                  .sort_by { |_email, display_email| display_name }
-                  .collect { |email, _display_email| email }
+              - emails = @temp[:email_to].sort_by { |_email, display_email| display_name }.collect { |email, _display_email| email }
             - elsif @edit[:new][:email][:to].present?
               - emails = @edit[:new][:email][:to].sort
             - else

--- a/vmdb/app/views/layouts/_edit_to_email.html.haml
+++ b/vmdb/app/views/layouts/_edit_to_email.html.haml
@@ -12,7 +12,7 @@
             = _("None")
           - else
             - if @temp[:email_to].present?
-              - emails = @temp[:email_to].sort_by { |_email, display_email| display_name }.collect { |email, _display_email| email }
+              - emails = @temp[:email_to].sort_by { |_email, display_email| display_email }.collect { |email, _display_email| email }
             - elsif @edit[:new][:email][:to].present?
               - emails = @edit[:new][:email][:to].sort
             - else


### PR DESCRIPTION
This fixes a typo in variable name and invalid formatting in haml.

Closes #1953.