### PR TITLE
Fix ruby2 trap logging and worker row status update

### DIFF
--- a/vmdb/lib/tasks/evm_application.rb
+++ b/vmdb/lib/tasks/evm_application.rb
@@ -21,7 +21,7 @@ class EvmApplication
     MiqServer.kill_all_workers
     rr      = File.expand_path(Rails.root)
     runner  = File.join(rr, "bin/rails runner")
-    program = File.join(rr, "lib/workers/evm_server.rb")
+    program = File.join(rr, "lib/workers/bin/evm_server.rb")
     command_line = "#{runner} #{program}"
 
     env_options = {}

--- a/vmdb/lib/workers/bin/evm_server.rb
+++ b/vmdb/lib/workers/bin/evm_server.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby script/runner
+
+require "workers/evm_server"
+EvmServer.start(*ARGV) if MiqEnvironment::Process.is_rails_runner?

--- a/vmdb/lib/workers/bin/evm_server.rb
+++ b/vmdb/lib/workers/bin/evm_server.rb
@@ -1,4 +1,2 @@
-#!/usr/bin/env ruby script/runner
-
 require "workers/evm_server"
 EvmServer.start(*ARGV) if MiqEnvironment::Process.is_rails_runner?

--- a/vmdb/lib/workers/bin/worker.rb
+++ b/vmdb/lib/workers/bin/worker.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby script/runner
-
 type = ARGV.shift
 require "workers/#{type}"
 type.camelize.constantize.start_worker(*ARGV)

--- a/vmdb/lib/workers/evm_server.rb
+++ b/vmdb/lib/workers/evm_server.rb
@@ -85,5 +85,3 @@ class EvmServer
     self.new(cfg).start
   end
 end
-
-EvmServer.start(*ARGV) if MiqEnvironment::Process.is_rails_runner?

--- a/vmdb/lib/workers/evm_server.rb
+++ b/vmdb/lib/workers/evm_server.rb
@@ -3,7 +3,7 @@ require 'pid_file'
 
 class EvmServer
   SOFT_INTERRUPT_SIGNALS = ["TERM", "USR1", "USR2"]
