### PR TITLE
Use newer foreman apipie gem

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -43,7 +43,7 @@ gem "uuidtools",            "~>2.1.3",       :require => false
 gem "sass",                 "3.1.20",        :require => false
 gem "trollop",              "~>1.16.2",      :require => false
 gem "psych",                "~>2.0.12"
-gem "foreman_api",          "~>0.1.11",      :require => false  # used by lib/manageiq_foreman
+gem "apipie-bindings",      "~>0.0.12",      :require => false
 
 # qpid group is needed to gate the inclusion of qpid_messaging gem on platforms
 # where the qpid-cpp-client-devel package is not available.  This includes

--- a/lib/manageiq_foreman/lib/manageiq_foreman.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman.rb
@@ -1,6 +1,6 @@
 require "manageiq_foreman/version"
 
-require 'foreman_api'
+require 'apipie-bindings'
 
 require "manageiq_foreman/paged_response"
 require "manageiq_foreman/connection"

--- a/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
@@ -2,23 +2,14 @@ module ManageiqForeman
   class Connection
     # some foreman servers don't have locations or organizations, just return nil
     ALLOW_404 = [:locations, :organizations]
-    CLASSES = {
-      :config_templates  => ForemanApi::Resources::ConfigTemplate,
-      :home              => ForemanApi::Resources::Home,
-      :hostgroups        => ForemanApi::Resources::Hostgroup,
-      :hosts             => ForemanApi::Resources::Host,
-      :media             => ForemanApi::Resources::Medium,
-      :operating_systems => ForemanApi::Resources::OperatingSystem,
-      :ptables           => ForemanApi::Resources::Ptable,
-      :subnets           => ForemanApi::Resources::Subnet,
-      :locations         => ForemanApi::Resources::Location,
-      :organizations     => ForemanApi::Resources::Organization,
-    }
-
     attr_accessor :connection_attrs
 
-    def initialize(connection_attrs)
-      @connection_attrs = connection_attrs
+    def initialize(attrs)
+      self.connection_attrs = attrs.dup
+      connection_attrs[:uri] = connection_attrs.delete(:base_url)
+      connection_attrs[:api_version] ||= 2
+      connection_attrs[:apidoc_cache_dir] ||= tmpdir
+      @api = ApipieBindings::API.new(connection_attrs)
     end
 
     def verify?
@@ -52,7 +43,7 @@ module ManageiqForeman
     # filter: "page" => 2, "per_page" => 50, "search" => "field=value", "value"
     def fetch(resource, action = :index, filter = {})
       action, filter = :index, action if action.kind_of?(Hash)
-      PagedResponse.new(raw(resource).send(action, filter).first)
+      PagedResponse.new(@api.resource(resource).action(action).call(filter))
     rescue RestClient::ResourceNotFound
       raise unless ALLOW_404.include?(resource)
       nil
@@ -66,10 +57,26 @@ module ManageiqForeman
       Inventory.new(self)
     end
 
+    # used for tests to manually invoke loading api from server
+    # this keeps http calls consistent
+
+    def api_cached?
+      File.exist?(@api.apidoc_cache_file)
+    end
+
+    def ensure_api_cached
+      @api.apidoc
+    end
+
     private
 
-    def raw(resource)
-      CLASSES[resource].new(connection_attrs)
+    def tmpdir
+      if defined?(Rails)
+        Rails.root.join("tmp/foreman").to_s
+      else
+        require 'tmpdir'
+        "#{Dir.tmpdir}/foreman"
+      end
     end
   end
 end

