### PR TITLE
Fix issue where count was undefined when purge called with a block.

### DIFF
--- a/vmdb/app/models/metric/purging.rb
+++ b/vmdb/app/models/metric/purging.rb
@@ -88,10 +88,10 @@ module Metric::Purging
         ids = ids[0, limit - total] if limit && total + ids.length > limit
 
         $log.info("#{log_header} Purging #{ids.length} #{interval} metrics.")
-        Benchmark.realtime_block(:purge_metrics) do
-          count  = klass.delete_all(:id => ids)
-          total += count
+        count, _ = Benchmark.realtime_block(:purge_metrics) do
+          klass.delete_all(:id => ids)
         end
+        total += count
 
         if interval != 'realtime'
           # Since VimPerformanceTagValues are 6 * number of tags per performance
@@ -99,11 +99,11 @@ module Metric::Purging
           count_tag_values = 0
           $log.info("#{log_header} Purging associated tag values.")
           ids.each_slice(50) do |vp_ids|
-            Benchmark.realtime_block(:purge_vim_performance_tag_values) do
-              count = VimPerformanceTagValue.delete_all(:metric_id => vp_ids, :metric_type => klass.name)
-              count_tag_values += count
-              total_tag_values += count
+            tv_count, _ = Benchmark.realtime_block(:purge_vim_performance_tag_values) do
+              VimPerformanceTagValue.delete_all(:metric_id => vp_ids, :metric_type => klass.name)
             end
+            count_tag_values += tv_count
+            total_tag_values += tv_count
           end
           $log.info("#{log_header} Purged #{count_tag_values} associated tag values.")
         end

--- a/vmdb/spec/models/metric/purging_spec.rb
+++ b/vmdb/spec/models/metric/purging_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+describe Metric::Purging do
+  context "::Purging" do
+    it "#purge_all_timer" do
+      EvmSpecHelper.seed_for_miq_queue
+
+      Timecop.freeze(Time.now) do
+        described_class.purge_all_timer
+
+        q = MiqQueue.all.to_a
+        q.length.should == 3
+
+        q.each do |qi|
+          qi.should have_attributes(
+            :class_name  => described_class.name,
+            :method_name => "purge"
+          )
+        end
+
+        modes = q.collect { |qi| qi.args.last }
+        modes.should match_array %w(daily hourly realtime)
+      end
+    end
+
+    context "with data" do
+      before(:each) do
+        @vmdb_config = {
+          :performance => {
+            :history => {
+              :keep_daily_performance    => "6.months",
+              :keep_hourly_performance   => "6.months",
+              :keep_realtime_performance => "4.hours",
+              :purge_window_size         => 1000
+            }
+          }
+        }
+        VMDB::Config.any_instance.stub(:config).and_return(@vmdb_config)
+
+        @metrics1 = [
+          FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => 1, :timestamp => (6.months + 1.days).ago.utc),
+          FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => 1, :timestamp => (6.months - 1.days).ago.utc)
+        ]
+        @metrics2 = [
+          FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => 2, :timestamp => (6.months + 2.days).ago.utc),
+          FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => 2, :timestamp => (6.months + 1.days).ago.utc),
+          FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => 2, :timestamp => (6.months - 1.days).ago.utc)
+        ]
+      end
+
+      it "#purge_count" do
+        described_class.purge_count(6.months.ago, "hourly").should == 3
+      end
+
+      context "#purge" do
+        it "without block" do
+          described_class.purge(6.months.ago, "hourly")
+          MetricRollup.where(:resource_id => 1).all.should == [@metrics1.last]
+          MetricRollup.where(:resource_id => 2).all.should == [@metrics2.last]
+        end
+
+        it "with a block" do
+          callbacks = []
+          # Adjust the window size to force multiple block callbacks
+          @vmdb_config.store_path(:performance, :history, :purge_window_size, 2)
+
+          described_class.purge(6.months.ago, "hourly") { |count, total| callbacks << [count, total] }
+          MetricRollup.where(:resource_id => 1).all.should == [@metrics1.last]
+          MetricRollup.where(:resource_id => 2).all.should == [@metrics2.last]
+
+          callbacks.should == [[2, 2], [1, 3]]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note that this only really affects calling .purge from the tools/purge_metrics.rb script.
Since normal scheduled purging does not pass the block it works correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1201932