### PR TITLE
Revert "process toolbar yaml with ERB before display"

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -259,10 +259,7 @@ module ApplicationHelper
   def build_toolbar_buttons_and_xml(tb_name)
     text = nil                                                      # Local vars for text and title
     title = nil
-    tb_hash = tb_name == "custom_buttons_tb" ?
-      build_custom_buttons_toolbar(@record) :
-      YAML::load(ERB.new(File.read("#{TOOLBARS_FOLDER}/#{tb_name}.yaml")).result(binding))
-
+    tb_hash = tb_name == "custom_buttons_tb" ? build_custom_buttons_toolbar(@record) : YAML::load(File.open("#{TOOLBARS_FOLDER}/#{tb_name}.yaml"))
     # Add custom buttons hash to tb button_groups array
     #custom_hash = custom_buttons_hash(@record) if @record && @lastaction == "show" &&
     # tb_name.ends_with?("center_tb") &&
@@ -344,13 +341,15 @@ module ApplicationHelper
                   props["text"] = CGI.escapeHTML(x_tree_history[bsi[:button].split("_").last.to_i][:text])
                 end
               else
-                props["text"] = CGI.escapeHTML(bsi[:text]) unless bsi[:text].blank?
+                eval("text = \"#{bsi[:text]}\"") unless bsi[:text].blank? # Evaluate substitutions in text
+                props["text"] = CGI.escapeHTML("#{text}") unless bsi[:text].blank?
               end
               props["enabled"] = "#{bsi[:enabled]}" unless bsi[:enabled].blank?
               dis_title = build_toolbar_disable_button(bsi[:button])
               props["enabled"] = "false" if dis_title
               bsi[:title] = dis_title if dis_title
-              props["title"] = dis_title.is_a?(String) ? CGI.escapeHTML(dis_title) : CGI.escapeHTML(bsi[:title].to_s)
+              eval("title = \"#{bsi[:title]}\"") unless bsi[:title].blank?  # Evaluate substitutions in text
+              props["title"] = dis_title.is_a?(String) ? CGI.escapeHTML(dis_title) : CGI.escapeHTML("#{title}")
             end
             bs_node.add_element("item", props)                      # Add buttonSelect child button node
             build_toolbar_save_button(tb_buttons, bsi, bgi[:buttonSelect]) if bsi[:button]  # Save if a button (not sep)
@@ -385,7 +384,8 @@ module ApplicationHelper
           props["text"] = CGI.escapeHTML("#{bgi[:text]}") unless bgi[:text].blank?
           #set pdf button to be hidden if graphical summary screen is set by default
           bgi[:hidden] = %w(download_view vm_download_pdf).include?(bgi[:button]) && button_hide
-          props["title"] = dis_title.is_a?(String) ? dis_title : bgi[:title]
+          eval("title = \"#{bgi[:title]}\"") if !bgi[:title].blank? # Evaluate substitutions in text
+          props["title"] = dis_title.is_a?(String) ? dis_title : title
 
           if bgi[:button] == "chargeback_report_only" && x_active_tree == :cb_reports_tree &&
              @report && !@report.contains_records?
@@ -410,6 +410,7 @@ module ApplicationHelper
                               "type"=>"buttonTwoState",
                               "img"=>"#{bgi[:image] ? bgi[:image] : bgi[:buttonTwoState]}.png",
                               "imgdis"=>"#{bgi[:image] ? bgi[:image] : bgi[:buttonTwoState]}.png"}
+          eval("title = \"#{bgi[:title]}\"") unless bgi[:title].blank?
           props["title"] = bgi[:title] unless bgi[:title].blank?
           props["enabled"] = "#{bgi[:enabled]}" unless bgi[:enabled].blank?
           props["enabled"] = "false" if build_toolbar_disable_button(bgi[:buttonTwoState])
@@ -1493,8 +1494,9 @@ module ApplicationHelper
     tb_buttons[button][:name] = button
     tb_buttons[button][:pressed] = item[:pressed] if item[:pressed]
     tb_buttons[button][:hidden] = item[:hidden] ? true : false
-    tb_buttons[button][:title] = item[:title] if parent && item[:title]
-    url = item[:url] if item[:url]
+    eval("title = \"#{item[:title]}\"") if parent && item[:title]
+    tb_buttons[button][:title] = title if parent && item[:title]
+    eval("url = \"#{item[:url]}\"") if item[:url]
     if ["view_grid","view_tile","view_list"].include?(tb_buttons[button][:name])
       # blows up in sub screens for CI's, need to get rid of first directory and anything after last slash in @gtl_url, that's being manipulated in JS function
       url.gsub!(/^\/[a-z|A-Z|0-9|_|-]+/,"")
@@ -1525,9 +1527,10 @@ module ApplicationHelper
     if tb_buttons[button][:name].in?(collect_log_buttons) && @record.try(:log_depot).try(:requires_support_case?)
       tb_buttons[button][:prompt] = true
     end
-    parms = item[:url_parms] if item[:url_parms]
+    eval("parms = \"#{item[:url_parms]}\"") if item[:url_parms]
     tb_buttons[button][:url_parms] = update_url_parms(parms) if item[:url_parms]
-    confirm_title = item[:confirm] if item[:confirm]
+    # doing eval for ui_lookup in confirm message
+    eval("confirm_title = \"#{item[:confirm]}\"") if item[:confirm]
     tb_buttons[button][:confirm] = confirm_title if item[:confirm]
     tb_buttons[button][:onwhen] = item[:onwhen] if item[:onwhen]
   end

--- a/vmdb/product/toolbars/availability_zone_center_tb.yaml
+++ b/vmdb/product/toolbars/availability_zone_center_tb.yaml
@@ -31,6 +31,6 @@
     - :button: availability_zone_timeline
       :image: timeline
       :text: 'Timelines'
-      :title: 'Show Timelines for this <%= ui_lookup(:table=>"availability_zone") %>'
+      :title: 'Show Timelines for this #{ui_lookup(:table=>"availability_zone")}'
       :url: '/show'
       :url_parms: '?display=timeline'

--- a/vmdb/product/toolbars/chargeback_center_tb.yaml
+++ b/vmdb/product/toolbars/chargeback_center_tb.yaml
@@ -25,7 +25,7 @@
   - :button: chargeback_report_only
     :image: reportonly
     :url: '/report_only'
-    #:url_parms: '?type=<%= @ght_type %>'
+    #:url_parms: '?type=#{@ght_type}'
     :url_parms: 'popup_only'
     :popup: true
     :title: "Show full screen report"

--- a/vmdb/product/toolbars/compare_center_tb.yaml
+++ b/vmdb/product/toolbars/compare_center_tb.yaml
@@ -9,15 +9,15 @@
     :image: compare_all
     :title: "All attributes"
     :url: 'compare_miq_all'
-    :url_parms: '?id=<%= $vms_comp %>&compare_task=all'
+    :url_parms: '?id=#{$vms_comp}&compare_task=all'
   - :buttonTwoState: compare_diff
     :title: "Attributes with different values"
     :url: 'compare_miq_differences'
-    :url_parms: '?id=<%= $vms_comp %>&compare_task=different'
+    :url_parms: '?id=#{$vms_comp}&compare_task=different'
   - :buttonTwoState: compare_same
     :title: "Attributes with same values"
     :url: 'compare_miq_same'
-    :url_parms: '?id=<%= $vms_comp %>&compare_task=same'
+    :url_parms: '?id=#{$vms_comp}&compare_task=same'
 - :name: compare_mode
   :items:
   - :buttonTwoState: comparemode_details

--- a/vmdb/product/toolbars/condition_center_tb.yaml
+++ b/vmdb/product/toolbars/condition_center_tb.yaml
@@ -23,18 +23,18 @@
       :url_parms: '?copy=true'
     - :button: condition_policy_copy
       :image: copy
