### PR TITLE
Change gettext back to I18n for test email subject.

### DIFF
--- a/vmdb/app/mailers/generic_mailer.rb
+++ b/vmdb/app/mailers/generic_mailer.rb
@@ -127,7 +127,7 @@ class GenericMailer < ActionMailer::Base
     options = {
       :to      => to,
       :from    => settings[:from],
-      :subject => "#{_("ManageIQ")} Test Email",
+      :subject => "#{I18n.t("product.name")} Test Email",
       :body    => "If you have received this email, your SMTP settings are correct."
     }
     prepare_generic_email(options)

--- a/vmdb/spec/mailers/generic_mailer_spec.rb
+++ b/vmdb/spec/mailers/generic_mailer_spec.rb
@@ -201,7 +201,8 @@ describe GenericMailer do
 
   describe "#test_mail" do
     it "should be called directly" do
-      GenericMailer.test_email(@args[:to], settings = {})
+      mail = GenericMailer.test_email(@args[:to], settings = {})
+      mail.subject.should start_with I18n.t("product.name")
     end
 
     it "should not change the input parameters" do


### PR DESCRIPTION
This was broken in commit: 80fbeeceecf0701ebe

https://bugzilla.redhat.com/show_bug.cgi?id=1202681

cc @jzigmund @dclarizio, please review the other changes in the above commit to see if there was anything else mistakenly converted to gettext.