### PR TITLE
Preserve & set the key domain attributes of domains after db reset

### DIFF
--- a/vmdb/app/models/miq_ae_datastore.rb
+++ b/vmdb/app/models/miq_ae_datastore.rb
@@ -174,8 +174,8 @@ module MiqAeDatastore
       domain_name = File.basename(File.dirname(domain_file))
       reset_domain(DATASTORE_DIRECTORY, domain_name)
     end
-    saved_attrs.each { |dom, attrs| MiqAeDomain.find_by_fqname(dom).update_attributes(attrs) }
 
+    restore_attrs_for_domains(saved_attrs)
     reset_default_namespace
   end
 
@@ -230,5 +230,9 @@ module MiqAeDatastore
       next if dom.name.downcase == MANAGEIQ_DOMAIN.downcase
       h[dom.name] = PRESERVED_ATTRS.each_with_object({}) { |attr, ih| ih[attr] = dom[attr] }
     end
+  end
+
+  def self.restore_attrs_for_domains(hash)
+    hash.each { |dom, attrs| MiqAeDomain.find_by_fqname(dom, false).update_attributes(attrs) }
   end
 end # module MiqAeDatastore

--- a/vmdb/app/models/miq_ae_datastore.rb
+++ b/vmdb/app/models/miq_ae_datastore.rb
@@ -7,6 +7,7 @@ module MiqAeDatastore
   DEFAULT_OBJECT_NAMESPACE = "$"
   TEMP_DOMAIN_PREFIX = "TEMP_DOMAIN"
   ALL_DOMAINS = "*"
+  PRESERVED_ATTRS = [:priority, :enabled, :system]
 
   # deprecated module
   module Import
@@ -168,10 +169,13 @@ module MiqAeDatastore
 
   def self.reset_to_defaults
     raise "Datastore directory [#{DATASTORE_DIRECTORY}] not found" unless Dir.exist?(DATASTORE_DIRECTORY)
+    saved_attrs = preserved_attrs_for_domains
     Dir.glob(DATASTORE_DIRECTORY.join("*", MiqAeDomain::DOMAIN_YAML_FILENAME)).each do |domain_file|
       domain_name = File.basename(File.dirname(domain_file))
       reset_domain(DATASTORE_DIRECTORY, domain_name)
     end
+    saved_attrs.each { |dom, attrs| MiqAeDomain.find_by_fqname(dom).update_attributes(attrs) }
+
     reset_default_namespace
   end
 
@@ -219,5 +223,12 @@ module MiqAeDatastore
     arel = MiqAeDomain.where("lower(name) = ?", name.downcase)
     arel = arel.where(:enabled => enabled) unless enabled.nil?
     arel.first
+  end
+
+  def self.preserved_attrs_for_domains
+    MiqAeDomain.all.each_with_object({}) do |dom, h|
+      next if dom.name.downcase == MANAGEIQ_DOMAIN.downcase
+      h[dom.name] = PRESERVED_ATTRS.each_with_object({}) { |attr, ih| ih[attr] = dom[attr] }
+    end
   end
 end # module MiqAeDatastore

--- a/vmdb/spec/models/miq_ae_datastore_spec.rb
+++ b/vmdb/spec/models/miq_ae_datastore_spec.rb
@@ -130,6 +130,19 @@ describe MiqAeDatastore do
       miq_ae_yaml_import_zipfs.should_receive(:import).once
       MiqAeDatastore.restore(dummy_zipfile)
     end
+
+    it "#restore_attrs_for_domains" do
+      d1 = FactoryGirl.create(:miq_ae_domain, :enabled => false, :system => true,
+                              :priority => 10, :name => "DOM1")
+      d2 = FactoryGirl.create(:miq_ae_domain, :enabled => true, :system => false,
+                              :priority => 11, :name => "DOM2")
+      domain_attributes = MiqAeDatastore.preserved_attrs_for_domains
+      d2.update_attributes(:priority => 6, :enabled => false, :system => true)
+      d1.update_attributes(:priority => 1, :enabled => true, :system => false)
+      MiqAeDatastore.preserved_attrs_for_domains.should_not eq(domain_attributes)
+      MiqAeDatastore.restore_attrs_for_domains(domain_attributes)
+      MiqAeDatastore.preserved_attrs_for_domains.should eq(domain_attributes)
+    end
   end
 
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1200925

Saves the priority, enabled and system attributes of all the domains and updates these after the reset