### PR TITLE
don't set instance variables that are internal to Rails in tests

### DIFF
--- a/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
@@ -194,21 +194,19 @@ end
 describe HostController do
   context "#show_association" do
     before(:each) do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
       @host = FactoryGirl.create(:host)
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
     end
+
     it "renders show_item" do
-      controller.instance_variable_set(:@_params, :id => @host.id, :show => @guest_application.id)
       controller.instance_variable_set(:@breadcrumbs, [])
       controller.stub(:get_view)
-      controller.should_receive(:show_item).once
-      controller.send(:show_association,
-                      'guest_applications',
-                      'Packages',
-                      'guest_application',
-                      :guest_applications,
-                      GuestApplication)
+      get :guest_applications, :id => @host.id, :show => @guest_application.id
       expect(response.status).to eq(200)
+      expect(response).to render_template('host/show')
       expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (Packages)",
                                             :url  => "/host/guest_applications/#{@host.id}?page="},
                                            {:name => "foo",
@@ -217,17 +215,11 @@ describe HostController do
     end
 
     it "renders show_details" do
-      controller.instance_variable_set(:@_params, :id => @host.id)
       controller.instance_variable_set(:@breadcrumbs, [])
       controller.stub(:get_view)
-      controller.should_receive(:show_details).once
-      controller.send(:show_association,
-                      'guest_applications',
-                      'Packages',
-                      'guest_application',
-                      :guest_applications,
-                      GuestApplication)
+      get :guest_applications, :id => @host.id
       expect(response.status).to eq(200)
+      expect(response).to render_template('host/show')
       expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (Packages)",
                                             :url  => "/host/guest_applications/#{@host.id}"}])
     end

--- a/vmdb/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/vmdb/spec/controllers/cloud_tenant_controller_spec.rb
@@ -2,17 +2,21 @@ require "spec_helper"
 
 describe CloudTenantController do
   context "#button" do
+    before(:each) do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
     it "when Instance Retire button is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "instance_retire")
       controller.should_receive(:retirevms).once
-      controller.button
+      post :button, :pressed => "instance_retire", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when Instance Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "instance_tag")
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => "instance_tag", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
   end

--- a/vmdb/spec/controllers/ems_infra_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_infra_controller_spec.rb
@@ -2,58 +2,55 @@ require "spec_helper"
 
 describe EmsInfraController do
   context "#button" do
+    before(:each) do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
     it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_right_size"})
       controller.should_receive(:vm_right_size)
-      controller.button
+      post :button, :pressed => "vm_right_size", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_migrate"})
       controller.should_receive(:prov_redirect).with("migrate")
-      controller.should_receive(:render)
-      controller.button
+      post :button, :pressed => "vm_migrate", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_retire"})
       controller.should_receive(:retirevms).once
-      controller.button
+      post :button, :pressed => "vm_retire", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_protect"})
       controller.should_receive(:assign_policies).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => "vm_protect", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "miq_template_protect"})
       controller.should_receive(:assign_policies).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => "miq_template_protect", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_tag"})
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => "vm_tag", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "miq_template_tag"})
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => 'miq_template_tag', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "should set correct VM for right-sizing when on list of VM's of another CI" do
-      set_user_privileges
       ems_infra = FactoryGirl.create(:ext_management_system)
       post :button, :pressed => "vm_right_size", :id => ems_infra.id, :display => 'vms', :check_10r839 => '1'
       controller.send(:flash_errors?).should_not be_true
@@ -61,11 +58,8 @@ describe EmsInfraController do
     end
 
     it "when Host Analyze then Check Compliance is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "host_analyze_check_compliance"})
-      controller.stub(:show)
       controller.should_receive(:analyze_check_compliance_hosts)
-      controller.should_receive(:render)
-      controller.button
+      post :button, :pressed => "host_analyze_check_compliance", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
   end

--- a/vmdb/spec/controllers/host_controller_spec.rb
+++ b/vmdb/spec/controllers/host_controller_spec.rb
@@ -4,8 +4,13 @@ describe HostController do
   context "#button" do
     render_views
 
-    it "doesn't break" do
+    before(:each) do
       set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    it "doesn't break" do
       h1 = FactoryGirl.create(:host)
       h2 = FactoryGirl.create(:host)
       session[:host_items] = [h1.id, h2.id]
@@ -17,52 +22,44 @@ describe HostController do
     end
 
     it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_right_size"})
       controller.should_receive(:vm_right_size)
-      controller.button
+      post :button, :pressed => 'vm_right_size', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_migrate"})
       controller.should_receive(:prov_redirect).with("migrate")
-      controller.should_receive(:render)
-      controller.button
+      post :button, :pressed => 'vm_migrate', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_retire"})
       controller.should_receive(:retirevms).once
-      controller.button
+      post :button, :pressed => 'vm_retire', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_protect"})
       controller.should_receive(:assign_policies).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => 'vm_protect', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "miq_template_protect"})
       controller.should_receive(:assign_policies).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => 'miq_template_protect', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_tag"})
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => 'vm_tag', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "miq_template_tag"})
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.button
+      post :button, :pressed => 'miq_template_tag', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
@@ -77,15 +74,14 @@ describe HostController do
       custom_button.save
       user = FactoryGirl.create(:user, :userid => 'wilma')
       session[:userid] = "wilma"
-      controller.should_receive(:render)
       post :button, :pressed => "custom_button", :id => host.id, :button_id => custom_button.id
+      expect(response.status).to eq(200)
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when Drift button is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "common_drift"})
       controller.should_receive(:drift_analysis)
-      controller.button
+      post :button, :pressed => 'common_drift', :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
   end

--- a/vmdb/spec/controllers/ontap_file_share_controller_spec.rb
+++ b/vmdb/spec/controllers/ontap_file_share_controller_spec.rb
@@ -1,63 +1,59 @@
 require "spec_helper"
 
-describe CimInstanceController do
+describe OntapFileShareController do
   context "#process_button" do
+    before(:each) do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+
     it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_right_size"})
       controller.should_receive(:vm_right_size)
-      controller.send(:process_button)
+      post :button, :pressed => "vm_right_size", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_migrate"})
       controller.should_receive(:prov_redirect).with("migrate")
-      controller.should_receive(:render)
-      controller.send(:process_button)
+      post :button, :pressed => "vm_migrate", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_retire"})
       controller.should_receive(:retirevms).once
-      controller.send(:process_button)
+      post :button, :pressed => "vm_retire", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_protect"})
       controller.should_receive(:assign_policies).with(VmOrTemplate)
-      controller.send(:process_button)
+      post :button, :pressed => "vm_protect", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "miq_template_protect"})
       controller.should_receive(:assign_policies).with(VmOrTemplate)
-      controller.send(:process_button)
+      post :button, :pressed => "miq_template_protect", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "vm_tag"})
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.send(:process_button)
+      post :button, :pressed => "vm_tag", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "miq_template_tag"})
       controller.should_receive(:tag).with(VmOrTemplate)
-      controller.send(:process_button)
+      post :button, :pressed => "miq_template_tag", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
 
     it "when Host Analyze then Check Compliance is pressed" do
-      controller.instance_variable_set(:@_params, {:pressed => "host_analyze_check_compliance"})
       controller.stub(:show)
       controller.should_receive(:analyze_check_compliance_hosts)
-      controller.should_receive(:render)
-      controller.send(:process_button)
+      post :button, :pressed => "host_analyze_check_compliance", :format => :js
       controller.send(:flash_errors?).should_not be_true
     end
   end


### PR DESCRIPTION
We should not know about these instance variables, they are internal to
Rails and we have no business setting them.