### PR TITLE
[WIP] Monkey patch MiqUtil.runcmd to prevent shelling out in test.

### DIFF
--- a/vmdb/spec/support/dont_shell_out_in_tests.rb
+++ b/vmdb/spec/support/dont_shell_out_in_tests.rb
@@ -1,0 +1,7 @@
+require 'runcmd'
+
+class MiqUtil
+  def self.runcmd(*_args)
+    raise "Don't shell out in tests!  Mock me instead!"
+  end
+end


### PR DESCRIPTION
 In #2277, we noticed that some of the database introspection tests were shelling out to run `df`.
Specifically, spec/models/vmdb_index_spec.rb and friends.

I'll use this PR to find all places we're not stubbing MiqUtil.runcmd and possibly keep this code even after the callers are fixed.  Maybe we can do the same thing with backtick and `AwesomeSpawn.run`.