-      :text: 'Copy this Condition to a new Condition assigned to Policy [<%= @condition_policy.description %>]'
-      :title: 'Copy this Condition to a new Condition assigned to Policy [<%= @condition_policy.description %>]'
+      :text: 'Copy this Condition to a new Condition assigned to Policy [#{@condition_policy.description}]'
+      :title: 'Copy this Condition to a new Condition assigned to Policy [#{@condition_policy.description}]'
       :url_parms: '?copy=true'
     - :button: condition_delete
       :image: delete
-      :text: 'Delete this <%= ui_lookup(:model=>@condition.towhat) %> Condition'
-      :title: 'Delete this <%= ui_lookup(:model=>@condition.towhat) %> Condition'
+      :text: 'Delete this #{ui_lookup(:model=>@condition.towhat)} Condition'
+      :title: 'Delete this #{ui_lookup(:model=>@condition.towhat)} Condition'
       :url_parms: 'main_div'
-      :confirm: 'Are you sure you want to delete this <%= ui_lookup(:model=>@condition.towhat) %> Condition?'
+      :confirm: 'Are you sure you want to delete this #{ui_lookup(:model=>@condition.towhat)} Condition?'
     - :button: condition_remove
       :image: delete
-      :text: 'Remove this Condition from Policy [<%= @condition_policy.description %>]'
-      :title: 'Remove this Condition from Policy [<%= @condition_policy.description %>]'
-      :url_parms: '?policy_id=<%= @condition_policy.id %>'
-      :confirm: 'Are you sure you want to remove this Condition from Policy [<%= @condition_policy.description %>]?'
+      :text: 'Remove this Condition from Policy [#{@condition_policy.description}]'
+      :title: 'Remove this Condition from Policy [#{@condition_policy.description}]'
+      :url_parms: '?policy_id=#{@condition_policy.id}'
+      :confirm: 'Are you sure you want to remove this Condition from Policy [#{@condition_policy.description}]?'

--- a/vmdb/product/toolbars/conditions_center_tb.yaml
+++ b/vmdb/product/toolbars/conditions_center_tb.yaml
@@ -13,5 +13,5 @@
     :items:
     - :button: condition_new
       :image: new
-      :text: 'Add a New <%= @sb[:folder].upcase == "VM" ? "VM" : ui_lookup(:model=>@sb[:folder]) %> Condition'
-      :title: 'Add a New <%= @sb[:folder].upcase == "VM" ? "VM" : ui_lookup(:model=>@sb[:folder]) %> Condition'
+      :text: 'Add a New #{@sb[:folder].upcase == "VM" ? "VM" : ui_lookup(:model=>@sb[:folder])} Condition'
+      :title: 'Add a New #{@sb[:folder].upcase == "VM" ? "VM" : ui_lookup(:model=>@sb[:folder])} Condition'

--- a/vmdb/product/toolbars/container_center_tb.yaml
+++ b/vmdb/product/toolbars/container_center_tb.yaml
@@ -13,12 +13,12 @@
     :items:
     - :button: container_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"container") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"container") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"container")}'
+      :title: 'Edit this #{ui_lookup(:table=>"container")}'
       :url: '/edit'
     - :button: container_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"container") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"container") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"container")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"container")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"container") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"container") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"container")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container")}?'

--- a/vmdb/product/toolbars/container_group_center_tb.yaml
+++ b/vmdb/product/toolbars/container_group_center_tb.yaml
@@ -13,12 +13,12 @@
     :items:
     - :button: container_group_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"container_group") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"container_group") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"container_group")}'
+      :title: 'Edit this #{ui_lookup(:table=>"container_group")}'
       :url: '/edit'
     - :button: container_group_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"container_group") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"container_group") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"container_group")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"container_group")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"container_group") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"container_group") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"container_group")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container_group")}?'

--- a/vmdb/product/toolbars/container_groups_center_tb.yaml
+++ b/vmdb/product/toolbars/container_groups_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: container_group_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"container_group") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"container_group") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"container_group")}'
+      :title: 'Add a New #{ui_lookup(:table=>"container_group")}'
     - :button: container_group_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"container_group") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"container_group") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"container_group")}'
+      :title: 'Select a single #{ui_lookup(:table=>"container_group")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: container_group_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"container_groups") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"container_groups") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"container_groups")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"container_groups")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"container_groups") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"container_groups") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"container_groups")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"container_groups")}?'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/container_node_center_tb.yaml
+++ b/vmdb/product/toolbars/container_node_center_tb.yaml
@@ -13,12 +13,12 @@
     :items:
     - :button: container_node_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"container_node") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"container_node") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"container_node")}'
+      :title: 'Edit this #{ui_lookup(:table=>"container_node")}'
       :url: '/edit'
     - :button: container_node_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"container_node") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"container_node") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"container_node")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"container_node")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"container_node") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"container_node") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"container_node")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container_node")}?'

--- a/vmdb/product/toolbars/container_nodes_center_tb.yaml
+++ b/vmdb/product/toolbars/container_nodes_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: container_node_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"container_node") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"container_node") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"container_node")}'
+      :title: 'Add a New #{ui_lookup(:table=>"container_node")}'
     - :button: container_node_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"container_node") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"container_node") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"container_node")}'
+      :title: 'Select a single #{ui_lookup(:table=>"container_node")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: container_node_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"container_nodes") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"container_nodes") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"container_nodes")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"container_nodes")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"container_nodes") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"container_nodes") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"container_nodes")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"container_nodes")}?'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/container_service_center_tb.yaml
+++ b/vmdb/product/toolbars/container_service_center_tb.yaml
@@ -13,12 +13,12 @@
     :items:
     - :button: container_service_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"container_service") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"container_service") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"container_service")}'
+      :title: 'Edit this #{ui_lookup(:table=>"container_service")}'
       :url: '/edit'
     - :button: container_service_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"container_service") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"container_service") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"container_service")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"container_service")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"container_service") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"container_service") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"container_service")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container_service")}?'

--- a/vmdb/product/toolbars/container_services_center_tb.yaml
+++ b/vmdb/product/toolbars/container_services_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: container_service_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"container_service") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"container_service") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"container_service")}'
+      :title: 'Add a New #{ui_lookup(:table=>"container_service")}'
     - :button: container_service_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"container_service") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"container_service") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"container_service")}'
+      :title: 'Select a single #{ui_lookup(:table=>"container_service")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: container_service_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"container_services") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"container_services") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"container_services")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"container_services")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"container_services") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"container_services") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"container_services")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"container_services")}?'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/containers_center_tb.yaml
+++ b/vmdb/product/toolbars/containers_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: container_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"container") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"container") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"container")}'
+      :title: 'Add a New #{ui_lookup(:table=>"container")}'
     - :button: container_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"container") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"container") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"container")}'
+      :title: 'Select a single #{ui_lookup(:table=>"container")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: container_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"containers") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"containers") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"containers")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"containers")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"containers") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"containers") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"containers")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"containers")}?'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/custom_button_set_center_tb.yaml
+++ b/vmdb/product/toolbars/custom_button_set_center_tb.yaml
@@ -22,4 +22,4 @@
     - :button: ab_group_reorder
       :image: edit-assign
       :text: 'Reorder'
-      :title: 'Reorder <%= x_active_tree == :ab_tree ? "Buttons Groups" : "Buttons and Groups" %>'
+      :title: 'Reorder #{x_active_tree == :ab_tree ? "Buttons Groups" : "Buttons and Groups"}'

--- a/vmdb/product/toolbars/diagnostics_region_center_tb.yaml
+++ b/vmdb/product/toolbars/diagnostics_region_center_tb.yaml
@@ -20,26 +20,26 @@
     # Roles by Server tab
     - :button: delete_server
       :image: delete
