### PR TITLE
Foreman default locations

### DIFF
--- a/vmdb/app/models/configuration_location.rb
+++ b/vmdb/app/models/configuration_location.rb
@@ -1,3 +1,5 @@
 class ConfigurationLocation < ActiveRecord::Base
   belongs_to :provisioning_manager
+
+  alias_attribute :display_name, :title
 end

--- a/vmdb/app/models/configuration_organization.rb
+++ b/vmdb/app/models/configuration_organization.rb
@@ -1,3 +1,5 @@
 class ConfigurationOrganization < ActiveRecord::Base
   belongs_to :provisioning_manager
+
+  alias_attribute :display_name, :title
 end

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -65,11 +65,11 @@ module EmsRefresh
       end
 
       def location_inv_to_hashes(locations)
-        basic_hash(locations, "ConfigurationLocation", "title")
+        basic_hash(locations || tax_refs, "ConfigurationLocation", "title")
       end
 
       def organization_inv_to_hashes(organizations)
-        basic_hash(organizations, "ConfigurationOrganization", "title")
+        basic_hash(organizations || tax_refs, "ConfigurationOrganization", "title")
       end
 
       def operating_system_flavors_inv_to_hashes(flavors_inv, indexes)
@@ -94,8 +94,8 @@ module EmsRefresh
             :operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),
             :customization_script_medium_id => id_lookup(indexes[:media], profile["medium_id"]),
             :customization_script_ptable_id => id_lookup(indexes[:ptables], profile["ptable_id"]),
-            :configuration_location_ids     => ids_lookup(indexes[:locations], profile["locations"]),
-            :configuration_organization_ids => ids_lookup(indexes[:organizations], profile["organizations"]),
+            :configuration_location_ids     => ids_lookup(indexes[:locations], profile["locations"] || tax_refs),
+            :configuration_organization_ids => ids_lookup(indexes[:organizations], profile["organizations"] || tax_refs),
           }
         end
       end
@@ -114,8 +114,8 @@ module EmsRefresh
             :build_state                    => cs["build"] ? "pending" : nil,
             :ipaddress                      => cs["ip"],
             :mac_address                    => cs["mac"],
-            :configuration_location_id      => id_lookup(indexes[:locations], cs["location_id"]),
-            :configuration_organization_id  => id_lookup(indexes[:organizations], cs["organization_id"]),
+            :configuration_location_id      => id_lookup(indexes[:locations], cs["location_id"] || 0),
+            :configuration_organization_id  => id_lookup(indexes[:organizations], cs["organization_id"] || 0),
           }
         end
       end
@@ -136,6 +136,11 @@ module EmsRefresh
 
       def ids_lookup(ids, records, id_key = "id")
         (records || []).collect { |record| id_lookup(ids, record[id_key]) }.compact
+      end
+
+      # default taxonomy reference (locations and organizations)
+      def tax_refs
+        [{"id" => 0, "name" => "Default", "title" => "Default"}]
       end
 
       def basic_hash(collection, type, extra_field = nil)

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -91,9 +91,9 @@ module EmsRefresh
             :manager_ref                    => profile["id"].to_s,
             :name                           => profile["name"],
             :description                    => profile["title"],
-            :operating_system_flavor_id     => id_lookup(indexes[:flavors], profile, "operatingsystem_id"),
-            :customization_script_medium_id => id_lookup(indexes[:media], profile, "medium_id"),
-            :customization_script_ptable_id => id_lookup(indexes[:ptables], profile, "ptable_id"),
+            :operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),
+            :customization_script_medium_id => id_lookup(indexes[:media], profile["medium_id"]),
+            :customization_script_ptable_id => id_lookup(indexes[:ptables], profile["ptable_id"]),
             :configuration_location_ids     => ids_lookup(indexes[:locations], profile["locations"]),
             :configuration_organization_ids => ids_lookup(indexes[:organizations], profile["organizations"]),
           }
@@ -106,16 +106,16 @@ module EmsRefresh
             :type                           => "ConfiguredSystemForeman",
             :manager_ref                    => cs["id"].to_s,
             :hostname                       => cs["name"],
