### PR TITLE
SIGKILL can't be trapped, so don't try

### DIFF
--- a/vmdb/lib/workers/worker_base.rb
+++ b/vmdb/lib/workers/worker_base.rb
@@ -5,7 +5,7 @@ class WorkerBase
   attr_accessor :last_hb, :worker, :worker_settings
   attr_reader   :vmdb_config, :active_roles
 
-  INTERRUPT_SIGNALS = ["INT", "TERM", "KILL"]
+  INTERRUPT_SIGNALS = ["INT", "TERM"]
 
   OPTIONS_PARSER_SETTINGS = [
     [:guid,       'EVM Worker GUID',       String],


### PR DESCRIPTION
The SIGKILL signal [cannot be trapped or ignored](http://en.wikipedia.org/wiki/Unix_signal#SIGKILL), so we shouldn't try.  Newer versions of Ruby will raise an exception if you try to trap this signal.