-  HARD_INTERRUPT_SIGNALS = ["INT", "KILL"]
+  HARD_INTERRUPT_SIGNALS = ["INT"]
 
   OPTIONS_PARSER_SETTINGS = [
     [:mode, 'EVM Server Mode', String],

--- a/vmdb/lib/workers/evm_server.rb
+++ b/vmdb/lib/workers/evm_server.rb
@@ -2,8 +2,7 @@ require 'miq-process'
 require 'pid_file'
 
 class EvmServer
-  SOFT_INTERRUPT_SIGNALS = ["TERM", "USR1", "USR2"]
-  HARD_INTERRUPT_SIGNALS = ["INT"]
+  SOFT_INTERRUPT_SIGNALS = ["SIGTERM", "SIGUSR1", "SIGUSR2"]
 
   OPTIONS_PARSER_SETTINGS = [
     [:mode, 'EVM Server Mode', String],
@@ -11,9 +10,6 @@ class EvmServer
 
   def initialize(cfg = {})
     @cfg = cfg
-
-    HARD_INTERRUPT_SIGNALS.each { |s| Signal.trap(s) { self.process_hard_signal(s) } if Signal.list.keys.include?(s) }
-    SOFT_INTERRUPT_SIGNALS.each { |s| Signal.trap(s) { self.process_soft_signal(s) } if Signal.list.keys.include?(s) }
 
     $log ||= Rails.logger
   end
@@ -63,12 +59,18 @@ class EvmServer
     end
 
     at_exit {
+      # TODO: should this be called on SOFT ints and SystemExit, not SIGINT?
       # register a shutdown method to run when server exits
       MiqServer.stop
     }
 
     PidFile.create(MiqServer.pidfile)
     MiqServer.start
+  rescue Interrupt => e
+    process_hard_signal(e.message)
+  rescue SignalException => e
+    raise unless SOFT_INTERRUPT_SIGNALS.include?(e.message)
+    process_soft_signal(e.message)
   end
 
   def self.start(*args)

--- a/vmdb/lib/workers/mixins/web_server_worker_mixin.rb
+++ b/vmdb/lib/workers/mixins/web_server_worker_mixin.rb
@@ -1,0 +1,15 @@
+module WebServerWorkerMixin
+  included do
+    self.wait_for_worker_monitor = false
+  end
+
+  def do_work
+  end
+
+  def do_before_work_loop
+    @worker.release_db_connection
+
+    # Since thin traps interrupts, log that we're going away and update our worker row
+    at_exit { do_exit("Exit request received.") }
+  end
+end

--- a/vmdb/lib/workers/ui_worker.rb
+++ b/vmdb/lib/workers/ui_worker.rb
@@ -1,15 +1,6 @@
 require 'workers/worker_base'
+require 'workers/mixins/web_server_worker_mixin'
 
 class UiWorker < WorkerBase
-  self.wait_for_worker_monitor = false
-
-  def do_work
-  end
-
-  def do_before_work_loop
-    @worker.release_db_connection
-
-    # Since thin traps interrupts, log that we're going away and update our worker row
-    at_exit { do_exit("Exit request received.") }
-  end
+  include WebServerWorkerMixin
 end

--- a/vmdb/lib/workers/ui_worker.rb
+++ b/vmdb/lib/workers/ui_worker.rb
@@ -3,15 +3,13 @@ require 'workers/worker_base'
 class UiWorker < WorkerBase
   self.wait_for_worker_monitor = false
 
-  # Do NOT process the signal that we use to terminate Mongrel
-  def self.interrupt_signals
-    INTERRUPT_SIGNALS - ['TERM']
-  end
-
   def do_work
   end
 
   def do_before_work_loop
     @worker.release_db_connection
+
+    # Since thin traps interrupts, log that we're going away and update our worker row
+    at_exit { do_exit("Exit request received.") }
   end
 end

--- a/vmdb/lib/workers/web_service_worker.rb
+++ b/vmdb/lib/workers/web_service_worker.rb
@@ -1,15 +1,6 @@
 require 'workers/worker_base'
+require 'workers/mixins/web_server_worker_mixin'
 
 class WebServiceWorker < WorkerBase
-  self.wait_for_worker_monitor = false
-
-  def do_work
-  end
-
-  def do_before_work_loop
-    @worker.release_db_connection
-
-    # Since thin traps interrupts, log that we're going away and update our worker row
-    at_exit { do_exit("Exit request received.") }
-  end
+  include WebServerWorkerMixin
 end

--- a/vmdb/lib/workers/web_service_worker.rb
+++ b/vmdb/lib/workers/web_service_worker.rb
@@ -3,15 +3,13 @@ require 'workers/worker_base'
 class WebServiceWorker < WorkerBase
   self.wait_for_worker_monitor = false
 
-  # Do NOT process the signal that we use to terminate Mongrel
-  def self.interrupt_signals
-    INTERRUPT_SIGNALS - ['TERM']
-  end
-
   def do_work
   end
 
   def do_before_work_loop
     @worker.release_db_connection
+
+    # Since thin traps interrupts, log that we're going away and update our worker row
+    at_exit { do_exit("Exit request received.") }
   end
 end

--- a/vmdb/lib/workers/worker_base.rb
+++ b/vmdb/lib/workers/worker_base.rb
@@ -52,6 +52,13 @@ class WorkerBase
 
     $log ||= Rails.logger
 
+    worker_initialization
+    after_initialize
+
+    @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
+  end
+
+  def worker_initialization
     starting_worker_record
 
     # Sync the config and roles early since heartbeats and logging require the configuration
@@ -59,10 +66,6 @@ class WorkerBase
     sync_config
 
     set_connection_pool_size
-
-    after_initialize
-
-    @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
   end
 
   def set_connection_pool_size

--- a/vmdb/spec/lib/workers/evm_server_spec.rb
+++ b/vmdb/spec/lib/workers/evm_server_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+require 'workers/evm_server'
+
+describe EvmServer do
+  context "#start" do
+    let(:server) { described_class.new }
+
+    before do
+      MiqServer.stub(:running? => false)
+      PidFile.stub(:create)
+    end
+
+    it "SIGINT" do
+      MiqServer.stub(:start).and_raise(Interrupt)
+      server.should_receive(:process_hard_signal)
+      server.start
+    end
+
+    it "SIGTERM" do
+      MiqServer.stub(:start).and_raise(SignalException, "SIGTERM")
+      server.should_receive(:process_soft_signal)
+      server.start
+    end
+
+    it "unhandled signal SIGALRM" do
+      MiqServer.stub(:start).and_raise(SignalException, "SIGALRM")
+      expect { server.start }.to raise_error(SignalException, "SIGALRM")
+    end
+  end
+end

--- a/vmdb/spec/lib/workers/worker_base_spec.rb
+++ b/vmdb/spec/lib/workers/worker_base_spec.rb
@@ -3,23 +3,14 @@ require "spec_helper"
 require 'workers/worker_base'
 
 describe WorkerBase do
-  context "with a worker script and worker row" do
+  context "#check_parent_process" do
     before(:each) do
-      @server_guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@server_guid)
-      @zone       = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server_master, :zone => @zone, :guid => @server_guid)
-      MiqServer.my_server(true)
+      _guid, @miq_server, _zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @worker_guid = MiqUUID.new_guid
       @worker = FactoryGirl.create(:miq_worker, :guid => @worker_guid, :miq_server_id => @miq_server.id)
 
