### PR TITLE
Add foreman automate model and service models

### DIFF
--- a/vmdb/app/models/miq_provision_configured_system_request.rb
+++ b/vmdb/app/models/miq_provision_configured_system_request.rb
@@ -12,11 +12,31 @@ class MiqProvisionConfiguredSystemRequest < MiqRequest
   default_value_for(:requester)    { |r| r.get_user }
 
   def host_name
-    options[:src_configured_system_ids].length == 1 ? src_hosts.pluck(:hostname).first : "Multiple Hosts"
+    options[:src_configured_system_ids].length == 1 ? src_configured_systems.pluck(:hostname).first : "Multiple Hosts"
   end
 
-  def src_hosts
+  def src_configured_systems
     ConfiguredSystem.where(:id => options[:src_configured_system_ids])
+  end
+
+  def requested_task_idx
+    options[:src_configured_system_ids]
+  end
+
+  def my_zone
+    src_configured_systems.first.my_zone
+  end
+
+  def my_role
+    'ems_operations'
+  end
+
+  def self.request_task_class_from(_attribs)
+    MiqProvisionTaskConfiguredSystemForeman
+  end
+
+  def self.new_request_task(attribs)
+    request_task_class_from(attribs).new(attribs)
   end
 
   private

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman.rb
@@ -5,4 +5,27 @@ class MiqProvisionTaskConfiguredSystemForeman < MiqProvisionTask
   def model_class
     ConfiguredSystemForeman
   end
+
+  def self.request_class
+    MiqProvisionConfiguredSystemRequest
+  end
+
+  def deliver_to_automate
+    super("configured_system_provision", my_zone)
+  end
+
+  def after_ae_delivery(ae_result)
+    log_header = "MIQ(#{self.class.name}.after_ae_delivery)"
+
+    $log.info("#{log_header} ae_result=#{ae_result.inspect}")
+
+    return if ae_result == 'retry'
+    return if miq_request.state == 'finished'
+
+    if ae_result == 'ok'
+      update_and_notify_parent(:state => "finished", :status => "Ok", :message => "#{request_class::TASK_DESCRIPTION} completed")
+    else
+      update_and_notify_parent(:state => "finished", :status => "Error")
+    end
+  end
 end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Lifecycle.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Lifecycle.class/__class__.yaml
