### PR TITLE
Move host's hostname_required? to the class level

### DIFF
--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1219,7 +1219,7 @@ class Host < ActiveRecord::Base
     self.reload
 
     self.attributes.each do |key, value|
-      next if %w{id guid ipmi_address mac_address name created_on updated_on vmm_vendor}.include?(key)
+      next if %w{id guid hostname ipmi_address mac_address name created_on updated_on vmm_vendor}.include?(key)
       self.send("#{key}=", nil)
     end
 

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -185,7 +185,11 @@ class Host < ActiveRecord::Base
   end
 
   def hostname_required?
-    self.vmm_vendor == "vmware"
+    self.class.hostname_required?
+  end
+
+  def self.hostname_required?
+    true
   end
 
   # host settings

--- a/vmdb/app/models/host_openstack_infra.rb
+++ b/vmdb/app/models/host_openstack_infra.rb
@@ -1,2 +1,5 @@
 class HostOpenstackInfra < Host
+  def self.hostname_required?
+    false
+  end
 end


### PR DESCRIPTION
Currently, this method is only used to validates_presence_of :hostname.

* Move hostname_required? to the Host class
  * Add instance method to delegate to the class method.
  * Subclasses can override this method to implement their own rules.

* hostname is required, don't clear it during host provisioning. …
  * When provisioning wants to create a new host, it duplicates the existing host's fields and clears most fields that can be discovered later.  We can't clear the hostname as it's now a required field all of the time.

* Apparently HostOpenstackInfra doesn't require hostname. …
  * Previously, only HostVmware required hostname, so this changes the behavior back as it was before for this class.

Fixes #2137, followup to #2136

Note, I "fixed" the host provisioning trying to "clear" the hostname field in the new destination record.  See the second commit. cc @gmcculloug @brandondunne 

For the 3rd commit, it looks like HostOpenstackInfra didn't previously require a `hostname` so it needs to override the `hostname_required?` otherwise the existing juno spec fails due to missing hostname in the validation.  Please help confirm this is ok @Ladas @rwsu @blomquisg.

EDIT:
Without the 3rd commit, it was failing with this:
```
  1) EmsRefresh::Refreshers::OpenstackInfraRefresher will perform a full refresh
     Failure/Error: Host.count.should                        == 6
       expected: 6
            got: 0 (using ==)
     # ./spec/models/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno_spec.rb:40:in `assert_table_counts'
     # ./spec/models/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno_spec.rb:29:in `block (3 levels) in <top (required)>'
     # ./spec/models/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno_spec.rb:14:in `times'
     # ./spec/models/ems_refresh/refreshers/openstack_infra_refresher_rhos_juno_spec.rb:14:in `block (2 levels) in <top (required)>'
```

[See the log here](https://gist.github.com/jrafanie/566d1a463b131d38aa42)