-      #FIXME: worker scripts need fix the below methods/instance variables to make it easier to test
-      WorkerBase.any_instance.stub(:sync_active_roles)
-      WorkerBase.any_instance.stub(:sync_config)
-      WorkerBase.any_instance.stub(:set_connection_pool_size)
-
-      # All that for this...
+      WorkerBase.any_instance.stub(:worker_initialization)
       @worker_base = WorkerBase.new(:guid => @worker_guid)
     end
 

--- a/vmdb/spec/lib/workers/worker_base_spec.rb
+++ b/vmdb/spec/lib/workers/worker_base_spec.rb
@@ -34,6 +34,30 @@ describe WorkerBase do
       @worker_base.should_receive(:do_exit).never
       @worker_base.send(:check_parent_process)
     end
+  end
 
+  context "#start" do
+    before do
+      WorkerBase.any_instance.stub(:worker_initialization)
+      @worker_base = WorkerBase.new
+      @worker_base.stub(:prepare)
+    end
+
+    it "SIGINT" do
+      @worker_base.stub(:run).and_raise(Interrupt)
+      @worker_base.should_receive(:do_exit)
+      @worker_base.start
+    end
+
+    it "SIGTERM" do
+      @worker_base.stub(:run).and_raise(SignalException, "SIGTERM")
+      @worker_base.should_receive(:do_exit)
+      @worker_base.start
+    end
+
+    it "unhandled signal SIGALRM" do
+      @worker_base.stub(:run).and_raise(SignalException, "SIGALRM")
+      expect { @worker_base.start }.to raise_error(SignalException, "SIGALRM")
+    end
   end
 end


### PR DESCRIPTION
EDIT:  Added worker_base tests and added signal handling of 'thin' based workers (UI/WebService workers).

Note, these changes to the 'thin' based workers also fixes an issue that was a problem with ruby 1.9.3, namely, UI/Webservice workers that are sent SIGINT/SIGTERM don't gracefully log their "exit" or update their worker row.  This caused them the server to wait for them to timeout, instead of restarting them immediately.

Among other things, you can't log in the trap signal handler in ruby 2.0.
https://bugs.ruby-lang.org/issues/7917

Results in the following ugly messages: 'Log writing failed. can't be called from trap context' 

* Add a EvmServer binstub so EvmServer can be required directly.

* Don't try to trap SIGKILL since it can't be trapped/ignored.

*  Cleanup WorkerBase initialization to simplify test setup.

* Convert server signal 'trap' to normal SignalException handling.

* Convert worker 'trap' to normal SignalException handling.

* Add at_exit for thin based workers since thin traps interrupts.

* Extract all of the commmon WS/UI worker script code to a mixin.

    https://bugzilla.redhat.com/show_bug.cgi?id=1205407