-            :configuration_profile          => id_lookup(indexes[:profiles], cs, "hostgroup_id"),
-            :operating_system_flavor_id     => id_lookup(indexes[:flavors], cs, "operatingsystem_id"),
-            :customization_script_medium_id => id_lookup(indexes[:media], cs, "medium_id"),
-            :customization_script_ptable_id => id_lookup(indexes[:ptables], cs, "ptable_id"),
+            :configuration_profile          => id_lookup(indexes[:profiles], cs["hostgroup_id"]),
+            :operating_system_flavor_id     => id_lookup(indexes[:flavors], cs["operatingsystem_id"]),
+            :customization_script_medium_id => id_lookup(indexes[:media], cs["medium_id"]),
+            :customization_script_ptable_id => id_lookup(indexes[:ptables], cs["ptable_id"]),
             :last_checkin                   => cs["last_compile"],
             :build_state                    => cs["build"] ? "pending" : nil,
             :ipaddress                      => cs["ip"],
             :mac_address                    => cs["mac"],
-            :configuration_location_id      => id_lookup(indexes[:locations], cs, "location_id"),
-            :configuration_organization_id  => id_lookup(indexes[:organizations], cs, "organization_id"),
+            :configuration_location_id      => id_lookup(indexes[:locations], cs["location_id"]),
+            :configuration_organization_id  => id_lookup(indexes[:organizations], cs["organization_id"]),
           }
         end
       end
@@ -127,8 +127,7 @@ module EmsRefresh
         target
       end
 
-      def id_lookup(ids, record, id_key)
-        key = record[id_key]
+      def id_lookup(ids, key)
         return unless key
         ids[key.to_s].tap do |v|
           @needs_provisioning_refresh = true unless v
@@ -136,7 +135,7 @@ module EmsRefresh
       end
 
       def ids_lookup(ids, records, id_key = "id")
-        (records || []).collect { |record| id_lookup(ids, record, id_key) }.compact
+        (records || []).collect { |record| id_lookup(ids, record[id_key]) }.compact
       end
 
       def basic_hash(collection, type, extra_field = nil)

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -57,43 +57,19 @@ module EmsRefresh
       end
 
       def media_inv_to_hashes(media)
-        media.collect do |m|
-          {
-            :manager_ref => m["id"].to_s,
-            :type        => "CustomizationScriptMedium",
-            :name        => m["name"]
-          }
-        end
+        basic_hash(media, "CustomizationScriptMedium")
       end
 
       def ptables_inv_to_hashes(ptables)
-        ptables.collect do |m|
-          {
-            :manager_ref => m["id"].to_s,
-            :type        => "CustomizationScriptPtable",
-            :name        => m["name"]
-          }
-        end
+        basic_hash(ptables, "CustomizationScriptPtable")
       end
 
       def location_inv_to_hashes(locations)
-        locations.collect do |m|
-          {
-            :manager_ref => m["id"].to_s,
-            :type        => "ConfigurationLocation",
-            :name        => m["name"],
-          }
-        end
+        basic_hash(locations, "ConfigurationLocation", "title")
       end
 
       def organization_inv_to_hashes(organizations)
-        organizations.collect do |m|
-          {
-            :manager_ref => m["id"].to_s,
-            :type        => "ConfigurationOrganization",
-            :name        => m["name"],
-          }
-        end
+        basic_hash(organizations, "ConfigurationOrganization", "title")
       end
 
       def operating_system_flavors_inv_to_hashes(flavors_inv, indexes)
@@ -161,6 +137,18 @@ module EmsRefresh
 
       def ids_lookup(ids, records, id_key = "id")
         (records || []).collect { |record| id_lookup(ids, record, id_key) }.compact
+      end
+
+      def basic_hash(collection, type, extra_field = nil)
+        collection.collect do |m|
+          {
+            :manager_ref => m["id"].to_s,
+            :type        => type,
+            :name        => m["name"],
+          }.tap do |h|
+            h[extra_field] = m[extra_field] if extra_field
+          end
+        end
       end
     end
   end

