### PR TITLE
Fleecing support for VSAN.

### DIFF
--- a/vmdb/app/models/job_proxy_dispatcher.rb
+++ b/vmdb/app/models/job_proxy_dispatcher.rb
@@ -287,7 +287,7 @@ class JobProxyDispatcher
         return []
       end
     else
-      unless ["VMFS", "NAS", "NFS", "ISCSI", "DIR", "FCP"].include?(@vm.storage.store_type)
+      unless ["VSAN", "VMFS", "NAS", "NFS", "ISCSI", "DIR", "FCP"].include?(@vm.storage.store_type)
         msg = "Vm storage type [#{@vm.storage.store_type}] not supported [#{job.target_id}], aborting job [#{job.guid}]."
         self.queue_signal(job, {:args => [:abort, msg, "error"]})
         return []

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1298,6 +1298,7 @@ class VmOrTemplate < ActiveRecord::Base
 
     case self.storage.store_type
     when "VMFS" then "[#{storage.name}] #{location}"
+    when "VSAN" then "[#{storage.name}] #{location}"
     when "NFS"  then "[#{storage.name}] #{location}"
     when "NAS"  then File.join(storage.name, location)
     else


### PR DESCRIPTION
Enable the fleecing ov VMs that reside on VSAN based datastores.
https://bugzilla.redhat.com/show_bug.cgi?id=1166303
https://bugzilla.redhat.com/show_bug.cgi?id=1205780