### PR TITLE
Alert - make Event to Check field required when adding/updating an Event Threshold Alert

### DIFF
--- a/vmdb/app/controllers/miq_policy_controller/alerts.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alerts.rb
@@ -105,7 +105,7 @@ module MiqPolicyController::Alerts
       @edit[:new][:repeat_time] = alert_default_repeat_time
     end
 
-    @edit[:new][:expression][:options][:event_types] = [params[:event_types]] if params[:event_types]
+    @edit[:new][:expression][:options][:event_types] = [params[:event_types]].reject(&:blank?) if params[:event_types]
     @edit[:new][:expression][:options][:time_threshold] = params[:time_threshold].to_i if params[:time_threshold]
     @edit[:new][:expression][:options][:hourly_time_threshold] = params[:hourly_time_threshold].to_i if params[:hourly_time_threshold]
     @edit[:new][:expression][:options][:freq_threshold] = params[:freq_threshold] if params[:freq_threshold]
@@ -534,6 +534,10 @@ module MiqPolicyController::Alerts
     if alert.options[:notifications][:automate]
       add_flash(_("%s is required") % "Event Name", :error) if alert.options[:notifications][:automate][:event_name].blank?
     end
+    if alert.expression[:eval_method] == 'event_threshold'
+      add_flash(_("%s is required") % "Event to Check", :error) if alert.expression[:options][:event_types].blank?
+    end
+
     if @edit.fetch_path(:new, :expression, :eval_method) == "realtime_performance"
       vt = @edit.fetch_path(:new, :expression, :options, :value_threshold)
       unless vt && is_integer?(vt)

--- a/vmdb/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -16,7 +16,11 @@
           "data-miq_sparkle_off" => true,
           "data-miq_observe"     => observe)
       - else
-        = h(@sb[:alert][:events][@alert.expression[:options][:event_types].first])
+        - if @alert.expression[:options][:event_types].nil?
+          %span.bg-warning
+            =_("No type set")
+        - else
+          = h(@sb[:alert][:events][@alert.expression[:options][:event_types].first])
   - when :time_threshold
     %td.key
       = h(option[:description])


### PR DESCRIPTION
What the subject says, prevents a crash trying to show the alert when Event to Check is an empty array. 

https://bugzilla.redhat.com/show_bug.cgi?id=1204635