### PR TITLE
kubernetes: handle new pod restartPolicy format

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -67,11 +67,17 @@ module EmsRefresh::Parsers
     def parse_pod(pod)
       # pod in kubernetes is container group in manageiq
       new_result = parse_base_item(pod)
+      # TODO: remove hash support when old versions are not in use anymore
+      #       https://github.com/GoogleCloudPlatform/kubernetes/issues/3607
+      if pod.spec.restartPolicy.kind_of?(Hash)
+        pod_restart_policy = pod.spec.restartPolicy.keys.first.to_s
+      else
+        pod_restart_policy = pod.spec.restartPolicy
+      end
       new_result.merge!(
         # namespace is overriden in more_core_extensions and hence needs a non method access
         :namespace      => pod.metadata.instance_values["table"][:namespace],
-        # workaround due to https://github.com/GoogleCloudPlatform/kubernetes/issues/3607
-        :restart_policy => pod.spec.restartPolicy.to_h.keys.first.to_s,
+        :restart_policy => pod_restart_policy,
         :dns_policy     => pod.spec.dnsPolicy
       )
       # TODO, map volumes


### PR DESCRIPTION
This patch adds the support of the new restartPolicy format:

  https://github.com/GoogleCloudPlatform/kubernetes/issues/3607

Until we're sure that everyone updated their kubernetes instance (probably until v1.0 is officially released) it's better to handle both.