-      :text: 'Delete Server <%= @record.name %> [<%= @record.id %>]'
-      :title: 'Delete Server <%= @record.name %> [<%= @record.id %>]'
-      :confirm: 'Do you want to delete Server <%= @record.name %> [<%= @record.id %>]?'
+      :text: 'Delete Server #{@record.name} [#{@record.id}]'
+      :title: 'Delete Server #{@record.name} [#{@record.id}]'
+      :confirm: 'Do you want to delete Server #{@record.name} [#{@record.id}]?'
     - :button: role_start
       :image: start
       :text: 'Start Role'
-      :title: 'Start the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]'
-      :confirm: 'Start the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]?'
+      :title: 'Start the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]'
+      :confirm: 'Start the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]?'
     - :button: role_suspend
       :image: suspend
       :text: 'Suspend Role'
-      :title: 'Suspend the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]'
-      :confirm: 'Suspend the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]?'
+      :title: 'Suspend the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]'
+      :confirm: 'Suspend the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]?'
     - :button: demote_server
       :image: remove_master
       :text: 'Demote Server'
-      :title: 'Demote Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>] to secondary for the <%= @record.server_role.description %> Role'
+      :title: 'Demote Server #{@record.miq_server.name} [#{@record.miq_server.id}] to secondary for the #{@record.server_role.description} Role'
       :confirm: 'Do you want to demote this Server to secondary?  This will leave no primary Server for this Role.'
     - :button: promote_server
       :image: set_master
       :text: 'Promote Server'
-      :title: 'Promote Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>] to primary for the <%= @record.server_role.description %> Role'
+      :title: 'Promote Server #{@record.miq_server.name} [#{@record.miq_server.id}] to primary for the #{@record.server_role.description} Role'
       :confirm: 'Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role.'

--- a/vmdb/product/toolbars/diagnostics_server_center_tb.yaml
+++ b/vmdb/product/toolbars/diagnostics_server_center_tb.yaml
@@ -33,11 +33,11 @@
   # production log
   - :button: refresh_production_log
     :image: reload
-    :title: 'Reload the <%= @sb[:rails_log] %> Log Display'
+    :title: 'Reload the #{@sb[:rails_log]} Log Display'
   - :button: fetch_production_log
     :url: '/fetch_production_log'
     :image: download
-    :title: 'Download the Entire <%= @sb[:rails_log] %> Log File'
+    :title: 'Download the Entire #{@sb[:rails_log]} Log File'
 - :name: ldap_domain_vmdb
   :items:
   # collect logs tab
@@ -49,15 +49,15 @@
     - :button: collect_current_logs
       :image: collect_current
       :text: 'Collect current logs'
-      :title: 'Collect the current logs from the selected <%= ui_lookup(:table=>"miq_servers") %>'
+      :title: 'Collect the current logs from the selected #{ui_lookup(:table=>"miq_servers")}'
     - :button: collect_logs
       :image: collect_all
       :text: 'Collect all logs'
-      :title: 'Collect all logs from the selected <%= ui_lookup(:table=>"miq_servers") %>'
+      :title: 'Collect all logs from the selected #{ui_lookup(:table=>"miq_servers")}'
   - :button: log_depot_edit
     :image: edit
     :text: 'Edit'
-    :title: 'Edit the Log Depot settings for the selected <%= ui_lookup(:table=>"miq_servers") %>'
+    :title: 'Edit the Log Depot settings for the selected #{ui_lookup(:table=>"miq_servers")}'
   - :buttonSelect: support_vmdb_choice
     :image: vmdb
     :title: Configuration

--- a/vmdb/product/toolbars/diagnostics_zone_center_tb.yaml
+++ b/vmdb/product/toolbars/diagnostics_zone_center_tb.yaml
@@ -20,28 +20,28 @@
     :items:
     - :button: zone_delete_server
       :image: delete
-      :text: 'Delete Server <%= @record.name %> [<%= @record.id %>]'
-      :title: 'Delete Server <%= @record.name %> [<%= @record.id %>]'
-      :confirm: 'Do you want to delete Server <%= @record.name %> [<%= @record.id %>]?'
+      :text: 'Delete Server #{@record.name} [#{@record.id}]'
+      :title: 'Delete Server #{@record.name} [#{@record.id}]'
+      :confirm: 'Do you want to delete Server #{@record.name} [#{@record.id}]?'
     - :button: zone_role_start
       :image: start
       :text: 'Start Role'
-      :title: 'Start the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]'
-      :confirm: 'Start the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]?'
+      :title: 'Start the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]'
+      :confirm: 'Start the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]?'
     - :button: zone_role_suspend
       :image: suspend
       :text: 'Suspend Role'
-      :title: 'Suspend the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]'
-      :confirm: 'Suspend the <%= @record.server_role.description %> Role on Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>]?'
+      :title: 'Suspend the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]'
+      :confirm: 'Suspend the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]?'
     - :button: zone_demote_server
       :image: remove_master
       :text: 'Demote Server'
-      :title: 'Demote Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>] to secondary for the <%= @record.server_role.description %> Role'
+      :title: 'Demote Server #{@record.miq_server.name} [#{@record.miq_server.id}] to secondary for the #{@record.server_role.description} Role'
       :confirm: 'Do you want to demote this Server to secondary?  This will leave no primary Server for this Role.'
     - :button: zone_promote_server
       :image: set_master
       :text: 'Promote Server'
-      :title: 'Promote Server <%= @record.miq_server.name %> [<%= @record.miq_server.id %>] to primary for the <%= @record.server_role.description %> Role'
+      :title: 'Promote Server #{@record.miq_server.name} [#{@record.miq_server.id}] to primary for the #{@record.server_role.description} Role'
       :confirm: 'Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role.'
     # collect logs tab
   - :buttonSelect: support_vmdb_choice
@@ -52,12 +52,12 @@
     - :button: zone_collect_current_logs
       :image: collect_current
       :text: 'Collect current logs'
-      :title: 'Collect the current logs from the selected <%= ui_lookup(:table=>"zone") %>'
+      :title: 'Collect the current logs from the selected #{ui_lookup(:table=>"zone")}'
     - :button: zone_collect_logs
       :image: collect_all
       :text: 'Collect all logs'
-      :title: 'Collect all logs from the selected <%= ui_lookup(:table=>"zone") %>'
+      :title: 'Collect all logs from the selected #{ui_lookup(:table=>"zone")}'
   - :button: zone_log_depot_edit
     :image: edit
     :text: 'Edit'
-    :title: 'Edit the Log Depot settings for the selected <%= ui_lookup(:table=>"zone") %>'
+    :title: 'Edit the Log Depot settings for the selected #{ui_lookup(:table=>"zone")}'

--- a/vmdb/product/toolbars/dialog_center_tb.yaml
+++ b/vmdb/product/toolbars/dialog_center_tb.yaml
@@ -38,26 +38,26 @@
       :image: new
       :text: "Add a new Tab to this Dialog"
       :title: Add a new Tab to this Dialog
-      :url_parms: '?typ=tab&id=<%= @edit[:rec_id] %>'
+      :url_parms: '?typ=tab&id=#{@edit[:rec_id]}'
     - :button: dialog_add_box
       :image: new
       :text: "Add a new Box to this Tab"
       :title: Add a new Box to this Tab
-      :url_parms: '?typ=box&id=<%= @edit[:rec_id] %>'
+      :url_parms: '?typ=box&id=#{@edit[:rec_id]}'
     - :button: dialog_add_element
       :image: new
       :text: "Add a new Element to this Box"
       :title: Add a new Element to this Box
-      :url_parms: '?typ=element&id=<%= @edit[:rec_id] %>'
+      :url_parms: '?typ=element&id=#{@edit[:rec_id]}'
 - :name: dialog_discard
   :items:
   - :button: dialog_res_discard
     :image: discard
