### PR TITLE
remove valid_route? method

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1333,7 +1333,7 @@ class ApplicationController < ActionController::Base
     if MiqProductFeature.feature_exists?(ident)
       role_allows(:feature => ident, :any => true)
     else
-      valid_route?(request.request_method, controller_name, action_name)
+      true
     end
   end
 
@@ -2690,11 +2690,6 @@ class ApplicationController < ActionController::Base
   def assert_privileges(feature)
     raise MiqException::RbacPrivilegeException,
           _("The user is not authorized for this task or item.") unless role_allows(:feature => feature)
-  end
-
-  def valid_route?(request_method, controller,  action)
-    valid_actions = CONTROLLER_ACTIONS.fetch_path(controller.to_sym, request_method.downcase.to_sym) || []
-    valid_actions.include?(action)
   end
 
   def previous_breadcrumb_url

--- a/vmdb/spec/controllers/application_controller_spec.rb
+++ b/vmdb/spec/controllers/application_controller_spec.rb
@@ -64,18 +64,6 @@ describe ApplicationController do
     end
   end
 
-  context "#valid_route?" do
-    it "should return true for a valid route" do
-      result = controller.send(:valid_route?, 'POST', 'host', 'show')
-      result.should be_true
-    end
-
-    it "should return false for an invalid route" do
-      result = controller.send(:valid_route?, 'POST', 'host', 'some_route')
-      result.should be_false
-    end
-  end
-
   context "#view_yaml_filename" do
     before do
       EvmSpecHelper.seed_specific_product_features("vm_infra_explorer", "host_edit")


### PR DESCRIPTION
Since b2fbab8d51f4708dae33415285de66fbf104455f removed the catch-all
route, the Rails router will not allow requests that we have not
specified.  This means we don't need to specifically check that a
request is part of the CONTROLLER_ACTIONS hash

/cc @martinpovolny @h-kataria 