### PR TITLE
Consolidate foreman refresh object index

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -22,14 +22,14 @@ module EmsRefresh
         result = {}
         media = media_inv_to_hashes(inv[:media])
         ptables = ptables_inv_to_hashes(inv[:ptables])
-        # pull out ids because operating system flavors cross link to the customization scripts
-        medium_ids = add_ids({}, media)
-        ptable_ids = add_ids({}, ptables)
+        # pull out ids for operating system flavors cross link to the customization scripts
+        indexes = {
+          :media   => add_ids({}, media),
+          :ptables => add_ids({}, ptables),
+        }
 
         result[:customization_scripts] = media + ptables
-        result[:operating_system_flavors] = operating_system_flavors_inv_to_hashes(inv[:operating_systems],
-                                                                                   medium_ids,
-                                                                                   ptable_ids)
+        result[:operating_system_flavors] = operating_system_flavors_inv_to_hashes(inv[:operating_systems], indexes)
         result[:configuration_locations] = location_inv_to_hashes(inv[:locations])
         result[:configuration_organizations] = organization_inv_to_hashes(inv[:organizations])
         result
@@ -39,28 +39,19 @@ module EmsRefresh
       #   :hostgroups
       #   :hosts
       # data coming in from database (already in the form of ids)
-      #   :media
-      #   :ptables
-      #   :operating_systems
-      #   :locations
-      #   :organizations
+      #   see indexes variable
       def configuration_inv_to_hashes(inv)
+        indexes = {
+          :flavors       => inv[:operating_system_flavors],
+          :media         => inv[:media],
+          :ptables       => inv[:ptables],
+          :locations     => inv[:locations],
+          :organizations => inv[:organizations],
+        }
         result = {}
-        ids = {}
-        result[:configuration_profiles] = configuration_profile_inv_to_hashes(inv[:hostgroups],
-                                                                              inv[:operating_system_flavors],
-                                                                              inv[:media],
-                                                                              inv[:ptables],
-                                                                              inv[:locations],
-                                                                              inv[:organizations])
-        add_ids(ids, result[:configuration_profiles])
-        result[:configured_systems] = configured_system_inv_to_hashes(inv[:hosts],
-                                                                      ids,
-                                                                      inv[:operating_system_flavors],
-                                                                      inv[:media],
-                                                                      inv[:ptables],
-                                                                      inv[:locations],
-                                                                      inv[:organizations])
+        result[:configuration_profiles] = configuration_profile_inv_to_hashes(inv[:hostgroups], indexes)
+        indexes[:profiles] = add_ids({}, result[:configuration_profiles])
+        result[:configured_systems] = configured_system_inv_to_hashes(inv[:hosts], indexes)
         result[:needs_provisioning_refresh] = true if needs_provisioning_refresh
         result
       end
@@ -105,49 +96,50 @@ module EmsRefresh
         end
       end
 
-      def operating_system_flavors_inv_to_hashes(flavors_inv, medium_ids, ptable_ids)
+      def operating_system_flavors_inv_to_hashes(flavors_inv, indexes)
         flavors_inv.collect do |os|
           {
             :manager_ref           => os["id"].to_s,
             :name                  => os["fullname"],
             :description           => os["description"],
-            :customization_scripts => ids_lookup(medium_ids, os["media"]) + ids_lookup(ptable_ids, os["ptables"])
+            :customization_scripts => ids_lookup(indexes[:media], os["media"]) +
+                                      ids_lookup(indexes[:ptables], os["ptables"])
           }
         end
       end
 
-      def configuration_profile_inv_to_hashes(recs, osfs, media, ptables, locations, organizations)
+      def configuration_profile_inv_to_hashes(recs, indexes)
         recs.collect do |profile|
           {
             :type                           => "ConfigurationProfileForeman",
             :manager_ref                    => profile["id"].to_s,
             :name                           => profile["name"],
             :description                    => profile["title"],
-            :operating_system_flavor_id     => id_lookup(osfs, profile, "operatingsystem_id"),
-            :customization_script_medium_id => id_lookup(media, profile, "medium_id"),
-            :customization_script_ptable_id => id_lookup(ptables, profile, "ptable_id"),
-            :configuration_location_ids     => ids_lookup(locations, profile["locations"]),
-            :configuration_organization_ids => ids_lookup(organizations, profile["organizations"]),
+            :operating_system_flavor_id     => id_lookup(indexes[:flavors], profile, "operatingsystem_id"),
+            :customization_script_medium_id => id_lookup(indexes[:media], profile, "medium_id"),
+            :customization_script_ptable_id => id_lookup(indexes[:ptables], profile, "ptable_id"),
+            :configuration_location_ids     => ids_lookup(indexes[:locations], profile["locations"]),
+            :configuration_organization_ids => ids_lookup(indexes[:organizations], profile["organizations"]),
           }
         end
       end
 
-      def configured_system_inv_to_hashes(recs, profiles, operatingsystems, media, ptables, locations, organizations)
+      def configured_system_inv_to_hashes(recs, indexes)
         recs.collect do |cs|
           {
             :type                           => "ConfiguredSystemForeman",
             :manager_ref                    => cs["id"].to_s,
             :hostname                       => cs["name"],
-            :configuration_profile          => id_lookup(profiles, cs, "hostgroup_id"),
-            :operating_system_flavor_id     => id_lookup(operatingsystems, cs, "operatingsystem_id"),
-            :customization_script_medium_id => id_lookup(media, cs, "medium_id"),
-            :customization_script_ptable_id => id_lookup(ptables, cs, "ptable_id"),
+            :configuration_profile          => id_lookup(indexes[:profiles], cs, "hostgroup_id"),
+            :operating_system_flavor_id     => id_lookup(indexes[:flavors], cs, "operatingsystem_id"),
+            :customization_script_medium_id => id_lookup(indexes[:media], cs, "medium_id"),
+            :customization_script_ptable_id => id_lookup(indexes[:ptables], cs, "ptable_id"),
             :last_checkin                   => cs["last_compile"],
             :build_state                    => cs["build"] ? "pending" : nil,
             :ipaddress                      => cs["ip"],
             :mac_address                    => cs["mac"],
-            :configuration_location_id      => id_lookup(locations, cs, "location_id"),
-            :configuration_organization_id  => id_lookup(organizations, cs, "organization_id"),
+            :configuration_location_id      => id_lookup(indexes[:locations], cs, "location_id"),
+            :configuration_organization_id  => id_lookup(indexes[:organizations], cs, "organization_id"),
           }
         end
       end

--- a/vmdb/spec/models/provider_foreman_spec.rb
+++ b/vmdb/spec/models/provider_foreman_spec.rb
@@ -28,8 +28,8 @@ describe ProviderForeman do
       provider.configuration_manager.configured_systems = [
         FactoryGirl.create(:configured_system, :computer_system =>
           FactoryGirl.create(:computer_system,
-            :operating_system => FactoryGirl.create(:operating_system),
-            :hardware         => FactoryGirl.create(:hardware),
+                             :operating_system => FactoryGirl.create(:operating_system),
+                             :hardware         => FactoryGirl.create(:hardware),
           )
         )
       ]


### PR DESCRIPTION
Each list of foreman indexes are kept separate
This merged them into a single list to make more manageable

/cc @Fryguy You had suggested going this route before.
Since we're adding a few more classes, want to make this change now.
/cc @brandondunne @gmcculloug too many args once we add the tags