### PR TITLE
Adding support for plugins adding Gems to miq. This lets rpms lay down g...

### DIFF
--- a/vmdb/.gitignore
+++ b/vmdb/.gitignore
@@ -114,3 +114,6 @@ vendor/plugins/princely/.gitignore
 
 # vendor/plugins/rails_sql_views/
 vendor/plugins/rails_sql_views/.gitignore
+
+# ignore included plugins in bundler.d
+bundler.d/*

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -73,6 +73,11 @@ gem "uglifier",                       "~>2.4.0",      :require => false
 gem "novnc-rails",                    "~>0.2"
 gem 'spice-html5-rails'
 
+## Include plugin gems
+Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
+  self.instance_eval(Bundler.read_file(bundle))
+end
+
 ### Start of gems excluded from the appliances.
 # The gems listed below do not need to be packaged until we find it necessary or useful.
 # Only add gems here that we do not need on an appliance.

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -73,11 +73,6 @@ gem "uglifier",                       "~>2.4.0",      :require => false
 gem "novnc-rails",                    "~>0.2"
 gem 'spice-html5-rails'
 
-## Include plugin gems
-Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
-  self.instance_eval(Bundler.read_file(bundle))
-end
-
 ### Start of gems excluded from the appliances.
 # The gems listed below do not need to be packaged until we find it necessary or useful.
 # Only add gems here that we do not need on an appliance.
@@ -143,3 +138,9 @@ end
 if File.exist?(File.expand_path("Gemfile.dev.rb", File.dirname(__FILE__)))
   MiqBundler.include_gemfile("Gemfile.dev.rb", binding)
 end
+
+# Load plugins that are packaged as Gems
+Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
+  MiqBundler.include_gemfile(bundle, binding)
+end
+


### PR DESCRIPTION
In CFME I need to be able to add a plugin Gem to vmdb like """gem 'redhat_access_cfme', '~>0.0.1'""". This plugin will be laid down with an RPM.

This PR uses something similar to https://github.com/theforeman/foreman/blob/develop/Gemfile#L30 to allow plugins to incluide Gems in MIQ and CFME without touching the Gemfile.