### PR TITLE
Disable the EmsRefresh resume-on-error behaviour in specs

### DIFF
--- a/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -29,6 +29,8 @@ module EmsRefresh
             end
             save_inventory(ems, targets, hashes)
           rescue => e
+            raise if EmsRefresh.debug_failures
+
             $log.error("#{log_ems_target} Refresh failed")
             $log.log_backtrace(e)
             $log.error("#{log_ems_target} Unable to perform refresh for the following targets:")

--- a/vmdb/app/models/ems_refresh/refreshers/vc_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/vc_refresher.rb
@@ -53,6 +53,8 @@ module EmsRefresh::Refreshers
 
           $log.info "#{log_header} Refreshing targets for EMS...Complete - Timings: #{timings.inspect}"
         rescue => e
+          raise if EmsRefresh.debug_failures
+
           $log.log_backtrace(e)
           $log.error("#{log_header} Unable to perform refresh for the following targets:" )
           targets.each { |t| $log.error "#{log_header}   #{t.class}: [#{t.name}], id: [#{t.id}]" }

--- a/vmdb/app/models/ems_refresh/save_inventory.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory.rb
@@ -110,8 +110,13 @@ module EmsRefresh::SaveInventory
         # If a vm failed to process, mark it as invalid and log an error
         h[:invalid] = invalids_found = true
         name = h[:name] || h[:uid_ems] || h[:ems_ref]
-        $log.send(err.kind_of?(MiqException::MiqIncompleteData) ? :warn : :error, "#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
-        $log.log_backtrace(err) unless err.kind_of?(MiqException::MiqIncompleteData)
+        if err.kind_of?(MiqException::MiqIncompleteData)
+          $log.warn("#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
+        else
+          raise if EmsRefresh.debug_failures
+          $log.error("#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
+          $log.log_backtrace(err)
+        end
       ensure
         restore_keys(h, remove_keys, key_backup)
       end

--- a/vmdb/app/models/ems_refresh/save_inventory_infra.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_infra.rb
@@ -193,8 +193,13 @@ module EmsRefresh::SaveInventoryInfra
         # If a host failed to process, mark it as invalid and log an error
         h[:invalid] = invalids_found = true
         name = h[:name] || h[:uid_ems] || h[:hostname] || h[:ipaddress] || h[:ems_ref]
-        $log.send(err.kind_of?(MiqException::MiqIncompleteData) ? :warn : :error, "#{log_header} Processing Host: [#{name}] failed with error [#{err.class}: #{err}]. Skipping Host.")
-        $log.log_backtrace(err) unless err.kind_of?(MiqException::MiqIncompleteData)
+        if err.kind_of?(MiqException::MiqIncompleteData)
+          $log.warn("#{log_header} Processing Host: [#{name}] failed with error [#{err.class}: #{err}]. Skipping Host.")
+        else
+          raise if EmsRefresh.debug_failures
+          $log.error("#{log_header} Processing Host: [#{name}] failed with error [#{err.class}: #{err}]. Skipping Host.")
+          $log.log_backtrace(err)
+        end
       ensure
         restore_keys(h, remove_keys, key_backup)
       end

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_errors_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_errors_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 describe EmsRefresh::Refreshers::OpenstackRefresher do
   before(:each) do
+    EmsRefresh.debug_failures = false
+
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(
       :ems_openstack,

--- a/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_errors_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_errors_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 describe EmsRefresh::Refreshers::VcRefresher do
   before(:each) do
+    EmsRefresh.debug_failures = false
+
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(
       :ems_vmware,

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -73,6 +73,9 @@ RSpec.configure do |config|
   }
   config.include RakeTaskExampleGroup, :type => :rake_task
 
+  config.before(:each) do
+    EmsRefresh.debug_failures = true
+  end
   config.after(:each) do
     EvmSpecHelper.clear_caches
   end


### PR DESCRIPTION
... except for the specs that are actually testing it, of course.

This way, when something goes wrong, instead of an unhelpful error like "unused HTTP interactions left in the cassette" or "expected: 10 got: 0", rspec directly reports the actual problem, complete with backtrace.