### PR TITLE
This is the wrong way to create a non-region zone.

### DIFF
--- a/vmdb/spec/controllers/application_controller/explorer_spec.rb
+++ b/vmdb/spec/controllers/application_controller/explorer_spec.rb
@@ -265,7 +265,6 @@ describe VmInfraController do
 
       it "Return Zones only in My Region" do
         my_region_zone = FactoryGirl.create(:zone)
-        non_my_region_zone = FactoryGirl.create(:zone, :id => "40", :name => "Zone2")
         controller.instance_variable_set(:@sb, {:trees =>
                                                     {:settings_tree => {:active_node => "root"}},
                                                 :active_tree => :utilization_tree})


### PR DESCRIPTION
The id 40 is not guaranteed to be unique across test runs.

It's not used anyway since we don't actually assert against it anyway, so let's delete it.

Related to #2317


Note, this test has other issues, namely it doesn't assert anything, but this pr should clear up the sporadic failure.

cc @tenderlove 