### PR TITLE
Foreman EMS refresh scheduling

### DIFF
--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -70,11 +70,15 @@ ems_refresh:
     get_shared_images: true
     get_public_images: false
     ignore_terminated_instances: true
-  scvmm:
+  foreman_configuration:
     :refresh_interval: 15.minutes
+  foreman_provisioning:
+    :refresh_interval: 1.hour
   full_refresh_threshold: 100
   raise_vm_snapshot_complete_if_created_within: 15.minutes
   refresh_interval: 24.hours
+  scvmm:
+    :refresh_interval: 15.minutes
 host_scan:
   queue_timeout: 20.minutes
 http_proxy:

--- a/vmdb/lib/workers/schedule_worker/jobs.rb
+++ b/vmdb/lib/workers/schedule_worker/jobs.rb
@@ -69,14 +69,8 @@ class ScheduleWorker < WorkerBase
       queue_work_on_each_zone(:class_name  => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate", :state => "ready")
     end
 
-    def ems_refresh_all_ems_timer
-      queue_work_on_each_zone(:class_name  => "ExtManagementSystem", :method_name => "refresh_all_ems_timer")
-    end
-
-    def ems_refresh_all_scvmm_timer
-      if EmsMicrosoft.any?
-        queue_work_on_each_zone(:class_name  => "EmsMicrosoft", :method_name => "refresh_all_ems_timer")
-      end
+    def ems_refresh_timer(klass)
+      queue_work_on_each_zone(:class_name  => klass.name, :method_name => "refresh_all_ems_timer") if klass.any?
     end
 
     def miq_alert_evaluate_hourly_timer

--- a/vmdb/spec/lib/workers/jobs/jobs_spec.rb
+++ b/vmdb/spec/lib/workers/jobs/jobs_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+require 'schedule_worker'
+
+describe ScheduleWorker::Jobs do
+  context "#ems_refresh_timer" do
+    it "with no EMSes" do
+      described_class.new.ems_refresh_timer(EmsVmware)
+
+      expect(MiqQueue.count).to eq(0)
+    end
+
+    it "with an EMS" do
+      _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+      FactoryGirl.create(:ems_vmware, :zone => zone)
+      described_class.new.ems_refresh_timer(EmsVmware)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => "EmsVmware",
+        :instance_id => nil,
+        :method_name => "refresh_all_ems_timer",
+        :zone        => zone.name
+      )
+    end
+  end
+end

--- a/vmdb/spec/lib/workers/schedule_worker_spec.rb
+++ b/vmdb/spec/lib/workers/schedule_worker_spec.rb
@@ -561,5 +561,19 @@ describe ScheduleWorker do
         @schedule_worker.check_dst
       end
     end
+
+    it "#schedule_settings_for_ems_refresh (private)" do
+      VMDB::Config.any_instance.stub(:config).and_return(
+        :ems_refresh => {
+          :refresh_interval => 24.hours,
+          :scvmm            => {:refresh_interval => 15.minutes}
+        }
+      )
+
+      settings = @schedule_worker.send(:schedule_settings_for_ems_refresh)
+
+      expect(settings[EmsVmware]).to    eq(86_400) # Uses default
+      expect(settings[EmsMicrosoft]).to eq(900)    # Uses override
+    end
   end
 end


### PR DESCRIPTION
I changed the EMS Refresh scheduling to be more generic, and not specific to just SCVMM.  To do so, instead of putting one giant `refresh_all_ems_timer` every `24.hours`, it puts a separate one per leaf subclass of only the types you have in the database, at the interval for that type.  This might technically be a little more overhead with more schedules on the queue, but I don't see it being a problem.

Then, adding Foreman is just a matter of adding a couple of configuration values.

@kbrock @brandondunne @gmcculloug @blomquisg Please review.  Are the configuration values good?  Should they be something else?

@jrafanie I want to write tests for the changes to the jobs that I made, but I'm not sure on the best approach.  Might need your help there.

cc @bronaghs @chessbyte on the changes re: SCVMM.  Technically, it's the same, just wanted to make you aware of it.