### PR TITLE
Avoid hitting the DB at load time

### DIFF
--- a/vmdb/app/models/metric/capture.rb
+++ b/vmdb/app/models/metric/capture.rb
@@ -4,7 +4,9 @@ module Metric::Capture
   REALTIME_PRIORITY = HOURLY_PRIORITY = DAILY_PRIORITY = MiqQueue::NORMAL_PRIORITY
   HISTORICAL_PRIORITY = MiqQueue::LOW_PRIORITY
 
-  CAPTURE_COLS = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float && c[0, 7] != "derived" }.compact
+  def self.capture_cols
+    Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float && c[0, 7] != "derived" }.compact
+  end
 
   def self.historical_days
     (VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, :initial_capture_days) || 7).to_i

--- a/vmdb/app/models/metric/capture/vim.rb
+++ b/vmdb/app/models/metric/capture/vim.rb
@@ -135,7 +135,7 @@ module Metric::Capture::Vim
       next if counter.nil?
 
       # Filter the metrics for only the cols we will use
-      next unless Metric::Capture::CAPTURE_COLS.include?(counter[:counter_key].to_sym)
+      next unless Metric::Capture.capture_cols.include?(counter[:counter_key].to_sym)
 
       vim_key      = metric["counterId"].to_s
       instance     = metric["instance"].to_s

--- a/vmdb/app/models/metric/rollup.rb
+++ b/vmdb/app/models/metric/rollup.rb
@@ -160,7 +160,7 @@ module Metric::Rollup
     new_perf_counts = {}
 
     rt_perfs.each do |rt|
-      Metric::Capture::CAPTURE_COLS.each do |col|
+      Metric::Capture.capture_cols.each do |col|
         new_perf[col] ||= 0
         new_perf_counts[col] ||= 0
 


### PR DESCRIPTION
.. at least for this particular module.

Nothing uses CAPTURE_COLS until runtime, so we can just make it a nice simple method, and life gets better.

Now, we needn't worry about older migration specs tripping over EmsRefresh.

Fixes #2307

/cc @jrafanie 

This fixes a (pre-existing but latent) problem I triggered with #2266.