-    :title: 'Discard this new <%= @sb[:node_typ].titleize %>'
-    :url_parms: '?id=<%= @edit[:rec_id] %>'
+    :title: 'Discard this new #{@sb[:node_typ].titleize}'
+    :url_parms: '?id=#{@edit[:rec_id]}'
 - :name: dialog_edit_delete
   :items:
   - :button: dialog_resource_remove
     :image: delete
-    :title: "Delete selected <%= @sb[:txt] %>"
-    :url_parms: '?id=<%= @edit[:rec_id] %>'
+    :title: "Delete selected #{@sb[:txt]}"
+    :url_parms: '?id=#{@edit[:rec_id]}'

--- a/vmdb/product/toolbars/drift_center_tb.yaml
+++ b/vmdb/product/toolbars/drift_center_tb.yaml
@@ -7,26 +7,26 @@
   :items:
   - :button: show_summary
     :image: summary-blue
-    :title: 'Show <%= @record.name %> Summary'
+    :title: 'Show #{@record.name} Summary'
     :url: '/show'
-    :url_parms: '?id=<%= @record.id %>'
+    :url_parms: '?id=#{@record.id}'
 - :name: comapre_tasks
   :items:
   - :buttonTwoState: drift_all
     :image: compare_all
     :title: "All attributes"
     :url: 'drift_all'
-    :url_parms: '?id=<%= $vms_comp %>&compare_task=all&db=<%= @compare_db %>&id=<%= @drift_obj.id %>'
+    :url_parms: '?id=#{$vms_comp}&compare_task=all&db=#{@compare_db}&id=#{@drift_obj.id}'
   - :buttonTwoState: drift_diff
     :image: compare_diff
     :title: "Attributes with different values"
     :url: 'drift_differences'
-    :url_parms: '?id=<%= $vms_comp %>&compare_task=different&db=<%= @compare_db %>&id=<%= @drift_obj.id %>'
+    :url_parms: '?id=#{$vms_comp}&compare_task=different&db=#{@compare_db}&id=#{@drift_obj.id}'
   - :buttonTwoState: drift_same
     :image: compare_same
     :title: "Attributes with same values"
     :url: 'drift_same'
-    :url_parms: '?id=<%= $vms_comp %>&compare_task=same&db=<%= @compare_db %>&id=<%= @drift_obj.id %>'
+    :url_parms: '?id=#{$vms_comp}&compare_task=same&db=#{@compare_db}&id=#{@drift_obj.id}'
 - :name: compare_mode
   :items:
   - :buttonTwoState: driftmode_details

--- a/vmdb/product/toolbars/ems_cloud_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_cloud_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: ems_cloud_refresh
       :image: refresh
       :text: 'Refresh Relationships and Power States'
-      :title: 'Refresh relationships and power states for all items related to this <%= ui_lookup(:table=>"ems_cloud") %>'
-      :confirm: 'Refresh relationships and power states for all items related to this <%= ui_lookup(:table=>"ems_cloud") %>?'
+      :title: 'Refresh relationships and power states for all items related to this #{ui_lookup(:table=>"ems_cloud")}'
+      :confirm: 'Refresh relationships and power states for all items related to this #{ui_lookup(:table=>"ems_cloud")}?'
     - :separator:
     - :button: ems_cloud_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"ems_cloud") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"ems_cloud") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"ems_cloud")}'
+      :title: 'Edit this #{ui_lookup(:table=>"ems_cloud")}'
       :url: '/edit'
     - :button: ems_cloud_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"ems_cloud") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"ems_cloud") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"ems_cloud")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"ems_cloud")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"ems_cloud") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"ems_cloud") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"ems_cloud")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"ems_cloud")}?'
 - :name: ems_cloud_policy
   :items:
   - :buttonSelect: ems_cloud_policy_choice
@@ -38,11 +38,11 @@
     - :button: ems_cloud_protect
       :image: protect
       :text: 'Manage Policies'
-      :title: 'Manage Policies for this <%= ui_lookup(:table=>"ems_cloud") %>'
+      :title: 'Manage Policies for this #{ui_lookup(:table=>"ems_cloud")}'
     - :button: ems_cloud_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for this <%= ui_lookup(:table=>"ems_cloud") %>'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"ems_cloud")}'
 - :name: ems_cloud_monitoring
   :items:
   - :buttonSelect: ems_cloud_monitoring_choice
@@ -53,6 +53,6 @@
     - :button: ems_cloud_timeline
       :image: timeline
       :text: 'Timelines'
-      :title: 'Show Timelines for this <%= ui_lookup(:table=>"ems_cloud") %>'
+      :title: 'Show Timelines for this #{ui_lookup(:table=>"ems_cloud")}'
       :url: '/show'
       :url_parms: '?display=timeline'

--- a/vmdb/product/toolbars/ems_clouds_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_clouds_center_tb.yaml
@@ -14,36 +14,36 @@
     - :button: ems_cloud_refresh
       :image: refresh
       :text: 'Refresh Relationships and Power States'
-      :title: 'Refresh relationships and power states for all items related to the selected <%= ui_lookup(:tables=>"ems_clouds") %>'
+      :title: 'Refresh relationships and power states for all items related to the selected #{ui_lookup(:tables=>"ems_clouds")}'
       :url_parms: 'main_div'
-      :confirm: 'Refresh relationships and power states for all items related to the selected <%= ui_lookup(:tables=>"ems_clouds") %>?'
+      :confirm: 'Refresh relationships and power states for all items related to the selected #{ui_lookup(:tables=>"ems_clouds")}?'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: ems_cloud_discover
       :image: discover
-      :text: 'Discover <%= ui_lookup(:tables=>"ems_clouds") %>'
-      :title: 'Discover <%= ui_lookup(:tables=>"ems_clouds") %>'
+      :text: 'Discover #{ui_lookup(:tables=>"ems_clouds")}'
+      :title: 'Discover #{ui_lookup(:tables=>"ems_clouds")}'
       :url: '/discover'
       :url_parms: '?discover_type=ems'
     - :separator:
     - :button: ems_cloud_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"ems_cloud") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"ems_cloud") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"ems_cloud")}'
+      :title: 'Add a New #{ui_lookup(:table=>"ems_cloud")}'
     - :button: ems_cloud_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"ems_cloud") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"ems_cloud") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"ems_cloud")}'
+      :title: 'Select a single #{ui_lookup(:table=>"ems_cloud")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: ems_cloud_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"ems_clouds") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"ems_clouds") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"ems_clouds")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"ems_clouds")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"ems_clouds") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"ems_clouds") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"ems_clouds")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"ems_clouds")}?'
       :enabled: 'false'
       :onwhen: '1+'
 #- :name: ems_cloud_scans
@@ -60,14 +60,14 @@
     - :button: ems_cloud_protect
       :image: protect
       :text: 'Manage Policies'
-      :title: 'Manage Policies for the selected <%= ui_lookup(:tables=>"ems_clouds") %>'
+      :title: 'Manage Policies for the selected #{ui_lookup(:tables=>"ems_clouds")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: ems_cloud_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for the selected <%= ui_lookup(:tables=>"ems_clouds") %>'
+      :title: 'Edit Tags for the selected #{ui_lookup(:tables=>"ems_clouds")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/ems_container_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_container_center_tb.yaml
@@ -13,12 +13,12 @@
     :items:
     - :button: ems_container_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"ems_container") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"ems_container") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"ems_container")}'
+      :title: 'Edit this #{ui_lookup(:table=>"ems_container")}'
       :url: '/edit'
     - :button: ems_container_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"ems_container") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"ems_container") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"ems_container")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"ems_container")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"ems_container") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"ems_container") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"ems_container")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"ems_container")}?'

