### PR TITLE
Fixed VMDB::Config cache misses seen mostly in test.

### DIFF
--- a/vmdb/lib/vmdb/config.rb
+++ b/vmdb/lib/vmdb/config.rb
@@ -162,10 +162,10 @@ module VMDB
     def config_mtime_from_db
       #log_header = "MIQ(Config.config_mtime_from_db) [#{@name}]"
       server = MiqServer.my_server(true)
-      return if server.nil?
+      return Time.at(0) if server.nil?
 
       conf = server.configurations.select("updated_on").where(:typ => @name).first
-      return if conf.nil?
+      return Time.at(0) if conf.nil?
 
       mtime = conf.updated_on
       #$log.debug("#{log_header} Config mtime retrieved from db [#{mtime}]") unless $log.nil? || mtime.nil?


### PR DESCRIPTION
Configuration records in the database imply changes have been made.
No configuration record implies that there have not been changes.

In the latter case, we were not caching the configuration modification time properly, causing a cache miss, forcing us to reload the configuration. In order to fix this, we are using Time.at(0) as the "modification" time of the valid, in memory, configuration. Once this is persisted, the mtime will be newer and we'll get it from the database.

Using stackprof on a slow test I noticed this line as the 3rd in terms of cpu time:
`1713  (13.2%)         672   (5.2%)     VMDB::Config.load_config_file`

After researching further, I found that the typical test scenario does VMDB::Config.new more than once per example and that these subsequent calls weren't cached so we went back to the filesystem and read/merged configurations.  :confused:

After this fix, the rest api test suite is 22 seconds faster (~18%).
Other tests don't call VMDB::Config.new as often but a rough before/after indicated nearly ~9% faster for the whole vmdb test suite.

**Before**:
```
time bundle exec rspec -f p spec/requests
...
Finished in 1 minute 56.01 seconds
```

**After**:
```
time bundle exec rspec -f p spec/requests
...
Finished in 1 minute 34.4 seconds
```

Stackprof of spec/requests/api/policies_assignment_spec.rb

**Before**:
```
==================================
  Mode: cpu(1000)
  Samples: 13000 (15.00% miss rate)
  GC: 803 (6.18%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2933  (22.6%)        2933  (22.6%)     block in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache
      1829  (14.1%)        1773  (13.6%)     block in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_cache
      1491  (11.5%)        1491  (11.5%)     block (2 levels) in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#execute
      1713  (13.2%)         672   (5.2%)     VMDB::Config.load_config_file
       354   (2.7%)         354   (2.7%)     block in Logger::LogDevice#write
       421   (3.2%)         332   (2.6%)     Psych::ScalarScanner#tokenize
       288   (2.2%)         287   (2.2%)     VMDB::Config#normalize_time
      2615  (20.1%)         286   (2.2%)     block in ActiveSupport::Dependencies::Loadable#require
       192   (1.5%)         192   (1.5%)     BCrypt::Engine.hash_secret
```

**After**:
```
==================================
  Mode: cpu(1000)
  Samples: 11113 (17.51% miss rate)
  GC: 753 (6.78%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3146  (28.3%)        3146  (28.3%)     block in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache
      1655  (14.9%)        1615  (14.5%)     block in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_cache
      1376  (12.4%)        1376  (12.4%)     block (2 levels) in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#execute
       302   (2.7%)         302   (2.7%)     block in Logger::LogDevice#write
      2753  (24.8%)         267   (2.4%)     block in ActiveSupport::Dependencies::Loadable#require
       196   (1.8%)         196   (1.8%)     BCrypt::Engine.hash_secret
       277   (2.5%)         182   (1.6%)     VMDB::Config#config_mtime_from_file
       536   (4.8%)         178   (1.6%)     #<Module:0x007fa0b1c6b200>.load_file
       264   (2.4%)         155   (1.4%)     #<Module:0x007fa0b1c6b200>.parse_stream
       330   (3.0%)         143   (1.3%)     VMDB::Config.load_config_file
```