### PR TITLE
User v/s System initiated vm or service retirement

### DIFF
--- a/vmdb/app/models/service.rb
+++ b/vmdb/app/models/service.rb
@@ -101,7 +101,7 @@ class Service < ActiveRecord::Base
 
   def self.invoke_tasks_local(options)
     options[:invoke_by] = :task
-    args = []
+    args = options[:task] == 'retire_now' ? [options[:userid]] : []
 
     services, tasks = self.validate_tasks(options)
 

--- a/vmdb/app/models/service/retirement_management.rb
+++ b/vmdb/app/models/service/retirement_management.rb
@@ -17,7 +17,7 @@ module Service::RetirementManagement
     self.service_resources.each do |sr|
       if sr.resource.respond_to?(:retire_now)
         $log.info("Retiring service resource for service: #{name} resource ID: #{sr.id}")
-        sr.resource.retire_now
+        sr.resource.retire_now(retirement_requester)
       end
     end
   end

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -416,6 +416,9 @@ class VmOrTemplate < ActiveRecord::Base
     elsif ["create_snapshot"].include?(options[:task])
       options[:invoke_by] = :task
       args = [options[:name], options[:description], options[:memory]]
+    elsif ["retire_now"].include?(options[:task])
+      options[:invoke_by] = :task
+      args = [options[:userid]]
     else
       options[:invoke_by] = :task
       args = []

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -407,16 +407,17 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def self.invoke_tasks_local(options)
-    if ["scan","sync"].include?(options[:task])
+    case options[:task]
+    when "scan", "sync" then
       options[:invoke_by] = :job
       args = [options[:userid]]
-    elsif ["remove_snapshot", "revert_to_snapshot"].include?(options[:task])
+    when "remove_snapshot", "revert_to_snapshot" then
       options[:invoke_by] = :task
       args = [options[:snap_selected]]
-    elsif ["create_snapshot"].include?(options[:task])
+    when "create_snapshot" then
       options[:invoke_by] = :task
       args = [options[:name], options[:description], options[:memory]]
-    elsif ["retire_now"].include?(options[:task])
+    when "retire_now" then
       options[:invoke_by] = :task
       args = [options[:userid]]
     else

--- a/vmdb/db/migrate/20150324111111_add_retirement_requester_to_vms_and_services.rb
+++ b/vmdb/db/migrate/20150324111111_add_retirement_requester_to_vms_and_services.rb
@@ -1,0 +1,7 @@
+class AddRetirementRequesterToVmsAndServices < ActiveRecord::Migration
+  def change
+    [:vms, :services].each do |klass|
+      add_column klass, :retirement_requester, :string
+    end
+  end
+end

--- a/vmdb/db/migrate/20150324111111_add_retirement_requester_to_vms_and_services.rb
+++ b/vmdb/db/migrate/20150324111111_add_retirement_requester_to_vms_and_services.rb
@@ -1,7 +1,6 @@
 class AddRetirementRequesterToVmsAndServices < ActiveRecord::Migration
   def change
-    [:vms, :services].each do |klass|
-      add_column klass, :retirement_requester, :string
-    end
+    add_column :vms, :retirement_requester, :string
+    add_column :services, :retirement_requester, :string
   end
 end

--- a/vmdb/spec/models/vm/retirement_management_spec.rb
+++ b/vmdb/spec/models/vm/retirement_management_spec.rb
@@ -37,6 +37,26 @@ describe "VM Retirement Management" do
     @vm.retire_now
   end
 
+  it "#retire_now with userid" do
+    event_name = 'request_vm_retire'
+    event_hash = {:vm => @vm, :host => @vm.host, :type => "VmVmware",
+                  :retirement_initiator => "user", :user_id => 'freddy'}
+
+    expect(MiqAeEvent).to receive(:raise_evm_event).with(event_name, @vm, event_hash).once
+
+    @vm.retire_now('freddy')
+  end
+
+  it "#retire_now without userid" do
+    event_name = 'request_vm_retire'
+    event_hash = {:vm => @vm, :host => @vm.host, :type => "VmVmware",
+                  :retirement_initiator => "system"}
+
+    expect(MiqAeEvent).to receive(:raise_evm_event).with(event_name, @vm, event_hash).once
+
+    @vm.retire_now
+  end
+
   it "#retire warn" do
     expect(AuditEvent).to receive(:success).once
     options = {}
@@ -127,7 +147,8 @@ describe "VM Retirement Management" do
 
   it "#raise_retirement_event" do
     event_name = 'foo'
-    event_hash = {:vm => @vm, :host => @vm.host, :type => "VmVmware"}
+    event_hash = {:vm => @vm, :host => @vm.host, :type => "VmVmware",
+                  :retirement_initiator => "system"}
 
     expect(MiqAeEvent).to receive(:raise_evm_event).with(event_name, @vm, event_hash).once
 

--- a/vmdb/spec/models/vm_spec.rb
+++ b/vmdb/spec/models/vm_spec.rb
@@ -99,6 +99,20 @@ describe Vm do
       Vm.stub(:start).and_raise(MiqException::MiqVimBrokerUnavailable)
       msg.deliver
     end
+
+    it "retirement passes in userid" do
+      options = {:task => "retire_now", :invoke_by => :task, :ids => [@vm.id], :userid => "Freddy"}
+      Vm.invoke_tasks_local(options)
+      MiqTask.count.should == 1
+      task = MiqTask.first
+      MiqQueue.count.should == 1
+      msg = MiqQueue.first
+
+      msg.miq_callback.should == {:class_name => "MiqTask", :method_name => :queue_callback,
+                                  :instance_id => task.id, :args => ["Finished"]}
+      msg.args.should == ["Freddy"]
+    end
+
   end
 
   context "#start" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=943865

This RFE requires us to identify if a retirement was called
by the user or by the system, which allows the customer to use
a different automate model based on the requester.

(1) We have added a new attribute called retirement_requester
    for service and vm class. This is set to user logged in from the UI
    or nil if it's being initiated by the scheduled system event.

(2) Two new attributes have been added to evm root object

    retirement_initiator          which can be either 'user' or 'system'
    user_id                            contains the user name for user initiated retirement

    To access it in a automate method use
      $evm.root["retirement_initiator"]

    In the automate model instances use
      /#retirement_initiator

    The above attributes can be used to control which automate models
    get used.