### PR TITLE
Serialize only current div when sending up transaction.

### DIFF
--- a/vmdb/app/views/miq_request/_prov_field.html.haml
+++ b/vmdb/app/views/miq_request/_prov_field.html.haml
@@ -442,7 +442,8 @@
             - # need to specify Checked/Disabled to check or disable a checkbox, so need separate lines for each depending upon radio button state
             - field_hash[:values].each do |f|
               - checked = options[field] && options[field][0] ==  f[0]
-              - onclick = remote_function(:with => "miqSerializeForm('main_div')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
+              - current_div = "#{@edit[:new][:current_tab_key]}_div"
+              - onclick = remote_function(:with => "miqSerializeForm('#{current_div}')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
               %input{:type => "radio", :id => field_id, :value => f[0], :name => field_id, :checked => checked, :onclick => disabled ? "" : onclick}
               = f[1]
           - else


### PR DESCRIPTION
Sending up main_div was causing some fields to reset, to fix that only current div needs to be sent up when radio button value is changed.

https://bugzilla.redhat.com/show_bug.cgi?id=1204115

@brandondunne can you please test/review.