### PR TITLE
search box not working before breakpoint

### DIFF
--- a/vmdb/app/views/layouts/_page_center.html.haml
+++ b/vmdb/app/views/layouts/_page_center.html.haml
@@ -14,13 +14,13 @@
               .col-md-12
                 = render :partial => "layouts/taskbar"
           .row
-            .col-sm-5.col-md-5.pull-right
-              %br
-              = render :partial => 'layouts/searchbar'
-            .col-sm-7.col-md-7
+            .col-sm-12.col-md-7
               = render :partial => "layouts/breadcrumbs"
               - if layout_uses_tabs?
                 = render :partial => 'layouts/tabs'
+            .col-sm-12.col-md-5
+              %br
+              = render :partial => 'layouts/searchbar'
           .row#main_content
             .col-md-12
               = yield


### PR DESCRIPTION
* Adjusted responsive columns so that search box isn't blocked before the breakpoint.

#1574