### PR TITLE
UI should be able to only display state machine classes

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -57,6 +57,7 @@ class CatalogController < ApplicationController
   def servicetemplate_edit
     assert_privileges(params[:pressed]) if params[:pressed]
     checked = find_checked_items
+    @sb[:fqname_array] = MiqAeClass.fqnames_for_state_machines
     checked[0] = params[:id] if checked.blank? && params[:id]
     @record = checked[0] ? find_by_id_filtered(ServiceTemplate, checked[0]) : ServiceTemplate.new
     @sb[:st_form_active_tab] = "basic"

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -57,7 +57,7 @@ class CatalogController < ApplicationController
   def servicetemplate_edit
     assert_privileges(params[:pressed]) if params[:pressed]
     checked = find_checked_items
-    @sb[:path_id_array] = MiqAeClass.waypoint_ids_for_state_machines
+    @sb[:cached_waypoint_ids] = MiqAeClass.waypoint_ids_for_state_machines
     checked[0] = params[:id] if checked.blank? && params[:id]
     @record = checked[0] ? find_by_id_filtered(ServiceTemplate, checked[0]) : ServiceTemplate.new
     @sb[:st_form_active_tab] = "basic"

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -57,7 +57,7 @@ class CatalogController < ApplicationController
   def servicetemplate_edit
     assert_privileges(params[:pressed]) if params[:pressed]
     checked = find_checked_items
-    @sb[:fqname_array] = MiqAeClass.fqnames_for_state_machines
+    @sb[:path_id_array] = MiqAeClass.waypoint_ids_for_state_machines
     checked[0] = params[:id] if checked.blank? && params[:id]
     @record = checked[0] ? find_by_id_filtered(ServiceTemplate, checked[0]) : ServiceTemplate.new
     @sb[:st_form_active_tab] = "basic"

--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -152,25 +152,27 @@ class MiqAeClass < ActiveRecord::Base
       )
     end
   end
-  def self.fqnames_for_state_machines
-    paths = []
+
+  def self.waypoint_ids_for_state_machines
+    ids = []
     MiqAeClass.all.select(&:state_machine?).each do |klass|
-      paths << klass.fqname
-      next if paths.include?(klass.namespace)
-      sub_namespaces(klass.ae_namespace.fqname, paths)
+      ids << klass.id
+      next if ids.include?(klass.ae_namespace.id)
+      sub_namespaces(klass.ae_namespace, ids)
     end
-    paths
+    ids
   end
 
   private
 
-  def self.sub_namespaces(fqname, paths)
-    nslist = fqname.split('/')
-    for i in 1..nslist.length - 1
-      ns = nslist[0..i].join('/')
-      paths << ns unless paths.include?(ns)
+  def self.sub_namespaces(ns_obj, ids)
+    loop do
+      break if ns_obj.nil? || (ns_obj && ids.include?(ns_obj.id))
+      ids << ns_obj.id
+      ns_obj = ns_obj.parent
     end
   end
+
   private_class_method :sub_namespaces
 
   def scoped_methods(s)

--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -154,20 +154,18 @@ class MiqAeClass < ActiveRecord::Base
   end
 
   def self.waypoint_ids_for_state_machines
-    ids = []
-    MiqAeClass.all.select(&:state_machine?).each do |klass|
+    MiqAeClass.all.select(&:state_machine?).each_with_object([]) do |klass, ids|
       ids << klass.id
       next if ids.include?(klass.ae_namespace.id)
       sub_namespaces(klass.ae_namespace, ids)
     end
-    ids
   end
 
   private
 
   def self.sub_namespaces(ns_obj, ids)
     loop do
-      break if ns_obj.nil? || (ns_obj && ids.include?(ns_obj.id))
+      break if ns_obj.nil? || ids.include?(ns_obj.id)
       ids << ns_obj.id
       ns_obj = ns_obj.parent
     end

--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -152,8 +152,26 @@ class MiqAeClass < ActiveRecord::Base
       )
     end
   end
+  def self.fqnames_for_state_machines
+    paths = []
+    MiqAeClass.all.select(&:state_machine?).each do |klass|
+      paths << klass.fqname
+      next if paths.include?(klass.namespace)
+      sub_namespaces(klass.ae_namespace.fqname, paths)
+    end
+    paths
+  end
 
   private
