### PR TITLE
Fixed the timer dropdowns

### DIFF
--- a/vmdb/app/views/report/_schedule_form_timer.html.haml
+++ b/vmdb/app/views/report/_schedule_form_timer.html.haml
@@ -7,9 +7,8 @@
       %td.key
         = _('Run')
       %td
-        - timer_types = [_("Hourly"), _("Daily"), _("Weekly"), _("Monthly")]
-        - if x_active_tree == :widgets_tree
-          - timer_types.unshift(_("Once"))
+        - timer_types = [_("Once"), _("Hourly"), _("Daily"), _("Weekly"), _("Monthly")]
+        - timer_types.shift if x_active_tree == :widgets_tree
         = select_tag("timer_typ",
           options_for_select(timer_types, @edit[:new][:timer_typ]),
           "data-miq_observe" => {:url => url}.to_json)


### PR DESCRIPTION
Timer types under Reports were being populated incorrectly for widgets_tree and schedules_tree (referred the original erb to populate them correctly)

https://bugzilla.redhat.com/show_bug.cgi?id=1202412