### PR TITLE
Use #connect, .raw_connect is on the class

### DIFF
--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -5,7 +5,7 @@ class ConfiguredSystemForeman < ConfiguredSystem
   belongs_to :configuration_organization
 
   def provider_object(connection = nil)
-    (connection || connection_source.raw_connect).host(manager_ref)
+    (connection || connection_source.connect).host(manager_ref)
   end
 
   # system is pending a build


### PR DESCRIPTION
Was causing:
```ruby
NoMethodError: undefined method `raw_connect' for #<ConfigurationManagerForeman:0x000000050400d8>
	from ~/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/activemodel/lib/active_model/attribute_methods.rb:407:in `method_missing'
	from ~/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/activerecord/lib/active_record/attribute_methods.rb:149:in `method_missing'
	from ~/projects/redhat/manageiq/vmdb/app/models/configured_system_foreman.rb:8:in `provider_object'
	from (irb):3
	from ~/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib/rails/commands/console.rb:47:in `start'
	from ~/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib/rails/commands/console.rb:8:in `start'
	from ~/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib/rails/commands.rb:41:in `<top (required)>'
	from script/rails:6:in `require'
	from script/rails:6:in `<main>'

```