### PR TITLE
Use the fixed syntax for IPv6 safe URI building via a backport.

### DIFF
--- a/lib/VMwareWebService/MiqVimClientBase.rb
+++ b/lib/VMwareWebService/MiqVimClientBase.rb
@@ -1,5 +1,6 @@
-
 $:.push(File.dirname(__FILE__))
+require 'pathname'
+require Pathname.new(__dir__).join("../util/extensions/miq-uri")
 
 require 'sync'
 require 'VimService'
@@ -36,17 +37,7 @@ class MiqVimClientBase < VimService
 	end
 
 	def sdk_uri
-		require 'uri'
-		uri = URI::HTTPS.build(:path => "/sdk")
-
-		# IPv6 addresses need to be wrapped in [] in URI's
-		# See: https://www.ietf.org/rfc/rfc2732.txt
-		# URI::Generic#hostname= will automatically wrap an ipv6 address in []
-		# uri.hostname = "::1"
-		# uri.to_s => "http://[::1]/foo"
-		# Feature request to URI::Generic.build: https://github.com/ruby/ruby/pull/765
-		uri.hostname = @server
-		uri
+		URI::HTTPS.build(:host => server, :path => "/sdk")
 	end
 	
 	def self.receiveTimeout=(val)

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -18,14 +18,7 @@ class EmsKubernetes < EmsContainer
   end
 
   def self.raw_api_endpoint(hostname, port)
-    require 'uri'
-
-    uri = URI::HTTP.build(:path => "/api", :port => port.to_i)
-
-    # URI::Generic#hostname= was added in ruby 1.9.3 and will automatically
-    # wrap an ipv6 address in []
-    uri.hostname = hostname
-    uri
+    URI::HTTP.build(:host => hostname, :port => port.to_i, :path => "/api")
   end
 
   def api_endpoint

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -25,14 +25,8 @@ class EmsMicrosoft < EmsInfra
     WinRM::WinRMWebService.new(auth_url, :ssl, :user => username, :pass => password, :disable_sspi => true)
   end
 
-  # Utilize URI::Generic#hostname to add support for IPv6 literals
-  # TODO: simplify this once https://github.com/ruby/ruby/pull/765 lands in our ruby
   def self.auth_url(hostname, port = nil)
-    port ||= 5985
-    require 'uri'
-    uri = URI::HTTP.build(:port => port, :path => "/wsman")
-    uri.hostname = hostname
-    uri.to_s
+    URI::HTTP.build(:host => hostname, :port => port || 5985, :path => "/wsman").to_s
   end
 
   def connect(options = {})

--- a/vmdb/app/models/mixins/web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/web_server_worker_mixin.rb
@@ -57,12 +57,8 @@ module WebServerWorkerMixin
       self.server_scope.all.collect { |w| w.port unless w.is_stopped? && !MiqProcess.is_worker?(w.pid)}.compact
     end
 
-    # Utilize URI::Generic#hostname to add support for IPv6 literals
-    # TODO: simplify this once https://github.com/ruby/ruby/pull/765 lands in our ruby
     def self.build_uri(port)
-      uri = URI::HTTP.build(:port => port)
-      uri.hostname = binding_address
-      uri.to_s
+      URI::HTTP.build(:host => binding_address, :port => port).to_s
     end
 
     def self.sync_workers

--- a/vmdb/spec/models/ems_kubernetes_spec.rb
+++ b/vmdb/spec/models/ems_kubernetes_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+describe EmsKubernetes do
+  it ".raw_api_endpoint (ipv6)" do
+    expect(described_class.raw_api_endpoint("::1", 123).to_s).to eq "http://[::1]:123/api"
+  end
+end

--- a/vmdb/spec/models/mixins/web_server_worker_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/web_server_worker_mixin_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe WebServerWorkerMixin do
   it "build_uri (ipv6)" do
-    class TestClass
+    test_class = Class.new do
       include WebServerWorkerMixin
     end
 
-    TestClass.stub(:binding_address => "::1")
-    expect(TestClass.build_uri(123)).to eq "http://[::1]:123"
+    test_class.stub(:binding_address => "::1")
+    expect(test_class.build_uri(123)).to eq "http://[::1]:123"
   end
 end

--- a/vmdb/spec/models/mixins/web_server_worker_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/web_server_worker_mixin_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe WebServerWorkerMixin do
+  it "build_uri (ipv6)" do
+    class TestClass
+      include WebServerWorkerMixin
+    end
+
+    TestClass.stub(:binding_address => "::1")
+    expect(TestClass.build_uri(123)).to eq "http://[::1]:123"
+  end
+end


### PR DESCRIPTION
The backport in #2172 enables us to use the fixed syntax now.

From #2172:

**Before backport**:
```ruby
 # Don't pass :host => "::1" to .build as it throws URI::InvalidComponentError
 uri = URI::HTTPS.build(:path => "/sdk")
 uri.hostname = "::1"
 uri.to_s # => "https://[::1]/sdk"
```

**After(client doesn't need to use hostname= method)**:
```ruby
 uri = URI::HTTPS.build(:host => "::1", :path => "/sdk")
 uri.to_s # => "https://[::1]/sdk"
```