--- a/vmdb/db/migrate/20150324143511_add_organization_title.rb
+++ b/vmdb/db/migrate/20150324143511_add_organization_title.rb
@@ -1,0 +1,6 @@
+class AddOrganizationTitle < ActiveRecord::Migration
+  def change
+    add_column :configuration_organizations, :title, :string
+    add_column :configuration_locations, :title, :string
+  end
+end

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_locations_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_locations_spec.rb
@@ -13,6 +13,8 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
 
   let(:provisioning_manager)  { provider.provisioning_manager }
   let(:configuration_manager) { provider.configuration_manager }
+  let(:orgs) { provisioning_manager.configuration_organizations.where(spec_related).sort_by(&:name) }
+  let(:locs) { provisioning_manager.configuration_locations.where(spec_related).sort_by(&:name) }
 
   it "loads data with locations and organizations" do
     EmsRefresh.stub(:queue_refresh) { |*args| EmsRefresh.refresh(*args) }
@@ -25,19 +27,50 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
       end
     end
 
-    orgs = provisioning_manager.configuration_organizations.where(spec_related)
-    locs = provisioning_manager.configuration_locations.where(spec_related)
+    test_orgs
+    test_locs
+    test_child
+    test_system
+  end
 
-    expect(orgs.size).to eq(2)
-    expect(locs.size).to eq(2)
-
+  def test_child
     child  = configuration_manager.configuration_profiles.where(:name => 'ProviderRefreshSpec-ChildHostGroup').first
-    expect(child.configuration_organizations.sort_by(&:id)).to eq(orgs.sort_by(&:id))
-    expect(child.configuration_locations.sort_by(&:id)).to     eq(locs.sort_by(&:id))
+    expect(child.configuration_organizations).to match_array(orgs)
+    expect(child.configuration_locations).to     match_array(locs)
+  end
 
+  def test_system
     system = configuration_manager.configured_systems.where("hostname like 'providerrefreshspec%'").first
     expect(system.configuration_organization).to eq(orgs.select { |h| h.name =~ /Child/ }.first)
     expect(system.configuration_location).to     eq(locs.select { |h| h.name =~ /Child/ }.first)
+  end
+
+  def test_orgs
+    expect(orgs.size).to eq(2)
+    child = orgs.first
+    parent = orgs.last
+    expect(child).to have_attributes(
+      :title => "Infra/ProviderRefreshSpecOrganization/ProviderRefreshSpecChildOrganization",
+      :name  => "ProviderRefreshSpecChildOrganization",
+    )
+    expect(parent).to have_attributes(
+      :title => "Infra/ProviderRefreshSpecOrganization",
+      :name  => "ProviderRefreshSpecOrganization",
+    )
+  end
+
+  def test_locs
+    expect(locs.size).to eq(2)
+    child = locs.first
+    parent = locs.last
+    expect(child).to have_attributes(
+      :title => "ProviderRefreshSpec-Location/ProviderRefreshSpec-ChildLocation",
+      :name  => "ProviderRefreshSpec-ChildLocation",
+    )
+    expect(parent).to have_attributes(
+      :title => "ProviderRefreshSpec-Location",
+      :name  => "ProviderRefreshSpec-Location",
+    )
   end
 
   private

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -17,6 +17,8 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
   let(:media)                 { provisioning_manager.customization_script_media }
   let(:ptables)               { provisioning_manager.customization_script_ptables }
   let(:configuration_manager) { provider.configuration_manager }
+  let(:default_location)      { provisioning_manager.configuration_locations.first }
+  let(:default_organization)  { provisioning_manager.configuration_organizations.first }
 
   it "will perform a full refresh on api v2" do
     # Stub the queueing of the refresh so that when the manager
@@ -35,6 +37,7 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     assert_ptables
     assert_media
     assert_osf
+    assert_loc_org
 
     assert_configuration_table_counts
     assert_configuration_profile_parent
@@ -49,9 +52,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
   end
 
   def assert_provisioning_table_counts
-    expect(media.count).to eq(8)
+    expect(media.count).to   eq(8)
     expect(ptables.count).to eq(11)
-    expect(osfs.count).to eq(5)
+    expect(osfs.count).to    eq(5)
   end
 
   def assert_media
