### PR TITLE
Limit df to local filesystems since that's all we care about

### DIFF
--- a/lib/fs/MiqFS/modules/RealFS.rb
+++ b/lib/fs/MiqFS/modules/RealFS.rb
@@ -8,7 +8,7 @@ module RealFS
 				self.fsType = "NTFS"
 				@guestOS = "Windows"
 			when :linux
-				self.fsType = `df -T / | tail -1 | awk '{ print $2 }'`
+				self.fsType = `df -lT / | tail -1 | awk '{ print $2 }'`
 				@guestOS = "Linux"
 			when :macosx
 		end

--- a/lib/util/miq-system.rb
+++ b/lib/util/miq-system.rb
@@ -396,8 +396,7 @@ class MiqSystem
   #
   ##############################################################################################################################
   def self.disk_usage(file=nil)
-    file = nil if file.blank?
-    raise "file #{file} does not exist" unless File.exist?(file.to_s) || file.nil?
+    file = normalize_df_file_argument(file)
 
     case Platform::IMPL
     when :linux
@@ -460,6 +459,13 @@ class MiqSystem
     end
   end
 
+  def self.normalize_df_file_argument(file = nil)
+    # limit disk usage to local filesystems if no file provided
+    return "-l" if file.blank?
+
+    raise "file #{file} does not exist" unless File.exist?(file)
+    file
+  end
 
   ##############################################################################################################################
   # DU(1)                                                         User Commands                                                        DU(1)

--- a/system/logrotate_free_space_check.sh
+++ b/system/logrotate_free_space_check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 file=$1
 logger_file=/var/www/miq/vmdb/log/appliance_console.log
-logvol_free_space=`df -k $file | awk '{ print $3 }' | tail -n 1`
+logvol_free_space=`df -lk $file | awk '{ print $3 }' | tail -n 1`
 existing_log_size=`du -k $file | awk '{ print $1 }' | tail -n 1`
 size_needed=$(($existing_log_size+($existing_log_size/5)))
 echo "$(date) Checking for enough free space to rotate: $file" >> $logger_file


### PR DESCRIPTION
* To avoid a hung process, limit df to local fs if no file is provided …
  Mounted NFS volumes that go bad/down can hang df so let's limit df to only the
  local filesystems we care about.

  Existing usage of MiqSystem.disk_usage has been:
  * where we pass no argument and log the output for server statistics from local filesystems
  * where we pass the Postgresql database disk location

* Force df to local filesystems even when a local path is provided.

https://bugzilla.redhat.com/show_bug.cgi?id=1203442