### PR TITLE
Provide default provisioning entry point for orchestration service

### DIFF
--- a/vmdb/app/models/service_template.rb
+++ b/vmdb/app/models/service_template.rb
@@ -172,4 +172,12 @@ class ServiceTemplate < ActiveRecord::Base
     end
     service.save
   end
+
+  def self.default_provisioning_entry_point
+    '/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template/default'
+  end
+
+  def self.default_retirement_entry_point
+    '/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement/default'
+  end
 end

--- a/vmdb/app/models/service_template_orchestration.rb
+++ b/vmdb/app/models/service_template_orchestration.rb
@@ -5,4 +5,8 @@ class ServiceTemplateOrchestration < ServiceTemplate
     # no sub task is needed for this service
     []
   end
+
+  def self.default_provisioning_entry_point
+    '/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision/default'
+  end
 end


### PR DESCRIPTION
@h-kataria @gmcculloug please review.
Should we provide default entry (provisioning/update/retirement) for other service types?