@@ -86,6 +89,11 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(osf.customization_script_media).not_to   include(mine(ptables))
   end
 
+  def assert_loc_org
+    expect(provisioning_manager.configuration_locations.count).to     eq(1)
+    expect(provisioning_manager.configuration_organizations.count).to eq(1)
+  end
+
   def assert_configuration_table_counts
     expect(configuration_manager.configured_systems.count).to     eq(39)
     expect(configuration_manager.configuration_profiles.count).to eq(14)
@@ -102,6 +110,8 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(child.operating_system_flavor).to     eq(mine(osfs))    # inherited from parent
     expect(child.customization_script_medium).to eq(mine(media))   # inherited from parent
     expect(child.customization_script_ptable).to eq(mine(ptables)) # declared
+    expect(child.configuration_locations).to     eq([default_location])
+    expect(child.configuration_organizations).to eq([default_organization])
   end
 
   def assert_configuration_profile_parent
@@ -115,6 +125,8 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(parent.operating_system_flavor).to     eq(mine(osfs))  # declared
     expect(parent.customization_script_medium).to eq(mine(media)) # declared
     expect(parent.customization_script_ptable).to be_nil          # blank
+    expect(parent.configuration_locations).to     eq([default_location])
+    expect(parent.configuration_organizations).to eq([default_organization])
   end
 
   def assert_configured_system
@@ -131,6 +143,8 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(system.operating_system_flavor).to     eq(mine(osfs))
     expect(system.customization_script_medium).to eq(mine(media))
     expect(system.customization_script_ptable).to eq(mine(ptables))
+    expect(system.configuration_location).to      eq(default_location)
+    expect(system.configuration_organization).to  eq(default_organization)
     expect(system.configuration_profile).to       eq(child)
   end
 

--- a/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/foreman_refresher_api_v2.yml
+++ b/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/foreman_refresher_api_v2.yml
@@ -826,8 +826,8 @@ http_interactions:
       - application/json
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Date:
       - Thu, 12 Mar 2015 22:33:50 GMT
@@ -856,28 +856,14 @@ http_interactions:
       Set-Cookie:
       - _session_id=395cf329e10451d91688d2fa57b0c1a9; path=/; HttpOnly
       Status:
-      - 200 OK
+      - 404 Not Found
       Connection:
       - close
       Transfer-Encoding:
       - chunked
       Content-Type:
       - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "total": 0,
-          "subtotal": 0,
-          "page": 1,
-          "per_page": 50,
-          "search": null,
-          "sort": {
-            "by": null,
-            "order": null
-          },
-          "results": []
-        }
+    body: ! '{"error":"The requested resource could not be found"}'
     http_version:
   recorded_at: Thu, 12 Mar 2015 22:33:51 GMT
 - request:
@@ -897,8 +883,8 @@ http_interactions:
       - application/json
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Date:
       - Thu, 12 Mar 2015 22:33:52 GMT
@@ -927,28 +913,14 @@ http_interactions:
       Set-Cookie:
       - _session_id=9bbb115e04e43228d4030eea858b00d1; path=/; HttpOnly
       Status:
-      - 200 OK
+      - 404 Not Found
       Connection:
       - close
       Transfer-Encoding:
       - chunked
       Content-Type:
       - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "total": 0,
-          "subtotal": 0,
-          "page": 1,
-          "per_page": 50,
-          "search": null,
-          "sort": {
-            "by": null,
-            "order": null
-          },
-          "results": []
-        }
+    body: ! '{"error":"The requested resource could not be found"}'
     http_version:
   recorded_at: Thu, 12 Mar 2015 22:33:52 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Some foreman servers have location or organization turned off.

So while a typical server requires both fields, when it is disabled, those fields are nil, and the url returns a 404.

For the cases where location is nil, assign a default location to a `ConfigurationProfile` and `ConfiguredSystem`. The same logic applies to the organization as well.

This simplifies the logic when matching whether a `ConfigurationProfile` can be assigned to a `ConfiguredSystem` since `nil` will no longer hold a special value.

/cc @gmcculloug @brandondunne 