### PR TITLE
Add security updates to kickstart install

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -8,6 +8,7 @@ install
 
 # repo to install the OS
 url --url=http://mirror.centos.org/centos/6/os/x86_64/
+repo --name=updates --baseurl=http://mirror.centos.org/centos/6/updates/x86_64/
 
 # repos to install packages in %packages section
 repo --name=extras --baseurl=http://mirror.centos.org/centos/6/extras/x86_64/


### PR DESCRIPTION
Fixes #2287

Installing certmonger blew up because an rpm associated with a security
update was not present.

This fix adds the repo with those updates to our kickstart.
It is installed by default to the appliance via
/etc/yum.repos.d/CentOS-Base.repo

/cc @JPrause @jrafanie @jvlcek 