### PR TITLE
Fixed calls to miqSerializeForm from views.

### DIFF
--- a/vmdb/app/views/miq_request/_prov_field.html.haml
+++ b/vmdb/app/views/miq_request/_prov_field.html.haml
@@ -442,7 +442,7 @@
             - # need to specify Checked/Disabled to check or disable a checkbox, so need separate lines for each depending upon radio button state
             - field_hash[:values].each do |f|
               - checked = options[field] && options[field][0] ==  f[0]
-              - onclick = remote_function(:with => 'miqSerializeForm(this)', :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
+              - onclick = remote_function(:with => "miqSerializeForm('main_div')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
               %input{:type => "radio", :id => field_id, :value => f[0], :name => field_id, :checked => checked, :onclick => disabled ? "" : onclick}
               = f[1]
           - else

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -185,7 +185,7 @@
                          :value    => rb[0],
                          :name     => field.name,
                          :checked  => field.default_value.to_s == rb[0].to_s ? '' : nil,
-                         :onclick  => remote_function(:with     => 'miqSerializeForm(this)',
+                         :onclick  => remote_function(:with     => "miqSerializeForm('dialog_tabs')",
                                                       :url      => { :action => 'dialog_field_changed',
                                                                      :id     => "#{(@edit && @edit[:rec_id]) || "new"}"},
                                                       :loading  => "miqSparkle(true);",
@@ -221,7 +221,7 @@
                     radio += 'checked="" ';
                   }
                   radio += 'onclick="' + "#{remote_function(
-                    :with     => 'miqSerializeForm(this)',
+                    :with     => 'miqSerializeForm(\'dialog_tabs\')',
                     :url      => {:action => 'dialog_field_changed', :id => (@edit && @edit[:rec_id]) || 'new'},
                     :loading  => 'miqSparkle(true);',
                     :complete => 'miqSparkle(false);'


### PR DESCRIPTION
Need to send div_id to miqSerializeForm method, this is a fallout from jquery conversion.

https://bugzilla.redhat.com/show_bug.cgi?id=1202543

@brandondunne can you please test.
@dclarizio please review/test.