### PR TITLE
hostname_required? and validation of hostname is no longer needed.

### DIFF
--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -36,7 +36,6 @@ class Host < ActiveRecord::Base
   }
 
   validates_presence_of     :name
-  validates_presence_of     :hostname, :if => :hostname_required?
   validates_uniqueness_of   :name
   validates_inclusion_of    :user_assigned_os, :in => ["linux_generic", "windows_generic", nil]
   validates_inclusion_of    :vmm_vendor, :in => VENDOR_TYPES.values
@@ -182,10 +181,6 @@ class Host < ActiveRecord::Base
   def v_annotation
     return nil if self.hardware.nil?
     self.hardware.annotation
-  end
-
-  def hostname_required?
-    self.vmm_vendor == "vmware"
   end
 
   # host settings


### PR DESCRIPTION
Replaces #2216
Fixes #2137 (via deletion) :fire:
Followup to #2136

The initial 4dd2d13fc0a3 SVN History merged commit had:
`validates_presence_of :name, :hostname, :ipaddress, :vmm_vendor`

ipaddress_hostname_required? for vmm_vendor (vmware) was added in 79b0e8df33f6 for initial support for amazon EC2 hosts. We don't use EC2 hosts anymore so this can be removed.