--- a/vmdb/product/toolbars/ems_containers_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_containers_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: ems_container_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"ems_container") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"ems_container") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"ems_container")}'
+      :title: 'Add a New #{ui_lookup(:table=>"ems_container")}'
     - :button: ems_container_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"ems_container") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"ems_container") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"ems_container")}'
+      :title: 'Select a single #{ui_lookup(:table=>"ems_container")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: ems_container_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"ems_containers") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"ems_containers") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"ems_containers")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"ems_containers")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"ems_containers") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"ems_containers") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"ems_containers")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"ems_containers")}?'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/ems_infra_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_infra_center_tb.yaml
@@ -14,20 +14,20 @@
     - :button: ems_infra_refresh
       :image: refresh
       :text: 'Refresh Relationships and Power States'
-      :title: 'Refresh relationships and power states for all items related to this <%= ui_lookup(:table=>"ems_infra") %>'
-      :confirm: 'Refresh relationships and power states for all items related to this <%= ui_lookup(:table=>"ems_infra") %>?'
+      :title: 'Refresh relationships and power states for all items related to this #{ui_lookup(:table=>"ems_infra")}'
+      :confirm: 'Refresh relationships and power states for all items related to this #{ui_lookup(:table=>"ems_infra")}?'
     - :separator:
     - :button: ems_infra_edit
       :image: edit
-      :text: 'Edit this <%= ui_lookup(:table=>"ems_infra") %>'
-      :title: 'Edit this <%= ui_lookup(:table=>"ems_infra") %>'
+      :text: 'Edit this #{ui_lookup(:table=>"ems_infra")}'
+      :title: 'Edit this #{ui_lookup(:table=>"ems_infra")}'
       :url: '/edit'
     - :button: ems_infra_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"ems_infra") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"ems_infra") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"ems_infra")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"ems_infra")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"ems_infra") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"ems_infra") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"ems_infra")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"ems_infra")}?'
 - :name: ems_infra_policy
   :items:
   - :buttonSelect: ems_infra_policy_choice
@@ -38,11 +38,11 @@
     - :button: ems_infra_protect
       :image: protect
       :text: 'Manage Policies'
-      :title: 'Manage Policies for this <%= ui_lookup(:table=>"ems_infra") %>'
+      :title: 'Manage Policies for this #{ui_lookup(:table=>"ems_infra")}'
     - :button: ems_infra_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for this <%= ui_lookup(:table=>"ems_infra") %>'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"ems_infra")}'
 - :name: ems_infra_monitoring
   :items:
   - :buttonSelect: ems_infra_monitoring_choice
@@ -53,6 +53,6 @@
     - :button: ems_infra_timeline
       :image: timeline
       :text: 'Timelines'
-      :title: 'Show Timelines for this <%= ui_lookup(:table=>"ems_infra") %>'
+      :title: 'Show Timelines for this #{ui_lookup(:table=>"ems_infra")}'
       :url: '/show'
       :url_parms: '?display=timeline'

--- a/vmdb/product/toolbars/ems_infras_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_infras_center_tb.yaml
@@ -14,36 +14,36 @@
     - :button: ems_infra_refresh
       :image: refresh
       :text: 'Refresh Relationships and Power States'
-      :title: 'Refresh relationships and power states for all items related to the selected <%= ui_lookup(:tables=>"ems_infras") %>'
+      :title: 'Refresh relationships and power states for all items related to the selected #{ui_lookup(:tables=>"ems_infras")}'
       :url_parms: 'main_div'
-      :confirm: 'Refresh relationships and power states for all items related to the selected <%= ui_lookup(:tables=>"ems_infras") %>?'
+      :confirm: 'Refresh relationships and power states for all items related to the selected #{ui_lookup(:tables=>"ems_infras")}?'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: ems_infra_discover
       :image: discover
-      :text: 'Discover <%= ui_lookup(:tables=>"ems_infras") %>'
-      :title: 'Discover <%= ui_lookup(:tables=>"ems_infras") %>'
+      :text: 'Discover #{ui_lookup(:tables=>"ems_infras")}'
+      :title: 'Discover #{ui_lookup(:tables=>"ems_infras")}'
       :url: '/discover'
       :url_parms: '?discover_type=ems'
     - :separator:
     - :button: ems_infra_new
       :image: new
       :url: '/new'
-      :text: 'Add a New <%= ui_lookup(:table=>"ems_infra") %>'
-      :title: 'Add a New <%= ui_lookup(:table=>"ems_infra") %>'
+      :text: 'Add a New #{ui_lookup(:table=>"ems_infra")}'
+      :title: 'Add a New #{ui_lookup(:table=>"ems_infra")}'
     - :button: ems_infra_edit
       :image: edit
-      :text: 'Edit Selected <%= ui_lookup(:table=>"ems_infra") %>'
-      :title: 'Select a single <%= ui_lookup(:table=>"ems_infra") %> to edit'
+      :text: 'Edit Selected #{ui_lookup(:table=>"ems_infra")}'
+      :title: 'Select a single #{ui_lookup(:table=>"ems_infra")} to edit'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1'
     - :button: ems_infra_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"ems_infras") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"ems_infras") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"ems_infras")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"ems_infras")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"ems_infras") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"ems_infras") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"ems_infras")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"ems_infras")}?'
       :enabled: 'false'
       :onwhen: '1+'
 #- :name: ems_infra_scans
@@ -60,14 +60,14 @@
     - :button: ems_infra_protect
       :image: protect
       :text: 'Manage Policies'
-      :title: 'Manage Policies for the selected <%= ui_lookup(:tables=>"ems_infras") %>'
+      :title: 'Manage Policies for the selected #{ui_lookup(:tables=>"ems_infras")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: ems_infra_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for the selected <%= ui_lookup(:tables=>"ems_infras") %>'
+      :title: 'Edit Tags for the selected #{ui_lookup(:tables=>"ems_infras")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/gtl_view_tb.yaml
+++ b/vmdb/product/toolbars/gtl_view_tb.yaml
@@ -7,15 +7,15 @@
   :items:
   - :buttonTwoState: view_grid
     :title: "Grid View"
-    :url: '<%= @gtl_url %>'
+    :url: '#{@gtl_url}'
     :url_parms: '?type=grid'
   - :buttonTwoState: view_tile
     :title: "Tile View"
-    :url: '<%= @gtl_url %>'
+    :url: '#{@gtl_url}'
     :url_parms: '?type=tile'
   - :buttonTwoState: view_list
     :title: "List View"
-    :url: '<%= @gtl_url %>'
+    :url: '#{@gtl_url}'
     :url_parms: '?type=list'
 - :name: download_main
   :items:

--- a/vmdb/product/toolbars/logs_center_tb.yaml
+++ b/vmdb/product/toolbars/logs_center_tb.yaml
@@ -8,8 +8,8 @@
   :items:
   - :button: refresh_log
     :image: reload
-    :title: 'Reload the <%= @msg_title %> Log Display'
+    :title: 'Reload the #{@msg_title} Log Display'
   - :button: fetch_log
     :image: download
-    :title: 'Download the Entire <%= @msg_title %> Log File'
+    :title: 'Download the Entire #{@msg_title} Log File'
     :url: '/fetch_log'

--- a/vmdb/product/toolbars/miq_alert_profiles_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_alert_profiles_center_tb.yaml
@@ -13,5 +13,5 @@
     :items:
     - :button: alert_profile_new
       :image: new
-      :text: 'Add a New <%= ui_lookup(:model=>@sb[:folder]) %> Alert Profile'
-      :title: 'Add a New <%= ui_lookup(:model=>@sb[:folder]) %> Alert Profile'
+      :text: 'Add a New #{ui_lookup(:model=>@sb[:folder])} Alert Profile'
+      :title: 'Add a New #{ui_lookup(:model=>@sb[:folder])} Alert Profile'

