### PR TITLE
simulate_queue_workers skips shutdown

### DIFF
--- a/vmdb/lib/vmdb/console_methods.rb
+++ b/vmdb/lib/vmdb/console_methods.rb
@@ -16,7 +16,7 @@ module Vmdb
     def simulate_queue_worker(break_on_complete = false)
       raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
       loop do
-        q = MiqQueue.order(:id).first
+        q = MiqQueue.where(MiqQueue.arel_table[:queue_name].not_eq("miq_server")).order(:id).first
         if q
           status, message, result = q.deliver
           q.delivered(status, message, result) unless status == MiqQueue::STATUS_RETRY


### PR DESCRIPTION
If a message to `shutdown_and_exit` is in MiqQueue, it will exit the vm.

While running `simulate_queue_workers` it never removes that message and will just exits rails console with no warning. Current solution is to know that you need to delete this message from the queue.

Not sure what to file this under since it is a bug in our tools.
Took me over an hour to track this down and would like to avoid having to deal with this again.

/cc @jrafanie this should solve this for us
/cc @Fryguy not sure if you have a better suggestion