### PR TITLE
Fix adding policy action of type remove or inherit tags

### DIFF
--- a/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
@@ -438,7 +438,7 @@ module MiqPolicyController::MiqActions
     end
 
     if %w(inherit_parent_tags remove_tags).include?(@action.action_type)
-      tag = Classification.find_tag_by_name(@action.options[:cats])
+      tag = Tag.find_by_classification_name(@action.options[:cats])
       cats = Classification.where(:tag_id => tag.id).pluck(:description)
       @temp[:cats] = cats.sort_by(&:downcase).join(" | ")
     end

--- a/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/vmdb/app/controllers/miq_policy_controller/miq_actions.rb
@@ -437,8 +437,9 @@ module MiqPolicyController::MiqActions
       @action_policies = @action.miq_policies.sort_by { |p| p.description.downcase }
     end
 
-    if ["inherit_parent_tags","remove_tags"].include?(@action.action_type)
-      cats = Classification.where(:name => @action.options[:cats]).pluck(:description)
+    if %w(inherit_parent_tags remove_tags).include?(@action.action_type)
+      tag = Classification.find_tag_by_name(@action.options[:cats])
+      cats = Classification.where(:tag_id => tag.id).pluck(:description)
       @temp[:cats] = cats.sort_by(&:downcase).join(" | ")
     end
   end

--- a/vmdb/app/models/classification.rb
+++ b/vmdb/app/models/classification.rb
@@ -310,16 +310,8 @@ class Classification < ActiveRecord::Base
     tag.nil? ? nil : self.class.find_by_tag_id(tag.id)
   end
 
-  def self.find_tag_by_name(name, region_id = self.my_region_number, ns = DEFAULT_NAMESPACE)
-    if region_id.nil?
-      Tag.find_by_name(Classification.name2tag(name, 0, ns))
-    else
-      Tag.in_region(region_id).find_by_name(Classification.name2tag(name, 0, ns))
-    end
-  end
-
   def self.find_by_name(name, region_id = self.my_region_number, ns = DEFAULT_NAMESPACE)
-    tag = self.find_tag_by_name(name, region_id, ns)
+    tag = Tag.find_by_classification_name(name, region_id, ns)
     tag.nil? ? nil : self.find_by_tag_id(tag.id)
   end
 

--- a/vmdb/app/models/classification.rb
+++ b/vmdb/app/models/classification.rb
@@ -310,12 +310,16 @@ class Classification < ActiveRecord::Base
     tag.nil? ? nil : self.class.find_by_tag_id(tag.id)
   end
 
-  def self.find_by_name(name, region_id = self.my_region_number, ns = DEFAULT_NAMESPACE)
+  def self.find_tag_by_name(name, region_id = self.my_region_number, ns = DEFAULT_NAMESPACE)
     if region_id.nil?
-      tag = Tag.find_by_name(Classification.name2tag(name, 0, ns))
+      Tag.find_by_name(Classification.name2tag(name, 0, ns))
     else
-      tag = Tag.in_region(region_id).find_by_name(Classification.name2tag(name, 0, ns))
+      Tag.in_region(region_id).find_by_name(Classification.name2tag(name, 0, ns))
     end
+  end
+
+  def self.find_by_name(name, region_id = self.my_region_number, ns = DEFAULT_NAMESPACE)
+    tag = self.find_tag_by_name(name, region_id, ns)
     tag.nil? ? nil : self.find_by_tag_id(tag.id)
   end
 

--- a/vmdb/app/models/tag.rb
+++ b/vmdb/app/models/tag.rb
@@ -104,6 +104,14 @@ class Tag < ActiveRecord::Base
     list
   end
 
+  def self.find_by_classification_name(name, region_id = Classification.my_region_number, ns = Classification::DEFAULT_NAMESPACE)
+    if region_id.nil?
+      Tag.find_by_name(Classification.name2tag(name, 0, ns))
+    else
+      Tag.in_region(region_id).find_by_name(Classification.name2tag(name, 0, ns))
+    end
+  end
+
   def ==(comparison_object)
     super || name.downcase == comparison_object.to_s.downcase
   end

--- a/vmdb/app/views/miq_policy/_action_details.html.haml
+++ b/vmdb/app/views/miq_policy/_action_details.html.haml
@@ -202,7 +202,7 @@
               %td= h(@temp[:cats])
           %hr
         - when "remove_tags"
-          %h3=_("Inherit Tags")
+          %h3=_("Remove Tags")
           %table.style1
             %tr
               %td.key=_("Categories")

--- a/vmdb/spec/models/tag_spec.rb
+++ b/vmdb/spec/models/tag_spec.rb
@@ -67,4 +67,27 @@ describe Tag do
       expect(categorization).to eq(expected_categorization)
     end
   end
+
+  context "classification" do
+    before do
+      parent = FactoryGirl.create(:classification, :name => "test_category")
+      FactoryGirl.create(:classification_tag,      :name => "test_entry",         :parent => parent)
+      FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
+    end
+
+    it "finds tag by name" do
+      Tag.find_by_classification_name("test_category").should_not.nil?
+      Tag.find_by_classification_name("test_category").name.should == '/managed/test_category'
+    end
+
+    it "doesn't find non tag" do
+      Tag.find_by_classification_name("test_entry").should.nil?
+    end
+
+    it "finds tag by name and ns" do
+      ns = '/managed/test_category'
+      Tag.find_by_classification_name("test_entry", nil, ns).should_not.nil?
+      Tag.find_by_classification_name("test_entry", nil, ns).name.should == "#{ns}/test_entry"
+    end
+  end
 end


### PR DESCRIPTION
Classification has custom find_by_name that looks up tag by name and classification by tag id
That got broken by the rails4 rewrite, this commit restores the same logic but on the caller side.
(No other callers call `Classification.where(:name => ...)`).

Pulled out the find tag by name functionality used in `Classification.find_by_name` into new `Classification.find_tag_by_name` so it's a bit cleaner.

Also the label for remove_tags should not say Inherit Tags :)

https://bugzilla.redhat.com/show_bug.cgi?id=1205496