### PR TITLE
Extract Install Time during RPM analysis

### DIFF
--- a/lib/metadata/linux/LinuxPackages.rb
+++ b/lib/metadata/linux/LinuxPackages.rb
@@ -180,7 +180,7 @@ module MiqLinux
             pkgs = doc.add_element 'applications'
             @packages.each do |p|
                 next if !p.installed
-                pkgs.add_element('application', {"name" => p.name, "version" => p.version, "description" => p.description, "typename" => p.category, "arch" => p.arch, "release" => p.release})
+                pkgs.add_element('application', {"name" => p.name, "version" => p.version, "description" => p.description, "typename" => p.category, "arch" => p.arch, "release" => p.release, "install_time" => p.installtime})
 									# "status" => p.status, "depends" => p.depends
             end
             doc

--- a/vmdb/db/migrate/20150326154800_add_application_install_time.rb
+++ b/vmdb/db/migrate/20150326154800_add_application_install_time.rb
@@ -1,0 +1,5 @@
+class AddApplicationInstallTime < ActiveRecord::Migration
+  def change
+    add_column :guest_applications, :install_time, :timestamp
+  end
+end


### PR DESCRIPTION
Expands rpm metadata analysis to extract installtime & convert to ruby date object.