--- a/vmdb/product/toolbars/miq_capacity_view_tb.yaml
+++ b/vmdb/product/toolbars/miq_capacity_view_tb.yaml
@@ -13,15 +13,15 @@
     - :button: miq_capacity_download_text
       :image: txt
       :title: "Download this report in text format"
-      :url: '/<%= x_active_tree == :utilization_tree ? "util_report" : "planning_report" %>_download'
+      :url: '/#{x_active_tree == :utilization_tree ? "util_report" : "planning_report"}_download'
       :url_parms: "?typ=txt"
     - :button: miq_capacity_download_csv
       :image: csv
       :title: "Download this report in CSV format"
-      :url: '/<%= x_active_tree == :utilization_tree ? "util_report" : "planning_report" %>_download'
+      :url: '/#{x_active_tree == :utilization_tree ? "util_report" : "planning_report"}_download'
       :url_parms: "?typ=csv"
     - :button: miq_capacity_download_pdf
       :image: pdf
       :title: "Download this report in PDF format"
-      :url: '/<%= x_active_tree == :utilization_tree ? "util_report" : "planning_report" %>_download'
+      :url: '/#{x_active_tree == :utilization_tree ? "util_report" : "planning_report"}_download'
       :url_parms: "?typ=pdf"

--- a/vmdb/product/toolbars/miq_group_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_group_center_tb.yaml
@@ -30,5 +30,5 @@
     :items:
     - :button: rbac_group_tags_edit
       :image: tag
-      :text: "Edit '<%= session[:customer_name] %>' Tags for this Group"
-      :title: "Edit '<%= session[:customer_name] %>' Tags for this Group"
+      :text: "Edit '#{session[:customer_name]}' Tags for this Group"
+      :title: "Edit '#{session[:customer_name]}' Tags for this Group"

--- a/vmdb/product/toolbars/miq_groups_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_groups_center_tb.yaml
@@ -44,8 +44,8 @@
     :items:
     - :button: rbac_group_tags_edit
       :image: tag
-      :text: "Edit '<%= session[:customer_name] %>' Tags for the selected Groups"
-      :title: "Edit '<%= session[:customer_name] %>' Tags for the selected Groups"
+      :text: "Edit '#{session[:customer_name]}' Tags for the selected Groups"
+      :title: "Edit '#{session[:customer_name]}' Tags for the selected Groups"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/miq_policies_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_policies_center_tb.yaml
@@ -13,6 +13,6 @@
     :items:
     - :button: policy_new
       :image: new
-      :text: 'Add a New <%= ui_lookup(:model=>@sb[:nodeid]) %> <%= @sb[:mode].capitalize %> Policy'
-      :title: 'Add a New <%= ui_lookup(:model=>@sb[:nodeid]) %> <%= @sb[:mode].capitalize %> Policy'
+      :text: 'Add a New #{ui_lookup(:model=>@sb[:nodeid])} #{@sb[:mode].capitalize} Policy'
+      :title: 'Add a New #{ui_lookup(:model=>@sb[:nodeid])} #{@sb[:mode].capitalize} Policy'
       :url_parms: '?typ=basic'

--- a/vmdb/product/toolbars/miq_policy_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_policy_center_tb.yaml
@@ -18,16 +18,16 @@
       :url_parms: '?typ=basic'
     - :button: policy_copy
       :image: copy
-      :text: 'Copy this <%= ui_lookup(:model=>@policy.towhat) %> Policy'
-      :title: 'Copy this Policy to new Policy [<%= truncate("Copy of <%= @policy.description %>", :length => 255, :omission => "") %>]'
-      :confirm: 'Are you sure you want to create Policy [<%= truncate("Copy of <%= @policy.description %>", :length => 255, :omission => "") %>] from this Policy?'
+      :text: 'Copy this #{ui_lookup(:model=>@policy.towhat)} Policy'
+      :title: 'Copy this Policy to new Policy [#{truncate("Copy of #{@policy.description}", :length => 255, :omission => "")}]'
+      :confirm: 'Are you sure you want to create Policy [#{truncate("Copy of #{@policy.description}", :length => 255, :omission => "")}] from this Policy?'
       :url_parms: 'main_div'
     - :button: policy_delete
       :image: delete
-      :text: 'Delete this <%= ui_lookup(:model=>@policy.towhat) %> Policy'
-      :title: 'Delete this <%= ui_lookup(:model=>@policy.towhat) %> Policy'
+      :text: 'Delete this #{ui_lookup(:model=>@policy.towhat)} Policy'
+      :title: 'Delete this #{ui_lookup(:model=>@policy.towhat)} Policy'
       :url_parms: 'main_div'
-      :confirm: 'Are you sure you want to delete this <%= ui_lookup(:model=>@policy.towhat) %> Policy?'
+      :confirm: 'Are you sure you want to delete this #{ui_lookup(:model=>@policy.towhat)} Policy?'
     - :button: condition_edit
       :image: new-condition
       :text: 'Create a new Condition assigned to this Policy'

--- a/vmdb/product/toolbars/miq_servers_center_tb.yaml
+++ b/vmdb/product/toolbars/miq_servers_center_tb.yaml
@@ -8,9 +8,9 @@
   :items:
   - :button: server_delete
     :image: delete
-    :title: 'Delete Server <%= session[:tree_selection].name %> [<%= session[:tree_selection].id %>]'
+    :title: 'Delete Server #{session[:tree_selection].name} [#{session[:tree_selection].id}]'
     :url_parms: 'main_div'
-    :confirm: 'Do you want to delete Server <%= session[:tree_selection].name %> [<%= session[:tree_selection].id %>]?'
+    :confirm: 'Do you want to delete Server #{session[:tree_selection].name} [#{session[:tree_selection].id}]?'
   - :button: role_suspend
     :image: suspend
     :title: 'Suspend the Role on Server'

--- a/vmdb/product/toolbars/ontap_file_share_center_tb.yaml
+++ b/vmdb/product/toolbars/ontap_file_share_center_tb.yaml
@@ -14,7 +14,7 @@
     - :button: ontap_file_share_create_datastore
       :image: create_datastore
       :text: 'Create Datastore'
-      :title: 'Create a Datastore based on this <%= ui_lookup(:model=>"OntapFileShare").split(" - ").last %>'
+      :title: 'Create a Datastore based on this #{ui_lookup(:model=>"OntapFileShare").split(" - ").last}'
 - :name: ontap_file_share_policy
   :items:
   - :buttonSelect: ontap_file_share_policy_choice
@@ -25,7 +25,7 @@
     - :button: ontap_file_share_tag
       :image: tag
       :text: "Edit Tags"
-      :title: 'Edit Tags for this <%= ui_lookup(:model=>"OntapFileShare").split(" - ").last %>'
+      :title: 'Edit Tags for this #{ui_lookup(:model=>"OntapFileShare").split(" - ").last}'
 - :name: ontap_file_share_monitoring
   :items:
   - :buttonSelect: ontap_file_share_monitoring_choice
@@ -36,5 +36,5 @@
     - :button: ontap_file_share_statistics
       :image: statistics
       :text: "Utilization"
-      :title: 'Show Utilization for this <%= ui_lookup(:model=>"OntapFileShare").split(" - ").last %>'
+      :title: 'Show Utilization for this #{ui_lookup(:model=>"OntapFileShare").split(" - ").last}'
       :url: '/show_statistics'

--- a/vmdb/product/toolbars/ontap_storage_system_center_tb.yaml
+++ b/vmdb/product/toolbars/ontap_storage_system_center_tb.yaml
@@ -14,7 +14,7 @@
     - :button: ontap_storage_system_create_logical_disk
       :image: create_logical_disk
       :text: 'Create Logical Disk'
