### PR TITLE
Automate Model - Fix cloud retirement update_retirement_status method.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
@@ -18,6 +18,8 @@ status_state = $evm.root['ae_status_state']
 $evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}>")
 $evm.log("info", "Step:<#{step}> Status_State:<#{status_state}> Status:<#{status}>")
 
+vm = $evm.root['vm']
+
 # Update Status for on_error for all states other than the first state which is startretirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'


### PR DESCRIPTION
Need to get $evm.root['vm'].