### PR TITLE
Dialog reordering fixes - JS event storm, using id instead of original order

### DIFF
--- a/vmdb/app/assets/javascripts/miq_application.js
+++ b/vmdb/app/assets/javascripts/miq_application.js
@@ -789,15 +789,18 @@ function miqAttachTextAreaWithLines(id){
 function miqInitDashboardCols() {
   if (miqDomElementExists('col1')) {
     $('#col1').sortable({connectWith:'#col2, #col3', handle:"h2"});
-    $('#col1').bind('sortupdate', miqDropComplete);
+    $('#col1').off('sortupdate');
+    $('#col1').on('sortupdate', miqDropComplete);
   }
   if (miqDomElementExists('col2')) {
     $('#col2').sortable({connectWith:'#col1, #col3', handle:"h2"});
-    $('#col2').bind('sortupdate', miqDropComplete);
+    $('#col2').off('sortupdate');
+    $('#col2').on('sortupdate', miqDropComplete);
   }
   if (miqDomElementExists('col3')) {
     $('#col3').sortable({connectWith:'#col1, #col2', handle:"h2"});
-    $('#col3').bind('sortupdate', miqDropComplete);
+    $('#col3').off('sortupdate');
+    $('#col3').on('sortupdate', miqDropComplete);
   }
 }
 


### PR DESCRIPTION
Reordering stuff in the service dialog editor wouldn't work unless each single reorder got saved. This was caused by the original order being used as index into the current array of items, meaning any subsequent change was using the wrong state. Rewritten to use ids, instead of order.

Aditionally, every single such change calls miqInitDashboardCols which *added* an event handler - meaning every reorder action generated twice more events than the previous one. Fixed to replace the event handler (`$.off` + `$.on` instead of `$.bind`).

https://bugzilla.redhat.com/show_bug.cgi?id=1203003