-      :title: 'Create a Logical Disk (NetApp Flexible Volume) on this <%= ui_lookup(:model=>"OntapStorageSystem").split(" - ").last %>'
+      :title: 'Create a Logical Disk (NetApp Flexible Volume) on this #{ui_lookup(:model=>"OntapStorageSystem").split(" - ").last}'
 - :name: ontap_storage_system_policy
   :items:
   - :buttonSelect: ontap_storage_system_policy_choice
@@ -25,7 +25,7 @@
     - :button: ontap_storage_system_tag
       :image: tag
       :text: "Edit Tags"
-      :title: 'Edit Tags for this <%= ui_lookup(:model=>"OntapStorageSystem").split(" - ").last %>'
+      :title: 'Edit Tags for this #{ui_lookup(:model=>"OntapStorageSystem").split(" - ").last}'
 - :name: ontap_storage_system_monitoring
   :items:
   - :buttonSelect: ontap_storage_system_monitoring_choice
@@ -36,5 +36,5 @@
     - :button: ontap_storage_system_statistics
       :image: statistics
       :text: "Utilization"
-      :title: 'Show Utilization for this <%= ui_lookup(:model=>"OntapStorageSystem").split(" - ").last %>'
+      :title: 'Show Utilization for this #{ui_lookup(:model=>"OntapStorageSystem").split(" - ").last}'
       :url: '/show_statistics'

--- a/vmdb/product/toolbars/orchestration_stack_center_tb.yaml
+++ b/vmdb/product/toolbars/orchestration_stack_center_tb.yaml
@@ -13,15 +13,15 @@
     :items:
 #    - :button: orchestration_stack_edit
 #      :image: edit
-#      :text: 'Edit this <%= ui_lookup(:table=>"orchestration_stack") %>'
-#      :title: 'Edit this <%= ui_lookup(:table=>"orchestration_stack") %>'
+#      :text: 'Edit this #{ui_lookup(:table=>"orchestration_stack")}'
+#      :title: 'Edit this #{ui_lookup(:table=>"orchestration_stack")}'
 #      :url: '/edit'
     - :button: orchestration_stack_delete
       :image: delete
-      :text: 'Remove this <%= ui_lookup(:table=>"orchestration_stack") %> from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"orchestration_stack") %> from the VMDB'
+      :text: 'Remove this #{ui_lookup(:table=>"orchestration_stack")} from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"orchestration_stack")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"orchestration_stack") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"orchestration_stack") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"orchestration_stack")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"orchestration_stack")}?'
 - :name: orchestration_stack_policy
   :items:
   - :buttonSelect: orchestration_stack_policy_choice
@@ -32,4 +32,4 @@
     - :button: orchestration_stack_tag
       :image: tag
       :text: "Edit Tags"
-      :title: 'Edit Tags for this <%= ui_lookup(:tables=>"orchestration_stack") %>'
+      :title: 'Edit Tags for this #{ui_lookup(:tables=>"orchestration_stack")}'

--- a/vmdb/product/toolbars/orchestration_stacks_center_tb.yaml
+++ b/vmdb/product/toolbars/orchestration_stacks_center_tb.yaml
@@ -13,17 +13,17 @@
     :items:
 #    - :button: orchestration_stack_edit
 #      :image: edit
-#      :text: 'Edit Selected <%= ui_lookup(:table=>"orchestration_stack") %>'
-#      :title: 'Select a single <%= ui_lookup(:table=>"orchestration_stack") %> to edit'
+#      :text: 'Edit Selected #{ui_lookup(:table=>"orchestration_stack")}'
+#      :title: 'Select a single #{ui_lookup(:table=>"orchestration_stack")} to edit'
 #      :url_parms: 'main_div'
 #      :enabled: 'false'
 #      :onwhen: '1'
     - :button: orchestration_stack_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"orchestration_stack") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"orchestration_stack") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"orchestration_stack")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"orchestration_stack")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"orchestration_stack") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"orchestration_stack") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"orchestration_stack")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"orchestration_stack")}?'
       :enabled: 'false'
       :onwhen: '1+'
 - :name: orchestration_stack_policy
@@ -38,7 +38,7 @@
     - :button: orchestration_stack_tag
       :image: tag
       :text: "Edit Tags"
-      :title: 'Edit Tags for the selected <%= ui_lookup(:tables=>"orchestration_stack") %>'
+      :title: 'Edit Tags for the selected #{ui_lookup(:tables=>"orchestration_stack")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/storage_center_tb.yaml
+++ b/vmdb/product/toolbars/storage_center_tb.yaml
@@ -14,15 +14,15 @@
     - :button: storage_scan
       :image: scan
       :text: 'Perform SmartState Analysis'
-      :title: 'Perform SmartState Analysis on this <%= ui_lookup(:table=>"storages") %>'
-      :confirm: 'Perform SmartState Analysis on this <%= ui_lookup(:table=>"storages") %>?'
+      :title: 'Perform SmartState Analysis on this #{ui_lookup(:table=>"storages")}'
+      :confirm: 'Perform SmartState Analysis on this #{ui_lookup(:table=>"storages")}?'
     - :separator:
     - :button: storage_delete
       :image: remove
       :text: 'Remove from the VMDB'
-      :title: 'Remove this <%= ui_lookup(:table=>"storages") %> from the VMDB'
+      :title: 'Remove this #{ui_lookup(:table=>"storages")} from the VMDB'
       :url_parms: '&refresh=y'
-      :confirm: 'Warning: This <%= ui_lookup(:table=>"storages") %> and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this <%= ui_lookup(:table=>"storages") %>?'
+      :confirm: 'Warning: This #{ui_lookup(:table=>"storages")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"storages")}?'
 - :name: storage_policy
   :items:
   - :buttonSelect: storage_policy_choice
@@ -33,7 +33,7 @@
     - :button: storage_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for this <%= ui_lookup(:table=>"storages") %>'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"storages")}'
 - :name: storage_monitoring
   :items:
   - :buttonSelect: storage_monitoring_choice
@@ -44,6 +44,6 @@
     - :button: storage_perf
       :image: capacity
       :text: 'Utilization'
-      :title: 'Show Capacity & Utilization data for this <%= ui_lookup(:table=>"storages") %>'
+      :title: 'Show Capacity & Utilization data for this #{ui_lookup(:table=>"storages")}'
       :url: '/show'
       :url_parms: '?display=performance'

--- a/vmdb/product/toolbars/storages_center_tb.yaml
+++ b/vmdb/product/toolbars/storages_center_tb.yaml
@@ -16,17 +16,17 @@
     - :button: storage_scan
       :image: scan
       :text: 'Perform SmartState Analysis'
-      :title: 'Perform SmartState Analysis on the selected <%= ui_lookup(:tables=>"storages") %>'
+      :title: 'Perform SmartState Analysis on the selected #{ui_lookup(:tables=>"storages")}'
       :url_parms: 'main_div'
-      :confirm: 'Perform SmartState Analysis on the selected <%= ui_lookup(:tables=>"storages") %>?'
+      :confirm: 'Perform SmartState Analysis on the selected #{ui_lookup(:tables=>"storages")}?'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: storage_delete
       :image: remove
-      :text: 'Remove <%= ui_lookup(:tables=>"storages") %> from the VMDB'
-      :title: 'Remove selected <%= ui_lookup(:tables=>"storages") %> from the VMDB'
+      :text: 'Remove #{ui_lookup(:tables=>"storages")} from the VMDB'
+      :title: 'Remove selected #{ui_lookup(:tables=>"storages")} from the VMDB'
       :url_parms: 'main_div'
-      :confirm: 'Warning: The selected <%= ui_lookup(:tables=>"storages") %> and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected <%= ui_lookup(:tables=>"storages") %>?'
+      :confirm: 'Warning: The selected #{ui_lookup(:tables=>"storages")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"storages")}?'
       :enabled: 'false'
       :onwhen: '1+'
 - :name: storage_policy
