### PR TITLE
Fixed quick and advanced search modals to send up single transaction.

### DIFF
--- a/vmdb/app/controllers/application_controller/filter.rb
+++ b/vmdb/app/controllers/application_controller/filter.rb
@@ -969,8 +969,7 @@ module ApplicationController::Filter
 
     render :update do |page|
       page << "cfmeDynatree_activateNodeSilently('#{x_active_tree.to_s}', '#{x_node}');" if @edit[:in_explorer]
-      page << javascript_hide_if_exists("blocker_div")
-      page << javascript_hide_if_exists("quicksearchbox")
+      page << "$('#quicksearchbox').modal('hide');"
       page << "miqSparkle(false);"
     end
   end
@@ -1044,11 +1043,8 @@ module ApplicationController::Filter
 
     render :update do |page|
       page.replace(:user_input_filter, :partial => "layouts/user_input_filter")
-      page << javascript_hide_if_exists("advsearchbox")
-      page << javascript_show("blocker_div")
-      page << javascript_show("quicksearchbox")
-      page << "$('#quicksearchbox').addClass('modal fade in');"
-      page << "if (miqDomElementExists('value_1')) $('#value_1').focus();"
+      page << "$('#advsearchModal').modal('hide');"
+      page << "$('#quicksearchbox').modal('show');"
       page << "miqSparkle(false);"
     end
   end

--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1755,8 +1755,8 @@ module VmCommon
     # Save open nodes, if any were added
     presenter[:save_open_states_trees] = [x_active_tree.to_s] if add_nodes
 
-    presenter[:set_visible_elements][:blocker_div]    = false unless @edit && @edit[:adv_search_open]
-    presenter[:set_visible_elements][:quicksearchbox] = false
+    presenter[:set_visible_elements][:blocker_div] = false unless @edit && @edit[:adv_search_open]
+    presenter[:hide_modal] = true
     presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
     # Render the JS responses to update the explorer screen
     render :js => presenter.to_html

--- a/vmdb/app/presenters/explorer_presenter.rb
+++ b/vmdb/app/presenters/explorer_presenter.rb
@@ -216,6 +216,8 @@ class ExplorerPresenter
 
     @out << "$('#clear_search').#{@options[:clear_search_show_or_hide]}();" if @options[:clear_search_show_or_hide]
 
+    @out << "$('#quicksearchbox').modal('hide');" if @options[:hide_modal]
+
     # Don't turn off spinner for charts/timelines
     @out << set_spinner_off unless @options[:ajax_action]
   end

--- a/vmdb/app/views/layouts/_adv_search.html.haml
+++ b/vmdb/app/views/layouts/_adv_search.html.haml
@@ -28,7 +28,8 @@
           = render(:partial => 'layouts/adv_search_footer', :locals => {:mode => mode})
 :javascript
   $(function(){
-    $("button[data-dismiss='modal']").click(function(){
+    $('#advsearchModal').off("click");
+    $('#advsearchModal').on('click', '[data-dismiss="modal"]', function() {
       miqJqueryRequest("adv_search_toggle", {beforeSend: true});
       return true;
     });

--- a/vmdb/app/views/layouts/_quick_search.html.haml
+++ b/vmdb/app/views/layouts/_quick_search.html.haml
@@ -7,10 +7,3 @@
                            "data-backdrop"   => "static",
                            :style            => "display: none"}
   = render :partial => "layouts/user_input_filter"
-:javascript
-  $(function(){
-    $("button[data-dismiss='modal']").click(function(){
-      miqJqueryRequest("listnav_search_selected", {beforeSend: true});
-      return true;
-    });
-  });

--- a/vmdb/app/views/layouts/_user_input_filter.html.haml
+++ b/vmdb/app/views/layouts/_user_input_filter.html.haml
@@ -94,10 +94,13 @@
                       :method => :post,
                       :id     => "cancel_button",
                       :title  => t)
-    = javascript_tag(javascript_focus_if_exists('value_1'))
 :javascript
   $(function(){
-    $("button[data-dismiss='modal']").click(function(){
+    $('#quicksearchbox').on('shown.bs.modal', function () {
+      if (miqDomElementExists('value_1')) $('#value_1').focus();
+    })
+    $('#quicksearchbox').off("click");
+    $('#quicksearchbox').on('click', '[data-dismiss="modal"]', function() {
       miqJqueryRequest("quick_search?button=cancel", {beforeSend: true});
       return true;
     });


### PR DESCRIPTION
Fixed quick and advanced search modals to send up single transaction.  

Made changes to close appropriate modals when X is clicked in the modal window. Also changed some of the show/hide div calls for modals to actually use bootstrap modal calls to show/hide modals so modal backdrop(blocker) can be removed appropriately. 
This also fixes an issue to close advanced search modal and show quick search modal when user loads a filter that requires user input from advanced search modal.  

Issue #2322

@dclarizio please review/test.