--- a/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
@@ -25,7 +25,7 @@ module ManageiqForeman
 
     def refresh_provisioning(_target = nil)
       {
-        :operating_systems => connection.all_with_details(:operating_systems),
+        :operating_systems => connection.all_with_details(:operatingsystems),
         :media             => connection.all(:media),
         :ptables           => connection.all(:ptables),
         :locations         => connection.all(:locations),

--- a/lib/manageiq_foreman/spec/connection_spec.rb
+++ b/lib/manageiq_foreman/spec/connection_spec.rb
@@ -1,6 +1,14 @@
 require_relative 'spec_helper'
 
 describe ManageiqForeman::Connection do
+  before do
+    unless connection.api_cached?
+      with_vcr("_json_info") do
+        connection.ensure_api_cached
+      end
+    end
+  end
+
   let(:connection) do
     described_class.new(:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => nil)
   end
@@ -27,7 +35,7 @@ describe ManageiqForeman::Connection do
 
   describe "#operating_system_detail" do
     context "with 2 operating_system details" do
-      let(:results) { connection.all_with_details(:operating_systems, "per_page" => 2) }
+      let(:results) { connection.all_with_details(:operatingsystems, "per_page" => 2) }
 
       it "fetches 2 operating_system details" do
         with_vcr("_2_operating_systems") do
@@ -42,7 +50,7 @@ describe ManageiqForeman::Connection do
       with_vcr("_all_methods") do
         expect(connection.fetch(:hosts, :per_page => 2).size).to eq(2)
         expect(connection.fetch(:hostgroups, :per_page => 2).size).to eq(2)
-        expect(connection.fetch(:operating_systems, :per_page => 2).size).to eq(2)
+        expect(connection.fetch(:operatingsystems, :per_page => 2).size).to eq(2)
         expect(connection.fetch(:media, :per_page => 2).size).to eq(2)
         expect(connection.fetch(:ptables, :per_page => 2).size).to eq(2)
         expect(connection.fetch(:config_templates, :per_page => 2).size).to eq(2)

--- a/vmdb/app/models/provider_foreman.rb
+++ b/vmdb/app/models/provider_foreman.rb
@@ -10,6 +10,8 @@ class ProviderForeman < Provider
           :dependent   => :destroy,
           :autosave    => true
 
+  delegate :api_cached?, :ensure_api_cached, :to => :connect
+
   before_validation :ensure_managers
 
   validates :name, :presence => true, :uniqueness => true

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_locations_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_locations_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe EmsRefresh::Refreshers::ForemanRefresher do
+  before do
+    unless provider.api_cached?
+      VCR.use_cassette("ems_refresh/refreshers/foreman_refresher_api_doc") do
+        provider.ensure_api_cached
+      end
+    end
+  end
+
   let(:spec_related) { "name like 'ProviderRefreshSpec%'" }
   let(:provider) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe EmsRefresh::Refreshers::ForemanRefresher do
+  before do
+    unless provider.api_cached?
+      VCR.use_cassette("ems_refresh/refreshers/foreman_refresher_api_doc") do
+        provider.ensure_api_cached
+      end
+    end
+  end
+
   let(:spec_related) { "name like 'ProviderRefreshSpec%'" }
   let(:provider) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/foreman_refresher_api_doc.yml
+++ b/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/foreman_refresher_api_doc.yml
@@ -1,0 +1,1447 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://admin:smartvm@example.com/apidoc/v2.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.alpha (darwin13.4.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Mar 2015 20:59:44 GMT
+      Server:
+      - Apache/2.2.15 (Red Hat)
+      Content-Disposition:
+      - inline; filename="v2.json"
+      Content-Transfer-Encoding:
+      - binary
+      Cache-Control:
+      - private
+      Apipie-Checksum:
+      - f0c66204518b52fe5a1aa2c2163e7166
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Request-Id:
+      - 45fe338e5ce1b2327a19d099f3b1914c
+      X-Runtime:
+      - '0.018285'
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.18
+      Status:
+      - 200 OK
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"docs":{"name":"Foreman","info":"\n<p>Foreman v2 is currently in development
+        and is not the default version. You\nmay use v2 by either passing ''version=2''
+        in the Accept Header or entering\napi/v2/ in the URL.</p>\n","copyright":"","doc_url":"../apidoc/v2","api_url":"/api","resources":{"smart_proxies":{"doc_url":"../apidoc/v2/smart_proxies","api_url":"/api","name":"Smart
+        proxies","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/smart_proxies/import_puppetclasses","name":"import_puppetclasses","apis":[{"api_url":"/api/smart_proxies/:id/import_puppetclasses","http_method":"POST","short_description":"Import
+        puppet classes from puppet proxy."},{"api_url":"/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses","http_method":"POST","short_description":"Import
+        puppet classes from puppet proxy for particular environment."},{"api_url":"/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses","http_method":"POST","short_description":"Import
+        puppet classes from puppet proxy for particular environment."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_proxy_id","full_name":"smart_proxy_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"environment_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dryrun","full_name":"dryrun","description":"","required":false,"allow_nil":false,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"except","full_name":"except","description":"\n<p>Optional
+        comma-deliminated string containing either ''new,updated,obsolete''\nused
+        to limit the import_puppetclasses actions</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_proxies/index","name":"index","apis":[{"api_url":"/api/smart_proxies","http_method":"GET","short_description":"List
+        all smart_proxies."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_proxies/show","name":"show","apis":[{"api_url":"/api/smart_proxies/:id","http_method":"GET","short_description":"Show
+        a smart proxy."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_proxies/create","name":"create","apis":[{"api_url":"/api/smart_proxies","http_method":"POST","short_description":"Create
+        a smart proxy."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"smart_proxy","full_name":"smart_proxy","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"smart_proxy[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"url","full_name":"smart_proxy[url]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_proxies/update","name":"update","apis":[{"api_url":"/api/smart_proxies/:id","http_method":"PUT","short_description":"Update
+        a smart proxy."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_proxy","full_name":"smart_proxy","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"smart_proxy[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"url","full_name":"smart_proxy[url]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_proxies/destroy","name":"destroy","apis":[{"api_url":"/api/smart_proxies/:id","http_method":"DELETE","short_description":"Delete
+        a smart_proxy."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_proxies/refresh","name":"refresh","apis":[{"api_url":"/api/smart_proxies/:id/refresh","http_method":"PUT","short_description":"Refresh
+        smart proxy features"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"reports":{"doc_url":"../apidoc/v2/reports","api_url":"/api","name":"Reports","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/reports/index","name":"index","apis":[{"api_url":"/api/reports","http_method":"GET","short_description":"List
+        all reports."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/reports/show","name":"show","apis":[{"api_url":"/api/reports/:id","http_method":"GET","short_description":"Show
+        a report."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/reports/create","name":"create","apis":[{"api_url":"/api/reports","http_method":"POST","short_description":"Create
+        a report."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"report","full_name":"report","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"host","full_name":"report[host]","description":"\n<p>Hostname
+        or certname</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"reported_at","full_name":"report[reported_at]","description":"\n<p>UTC
+        time of report</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"status","full_name":"report[status]","description":"\n<p>Hash
+        of status type totals</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be Hash","metadata":null,"show":true,"expected_type":"hash"},{"name":"metrics","full_name":"report[metrics]","description":"\n<p>Hash
+        of report metrics, can be just {}</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be Hash","metadata":null,"show":true,"expected_type":"hash"},{"name":"logs","full_name":"report[logs]","description":"\n<p>Optional
+        array of log hashes</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/reports/destroy","name":"destroy","apis":[{"api_url":"/api/reports/:id","http_method":"DELETE","short_description":"Delete
+        a report."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/reports/last","name":"last","apis":[{"api_url":"/api/hosts/:host_id/reports/last","http_method":"GET","short_description":"Show
+        the last report for a given host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"home":{"doc_url":"../apidoc/v2/home","api_url":"/api","name":"Home","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/home/index","name":"index","apis":[{"api_url":"/api","http_method":"GET","short_description":"Show
+        available links."}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/home/status","name":"status","apis":[{"api_url":"/api/status","http_method":"GET","short_description":"Show
+        status."}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"smart_variables":{"doc_url":"../apidoc/v2/smart_variables","api_url":"/api","name":"Smart
+        variables","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/smart_variables/index","name":"index","apis":[{"api_url":"/api/smart_variables","http_method":"GET","short_description":"List
+        all smart variables"},{"api_url":"/api/hosts/:host_id/smart_variables","http_method":"GET","short_description":"List
+        of smart variables for a specific host"},{"api_url":"/api/hostgroups/:hostgroup_id/smart_variables","http_method":"GET","short_description":"List
+        of smart variables for a specific hostgroup"},{"api_url":"/api/puppetclasses/:puppetclass_id/smart_variables","http_method":"GET","short_description":"List
+        of smart variables for a specific puppetclass"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass_id","full_name":"puppetclass_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_variables/show","name":"show","apis":[{"api_url":"/api/smart_variables/:id","http_method":"GET","short_description":"Show
+        a smart variable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_variables/create","name":"create","apis":[{"api_url":"/api/smart_variables","http_method":"POST","short_description":"Create
+        a smart variable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"smart_variable","full_name":"smart_variable","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"variable","full_name":"smart_variable[variable]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass_id","full_name":"smart_variable[puppetclass_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"default_value","full_name":"smart_variable[default_value]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"override_value_order","full_name":"smart_variable[override_value_order]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"smart_variable[description]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"validator_type","full_name":"smart_variable[validator_type]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"validator_rule","full_name":"smart_variable[validator_rule]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"variable_type","full_name":"smart_variable[variable_type]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_variables/update","name":"update","apis":[{"api_url":"/api/smart_variables/:id","http_method":"PUT","short_description":"Update
+        a smart variable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_variable","full_name":"smart_variable","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"variable","full_name":"smart_variable[variable]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass_id","full_name":"smart_variable[puppetclass_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"default_value","full_name":"smart_variable[default_value]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"override_value_order","full_name":"smart_variable[override_value_order]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"smart_variable[description]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"validator_type","full_name":"smart_variable[validator_type]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"validator_rule","full_name":"smart_variable[validator_rule]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"variable_type","full_name":"smart_variable[variable_type]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_variables/destroy","name":"destroy","apis":[{"api_url":"/api/smart_variables/:id","http_method":"DELETE","short_description":"Delete
+        a smart variable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"roles":{"doc_url":"../apidoc/v2/roles","api_url":"/api","name":"Roles","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/roles/index","name":"index","apis":[{"api_url":"/api/roles","http_method":"GET","short_description":"List
+        all roles."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/roles/show","name":"show","apis":[{"api_url":"/api/roles/:id","http_method":"GET","short_description":"Show
+        an role."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/roles/create","name":"create","apis":[{"api_url":"/api/roles","http_method":"POST","short_description":"Create
+        an role."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"role","full_name":"role","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"role[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/roles/update","name":"update","apis":[{"api_url":"/api/roles/:id","http_method":"PUT","short_description":"Update
+        an role."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"role","full_name":"role","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"role[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/roles/destroy","name":"destroy","apis":[{"api_url":"/api/roles/:id","http_method":"DELETE","short_description":"Delete
+        an role."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"permissions":{"doc_url":"../apidoc/v2/permissions","api_url":"/api","name":"Permissions","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/permissions/index","name":"index","apis":[{"api_url":"/api/permissions","http_method":"GET","short_description":"List
+        all permissions."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"resource_type","full_name":"resource_type","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"name","full_name":"name","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/permissions/show","name":"show","apis":[{"api_url":"/api/permissions/:id","http_method":"GET","short_description":"Show
+        a permission."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"domains":{"doc_url":"../apidoc/v2/domains","api_url":"/api","name":"Domains","short_description":null,"full_description":"\n<p>Foreman
+        considers a domain and a DNS zone as the same thing. That is, if\nyou are
+        planning to manage a site where all the machines are or the form\n<em>hostname</em>.<b>somewhere.com</b>
+        then the domain is\n<b>somewhere.com</b>. This allows Foreman to associate
+        a puppet variable\nwith a domain/site and automatically append this variable
+        to all external\nnode requests made by machines at that site.</p>\n","version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/domains/index","name":"index","apis":[{"api_url":"/api/domains","http_method":"GET","short_description":"List
+        of domains"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/domains/show","name":"show","apis":[{"api_url":"/api/domains/:id","http_method":"GET","short_description":"Show
+        a domain."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"\n<p>May
+        be numerical id or domain name</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/domains/create","name":"create","apis":[{"api_url":"/api/domains","http_method":"POST","short_description":"Create
+        a domain."}],"formats":null,"full_description":"\n<p>The <b>fullname</b> field
+        is used for human readability in reports and\nother pages that refer to domains,
+        and also available as an external node\nparameter</p>\n","errors":[],"params":[{"name":"domain","full_name":"domain","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"domain[name]","description":"\n<p>The
+        full DNS Domain name</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"fullname","full_name":"domain[fullname]","description":"\n<p>Full
+        name describing the domain</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_id","full_name":"domain[dns_id]","description":"\n<p>DNS
+        Proxy to use within this domain</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_parameters_attributes","full_name":"domain[domain_parameters_attributes]","description":"\n<p>Array
+        of parameters (name, value)</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/domains/update","name":"update","apis":[{"api_url":"/api/domains/:id","http_method":"PUT","short_description":"Update
+        a domain."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain","full_name":"domain","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"domain[name]","description":"\n<p>The
+        full DNS Domain name</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"fullname","full_name":"domain[fullname]","description":"\n<p>Full
+        name describing the domain</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_id","full_name":"domain[dns_id]","description":"\n<p>DNS
+        Proxy to use within this domain</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_parameters_attributes","full_name":"domain[domain_parameters_attributes]","description":"\n<p>Array
+        of parameters (name, value)</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/domains/destroy","name":"destroy","apis":[{"api_url":"/api/domains/:id","http_method":"DELETE","short_description":"Delete
+        a domain."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"bookmarks":{"doc_url":"../apidoc/v2/bookmarks","api_url":"/api","name":"Bookmarks","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/bookmarks/index","name":"index","apis":[{"api_url":"/api/bookmarks","http_method":"GET","short_description":"List
+        all bookmarks."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/bookmarks/show","name":"show","apis":[{"api_url":"/api/bookmarks/:id","http_method":"GET","short_description":"Show
+        a bookmark."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/bookmarks/create","name":"create","apis":[{"api_url":"/api/bookmarks","http_method":"POST","short_description":"Create
+        a bookmark."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"bookmark","full_name":"bookmark","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"bookmark[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"controller","full_name":"bookmark[controller]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"query","full_name":"bookmark[query]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"public","full_name":"bookmark[public]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/bookmarks/update","name":"update","apis":[{"api_url":"/api/bookmarks/:id","http_method":"PUT","short_description":"Update
+        a bookmark."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"bookmark","full_name":"bookmark","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"bookmark[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"controller","full_name":"bookmark[controller]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"query","full_name":"bookmark[query]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"public","full_name":"bookmark[public]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/bookmarks/destroy","name":"destroy","apis":[{"api_url":"/api/bookmarks/:id","http_method":"DELETE","short_description":"Delete
+        a bookmark."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"subnets":{"doc_url":"../apidoc/v2/subnets","api_url":"/api","name":"Subnets","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/subnets/index","name":"index","apis":[{"api_url":"/api/subnets","http_method":"GET","short_description":"List
+        of subnets"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/subnets/show","name":"show","apis":[{"api_url":"/api/subnets/:id","http_method":"GET","short_description":"Show
+        a subnet."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/subnets/create","name":"create","apis":[{"api_url":"/api/subnets","http_method":"POST","short_description":"Create
+        a subnet"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"subnet","full_name":"subnet","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"subnet[name]","description":"\n<p>Subnet
+        name</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"network","full_name":"subnet[network]","description":"\n<p>Subnet
+        network</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"mask","full_name":"subnet[mask]","description":"\n<p>Netmask
+        for this subnet</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"gateway","full_name":"subnet[gateway]","description":"\n<p>Primary
+        DNS for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_primary","full_name":"subnet[dns_primary]","description":"\n<p>Primary
+        DNS for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_secondary","full_name":"subnet[dns_secondary]","description":"\n<p>Secondary
+        DNS for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"from","full_name":"subnet[from]","description":"\n<p>Starting
+        IP Address for IP auto suggestion</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"to","full_name":"subnet[to]","description":"\n<p>Ending
+        IP Address for IP auto suggestion</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"vlanid","full_name":"subnet[vlanid]","description":"\n<p>VLAN
+        ID for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_ids","full_name":"subnet[domain_ids]","description":"\n<p>Domains
+        in which this subnet is part</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"dhcp_id","full_name":"subnet[dhcp_id]","description":"\n<p>DHCP
+        Proxy to use within this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"tftp_id","full_name":"subnet[tftp_id]","description":"\n<p>TFTP
+        Proxy to use within this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_id","full_name":"subnet[dns_id]","description":"\n<p>DNS
+        Proxy to use within this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/subnets/update","name":"update","apis":[{"api_url":"/api/subnets/:id","http_method":"PUT","short_description":"Update
+        a subnet"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"\n<p>Subnet
+        numeric identifier</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet","full_name":"subnet","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"subnet[name]","description":"\n<p>Subnet
+        name</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"network","full_name":"subnet[network]","description":"\n<p>Subnet
+        network</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"mask","full_name":"subnet[mask]","description":"\n<p>Netmask
+        for this subnet</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"gateway","full_name":"subnet[gateway]","description":"\n<p>Primary
+        DNS for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_primary","full_name":"subnet[dns_primary]","description":"\n<p>Primary
+        DNS for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_secondary","full_name":"subnet[dns_secondary]","description":"\n<p>Secondary
+        DNS for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"from","full_name":"subnet[from]","description":"\n<p>Starting
+        IP Address for IP auto suggestion</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"to","full_name":"subnet[to]","description":"\n<p>Ending
+        IP Address for IP auto suggestion</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"vlanid","full_name":"subnet[vlanid]","description":"\n<p>VLAN
+        ID for this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_ids","full_name":"subnet[domain_ids]","description":"\n<p>Domains
+        in which this subnet is part</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"dhcp_id","full_name":"subnet[dhcp_id]","description":"\n<p>DHCP
+        Proxy to use within this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"tftp_id","full_name":"subnet[tftp_id]","description":"\n<p>TFTP
+        Proxy to use within this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"dns_id","full_name":"subnet[dns_id]","description":"\n<p>DNS
+        Proxy to use within this subnet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/subnets/destroy","name":"destroy","apis":[{"api_url":"/api/subnets/:id","http_method":"DELETE","short_description":"Delete
+        a subnet"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"\n<p>Subnet
+        numeric identifier</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"host_classes":{"doc_url":"../apidoc/v2/host_classes","api_url":"/api","name":"Host
+        classes","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/host_classes/index","name":"index","apis":[{"api_url":"/api/hosts/:host_id/puppetclass_ids","http_method":"GET","short_description":"List
+        all puppetclass id''s for host"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/host_classes/create","name":"create","apis":[{"api_url":"/api/hosts/:host_id/puppetclass_ids","http_method":"POST","short_description":"Add
+        a puppetclass to host"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass_id","full_name":"puppetclass_id","description":"\n<p>id
+        of puppetclass</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/host_classes/destroy","name":"destroy","apis":[{"api_url":"/api/hosts/:host_id/puppetclass_ids/:id","http_method":"DELETE","short_description":"Remove
+        a puppetclass from host"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        of puppetclass</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"settings":{"doc_url":"../apidoc/v2/settings","api_url":"/api","name":"Settings","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/settings/index","name":"index","apis":[{"api_url":"/api/settings","http_method":"GET","short_description":"List
+        all settings."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/settings/show","name":"show","apis":[{"api_url":"/api/settings/:id","http_method":"GET","short_description":"Show
+        an setting."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/settings/update","name":"update","apis":[{"api_url":"/api/settings/:id","http_method":"PUT","short_description":"Update
+        a setting."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"setting","full_name":"setting","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"value","full_name":"setting[value]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]}]},"tasks":{"doc_url":"../apidoc/v2/tasks","api_url":"/api","name":"Tasks","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/tasks/index","name":"index","apis":[{"api_url":"/api/orchestration/:id/tasks","http_method":"GET","short_description":"List
+        all tasks for a given orchestration event"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"compute_attributes":{"doc_url":"../apidoc/v2/compute_attributes","api_url":"/api","name":"Compute
+        attributes","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/compute_attributes/create","name":"create","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes","http_method":"POST","short_description":"Create
+        a compute attribute"},{"api_url":"/api/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes","http_method":"POST","short_description":"Create
+        a compute attribute"},{"api_url":"/api/compute_resources/:compute_resource_id/compute_attributes","http_method":"POST","short_description":"Create
+        a compute attribute"},{"api_url":"/api/compute_profiles/:compute_profile_id/compute_attributes","http_method":"POST","short_description":"Create
+        a compute attribute"},{"api_url":"/api/compute_attributes","http_method":"POST","short_description":"Create
+        a compute attribute."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_profile_id","full_name":"compute_profile_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_attribute","full_name":"compute_attribute","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"vm_attrs","full_name":"compute_attribute[vm_attrs]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be Hash","metadata":null,"show":true,"expected_type":"hash"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_attributes/update","name":"update","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/:id","http_method":"PUT","short_description":"Update
+        a compute attribute"},{"api_url":"/api/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes/:id","http_method":"PUT","short_description":"Update
+        a compute attribute"},{"api_url":"/api/compute_resources/:compute_resource_id/compute_attributes/:id","http_method":"PUT","short_description":"Update
+        a compute attribute"},{"api_url":"/api/compute_profiles/:compute_profile_id/compute_attributes/:id","http_method":"PUT","short_description":"Update
+        a compute attribute"},{"api_url":"/api/compute_attributes/:id","http_method":"PUT","short_description":"Update
+        a compute attribute."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_profile_id","full_name":"compute_profile_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_attribute","full_name":"compute_attribute","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"vm_attrs","full_name":"compute_attribute[vm_attrs]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be Hash","metadata":null,"show":true,"expected_type":"hash"}]}],"examples":[],"metadata":null,"see":[]}]},"models":{"doc_url":"../apidoc/v2/models","api_url":"/api","name":"Models","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/models/index","name":"index","apis":[{"api_url":"/api/models","http_method":"GET","short_description":"List
+        all models."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/models/show","name":"show","apis":[{"api_url":"/api/models/:id","http_method":"GET","short_description":"Show
+        a model."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/models/create","name":"create","apis":[{"api_url":"/api/models","http_method":"POST","short_description":"Create
+        a model."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"model","full_name":"model","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"model[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"info","full_name":"model[info]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"vendor_class","full_name":"model[vendor_class]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hardware_model","full_name":"model[hardware_model]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/models/update","name":"update","apis":[{"api_url":"/api/models/:id","http_method":"PUT","short_description":"Update
+        a model."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"model","full_name":"model","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"model[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"info","full_name":"model[info]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"vendor_class","full_name":"model[vendor_class]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hardware_model","full_name":"model[hardware_model]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/models/destroy","name":"destroy","apis":[{"api_url":"/api/models/:id","http_method":"DELETE","short_description":"Delete
+        a model."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"audits":{"doc_url":"../apidoc/v2/audits","api_url":"/api","name":"Audits","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/audits/index","name":"index","apis":[{"api_url":"/api/audits","http_method":"GET","short_description":"List
+        all audits."},{"api_url":"/api/hosts/:host_id/audits","http_method":"GET","short_description":"List
+        all audits for a given host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/audits/show","name":"show","apis":[{"api_url":"/api/audits/:id","http_method":"GET","short_description":"Show
+        an audit"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"operatingsystems":{"doc_url":"../apidoc/v2/operatingsystems","api_url":"/api","name":"Operating
+        systems","short_description":null,"full_description":"","version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/operatingsystems/index","name":"index","apis":[{"api_url":"/api/operatingsystems","http_method":"GET","short_description":"List
+        all operating systems."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>for
+        example, name ASC, or name DESC</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/operatingsystems/show","name":"show","apis":[{"api_url":"/api/operatingsystems/:id","http_method":"GET","short_description":"Show
+        an OS."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/operatingsystems/create","name":"create","apis":[{"api_url":"/api/operatingsystems","http_method":"POST","short_description":"Create
+        an OS."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"operatingsystem","full_name":"operatingsystem","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"operatingsystem[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        match regular expression /\\A(\\S+)\\Z/.","metadata":null,"show":true,"expected_type":"string"},{"name":"major","full_name":"operatingsystem[major]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"minor","full_name":"operatingsystem[minor]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"operatingsystem[description]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"family","full_name":"operatingsystem[family]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"release_name","full_name":"operatingsystem[release_name]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/operatingsystems/update","name":"update","apis":[{"api_url":"/api/operatingsystems/:id","http_method":"PUT","short_description":"Update
+        an OS."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem","full_name":"operatingsystem","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"operatingsystem[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        match regular expression /\\A(\\S+)\\Z/.","metadata":null,"show":true,"expected_type":"string"},{"name":"major","full_name":"operatingsystem[major]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"minor","full_name":"operatingsystem[minor]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"operatingsystem[description]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"family","full_name":"operatingsystem[family]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"release_name","full_name":"operatingsystem[release_name]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/operatingsystems/destroy","name":"destroy","apis":[{"api_url":"/api/operatingsystems/:id","http_method":"DELETE","short_description":"Delete
+        an OS."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/operatingsystems/bootfiles","name":"bootfiles","apis":[{"api_url":"/api/operatingsystems/:id/bootfiles","http_method":"GET","short_description":"List
+        boot files an OS."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"medium","full_name":"medium","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture","full_name":"architecture","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"hostgroups":{"doc_url":"../apidoc/v2/hostgroups","api_url":"/api","name":"Hostgroups","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/hostgroups/index","name":"index","apis":[{"api_url":"/api/hostgroups","http_method":"GET","short_description":"List
+        all hostgroups."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hostgroups/show","name":"show","apis":[{"api_url":"/api/hostgroups/:id","http_method":"GET","short_description":"Show
+        a hostgroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hostgroups/create","name":"create","apis":[{"api_url":"/api/hostgroups","http_method":"POST","short_description":"Create
+        an hostgroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"hostgroup","full_name":"hostgroup","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"hostgroup[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"parent_id","full_name":"hostgroup[parent_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"hostgroup[environment_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"hostgroup[operatingsystem_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture_id","full_name":"hostgroup[architecture_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"medium_id","full_name":"hostgroup[medium_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"ptable_id","full_name":"hostgroup[ptable_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_ca_proxy_id","full_name":"hostgroup[puppet_ca_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet_id","full_name":"hostgroup[subnet_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"hostgroup[domain_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_id","full_name":"hostgroup[realm_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_proxy_id","full_name":"hostgroup[puppet_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hostgroups/update","name":"update","apis":[{"api_url":"/api/hostgroups/:id","http_method":"PUT","short_description":"Update
+        an hostgroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup","full_name":"hostgroup","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"hostgroup[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"parent_id","full_name":"hostgroup[parent_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"hostgroup[environment_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"hostgroup[operatingsystem_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture_id","full_name":"hostgroup[architecture_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"medium_id","full_name":"hostgroup[medium_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"ptable_id","full_name":"hostgroup[ptable_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_ca_proxy_id","full_name":"hostgroup[puppet_ca_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet_id","full_name":"hostgroup[subnet_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"hostgroup[domain_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_id","full_name":"hostgroup[realm_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_proxy_id","full_name":"hostgroup[puppet_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hostgroups/destroy","name":"destroy","apis":[{"api_url":"/api/hostgroups/:id","http_method":"DELETE","short_description":"Delete
+        an hostgroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"common_parameters":{"doc_url":"../apidoc/v2/common_parameters","api_url":"/api","name":"Common
+        parameters","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/common_parameters/index","name":"index","apis":[{"api_url":"/api/common_parameters","http_method":"GET","short_description":"List
+        all common parameters."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/common_parameters/show","name":"show","apis":[{"api_url":"/api/common_parameters/:id","http_method":"GET","short_description":"Show
+        a common parameter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/common_parameters/create","name":"create","apis":[{"api_url":"/api/common_parameters","http_method":"POST","short_description":"Create
+        a common_parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"common_parameter","full_name":"common_parameter","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"common_parameter[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"value","full_name":"common_parameter[value]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/common_parameters/update","name":"update","apis":[{"api_url":"/api/common_parameters/:id","http_method":"PUT","short_description":"Update
+        a common_parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"common_parameter","full_name":"common_parameter","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"common_parameter[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"value","full_name":"common_parameter[value]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/common_parameters/destroy","name":"destroy","apis":[{"api_url":"/api/common_parameters/:id","http_method":"DELETE","short_description":"Delete
+        a common_parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"filters":{"doc_url":"../apidoc/v2/filters","api_url":"/api","name":"Filters","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/filters/index","name":"index","apis":[{"api_url":"/api/filters","http_method":"GET","short_description":"List
+        all filters."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/filters/show","name":"show","apis":[{"api_url":"/api/filters/:id","http_method":"GET","short_description":"Show
+        a filter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/filters/create","name":"create","apis":[{"api_url":"/api/filters","http_method":"POST","short_description":"Create
+        a filter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"filter","full_name":"filter","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"role_id","full_name":"filter[role_id]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"filter[search]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"permission_ids","full_name":"filter[permission_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"organization_ids","full_name":"filter[organization_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"location_ids","full_name":"filter[location_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/filters/update","name":"update","apis":[{"api_url":"/api/filters/:id","http_method":"PUT","short_description":"Update
+        a filter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"filter","full_name":"filter","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"role_id","full_name":"filter[role_id]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"filter[search]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"permission_ids","full_name":"filter[permission_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"organization_ids","full_name":"filter[organization_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"location_ids","full_name":"filter[location_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/filters/destroy","name":"destroy","apis":[{"api_url":"/api/filters/:id","http_method":"DELETE","short_description":"Delete
+        a filter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"auth_source_ldaps":{"doc_url":"../apidoc/v2/auth_source_ldaps","api_url":"/api","name":"Auth
+        source ldaps","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/auth_source_ldaps/index","name":"index","apis":[{"api_url":"/api/auth_source_ldaps","http_method":"GET","short_description":"List
+        all authsource ldaps"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/auth_source_ldaps/show","name":"show","apis":[{"api_url":"/api/auth_source_ldaps/:id","http_method":"GET","short_description":"Show
+        an authsource ldap."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/auth_source_ldaps/create","name":"create","apis":[{"api_url":"/api/auth_source_ldaps","http_method":"POST","short_description":"Create
+        an auth_source_ldap."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"auth_source_ldap","full_name":"auth_source_ldap","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"auth_source_ldap[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"host","full_name":"auth_source_ldap[host]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"port","full_name":"auth_source_ldap[port]","description":"\n<p>defaults
+        to 389</p>\n","required":false,"allow_nil":true,"validator":"Must be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"account","full_name":"auth_source_ldap[account]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"base_dn","full_name":"auth_source_ldap[base_dn]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"account_password","full_name":"auth_source_ldap[account_password]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_login","full_name":"auth_source_ldap[attr_login]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_firstname","full_name":"auth_source_ldap[attr_firstname]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_lastname","full_name":"auth_source_ldap[attr_lastname]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_mail","full_name":"auth_source_ldap[attr_mail]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_photo","full_name":"auth_source_ldap[attr_photo]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"onthefly_register","full_name":"auth_source_ldap[onthefly_register]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"tls","full_name":"auth_source_ldap[tls]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/auth_source_ldaps/update","name":"update","apis":[{"api_url":"/api/auth_source_ldaps/:id","http_method":"PUT","short_description":"Update
+        an auth_source_ldap."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"auth_source_ldap","full_name":"auth_source_ldap","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"auth_source_ldap[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"host","full_name":"auth_source_ldap[host]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"port","full_name":"auth_source_ldap[port]","description":"\n<p>defaults
+        to 389</p>\n","required":false,"allow_nil":true,"validator":"Must be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"account","full_name":"auth_source_ldap[account]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"base_dn","full_name":"auth_source_ldap[base_dn]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"account_password","full_name":"auth_source_ldap[account_password]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_login","full_name":"auth_source_ldap[attr_login]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_firstname","full_name":"auth_source_ldap[attr_firstname]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_lastname","full_name":"auth_source_ldap[attr_lastname]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_mail","full_name":"auth_source_ldap[attr_mail]","description":"\n<p>required
+        if onthefly_register is true</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"attr_photo","full_name":"auth_source_ldap[attr_photo]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"onthefly_register","full_name":"auth_source_ldap[onthefly_register]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"tls","full_name":"auth_source_ldap[tls]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/auth_source_ldaps/destroy","name":"destroy","apis":[{"api_url":"/api/auth_source_ldaps/:id","http_method":"DELETE","short_description":"Delete
+        an auth_source_ldap."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"realms":{"doc_url":"../apidoc/v2/realms","api_url":"/api","name":"Realms","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/realms/index","name":"index","apis":[{"api_url":"/api/realms","http_method":"GET","short_description":"List
+        of realms"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/realms/show","name":"show","apis":[{"api_url":"/api/realms/:id","http_method":"GET","short_description":"Show
+        a realm."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"\n<p>May
+        be numerical id or realm name</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/realms/create","name":"create","apis":[{"api_url":"/api/realms","http_method":"POST","short_description":"Create
+        a realm."}],"formats":null,"full_description":"\n<p>The <b>name</b> field
+        is used for the name of the realm.</p>\n","errors":[],"params":[{"name":"realm","full_name":"realm","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"realm[name]","description":"\n<p>The
+        realm name, e.g. EXAMPLE.COM</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_proxy_id","full_name":"realm[realm_proxy_id]","description":"\n<p>Proxy
+        to use for this realm</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_type","full_name":"realm[realm_type]","description":"\n<p>Realm
+        type, e.g. FreeIPA or Active Directory</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/realms/update","name":"update","apis":[{"api_url":"/api/realms/:id","http_method":"PUT","short_description":"Update
+        a realm."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm","full_name":"realm","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"realm[name]","description":"\n<p>The
+        realm name, e.g. EXAMPLE.COM</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_proxy_id","full_name":"realm[realm_proxy_id]","description":"\n<p>Proxy
+        to use for this realm</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_type","full_name":"realm[realm_type]","description":"\n<p>Realm
+        type, e.g. FreeIPA or Active Directory</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/realms/destroy","name":"destroy","apis":[{"api_url":"/api/realms/:id","http_method":"DELETE","short_description":"Delete
+        a realm."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"config_templates":{"doc_url":"../apidoc/v2/config_templates","api_url":"/api","name":"Config
+        templates","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/config_templates/index","name":"index","apis":[{"api_url":"/api/config_templates","http_method":"GET","short_description":"List
+        templates"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_templates/show","name":"show","apis":[{"api_url":"/api/config_templates/:id","http_method":"GET","short_description":"Show
+        template details"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_templates/create","name":"create","apis":[{"api_url":"/api/config_templates","http_method":"POST","short_description":"Create
+        a template"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"config_template","full_name":"config_template","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"config_template[name]","description":"\n<p>template
+        name</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"template","full_name":"config_template[template]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"snippet","full_name":"config_template[snippet]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"audit_comment","full_name":"config_template[audit_comment]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"template_kind_id","full_name":"config_template[template_kind_id]","description":"\n<p>not
+        relevant for snippet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"template_combinations_attributes","full_name":"config_template[template_combinations_attributes]","description":"\n<p>Array
+        of template combinations (hostgroup_id, environment_id)</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"operatingsystem_ids","full_name":"config_template[operatingsystem_ids]","description":"\n<p>Array
+        of operating systems ID to associate the template with</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_templates/update","name":"update","apis":[{"api_url":"/api/config_templates/:id","http_method":"PUT","short_description":"Update
+        a template"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"config_template","full_name":"config_template","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"config_template[name]","description":"\n<p>template
+        name</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"template","full_name":"config_template[template]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"snippet","full_name":"config_template[snippet]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"audit_comment","full_name":"config_template[audit_comment]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"template_kind_id","full_name":"config_template[template_kind_id]","description":"\n<p>not
+        relevant for snippet</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"template_combinations_attributes","full_name":"config_template[template_combinations_attributes]","description":"\n<p>Array
+        of template combinations (hostgroup_id, environment_id)</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"operatingsystem_ids","full_name":"config_template[operatingsystem_ids]","description":"\n<p>Array
+        of operating systems ID to associate the template with</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_templates/revision","name":"revision","apis":[{"api_url":"/api/config_templates/revision","http_method":"GET","short_description":null}],"formats":null,"full_description":"","errors":[],"params":[{"name":"version","full_name":"version","description":"\n<p>template
+        version</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_templates/destroy","name":"destroy","apis":[{"api_url":"/api/config_templates/:id","http_method":"DELETE","short_description":"Delete
+        a template"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_templates/build_pxe_default","name":"build_pxe_default","apis":[{"api_url":"/api/config_templates/build_pxe_default","http_method":"GET","short_description":"Change
+        the default PXE menu on all configured TFTP servers"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"template_combinations":{"doc_url":"../apidoc/v2/template_combinations","api_url":"/api","name":"Template
+        combinations","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/template_combinations/index","name":"index","apis":[{"api_url":"/api/config_templates/:config_template_id/template_combinations","http_method":"GET","short_description":"List
+        Template Combination"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"config_template_id","full_name":"config_template_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/template_combinations/create","name":"create","apis":[{"api_url":"/api/config_templates/:config_template_id/template_combinations","http_method":"POST","short_description":"Add
+        a Template Combination"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"config_template_id","full_name":"config_template_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"template_combination","full_name":"template_combination","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"environment_id","full_name":"template_combination[environment_id]","description":"\n<p>environment
+        id</p>\n","required":false,"allow_nil":true,"validator":"Must be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"template_combination[hostgroup_id]","description":"\n<p>hostgroup
+        id</p>\n","required":false,"allow_nil":true,"validator":"Must be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/template_combinations/show","name":"show","apis":[{"api_url":"/api/template_combinations/:id","http_method":"GET","short_description":"Show
+        Template Combination"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/template_combinations/destroy","name":"destroy","apis":[{"api_url":"/api/template_combinations/:id","http_method":"DELETE","short_description":"Delete
+        a template"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"compute_resources":{"doc_url":"../apidoc/v2/compute_resources","api_url":"/api","name":"Compute
+        resources","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/compute_resources/index","name":"index","apis":[{"api_url":"/api/compute_resources","http_method":"GET","short_description":"List
+        all compute resources."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/show","name":"show","apis":[{"api_url":"/api/compute_resources/:id","http_method":"GET","short_description":"Show
+        an compute resource."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/create","name":"create","apis":[{"api_url":"/api/compute_resources","http_method":"POST","short_description":"Create
+        a compute resource."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_resource","full_name":"compute_resource","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"compute_resource[name]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"provider","full_name":"compute_resource[provider]","description":"\n<p>Providers
+        include Ovirt, EC2, Vmware, Openstack, Rackspace</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"url","full_name":"compute_resource[url]","description":"\n<p>URL
+        for Libvirt, Ovirt, and Openstack</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"compute_resource[description]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"user","full_name":"compute_resource[user]","description":"\n<p>Username
+        for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"password","full_name":"compute_resource[password]","description":"\n<p>Password
+        for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"uuid","full_name":"compute_resource[uuid]","description":"\n<p>for
+        Ovirt, Vmware Datacenter</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"region","full_name":"compute_resource[region]","description":"\n<p>for
+        EC2 only</p>\n","required":false,"allow_nil":true,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"tenant","full_name":"compute_resource[tenant]","description":"\n<p>for
+        Openstack only</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"server","full_name":"compute_resource[server]","description":"\n<p>for
+        Vmware</p>\n","required":false,"allow_nil":true,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/update","name":"update","apis":[{"api_url":"/api/compute_resources/:id","http_method":"PUT","short_description":"Update
+        a compute resource."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource","full_name":"compute_resource","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"compute_resource[name]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"provider","full_name":"compute_resource[provider]","description":"\n<p>Providers
+        include Ovirt, EC2, Vmware, Openstack, Rackspace</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"url","full_name":"compute_resource[url]","description":"\n<p>URL
+        for Libvirt, Ovirt, and Openstack</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"compute_resource[description]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"user","full_name":"compute_resource[user]","description":"\n<p>Username
+        for Ovirt, EC2, Vmware, Openstack. Access Key for EC2.</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"password","full_name":"compute_resource[password]","description":"\n<p>Password
+        for Ovirt, EC2, Vmware, Openstack. Secret key for EC2</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"uuid","full_name":"compute_resource[uuid]","description":"\n<p>for
+        Ovirt, Vmware Datacenter</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"region","full_name":"compute_resource[region]","description":"\n<p>for
+        EC2 only</p>\n","required":false,"allow_nil":true,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"tenant","full_name":"compute_resource[tenant]","description":"\n<p>for
+        Openstack only</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"server","full_name":"compute_resource[server]","description":"\n<p>for
+        Vmware</p>\n","required":false,"allow_nil":true,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/destroy","name":"destroy","apis":[{"api_url":"/api/compute_resources/:id","http_method":"DELETE","short_description":"Delete
+        a compute resource."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/available_images","name":"available_images","apis":[{"api_url":"/api/compute_resources/:id/available_images","http_method":"GET","short_description":"List
+        available images for a compute resource."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/available_clusters","name":"available_clusters","apis":[{"api_url":"/api/compute_resources/:id/available_clusters","http_method":"GET","short_description":"List
+        available clusters for a compute resource"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/available_networks","name":"available_networks","apis":[{"api_url":"/api/compute_resources/:id/available_networks","http_method":"GET","short_description":"List
+        available networks for a compute resource"},{"api_url":"/api/compute_resources/:id/available_clusters/:cluster_id/available_networks","http_method":"GET","short_description":"List
+        available networks for a compute resource cluster"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"cluster_id","full_name":"cluster_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_resources/available_storage_domains","name":"available_storage_domains","apis":[{"api_url":"/api/compute_resources/:id/available_storage_domains","http_method":"GET","short_description":"List
+        storage_domains for a compute resource"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"plugins":{"doc_url":"../apidoc/v2/plugins","api_url":"/api","name":"Plugins","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/plugins/index","name":"index","apis":[{"api_url":"/api/plugins","http_method":"GET","short_description":"List
+        of installed plugins"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"media":{"doc_url":"../apidoc/v2/media","api_url":"/api","name":"Media","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/media/index","name":"index","apis":[{"api_url":"/api/media","http_method":"GET","short_description":"List
+        all media."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>for
+        example, name ASC, or name DESC</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/media/show","name":"show","apis":[{"api_url":"/api/media/:id","http_method":"GET","short_description":"Show
+        a medium."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/media/create","name":"create","apis":[{"api_url":"/api/media","http_method":"POST","short_description":"Create
+        a medium."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"medium","full_name":"medium","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"medium[name]","description":"\n<p>Name
+        of media</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"path","full_name":"medium[path]","description":"\n<p>The
+        path to the medium, can be a URL or a valid NFS server (exclusive of\nthe
+        architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere
+        $arch will be substituted for the host''s actual OS architecture and\n$version,
+        $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris
+        and Debian media may also use $release.</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"os_family","full_name":"medium[os_family]","description":"\n<p>The
+        family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_ids","full_name":"medium[operatingsystem_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/media/update","name":"update","apis":[{"api_url":"/api/media/:id","http_method":"PUT","short_description":"Update
+        a medium."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"medium","full_name":"medium","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"medium[name]","description":"\n<p>Name
+        of media</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"path","full_name":"medium[path]","description":"\n<p>The
+        path to the medium, can be a URL or a valid NFS server (exclusive of\nthe
+        architecture).</p>\n\n<p>for example <a\nhref=\"http://mirror.centos.org/centos/$version/os/$arch\">mirror.centos.org/centos/$version/os/$arch</a>\nwhere
+        $arch will be substituted for the host''s actual OS architecture and\n$version,
+        $major and $minor will be substituted for the version of the\noperating system.</p>\n\n<p>Solaris
+        and Debian media may also use $release.</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"os_family","full_name":"medium[os_family]","description":"\n<p>The
+        family that the operating system belongs to.</p>\n\n<p>Available families:</p>\n<ul><li>\n<p>AIX</p>\n</li><li>\n<p>Archlinux</p>\n</li><li>\n<p>Debian</p>\n</li><li>\n<p>Freebsd</p>\n</li><li>\n<p>Gentoo</p>\n</li><li>\n<p>Junos</p>\n</li><li>\n<p>Redhat</p>\n</li><li>\n<p>Solaris</p>\n</li><li>\n<p>Suse</p>\n</li><li>\n<p>Windows</p>\n</li></ul>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_ids","full_name":"medium[operatingsystem_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/media/destroy","name":"destroy","apis":[{"api_url":"/api/media/:id","http_method":"DELETE","short_description":"Delete
+        a medium."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"interfaces":{"doc_url":"../apidoc/v2/interfaces","api_url":"/api","name":"Interfaces","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/interfaces/index","name":"index","apis":[{"api_url":"/api/hosts/:host_id/interfaces","http_method":"GET","short_description":"List
+        all interfaces for host"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        or name of host</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/interfaces/show","name":"show","apis":[{"api_url":"/api/hosts/:host_id/interfaces/:id","http_method":"GET","short_description":"Show
+        an interface for host"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        or name of nested host</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        or name of interface</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/interfaces/create","name":"create","apis":[{"api_url":"/api/hosts/:host_id/interfaces","http_method":"POST","short_description":"Create
+        an interface linked to a host"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        or name of host</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"interface","full_name":"interface","description":"\n<p>interface
+        information</p>\n","required":false,"allow_nil":true,"validator":"Must be
+        a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"mac","full_name":"interface[mac]","description":"\n<p>MAC
+        address of interface</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"ip","full_name":"interface[ip]","description":"\n<p>IP
+        address of interface</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"type","full_name":"interface[type]","description":"\n<p>Interface
+        type, i.e: Nic::BMC</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"name","full_name":"interface[name]","description":"\n<p>Interface
+        name</p>\n","required":true,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet_id","full_name":"interface[subnet_id]","description":"\n<p>Foreman
+        subnet id of interface</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Fixnum","metadata":null,"show":true,"expected_type":"numeric"},{"name":"domain_id","full_name":"interface[domain_id]","description":"\n<p>Foreman
+        domain id of interface</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Fixnum","metadata":null,"show":true,"expected_type":"numeric"},{"name":"username","full_name":"interface[username]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"password","full_name":"interface[password]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"provider","full_name":"interface[provider]","description":"\n<p>Interface
+        provider, i.e: IPMI</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/interfaces/update","name":"update","apis":[{"api_url":"/api/hosts/:host_id/interfaces/:id","http_method":"PUT","short_description":"Update
+        host interface"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        or name of host</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"interface","full_name":"interface","description":"\n<p>interface
+        information</p>\n","required":false,"allow_nil":true,"validator":"Must be
+        a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"mac","full_name":"interface[mac]","description":"\n<p>MAC
+        address of interface</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"ip","full_name":"interface[ip]","description":"\n<p>IP
+        address of interface</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"type","full_name":"interface[type]","description":"\n<p>Interface
+        type, i.e: Nic::BMC</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"name","full_name":"interface[name]","description":"\n<p>Interface
+        name</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet_id","full_name":"interface[subnet_id]","description":"\n<p>Foreman
+        subnet id of interface</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Fixnum","metadata":null,"show":true,"expected_type":"numeric"},{"name":"domain_id","full_name":"interface[domain_id]","description":"\n<p>Foreman
+        domain id of interface</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be Fixnum","metadata":null,"show":true,"expected_type":"numeric"},{"name":"username","full_name":"interface[username]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"password","full_name":"interface[password]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"provider","full_name":"interface[provider]","description":"\n<p>Interface
+        provider, i.e: IPMI</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/interfaces/destroy","name":"destroy","apis":[{"api_url":"/api/hosts/:host_id/interfaces/:id","http_method":"DELETE","short_description":"Delete
+        a host interface"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"\n<p>id
+        of interface</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"hosts":{"doc_url":"../apidoc/v2/hosts","api_url":"/api","name":"Hosts","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/hosts/index","name":"index","apis":[{"api_url":"/api/hosts","http_method":"GET","short_description":"List
+        all hosts."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/show","name":"show","apis":[{"api_url":"/api/hosts/:id","http_method":"GET","short_description":"Show
+        a host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/create","name":"create","apis":[{"api_url":"/api/hosts","http_method":"POST","short_description":"Create
+        a host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host","full_name":"host","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"host[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"host[environment_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"ip","full_name":"host[ip]","description":"\n<p>not
+        required if using a subnet with dhcp proxy</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"mac","full_name":"host[mac]","description":"\n<p>not
+        required if its a virtual machine</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture_id","full_name":"host[architecture_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"host[domain_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_id","full_name":"host[realm_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_proxy_id","full_name":"host[puppet_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_class_ids","full_name":"host[puppet_class_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"operatingsystem_id","full_name":"host[operatingsystem_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"medium_id","full_name":"host[medium_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"ptable_id","full_name":"host[ptable_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet_id","full_name":"host[subnet_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"host[compute_resource_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"sp_subnet_id","full_name":"host[sp_subnet_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"model_id","full_name":"host[model_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"host[hostgroup_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"owner_id","full_name":"host[owner_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_ca_proxy_id","full_name":"host[puppet_ca_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"image_id","full_name":"host[image_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"host_parameters_attributes","full_name":"host[host_parameters_attributes]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"build","full_name":"host[build]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"enabled","full_name":"host[enabled]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"provision_method","full_name":"host[provision_method]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"managed","full_name":"host[managed]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"progress_report_id","full_name":"host[progress_report_id]","description":"\n<p>UUID
+        to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"capabilities","full_name":"host[capabilities]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_profile_id","full_name":"host[compute_profile_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_attributes","full_name":"host[compute_attributes]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[]}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/update","name":"update","apis":[{"api_url":"/api/hosts/:id","http_method":"PUT","short_description":"Update
+        a host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"host","full_name":"host","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"host[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"host[environment_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"ip","full_name":"host[ip]","description":"\n<p>not
+        required if using a subnet with dhcp proxy</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"mac","full_name":"host[mac]","description":"\n<p>not
+        required if its a virtual machine</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture_id","full_name":"host[architecture_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"host[domain_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"realm_id","full_name":"host[realm_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_proxy_id","full_name":"host[puppet_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_class_ids","full_name":"host[puppet_class_ids]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"operatingsystem_id","full_name":"host[operatingsystem_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"medium_id","full_name":"host[medium_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"ptable_id","full_name":"host[ptable_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"subnet_id","full_name":"host[subnet_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"host[compute_resource_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"sp_subnet_id","full_name":"host[sp_subnet_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"model_id","full_name":"host[model_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"host[hostgroup_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"owner_id","full_name":"host[owner_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppet_ca_proxy_id","full_name":"host[puppet_ca_proxy_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"image_id","full_name":"host[image_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"host_parameters_attributes","full_name":"host[host_parameters_attributes]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be Array","metadata":null,"show":true,"expected_type":"array"},{"name":"build","full_name":"host[build]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"enabled","full_name":"host[enabled]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"provision_method","full_name":"host[provision_method]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"managed","full_name":"host[managed]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"progress_report_id","full_name":"host[progress_report_id]","description":"\n<p>UUID
+        to track orchestration tasks status, GET\n/api/orchestration/:UUID/tasks</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"capabilities","full_name":"host[capabilities]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_profile_id","full_name":"host[compute_profile_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_attributes","full_name":"host[compute_attributes]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[]}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/destroy","name":"destroy","apis":[{"api_url":"/api/hosts/:id","http_method":"DELETE","short_description":"Delete
+        an host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/status","name":"status","apis":[{"api_url":"/api/hosts/:id/status","http_method":"GET","short_description":"Get
+        status of host"}],"formats":null,"full_description":"\n<p>Return value may
+        either be one of the following:</p>\n<ul><li>\n<p>missing</p>\n</li><li>\n<p>failed</p>\n</li><li>\n<p>pending</p>\n</li><li>\n<p>changed</p>\n</li><li>\n<p>unchanged</p>\n</li><li>\n<p>unreported</p>\n</li></ul>\n","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/puppetrun","name":"puppetrun","apis":[{"api_url":"/api/hosts/:id/puppetrun","http_method":"PUT","short_description":"Force
+        a puppet run on the agent."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/power","name":"power","apis":[{"api_url":"/api/hosts/:id/power","http_method":"PUT","short_description":"Run
+        power operation on host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.","metadata":null,"show":true,"expected_type":"string"},{"name":"power_action","full_name":"power_action","description":"\n<p>power
+        action, valid actions are (''on'', ''start'')'', (''off'', ''stop''), (''soft'',\n''reboot''),
+        (''cycle'', ''reset''), (''state'', ''status'')</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/boot","name":"boot","apis":[{"api_url":"/api/hosts/:id/boot","http_method":"PUT","short_description":"Boot
+        host from specified device."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, dot(.), space, underscore(_), hypen(-) with no leading or trailing
+        space.","metadata":null,"show":true,"expected_type":"string"},{"name":"device","full_name":"device","description":"\n<p>boot
+        device, valid devices are disk, cdrom, pxe, bios</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hosts/facts","name":"facts","apis":[{"api_url":"/api/hosts/facts","http_method":"POST","short_description":"Upload
+        facts for a host, creating the host if required."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"name","full_name":"name","description":"\n<p>hostname
+        of the host</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"facts","full_name":"facts","description":"\n<p>hash
+        containing the facts for the host</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be Hash","metadata":null,"show":true,"expected_type":"hash"},{"name":"certname","full_name":"certname","description":"\n<p>optional:
+        certname of the host</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"type","full_name":"type","description":"\n<p>optional:
+        the STI type of host to create</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"fact_values":{"doc_url":"../apidoc/v2/fact_values","api_url":"/api","name":"Fact
+        values","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/fact_values/index","name":"index","apis":[{"api_url":"/api/fact_values","http_method":"GET","short_description":"List
+        all fact values."},{"api_url":"/api/hosts/:host_id/facts","http_method":"GET","short_description":"List
+        all fact values of a given host."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"smart_class_parameters":{"doc_url":"../apidoc/v2/smart_class_parameters","api_url":"/api","name":"Smart
+        class parameters","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/smart_class_parameters/index","name":"index","apis":[{"api_url":"/api/smart_class_parameters","http_method":"GET","short_description":"List
+        all smart class parameters"},{"api_url":"/api/hosts/:host_id/smart_class_parameters","http_method":"GET","short_description":"List
+        of smart class parameters for a specific host"},{"api_url":"/api/hostgroups/:hostgroup_id/smart_class_parameters","http_method":"GET","short_description":"List
+        of smart class parameters for a specific hostgroup"},{"api_url":"/api/puppetclasses/:puppetclass_id/smart_class_parameters","http_method":"GET","short_description":"List
+        of smart class parameters for a specific puppetclass"},{"api_url":"/api/environments/:environment_id/smart_class_parameters","http_method":"GET","short_description":"List
+        of smart class parameters for a specific environment"},{"api_url":"/api/environments/:environment_id/puppetclasses/:puppetclass_id/smart_class_parameters","http_method":"GET","short_description":"List
+        of smart class parameters for a specific environment/puppetclass combination"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass_id","full_name":"puppetclass_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"environment_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_class_parameters/show","name":"show","apis":[{"api_url":"/api/smart_class_parameters/:id","http_method":"GET","short_description":"Show
+        a smart class parameter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/smart_class_parameters/update","name":"update","apis":[{"api_url":"/api/smart_class_parameters/:id","http_method":"PUT","short_description":"Update
+        a smart class parameter."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_class_parameter","full_name":"smart_class_parameter","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"override","full_name":"smart_class_parameter[override]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"description","full_name":"smart_class_parameter[description]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"default_value","full_name":"smart_class_parameter[default_value]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"path","full_name":"smart_class_parameter[path]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"validator_type","full_name":"smart_class_parameter[validator_type]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"validator_rule","full_name":"smart_class_parameter[validator_rule]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"override_value_order","full_name":"smart_class_parameter[override_value_order]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"parameter_type","full_name":"smart_class_parameter[parameter_type]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"required","full_name":"smart_class_parameter[required]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]}]},"users":{"doc_url":"../apidoc/v2/users","api_url":"/api","name":"Users","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/users/index","name":"index","apis":[{"api_url":"/api/users","http_method":"GET","short_description":"List
+        all users."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/users/show","name":"show","apis":[{"api_url":"/api/users/:id","http_method":"GET","short_description":"Show
+        an user."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/users/create","name":"create","apis":[{"api_url":"/api/users","http_method":"POST","short_description":"Create
+        an user."}],"formats":null,"full_description":"\n<p>Adds role ''Anonymous''
+        to the user by default</p>\n","errors":[],"params":[{"name":"user","full_name":"user","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"login","full_name":"user[login]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"firstname","full_name":"user[firstname]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"lastname","full_name":"user[lastname]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"mail","full_name":"user[mail]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"admin","full_name":"user[admin]","description":"\n<p>Is
+        an admin account?</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"password","full_name":"user[password]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"auth_source_id","full_name":"user[auth_source_id]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be Integer","metadata":null,"show":true,"expected_type":"numeric"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/users/update","name":"update","apis":[{"api_url":"/api/users/:id","http_method":"PUT","short_description":"Update
+        an user."}],"formats":null,"full_description":"\n<p>Adds role ''Anonymous''
+        to the user if it is not already present. Only admin\ncan set admin account.</p>\n","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"user","full_name":"user","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"login","full_name":"user[login]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"firstname","full_name":"user[firstname]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"lastname","full_name":"user[lastname]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"mail","full_name":"user[mail]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"admin","full_name":"user[admin]","description":"\n<p>Is
+        an admin account?</p>\n","required":false,"allow_nil":true,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"password","full_name":"user[password]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"auth_source_id","full_name":"user[auth_source_id]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be Integer","metadata":null,"show":true,"expected_type":"numeric"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/users/destroy","name":"destroy","apis":[{"api_url":"/api/users/:id","http_method":"DELETE","short_description":"Delete
+        an user."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"hostgroup_classes":{"doc_url":"../apidoc/v2/hostgroup_classes","api_url":"/api","name":"Hostgroup
+        classes","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/hostgroup_classes/index","name":"index","apis":[{"api_url":"/api/hostgroups/:hostgroup_id/puppetclass_ids","http_method":"GET","short_description":"List
+        all puppetclass id''s for hostgroup"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hostgroup_classes/create","name":"create","apis":[{"api_url":"/api/hostgroups/:hostgroup_id/puppetclass_ids","http_method":"POST","short_description":"Add
+        a puppetclass to hostgroup"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass_id","full_name":"puppetclass_id","description":"\n<p>id
+        of puppetclass</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/hostgroup_classes/destroy","name":"destroy","apis":[{"api_url":"/api/hostgroups/:hostgroup_id/puppetclass_ids/:id","http_method":"DELETE","short_description":"Remove
+        a puppetclass from hostgroup"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        of puppetclass</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"images":{"doc_url":"../apidoc/v2/images","api_url":"/api","name":"Images","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/images/index","name":"index","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/images","http_method":"GET","short_description":"List
+        all images for compute resource"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/images/show","name":"show","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/images/:id","http_method":"GET","short_description":"Show
+        an image"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/images/create","name":"create","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/images","http_method":"POST","short_description":"Create
+        a image"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"image","full_name":"image","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"image[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"username","full_name":"image[username]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"uuid","full_name":"image[uuid]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"image[compute_resource_id]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture_id","full_name":"image[architecture_id]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"image[operatingsystem_id]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/images/update","name":"update","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/images/:id","http_method":"PUT","short_description":"Update
+        a image."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"image","full_name":"image","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"image[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"username","full_name":"image[username]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"uuid","full_name":"image[uuid]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_resource_id","full_name":"image[compute_resource_id]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture_id","full_name":"image[architecture_id]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"image[operatingsystem_id]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/images/destroy","name":"destroy","apis":[{"api_url":"/api/compute_resources/:compute_resource_id/images/:id","http_method":"DELETE","short_description":"Delete
+        an image."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_resource_id","full_name":"compute_resource_id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"compute_profiles":{"doc_url":"../apidoc/v2/compute_profiles","api_url":"/api","name":"Compute
+        profiles","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/compute_profiles/index","name":"index","apis":[{"api_url":"/api/compute_profiles","http_method":"GET","short_description":"List
+        of compute profiles"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_profiles/show","name":"show","apis":[{"api_url":"/api/compute_profiles/:id","http_method":"GET","short_description":"Show
+        a compute profile."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_profiles/create","name":"create","apis":[{"api_url":"/api/compute_profiles","http_method":"POST","short_description":"Create
+        a compute profile."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"compute_profile","full_name":"compute_profile","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"compute_profile[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_profiles/update","name":"update","apis":[{"api_url":"/api/compute_profiles/:id","http_method":"PUT","short_description":"Update
+        a compute profile."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"compute_profile","full_name":"compute_profile","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"compute_profile[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/compute_profiles/destroy","name":"destroy","apis":[{"api_url":"/api/compute_profiles/:id","http_method":"DELETE","short_description":"Delete
+        a compute profile."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"override_values":{"doc_url":"../apidoc/v2/override_values","api_url":"/api","name":"Override
+        values","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/override_values/index","name":"index","apis":[{"api_url":"/api/smart_variables/:smart_variable_id/override_values","http_method":"GET","short_description":"List
+        of override values for a specific smart_variable"},{"api_url":"/api/smart_class_parameters/:smart_class_parameter_id/override_values","http_method":"GET","short_description":"List
+        of override values for a specific smart class parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"smart_variable_id","full_name":"smart_variable_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_class_parameter_id","full_name":"smart_class_parameter_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/override_values/show","name":"show","apis":[{"api_url":"/api/smart_variables/:smart_variable_id/override_values/:id","http_method":"GET","short_description":"Show
+        an override value for a specific smart_variable"},{"api_url":"/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id","http_method":"GET","short_description":"Show
+        an override value for a specific smart class parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"smart_variable_id","full_name":"smart_variable_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_class_parameter_id","full_name":"smart_class_parameter_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/override_values/create","name":"create","apis":[{"api_url":"/api/smart_variables/:smart_variable_id/override_values","http_method":"POST","short_description":"Create
+        an override value for a specific smart_variable"},{"api_url":"/api/smart_class_parameters/:smart_class_parameter_id/override_values","http_method":"POST","short_description":"Create
+        an override value for a specific smart class parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"smart_variable_id","full_name":"smart_variable_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"override_value","full_name":"override_value","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"match","full_name":"override_value[match]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"value","full_name":"override_value[value]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/override_values/update","name":"update","apis":[{"api_url":"/api/smart_variables/:smart_variable_id/override_values/:id","http_method":"PUT","short_description":"Update
+        an override value for a specific smart_variable"},{"api_url":"/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id","http_method":"PUT","short_description":"Update
+        an override value for a specific smart class parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"override_value","full_name":"override_value","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"match","full_name":"override_value[match]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"value","full_name":"override_value[value]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/override_values/destroy","name":"destroy","apis":[{"api_url":"/api/smart_variables/:smart_variable_id/override_values/:id","http_method":"DELETE","short_description":"Delete
+        an override value for a specific smart_variable"},{"api_url":"/api/smart_class_parameters/:smart_class_parameter_id/override_values/:id","http_method":"DELETE","short_description":"Delete
+        an override value for a specific smart class parameter"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"autosign":{"doc_url":"../apidoc/v2/autosign","api_url":"/api","name":"Autosign","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/autosign/index","name":"index","apis":[{"api_url":"/api/smart_proxies/smart_proxy_id/autosign","http_method":"GET","short_description":"List
+        all autosign"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"architectures":{"doc_url":"../apidoc/v2/architectures","api_url":"/api","name":"Architectures","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/architectures/index","name":"index","apis":[{"api_url":"/api/architectures","http_method":"GET","short_description":"List
+        all architectures."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/architectures/show","name":"show","apis":[{"api_url":"/api/architectures/:id","http_method":"GET","short_description":"Show
+        an architecture."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/architectures/create","name":"create","apis":[{"api_url":"/api/architectures","http_method":"POST","short_description":"Create
+        an architecture."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"architecture","full_name":"architecture","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"architecture[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_ids","full_name":"architecture[operatingsystem_ids]","description":"\n<p>Operatingsystem
+        ID''s</p>\n","required":false,"allow_nil":true,"validator":"Must be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/architectures/update","name":"update","apis":[{"api_url":"/api/architectures/:id","http_method":"PUT","short_description":"Update
+        an architecture."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"architecture","full_name":"architecture","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"architecture[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_ids","full_name":"architecture[operatingsystem_ids]","description":"\n<p>Operatingsystem
+        ID''s</p>\n","required":false,"allow_nil":true,"validator":"Must be Array","metadata":null,"show":true,"expected_type":"array"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/architectures/destroy","name":"destroy","apis":[{"api_url":"/api/architectures/:id","http_method":"DELETE","short_description":"Delete
+        an architecture."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"parameters":{"doc_url":"../apidoc/v2/parameters","api_url":"/api","name":"Parameters","short_description":null,"full_description":"\n<p>These
+        API calls are related to <b>nested parameters for host, domain,\nhostgroup,
+        operating system</b>. If you are looking for &lt;a\nhref=\"common_parameters.html\"&gt;global
+        parameters&lt;/a&gt;, go to &lt;a\nhref=\"common_parameters.html\"&gt;this
+        link&lt;/a&gt;.</p>\n","version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/parameters/index","name":"index","apis":[{"api_url":"/api/hosts/:host_id/parameters","http_method":"GET","short_description":"List
+        all parameters for host"},{"api_url":"/api/hostgroups/:hostgroup_id/parameters","http_method":"GET","short_description":"List
+        all parameters for hostgroup"},{"api_url":"/api/domains/:domain_id/parameters","http_method":"GET","short_description":"List
+        all parameters for domain"},{"api_url":"/api/operatingsystems/:operatingsystem_id/parameters","http_method":"GET","short_description":"List
+        all parameters for operating system"},{"api_url":"/api/locations/:location_id/parameters","http_method":"GET","short_description":"List
+        all parameters for location"},{"api_url":"/api/organizations/:organization_id/parameters","http_method":"GET","short_description":"List
+        all parameters for organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"domain_id","description":"\n<p>id
+        of domain</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"location_id","full_name":"location_id","description":"\n<p>id
+        of location</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"organization_id","full_name":"organization_id","description":"\n<p>id
+        of organization</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/parameters/show","name":"show","apis":[{"api_url":"/api/hosts/:host_id/parameters/:id","http_method":"GET","short_description":"Show
+        a nested parameter for host"},{"api_url":"/api/hostgroups/:hostgroup_id/parameters/:id","http_method":"GET","short_description":"Show
+        a nested parameter for hostgroup"},{"api_url":"/api/domains/:domain_id/parameters/:id","http_method":"GET","short_description":"Show
+        a nested parameter for domain"},{"api_url":"/api/operatingsystems/:operatingsystem_id/parameters/:id","http_method":"GET","short_description":"Show
+        a nested parameter for operating system"},{"api_url":"/api/locations/:location_id/parameters/:id","http_method":"GET","short_description":"Show
+        a nested parameter for location"},{"api_url":"/api/organizations/:organization_id/parameters/:id","http_method":"GET","short_description":"Show
+        a nested parameter for organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"domain_id","description":"\n<p>id
+        of domain</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"location_id","full_name":"location_id","description":"\n<p>id
+        of location</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"organization_id","full_name":"organization_id","description":"\n<p>id
+        of organization</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        of parameter</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/parameters/create","name":"create","apis":[{"api_url":"/api/hosts/:host_id/parameters","http_method":"POST","short_description":"Create
+        a nested parameter for host"},{"api_url":"/api/hostgroups/:hostgroup_id/parameters","http_method":"POST","short_description":"Create
+        a nested parameter for hostgroup"},{"api_url":"/api/domains/:domain_id/parameters","http_method":"POST","short_description":"Create
+        a nested parameter for domain"},{"api_url":"/api/operatingsystems/:operatingsystem_id/parameters","http_method":"POST","short_description":"Create
+        a nested parameter for operating system"},{"api_url":"/api/locations/:location_id/parameters","http_method":"POST","short_description":"Create
+        a nested parameter for location"},{"api_url":"/api/organizations/:organization_id/parameters","http_method":"POST","short_description":"Create
+        a nested parameter for organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"domain_id","description":"\n<p>id
+        of domain</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"location_id","full_name":"location_id","description":"\n<p>id
+        of location</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"organization_id","full_name":"organization_id","description":"\n<p>id
+        of organization</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"parameter","full_name":"parameter","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"parameter[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"value","full_name":"parameter[value]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/parameters/update","name":"update","apis":[{"api_url":"/api/hosts/:host_id/parameters/:id","http_method":"PUT","short_description":"Update
+        a nested parameter for host"},{"api_url":"/api/hostgroups/:hostgroup_id/parameters/:id","http_method":"PUT","short_description":"Update
+        a nested parameter for hostgroup"},{"api_url":"/api/domains/:domain_id/parameters/:id","http_method":"PUT","short_description":"Update
+        a nested parameter for domain"},{"api_url":"/api/operatingsystems/:operatingsystem_id/parameters/:id","http_method":"PUT","short_description":"Update
+        a nested parameter for operating system"},{"api_url":"/api/locations/:location_id/parameters/:id","http_method":"PUT","short_description":"Update
+        a nested parameter for location"},{"api_url":"/api/organizations/:organization_id/parameters/:id","http_method":"PUT","short_description":"Update
+        a nested parameter for organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"domain_id","description":"\n<p>id
+        of domain</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"location_id","full_name":"location_id","description":"\n<p>id
+        of location</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"organization_id","full_name":"organization_id","description":"\n<p>id
+        of organization</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        of parameter</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"parameter","full_name":"parameter","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"parameter[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"value","full_name":"parameter[value]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/parameters/destroy","name":"destroy","apis":[{"api_url":"/api/hosts/:host_id/parameters/:id","http_method":"DELETE","short_description":"Delete
+        a nested parameter for host"},{"api_url":"/api/hostgroups/:hostgroup_id/parameters/:id","http_method":"DELETE","short_description":"Delete
+        a nested parameter for hostgroup"},{"api_url":"/api/domains/:domain_id/parameters/:id","http_method":"DELETE","short_description":"Delete
+        a nested parameter for domain"},{"api_url":"/api/operatingsystems/:operatingsystem_id/parameters/:id","http_method":"DELETE","short_description":"Delete
+        a nested parameter for operating system"},{"api_url":"/api/locations/:location_id/parameters/:id","http_method":"DELETE","short_description":"Delete
+        a nested parameter for location"},{"api_url":"/api/organizations/:organization_id/parameters/:id","http_method":"DELETE","short_description":"Delete
+        a nested parameter for organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"domain_id","description":"\n<p>id
+        of domain</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"location_id","full_name":"location_id","description":"\n<p>id
+        of location</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"organization_id","full_name":"organization_id","description":"\n<p>id
+        of organization</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        of parameter</p>\n","required":true,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/parameters/reset","name":"reset","apis":[{"api_url":"/api/hosts/:host_id/parameters","http_method":"DELETE","short_description":"Delete
+        all nested parameters for host"},{"api_url":"/api/hostgroups/:hostgroup_id/parameters","http_method":"DELETE","short_description":"Delete
+        all nested parameters for hostgroup"},{"api_url":"/api/domains/:domain_id/parameters","http_method":"DELETE","short_description":"Delete
+        all nested parameters for domain"},{"api_url":"/api/operatingsystems/:operatingsystem_id/parameters","http_method":"DELETE","short_description":"Delete
+        all nested parameters for operating system"},{"api_url":"/api/locations/:location_id/parameters","http_method":"DELETE","short_description":"Delete
+        all nested parameter for location"},{"api_url":"/api/organizations/:organization_id/parameters","http_method":"DELETE","short_description":"Delete
+        all nested parameter for organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of host</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"domain_id","full_name":"domain_id","description":"\n<p>id
+        of domain</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"location_id","full_name":"location_id","description":"\n<p>id
+        of location</p>\n","required":false,"allow_nil":false,"validator":"Must be
+        String","metadata":null,"show":true,"expected_type":"string"},{"name":"organization_id","full_name":"organization_id","description":"\n<p>id
+        of organization</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"organizations":{"doc_url":"../apidoc/v2/organizations","api_url":"/api","name":"Organizations","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/organizations/index","name":"index","apis":[{"api_url":"/api/organizations","http_method":"GET","short_description":"List
+        all organizations"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/organizations/show","name":"show","apis":[{"api_url":"/api/organizations/:id","http_method":"GET","short_description":"Show
+        an organization"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/organizations/create","name":"create","apis":[{"api_url":"/api/organizations","http_method":"POST","short_description":"Create
+        an organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"organization","full_name":"organization","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"organization[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/organizations/update","name":"update","apis":[{"api_url":"/api/organizations/:id","http_method":"PUT","short_description":"Update
+        an organization"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"organization","full_name":"organization","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"organization[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/organizations/destroy","name":"destroy","apis":[{"api_url":"/api/organizations/:id","http_method":"DELETE","short_description":"Delete
+        an organization"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"locations":{"doc_url":"../apidoc/v2/locations","api_url":"/api","name":"Locations","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/locations/index","name":"index","apis":[{"api_url":"/api/locations","http_method":"GET","short_description":"List
+        all locations"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/locations/show","name":"show","apis":[{"api_url":"/api/locations/:id","http_method":"GET","short_description":"Show
+        a location"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/locations/create","name":"create","apis":[{"api_url":"/api/locations","http_method":"POST","short_description":"Create
+        a location"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"location","full_name":"location","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"location[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/locations/update","name":"update","apis":[{"api_url":"/api/locations/:id","http_method":"PUT","short_description":"Update
+        a location"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"location","full_name":"location","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"location[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/locations/destroy","name":"destroy","apis":[{"api_url":"/api/locations/:id","http_method":"DELETE","short_description":"Delete
+        a location"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]},"config_groups":{"doc_url":"../apidoc/v2/config_groups","api_url":"/api","name":"Config
+        groups","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/config_groups/index","name":"index","apis":[{"api_url":"/api/config_groups","http_method":"GET","short_description":"List
+        of config groups"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_groups/show","name":"show","apis":[{"api_url":"/api/config_groups/:id","http_method":"GET","short_description":"Show
+        a config group."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_groups/create","name":"create","apis":[{"api_url":"/api/config_groups","http_method":"POST","short_description":"Create
+        a config group."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"config_group","full_name":"config_group","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"config_group[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_groups/update","name":"update","apis":[{"api_url":"/api/config_groups/:id","http_method":"PUT","short_description":"Update
+        a config group."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"config_group","full_name":"config_group","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"config_group[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/config_groups/destroy","name":"destroy","apis":[{"api_url":"/api/config_groups/:id","http_method":"DELETE","short_description":"Delete
+        a config group."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"puppetclasses":{"doc_url":"../apidoc/v2/puppetclasses","api_url":"/api","name":"Puppetclasses","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/puppetclasses/index","name":"index","apis":[{"api_url":"/api/puppetclasses","http_method":"GET","short_description":"List
+        all puppetclasses."},{"api_url":"/api/hosts/:host_id/puppetclasses","http_method":"GET","short_description":"List
+        all puppetclasses for host"},{"api_url":"/api/hostgroups/:hostgroup_id/puppetclasses","http_method":"GET","short_description":"List
+        all puppetclasses for hostgroup"},{"api_url":"/api/environments/:environment_id/puppetclasses","http_method":"GET","short_description":"List
+        all puppetclasses for environment"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of nested host</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of nested hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"environment_id","description":"\n<p>id
+        of nested environment</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/puppetclasses/show","name":"show","apis":[{"api_url":"/api/puppetclasses/:id","http_method":"GET","short_description":"Show
+        a puppetclass"},{"api_url":"/api/hosts/:host_id/puppetclasses/:id","http_method":"GET","short_description":"Show
+        a puppetclass for host"},{"api_url":"/api/hostgroups/:hostgroup_id/puppetclasses/:id","http_method":"GET","short_description":"Show
+        a puppetclass for hostgroup"},{"api_url":"/api/environments/:environment_id/puppetclasses/:id","http_method":"GET","short_description":"Show
+        a puppetclass for environment"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"host_id","full_name":"host_id","description":"\n<p>id
+        of nested host</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"hostgroup_id","full_name":"hostgroup_id","description":"\n<p>id
+        of nested hostgroup</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"environment_id","description":"\n<p>id
+        of nested environment</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"\n<p>id
+        of puppetclass</p>\n","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/puppetclasses/create","name":"create","apis":[{"api_url":"/api/puppetclasses","http_method":"POST","short_description":"Create
+        a puppetclass."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"puppetclass","full_name":"puppetclass","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"puppetclass[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/puppetclasses/update","name":"update","apis":[{"api_url":"/api/puppetclasses/:id","http_method":"PUT","short_description":"Update
+        a puppetclass."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"puppetclass","full_name":"puppetclass","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"puppetclass[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/puppetclasses/destroy","name":"destroy","apis":[{"api_url":"/api/puppetclasses/:id","http_method":"DELETE","short_description":"Delete
+        a puppetclass."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"os_default_templates":{"doc_url":"../apidoc/v2/os_default_templates","api_url":"/api","name":"Os
+        default templates","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/os_default_templates/index","name":"index","apis":[{"api_url":"/api/operatingsystems/:operatingsystem_id/os_default_templates","http_method":"GET","short_description":"List
+        os default templates for operating system"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/os_default_templates/show","name":"show","apis":[{"api_url":"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id","http_method":"GET","short_description":"Show
+        a os default template kind for operating system"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/os_default_templates/create","name":"create","apis":[{"api_url":"/api/operatingsystems/:operatingsystem_id/os_default_templates","http_method":"POST","short_description":"Create
+        a os default template for operating system"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"os_default_template","full_name":"os_default_template","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"template_kind_id","full_name":"os_default_template[template_kind_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"config_template_id","full_name":"os_default_template[config_template_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/os_default_templates/update","name":"update","apis":[{"api_url":"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id","http_method":"PUT","short_description":"Update
+        a os default template for operating system"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"os_default_template","full_name":"os_default_template","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"template_kind_id","full_name":"os_default_template[template_kind_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"},{"name":"config_template_id","full_name":"os_default_template[config_template_id]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a number.","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/os_default_templates/destroy","name":"destroy","apis":[{"api_url":"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id","http_method":"DELETE","short_description":"Delete
+        a os default template for operating system"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"operatingsystem_id","full_name":"operatingsystem_id","description":"\n<p>id
+        of operating system</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"template_kinds":{"doc_url":"../apidoc/v2/template_kinds","api_url":"/api","name":"Template
+        kinds","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/template_kinds/index","name":"index","apis":[{"api_url":"/api/template_kinds","http_method":"GET","short_description":"List
+        all template kinds."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"dashboard":{"doc_url":"../apidoc/v2/dashboard","api_url":"/api","name":"Dashboard","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/dashboard/index","name":"index","apis":[{"api_url":"/api/dashboard","http_method":"GET","short_description":"Get
+        Dashboard results"}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"environments":{"doc_url":"../apidoc/v2/environments","api_url":"/api","name":"Environments","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/environments/import_puppetclasses","name":"import_puppetclasses","apis":[{"api_url":"/api/smart_proxies/:id/import_puppetclasses","http_method":"POST","short_description":"Import
+        puppet classes from puppet proxy."},{"api_url":"/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses","http_method":"POST","short_description":"Import
+        puppet classes from puppet proxy for particular environment."},{"api_url":"/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses","http_method":"POST","short_description":"Import
+        puppet classes from puppet proxy for particular environment."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"smart_proxy_id","full_name":"smart_proxy_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"environment_id","full_name":"environment_id","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"dryrun","full_name":"dryrun","description":"","required":false,"allow_nil":false,"validator":"Must
+        be ''true'' or ''false''","metadata":null,"show":true,"expected_type":"string"},{"name":"except","full_name":"except","description":"\n<p>Optional
+        comma-deliminated string containing either ''new,updated,obsolete''\nused
+        to limit the import_puppetclasses actions</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/environments/index","name":"index","apis":[{"api_url":"/api/environments","http_method":"GET","short_description":"List
+        all environments."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>Filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>Sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/environments/show","name":"show","apis":[{"api_url":"/api/environments/:id","http_method":"GET","short_description":"Show
+        an environment."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/environments/create","name":"create","apis":[{"api_url":"/api/environments","http_method":"POST","short_description":"Create
+        an environment."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"environment","full_name":"environment","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"environment[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/environments/update","name":"update","apis":[{"api_url":"/api/environments/:id","http_method":"PUT","short_description":"Update
+        an environment."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"},{"name":"environment","full_name":"environment","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"environment[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/environments/destroy","name":"destroy","apis":[{"api_url":"/api/environments/:id","http_method":"DELETE","short_description":"Delete
+        an environment."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"ptables":{"doc_url":"../apidoc/v2/ptables","api_url":"/api","name":"Ptables","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/ptables/index","name":"index","apis":[{"api_url":"/api/ptables","http_method":"GET","short_description":"List
+        all ptables."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/ptables/show","name":"show","apis":[{"api_url":"/api/ptables/:id","http_method":"GET","short_description":"Show
+        a ptable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/ptables/create","name":"create","apis":[{"api_url":"/api/ptables","http_method":"POST","short_description":"Create
+        a ptable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"ptable","full_name":"ptable","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"ptable[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"layout","full_name":"ptable[layout]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"os_family","full_name":"ptable[os_family]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/ptables/update","name":"update","apis":[{"api_url":"/api/ptables/:id","http_method":"PUT","short_description":"Update
+        a ptable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"ptable","full_name":"ptable","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"ptable[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"layout","full_name":"ptable[layout]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"os_family","full_name":"ptable[os_family]","description":"","required":false,"allow_nil":true,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/ptables/destroy","name":"destroy","apis":[{"api_url":"/api/ptables/:id","http_method":"DELETE","short_description":"Delete
+        a ptable."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"usergroups":{"doc_url":"../apidoc/v2/usergroups","api_url":"/api","name":"Usergroups","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/usergroups/index","name":"index","apis":[{"api_url":"/api/usergroups","http_method":"GET","short_description":"List
+        all usergroups."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"page","full_name":"page","description":"\n<p>paginate
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"per_page","full_name":"per_page","description":"\n<p>number
+        of entries per request</p>\n","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"search","full_name":"search","description":"\n<p>filter
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"},{"name":"order","full_name":"order","description":"\n<p>sort
+        results</p>\n","required":false,"allow_nil":false,"validator":"Must be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/usergroups/show","name":"show","apis":[{"api_url":"/api/usergroups/:id","http_method":"GET","short_description":"Show
+        a usergroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be an identifier, string from 1 to 128 characters containing only alphanumeric
+        characters, space, underscore(_), hypen(-) with no leading or trailing space.","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/usergroups/create","name":"create","apis":[{"api_url":"/api/usergroups","http_method":"POST","short_description":"Create
+        a usergroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"usergroup","full_name":"usergroup","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"usergroup[name]","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/usergroups/update","name":"update","apis":[{"api_url":"/api/usergroups/:id","http_method":"PUT","short_description":"Update
+        a usergroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"},{"name":"usergroup","full_name":"usergroup","description":"","required":false,"allow_nil":true,"validator":"Must
+        be a Hash","expected_type":"hash","metadata":null,"show":true,"params":[{"name":"name","full_name":"usergroup[name]","description":"","required":false,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}]}],"examples":[],"metadata":null,"see":[]},{"doc_url":"../apidoc/v2/usergroups/destroy","name":"destroy","apis":[{"api_url":"/api/usergroups/:id","http_method":"DELETE","short_description":"Delete
+        a usergroup."}],"formats":null,"full_description":"","errors":[],"params":[{"name":"id","full_name":"id","description":"","required":true,"allow_nil":false,"validator":"Must
+        be String","metadata":null,"show":true,"expected_type":"string"}],"examples":[],"metadata":null,"see":[]}]},"statistics":{"doc_url":"../apidoc/v2/statistics","api_url":"/api","name":"Statistics","short_description":null,"full_description":null,"version":"v2","formats":null,"metadata":null,"methods":[{"doc_url":"../apidoc/v2/statistics/index","name":"index","apis":[{"api_url":"/api/statistics","http_method":"GET","short_description":"Get
+        statistics"}],"formats":null,"full_description":"","errors":[],"params":[],"examples":[],"metadata":null,"see":[]}]}}}}'
+    http_version:
+  recorded_at: Tue, 24 Mar 2015 20:59:44 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
A few of the data models that we need are not available in the old `foreman_api` gem.
gem `apipie-binding` is the official foreman gem and supports all the latest data models

/cc @gmcculloug @brandondunne