@@ -41,7 +41,7 @@
     - :button: storage_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for the selected <%= ui_lookup(:tables=>"storages") %>'
+      :title: 'Edit Tags for the selected #{ui_lookup(:tables=>"storages")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/summary_center_tb.yaml
+++ b/vmdb/product/toolbars/summary_center_tb.yaml
@@ -8,6 +8,6 @@
   :items:
   - :button: show_summary
     :image: summary-blue
-    :title: 'Show <%= @layout == "cim_base_storage_extent" ? @record.evm_display_name : @record.name %> Summary'
+    :title: 'Show #{@layout == "cim_base_storage_extent" ? @record.evm_display_name : @record.name} Summary'
     :url: '/show'
-    :url_parms: '?id=<%= @record.id %>'
+    :url_parms: '?id=#{@record.id}'

--- a/vmdb/product/toolbars/user_center_tb.yaml
+++ b/vmdb/product/toolbars/user_center_tb.yaml
@@ -34,5 +34,5 @@
     :items:
     - :button: rbac_user_tags_edit
       :image: tag
-      :text: "Edit '<%= session[:customer_name] %>' Tags for this User"
-      :title: "Edit '<%= session[:customer_name] %>' Tags for this User"
+      :text: "Edit '#{session[:customer_name]}' Tags for this User"
+      :title: "Edit '#{session[:customer_name]}' Tags for this User"

--- a/vmdb/product/toolbars/users_center_tb.yaml
+++ b/vmdb/product/toolbars/users_center_tb.yaml
@@ -46,8 +46,8 @@
     :items:
     - :button: rbac_user_tags_edit
       :image: tag
-      :text: "Edit '<%= session[:customer_name] %>' Tags for the selected Users"
-      :title: "Edit '<%= session[:customer_name] %>' Tags for the selected Users"
+      :text: "Edit '#{session[:customer_name]}' Tags for the selected Users"
+      :title: "Edit '#{session[:customer_name]}' Tags for the selected Users"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/x_edit_view_tb.yaml
+++ b/vmdb/product/toolbars/x_edit_view_tb.yaml
@@ -9,23 +9,23 @@
     :image: add
     :title: "Add"
     :text: Add
-    :url: '<%= @edit[:url] %>'
+    :url: '#{@edit[:url]}'
     :url_parms: '?button=add'
   - :button: button_save
     :image: save
     :title: "Save Changes"
     :text: Save
-    :url: '<%= @edit[:url] %>'
+    :url: '#{@edit[:url]}'
     :url_parms: '?button=save'
   - :button: button_reset
     :image: reset
     :title: "Reset"
     :text: Reset
-    :url: '<%= @edit[:url] %>'
+    :url: '#{@edit[:url]}'
     :url_parms: '?button=reset'
   - :button: button_cancel
     :image: cancel
     :title: "Cancel Changes"
     :text: Cancel
-    :url: '<%= @edit[:url] %>'
+    :url: '#{@edit[:url]}'
     :url_parms: '?button=cancel'

--- a/vmdb/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/vmdb/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -58,6 +58,24 @@ end
 
 describe OpsController do
   render_views
+  context "#tree_select" do
+    it "renders zone list for diagnostics_tree root node" do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+
+      expect(MiqServer.my_guid).to be
+      expect(MiqServer.my_server).to be
+
+      session[:userid] = User.current_user.userid
+      session[:sandboxes] = { "ops" => { :active_tree => :diagnostics_tree } }
+      post :tree_select, :id => 'root', :format => :js
+
+      response.should render_template('ops/_diagnostics_zones_tab')
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "::Diagnostics" do
     before do
       set_user_privileges

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -2,55 +2,6 @@ require "spec_helper"
 include JsHelper
 
 describe ApplicationHelper do
-  context "build_custom_buttons_toolbar" do
-    class Controller
-      include ApplicationHelper
-
-      attr_reader :request
-
-      def initialize(sb, request)
-        @sb      = sb
-        @request = request
-      end
-
-      def role_allows(options)
-        true
-      end
-    end
-
-    it 'should substitute dynamic function values' do
-      req        = ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=foo'
-      controller = Controller.new({:active_tree => :cb_reports_tree}, req)
-      json,      = controller.build_toolbar_buttons_and_xml 'storages_center_tb'
-      title_text = ui_lookup(:tables => "storages")
-      menu_info  = JSON.parse json
-
-      menu_info.each_value do |value|
-        %w( title confirm ).each do |field|
-          if value[field]
-            expect(value[field]).to match(title_text)
-          end
-        end
-      end
-    end
-
-    it 'should substitute dynamic ivar values' do
-      req = ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=foo'
-      controller = Controller.new({:active_tree => :cb_reports_tree,
-                                   :nodeid      => 'storages',
-                                   :mode        => 'foo' }, req)
-
-      json, = controller.build_toolbar_buttons_and_xml 'miq_policies_center_tb'
-      title_text = ui_lookup(:model => "storages")
-
-      menu_info = JSON.parse json
-      menu_info.each_value do |value|
-        next unless value['title']
-        expect(value['title']).to match(title_text)
-        expect(value['title']).to match("Foo") # from :mode
-      end
-    end
-  end
 
   describe "#role_allows" do
     before(:each) do

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,55 @@ require "spec_helper"
 include JsHelper
 
 describe ApplicationHelper do
+  context "build_custom_buttons_toolbar" do
+    class Controller
+      include ApplicationHelper
+
+      attr_reader :request
+
+      def initialize(sb, request)
+        @sb      = sb
+        @request = request
+      end
+
+      def role_allows(options)
+        true
+      end
+    end
+
+    it 'should substitute dynamic function values' do
+      req        = ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=foo'
+      controller = Controller.new({:active_tree => :cb_reports_tree}, req)
+      json,      = controller.build_toolbar_buttons_and_xml 'storages_center_tb'
+      title_text = ui_lookup(:tables => "storages")
+      menu_info  = JSON.parse json
+
+      menu_info.each_value do |value|
+        %w( title confirm ).each do |field|
+          if value[field]
+            expect(value[field]).to match(title_text)
+          end
+        end
+      end
+    end
+
+    it 'should substitute dynamic ivar values' do
+      req = ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=foo'
+      controller = Controller.new({:active_tree => :cb_reports_tree,
+                                   :nodeid      => 'storages',
+                                   :mode        => 'foo' }, req)
+
+      json, = controller.build_toolbar_buttons_and_xml 'miq_policies_center_tb'
+      title_text = ui_lookup(:model => "storages")
+
+      menu_info = JSON.parse json
+      menu_info.each_value do |value|
+        next unless value['title']
+        expect(value['title']).to match(title_text)
+        expect(value['title']).to match("Foo") # from :mode
+      end
+    end
+  end
 
   describe "#role_allows" do
     before(:each) do


### PR DESCRIPTION
Reverting b06140a1b4f502fb4f70c4477b0821b9bad90256

@tenderlove : please review.

There's a flaw in the change: previously the `eval` was called only on some lines in __some buttons__ because not all buttons where added and 1st there was decided what to add and after that the `eval` calls where done.

Now, the ERB is called an all the buttons in the toolbar. Therefor even on buttons that will not be added. And that's the problem. Eg. in Config--->Configuration---> Diagnostics there's a toolbar `product/toolbars/diagnostics_zone_center_tb.yaml` that has `#{@record.server_role.description}` in it. This is evaled by ERB even where there's no 'server_role' under `@record`. Because `@record` may be an instance of various classes.

I apology for the mess. I clicked on many parts to test many toolbars, but not all :-(

Fixes: https://github.com/ManageIQ/manageiq/issues/2248