### PR TITLE
Bump timecop to latest

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -78,7 +78,7 @@ unless ENV['APPLIANCE']
     gem "jasmine",    "~>2.0",    :require => false
     gem "rspec",      "~>2.14.0", :require => false
     gem "rspec-fire", "~>1.3.0",  :require => false
-    gem "timecop",    "~>0.5.3",  :require => false
+    gem "timecop",    "~>0.7.3",  :require => false
     gem "xml-simple", "=1.0.12",  :require => false  # Used by test/xml/tc_xmlhash_methods.rb
     gem "vcr",        "~>2.6",    :require => false  # Used by manageiq-foreman
     gem "webmock",                :require => false  # Used by vcr / manageiq-foreman


### PR DESCRIPTION
The older version's interference with `Time.new` interacts badly with Rails 4.