+
+  def self.sub_namespaces(fqname, paths)
+    nslist = fqname.split('/')
+    for i in 1..nslist.length - 1
+      ns = nslist[0..i].join('/')
+      paths << ns unless paths.include?(ns)
+    end
+  end
+  private_class_method :sub_namespaces
 
   def scoped_methods(s)
     self.ae_methods.select { |m| m.scope == s }

--- a/vmdb/app/presenters/tree_builder_ae_class.rb
+++ b/vmdb/app/presenters/tree_builder_ae_class.rb
@@ -17,7 +17,7 @@ class TreeBuilderAeClass  < TreeBuilder
     objects = if MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
                 [MiqAeDomain.find_by_id(@sb[:domain_id])] # GIT support can't use where
               else
-                MiqAeDomain.all
+                filter_ae_objects(MiqAeDomain.all, @sb[:fqname_array])
               end
     count_only_or_objects(options[:count_only], objects, [:priority]).reverse
   end
@@ -34,11 +34,16 @@ class TreeBuilderAeClass  < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, options)
-    objects = object.ae_namespaces
+    objects = filter_ae_objects(object.ae_namespaces, @sb[:fqname_array])
     unless MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-      ns_classes = object.ae_classes
+      ns_classes = filter_ae_objects(object.ae_classes, @sb[:fqname_array])
       objects += ns_classes.flatten unless ns_classes.blank?
     end
     count_only_or_objects(options[:count_only], objects, [:display_name, :name])
+  end
+
+  def filter_ae_objects(objects, fqname_array)
+    return objects unless fqname_array
+    objects.select { |obj| fqname_array.include?(obj.fqname) }
   end
 end

--- a/vmdb/app/presenters/tree_builder_ae_class.rb
+++ b/vmdb/app/presenters/tree_builder_ae_class.rb
@@ -17,7 +17,7 @@ class TreeBuilderAeClass  < TreeBuilder
     objects = if MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
                 [MiqAeDomain.find_by_id(@sb[:domain_id])] # GIT support can't use where
               else
-                filter_ae_objects(MiqAeDomain.all, @sb[:fqname_array])
+                filter_ae_objects(MiqAeDomain.all, @sb[:path_id_array])
               end
     count_only_or_objects(options[:count_only], objects, [:priority]).reverse
   end
@@ -34,16 +34,16 @@ class TreeBuilderAeClass  < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, options)
-    objects = filter_ae_objects(object.ae_namespaces, @sb[:fqname_array])
+    objects = filter_ae_objects(object.ae_namespaces, @sb[:path_id_array])
     unless MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-      ns_classes = filter_ae_objects(object.ae_classes, @sb[:fqname_array])
+      ns_classes = filter_ae_objects(object.ae_classes, @sb[:path_id_array])
       objects += ns_classes.flatten unless ns_classes.blank?
     end
     count_only_or_objects(options[:count_only], objects, [:display_name, :name])
   end
 
-  def filter_ae_objects(objects, fqname_array)
-    return objects unless fqname_array
-    objects.select { |obj| fqname_array.include?(obj.fqname) }
+  def filter_ae_objects(objects, path_id_array)
+    return objects unless path_id_array
+    objects.select { |obj| path_id_array.include?(obj.id) }
   end
 end

--- a/vmdb/app/presenters/tree_builder_ae_class.rb
+++ b/vmdb/app/presenters/tree_builder_ae_class.rb
@@ -17,7 +17,7 @@ class TreeBuilderAeClass  < TreeBuilder
     objects = if MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
                 [MiqAeDomain.find_by_id(@sb[:domain_id])] # GIT support can't use where
               else
-                filter_ae_objects(MiqAeDomain.all, @sb[:path_id_array])
+                filter_ae_objects(MiqAeDomain.all)
               end
     count_only_or_objects(options[:count_only], objects, [:priority]).reverse
   end
@@ -34,16 +34,16 @@ class TreeBuilderAeClass  < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, options)
-    objects = filter_ae_objects(object.ae_namespaces, @sb[:path_id_array])
+    objects = filter_ae_objects(object.ae_namespaces)
     unless MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-      ns_classes = filter_ae_objects(object.ae_classes, @sb[:path_id_array])
+      ns_classes = filter_ae_objects(object.ae_classes)
       objects += ns_classes.flatten unless ns_classes.blank?
     end
     count_only_or_objects(options[:count_only], objects, [:display_name, :name])
   end
 
