### PR TITLE
remove "cancel" handling from `create`

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -228,12 +228,7 @@ module EmsCommon
     assert_privileges("#{model.to_s.underscore}_new")
     return unless load_edit("ems_edit__new")
     get_form_vars
-    _model = model # render blocks instance eval, so cache the value on the stack
     case params[:button]
-    when "cancel"
-      render :update do |page|
-        page.redirect_to :action=>'show_list', :flash_msg=>_("Add of new %s was cancelled by the user") % ui_lookup(:model=>_model.to_s)
-      end
     when "add"
       if @edit[:new][:emstype].blank?
         add_flash(_("%s is required") % "Type", :error)

--- a/vmdb/app/views/shared/views/ems_common/_form.html.haml
+++ b/vmdb/app/views/shared/views/ems_common/_form.html.haml
@@ -75,7 +75,8 @@
       %tr
         %td{:align => "right"}
           #buttons_on
-            - t = _("Add this %s") % ui_lookup(:model => model_for_ems(@ems).to_s)
+            - name = ui_lookup(:model => model_for_ems(@ems).to_s)
+            - t = _("Add this %s") % name
             = button_tag(_('Add'),
               :class   => "btn btn-primary",
               :alt     => t,
@@ -86,6 +87,7 @@
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :onclick => "miqAjaxButton('#{url_for(:action => "create", :id => "new", :button => "cancel")}');")
+              :href    => url_for(:action => "show_list", :flash_msg=>_("Add of new %s was cancelled by the user") % name),
+              :onclick => 'window.location = this.getAttribute("href");')
   - else
     = render :partial => '/layouts/edit_form_buttons', :locals  => {:record_id => @ems.id, :ajax_buttons => true}

--- a/vmdb/spec/controllers/ems_infra_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_infra_controller_spec.rb
@@ -8,15 +8,6 @@ describe EmsInfraController do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    it "can use the cancel button on create" do
-      controller.instance_variable_set(:@edit, {:new => {},
-                                                :key => "ems_edit__new"})
-      session[:edit] = assigns(:edit)
-      controller.stub(:drop_breadcrumb)
-      post :create, :button => "cancel"
-      expect(response.status).to eq(200)
-    end
-
     it "when VM Right Size Recommendations is pressed" do
       controller.should_receive(:vm_right_size)
       post :button, :pressed => "vm_right_size", :format => :js


### PR DESCRIPTION
This patch allows us to avoid doing a roundtrip to the server just to
gereate a string and redirect the user.  It implements the "cancel"
button just with javascript.  This means that clicking "cancel" will
simply take the user to the page they want in 1 request rather than 2
requests (plus RJS).