### PR TITLE
Prevent crash when LDAP user authentication succeeds but the user shouldn't login anyway

### DIFF
--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -709,6 +709,7 @@ class DashboardController < ApplicationController
     session[:winW]     = winw
     session['referer'] = referer
 
+    return nil if db_user.nil? || !db_user.userid
     session[:userid] = db_user.userid
 
     # Set the current userid in the User class for this thread for models to use


### PR DESCRIPTION
In these cases, the user is not created nor found and UserValidationService#validate_user passes nil to session_reset, which couldn't handle it.

In the end, the crash was the only thing preventing the proper error message to show.

https://bugzilla.redhat.com/show_bug.cgi?id=1203713