@@ -1,0 +1,613 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Lifecycle
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: assertion
+      name: guard
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_entry
+      display_name: 
+      datatype: 
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship1
+      display_name: 
+      datatype: 
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method1
+      display_name: 
+      datatype: 
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship2
+      display_name: 
+      datatype: 
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method2
+      display_name: 
+      datatype: 
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship3
+      display_name: 
+      datatype: 
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method3
+      display_name: 
+      datatype: 
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship4
+      display_name: 
+      datatype: 
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method4
+      display_name: 
+      datatype: 
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship5
+      display_name: 
+      datatype: 
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method5
+      display_name: 
+      datatype: 
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship6
+      display_name: 
+      datatype: 
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method6
+      display_name: 
+      datatype: 
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship7
+      display_name: 
+      datatype: 
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method7
+      display_name: 
+      datatype: 
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship8
+      display_name: 
+      datatype: 
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method8
+      display_name: 
+      datatype: 
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship9
+      display_name: 
+      datatype: 
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method9
+      display_name: 
+      datatype: 
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship10
+      display_name: 
+      datatype: 
+      priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method10
+      display_name: 
+      datatype: 
+      priority: 22
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship11
+      display_name: 
+      datatype: 
+      priority: 23
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method11
+      display_name: 
+      datatype: 
+      priority: 24
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship12
+      display_name: 
+      datatype: 
+      priority: 25
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method12
+      display_name: 
+      datatype: 
+      priority: 26
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship13
+      display_name: 
+      datatype: 
+      priority: 27
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method13
+      display_name: 
+      datatype: 
+      priority: 28
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship14
+      display_name: 
+      datatype: 
+      priority: 29
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_exit
+      display_name: 
+      datatype: 
+      priority: 30
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Lifecycle.class/provisioning.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Lifecycle.class/provisioning.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Provisioning
+    inherits: 
+    description: 
+  fields:
+  - Relationship5:
+      value: "/Infrastructure/Configured_System/Provisioning/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+  - Relationship6:
+      value: "/Infrastructure/Configured_System/Provisioning/StateMachines/${/#state_machine}/${/#miq_provision_task.request_type}"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__class__.yaml
@@ -1,0 +1,113 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Email
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: to_email_address
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: evmadmin@company.com
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: from_email_address
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: evmadmin@company.com
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: signature
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: Virtualization Infrastructure Team
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: vm_retire_extend_days
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: method1
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/provision_complete.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/provision_complete.rb
@@ -1,0 +1,3 @@
+#
+# Description: Place holder for Provision Complete email #
+#

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/provision_complete.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/provision_complete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Provision_Complete
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/request_approved.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/request_approved.rb
@@ -1,0 +1,3 @@
+#
+# Description: Place holder for Provision Request Approved email #
+#

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/request_approved.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/request_approved.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Request_Approved
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/provision_complete.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/provision_complete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Provision_Complete
+    inherits: 
+    description: Provision_Complete
+  fields:
+  - method1:
+      value: Provision_Complete

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/request_approved.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/request_approved.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Request_Approved
+    inherits: 
+    description: 
+  fields:
+  - method1:
+      value: Request_Approved

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/request_denied.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/request_denied.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Request_Denied
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/request_pending.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/request_pending.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Request_Pending
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Profile.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Profile.class/__class__.yaml
@@ -1,0 +1,113 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Profile
+    display_name: 
+    name: Profile
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: method
+      name: get_dialog_name
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: get_dialog_name
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: dialog_name
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: miq_provision_configured_system_foreman_dialogs
+      substitute: true
+      message: get_dialog_name
+      visibility: 
+      collect: "/dialog_name = dialog_name"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: auto_approval_state_machine
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: ProvisionRequestApproval
+      substitute: true
+      message: get_auto_approval_state_machine
+      visibility: 
+      collect: "/state_machine = auto_approval_state_machine"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: quota_state_machine
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: ProvisionRequestQuotaVerification
+      substitute: true
+      message: get_quota_state_machine
+      visibility: 
+      collect: "/state_machine = quota_state_machine"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: state_machine
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: Provision
+      substitute: true
+      message: get_state_machine
+      visibility: 
+      collect: "/state_machine = state_machine"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Profile.class/_missing.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Profile.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Profile.class/evmgroup-super_administrator.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/Profile.class/evmgroup-super_administrator.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EvmGroup-super_administrator
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__class__.yaml
@@ -1,0 +1,33 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Methods
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -1,0 +1,24 @@
+#
+# Description: This method checks to see if the configured_system has been provisioned
+#
+
+# Get current provisioning status
+task = $evm.root['miq_provision_task']
+task_status = task['status']
+result = task.statemachine_task_status
+
+$evm.log('info', "ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task_status}>")
+
+case result
+when 'error'
+  $evm.root['ae_result'] = 'error'
+  reason = $evm.root['miq_provision_task'].message
+  reason = reason[7..-1] if reason[0..6] == 'Error: '
+  $evm.root['ae_reason'] = reason
+when 'retry'
+  $evm.root['ae_result']         = 'retry'
+  $evm.root['ae_retry_interval'] = '1.minute'
+when 'ok'
+  # Bump State
+  $evm.root['ae_result'] = 'ok'
+end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: check_provisioned
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/preprovision.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/preprovision.rb
@@ -1,0 +1,8 @@
+#
+# Description: This method is used to apply PreProvision customizations
+#
+
+# Get provisioning object
+prov = $evm.root['miq_provision_task']
+
+$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_request.id}> Provision Type: <#{prov.request_type}>")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/preprovision.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/preprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: preprovision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -1,0 +1,5 @@
+#
+# Decription: This method launches the VM provisioning job
+#
+
+$evm.root["miq_provision_task"].execute

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/provision.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/__methods__/provision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: provision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/checkprovisioned.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/checkprovisioned.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CheckProvisioned
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: check_provisioned

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/preprovision.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/preprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: preprovision
+    inherits: 
+    description: preprovision
+  fields:
+  - execute:
+      value: preprovision

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/provision.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Methods.class/provision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: provision
+    inherits: 
+    description: provision
+  fields:
+  - execute:
+      value: provision

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -1,0 +1,293 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Orchestration Provision State Machine
+    display_name: 
+    name: Provision
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: pre1
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: /Infrastructure/Configured_System/Provisioning/StateMachines/Methods/Preprovision
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Pre1')
+      on_exit: update_provision_status(status => 'Processed Pre1')
+      on_error: update_provision_status(status => 'Error Processing Pre1')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre2
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Pre2')
+      on_exit: update_provision_status(status => 'Processed Pre2')
+      on_error: update_provision_status(status => 'Error Processing Pre2')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre3
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Pre3')
+      on_exit: update_provision_status(status => 'Processed Pre3')
+      on_error: update_provision_status(status => 'Error Processing Pre3')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre4
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Pre4')
+      on_exit: update_provision_status(status => 'Processed Pre4')
+      on_error: update_provision_status(status => 'Error Processing Pre4')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre5
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Pre5')
+      on_exit: update_provision_status(status => 'Processed Pre5')
+      on_error: update_provision_status(status => 'Error Processing Pre5')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: provision
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: /Infrastructure/Configured_System/Provisioning/StateMachines/Methods/Provision
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Provision System')
+      on_exit: update_provision_status(status => 'Provision System')
+      on_error: update_provision_status(status => '${/#ae_reason}')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: checkprovisioned
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: /Infrastructure/Configured_System/Provisioning/StateMachines/Methods/CheckProvisioned
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: update_provision_status(status => 'Provision System')
+      on_error: update_provision_status(status => '${/#ae_reason}')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: post1
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Post1 Customizations')
+      on_exit: update_provision_status(status => 'Processed Post1 Customizations')
+      on_error: update_provision_status(status => 'Error Processing Post1 Customizations')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: post2
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Post2 Customizations')
+      on_exit: update_provision_status(status => 'Processed Post2 Customizations')
+      on_error: update_provision_status(status => 'Error Processing Post2 Customizations')
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: post3
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Post3 Customizations')
+      on_exit: update_provision_status(status => 'Processed Post3 Customizations')
+      on_error: update_provision_status(status => 'Error Processing Post3 Customizations')
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: post4
+      display_name: 
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Post4 Customizations')
+      on_exit: update_provision_status(status => 'Processed Post4 Customizations')
+      on_error: update_provision_status(status => 'Error Processing Post4 Customizations')
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: post5
+      display_name: 
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Processing Post5 Customizations')
+      on_exit: update_provision_status(status => 'Processed Post5 Customizations')
+      on_error: update_provision_status(status => 'Error Processing Post5 Customizations')
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: EmailOwner
+      display_name: 
+      datatype: string
+      priority: 13
+      owner: 
+      default_value: /Infrastructure/Configured_System/Provisioning/Email/Provision_complete?event=configured_system_provisioned
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Emailing Owner')
+      on_exit: update_provision_status(status => 'Emailed Owner')
+      on_error: update_provision_status(status => 'Error Emailing Owner')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: Finished
+      display_name: 
+      datatype: string
+      priority: 14
+      owner: 
+      default_value: /System/CommonMethods/StateMachineMethods/configured_system_provision_finished
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: '100'
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.rb
@@ -1,0 +1,14 @@
+#
+# Description: This method updates the service provisioning status
+# Required inputs: status
+#
+
+prov = $evm.root['miq_provision_task']
+
+# Get status from input field status
+status = $evm.inputs['status']
+
+# Update Status for on_entry,on_exit
+if $evm.root['ae_result'] == 'ok' || $evm.root['ae_result'] == 'error'
+  prov.message = status
+end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: update_provision_status
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: status
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/default.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: provision_via_foreman
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__class__.yaml
@@ -1,0 +1,53 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Factory State Machines
+    display_name: 
+    name: ProvisionRequestApproval
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: ValidateRequest
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: validate_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: ApproveRequest
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: approve_request
+      on_exit: 
+      on_error: 
+      max_retries: '100'
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/approve_request.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/approve_request.rb
@@ -1,0 +1,5 @@
+# Description: This method is executed when the provisioning request is auto-approved
+
+# Auto-Approve request
+# $evm.log("info", "AUTO-APPROVING")
+# $evm.root["miq_request"].approve("admin", "Auto-Approved")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/approve_request.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/approve_request.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: approve_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
@@ -1,0 +1,10 @@
+#
+# Description: This method is executed when the provisioning request is NOT auto-approved
+#
+
+# Get objects
+msg = $evm.object['reason']
+$evm.log('info', "#{msg}")
+
+# Raise automation event: request_pending
+$evm.root["miq_request"].pending

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: pending_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: reason
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: validate_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/default.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Default
+    name: Default
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__class__.yaml
@@ -1,0 +1,33 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Factory State Machines
+    display_name: 
+    name: ProvisionRequestQuotaVerification
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: ValidateQuotas
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: validate_quotas
+      on_exit: 
+      on_error: rejected
+      max_retries: '100'
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__methods__/rejected.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__methods__/rejected.rb
@@ -1,0 +1,7 @@
+#
+# Description: This method runs when the provision request quota validation has failed
+#
+
+# Deny the request
+$evm.log('info', "Request denied because of Quota")
+$evm.root["miq_request"].deny("admin", "Quota Exceeded")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__methods__/rejected.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__methods__/rejected.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: rejected
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: reason
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__methods__/validate_quotas.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/__methods__/validate_quotas.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: validate_quotas
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/default.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Default
+    name: Default
+    inherits: 
+    description: 
+  fields: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/__namespace__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/__namespace__.yaml
@@ -1,0 +1,11 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: StateMachines
+    description: 
+    display_name: 
+    system: 
+    priority: 
+    enabled: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/__namespace__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/__namespace__.yaml
@@ -1,0 +1,11 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Provisioning
+    description: 
+    display_name: 
+    system: 
+    priority: 
+    enabled: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/__namespace__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/__namespace__.yaml
@@ -1,0 +1,11 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Configured_System
+    description: 
+    display_name: 
+    system: 
+    priority: 
+    enabled: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/StateMachineMethods.class/configured_system_provision_finished.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/StateMachineMethods.class/configured_system_provision_finished.yaml
@@ -1,0 +1,13 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: configured_system_provision_finished
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: task_finished(object => 'miq_provision_task', message =>
+        'Configured System Provisioned Successfully')

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_approved.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_approved.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqProvisionConfiguredSystemRequest_approved
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Email/Request_Approved"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_created.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_created.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqProvisionConfiguredSystemRequest_created
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_auto_approval_state_machine"
+  - rel6:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/StateMachines/${/#state_machine}/Default"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_denied.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_denied.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqProvisionConfiguredSystemRequest_denied
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Email/Request_denied"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_pending.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_pending.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqProvisionConfiguredSystemRequest_pending
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Email/Request_pending"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_starting.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_starting.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqProvisionConfiguredSystemRequest_starting
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_quota_state_machine"
+  - rel6:
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/StateMachines/${/#state_machine}/Default"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_automation_request.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_automation_request.rb
@@ -9,6 +9,9 @@ cur['target_component'], cur['target_class'], cur['target_instance'] =
   when 'vm_retired'     then %w(VM   Lifecycle Retirement)
   when 'vm_migrate'     then %w(VM   Lifecycle Migrate)
   when 'host_provision' then %w(Host Lifecycle Provisioning)
+  when 'configured_system_provision'
+    $evm.root['ae_provider_category'] = 'infrastructure'
+    %w(Configured_System Lifecycle Provisioning)
   end
 
 $evm.log("info", "Request:<#{cur['request']}> Target Component:<#{cur['target_component']}> Target Class:<#{cur['target_class']}> Target Instance:<#{cur['target_instance']}>")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_automation_request.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_automation_request.rb
@@ -3,23 +3,12 @@
 #
 
 cur = $evm.object
-case cur['request']
-when 'vm_provision'
-  cur['target_component'] = 'VM'
-  cur['target_class']     = 'Lifecycle'
-  cur['target_instance']  = 'Provisioning'
-when 'vm_retired'
-  cur['target_component'] = 'VM'
-  cur['target_class']     = 'Lifecycle'
-  cur['target_instance']  = 'Retirement'
-when 'vm_migrate'
-  cur['target_component'] = 'VM'
-  cur['target_class']     = 'Lifecycle'
-  cur['target_instance']  = 'Migrate'
-when 'host_provision'
-  cur['target_component'] = 'Host'
-  cur['target_class']     = 'Lifecycle'
-  cur['target_instance']  = 'Provisioning'
-end
+cur['target_component'], cur['target_class'], cur['target_instance'] =
+  case cur['request']
+  when 'vm_provision'   then %w(VM   Lifecycle Provisioning)
+  when 'vm_retired'     then %w(VM   Lifecycle Retirement)
+  when 'vm_migrate'     then %w(VM   Lifecycle Migrate)
+  when 'host_provision' then %w(Host Lifecycle Provisioning)
+  end
 
 $evm.log("info", "Request:<#{cur['request']}> Target Component:<#{cur['target_component']}> Target Class:<#{cur['target_class']}> Target Instance:<#{cur['target_instance']}>")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Request.class/ui_configured_system_provision_info.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Request.class/ui_configured_system_provision_info.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: UI_Configured_System_Provision_Info
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Infrastructure/Configured_System/Provisioning/Profile/${/#user.normalized_ldap_group}#${process#message}"

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceMiqProvision < MiqAeServiceMiqRequestTask
+  class MiqAeServiceMiqProvision < MiqAeServiceMiqProvisionTask
     require_relative "mixins/miq_ae_service_miq_provision_mixin"
     include MiqAeServiceMiqProvisionMixin
 

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_configured_system_request.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_configured_system_request.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqProvisionConfiguredSystemRequest < MiqAeServiceMiqRequest
+    def ci_type
+      'configured_system'
+    end
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_task.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_task.rb
@@ -1,0 +1,13 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqProvisionTask < MiqAeServiceMiqRequestTask
+    def statemachine_task_status
+      ar_method do
+        if %w(finished provisioned).include?(@object.state)
+          @object.status.to_s.downcase == 'error' ? 'error' : 'ok'
+        else
+          'retry'
+        end
+      end
+    end
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_task_configured_system_foreman.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_task_configured_system_foreman.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqProvisionTaskConfiguredSystemForeman < MiqAeServiceMiqProvisionTask
+  end
+end


### PR DESCRIPTION
The majority of files here are automate modeling to support Foreman requests and tasks plus the automate state machine.  

In addition there are a few required model updates and new automate service models.
Fixed the subclassing of MiqProvision in the service models.

cc @brandondunne @kbrock