### PR TITLE
Mark Domain as disabled in UI.

### DIFF
--- a/vmdb/app/assets/javascripts/dynatree_1.2.4/skin-cfme/ui.dynatree.css.erb
+++ b/vmdb/app/assets/javascripts/dynatree_1.2.4/skin-cfme/ui.dynatree.css.erb
@@ -603,3 +603,9 @@ span.ae-valid-node a
     background-color: #40a0ce !important;
     color: white !important; /* @ IE6 */
 }
+
+span.product-strikethru-node a
+{
+  color: black !important; /* @ IE6 */
+  text-decoration: line-through;
+}

--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -2078,8 +2078,8 @@ private
 
   def get_rec_name(rec)
     column = rec.display_name.blank? ? :name : :display_name
-    if rec.kind_of?(MiqAeNamespace) && rec.domain? && !rec.editable?
-      add_read_only_suffix(rec.send(column))
+    if rec.kind_of?(MiqAeNamespace) && rec.domain? && (!rec.editable? || !rec.enabled)
+      add_read_only_suffix(rec, rec.send(column))
     else
       rec.send(column)
     end
@@ -2719,7 +2719,7 @@ private
     }
     domains = MiqAeDomain.order('priority DESC')
     order = @edit[:new][:domain_order]
-    domains.collect { |d| order.push("#{d.editable? ? d.name : add_read_only_suffix(d.name)}") unless d.priority == 0 }
+    domains.collect { |d| order.push("#{d.editable? ? d.name : add_read_only_suffix(d, d.name)}") unless d.priority == 0 }
     @edit[:current] = copy_hash(@edit[:new])
     session[:edit]  = @edit
   end

--- a/vmdb/app/helpers/miq_ae_class_helper.rb
+++ b/vmdb/app/helpers/miq_ae_class_helper.rb
@@ -1,6 +1,13 @@
 module MiqAeClassHelper
-  def add_read_only_suffix(node_string)
-    "#{node_string} (Locked)"
+  def add_read_only_suffix(rec, node_string)
+    if rec.enabled && !rec.editable?
+      suffix = "Locked"
+    elsif rec.editable? && !rec.enabled
+      suffix = "Disabled"
+    else # !rec.enabled && !rec.editable?
+      suffix = "Locked & Disabled"
+    end
+    "#{node_string} (#{suffix})"
   end
 
   def domain_display_name(domain)

--- a/vmdb/app/presenters/tree_node_builder.rb
+++ b/vmdb/app/presenters/tree_node_builder.rb
@@ -168,8 +168,24 @@ class TreeNodeBuilder
 
   def node_with_display_name(image)
     text = object.display_name.blank? ? object.name : "#{object.display_name} (#{object.name})"
-    text = add_read_only_suffix(text) if object.kind_of?(MiqAeNamespace) && object.domain? && !object.editable?
-    generic_node(text, image_for_node(object, image), "#{tooltip_prefix_for_node(object)}: #{text}")
+    if object.kind_of?(MiqAeNamespace) && object.domain? && (!object.editable? || !object.enabled)
+      text = add_read_only_suffix(object, text)
+      miq_ae_node(object.enabled, text, image_for_node(object, image), "#{tooltip_prefix_for_node(object)}: #{text}")
+    else
+      generic_node(text, image_for_node(object, image), "#{tooltip_prefix_for_node(object)}: #{text}")
+    end
+  end
+
+  def miq_ae_node(enabled, text, image, tip)
+    text = ERB::Util.html_escape(text) unless text.html_safe?
+    @node = {
+      :key   => build_object_id,
+      :title => text,
+      :icon  => image
+    }
+    @node[:addClass] = "product-strikethru-node" unless enabled
+    @node[:expand] = true if options[:open_all]  # Start with all nodes open
+    tooltip(tip)
   end
 
   def image_for_node(object, image)


### PR DESCRIPTION
Show (Disabled) suffix next to disabled domains in UI and line-through the node on the tree to make disabled domain nodes stand out.

https://bugzilla.redhat.com/show_bug.cgi?id=1201883

@dclarizio please review/test
@epwinchell please review, and suggest if anything needs to be changed in css.

before:
![domain_before_marking_disabled](https://cloud.githubusercontent.com/assets/3450808/6735079/4651bada-ce32-11e4-96df-26d61c7e26d7.png)

after:
![mark_disabled_domains](https://cloud.githubusercontent.com/assets/3450808/6735985/7256bf3a-ce38-11e4-8d39-1288a254c85e.png)


