### PR TITLE
Ensure key comparisons are made as strings

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -104,7 +104,7 @@ module EmsRefresh::SaveInventoryHelper
   def store_ids_for_new_records(records, hashes, keys)
     keys = Array(keys)
     hashes.each do |h|
-      r = records.detect { |r| keys.all? { |k| r.send(k) == h[k] } }
+      r = records.detect { |r| keys.all? { |k| r.send(k).to_s == h[k].to_s } }
       h[:id] = r.id
     end
   end


### PR DESCRIPTION
Rails 4's stricter column typecasting can otherwise be problematic: comparing a string to an integer will not go well.