-  def filter_ae_objects(objects, path_id_array)
-    return objects unless path_id_array
-    objects.select { |obj| path_id_array.include?(obj.id) }
+  def filter_ae_objects(objects)
+    return objects unless @sb[:cached_waypoint_ids]
+    objects.select { |obj| @sb[:cached_waypoint_ids].include?(obj.id) }
   end
 end

--- a/vmdb/spec/models/miq_ae_class_spec.rb
+++ b/vmdb/spec/models/miq_ae_class_spec.rb
@@ -324,5 +324,10 @@ describe MiqAeClass do
       ids += class_fqnames.collect { |cls| MiqAeClass.find_by_fqname(cls).id }
       MiqAeClass.waypoint_ids_for_state_machines.should match_array(ids)
     end
+
+    it "no state machine classes" do
+      create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
+      MiqAeClass.waypoint_ids_for_state_machines.should be_empty
+    end
   end
 end

--- a/vmdb/spec/models/miq_ae_class_spec.rb
+++ b/vmdb/spec/models/miq_ae_class_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 
+include AutomationSpecHelper
 describe MiqAeClass do
 
   it { should validate_presence_of(:name) }
@@ -309,6 +310,19 @@ describe MiqAeClass do
       field1.destroy
       @c1.reload
       @c1.state_machine?.should be_false
+    end
+  end
+
+  context "waypoint_ids_for_state_machine" do
+    it "check ids" do
+      create_state_ae_model(:name => 'FRED', :ae_class => 'CLASS1', :ae_namespace  => 'A/B/C')
+      create_state_ae_model(:name => 'FREDDY', :ae_class => 'CLASS2', :ae_namespace  => 'C/D/E')
+      create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
+      ns_fqnames = %w(FRED FRED/A FRED/A/B FRED/A/B/C FREDDY FREDDY/C FREDDY/C/D FREDDY/C/D/E)
+      class_fqnames = %w(/FRED/A/B/C/CLASS1 /FREDDY/C/D/E/CLASS2)
+      ids = ns_fqnames.collect { |ns| MiqAeNamespace.find_by_fqname(ns, false).id }
+      ids += class_fqnames.collect { |cls| MiqAeClass.find_by_fqname(cls).id }
+      MiqAeClass.waypoint_ids_for_state_machines.should match_array(ids)
     end
   end
 end

--- a/vmdb/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/vmdb/spec/presenters/tree_builder_ae_class_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+include AutomationSpecHelper
+
+describe TreeBuilderAeClass do
+  before do
+    create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace  => 'A/B/C')
+    create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
+    @sb = {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
+  end
+
+  context "initialize" do
+    it "a tree with filter" do
+      @sb[:cached_waypoint_ids] =  MiqAeClass.waypoint_ids_for_state_machines
+      tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
+      domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      domains.should match_array ['LUIGI']
+    end
+
+    it "a tree without filter" do
+      tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
+      domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      domains.should match_array %w(LUIGI MARIO)
+    end
+  end
+end

--- a/vmdb/spec/support/automation_spec_helper.rb
+++ b/vmdb/spec/support/automation_spec_helper.rb
@@ -38,6 +38,16 @@ module AutomationSpecHelper
                        attrs.merge('ae_fields' => ae_fields, 'ae_instances' => ae_instances))
   end
 
+  def create_state_ae_model(attrs = {})
+    attrs = default_ae_model_attributes(attrs)
+    instance_name = attrs.delete(:instance_name)
+    ae_fields = {'field1' => {:aetype => 'state', :datatype => 'string'}}
+    ae_instances = {instance_name => {'field1' => {:value => 'phases of matter'}}}
+
+    FactoryGirl.create(:miq_ae_domain, :with_small_model, :with_instances,
+                       attrs.merge('ae_fields' => ae_fields, 'ae_instances' => ae_instances))
+  end
+
   def default_ae_model_attributes(attrs = {})
     attrs.reverse_merge!(
       :ae_class      => 'CLASS1',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1205453

The UI displays a tree control allowing the user to select retirement entry points for provisioning, reconfiguring and retirement. The current display shows all classes state machine and non state machine classes. This PR allows the UI to only display only those classes which are state machine classes.


