### PR TITLE
pass :utc to calls to String#to_time

### DIFF
--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -2138,8 +2138,10 @@ class Host < ActiveRecord::Base
 
     time_range = if range.kind_of?(Array)
       range
-    elsif range.kind_of?(Time) || range.kind_of?(String)
-      [range.to_time.utc, Time.now.utc]
+    elsif range.kind_of?(Time)
+      [range.utc, Time.now.utc]
+    elsif range.kind_of?(String)
+      [range.to_time(:utc), Time.now.utc]
     elsif range.kind_of?(Integer)
       [range.seconds.ago.utc, Time.now.utc]
     else

--- a/vmdb/app/models/metric/ci_mixin/state_finders.rb
+++ b/vmdb/app/models/metric/ci_mixin/state_finders.rb
@@ -7,12 +7,12 @@ module Metric::CiMixin::StateFinders
     if state.nil?
       if self.vim_performance_states.loaded?
         # Look for requested time in cache
-        t = ts.to_time
+        t = ts.to_time(:utc)
         state = self.vim_performance_states.detect { |s| s.timestamp == t }
         if state.nil?
           # Look for state for current hour in cache if still nil because the
           #   capture will return a state for the current hour only.
-          t = Metric::Helper.nearest_hourly_timestamp(Time.now.utc).to_time
+          t = Metric::Helper.nearest_hourly_timestamp(Time.now.utc).to_time(:utc)
           state = self.vim_performance_states.detect { |s| s.timestamp == t }
         end
       else

--- a/vmdb/spec/models/metric_spec.rb
+++ b/vmdb/spec/models/metric_spec.rb
@@ -864,9 +864,9 @@ describe Metric do
               @host1.get_performance_metric(:realtime, :cpu_usage_rate_average, ["2010-04-14T20:52:40Z", "2010-04-14T22:52:40Z"], :max).should == 100.0
 
               # Test supported formats of time range
-              @host1.get_performance_metric(:realtime, :cpu_usage_rate_average, ["2010-04-14T20:52:40Z".to_time.utc, "2010-04-14T22:52:40Z".to_time.utc], :min).should == 2.0
+              @host1.get_performance_metric(:realtime, :cpu_usage_rate_average, ["2010-04-14T20:52:40Z".to_time(:utc), "2010-04-14T22:52:40Z".to_time(:utc)], :min).should == 2.0
               @host1.get_performance_metric(:realtime, :cpu_usage_rate_average, "2010-04-14T20:52:40Z", :max).should == 100.0
-              @host1.get_performance_metric(:realtime, :cpu_usage_rate_average, "2010-04-14T20:52:40Z".to_time.utc, :max).should == 100.0
+              @host1.get_performance_metric(:realtime, :cpu_usage_rate_average, "2010-04-14T20:52:40Z".to_time(:utc), :max).should == 100.0
             end
           end
         end


### PR DESCRIPTION
Rails changed the default to parse time with regard to local time rather
than UTC.  Our code assumes that times that come from String#to_time are
in UTC and not local.  This patch passes :utc to to_time so that we will
get utc times after upgrading