### PR TITLE
assign more attributes to configured_systems

### DIFF
--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -3,6 +3,8 @@ class ConfiguredSystemForeman < ConfiguredSystem
 
   belongs_to :configuration_location
   belongs_to :configuration_organization
+  belongs_to :customization_script_medium
+  belongs_to :customization_script_ptable
 
   def provider_object(connection = nil)
     (connection || connection_source.raw_connect).host(manager_ref)

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -57,6 +57,8 @@ module EmsRefresh
         result[:configured_systems] = configured_system_inv_to_hashes(inv[:hosts],
                                                                       ids,
                                                                       inv[:operating_system_flavors],
+                                                                      inv[:media],
+                                                                      inv[:ptables],
                                                                       inv[:locations],
                                                                       inv[:organizations])
         result[:needs_provisioning_refresh] = true if needs_provisioning_refresh
@@ -130,18 +132,22 @@ module EmsRefresh
         end
       end
 
-      def configured_system_inv_to_hashes(recs, profiles, operatingsystems, locations, organizations)
+      def configured_system_inv_to_hashes(recs, profiles, operatingsystems, media, ptables, locations, organizations)
         recs.collect do |cs|
           {
-            :type                          => "ConfiguredSystemForeman",
-            :manager_ref                   => cs["id"].to_s,
-            :hostname                      => cs["name"],
-            :configuration_profile         => id_lookup(profiles, cs, "hostgroup_id"),
-            :operating_system_flavor_id    => id_lookup(operatingsystems, cs, "operatingsystem_id"),
-            :last_checkin                  => cs["last_compile"],
-            :build_state                   => cs["build"] ? "pending" : nil,
-            :configuration_location_id     => id_lookup(locations, cs, "location_id"),
-            :configuration_organization_id => id_lookup(organizations, cs, "organization_id"),
+            :type                           => "ConfiguredSystemForeman",
+            :manager_ref                    => cs["id"].to_s,
+            :hostname                       => cs["name"],
+            :configuration_profile          => id_lookup(profiles, cs, "hostgroup_id"),
+            :operating_system_flavor_id     => id_lookup(operatingsystems, cs, "operatingsystem_id"),
+            :customization_script_medium_id => id_lookup(media, cs, "medium_id"),
+            :customization_script_ptable_id => id_lookup(ptables, cs, "ptable_id"),
+            :last_checkin                   => cs["last_compile"],
+            :build_state                    => cs["build"] ? "pending" : nil,
+            :ipaddress                      => cs["ip"],
+            :mac_address                    => cs["mac"],
+            :configuration_location_id      => id_lookup(locations, cs, "location_id"),
+            :configuration_organization_id  => id_lookup(organizations, cs, "organization_id"),
           }
         end
       end

--- a/vmdb/db/migrate/20150323003436_add_configured_system_attributes.rb
+++ b/vmdb/db/migrate/20150323003436_add_configured_system_attributes.rb
@@ -1,0 +1,10 @@
+class AddConfiguredSystemAttributes < ActiveRecord::Migration
+  def change
+    add_column :configured_systems, :ipaddress, :string
+    add_column :configured_systems, :mac_address, :string
+    add_column :configured_systems, :ipmi_present, :boolean
+    add_column :configured_systems, :puppet_status, :string
+    add_column :configured_systems, :customization_script_ptable_id, :bigint
+    add_column :configured_systems, :customization_script_medium_id, :bigint
+  end
+end

--- a/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
+++ b/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
@@ -60,6 +60,8 @@ describe EmsRefresh::Parsers::Foreman do
       {
         "id"                 => 1,
         "name"               => "h1",
+        "ip"                 => "192.186.1.101",
+        "mac"                => "aa:bb:cc:dd:01",
         "hostgroup_id"       => 8,
         "operatingsystem_id" => 20,
         "medium_id"          => 10,
@@ -67,11 +69,14 @@ describe EmsRefresh::Parsers::Foreman do
         "last_compile"       => nil,
         "location_id"        => 10,
         "organization_id"    => 20,
+        "puppet_status"      => 0,
         "build"              => false,
       },
       {
         "id"                 => 2,
         "name"               => "h2",
+        "ip"                 => "192.186.1.102",
+        "mac"                => "aa:bb:cc:dd:02",
         "hostgroup_id"       => 9,
         "operatingsystem_id" => 30,
         "medium_id"          => 20,
@@ -79,7 +84,8 @@ describe EmsRefresh::Parsers::Foreman do
         "last_compile"       => date1,
         "location_id"        => 20,
         "organization_id"    => 10,
-        "build"              => true
+        "puppet_status"      => 0,
+        "build"              => true,
       },
     ]
   end

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -122,12 +122,16 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     system = configuration_manager.configured_systems.where("hostname like 'providerrefreshspec%'").first
 
     expect(system).to have_attributes(
+      :ipaddress   => "169.254.169.254",
+      :mac_address => "00:00:00:00:00:00",
       :type        => "ConfiguredSystemForeman",
       :hostname    => "providerrefreshspec-hostbaremetal.example.com",
       :manager_ref => "38",
     )
-    expect(system.operating_system_flavor).to eq(mine(osfs))
-    expect(system.configuration_profile).to   eq(child)
+    expect(system.operating_system_flavor).to     eq(mine(osfs))
+    expect(system.customization_script_medium).to eq(mine(media))
+    expect(system.customization_script_ptable).to eq(mine(ptables))
+    expect(system.configuration_profile).to       eq(child)
   end
 
   private


### PR DESCRIPTION
the foreman host (`ConfiguredSystem`) has a number of fields similar to the `Host` record.
This fills out a few that will be used for linking the 2 managed entities specifically primary ip address and mac address.

Also, a host possibly overrides a `ConfigurationProfile`'s value for the ptable and medium link (both a form of `CustomizationScript` records)

/cc @gmcculloug @brandondunne 