### PR TITLE
Reinforce universal newlines for orchestration template

### DIFF
--- a/vmdb/app/models/orchestration_template.rb
+++ b/vmdb/app/models/orchestration_template.rb
@@ -16,7 +16,7 @@ class OrchestrationTemplate < ActiveRecord::Base
   end
 
   def self.find_with_content(template_content)
-    available.where(:md5 => calc_md5(template_content)).first
+    available.where(:md5 => calc_md5(with_universal_newline(template_content))).first
   end
 
   # Find only by template content. Here we only compare md5 considering the table is expected
@@ -30,7 +30,7 @@ class OrchestrationTemplate < ActiveRecord::Base
                  create!(hash.except(:md5)) # always create a new template if it is a draft
                  true
                else
-                 md5s << calc_md5(hash[:content])
+                 md5s << calc_md5(with_universal_newline(hash[:content]))
                  false
                end
              end
@@ -48,8 +48,8 @@ class OrchestrationTemplate < ActiveRecord::Base
   end
 
   def content=(text)
-    super
-    self.md5 = calc_md5(text)
+    super(with_universal_newline(text))
+    self.md5 = calc_md5(content)
   end
 
   # Check whether a template has been referenced by any stack. A template that is in use should be
@@ -102,5 +102,14 @@ class OrchestrationTemplate < ActiveRecord::Base
 
   def calc_md5(text)
     self.class.calc_md5(text)
+  end
+
+  def self.with_universal_newline(text)
+    # ensure universal new lines and content ending with a new line
+    text.encode(:universal_newline => true).chomp.concat("\n")
+  end
+
+  def with_universal_newline(text)
+    self.class.with_universal_newline(text)
   end
 end

--- a/vmdb/spec/controllers/catalog_controller_spec.rb
+++ b/vmdb/spec/controllers/catalog_controller_spec.rb
@@ -84,7 +84,7 @@ describe CatalogController do
       controller.should_receive(:render)
       @new_name = "New Name"
       @new_description = "New Description"
-      @new_content = "New Content"
+      @new_content = "New Content\n"
       session[:edit] = {
         :new    => {
           :name        => @new_name,

--- a/vmdb/spec/models/orchestration_template_spec.rb
+++ b/vmdb/spec/models/orchestration_template_spec.rb
@@ -148,4 +148,25 @@ describe OrchestrationTemplate do
       result.should == existing_template
     end
   end
+
+  context "when content has non-universal newlines" do
+    let(:raw_text) { "abc\r\nxyz\r123\nend" }
+    let(:content) { "abc\nxyz\n123\nend\n" }
+    let(:existing_template) { FactoryGirl.create(:orchestration_template, :content => raw_text) }
+
+    it "stores content with universal newlines" do
+      existing_template.content.should == content
+    end
+
+    it "is retrievable through either raw or normalized content" do
+      existing_template.should == OrchestrationTemplate.find_with_content(raw_text)
+      existing_template.should == OrchestrationTemplate.find_with_content(content)
+    end
+
+    it "does not save a new template if the request has either the raw or normalized content" do
+      existing_template.should == OrchestrationTemplate.find_or_create_by_contents(:content => raw_text)[0]
+      existing_template.should == OrchestrationTemplate.find_or_create_by_contents(:content => content)[0]
+      OrchestrationTemplate.count.should == 1
+    end
+  end
 end


### PR DESCRIPTION
proposed in https://github.com/ManageIQ/manageiq/issues/2082
We now ensure every saved template content has newline character "\n"
and the last line ends with  a newline