### PR TITLE
Fixes Bootstrap conflicts with old style3 class tables

### DIFF
--- a/vmdb/app/assets/stylesheets/patternfly_overrides.less
+++ b/vmdb/app/assets/stylesheets/patternfly_overrides.less
@@ -185,7 +185,7 @@ table.table tbody td img {
   font-family: inherit !important;
 }
 
-table.table .narrow {
+table .narrow {
   width: 1%
 }
 

--- a/vmdb/app/assets/stylesheets/template.css.erb
+++ b/vmdb/app/assets/stylesheets/template.css.erb
@@ -302,8 +302,6 @@ table.style3 thead tr th, .modtitle{
 } 
 table.style3 thead tr th.special{height: 30px; border-bottom:0px; text-align: left;} /*special header formatting for dropdowns, etc  within table above table data*/
 table.style3 thead tr th.special div {display:inline-block}
-table.style3 thead tr th.checkbox {height: 26px;}
-table.style3 thead tr th.icon {width:24px; padding-left:6px;}
 table.style3 thead .sorting_asc, table.style3 thead .sorting_desc {
   display: block;
   position: relative;
@@ -346,12 +344,10 @@ table.style3 tbody tr:hover td {background: #d5ecf8 !important; cursor: pointer;
 table.style3 tbody tr.no-hover:hover td {background: none !important; cursor:default} /*disables hover and pointer on row*/
 table.style3 tbody tr.seperator td {margin:0; padding:0;height:5px;border: 0;background: #ccc;font-size: 2%;}
 table.style3 tbody tr td {border: 1px solid transparent;border-right: 1px solid #d1d1d1;border-bottom-color: #e7e7e7;padding: 2px 2px 2px 10px;margin: 0;vertical-align: top;cursor: default;}
-table.style3 tbody tr td img {height: 20px; float:left; padding-right: 5px}
-table.style3 tbody tr td.checkbox {width: 20px; height: 32px;padding-left: 24px;}
-table.style3 tbody tr td.group_spacer {font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;} /*used in miq_report*/
-table.style3 tbody tr td.icon {min-width:24px; padding-left:6px; text-align: center} 
+table.style3 tbody tr td.group_spacer {font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;} /*used in miq_report*/ 
 table.style3 tbody tr td.label {display: table-cell;width: 20% !important; min-width: 200px; font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;cursor: default;color: #333; text-align: left;}
 table.style3 tbody tr td.select {text-align:center;}
+table.style3 tbody tr td.narrow {padding-left: 3px;}
 table.style3 tfoot {display: none}
 
 .rss_widget table.style3 tbody tr td {font-style:italic;}

--- a/vmdb/app/views/layouts/gtl/_list.html.haml
+++ b/vmdb/app/views/layouts/gtl/_list.html.haml
@@ -37,10 +37,10 @@
     %thead
       %tr
         - unless @embedded || @no_checkboxes
-          %th.checkbox
+          %th.narrow
             &nbsp;
         - unless @no_listicon
-          %th.icon
+          %th.narrow
             &nbsp;
         - view.headers.each_with_index do |h, i|
           - if !@embedded && @pages
@@ -66,10 +66,10 @@
       - if get_vmdb_config[:product][:vmdb_connections_filter] && view.db == "VmdbDatabaseConnection"
         %tr
           - unless @embedded || @no_checkboxes
-            %th.checkbox
+            %th.narrow
               &nbsp;
           - unless @no_listicon
-            %th.icon
+            %th.narrow
               &nbsp;
           - view.col_order.each do |col|
             %th{:nowrap => 1}
@@ -86,7 +86,7 @@
         %tr{:class => cls}
           - cursor = %w(MiqEvent MiqTask VmdbDatabaseConnection VmdbDatabaseSetting).include?(view.db) || @embedded ? "default" : "pointer"
           - unless @embedded || @no_checkboxes
-            %td{:class => "checkbox", :style => "cursor: #{cursor}"}
+            %td{:class => "narrow", :style => "cursor: #{cursor}"}
               = check_box_tag("check_#{@id}", 1, false,
                 :id      => "listcheckbox",
                 :onclick => "miqUpdateButtons(this, '#{button_div}');")
@@ -164,7 +164,7 @@
                 - click = remote_function(:url => {:action => 'diagnostics_worker_selected', :id => "#{row['id']}"})
               - else
                 - click = "DoNav('#{url_for_db(view.db)}');"
-            %td.icon{:title => title, :onclick => click, :nowrap => true,
+            %td.narrow{:title => title, :onclick => click, :nowrap => true,
               :onmouseover  => "ChangeColor(this, true); this.style.cursor='#{cursor}';",
               :onmouseout   => "ChangeColor(this, false);"}
               = render :partial => "layouts/listicon", :locals => {:db => view.db, :row => row, :icon_image => listicon_image}


### PR DESCRIPTION
* removed icon and checkbox classes, replaced with .narrow class used in new tables

https://bugzilla.redhat.com/show_bug.cgi?id=1206124
https://bugzilla.redhat.com/show_bug.cgi?id=1201140