### PR TITLE
Smart State Analysis for Hyper-V Disks

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -287,8 +287,8 @@ class JobProxyDispatcher
         return []
       end
     else
-      unless ["VSAN", "VMFS", "NAS", "NFS", "ISCSI", "DIR", "FCP"].include?(@vm.storage.store_type)
-        msg = "Vm storage type [#{@vm.storage.store_type}] not supported [#{job.target_id}], aborting job [#{job.guid}]."
+      unless %w(VSAN VMFS NAS NFS ISCSI DIR FCP CSVFS NTFS).include?(@vm.storage.store_type)
+        msg = "Vm storage type [#{@vm.storage.store_type}] unsupported [#{job.target_id}], aborting job [#{job.guid}]."
         queue_signal(job, {:args => [:abort, msg, "error"]})
         return []
       end

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -102,6 +102,28 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     execute_power_operation("Resume", vm.uid_ems)
   end
 
+  def vm_create_evm_snapshot(vm, options = {})
+    log_prefix = "vm_create_evm_snapshot: vm=[#{vm.name}]"
+
+    host_handle = vm_host_handle(vm, options)
+    host_handle.vm_create_evm_checkpoint(vm.name)
+  rescue => err
+    $scvmm_log.error "#{log_prefix}, error: #{err}"
+    $scvmm_log.debug { err.backtrace.join("\n") }
+    raise
+  end
+
+  def vm_delete_evm_snapshot(vm, options = {})
+    log_prefix = "vm_delete_evm_snapshot: vm=[#{vm.name}]"
+
+    host_handle = vm_host_handle(vm, options)
+    host_handle.vm_remove_evm_checkpoint(vm.name)
+  rescue => err
+    $scvmm_log.error "#{log_prefix}, error: #{err}"
+    $scvmm_log.debug { err.backtrace.join("\n") }
+    raise
+  end
+
   private
 
   def execute_power_operation(cmdlet, vm_uid_ems, *parameters)
@@ -132,5 +154,14 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     end
 
     connect_params
+  end
+
+  def vm_host_handle(vm, options)
+    require 'Scvmm/miq_scvmm_vm_ssa_info'
+    raise "no credentials defined in options #{options}" if self.missing_credentials?(options[:auth_type])
+    user = options[:user] || authentication_userid(options[:auth_type])
+    pass = options[:pass] || authentication_password(options[:auth_type])
+
+    MiqScvmmVmSSAInfo.new(vm.host.hostname, user, pass)
   end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -105,7 +105,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
   def vm_create_evm_snapshot(vm, options = {})
     log_prefix = "vm_create_evm_snapshot: vm=[#{vm.name}]"
 
-    host_handle = vm_host_handle(vm, options)
+    host_handle = host_handle(vm, options)
     host_handle.vm_create_evm_checkpoint(vm.name)
   rescue => err
     $scvmm_log.error "#{log_prefix}, error: #{err}"
@@ -116,7 +116,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
   def vm_delete_evm_snapshot(vm, options = {})
     log_prefix = "vm_delete_evm_snapshot: vm=[#{vm.name}]"
 
-    host_handle = vm_host_handle(vm, options)
+    host_handle = host_handle(vm, options)
     host_handle.vm_remove_evm_checkpoint(vm.name)
   rescue => err
     $scvmm_log.error "#{log_prefix}, error: #{err}"
@@ -156,7 +156,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     connect_params
   end
 
-  def vm_host_handle(vm, options)
+  def host_handle(vm, options)
     require 'Scvmm/miq_scvmm_vm_ssa_info'
     raise "no credentials defined in options #{options}" if self.missing_credentials?(options[:auth_type])
     user = options[:user] || authentication_userid(options[:auth_type])

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -1,5 +1,3 @@
-$LOAD_PATH << File.join(GEMS_PENDING_ROOT, "Scvmm")
-
 class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraManager
   require_nested :Host
   require_nested :Provision
@@ -102,10 +100,10 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     execute_power_operation("Resume", vm.uid_ems)
   end
 
-  def vm_create_evm_snapshot(vm, options = {})
+  def vm_create_evm_snapshot(vm, _options)
     log_prefix = "vm_create_evm_snapshot: vm=[#{vm.name}]"
 
-    host_handle = host_handle(vm, options)
+    host_handle = vm.host.host_handle
     host_handle.vm_create_evm_checkpoint(vm.name)
   rescue => err
     $scvmm_log.error "#{log_prefix}, error: #{err}"
@@ -113,10 +111,10 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     raise
   end
 
-  def vm_delete_evm_snapshot(vm, options = {})
+  def vm_delete_evm_snapshot(vm, _options)
     log_prefix = "vm_delete_evm_snapshot: vm=[#{vm.name}]"
 
-    host_handle = host_handle(vm, options)
+    host_handle = vm.host.host_handle
     host_handle.vm_remove_evm_checkpoint(vm.name)
   rescue => err
     $scvmm_log.error "#{log_prefix}, error: #{err}"
@@ -154,14 +152,5 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     end
 
     connect_params
-  end
-
-  def host_handle(vm, options)
-    require 'Scvmm/miq_scvmm_vm_ssa_info'
-    raise "no credentials defined in options #{options}" if self.missing_credentials?(options[:auth_type])
-    user = options[:user] || authentication_userid(options[:auth_type])
-    pass = options[:pass] || authentication_password(options[:auth_type])
-
-    MiqScvmmVmSSAInfo.new(vm.host.hostname, user, pass)
   end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/host.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/host.rb
@@ -3,21 +3,18 @@ $LOAD_PATH << File.join(GEMS_PENDING_ROOT, "Scvmm")
 class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
   def verify_credentials(auth_type = nil, _options = {})
     raise MiqException::MiqHostError "No credentials defined" if missing_credentials?(auth_type)
-    verify_credentials_windows(hostname, *auth_user_pwd(auth_type))
+    options                        = {}
+    options[:user], options[:pass] = auth_user_pwd(auth_type)
+    options[:hostname]             = hostname
+    verify_credentials_windows(options)
   end
 
-  def verify_credentials_windows(server = nil, username = nil, password = nil, _namespace = nil)
+  def verify_credentials_windows(options)
     require 'miq_winrm'
-    log_header = "MIQ(#{self.class.name}.#{__method__})"
+    $scvmm_log.info "MIQ(#{self.class.name}.#{__method__}) Verifying credentials for hostname #{options[:hostname]}"
     begin
-      winrm              = MiqWinRM.new
-      options            = {}
-      options[:user]     = username
-      options[:pass]     = password
-      options[:hostname] = server
-      $scvmm_log.info("#{log_header} Verifying credentials for hostname #{server}")
-      connection = winrm.connect(options)
-      connection.run_powershell_script("hostname")
+      winrm = MiqWinRM.new
+      winrm.connect(options).run_powershell_script("hostname")
     rescue WinRM::WinRMHTTPTransportError => e
       raise MiqException::MiqHostError, "Check credentials and WinRM configuration settings. " \
       "Remote error message: #{e.message}"

--- a/app/models/manageiq/providers/microsoft/infra_manager/host.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/host.rb
@@ -1,5 +1,3 @@
-$LOAD_PATH << File.join(GEMS_PENDING_ROOT, "Scvmm")
-
 class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
   def verify_credentials(auth_type = nil, _options = {})
     raise MiqException::MiqHostError "No credentials defined" if missing_credentials?(auth_type)
@@ -24,5 +22,13 @@ class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
       raise MiqException::MiqHostError, "Unable to connect: #{e.message}."
     end
     true
+  end
+
+  def host_handle
+    require 'Scvmm/miq_scvmm_vm_ssa_info'
+
+    auth_type = nil
+    user, pass = auth_user_pwd(auth_type)
+    MiqScvmmVmSSAInfo.new(hostname, user, pass)
   end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -13,12 +13,4 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
   def validate_migrate
     validate_unsupported("Migrate")
   end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
-  end
-
-  def scan_via_ems?
-    false
-  end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
+  include_concern 'ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared'
+
   def self.calculate_power_state(raw_power_state)
     case raw_power_state
     when "Running"         then "on"
@@ -10,5 +12,13 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
 
   def validate_migrate
     validate_unsupported("Migrate")
+  end
+
+  def validate_smartstate_analysis
+    validate_supported_check("Smartstate Analysis")
+  end
+
+  def scan_via_ems?
+    false
   end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared
+  extend ActiveSupport::Concern
+  include_concern 'Scanning'
+end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -3,12 +3,11 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
     require 'MiqVm/miq_scvmm_vm'
 
     log_pref = "MIQ(#{self.class.name}##{__method__})"
-    vm_name  = name
-    $log.debug "#{log_pref} VM = #{vm_name}"
+    $log.debug "#{log_pref} VM = #{name}"
 
     begin
-      setup_for_ems_connection(vm_name, ost)
-      miq_vm = MiqScvmmVm.new(vm_name, ost)
+      setup_for_ems_connection(name, ost)
+      miq_vm = MiqScvmmVm.new(name, ost)
       scan_via_miq_vm(miq_vm, ost)
     rescue => err
       $log.error "#{log_pref}: #{err}"

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -1,0 +1,73 @@
+module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scanning
+  def perform_metadata_scan(ost)
+    require 'MiqVm/miq_scvmm_vm'
+
+    log_pref = "MIQ(#{self.class.name}##{__method__})"
+    vm_name  = name
+    $log.debug "#{log_pref} VM = #{vm_name}"
+
+    begin
+      $log.debug "perform_metadata_scan: vm_name = #{vm_name}"
+      connect_to_ems(vm_name, ost)
+      miq_vm = MiqScvmmVm.new(vm_name, ost)
+      scan_via_miq_vm(miq_vm, ost)
+    rescue => err
+      $log.error "#{log_pref}: #{err}"
+      $log.debug err.backtrace.join("\n")
+      raise
+    ensure
+      miq_vm.unmount if miq_vm
+    end
+  end
+
+  def perform_metadata_sync(ost)
+    sync_stashed_metadata(ost)
+  end
+
+  private
+
+  # Moved from MIQExtract.rb
+  # TODO: Should this be in the ems?
+  def connect_to_ems(vm_name, ost)
+    log_header = "MIQ(#{self.class.name}.#{__method__})"
+
+    # Check if we've been told explicitly not to connect to the ems
+    if ost.scanData.fetch_path("ems", 'connect') == false
+      $log.debug "#{log_header}: returning, ems/connect == false"
+      return
+    end
+
+    # Make sure we were given a ems/host to connect to
+    ems_connect_type = ost.scanData.fetch_path('ems', 'connect_to') || 'host'
+    miq_vm_host = ost.scanData.fetch_path("ems", ems_connect_type)
+    if miq_vm_host
+      st = Time.now.getlocal
+      use_broker = false
+      miq_vm_host[:address] = miq_vm_host[:ipaddress] if miq_vm_host[:address].nil?
+      ems_text = "#{ems_connect_type}(#{use_broker ? 'via broker' : 'directly'}):#{miq_vm_host[:address]}"
+      log.text = "#{log_header}: Connection to [#{ems_text}]"
+      $log.info "#{log_header}: Connecting to [#{ems_text}] for VM:[#{vm_name}]"
+      miq_vm_host[:password_decrypt] = MiqPassword.decrypt(miq_vm_host[:password])
+
+      begin
+        hyperv_config = {:host     => miq_vm_host[:address],
+                         :port     => miq_vm_host[:port],
+                         :user     => miq_vm_host[:username],
+                         :password => miq_vm_host[:password_decrypt],
+        }
+
+        ost.miq_scvmm  = ost.miq_hyperv = hyperv_config
+        ost.miq_vm     = ost.fileName = vm_name
+        $log.info "#{log_text} completed for VM:[#{vm_name}] in [#{Time.now.getlocal - st}] seconds"
+      rescue Timeout::Error => err
+        msg = "#{log_text} timed out for VM:[#{vm_name}] with error [#{err}] after [#{Time.now.getlocal - st}] seconds"
+        $log.error msg
+        raise err, msg, err.backtrace
+      rescue Exception => err
+        msg = "#{log_text} failed for VM:[#{vm_name}] with error [#{err}] after [#{Time.now.getlocal - st}] seconds"
+        $log.error msg
+        raise err, msg, err.backtrace
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -7,8 +7,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
     $log.debug "#{log_pref} VM = #{vm_name}"
 
     begin
-      $log.debug "perform_metadata_scan: vm_name = #{vm_name}"
-      connect_to_ems(vm_name, ost)
+      setup_for_ems_connection(vm_name, ost)
       miq_vm = MiqScvmmVm.new(vm_name, ost)
       scan_via_miq_vm(miq_vm, ost)
     rescue => err
@@ -24,11 +23,19 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
     sync_stashed_metadata(ost)
   end
 
+  def validate_smartstate_analysis
+    validate_supported_check("Smartstate Analysis")
+  end
+
+  def scan_via_ems?
+    false
+  end
+
   private
 
   # Moved from MIQExtract.rb
   # TODO: Should this be in the ems?
-  def connect_to_ems(vm_name, ost)
+  def setup_for_ems_connection(vm_name, ost)
     log_header = "MIQ(#{self.class.name}.#{__method__})"
 
     # Check if we've been told explicitly not to connect to the ems
@@ -45,7 +52,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
       use_broker = false
       miq_vm_host[:address] = miq_vm_host[:ipaddress] if miq_vm_host[:address].nil?
       ems_text = "#{ems_connect_type}(#{use_broker ? 'via broker' : 'directly'}):#{miq_vm_host[:address]}"
-      log.text = "#{log_header}: Connection to [#{ems_text}]"
+      log_text = "#{log_header}: Connection to [#{ems_text}]"
       $log.info "#{log_header}: Connecting to [#{ems_text}] for VM:[#{vm_name}]"
       miq_vm_host[:password_decrypt] = MiqPassword.decrypt(miq_vm_host[:password])
 

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -115,7 +115,6 @@ module MiqServer::ServerSmartProxy
     job    = Job.find_by_guid(ost.taskid)
     _log.debug "#{target.name} (#{target.class.name})"
     begin
-      ost.args[0]  = target.name
       ost.args[1]  = YAML.load(ost.args[1]) # TODO: YAML.dump'd in call_scan - need it be?
       ost.scanData = ost.args[1].kind_of?(Hash) ? ost.args[1] : {}
       ost.config = OpenStruct.new(

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -86,6 +86,9 @@ module MiqServer::ServerSmartProxy
         if target.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm) ||
            target.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
           timeout_adj = 4
+        elsif target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
+              target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
+          timeout_adj = 8
         end
       end
       $log.debug "#{log_prefix}: queuing call to #{self.class.name}##{ost.method_name}"
@@ -112,6 +115,7 @@ module MiqServer::ServerSmartProxy
     job    = Job.find_by_guid(ost.taskid)
     _log.debug "#{target.name} (#{target.class.name})"
     begin
+      ost.args[0]  = target.name
       ost.args[1]  = YAML.load(ost.args[1]) # TODO: YAML.dump'd in call_scan - need it be?
       ost.scanData = ost.args[1].kind_of?(Hash) ? ost.args[1] : {}
       ost.config = OpenStruct.new(

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1055,8 +1055,6 @@ class VmOrTemplate < ActiveRecord::Base
     when 'VMware'
       # VM cannot be scanned by server if they are on a repository
       return [] if storage_id.blank? || self.repository_vm?
-    when 'RedHat'
-      return [] if storage_id.blank?
     when 'Microsoft'
       return [] if storage_id.blank?
     else

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1055,6 +1055,10 @@ class VmOrTemplate < ActiveRecord::Base
     when 'VMware'
       # VM cannot be scanned by server if they are on a repository
       return [] if storage_id.blank? || self.repository_vm?
+    when 'RedHat'
+      return [] if storage_id.blank?
+    when 'Microsoft'
+      return [] if storage_id.blank?
     else
       _log.debug "else"
       return []
@@ -1257,10 +1261,12 @@ class VmOrTemplate < ActiveRecord::Base
     return rhevm_config_path if vendor.to_s == 'RedHat'
 
     case storage.store_type
-    when "VMFS" then "[#{storage.name}] #{location}"
-    when "VSAN" then "[#{storage.name}] #{location}"
-    when "NFS"  then "[#{storage.name}] #{location}"
-    when "NAS"  then File.join(storage.name, location)
+    when "VMFS"  then "[#{storage.name}] #{location}"
+    when "VSAN"  then "[#{storage.name}] #{location}"
+    when "NFS"   then "[#{storage.name}] #{location}"
+    when "NTFS"  then "[#{storage.name}] #{location}"
+    when "CSVFS" then "[#{storage.name}] #{location}"
+    when "NAS"   then File.join(storage.name, location)
     else
       _log.warn("VM [#{name}] storage type [#{storage.store_type}] not supported")
       @path = location

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -21,12 +21,19 @@ module VmOrTemplate::Scanning
       return nil
     end
 
+    timeout_adj = 1
+    vm = VmOrTemplate.find(id)
+    if vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
+       vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
+      timeout_adj = 4
+    end
     options = {
       :target_id    => id,
       :target_class => self.class.base_class.name,
       :name         => "Scan from Vm #{name}",
       :userid       => userid,
-      :sync_key     => guid
+      :sync_key     => guid,
+      :timeout_adj  => timeout_adj
     }.merge(options)
     options[:zone] = ext_management_system.my_zone unless ext_management_system.nil?
     # options = {:agent_id => myhost.id, :agent_class => myhost.class.to_s}.merge!(options) unless myhost.nil?

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -21,19 +21,12 @@ module VmOrTemplate::Scanning
       return nil
     end
 
-    timeout_adj = 1
-    vm = VmOrTemplate.find(id)
-    if vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-       vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
-      timeout_adj = 4
-    end
     options = {
       :target_id    => id,
       :target_class => self.class.base_class.name,
       :name         => "Scan from Vm #{name}",
       :userid       => userid,
       :sync_key     => guid,
-      :timeout_adj  => timeout_adj
     }.merge(options)
     options[:zone] = ext_management_system.my_zone unless ext_management_system.nil?
     # options = {:agent_id => myhost.id, :agent_class => myhost.class.to_s}.merge!(options) unless myhost.nil?

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -7,13 +7,9 @@ class VmScan < Job
   #
   DEFAULT_TIMEOUT = defined?(RSpec) ? 300 : 3000
 
-  def self.current_job_timeout
-    if options.nil? || options[:timeout_adj].nil? || defined?(RSpec)
-      timeout_adj = 1
-    else
-      timeout_adj = options[:timeout_adj]
-    end
-    DEFAULT_TIMEOUT * timeout_adj
+  def self.current_job_timeout(timeout_adjustment = 1)
+    timeout_adjustment = 1 if defined?(RSpec)
+    DEFAULT_TIMEOUT * timeout_adjustment
   end
 
   def load_transitions

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -8,9 +8,9 @@ class VmScan < Job
   DEFAULT_TIMEOUT = defined?(RSpec) ? 300 : 3000
 
   def self.current_job_timeout
-    if options[:timeout_adj].nil?
+    if options.nil? || options[:timeout_adj].nil? || defined?(RSpec)
       timeout_adj = 1
-    else 
+    else
       timeout_adj = options[:timeout_adj]
     end
     DEFAULT_TIMEOUT * timeout_adj

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -8,7 +8,12 @@ class VmScan < Job
   DEFAULT_TIMEOUT = defined?(RSpec) ? 300 : 3000
 
   def self.current_job_timeout
-    DEFAULT_TIMEOUT
+    if options[:timeout_adj].nil?
+      timeout_adj = 1
+    else 
+      timeout_adj = options[:timeout_adj]
+    end
+    DEFAULT_TIMEOUT * timeout_adj
   end
 
   def load_transitions

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -95,7 +95,8 @@ class VmScan < Job
 
       # TODO: should this logic be moved to a VM subclass implementation?
       #       or, make type-specific Job classes.
-      if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
+      if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm) ||
+         vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
         if vm.ext_management_system
           sn_description = snapshotDescription
           _log.info("Creating snapshot, description: [#{sn_description}]")
@@ -280,6 +281,8 @@ class VmScan < Job
           #       or, make type-specific Job classes.
           if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
+          elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
+            vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
           else
             delete_snapshot(mor)
           end
@@ -532,6 +535,8 @@ class VmScan < Job
         set_status("Deleting snapshot before aborting job")
         if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
+        elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
+          vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
         else
           delete_snapshot(mor)
         end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -15,7 +15,7 @@ gem "activerecord",            "~>4.2.5"
 # Not locally modified and not required
 gem "awesome_spawn",           "~> 1.3",            :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
-gem "binary_struct",           "~> 2.0",            :require => false
+gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false

--- a/gems/pending/MiqVm/MiqScvmmVm.rb
+++ b/gems/pending/MiqVm/MiqScvmmVm.rb
@@ -1,0 +1,81 @@
+require 'MiqVm/MiqVm'
+require 'Scvmm/miq_scvmm_vm_ssa_info'
+
+class MiqScvmmVm < MiqVm
+
+  def openDisks(disk_files)
+    part_volumes = Array.new
+
+    $log.debug "MiqScvmmVm::openDisks: no disk files supplied." if !disk_files
+    raise "MiqScvmmVm::openDisks: Uninitialized miq_scvmm" if @ost.miq_scvmm.nil?
+    #
+    # Build a list of the VM's physical volumes.
+    #
+    disk_files.each do |disk_tag, disk_file|
+      disk_info = OpenStruct.new
+      disk_info.hyperv_connection            = Hash.new
+      disk_info.fileName                     = disk_file
+      disk_info.hyperv_connection[:host]     = @ost.miq_hyperv[:host]
+      disk_info.hyperv_connection[:port]     = @ost.miq_hyperv[:port]
+      if @ost.miq_hyperv[:domain].nil?
+        disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:user]
+      else
+        disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:domain] + "\\" + @ost.miq_hyperv[:user]
+      end
+      disk_info.hyperv_connection[:password] = @ost.miq_hyperv[:password]
+ 
+      mode = @vmConfig.getHash["#{disk_tag}.mode"]
+      disk_info.hardwareId = disk_tag
+      disk_info.baseOnly   = @ost.openParent unless mode && mode["independent"]
+      disk_info.rawDisk    = @ost.rawDisk
+    
+      begin
+        disk = MiqDisk.getDisk(disk_info)
+        next if disk.nil?
+      rescue => err
+        $log.error "Couldn't open disk file: #{diskfile}"
+        $log.error err.to_s
+        $log.debug err.backtrace.join("\n")
+        @diskInitErrors[disk_file] = err.to_s
+        next
+      end
+
+      part = disk.getPartitions
+      if part.empty?
+        part_volumes << disk
+      else
+        part_volumes.concat(part)
+      end
+    end
+    return part_volumes
+  end
+
+  def getCfg(snap = nil)
+
+    cfg_hash = {}
+    # Collect disk information
+    # Call out to the Hyper-V host for Info about the VM.
+    host              = @ost.miq_hyperv[:host]
+    port              = @ost.miq_hyperv[:port]
+    if @ost.miq_hyperv[:domain].nil?
+      user = @ost.miq_hyperv[:user]
+    else
+      user = @ost.miq_hyperv[:domain] + "\\" + @ost.miq_hyperv[:user]
+    end
+    password          = @ost.miq_hyperv[:password]
+    scvmm_info_handle = MiqScvmmVmSSAInfo.new(host, user, password, port)
+    vhds              = scvmm_info_handle.vm_all_harddisks(@ost.miq_vm)
+    raise "Unable to get Hard Disk Info from VM #{@ost.miq_vm}." unless vhds.any?
+    vhds.each do |vhd_attributes|
+      vhd      = vhd_attributes["Path"]
+      type     = vhd_attributes["ControllerType"].downcase
+      number   = vhd_attributes["ControllerNumber"]
+      index = vhd_attributes["ControllerLocation"]
+      tag = "#{type}#{number}:#{index}"
+      cfg_hash["#{tag}.present"]    = "true"
+      cfg_hash["#{tag}.devicetype"] = "disk"
+      cfg_hash["#{tag}.filename"]   = vhd
+    end
+    cfg_hash
+  end
+end

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -48,6 +48,7 @@ class MiqVm
       @vmConfig = VmConfig.new(getCfg(@ost.snapId))
       $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
       $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
+    # TODO: move this to miq_scvmm_vm
     elsif @ost.miq_hyperv
       $log.debug "MiqVm::initialize: accessing VM through HyperV server" if $log.debug?
       @scvmm_vm = @ost.miq_vm
@@ -70,7 +71,7 @@ class MiqVm
   end
 
   def openDisks(diskFiles)
-    pVolumes = Array.new
+    pVolumes = []
 
     $log.debug "openDisks: no disk files supplied." unless diskFiles
 
@@ -99,6 +100,8 @@ class MiqVm
           $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
         end
         dInfo.vixDiskInfo[:connection]  = @vdlConnection
+      elsif @ost.miq_hyperv
+        init_disk_info(dInfo, df)
       else
         dInfo.fileName = df
         disk_format = @vmConfig.getHash["#{dtag}.format"]  # Set by rhevm for iscsi and fcp disks
@@ -109,7 +112,7 @@ class MiqVm
 
       dInfo.hardwareId = dtag
       dInfo.baseOnly = @ost.openParent unless mode && mode["independent"]
-      dInfo.rawDisk = @ost.rawDisk # force raw disk for testing
+      dInfo.rawDisk = @ost.rawDisk
       $log.debug "MiqVm::openDisks: dInfo.baseOnly = #{dInfo.baseOnly}"
 
       begin

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -49,7 +49,7 @@ class MiqVm
       $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
       $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
     # TODO: move this to miq_scvmm_vm
-    elsif @scvmm = @ost.miq_scvmm
+    elsif (@scvmm = @ost.miq_scvmm)
       $log.debug "MiqVm::initialize: accessing VM through HyperV server" if $log.debug?
       @vmConfig = VmConfig.new(getCfg(@ost.snapId))
       $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
@@ -306,7 +306,7 @@ if __FILE__ == $0
     puts "\t#{rt.guestOS}"
     if rt.guestOS == "Linux"
       puts "\n\t\t*** /etc/fstab contents:"
-      rt.fileOpen("/etc/fstab") { |fo| fo.read }.each_line do |fstl|
+      rt.fileOpen("/etc/fstab", &:read).each_line do |fstl|
         next if fstl =~ /^#.*$/
         puts "\t\t\t#{fstl}"
       end

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -49,10 +49,8 @@ class MiqVm
       $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
       $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
     # TODO: move this to miq_scvmm_vm
-    elsif @ost.miq_hyperv
+    elsif @scvmm = @ost.miq_scvmm
       $log.debug "MiqVm::initialize: accessing VM through HyperV server" if $log.debug?
-      @scvmm_vm = @ost.miq_vm
-      @ost.miq_scvmm_vm = @scvmm_vm
       @vmConfig = VmConfig.new(getCfg(@ost.snapId))
       $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
     else

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -93,6 +93,7 @@ class MiqVm
           $log.debug "MiqVm::initialize: accessing VM through SCVMM server" if $log.debug?
           @scvmm_vm = @scvmm.get_vm(vmCfg)
           $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+          @ost.miq_scvmm_vm = @scvmm_vm
           @vmConfig = VmConfig.new(@scvmm_vm.getCfg(@ost.snapId))
         else
           @vdlConnection = @ost.miqVim.vdlConnection unless @vdlConnection

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -6,359 +6,358 @@ require 'fs/MiqMountManager'
 require 'metadata/MIQExtract/MIQExtract'
 
 class MiqVm
-  attr_reader :vmConfig, :vmConfigFile, :vim, :vimVm, :rhevm, :rhevmVm, :diskInitErrors, :wholeDisks
+    attr_reader :vmConfig, :vmConfigFile, :vim, :vimVm, :rhevm, :rhevmVm, :diskInitErrors, :wholeDisks
 
-  def initialize(vmCfg, ost = nil)
-    @ost = ost || OpenStruct.new
-    $log.debug "MiqVm::initialize: @ost = nil" if $log && !@ost
-    @vmDisks = nil
-    @wholeDisks = []
-    @rootTrees = nil
-    @volumeManager = nil
-    @applianceVolumeManager = nil
-    @vmConfigFile = ""
-    @diskInitErrors = {}
-    unless vmCfg.kind_of?(Hash)
-      @vmConfigFile = vmCfg
-      @vmDir = File.dirname(vmCfg)
-    end
+    def initialize(vmCfg, ost=nil)
+        @ost = ost || OpenStruct.new
+        $log.debug "MiqVm::initialize: @ost = nil" if $log && !@ost
+        @vmDisks = nil
+        @wholeDisks = []
+        @rootTrees = nil
+        @volumeManager = nil
+        @applianceVolumeManager = nil
+        @vmConfigFile = ""
+        @diskInitErrors = {}
+        unless vmCfg.kind_of?(Hash)
+            @vmConfigFile = vmCfg
+            @vmDir = File.dirname(vmCfg)
+        end
 
-<<<<<<< HEAD
-    $log.debug "MiqVm::initialize: @ost.openParent = #{@ost.openParent}" if $log
+        $log.debug "MiqVm::initialize: @ost.openParent = #{@ost.openParent}" if $log
 
-    #
-    # If we're passed an MiqVim object, then use VIM to obtain the Vm's
-    # configuration through the instantiated server.
-    # If we're passed a snapshot ID, then obtain the configration of the
-    # VM when the snapshot was taken.
-    #
-    # TODO: move to MiqVmwareVm
-    if (@vim = @ost.miqVim)
-      $log.debug "MiqVm::initialize: accessing VM through server: #{@vim.server}" if $log.debug?
-      @vimVm = @vim.getVimVm(vmCfg)
-      $log.debug "MiqVm::initialize: setting @ost.miqVimVm = #{@vimVm.class}" if $log.debug?
-      @ost.miqVimVm = @vimVm
-      @vmConfig = VmConfig.new(@vimVm.getCfg(@ost.snapId))
-    # TODO: move this to MiqRhevmVm.
-    elsif (@rhevm = @ost.miqRhevm)
-      $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
-      $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
-      @rhevmVm = @rhevm.get_vm(vmCfg)
-      $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
-      @ost.miqRhevmVm = @rhevmVm
-      @vmConfig = VmConfig.new(getCfg(@ost.snapId))
-      $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
-      $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
-    else
-      @vimVm = nil
-      @vmConfig = VmConfig.new(vmCfg)
-    end
-  end # def initialize
-
-  def vmDisks
-    @vmDisks ||= begin
-      @volMgrPS = VolMgrPlatformSupport.new(@vmConfig.configFile, @ost)
-      @volMgrPS.preMount
-
-      openDisks(@vmConfig.getDiskFileHash)
-    end
-  end
-
-  def openDisks(diskFiles)
-    pVolumes = []
-
-    $log.debug "openDisks: no disk files supplied." unless diskFiles
-
-    #
-    # Build a list of the VM's physical volumes.
-    #
-    diskFiles.each do |dtag, df|
-      $log.debug "openDisks: processing disk file (#{dtag}): #{df}"
-      dInfo = OpenStruct.new
-
-      if @ost.miqVim
-        dInfo.vixDiskInfo = Hash.new
-        dInfo.vixDiskInfo[:fileName]    = @ost.miqVim.datastorePath(df)
-        if @ost.miqVimVm && @ost.miqVim.isVirtualCenter?
-          thumb_print    = VcenterThumbPrint.new(@ost.miqVimVm.invObj.server)
-          @vdlConnection = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
-          $log.debug "openDisks (VC): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
-        elsif @ost.miqVimVm
-          esx_host         = @ost.miqVimVm.invObj.server
-          esx_username     = @ost.miqVimVm.invObj.username
-          esx_password     = @ost.miqVimVm.invObj.password
-          thumb_print      = ESXThumbPrint.new(esx_host, esx_username, esx_password)
-          @vdlConnection   = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
+        #
+        # If we're passed an MiqVim object, then use VIM to obtain the Vm's
+        # configuration through the instantiated server.
+        # If we're passed a snapshot ID, then obtain the configration of the
+        # VM when the snapshot was taken.
+        #
+        # TODO: move to MiqVmwareVm
+        if (@vim = @ost.miqVim)
+            $log.debug "MiqVm::initialize: accessing VM through server: #{@vim.server}" if $log.debug?
+            @vimVm = @vim.getVimVm(vmCfg)
+            $log.debug "MiqVm::initialize: setting @ost.miqVimVm = #{@vimVm.class}" if $log.debug?
+            @ost.miqVimVm = @vimVm
+            @vmConfig = VmConfig.new(@vimVm.getCfg(@ost.snapId))
+        # TODO: move this to MiqRhevmVm.
+        elsif (@rhevm = @ost.miqRhevm)
+            $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
+            $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
+            @rhevmVm = @rhevm.get_vm(vmCfg)
+            $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
+            @ost.miqRhevmVm = @rhevmVm
+            @vmConfig = VmConfig.new(getCfg(@ost.snapId))
+            $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
+            $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
         elsif (@scvmm = @ost.miq_scvmm)
           $log.debug "MiqVm::initialize: accessing VM through SCVMM server" if $log.debug?
-          @scvmm_vm = @scvmm.get_vm(vmCfg)
-          $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+          @scvmm_vm = @ost.miq_vm
           @ost.miq_scvmm_vm = @scvmm_vm
-          @vmConfig = VmConfig.new(@scvmm_vm.getCfg(@ost.snapId))
+          @vmConfig = VmConfig.new(getCfg(@ost.snapId))
+          $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
         else
-          @vdlConnection = @ost.miqVim.vdlConnection unless @vdlConnection
-          $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
+            @vimVm = nil
+            @vmConfig = VmConfig.new(vmCfg)
         end
-        dInfo.vixDiskInfo[:connection]  = @vdlConnection
-      else
-        dInfo.fileName = df
-        disk_format = @vmConfig.getHash["#{dtag}.format"]  # Set by rhevm for iscsi and fcp disks
-        dInfo.format = disk_format unless disk_format.blank?
-      end
+    end # def initialize
 
-      mode = @vmConfig.getHash["#{dtag}.mode"]
+    def vmDisks
+        @vmDisks ||= begin
+            @volMgrPS = VolMgrPlatformSupport.new(@vmConfig.configFile, @ost)
+            @volMgrPS.preMount
 
-      dInfo.hardwareId = dtag
-      dInfo.baseOnly = @ost.openParent unless mode && mode["independent"]
-      dInfo.rawDisk = @ost.rawDisk
-      $log.debug "MiqVm::openDisks: dInfo.baseOnly = #{dInfo.baseOnly}"
-      $log.debug "MiqVolumeManager::openDisks: dInfo.rawDisk = #{dInfo.rawDisk}"
-
-      begin
-        d = applianceVolumeManager && applianceVolumeManager.lvHash[dInfo.fileName] if @rhevm
-        if d
-          $log.debug "MiqVm::openDisks: using applianceVolumeManager for #{dInfo.fileName}" if $log.debug?
-          d.dInfo.fileName = dInfo.fileName
-          d.dInfo.hardwareId = dInfo.hardwareId
-          d.dInfo.baseOnly = dInfo.baseOnly
-          d.dInfo.format = dInfo.format if dInfo.format
-          d.dInfo.applianceVolumeManager = applianceVolumeManager
-          #
-          # Here, we need to probe the disk to determine its data format,
-          # QCOW for example. If the disk format is not flat, push a disk
-          # supporting the format on top of this disk. Then set d to point
-          # to the new top disk.
-          #
-          d = d.pushFormatSupport
-        else
-          d = MiqDisk.getDisk(dInfo)
-          # I am not sure if getting a nil handle back should throw an error or not.
-          # For now I am just skipping to the next disk.  (GMM)
-          next if d.nil?
+            openDisks(@vmConfig.getDiskFileHash)
         end
-      rescue => err
-        $log.error "Couldn't open disk file: #{df}"
-        $log.error err.to_s
-        $log.debug err.backtrace.join("\n")
-        @diskInitErrors[df] = err.to_s
-        next
-      end
-
-      @wholeDisks << d
-      p = d.getPartitions
-      if p.empty?
-        #
-        # If the disk has no partitions, the whole disk can be a single volume.
-        #
-        pVolumes << d
-      else
-        #
-        # If the disk is partitioned, the partitions are physical volumes,
-        # but not the whild disk.
-        #
-        pVolumes.concat(p)
-      end
     end
 
-    pVolumes
-  end # def openDisks
+    def openDisks(diskFiles)        
+        pVolumes = Array.new
+        
+        $log.debug "openDisks: no disk files supplied." if !diskFiles
 
-  def rootTrees
-    return @rootTrees if @rootTrees
-    @rootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
-    volumeManager.rootTrees = @rootTrees
-    @rootTrees
-  end
+        #
+        # Build a list of the VM's physical volumes.
+        #
+        diskFiles.each do |dtag, df|
+            $log.debug "openDisks: processing disk file (#{dtag}): #{df}"
+            dInfo = OpenStruct.new
 
-  def volumeManager
-    @volumeManager ||= MiqVolumeManager.new(vmDisks)
-  end
+            if @ost.miqVim
+                dInfo.vixDiskInfo = Hash.new
+                dInfo.vixDiskInfo[:fileName]    = @ost.miqVim.datastorePath(df)
+                if @ost.miqVimVm && @ost.miqVim.isVirtualCenter?
+                    thumb_print    = VcenterThumbPrint.new(@ost.miqVimVm.invObj.server)
+                    @vdlConnection = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
+                    $log.debug "openDisks (VC): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
+                elsif @ost.miqVimVm
+                    esx_host         = @ost.miqVimVm.invObj.server
+                    esx_username     = @ost.miqVimVm.invObj.username
+                    esx_password     = @ost.miqVimVm.invObj.password
+                    thumb_print      = ESXThumbPrint.new(esx_host, esx_username, esx_password)
+                    @vdlConnection   = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
+                else
+                    @vdlConnection = @ost.miqVim.vdlConnection unless @vdlConnection
+                    $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
+                end
+                dInfo.vixDiskInfo[:connection]  = @vdlConnection
+            else
+                dInfo.fileName = df
+                disk_format = @vmConfig.getHash["#{dtag}.format"]  # Set by rhevm for iscsi and fcp disks
+                dInfo.format = disk_format unless disk_format.blank?
+            end
 
-  def applianceVolumeManager
-    return nil if @ost.nfs_storage_mounted
-    @applianceVolumeManager ||= MiqVolumeManager.fromNativePvs
-  end
-
-  def snapshots(refresh = false)
-    return nil unless @vimVm
-    return @vimVm.snapshotInfo(refresh) if @vimVm
-  end
-
-  def unmount
-    $log.info "MiqVm.unmount called."
-    @wholeDisks.each(&:close)
-    @wholeDisks.clear
-    if @volumeManager
-      @volumeManager.close
-      @volumeManager = nil
+            mode = @vmConfig.getHash["#{dtag}.mode"]
+            
+            dInfo.hardwareId = dtag
+            dInfo.baseOnly = @ost.openParent unless mode && mode["independent"]
+            dInfo.rawDisk = @ost.rawDisk # force raw disk for testing
+            $log.debug "MiqVm::openDisks: dInfo.baseOnly = #{dInfo.baseOnly}"
+            
+            begin
+                d = applianceVolumeManager && applianceVolumeManager.lvHash[dInfo.fileName] if @rhevm
+                if d
+                    $log.debug "MiqVm::openDisks: using applianceVolumeManager for #{dInfo.fileName}" if $log.debug?
+                    d.dInfo.fileName = dInfo.fileName
+                    d.dInfo.hardwareId = dInfo.hardwareId
+                    d.dInfo.baseOnly = dInfo.baseOnly
+                    d.dInfo.format = dInfo.format if dInfo.format
+                    d.dInfo.applianceVolumeManager = applianceVolumeManager
+                    #
+                    # Here, we need to probe the disk to determine its data format,
+                    # QCOW for example. If the disk format is not flat, push a disk
+                    # supporting the format on top of this disk. Then set d to point
+                    # to the new top disk.
+                    #
+                    d = d.pushFormatSupport
+                else
+                    d = MiqDisk.getDisk(dInfo)
+                    # I am not sure if getting a nil handle back should throw an error or not.
+                    # For now I am just skipping to the next disk.  (GMM)
+                    next if d.nil?
+                end
+            rescue => err
+                $log.error "Couldn't open disk file: #{df}"
+                $log.error err.to_s
+                $log.debug err.backtrace.join("\n")
+                @diskInitErrors[df] = err.to_s
+                next
+            end
+            
+            @wholeDisks << d
+            p = d.getPartitions 
+            if p.empty?
+                #
+                # If the disk has no partitions, the whole disk can be a single volume.
+                #
+                pVolumes << d
+            else
+                #
+                # If the disk is partitioned, the partitions are physical volumes,
+                # but not the whild disk.
+                #
+                pVolumes.concat(p)
+            end
+        end
+        
+        return pVolumes
+    end # def openDisks
+    
+    def rootTrees
+        return @rootTrees if @rootTrees
+        @rootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
+        volumeManager.rootTrees = @rootTrees
+        return @rootTrees
     end
-    @applianceVolumeManager.closeAll if @applianceVolumeManager
-    @applianceVolumeManager = nil
-    @ost.miqVim.closeVdlConnection(@vdlConnection) if @vdlConnection
-    if @volMgrPS
-      @volMgrPS.postMount
-      @volMgrPS = nil
+    
+    def volumeManager
+        @volumeManager ||= MiqVolumeManager.new(vmDisks)
     end
-    @vimVm.release if @vimVm
-    @rootTrees = nil
-    @vmDisks = nil
-  end
 
-  def miq_extract
-    @miq_extract ||= MIQExtract.new(self, @ost)
-  end
+    def applianceVolumeManager
+        return nil if @ost.nfs_storage_mounted
+        @applianceVolumeManager ||= MiqVolumeManager.fromNativePvs
+    end
 
-  def extract(c)
-    xml = miq_extract.extract(c)
-    raise "Could not extract \"#{c}\" from VM" unless xml
-    (xml)
-  end
+    def snapshots(refresh=false)
+      return nil unless @vimVm
+      return @vimVm.snapshotInfo(refresh) if @vimVm
+    end
+    
+    def unmount
+		$log.info "MiqVm.unmount called."
+        @wholeDisks.each(&:close)
+        @wholeDisks.clear
+        if @volumeManager
+            @volumeManager.close
+            @volumeManager = nil
+        end
+        @applianceVolumeManager.closeAll if @applianceVolumeManager
+        @applianceVolumeManager = nil
+        @ost.miqVim.closeVdlConnection(@vdlConnection) if @vdlConnection
+        if @volMgrPS
+            @volMgrPS.postMount
+            @volMgrPS = nil
+        end
+        @vimVm.release if @vimVm
+        @rootTrees = nil
+        @vmDisks = nil
+    end
+
+    def miq_extract
+        @miq_extract ||= MIQExtract.new(self, @ost)
+    end
+    
+    def extract(c)
+        xml = miq_extract.extract(c)
+        raise "Could not extract \"#{c}\" from VM" if !xml
+        return(xml)
+    end
+    
 end # class MiqVm
 
 if __FILE__ == $0
-  require 'log4r'
-  require 'metadata/util/win32/boot_info_win'
-
-  # vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
-  vmDir = "/volumes/WDpassport/Virtual Machines"
-  puts "vmDir = #{vmDir}"
-
-  targetLv = "rpolv2"
-  rootLv = "LogVol00"
-
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
+    require 'log4r'
+    require 'metadata/util/win32/boot_info_win'
+    
+    # vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
+	vmDir = "/volumes/WDpassport/Virtual Machines"
+    puts "vmDir = #{vmDir}"
+    
+    targetLv = "rpolv2"
+    rootLv = "LogVol00"
+    
+    class ConsoleFormatter < Log4r::Formatter
+    	def format(event)
+    		(event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
+    	end
     end
-  end
 
-  toplog = Log4r::Logger.new 'toplog'
-  Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-  toplog.add 'err_console'
-  $log = toplog if $log.nil?
-
-  #
-  # *** Test start
-  #
-
-  # vmCfg = File.join(vmDir, "cacheguard/cacheguard.vmx")
-  # vmCfg = File.join(vmDir, "Red Hat Linux.vmwarevm/Red Hat Linux.vmx")
-  # vmCfg = File.join(vmDir, "MIQ Server Appliance - Ubuntu MD - small/MIQ Server Appliance - Ubuntu.vmx")
-  # vmCfg = File.join(vmDir, "winxpDev.vmwarevm/winxpDev.vmx")
-  vmCfg = File.join(vmDir, "Win2K_persistent/Windows 2000 Professional.vmx")
-  # vmCfg = File.join(vmDir, "Win2K_non_persistent/Windows 2000 Professional.vmx")
-  puts "VM config file: #{vmCfg}"
-
-  ost = OpenStruct.new
-  ost.openParent = true
-
-  vm = MiqVm.new(vmCfg, ost)
-
-  puts "\n*** Disk Files:"
-  vm.vmConfig.getDiskFileHash.each do |k, v|
-    puts "\t#{k}\t#{v}"
-  end
-
-  puts "\n*** configHash:"
-  vm.vmConfig.getHash.each do |k, v|
-    puts "\t#{k} => #{v}"
-  end
-
-  tlv = nil
-  rlv = nil
-  puts "\n*** Visible Volumes:"
-  vm.volumeManager.visibleVolumes.each do |vv|
-    puts "\tDisk type: #{vv.diskType}"
-    puts "\tDisk sig: #{vv.diskSig}"
-    puts "\tStart LBA: #{vv.lbaStart}"
-    if vv.respond_to?(:logicalVolume)
-      puts "\t\tLV name: #{vv.logicalVolume.lvName}"
-      puts "\t\tLV UUID: #{vv.logicalVolume.lvId}"
-      tlv = vv if vv.logicalVolume.lvName == targetLv
-      rlv = vv if vv.logicalVolume.lvName == rootLv
-    end
-  end
-
-  # raise "#{targetLv} not found" if !tlv
-  #
-  # tlv.seek(0, IO::SEEK_SET)
-  # rs = tlv.read(2040)
-  # puts "\n***** START *****"
-  # puts rs
-  # puts "****** END ******"
-  #
-  # tlv.seek(2048*512*5119, IO::SEEK_SET)
-  # rs = tlv.read(2040)
-  # puts "\n***** START *****"
-  # puts rs
-  # puts "****** END ******"
-  #
-  # raise "#{rootLv} not found" if !rlv
-  #
-  # puts "\n*** Mounting #{rootLv}"
-  # rfs = MiqFS.getFS(rlv)
-  # puts "\tFS Type: #{rfs.fsType}"
-  # puts "\t*** Root-level files and directories:"
-  # rfs.dirForeach("/") { |de| puts "\t\t#{de}" }
-
-  puts "\n***** Detected Guest OSs:"
-  raise "No OSs detected" if vm.rootTrees.length == 0
-  vm.rootTrees.each do |rt|
-    puts "\t#{rt.guestOS}"
-    if rt.guestOS == "Linux"
-      puts "\n\t\t*** /etc/fstab contents:"
-      rt.fileOpen("/etc/fstab", &:read).each_line do |fstl|
-        next if fstl =~ /^#.*$/
-        puts "\t\t\t#{fstl}"
-      end
-    end
-  end
-
-  vm.rootTrees.each do |rt|
-    if rt.guestOS == "Linux"
-      # tdirArr = [ "/", "/boot", "/var/www/miq", "/var/www/miq/vmdb/log", "/var/lib/mysql" ]
-      tdirArr = ["/", "/boot", "/etc/init.d", "/etc/rc.d/init.d", "/etc/rc.d/rc0.d"]
-
-      tdirArr.each do |tdir|
-        begin
-          puts "\n*** Listing #{tdir} directory (1):"
-          rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
-          puts "*** end"
-
-          puts "\n*** Listing #{tdir} directory (2):"
-          rt.chdir(tdir)
-          rt.dirForeach { |de| puts "\t\t#{de}" }
-          puts "*** end"
-        rescue => err
-          puts "*** #{err}"
-        end
-      end
-
-    # lf = rt.fileOpen("/etc/rc0.d/S01halt")
-    # puts "\n*** Contents of /etc/rc0.d/S01halt:"
-    # puts lf.read
-    # puts "*** END"
-    # lf.close
+    toplog = Log4r::Logger.new 'toplog'
+    Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
+    toplog.add 'err_console'
+    $log = toplog if $log.nil?
+    
     #
-    # lfn = "/etc/rc0.d/S01halt"
-    # puts "Is #{lfn} a symbolic link? #{rt.fileSymLink?(lfn)}"
-    # puts "#{lfn} => #{rt.getLinkPath(lfn)}"
-    else  # Windows
-      tdirArr = ["c:/", "e:/", "e:/testE2", "f:/"]
+    # *** Test start
+    #
+    
+    # vmCfg = File.join(vmDir, "cacheguard/cacheguard.vmx")
+    # vmCfg = File.join(vmDir, "Red Hat Linux.vmwarevm/Red Hat Linux.vmx")
+    # vmCfg = File.join(vmDir, "MIQ Server Appliance - Ubuntu MD - small/MIQ Server Appliance - Ubuntu.vmx")
+    # vmCfg = File.join(vmDir, "winxpDev.vmwarevm/winxpDev.vmx")
+	vmCfg = File.join(vmDir, "Win2K_persistent/Windows 2000 Professional.vmx")
+	# vmCfg = File.join(vmDir, "Win2K_non_persistent/Windows 2000 Professional.vmx")
+    puts "VM config file: #{vmCfg}"
 
-      tdirArr.each do |tdir|
-        puts "\n*** Listing #{tdir} directory (1):"
-        rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
-        puts "*** end"
-
-        puts "\n*** Listing #{tdir} directory (2):"
-        rt.chdir(tdir)
-        rt.dirForeach { |de| puts "\t\t#{de}" }
-        puts "*** end"
-      end
+	ost = OpenStruct.new
+	ost.openParent = true
+    
+    vm = MiqVm.new(vmCfg, ost)
+    
+    puts "\n*** Disk Files:"
+    vm.vmConfig.getDiskFileHash.each do |k, v|
+        puts "\t#{k}\t#{v}"
     end
-  end
 
-  vm.unmount
-  puts "...done"
+	puts "\n*** configHash:"
+	vm.vmConfig.getHash.each do |k, v|
+		puts "\t#{k} => #{v}"
+	end
+    
+    tlv = nil
+    rlv = nil
+    puts "\n*** Visible Volumes:"
+    vm.volumeManager.visibleVolumes.each do |vv|
+        puts "\tDisk type: #{vv.diskType}"
+        puts "\tDisk sig: #{vv.diskSig}"
+        puts "\tStart LBA: #{vv.lbaStart}"
+        if vv.respond_to?(:logicalVolume)
+            puts "\t\tLV name: #{vv.logicalVolume.lvName}"
+            puts "\t\tLV UUID: #{vv.logicalVolume.lvId}"
+            tlv = vv if vv.logicalVolume.lvName == targetLv
+            rlv = vv if vv.logicalVolume.lvName == rootLv
+        end
+    end
+     
+   # raise "#{targetLv} not found" if !tlv
+   # 
+   # tlv.seek(0, IO::SEEK_SET)
+   # rs = tlv.read(2040)
+   # puts "\n***** START *****"
+   # puts rs
+   # puts "****** END ******"
+   # 
+   # tlv.seek(2048*512*5119, IO::SEEK_SET)
+   # rs = tlv.read(2040)
+   # puts "\n***** START *****"
+   # puts rs
+   # puts "****** END ******"
+   # 
+   # raise "#{rootLv} not found" if !rlv
+   # 
+   # puts "\n*** Mounting #{rootLv}"
+   # rfs = MiqFS.getFS(rlv)
+   # puts "\tFS Type: #{rfs.fsType}"
+   # puts "\t*** Root-level files and directories:"
+   # rfs.dirForeach("/") { |de| puts "\t\t#{de}" }
+    
+    puts "\n***** Detected Guest OSs:"
+    raise "No OSs detected" if vm.rootTrees.length == 0
+    vm.rootTrees.each do |rt|
+        puts "\t#{rt.guestOS}"
+        if rt.guestOS == "Linux"
+            puts "\n\t\t*** /etc/fstab contents:"
+            rt.fileOpen("/etc/fstab") { |fo| fo.read }.each_line do |fstl|
+                next if fstl =~ /^#.*$/
+                puts "\t\t\t#{fstl}"
+            end
+        end
+    end
+    
+    vm.rootTrees.each do |rt|
+        if rt.guestOS == "Linux"
+            # tdirArr = [ "/", "/boot", "/var/www/miq", "/var/www/miq/vmdb/log", "/var/lib/mysql" ]
+            tdirArr = [ "/", "/boot", "/etc/init.d", "/etc/rc.d/init.d", "/etc/rc.d/rc0.d" ]
+    
+            tdirArr.each do |tdir|
+                begin
+                    puts "\n*** Listing #{tdir} directory (1):"
+                    rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
+                    puts "*** end"
+    
+                    puts "\n*** Listing #{tdir} directory (2):"
+                    rt.chdir(tdir)
+                    rt.dirForeach { |de| puts "\t\t#{de}" }
+                    puts "*** end"
+                rescue => err
+                    puts "*** #{err}"
+                end
+            end
+            
+            # lf = rt.fileOpen("/etc/rc0.d/S01halt")
+            # puts "\n*** Contents of /etc/rc0.d/S01halt:"
+            # puts lf.read
+            # puts "*** END"
+            # lf.close
+            # 
+            # lfn = "/etc/rc0.d/S01halt"
+            # puts "Is #{lfn} a symbolic link? #{rt.fileSymLink?(lfn)}"
+            # puts "#{lfn} => #{rt.getLinkPath(lfn)}"
+        else  # Windows
+            tdirArr = [ "c:/", "e:/", "e:/testE2", "f:/" ]
+
+            tdirArr.each do |tdir|
+                puts "\n*** Listing #{tdir} directory (1):"
+                rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
+                puts "*** end"
+
+                puts "\n*** Listing #{tdir} directory (2):"
+                rt.chdir(tdir)
+                rt.dirForeach { |de| puts "\t\t#{de}" }
+                puts "*** end"
+            end
+        end
+    end
+    
+    vm.unmount
+    puts "...done"
 end

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -23,6 +23,7 @@ class MiqVm
       @vmDir = File.dirname(vmCfg)
     end
 
+<<<<<<< HEAD
     $log.debug "MiqVm::initialize: @ost.openParent = #{@ost.openParent}" if $log
 
     #
@@ -88,6 +89,11 @@ class MiqVm
           esx_password     = @ost.miqVimVm.invObj.password
           thumb_print      = ESXThumbPrint.new(esx_host, esx_username, esx_password)
           @vdlConnection   = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
+        elsif (@scvmm = @ost.miq_scvmm)
+          $log.debug "MiqVm::initialize: accessing VM through SCVMM server" if $log.debug?
+          @scvmm_vm = @scvmm.get_vm(vmCfg)
+          $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+          @vmConfig = VmConfig.new(@scvmm_vm.getCfg(@ost.snapId))
         else
           @vdlConnection = @ost.miqVim.vdlConnection unless @vdlConnection
           $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -6,358 +6,357 @@ require 'fs/MiqMountManager'
 require 'metadata/MIQExtract/MIQExtract'
 
 class MiqVm
-    attr_reader :vmConfig, :vmConfigFile, :vim, :vimVm, :rhevm, :rhevmVm, :diskInitErrors, :wholeDisks
+  attr_reader :vmConfig, :vmConfigFile, :vim, :vimVm, :rhevm, :rhevmVm, :diskInitErrors, :wholeDisks
 
-    def initialize(vmCfg, ost=nil)
-        @ost = ost || OpenStruct.new
-        $log.debug "MiqVm::initialize: @ost = nil" if $log && !@ost
-        @vmDisks = nil
-        @wholeDisks = []
-        @rootTrees = nil
-        @volumeManager = nil
-        @applianceVolumeManager = nil
-        @vmConfigFile = ""
-        @diskInitErrors = {}
-        unless vmCfg.kind_of?(Hash)
-            @vmConfigFile = vmCfg
-            @vmDir = File.dirname(vmCfg)
-        end
+  def initialize(vmCfg, ost = nil)
+    @ost = ost || OpenStruct.new
+    $log.debug "MiqVm::initialize: @ost = nil" if $log && !@ost
+    @vmDisks = nil
+    @wholeDisks = []
+    @rootTrees = nil
+    @volumeManager = nil
+    @applianceVolumeManager = nil
+    @vmConfigFile = ""
+    @diskInitErrors = {}
+    unless vmCfg.kind_of?(Hash)
+      @vmConfigFile = vmCfg
+      @vmDir = File.dirname(vmCfg)
+    end
 
-        $log.debug "MiqVm::initialize: @ost.openParent = #{@ost.openParent}" if $log
+    $log.debug "MiqVm::initialize: @ost.openParent = #{@ost.openParent}" if $log
 
-        #
-        # If we're passed an MiqVim object, then use VIM to obtain the Vm's
-        # configuration through the instantiated server.
-        # If we're passed a snapshot ID, then obtain the configration of the
-        # VM when the snapshot was taken.
-        #
-        # TODO: move to MiqVmwareVm
-        if (@vim = @ost.miqVim)
-            $log.debug "MiqVm::initialize: accessing VM through server: #{@vim.server}" if $log.debug?
-            @vimVm = @vim.getVimVm(vmCfg)
-            $log.debug "MiqVm::initialize: setting @ost.miqVimVm = #{@vimVm.class}" if $log.debug?
-            @ost.miqVimVm = @vimVm
-            @vmConfig = VmConfig.new(@vimVm.getCfg(@ost.snapId))
-        # TODO: move this to MiqRhevmVm.
-        elsif (@rhevm = @ost.miqRhevm)
-            $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
-            $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
-            @rhevmVm = @rhevm.get_vm(vmCfg)
-            $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
-            @ost.miqRhevmVm = @rhevmVm
-            @vmConfig = VmConfig.new(getCfg(@ost.snapId))
-            $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
-            $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
-        elsif (@scvmm = @ost.miq_scvmm)
-          $log.debug "MiqVm::initialize: accessing VM through SCVMM server" if $log.debug?
-          @scvmm_vm = @ost.miq_vm
-          @ost.miq_scvmm_vm = @scvmm_vm
-          @vmConfig = VmConfig.new(getCfg(@ost.snapId))
-          $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+    #
+    # If we're passed an MiqVim object, then use VIM to obtain the Vm's
+    # configuration through the instantiated server.
+    # If we're passed a snapshot ID, then obtain the configration of the
+    # VM when the snapshot was taken.
+    #
+    # TODO: move to MiqVmwareVm
+    if (@vim = @ost.miqVim)
+      $log.debug "MiqVm::initialize: accessing VM through server: #{@vim.server}" if $log.debug?
+      @vimVm = @vim.getVimVm(vmCfg)
+      $log.debug "MiqVm::initialize: setting @ost.miqVimVm = #{@vimVm.class}" if $log.debug?
+      @ost.miqVimVm = @vimVm
+      @vmConfig = VmConfig.new(@vimVm.getCfg(@ost.snapId))
+    # TODO: move this to MiqRhevmVm.
+    elsif (@rhevm = @ost.miqRhevm)
+      $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
+      $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
+      @rhevmVm = @rhevm.get_vm(vmCfg)
+      $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
+      @ost.miqRhevmVm = @rhevmVm
+      @vmConfig = VmConfig.new(getCfg(@ost.snapId))
+      $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
+      $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
+    elsif @ost.miq_hyperv
+      $log.debug "MiqVm::initialize: accessing VM through HyperV server" if $log.debug?
+      @scvmm_vm = @ost.miq_vm
+      @ost.miq_scvmm_vm = @scvmm_vm
+      @vmConfig = VmConfig.new(getCfg(@ost.snapId))
+      $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+    else
+      @vimVm = nil
+      @vmConfig = VmConfig.new(vmCfg)
+    end
+  end # def initialize
+
+  def vmDisks
+    @vmDisks ||= begin
+      @volMgrPS = VolMgrPlatformSupport.new(@vmConfig.configFile, @ost)
+      @volMgrPS.preMount
+
+      openDisks(@vmConfig.getDiskFileHash)
+    end
+  end
+
+  def openDisks(diskFiles)
+    pVolumes = Array.new
+
+    $log.debug "openDisks: no disk files supplied." unless diskFiles
+
+    #
+    # Build a list of the VM's physical volumes.
+    #
+    diskFiles.each do |dtag, df|
+      $log.debug "openDisks: processing disk file (#{dtag}): #{df}"
+      dInfo = OpenStruct.new
+
+      if @ost.miqVim
+        dInfo.vixDiskInfo            = {}
+        dInfo.vixDiskInfo[:fileName] = @ost.miqVim.datastorePath(df)
+        if @ost.miqVimVm && @ost.miqVim.isVirtualCenter?
+          thumb_print    = VcenterThumbPrint.new(@ost.miqVimVm.invObj.server)
+          @vdlConnection = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
+          $log.debug "openDisks (VC): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
+        elsif @ost.miqVimVm
+          esx_host       = @ost.miqVimVm.invObj.server
+          esx_username   = @ost.miqVimVm.invObj.username
+          esx_password   = @ost.miqVimVm.invObj.password
+          thumb_print    = ESXThumbPrint.new(esx_host, esx_username, esx_password)
+          @vdlConnection = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
         else
-            @vimVm = nil
-            @vmConfig = VmConfig.new(vmCfg)
+          @vdlConnection = @ost.miqVim.vdlConnection unless @vdlConnection
+          $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
         end
-    end # def initialize
+        dInfo.vixDiskInfo[:connection]  = @vdlConnection
+      else
+        dInfo.fileName = df
+        disk_format = @vmConfig.getHash["#{dtag}.format"]  # Set by rhevm for iscsi and fcp disks
+        dInfo.format = disk_format unless disk_format.blank?
+      end
 
-    def vmDisks
-        @vmDisks ||= begin
-            @volMgrPS = VolMgrPlatformSupport.new(@vmConfig.configFile, @ost)
-            @volMgrPS.preMount
+      mode = @vmConfig.getHash["#{dtag}.mode"]
 
-            openDisks(@vmConfig.getDiskFileHash)
+      dInfo.hardwareId = dtag
+      dInfo.baseOnly = @ost.openParent unless mode && mode["independent"]
+      dInfo.rawDisk = @ost.rawDisk # force raw disk for testing
+      $log.debug "MiqVm::openDisks: dInfo.baseOnly = #{dInfo.baseOnly}"
+
+      begin
+        d = applianceVolumeManager && applianceVolumeManager.lvHash[dInfo.fileName] if @rhevm
+        if d
+          $log.debug "MiqVm::openDisks: using applianceVolumeManager for #{dInfo.fileName}" if $log.debug?
+          d.dInfo.fileName = dInfo.fileName
+          d.dInfo.hardwareId = dInfo.hardwareId
+          d.dInfo.baseOnly = dInfo.baseOnly
+          d.dInfo.format = dInfo.format if dInfo.format
+          d.dInfo.applianceVolumeManager = applianceVolumeManager
+          #
+          # Here, we need to probe the disk to determine its data format,
+          # QCOW for example. If the disk format is not flat, push a disk
+          # supporting the format on top of this disk. Then set d to point
+          # to the new top disk.
+          #
+          d = d.pushFormatSupport
+        else
+          d = MiqDisk.getDisk(dInfo)
+          # I am not sure if getting a nil handle back should throw an error or not.
+          # For now I am just skipping to the next disk.  (GMM)
+          next if d.nil?
         end
-    end
+      rescue => err
+        $log.error "Couldn't open disk file: #{df}"
+        $log.error err.to_s
+        $log.debug err.backtrace.join("\n")
+        @diskInitErrors[df] = err.to_s
+        next
+      end
 
-    def openDisks(diskFiles)        
-        pVolumes = Array.new
-        
-        $log.debug "openDisks: no disk files supplied." if !diskFiles
-
+      @wholeDisks << d
+      p = d.getPartitions
+      if p.empty?
         #
-        # Build a list of the VM's physical volumes.
+        # If the disk has no partitions, the whole disk can be a single volume.
         #
-        diskFiles.each do |dtag, df|
-            $log.debug "openDisks: processing disk file (#{dtag}): #{df}"
-            dInfo = OpenStruct.new
-
-            if @ost.miqVim
-                dInfo.vixDiskInfo = Hash.new
-                dInfo.vixDiskInfo[:fileName]    = @ost.miqVim.datastorePath(df)
-                if @ost.miqVimVm && @ost.miqVim.isVirtualCenter?
-                    thumb_print    = VcenterThumbPrint.new(@ost.miqVimVm.invObj.server)
-                    @vdlConnection = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
-                    $log.debug "openDisks (VC): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
-                elsif @ost.miqVimVm
-                    esx_host         = @ost.miqVimVm.invObj.server
-                    esx_username     = @ost.miqVimVm.invObj.username
-                    esx_password     = @ost.miqVimVm.invObj.password
-                    thumb_print      = ESXThumbPrint.new(esx_host, esx_username, esx_password)
-                    @vdlConnection   = @ost.miqVimVm.vdlVcConnection(thumb_print) unless @vdlConnection
-                else
-                    @vdlConnection = @ost.miqVim.vdlConnection unless @vdlConnection
-                    $log.debug "openDisks (ESX): using disk file path: #{dInfo.vixDiskInfo[:fileName]}"
-                end
-                dInfo.vixDiskInfo[:connection]  = @vdlConnection
-            else
-                dInfo.fileName = df
-                disk_format = @vmConfig.getHash["#{dtag}.format"]  # Set by rhevm for iscsi and fcp disks
-                dInfo.format = disk_format unless disk_format.blank?
-            end
-
-            mode = @vmConfig.getHash["#{dtag}.mode"]
-            
-            dInfo.hardwareId = dtag
-            dInfo.baseOnly = @ost.openParent unless mode && mode["independent"]
-            dInfo.rawDisk = @ost.rawDisk # force raw disk for testing
-            $log.debug "MiqVm::openDisks: dInfo.baseOnly = #{dInfo.baseOnly}"
-            
-            begin
-                d = applianceVolumeManager && applianceVolumeManager.lvHash[dInfo.fileName] if @rhevm
-                if d
-                    $log.debug "MiqVm::openDisks: using applianceVolumeManager for #{dInfo.fileName}" if $log.debug?
-                    d.dInfo.fileName = dInfo.fileName
-                    d.dInfo.hardwareId = dInfo.hardwareId
-                    d.dInfo.baseOnly = dInfo.baseOnly
-                    d.dInfo.format = dInfo.format if dInfo.format
-                    d.dInfo.applianceVolumeManager = applianceVolumeManager
-                    #
-                    # Here, we need to probe the disk to determine its data format,
-                    # QCOW for example. If the disk format is not flat, push a disk
-                    # supporting the format on top of this disk. Then set d to point
-                    # to the new top disk.
-                    #
-                    d = d.pushFormatSupport
-                else
-                    d = MiqDisk.getDisk(dInfo)
-                    # I am not sure if getting a nil handle back should throw an error or not.
-                    # For now I am just skipping to the next disk.  (GMM)
-                    next if d.nil?
-                end
-            rescue => err
-                $log.error "Couldn't open disk file: #{df}"
-                $log.error err.to_s
-                $log.debug err.backtrace.join("\n")
-                @diskInitErrors[df] = err.to_s
-                next
-            end
-            
-            @wholeDisks << d
-            p = d.getPartitions 
-            if p.empty?
-                #
-                # If the disk has no partitions, the whole disk can be a single volume.
-                #
-                pVolumes << d
-            else
-                #
-                # If the disk is partitioned, the partitions are physical volumes,
-                # but not the whild disk.
-                #
-                pVolumes.concat(p)
-            end
-        end
-        
-        return pVolumes
-    end # def openDisks
-    
-    def rootTrees
-        return @rootTrees if @rootTrees
-        @rootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
-        volumeManager.rootTrees = @rootTrees
-        return @rootTrees
-    end
-    
-    def volumeManager
-        @volumeManager ||= MiqVolumeManager.new(vmDisks)
+        pVolumes << d
+      else
+        #
+        # If the disk is partitioned, the partitions are physical volumes,
+        # but not the whild disk.
+        #
+        pVolumes.concat(p)
+      end
     end
 
-    def applianceVolumeManager
-        return nil if @ost.nfs_storage_mounted
-        @applianceVolumeManager ||= MiqVolumeManager.fromNativePvs
-    end
+    pVolumes
+  end # def openDisks
 
-    def snapshots(refresh=false)
-      return nil unless @vimVm
-      return @vimVm.snapshotInfo(refresh) if @vimVm
-    end
-    
-    def unmount
-		$log.info "MiqVm.unmount called."
-        @wholeDisks.each(&:close)
-        @wholeDisks.clear
-        if @volumeManager
-            @volumeManager.close
-            @volumeManager = nil
-        end
-        @applianceVolumeManager.closeAll if @applianceVolumeManager
-        @applianceVolumeManager = nil
-        @ost.miqVim.closeVdlConnection(@vdlConnection) if @vdlConnection
-        if @volMgrPS
-            @volMgrPS.postMount
-            @volMgrPS = nil
-        end
-        @vimVm.release if @vimVm
-        @rootTrees = nil
-        @vmDisks = nil
-    end
+  def rootTrees
+    return @rootTrees if @rootTrees
+    @rootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
+    volumeManager.rootTrees = @rootTrees
+    @rootTrees
+  end
 
-    def miq_extract
-        @miq_extract ||= MIQExtract.new(self, @ost)
+  def volumeManager
+    @volumeManager ||= MiqVolumeManager.new(vmDisks)
+  end
+
+  def applianceVolumeManager
+    return nil if @ost.nfs_storage_mounted
+    @applianceVolumeManager ||= MiqVolumeManager.fromNativePvs
+  end
+
+  def snapshots(refresh = false)
+    return nil unless @vimVm
+    return @vimVm.snapshotInfo(refresh) if @vimVm
+  end
+
+  def unmount
+    $log.info "MiqVm.unmount called."
+    @wholeDisks.each(&:close)
+    @wholeDisks.clear
+    if @volumeManager
+      @volumeManager.close
+      @volumeManager = nil
     end
-    
-    def extract(c)
-        xml = miq_extract.extract(c)
-        raise "Could not extract \"#{c}\" from VM" if !xml
-        return(xml)
+    @applianceVolumeManager.closeAll if @applianceVolumeManager
+    @applianceVolumeManager = nil
+    @ost.miqVim.closeVdlConnection(@vdlConnection) if @vdlConnection
+    if @volMgrPS
+      @volMgrPS.postMount
+      @volMgrPS = nil
     end
-    
+    @vimVm.release if @vimVm
+    @rootTrees = nil
+    @vmDisks = nil
+  end
+
+  def miq_extract
+    @miq_extract ||= MIQExtract.new(self, @ost)
+  end
+
+  def extract(c)
+    xml = miq_extract.extract(c)
+    raise "Could not extract \"#{c}\" from VM" unless xml
+    (xml)
+  end
 end # class MiqVm
 
 if __FILE__ == $0
-    require 'log4r'
-    require 'metadata/util/win32/boot_info_win'
-    
-    # vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
-	vmDir = "/volumes/WDpassport/Virtual Machines"
-    puts "vmDir = #{vmDir}"
-    
-    targetLv = "rpolv2"
-    rootLv = "LogVol00"
-    
-    class ConsoleFormatter < Log4r::Formatter
-    	def format(event)
-    		(event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-    	end
+  require 'log4r'
+  require 'metadata/util/win32/boot_info_win'
+
+  # vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
+  vmDir = "/volumes/WDpassport/Virtual Machines"
+  puts "vmDir = #{vmDir}"
+
+  targetLv = "rpolv2"
+  rootLv = "LogVol00"
+
+  class ConsoleFormatter < Log4r::Formatter
+    def format(event)
+      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
     end
+  end
 
-    toplog = Log4r::Logger.new 'toplog'
-    Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
-    toplog.add 'err_console'
-    $log = toplog if $log.nil?
-    
-    #
-    # *** Test start
-    #
-    
-    # vmCfg = File.join(vmDir, "cacheguard/cacheguard.vmx")
-    # vmCfg = File.join(vmDir, "Red Hat Linux.vmwarevm/Red Hat Linux.vmx")
-    # vmCfg = File.join(vmDir, "MIQ Server Appliance - Ubuntu MD - small/MIQ Server Appliance - Ubuntu.vmx")
-    # vmCfg = File.join(vmDir, "winxpDev.vmwarevm/winxpDev.vmx")
-	vmCfg = File.join(vmDir, "Win2K_persistent/Windows 2000 Professional.vmx")
-	# vmCfg = File.join(vmDir, "Win2K_non_persistent/Windows 2000 Professional.vmx")
-    puts "VM config file: #{vmCfg}"
+  toplog = Log4r::Logger.new 'toplog'
+  Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
+  toplog.add 'err_console'
+  $log = toplog if $log.nil?
 
-	ost = OpenStruct.new
-	ost.openParent = true
-    
-    vm = MiqVm.new(vmCfg, ost)
-    
-    puts "\n*** Disk Files:"
-    vm.vmConfig.getDiskFileHash.each do |k, v|
-        puts "\t#{k}\t#{v}"
+  #
+  # *** Test start
+  #
+
+  # vmCfg = File.join(vmDir, "cacheguard/cacheguard.vmx")
+  # vmCfg = File.join(vmDir, "Red Hat Linux.vmwarevm/Red Hat Linux.vmx")
+  # vmCfg = File.join(vmDir, "MIQ Server Appliance - Ubuntu MD - small/MIQ Server Appliance - Ubuntu.vmx")
+  # vmCfg = File.join(vmDir, "winxpDev.vmwarevm/winxpDev.vmx")
+  vmCfg = File.join(vmDir, "Win2K_persistent/Windows 2000 Professional.vmx")
+  # vmCfg = File.join(vmDir, "Win2K_non_persistent/Windows 2000 Professional.vmx")
+  puts "VM config file: #{vmCfg}"
+
+  ost = OpenStruct.new
+  ost.openParent = true
+
+  vm = MiqVm.new(vmCfg, ost)
+
+  puts "\n*** Disk Files:"
+  vm.vmConfig.getDiskFileHash.each do |k, v|
+    puts "\t#{k}\t#{v}"
+  end
+
+  puts "\n*** configHash:"
+  vm.vmConfig.getHash.each do |k, v|
+    puts "\t#{k} => #{v}"
+  end
+
+  tlv = nil
+  rlv = nil
+  puts "\n*** Visible Volumes:"
+  vm.volumeManager.visibleVolumes.each do |vv|
+    puts "\tDisk type: #{vv.diskType}"
+    puts "\tDisk sig: #{vv.diskSig}"
+    puts "\tStart LBA: #{vv.lbaStart}"
+    if vv.respond_to?(:logicalVolume)
+      puts "\t\tLV name: #{vv.logicalVolume.lvName}"
+      puts "\t\tLV UUID: #{vv.logicalVolume.lvId}"
+      tlv = vv if vv.logicalVolume.lvName == targetLv
+      rlv = vv if vv.logicalVolume.lvName == rootLv
     end
+  end
 
-	puts "\n*** configHash:"
-	vm.vmConfig.getHash.each do |k, v|
-		puts "\t#{k} => #{v}"
-	end
-    
-    tlv = nil
-    rlv = nil
-    puts "\n*** Visible Volumes:"
-    vm.volumeManager.visibleVolumes.each do |vv|
-        puts "\tDisk type: #{vv.diskType}"
-        puts "\tDisk sig: #{vv.diskSig}"
-        puts "\tStart LBA: #{vv.lbaStart}"
-        if vv.respond_to?(:logicalVolume)
-            puts "\t\tLV name: #{vv.logicalVolume.lvName}"
-            puts "\t\tLV UUID: #{vv.logicalVolume.lvId}"
-            tlv = vv if vv.logicalVolume.lvName == targetLv
-            rlv = vv if vv.logicalVolume.lvName == rootLv
+  # raise "#{targetLv} not found" if !tlv
+  #
+  # tlv.seek(0, IO::SEEK_SET)
+  # rs = tlv.read(2040)
+  # puts "\n***** START *****"
+  # puts rs
+  # puts "****** END ******"
+  #
+  # tlv.seek(2048*512*5119, IO::SEEK_SET)
+  # rs = tlv.read(2040)
+  # puts "\n***** START *****"
+  # puts rs
+  # puts "****** END ******"
+  #
+  # raise "#{rootLv} not found" if !rlv
+  #
+  # puts "\n*** Mounting #{rootLv}"
+  # rfs = MiqFS.getFS(rlv)
+  # puts "\tFS Type: #{rfs.fsType}"
+  # puts "\t*** Root-level files and directories:"
+  # rfs.dirForeach("/") { |de| puts "\t\t#{de}" }
+
+  puts "\n***** Detected Guest OSs:"
+  raise "No OSs detected" if vm.rootTrees.length == 0
+  vm.rootTrees.each do |rt|
+    puts "\t#{rt.guestOS}"
+    if rt.guestOS == "Linux"
+      puts "\n\t\t*** /etc/fstab contents:"
+      rt.fileOpen("/etc/fstab") { |fo| fo.read }.each_line do |fstl|
+        next if fstl =~ /^#.*$/
+        puts "\t\t\t#{fstl}"
+      end
+    end
+  end
+
+  vm.rootTrees.each do |rt|
+    if rt.guestOS == "Linux"
+      # tdirArr = [ "/", "/boot", "/var/www/miq", "/var/www/miq/vmdb/log", "/var/lib/mysql" ]
+      tdirArr = ["/", "/boot", "/etc/init.d", "/etc/rc.d/init.d", "/etc/rc.d/rc0.d"]
+
+      tdirArr.each do |tdir|
+        begin
+          puts "\n*** Listing #{tdir} directory (1):"
+          rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
+          puts "*** end"
+
+          puts "\n*** Listing #{tdir} directory (2):"
+          rt.chdir(tdir)
+          rt.dirForeach { |de| puts "\t\t#{de}" }
+          puts "*** end"
+        rescue => err
+          puts "*** #{err}"
         end
-    end
-     
-   # raise "#{targetLv} not found" if !tlv
-   # 
-   # tlv.seek(0, IO::SEEK_SET)
-   # rs = tlv.read(2040)
-   # puts "\n***** START *****"
-   # puts rs
-   # puts "****** END ******"
-   # 
-   # tlv.seek(2048*512*5119, IO::SEEK_SET)
-   # rs = tlv.read(2040)
-   # puts "\n***** START *****"
-   # puts rs
-   # puts "****** END ******"
-   # 
-   # raise "#{rootLv} not found" if !rlv
-   # 
-   # puts "\n*** Mounting #{rootLv}"
-   # rfs = MiqFS.getFS(rlv)
-   # puts "\tFS Type: #{rfs.fsType}"
-   # puts "\t*** Root-level files and directories:"
-   # rfs.dirForeach("/") { |de| puts "\t\t#{de}" }
-    
-    puts "\n***** Detected Guest OSs:"
-    raise "No OSs detected" if vm.rootTrees.length == 0
-    vm.rootTrees.each do |rt|
-        puts "\t#{rt.guestOS}"
-        if rt.guestOS == "Linux"
-            puts "\n\t\t*** /etc/fstab contents:"
-            rt.fileOpen("/etc/fstab") { |fo| fo.read }.each_line do |fstl|
-                next if fstl =~ /^#.*$/
-                puts "\t\t\t#{fstl}"
-            end
-        end
-    end
-    
-    vm.rootTrees.each do |rt|
-        if rt.guestOS == "Linux"
-            # tdirArr = [ "/", "/boot", "/var/www/miq", "/var/www/miq/vmdb/log", "/var/lib/mysql" ]
-            tdirArr = [ "/", "/boot", "/etc/init.d", "/etc/rc.d/init.d", "/etc/rc.d/rc0.d" ]
-    
-            tdirArr.each do |tdir|
-                begin
-                    puts "\n*** Listing #{tdir} directory (1):"
-                    rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
-                    puts "*** end"
-    
-                    puts "\n*** Listing #{tdir} directory (2):"
-                    rt.chdir(tdir)
-                    rt.dirForeach { |de| puts "\t\t#{de}" }
-                    puts "*** end"
-                rescue => err
-                    puts "*** #{err}"
-                end
-            end
-            
-            # lf = rt.fileOpen("/etc/rc0.d/S01halt")
-            # puts "\n*** Contents of /etc/rc0.d/S01halt:"
-            # puts lf.read
-            # puts "*** END"
-            # lf.close
-            # 
-            # lfn = "/etc/rc0.d/S01halt"
-            # puts "Is #{lfn} a symbolic link? #{rt.fileSymLink?(lfn)}"
-            # puts "#{lfn} => #{rt.getLinkPath(lfn)}"
-        else  # Windows
-            tdirArr = [ "c:/", "e:/", "e:/testE2", "f:/" ]
+      end
 
-            tdirArr.each do |tdir|
-                puts "\n*** Listing #{tdir} directory (1):"
-                rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
-                puts "*** end"
+      # lf = rt.fileOpen("/etc/rc0.d/S01halt")
+      # puts "\n*** Contents of /etc/rc0.d/S01halt:"
+      # puts lf.read
+      # puts "*** END"
+      # lf.close
+      #
+      # lfn = "/etc/rc0.d/S01halt"
+      # puts "Is #{lfn} a symbolic link? #{rt.fileSymLink?(lfn)}"
+      # puts "#{lfn} => #{rt.getLinkPath(lfn)}"
+    else  # Windows
+      tdirArr = ["c:/", "e:/", "e:/testE2", "f:/"]
 
-                puts "\n*** Listing #{tdir} directory (2):"
-                rt.chdir(tdir)
-                rt.dirForeach { |de| puts "\t\t#{de}" }
-                puts "*** end"
-            end
-        end
+      tdirArr.each do |tdir|
+        puts "\n*** Listing #{tdir} directory (1):"
+        rt.dirForeach(tdir) { |de| puts "\t\t#{de}" }
+        puts "*** end"
+
+        puts "\n*** Listing #{tdir} directory (2):"
+        rt.chdir(tdir)
+        rt.dirForeach { |de| puts "\t\t#{de}" }
+        puts "*** end"
+      end
     end
-    
-    vm.unmount
-    puts "...done"
+  end
+
+  vm.unmount
+  puts "...done"
 end

--- a/gems/pending/MiqVm/miq_scvmm_vm.rb
+++ b/gems/pending/MiqVm/miq_scvmm_vm.rb
@@ -2,39 +2,22 @@ require 'MiqVm/MiqVm'
 require 'Scvmm/miq_scvmm_vm_ssa_info'
 
 class MiqScvmmVm < MiqVm
-
   def openDisks(disk_files)
-    part_volumes = Array.new
+    part_volumes = []
 
-    $log.debug "MiqScvmmVm::openDisks: no disk files supplied." if !disk_files
-    raise "MiqScvmmVm::openDisks: Uninitialized miq_scvmm" if @ost.miq_scvmm.nil?
+    $log.debug "MiqScvmmVm::openDisks: no disk files supplied." unless disk_files
+    raise "MiqScvmmVm::openDisks: Uninitialized miq_scvmm" if @ost.miq_hyperv.nil?
     #
     # Build a list of the VM's physical volumes.
     #
     disk_files.each do |disk_tag, disk_file|
-      disk_info = OpenStruct.new
-      disk_info.hyperv_connection            = Hash.new
-      disk_info.fileName                     = disk_file
-      disk_info.hyperv_connection[:host]     = @ost.miq_hyperv[:host]
-      disk_info.hyperv_connection[:port]     = @ost.miq_hyperv[:port]
-      if @ost.miq_hyperv[:domain].nil?
-        disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:user]
-      else
-        disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:domain] + "\\" + @ost.miq_hyperv[:user]
-      end
-      disk_info.hyperv_connection[:password] = @ost.miq_hyperv[:password]
- 
-      mode = @vmConfig.getHash["#{disk_tag}.mode"]
-      disk_info.hardwareId = disk_tag
-      disk_info.baseOnly   = @ost.openParent unless mode && mode["independent"]
-      disk_info.rawDisk    = @ost.rawDisk
-    
+      disk_info = init_disk_info(disk_file, disk_tag)
+
       begin
         disk = MiqDisk.getDisk(disk_info)
         next if disk.nil?
       rescue => err
-        $log.error "Couldn't open disk file: #{diskfile}"
-        $log.error err.to_s
+        $log.error "Couldn't open disk file: #{disk_file} #{err}"
         $log.debug err.backtrace.join("\n")
         @diskInitErrors[disk_file] = err.to_s
         next
@@ -47,11 +30,10 @@ class MiqScvmmVm < MiqVm
         part_volumes.concat(part)
       end
     end
-    return part_volumes
+    part_volumes
   end
 
-  def getCfg(snap = nil)
-
+  def getCfg(_snap = nil)
     cfg_hash = {}
     # Collect disk information
     # Call out to the Hyper-V host for Info about the VM.
@@ -77,5 +59,27 @@ class MiqScvmmVm < MiqVm
       cfg_hash["#{tag}.filename"]   = vhd
     end
     cfg_hash
+  end
+
+  private
+
+  def init_disk_info(disk_file, disk_tag)
+    disk_info                          = OpenStruct.new
+    disk_info.hyperv_connection        = {}
+    disk_info.fileName                 = disk_file
+    disk_info.hyperv_connection[:host] = @ost.miq_hyperv[:host]
+    disk_info.hyperv_connection[:port] = @ost.miq_hyperv[:port]
+    if @ost.miq_hyperv[:domain].nil?
+      disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:user]
+    else
+      disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:domain] + "\\" + @ost.miq_hyperv[:user]
+    end
+    disk_info.hyperv_connection[:password] = @ost.miq_hyperv[:password]
+
+    mode                 = @vmConfig.getHash["#{disk_tag}.mode"]
+    disk_info.hardwareId = disk_tag
+    disk_info.baseOnly   = @ost.openParent unless mode && mode["independent"]
+    disk_info.rawDisk    = @ost.rawDisk
+    disk_info
   end
 end

--- a/gems/pending/MiqVm/miq_scvmm_vm.rb
+++ b/gems/pending/MiqVm/miq_scvmm_vm.rb
@@ -5,17 +5,7 @@ class MiqScvmmVm < MiqVm
   def getCfg(_snap = nil)
     cfg_hash = {}
     # Collect disk information
-    # Call out to the Hyper-V host for Info about the VM.
-    host              = @ost.miq_hyperv[:host]
-    port              = @ost.miq_hyperv[:port]
-    if @ost.miq_hyperv[:domain].nil?
-      user = @ost.miq_hyperv[:user]
-    else
-      user = @ost.miq_hyperv[:domain] + "\\" + @ost.miq_hyperv[:user]
-    end
-    password          = @ost.miq_hyperv[:password]
-    scvmm_info_handle = MiqScvmmVmSSAInfo.new(host, user, password, port)
-    vhds              = scvmm_info_handle.vm_all_harddisks(@ost.miq_vm)
+    vhds = @scvmm.vm_all_harddisks(@ost.miq_vm)
     raise "Unable to get Hard Disk Info from VM #{@ost.miq_vm}." unless vhds.any?
     vhds.each do |vhd_attributes|
       vhd      = vhd_attributes["Path"]

--- a/gems/pending/MiqVm/test/localVm.rb
+++ b/gems/pending/MiqVm/test/localVm.rb
@@ -9,16 +9,19 @@ class ConsoleFormatter < Log4r::Formatter
   end
 end
 
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$vim_log = $log = toplog if $log.nil?
+$log = Log4r::Logger.new 'toplog'
+Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
+$log.add 'err_console'
 
-VMX = "/Users/rpo/Documents/Virtual Machines.localized/Red Hat Enterprise Linux 5.vmwarevm/Red Hat Enterprise Linux 5.vmx"
+VHD = raise "Please define VHD"
+diskid    = "ide0:0"
+hardware  = "#{diskid}.present = \"TRUE\"\n"
+hardware += "#{diskid}.filename = \"#{VHD}\"\n"
 
 begin
   ost = OpenStruct.new
-  vm = MiqVm.new(VMX, ost)
+  ost.fileName = VHD
+  vm = MiqVm.new(hardware, ost)
 
   vm.rootTrees.each do |fs|
     puts "*** Found root tree for #{fs.guestOS}"
@@ -27,11 +30,13 @@ begin
     puts
   end
 
-  # wte = "software"
-  # puts "Extracting: #{wte}:"
-  # xml = vm.extract(wte)
-  # xml.write($stdout, 4)
-  # puts
+  CATEGORIES	= %w(accounts services software system)
+  CATEGORIES.each do |cat|
+    puts "Extracting: #{cat}:"
+    xml = vm.extract(cat)
+    xml.write($stdout, 4)
+    puts
+  end
 
   vm.unmount
 rescue => err

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -9,7 +9,7 @@ require 'memory_buffer'
 require 'rufus/lru'
 
 class MiqHyperVDisk
-  MIN_SECTORS_TO_CACHE = 16
+  MIN_SECTORS_TO_CACHE = 4
   DEF_BLOCK_CACHE_SIZE = 200
 
   attr_reader :hostname, :virtual_disk, :file_offset, :file_size, :parser, :vm_name, :temp_snapshot_name

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -11,23 +11,38 @@ class MiqHyperVDisk
   def initialize(hyperv_host, user, pass, port = nil)
     @hostname  = hyperv_host
     @winrm     = MiqWinRM.new
-    port       ||= 5985
-    options    = {:port     => port,
-                  :user     => user,
-                  :pass     => pass,
-                  :hostname => @hostname
-                 }
+    port ||= 5985
+    options = {:port     => port,
+               :user     => user,
+               :pass     => pass,
+               :hostname => @hostname
+              }
     @connection = @winrm.connect(options)
     @parser     = MiqScvmmParsePowershell.new
   end
 
   def open(vm_disk)
-    @virtual_disk = vm_disk
+    @virtual_disk  = vm_disk
     @file_offset   = 0
   end
 
-  def seek(offset)
-    @file_offset = offset
+  def close
+    @file_offset   = 0
+    @connection    = nil
+    @winrm         = nil
+  end
+
+  def seek(offset, whence = IO::SEEK_SET)
+    case whence
+    when IO::SEEK_CUR
+      @file_offset += offset
+    when IO::SEEK_END
+      # TODO: Get Filesize from Windows and save offset from EOF here.
+      # @file_offset = @endByteAddr + offset
+    when IO::SEEK_SET
+      @file_offset = offset
+    end
+    @file_offset
   end
 
   def read(size)
@@ -36,14 +51,17 @@ $file_stream = [System.IO.File]::Open("#{@virtual_disk}", "Open")
 $buffer      = New-Object System.Byte[] #{size}
 $file_stream.seek(#{@file_offset}, 0)
 $file_stream.read($buffer, 0, #{size})
-[System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($buffer))
+[System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($buffer))
+$file_stream.Close()
 READ_EOL
 
     # TODO: Error Handling
     encoded_data = @parser.output_to_attribute(@winrm.run_powershell_script(read_script))
     # TODO: If size > EOF offset should be at EOF.
     @file_offset += size
-    Base64.decode64(encoded_data)
+    temp_buf     = ""
+    Base64.decode64(encoded_data).split(' ').each { |c| temp_buf += c.to_i.chr }
+    temp_buf
   end
 
   def snap(vm_name)

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -18,11 +18,7 @@ class MiqHyperVDisk
     @hostname  = hyperv_host
     @winrm     = MiqWinRM.new
     port ||= 5985
-    options = {:port     => port,
-               :user     => user,
-               :pass     => pass,
-               :hostname => @hostname
-              }
+    options = {:port => port, :user => user, :pass => pass, :hostname => @hostname}
     @connection  = @winrm.connect(options)
     @parser      = MiqScvmmParsePowershell.new
     @block_size  = 4096
@@ -50,8 +46,7 @@ STAT_EOL
 
   def close
     @file_offset   = 0
-    @connection    = nil
-    @winrm         = nil
+    @connection    = @winrm = nil
   end
 
   def seek(offset, whence = IO::SEEK_SET)

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -10,7 +10,7 @@ require 'rufus/lru'
 
 class MiqHyperVDisk
   MIN_SECTORS_TO_CACHE = 4
-  DEF_BLOCK_CACHE_SIZE = 200
+  DEF_BLOCK_CACHE_SIZE = 300
 
   attr_reader :hostname, :virtual_disk, :file_offset, :file_size, :parser, :vm_name, :temp_snapshot_name
 

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -4,9 +4,16 @@ require 'miq_winrm'
 require 'miq_scvmm_parse_powershell'
 require 'base64'
 require 'securerandom'
+require 'memory_buffer'
+
+require 'rufus/lru'
 
 class MiqHyperVDisk
-  attr_reader :hostname, :virtual_disk, :file_offset, :parser, :vm_name, :temp_snapshot_name
+
+  MIN_SECTORS_TO_CACHE = 16
+  DEF_BLOCK_CACHE_SIZE = 200
+
+  attr_reader :hostname, :virtual_disk, :file_offset, :file_size, :parser, :vm_name, :temp_snapshot_name
 
   def initialize(hyperv_host, user, pass, port = nil)
     @hostname  = hyperv_host
@@ -17,13 +24,29 @@ class MiqHyperVDisk
                :pass     => pass,
                :hostname => @hostname
               }
-    @connection = @winrm.connect(options)
-    @parser     = MiqScvmmParsePowershell.new
+    @connection  = @winrm.connect(options)
+    @parser      = MiqScvmmParsePowershell.new
+    @block_size  = 4096
+    @file_size   = 0
+    @block_cache = LruHash.new(DEF_BLOCK_CACHE_SIZE)
   end
 
   def open(vm_disk)
     @virtual_disk  = vm_disk
     @file_offset   = 0
+    stat_script = <<-STAT_EOL
+    (Get-Item "#{@virtual_disk}").length
+STAT_EOL
+    file_size, _stderr  = @parser.parse_single_powershell_value(@winrm.run_powershell_script(stat_script))
+    @file_size          = file_size.to_i
+    @end_byte_addr      = @file_size - 1
+    # @size_in_blocks     = @file_size / @block_size
+    @size_in_blocks     = @file_size / @block_size + 1
+    @lba_end            = @size_in_blocks - 1
+  end
+
+  def size
+    @file_size
   end
 
   def close
@@ -37,8 +60,7 @@ class MiqHyperVDisk
     when IO::SEEK_CUR
       @file_offset += offset
     when IO::SEEK_END
-      # TODO: Get Filesize from Windows and save offset from EOF here.
-      # @file_offset = @endByteAddr + offset
+      @file_offset = @end_byte_addr + offset
     when IO::SEEK_SET
       @file_offset = offset
     end
@@ -46,22 +68,58 @@ class MiqHyperVDisk
   end
 
   def read(size)
+    return nil if @file_offset >= @file_size
+    size = @file_size - @file_offset if (@file_offset + size) > @file_size
+
+    start_sector, start_offset = @file_offset.divmod(@block_size)
+    end_sector                 = (@file_offset + size - 1) / @block_size
+    number_sectors             = end_sector - start_sector + 1
+
+    read_buf                   = bread_cached(start_sector, number_sectors)
+    @file_offset               += size
+
+    read_buf[start_offset, size]
+  end
+
+  def bread_cached(start_sector, number_sectors)
+    @block_cache.keys.each do |block_range|
+      if block_range.include?(start_sector) && block_range.include?(start_sector + number_sectors - 1)
+        sector_offset = start_sector - block_range.first
+        buffer_offset = sector_offset * @block_size
+        length = number_sectors * @block_size
+        return @block_cache[block_range][buffer_offset, length]
+      end
+    end
+    sectors_to_read           = [MIN_SECTORS_TO_CACHE, number_sectors].max
+    end_sector                = start_sector + sectors_to_read - 1
+    block_range               = Range.new(start_sector, end_sector)
+    @block_cache[block_range] = bread(start_sector, sectors_to_read)
+
+    sector_offset             = start_sector  - block_range.first
+    buffer_offset             = sector_offset * @block_size
+    length                    = number_sectors * @block_size
+
+    return @block_cache[block_range][buffer_offset, length]
+  end
+
+  def bread(start_sector, number_sectors)
+    return nil if start_sector > @lba_end
+    number_sectors = @size_in_blocks - start_sector if (start_sector + number_sectors) > @size_in_blocks
     read_script = <<-READ_EOL
-$file_stream = [System.IO.File]::Open("#{@virtual_disk}", "Open")
-$buffer      = New-Object System.Byte[] #{size}
-$file_stream.seek(#{@file_offset}, 0)
-$file_stream.read($buffer, 0, #{size})
+$file_stream = [System.IO.File]::Open("#{@virtual_disk}", "Open", "Read", "Read")
+$buffer      = New-Object System.Byte[] #{number_sectors * @block_size}
+$file_stream.seek(#{start_sector * @block_size}, 0)
+$file_stream.read($buffer, 0, #{number_sectors * @block_size})
 [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($buffer))
 $file_stream.Close()
 READ_EOL
 
     # TODO: Error Handling
     encoded_data = @parser.output_to_attribute(@winrm.run_powershell_script(read_script))
-    # TODO: If size > EOF offset should be at EOF.
-    @file_offset += size
-    temp_buf     = ""
-    Base64.decode64(encoded_data).split(' ').each { |c| temp_buf += c.to_i.chr }
-    temp_buf
+    buffer       = MemoryBuffer.create(@block_size * number_sectors)
+    buffer       = ""
+    Base64.decode64(encoded_data).split(' ').each { |c| buffer += c.to_i.chr }
+    buffer
   end
 
   def snap(vm_name)

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -1,0 +1,47 @@
+$:.push("#{File.dirname(__FILE__)}/../util")
+
+require 'miq_winrm'
+require 'miq_scvmm_parse_powershell'
+require 'base64'
+
+class MiqHyperVDisk
+  attr_reader :hostname, :virtual_disk, :file_offset
+
+  def initialize(hyperv_host, user, pass, port = nil)
+    @hostname  = hyperv_host
+    @winrm     = MiqWinRM.new
+    port       ||= 5985
+    options    = {:port     => port,
+                  :user     => user,
+                  :pass     => pass,
+                  :hostname => @hostname
+                 }
+    @connection = @winrm.connect(options)
+  end
+
+  def open(vm_disk)
+    @virtual_disk = vm_disk
+    @file_offset   = 0
+  end
+
+  def seek(offset)
+    @file_offset = offset
+  end
+
+  def read(size)
+    read_script = <<-READ_EOL
+$file_stream = [System.IO.File]::Open("#{@virtual_disk}", "Open")
+$buffer      = New-Object System.Byte[] #{size}
+$file_stream.seek(#{@file_offset}, 0)
+$file_stream.read($buffer, 0, #{size})
+[System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($buffer))
+READ_EOL
+
+    # TODO: Error Handling
+    parser = MiqScvmmParsePowershell.new
+    encoded_data = parser.output_to_attribute(@winrm.run_powershell_script(read_script))
+    # TODO: If size > EOF offset should be at EOF.
+    @file_offset += size
+    Base64.decode64(encoded_data)
+  end
+end

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -9,7 +9,6 @@ require 'memory_buffer'
 require 'rufus/lru'
 
 class MiqHyperVDisk
-
   MIN_SECTORS_TO_CACHE = 16
   DEF_BLOCK_CACHE_SIZE = 200
 
@@ -68,6 +67,7 @@ STAT_EOL
   end
 
   def read(size)
+    $log.debug "miq_hyperv_disk.read(#{size})"
     return nil if @file_offset >= @file_size
     size = @file_size - @file_offset if (@file_offset + size) > @file_size
 
@@ -75,34 +75,31 @@ STAT_EOL
     end_sector                 = (@file_offset + size - 1) / @block_size
     number_sectors             = end_sector - start_sector + 1
 
-    read_buf                   = bread_cached(start_sector, number_sectors)
-    @file_offset               += size
-
-    read_buf[start_offset, size]
+    @file_offset += size
+    bread_cached(start_sector, number_sectors)[start_offset, size]
   end
 
   def bread_cached(start_sector, number_sectors)
+    $log.debug "miq_hyperv_disk.bread_cached(#{start_sector}, #{number_sectors})"
     @block_cache.keys.each do |block_range|
-      if block_range.include?(start_sector) && block_range.include?(start_sector + number_sectors - 1)
-        sector_offset = start_sector - block_range.first
-        buffer_offset = sector_offset * @block_size
-        length = number_sectors * @block_size
-        return @block_cache[block_range][buffer_offset, length]
-      end
+      next unless block_range.include?(start_sector) && block_range.include?(start_sector + number_sectors - 1)
+      sector_offset = start_sector - block_range.first
+      buffer_offset = sector_offset * @block_size
+      length        = number_sectors * @block_size
+      return @block_cache[block_range][buffer_offset, length]
     end
-    sectors_to_read           = [MIN_SECTORS_TO_CACHE, number_sectors].max
-    end_sector                = start_sector + sectors_to_read - 1
-    block_range               = Range.new(start_sector, end_sector)
-    @block_cache[block_range] = bread(start_sector, sectors_to_read)
+    block_range               = entry_range(start_sector, number_sectors)
+    @block_cache[block_range] = bread(start_sector, block_range.last - start_sector + 1)
 
-    sector_offset             = start_sector  - block_range.first
+    sector_offset             = start_sector - block_range.first
     buffer_offset             = sector_offset * @block_size
     length                    = number_sectors * @block_size
 
-    return @block_cache[block_range][buffer_offset, length]
+    @block_cache[block_range][buffer_offset, length]
   end
 
   def bread(start_sector, number_sectors)
+    $log.debug "miq_hyperv_disk.bread(#{start_sector}, #{number_sectors})"
     return nil if start_sector > @lba_end
     number_sectors = @size_in_blocks - start_sector if (start_sector + number_sectors) > @size_in_blocks
     read_script = <<-READ_EOL
@@ -138,5 +135,13 @@ SNAP_EOL
 Remove-VMSnapShot -VMName #{@vm_name} -Name #{@temp_snapshot_name}
 DELETE_SNAP_EOL
     @winrm.run_powershell_script(delete_snap_script)
+  end
+
+  private
+
+  def entry_range(start_sector, number_sectors)
+    sectors_to_read = [MIN_SECTORS_TO_CACHE, number_sectors].max
+    end_sector      = start_sector + sectors_to_read - 1
+    Range.new(start_sector, end_sector)
   end
 end

--- a/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
+++ b/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
@@ -57,8 +57,8 @@ class MiqScvmmParsePowershell
 
   def parse_powershell_value(output)
     stdout, stderr = stdout_stderr(output)
-    $log.debug "MiqScvmmParsePowershell: STDOUT is \"#{stdout}\"" unless stdout.nil?
-    $log.debug "MiqScvmmParsePowershell: STDERR is \"#{stderr}\"" unless stderr.nil?
+    $log.debug "MiqScvmmParsePowershell: STDOUT is \"#{stdout}\"" unless stdout.nil? || $log.nil?
+    $log.debug "MiqScvmmParsePowershell: STDERR is \"#{stderr}\"" unless stderr.nil? || $log.nil?
     return stdout, stderr
   end
 

--- a/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
+++ b/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
@@ -1,10 +1,75 @@
 class MiqScvmmParsePowershell
   def output_to_attribute(winrm_output)
     attribute = ""
+    stderr = ""
     winrm_output[:data].each do |d|
       attribute << d[:stdout] unless d[:stdout].nil?
+      stderr << d[:stderr] unless d[:stderr].nil?
     end
-    # attribute.split("\r\n").first
+    if stderr =~ /Exception/ || stderr =~ /At line:/
+      raise "Error running PowerShell command.\n #{stderr}"
+    end
     attribute.split("\r\n").last
+  end
+
+  #
+  # This method handles one or more lines of exactly one attribute.
+  #
+  def parse_single_attribute_values(output)
+    parse_attribute_values(output)
+  end
+
+  def parse_multiple_attribute_values(output)
+    parse_attribute_values(output, true)
+  end
+
+  #
+  # This method handles one or more lines of one or more attributes.
+  #
+  def parse_attribute_values(output, multiple = nil)
+    stdout, stderr  = parse_powershell_value(output)
+    lines            = stdout.split("\r\n")
+    dashes           = nil
+    attributes       = []
+    attribute_names  = []
+    lines.each do |line|
+      next if line.nil? || line == ""
+      if line =~ /^-+/
+        dashes = true
+        next
+      end
+      if dashes.nil?
+        attribute_names = line.split(" ")
+        next
+      end
+      line_parts = [line.rstrip]
+      line_parts = line.split(" ") unless multiple.nil?
+      raise "Incorrect number of PowerShell Output Attributes Found" if line_parts.size != attribute_names.size
+      i = 0
+      line_hash = {}
+      attribute_names.each do |attribute|
+        line_hash[attribute] = line_parts[i]
+        i += 1
+      end
+      attributes << line_hash
+    end
+    return attributes, stderr
+  end
+
+  def parse_single_powershell_value(output)
+    stdout, stderr = parse_powershell_value(output)
+    return stdout.split("\r\n").first, stderr
+  end
+
+  def parse_powershell_value(output)
+    stdout = ""
+    stderr = ""
+    output[:data].each do |d|
+      stdout << d[:stdout] unless d[:stdout].nil?
+      stderr << d[:stderr] unless d[:stderr].nil?
+    end
+    $log.debug "MiqScvmmParsePowershell: STDOUT is \"#{stdout}\"" unless stdout.nil?
+    $log.debug "MiqScvmmParsePowershell: STDERR is \"#{stderr}\"" unless stderr.nil?
+    return stdout, stderr
   end
 end

--- a/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
+++ b/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
@@ -1,0 +1,10 @@
+class MiqScvmmParsePowershell
+  def output_to_attribute(winrm_output)
+    attribute = ""
+    winrm_output[:data].each do |d|
+      attribute << d[:stdout] unless d[:stdout].nil?
+    end
+    # attribute.split("\r\n").first
+    attribute.split("\r\n").last
+  end
+end

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -13,11 +13,7 @@ class MiqScvmmVmSSAInfo
     @vhd_type    = nil
     @winrm       = MiqWinRM.new
     winrmport    = port.nil? ? 5985 : port
-    options      = {:port     => winrmport,
-                    :user     => user,
-                    :pass     => pass,
-                    :hostname => provider
-                   }
+    options      = {:port     => winrmport, :user     => user, :pass     => pass, :hostname => provider}
 
     @connection = @winrm.connect(options)
     @parser     = MiqScvmmParsePowershell.new

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -36,55 +36,20 @@ HOST_EOL
 
   # Note the following method returns *all* hard disks and some common attributes from the Hyper-V host
   def vm_all_harddisks(vm_name, snapshot = nil, check_snapshot = TRUE)
-    unless check_snapshot.nil?
-      snapshot = vm_name + "__EVM_SNAPSHOT" if snapshot.nil?
-      raise "Checkpoint #{snapshot} for VM #{vm_name} missing" if vm_get_checkpoint(vm_name, snapshot).nil?
-      vhd_script = <<-SNAP_EOL
-Get-VMSnapShot -VMName "#{vm_name}" -Name "#{snapshot}" |  Get-VMHardDiskDrive | \
-  Format-Table -Property Path | out-string -Width 200
-SNAP_EOL
-    else
-      vhd_script = <<-VHD_EOL
-Get-VMHardDiskDrive -VMName "#{vm_name}" | \
-  Format-Table -Property Path | out-string -Width 200
-VHD_EOL
-    end
-
-     properties_script = <<-PROPERTIES_EOL
-Get-VMHardDiskDrive -VMName "#{vm_name}" | \
-  Format-Table -Property ControllerType,ControllerNumber,ControllerLocation -Autosize
-PROPERTIES_EOL
-
-    vhds, stderr       = @parser.parse_single_attribute_values(@winrm.run_powershell_script(vhd_script))
-    raise "Unable to obtain VHD Name(s) for #{vm_name}" if stderr =~ /At line:/
-    properties, stderr = @parser.parse_multiple_attribute_values(@winrm.run_powershell_script(properties_script))
-    raise "Error getting VHD(s) and Attributes for #{vm_name}" if stderr =~ /At line:/ || vhds.size != properties.size
+    vhds       = vm_get_disks(vm_name, snapshot, check_snapshot)
+    properties = vm_get_properties(vm_name)
+    raise "Error getting VHD(s) and Attributes for #{vm_name}" if vhds.size != properties.size
     raise "No Virtual Hard Disk found for VM #{vm_name}" unless vhds.any?
+
     i = 0
     new_vhds = []
     $log.debug "vm_all_harddisks: #{vhds.size} vhds found:\n"
     vhds.each do |vhd|
       vhd.merge!(properties[i])
       new_vhds << vhd
+      i += 1
     end
     new_vhds
-  end
-
-  # Note the following method returns the first hard disk for a VM from the SCVMM
-  def vm_harddisk_from_scvmm(vm_name)
-    location_script = <<-LOCATION_EOL
-Get-SCVirtualHardDisk -VMMServer localhost -VM "#{vm_name}" | \
-  Select-Object -ExpandProperty Location
-LOCATION_EOL
-
-    @vhd_type ||= vm_vhdtype(vm_name)
-    if @vhd_type == "DynamicallyExpanding" || @vhd_type == "Differencing"
-      @vhd, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(location_script))
-      raise "Unable to obtain VHD From SCVMM for #{vm_name}" if stderr =~ /At line:/
-    else
-      raise "Currently unsupported VHD Type #{@vhd_type}"
-    end
-    @vhd
   end
 
   def vm_vhdtype(vm_name)
@@ -130,5 +95,38 @@ RM_CHECKPOINT_EOL
 
     _stdout, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(rm_checkpoint_script))
     raise "Unable to remove Snapshot for #{vm_name}" if stderr =~ /At line:/
+  end
+
+  private
+
+  def vm_get_properties(vm_name)
+    properties_script = <<-PROPERTIES_EOL
+Get-VMHardDiskDrive -VMName "#{vm_name}" | \
+  Format-Table -Property ControllerType,ControllerNumber,ControllerLocation -Autosize
+PROPERTIES_EOL
+
+    properties, stderr = @parser.parse_multiple_attribute_values(@winrm.run_powershell_script(properties_script))
+    raise "Error getting VHD(s) and Attributes for #{vm_name}" if stderr =~ /At line:/
+    properties
+  end
+
+  def vm_get_disks(vm_name, snapshot, check_snapshot)
+    if check_snapshot.nil?
+      vhd_script = <<-VHD_EOL
+Get-VMHardDiskDrive -VMName "#{vm_name}" | \
+  Format-Table -Property Path | out-string -Width 200
+VHD_EOL
+    else
+      snapshot = vm_name + "__EVM_SNAPSHOT" if snapshot.nil?
+      raise "Checkpoint #{snapshot} for VM #{vm_name} missing" if vm_get_checkpoint(vm_name, snapshot).nil?
+      vhd_script = <<-SNAP_EOL
+Get-VMSnapShot -VMName "#{vm_name}" -Name "#{snapshot}" |  Get-VMHardDiskDrive | \
+  Format-Table -Property Path | out-string -Width 200
+SNAP_EOL
+    end
+
+    vhds, stderr = @parser.parse_single_attribute_values(@winrm.run_powershell_script(vhd_script))
+    raise "Unable to obtain VHD Name(s) for #{vm_name}" if stderr =~ /At line:/
+    vhds
   end
 end

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -13,7 +13,7 @@ class MiqScvmmVmSSAInfo
     @vhd_type    = nil
     @winrm       = MiqWinRM.new
     winrmport    = port.nil? ? 5985 : port
-    options      = {:port     => winrmport, :user     => user, :pass     => pass, :hostname => provider}
+    options      = {:port => winrmport, :user => user, :pass => pass, :hostname => provider}
 
     @connection = @winrm.connect(options)
     @parser     = MiqScvmmParsePowershell.new

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -18,7 +18,7 @@ class MiqScvmmVmSSAInfo
                     :hostname => provider
                    }
 
-    @connection  = @winrm.connect(options)
+    @connection = @winrm.connect(options)
   end
 
   def vm_host(vm_name)
@@ -60,7 +60,7 @@ VHDTYPE_EOL
   private
 
   def parse_single_powershell_value(output)
-    stdout    = ""
+    stdout = ""
     output[:data].each do |d|
       stdout << d[:stdout] unless d[:stdout].nil?
     end

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -1,13 +1,14 @@
 $LOAD_PATH.push("#{File.dirname(__FILE__)}/../util")
+$LOAD_PATH.push("#{File.dirname(__FILE__)}")
 
 require 'miq_winrm'
 require 'miq_scvmm_parse_powershell'
 
 class MiqScvmmVmSSAInfo
-  attr_reader :vhd, :hostname, :checkpoints, :connection, :vhd_type
+  attr_reader :vhds, :hostname, :checkpoints, :connection, :vhd_type
   def initialize(provider, user, pass, port = nil)
     @checkpoints = []
-    @vhd         = nil
+    @vhds        = []
     @hostname    = nil
     @vhd_type    = nil
     @winrm       = MiqWinRM.new
@@ -19,6 +20,7 @@ class MiqScvmmVmSSAInfo
                    }
 
     @connection = @winrm.connect(options)
+    @parser     = MiqScvmmParsePowershell.new
   end
 
   def vm_host(vm_name)
@@ -27,25 +29,62 @@ Get-SCVirtualMachine -VMMServer localhost -Name "#{vm_name}" | \
   Select-Object -ExpandProperty Hostname
 HOST_EOL
 
-    # TODO: Examine this code for multiple hard drives.
-    @hostname = parse_single_powershell_value(@winrm.run_powershell_script(host_script))
+    @hostname, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(host_script))
+    raise "Unable to obtain Host for #{vm_name}" if stderr =~ /At line:/
+    @hostname
   end
 
-  def vm_harddisks(vm_name)
+  # Note the following method returns *all* hard disks and some common attributes from the Hyper-V host
+  def vm_all_harddisks(vm_name, snapshot = nil, check_snapshot = TRUE)
+    unless check_snapshot.nil?
+      snapshot = vm_name + "__EVM_SNAPSHOT" if snapshot.nil?
+      raise "Checkpoint #{snapshot} for VM #{vm_name} missing" if vm_get_checkpoint(vm_name, snapshot).nil?
+      vhd_script = <<-SNAP_EOL
+Get-VMSnapShot -VMName "#{vm_name}" -Name "#{snapshot}" |  Get-VMHardDiskDrive | \
+  Format-Table -Property Path | out-string -Width 200
+SNAP_EOL
+    else
+      vhd_script = <<-VHD_EOL
+Get-VMHardDiskDrive -VMName "#{vm_name}" | \
+  Format-Table -Property Path | out-string -Width 200
+VHD_EOL
+    end
+
+     properties_script = <<-PROPERTIES_EOL
+Get-VMHardDiskDrive -VMName "#{vm_name}" | \
+  Format-Table -Property ControllerType,ControllerNumber,ControllerLocation -Autosize
+PROPERTIES_EOL
+
+    vhds, stderr       = @parser.parse_single_attribute_values(@winrm.run_powershell_script(vhd_script))
+    raise "Unable to obtain VHD Name(s) for #{vm_name}" if stderr =~ /At line:/
+    properties, stderr = @parser.parse_multiple_attribute_values(@winrm.run_powershell_script(properties_script))
+    raise "Error getting VHD(s) and Attributes for #{vm_name}" if stderr =~ /At line:/ || vhds.size != properties.size
+    raise "No Virtual Hard Disk found for VM #{vm_name}" unless vhds.any?
+    i = 0
+    new_vhds = []
+    $log.debug "vm_all_harddisks: #{vhds.size} vhds found:\n"
+    vhds.each do |vhd|
+      vhd.merge!(properties[i])
+      new_vhds << vhd
+    end
+    new_vhds
+  end
+
+  # Note the following method returns the first hard disk for a VM from the SCVMM
+  def vm_harddisk_from_scvmm(vm_name)
     location_script = <<-LOCATION_EOL
 Get-SCVirtualHardDisk -VMMServer localhost -VM "#{vm_name}" | \
   Select-Object -ExpandProperty Location
 LOCATION_EOL
 
     @vhd_type ||= vm_vhdtype(vm_name)
-    if @vhd_type == "DynamicallyExpanding"
-      @vhd = parse_single_powershell_value(@winrm.run_powershell_script(location_script))
-    elsif @vhd_type == "Differencing"
-      # TODO: return both the Parent Disk and the Checkpoint Disk
-      raise "Currently unsupported VHD Type #{@vhd_type}"
+    if @vhd_type == "DynamicallyExpanding" || @vhd_type == "Differencing"
+      @vhd, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(location_script))
+      raise "Unable to obtain VHD From SCVMM for #{vm_name}" if stderr =~ /At line:/
     else
       raise "Currently unsupported VHD Type #{@vhd_type}"
     end
+    @vhd
   end
 
   def vm_vhdtype(vm_name)
@@ -54,16 +93,42 @@ Get-SCVirtualHardDisk -VMMServer localhost -VM "#{vm_name}" | \
   Select-Object -ExpandProperty VHDType
 VHDTYPE_EOL
 
-    @vhd_type = parse_single_powershell_value(@winrm.run_powershell_script(vhdtype_script))
+    @vhd_type, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(vhdtype_script))
+    raise "Unable to obtain VHD Type for #{vm_name}" if stderr =~ /At line:/
+    @vhd_type
   end
 
-  private
+  def vm_get_checkpoint(vm_name, snapshot)
+    get_checkpoint_script = <<-GETCHECKPOINT_EOL
+Get-VMSnapShot -ComputerName localhost -VMName "#{vm_name}" -Name "#{snapshot}"| \
+  Select-Object -ExpandProperty Name
+GETCHECKPOINT_EOL
 
-  def parse_single_powershell_value(output)
-    stdout = ""
-    output[:data].each do |d|
-      stdout << d[:stdout] unless d[:stdout].nil?
-    end
-    stdout.split("\r\n").first
+    checkpoint, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(get_checkpoint_script))
+    return nil if stderr =~ /Unable to find a snapshot/
+    checkpoint
+  end
+
+  def vm_create_evm_checkpoint(vm_name, snapshot = nil)
+    snapshot = vm_name + "__EVM_SNAPSHOT" if snapshot.nil?
+    raise "Checkpoint for VM #{vm_name} Already Exists" unless vm_get_checkpoint(vm_name, snapshot).nil?
+
+    checkpoint_script = <<-CHECKPOINT_EOL
+Checkpoint-VM -ComputerName localhost -Name "#{vm_name}" -SnapshotName "#{snapshot}"
+CHECKPOINT_EOL
+
+    _stdout, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(checkpoint_script))
+    raise "Unable to create Snapshot for #{vm_name}" if stderr =~ /At line:/
+    snapshot
+  end
+
+  def vm_remove_evm_checkpoint(vm_name, snapshot = nil)
+    snapshot = vm_name + "__EVM_SNAPSHOT" if snapshot.nil?
+    rm_checkpoint_script = <<-RM_CHECKPOINT_EOL
+Remove-VMSnapshot -ComputerName localhost -VMName "#{vm_name}" -Name "#{snapshot}"
+RM_CHECKPOINT_EOL
+
+    _stdout, stderr = @parser.parse_single_powershell_value(@winrm.run_powershell_script(rm_checkpoint_script))
+    raise "Unable to remove Snapshot for #{vm_name}" if stderr =~ /At line:/
   end
 end

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -1,8 +1,7 @@
-$LOAD_PATH.push("#{File.dirname(__FILE__)}/../util")
-$LOAD_PATH.push("#{File.dirname(__FILE__)}")
+# encoding: US-ASCII
 
-require 'miq_winrm'
-require 'miq_scvmm_parse_powershell'
+require 'util/miq_winrm'
+require 'Scvmm/miq_scvmm_parse_powershell'
 
 class MiqScvmmVmSSAInfo
   attr_reader :vhds, :hostname, :checkpoints, :connection, :vhd_type

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -1,0 +1,69 @@
+$:.push("#{File.dirname(__FILE__)}/../util")
+
+require 'miq_winrm'
+require 'miq_scvmm_parse_powershell'
+
+class MiqScvmmVmSSAInfo
+  attr_reader :vhd, :hostname, :checkpoints, :connection, :vhd_type
+  def initialize(provider, user, pass, port = nil)
+    @checkpoints = []
+    @vhd         = nil
+    @hostname    = nil
+    @vhd_type    = nil
+    @winrm       = MiqWinRM.new
+    winrmport    = port.nil? ? 5985 : port
+    options      = {:port     => winrmport,
+                    :user     => user,
+                    :pass     => pass,
+                    :hostname => provider
+                   }
+
+    @connection  = @winrm.connect(options)
+  end
+
+  def vm_host(vm_name)
+    host_script = <<-HOST_EOL
+Get-SCVirtualMachine -VMMServer localhost -Name "#{vm_name}" | \
+  Select-Object -ExpandProperty Hostname
+HOST_EOL
+
+    # TODO: Examine this code for multiple hard drives.
+    @hostname = parse_single_powershell_value(@winrm.run_powershell_script(host_script))
+  end
+
+  def vm_harddisks(vm_name)
+    location_script = <<-LOCATION_EOL
+Get-SCVirtualHardDisk -VMMServer localhost -VM "#{vm_name}" | \
+  Select-Object -ExpandProperty Location
+LOCATION_EOL
+
+    @vhd_type ||= vm_vhdtype(vm_name)
+    if @vhd_type == "DynamicallyExpanding"
+      @vhd = parse_single_powershell_value(@winrm.run_powershell_script(location_script))
+    elsif @vhd_type == "Differencing"
+      # TODO: return both the Parent Disk and the Checkpoint Disk
+      raise "Currently unsupported VHD Type #{@vhd_type}"
+    else
+      raise "Currently unsupported VHD Type #{@vhd_type}"
+    end
+  end
+
+  def vm_vhdtype(vm_name)
+    vhdtype_script = <<-VHDTYPE_EOL
+Get-SCVirtualHardDisk -VMMServer localhost -VM "#{vm_name}" | \
+  Select-Object -ExpandProperty VHDType
+VHDTYPE_EOL
+
+    @vhd_type = parse_single_powershell_value(@winrm.run_powershell_script(vhdtype_script))
+  end
+
+  private
+
+  def parse_single_powershell_value(output)
+    stdout    = ""
+    output[:data].each do |d|
+      stdout << d[:stdout] unless d[:stdout].nil?
+    end
+    stdout.split("\r\n").first
+  end
+end

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -1,4 +1,4 @@
-$:.push("#{File.dirname(__FILE__)}/../util")
+$LOAD_PATH.push("#{File.dirname(__FILE__)}/../util")
 
 require 'miq_winrm'
 require 'miq_scvmm_parse_powershell'

--- a/gems/pending/Scvmm/test/miq_hyperv_disk_test.rb
+++ b/gems/pending/Scvmm/test/miq_hyperv_disk_test.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.push("#{File.dirname(__FILE__)}/..")
 
+require_relative '../../bundler_setup'
 require 'rubygems'
 require 'log4r'
 require 'miq_hyperv_disk'

--- a/gems/pending/Scvmm/test/miq_hyperv_disk_test.rb
+++ b/gems/pending/Scvmm/test/miq_hyperv_disk_test.rb
@@ -1,0 +1,34 @@
+$LOAD_PATH.push("#{File.dirname(__FILE__)}/..")
+
+require 'rubygems'
+require 'log4r'
+require 'miq_hyperv_disk'
+
+#
+# Formatter to output log messages to the console.
+#
+class ConsoleFormatter < Log4r::Formatter
+  def format(event)
+    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
+  end
+end
+
+$log = Log4r::Logger.new 'toplog'
+Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
+$log.add 'err_console'
+
+HOST = raise "Please define SERVERNAME"
+PORT = raise "Please define PORT"
+USER = raise "Please define USER"
+PASS = raise "Please define PASS"
+DISK = raise "Please define DISK"
+
+hyperv_disk = MiqHyperVDisk.new(HOST, USER, PASS, PORT)
+
+$log.debug "Reading 256 byte slices"
+hyperv_disk.open(DISK)
+hyperv_disk.seek(0)
+(1..8).each do |i|
+  buffer = hyperv_disk.read(256)
+  $log.debug "Buffer #{i}: \n#{buffer}\n"
+end

--- a/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
+++ b/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
@@ -25,10 +25,10 @@ VM   = raise "Please define VM"
 
 vm_info_handle = MiqScvmmVmSSAInfo.new(HOST, USER, PASS, PORT)
 $log.debug "Getting Hyper-V Host for VM #{VM}"
-hyperv_host    = vm_info_handle.vm_host(VM)
+hyperv_host = vm_info_handle.vm_host(VM)
 $log.debug "Hyper-V Host is #{hyperv_host}"
 $log.debug "Getting VHD Type for VM #{VM}"
-vhd_type       = vm_info_handle.vm_vhdtype(VM)
+vhd_type = vm_info_handle.vm_vhdtype(VM)
 $log.debug "VHD Type is #{vhd_type}"
-vhd            = vm_info_handle.vm_harddisks(VM)
+vhd = vm_info_handle.vm_harddisks(VM)
 $log.debug "VHD is #{vhd}"

--- a/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
+++ b/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.push("#{File.dirname(__FILE__)}/..")
 
+require_relative "../../bundler_setup"
 require 'rubygems'
 require 'log4r'
 require 'miq_scvmm_vm_ssa_info'
@@ -32,3 +33,11 @@ vhd_type = vm_info_handle.vm_vhdtype(VM)
 $log.debug "VHD Type is #{vhd_type}"
 vhd = vm_info_handle.vm_harddisks(VM)
 $log.debug "VHD is #{vhd}"
+vm_info_handle.vm_create_checkpoint(VM)
+checkpoint = vm_info_handle.vm_get_checkpoint(VM)
+$log.debug "Checkpoint for #{vhd} is #{checkpoint}"
+vm_info_handle.vm_remove_checkpoint(VM)
+vm_info_handle.vm_create_checkpoint(VM)
+checkpoint = vm_info_handle.vm_get_checkpoint(VM)
+$log.debug "Checkpoint for #{vhd} is #{checkpoint}"
+vm_info_handle.vm_remove_checkpoint(VM)

--- a/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
+++ b/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
@@ -17,7 +17,6 @@ $log = Log4r::Logger.new 'toplog'
 Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
 $log.add 'err_console'
 
-
 HOST = raise "Please define SERVERNAME"
 PORT = raise "Please define PORT"
 USER = raise "Please define USER"

--- a/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
+++ b/gems/pending/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
@@ -1,0 +1,35 @@
+$LOAD_PATH.push("#{File.dirname(__FILE__)}/..")
+
+require 'rubygems'
+require 'log4r'
+require 'miq_scvmm_vm_ssa_info'
+
+#
+# Formatter to output log messages to the console.
+#
+class ConsoleFormatter < Log4r::Formatter
+  def format(event)
+    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
+  end
+end
+
+$log = Log4r::Logger.new 'toplog'
+Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
+$log.add 'err_console'
+
+
+HOST = raise "Please define SERVERNAME"
+PORT = raise "Please define PORT"
+USER = raise "Please define USER"
+PASS = raise "Please define PASS"
+VM   = raise "Please define VM"
+
+vm_info_handle = MiqScvmmVmSSAInfo.new(HOST, USER, PASS, PORT)
+$log.debug "Getting Hyper-V Host for VM #{VM}"
+hyperv_host    = vm_info_handle.vm_host(VM)
+$log.debug "Hyper-V Host is #{hyperv_host}"
+$log.debug "Getting VHD Type for VM #{VM}"
+vhd_type       = vm_info_handle.vm_vhdtype(VM)
+$log.debug "VHD Type is #{vhd_type}"
+vhd            = vm_info_handle.vm_harddisks(VM)
+$log.debug "VHD is #{vhd}"

--- a/gems/pending/disk/modules/MSVSDiffDisk.rb
+++ b/gems/pending/disk/modules/MSVSDiffDisk.rb
@@ -14,7 +14,11 @@ module MSVSDiffDisk
     else
       raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
-    @msDisk_file = MiqLargeFile.open(@dInfo.fileName, fileMode) unless @dInfo.baseOnly
+    if @dInfo.hyperv_connection
+      @msDisk_file = MSCommon.connect_to_hyperv(@dInfo)
+    else
+      @msDisk_file = MiqLargeFile.open(@dInfo.fileName, fileMode) unless @dInfo.baseOnly
+    end
     MSCommon.d_init_common(@dInfo, @msDisk_file) unless @dInfo.baseOnly
 
     # Get parent locators.

--- a/gems/pending/disk/modules/MSVSDiffDisk.rb
+++ b/gems/pending/disk/modules/MSVSDiffDisk.rb
@@ -15,11 +15,11 @@ module MSVSDiffDisk
       raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
     if @dInfo.hyperv_connection
-      @msDisk_file = MSCommon.connect_to_hyperv(@dInfo)
+      @ms_disk_file = MSCommon.connect_to_hyperv(@dInfo)
     else
-      @msDisk_file = MiqLargeFile.open(@dInfo.fileName, fileMode) unless @dInfo.baseOnly
+      @ms_disk_file = MiqLargeFile.open(@dInfo.fileName, fileMode) unless @dInfo.baseOnly
     end
-    MSCommon.d_init_common(@dInfo, @msDisk_file) unless @dInfo.baseOnly
+    MSCommon.d_init_common(@dInfo, @ms_disk_file) unless @dInfo.baseOnly
 
     # Get parent locators.
     @locators = []
@@ -78,13 +78,13 @@ module MSVSDiffDisk
 
   def d_close
     @parent.close if @parent
-    @msDisk_file.close
+    @ms_disk_file.close
   end
 
   def d_size
     total = 0
     total = @parent.d_size if @parent
-    total += @msDisk_file.size
+    total += @ms_disk_file.size
     total
   end
 
@@ -118,7 +118,7 @@ module MSVSDiffDisk
   end
 
   def getPathData(locator)
-    @msDisk_file.seek(MSCommon.getHiLo(locator, "data_offset"), IO::SEEK_SET)
-    @msDisk_file.read(locator['data_length'])
+    @ms_disk_file.seek(MSCommon.getHiLo(locator, "data_offset"), IO::SEEK_SET)
+    @ms_disk_file.read(locator['data_length'])
   end
 end

--- a/gems/pending/disk/modules/MSVSDiskProbe.rb
+++ b/gems/pending/disk/modules/MSVSDiskProbe.rb
@@ -24,14 +24,13 @@ module MSVSDiskProbe
     return nil if ext != ".vhd" && ext != ".avhd" && ext != ".miq"
 
     if ostruct.hyperv_connection
-      msDisk_file = connect_to_hyperv(ostruct)
+      ms_disk_file = connect_to_hyperv(ostruct)
     else
       # Get (assumed) footer.
-      msDisk_file = MiqLargeFile.open(ostruct.fileName, "rb")
+      ms_disk_file = MiqLargeFile.open(ostruct.fileName, "rb")
     end
-    footer = MSCommon.getFooter(msDisk_file, true)
-    msDisk_file.close
-    msDisk_file = nil
+    footer = MSCommon.getFooter(ms_disk_file, true)
+    ms_disk_file.close
 
     # Check for MS disk.
     return nil if footer['cookie'] != MS_MAGIC

--- a/gems/pending/disk/modules/MSVSDiskProbe.rb
+++ b/gems/pending/disk/modules/MSVSDiskProbe.rb
@@ -1,7 +1,6 @@
 # encoding: US-ASCII
-$LOAD_PATH.push("#{File.dirname(__FILE__)}/../../Scvmm")
 
-require 'miq_hyperv_disk'
+require 'Scvmm/miq_hyperv_disk'
 require 'disk/modules/MiqLargeFile'
 require 'disk/modules/MSCommon'
 

--- a/gems/pending/disk/modules/MSVSDynamicDisk.rb
+++ b/gems/pending/disk/modules/MSVSDynamicDisk.rb
@@ -13,11 +13,11 @@ module MSVSDynamicDisk
       raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
     if @dInfo.hyperv_connection
-      @msDisk_file = MSCommon.connect_to_hyperv(@dInfo)
+      @ms_disk_file = MSCommon.connect_to_hyperv(@dInfo)
     else
-      @msDisk_file = MiqLargeFile.open(@dInfo.fileName, fileMode)
+      @ms_disk_file = MiqLargeFile.open(@dInfo.fileName, fileMode)
     end
-    MSCommon.d_init_common(@dInfo, @msDisk_file)
+    MSCommon.d_init_common(@dInfo, @ms_disk_file)
   end
 
   def getBase
@@ -33,7 +33,7 @@ module MSVSDynamicDisk
   end
 
   def d_close
-    @msDisk_file.close
+    @ms_disk_file.close
   end
 
   def d_size

--- a/gems/pending/disk/modules/MSVSDynamicDisk.rb
+++ b/gems/pending/disk/modules/MSVSDynamicDisk.rb
@@ -12,7 +12,11 @@ module MSVSDynamicDisk
     else
       raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
-    @msDisk_file = MiqLargeFile.open(@dInfo.fileName, fileMode)
+    if @dInfo.hyperv_connection
+      @msDisk_file = MSCommon.connect_to_hyperv(@dInfo)
+    else
+      @msDisk_file = MiqLargeFile.open(@dInfo.fileName, fileMode)
+    end
     MSCommon.d_init_common(@dInfo, @msDisk_file)
   end
 

--- a/gems/pending/disk/modules/MSVSFixedDisk.rb
+++ b/gems/pending/disk/modules/MSVSFixedDisk.rb
@@ -15,15 +15,15 @@ module MSVSFixedDisk
     end
 
     if dInfo.hyperv_connection
-      @msFlatDisk_file = MSCommon.connect_to_hyperv(dInfo)
+      @ms_flat_disk_file = MSCommon.connect_to_hyperv(dInfo)
     else
-      @msFlatDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+      @ms_flat_disk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
     end
   end
 
   def d_read(pos, len)
-    @msFlatDisk_file.seek(pos, IO::SEEK_SET)
-    @msFlatDisk_file.read(len)
+    @ms_flat_disk_file.seek(pos, IO::SEEK_SET)
+    @ms_flat_disk_file.read(len)
   end
 
   def getBase
@@ -31,12 +31,12 @@ module MSVSFixedDisk
   end
 
   def d_write(pos, buf, len)
-    @msFlatDisk_file.seek(pos, IO::SEEK_SET)
-    @msFlatDisk_file.write(buf, len)
+    @ms_flat_disk_file.seek(pos, IO::SEEK_SET)
+    @ms_flat_disk_file.write(buf, len)
   end
 
   def d_close
-    @msFlatDisk_file.close
+    @ms_flat_disk_file.close
   end
 
   def d_size

--- a/gems/pending/disk/modules/MSVSFixedDisk.rb
+++ b/gems/pending/disk/modules/MSVSFixedDisk.rb
@@ -14,7 +14,11 @@ module MSVSFixedDisk
       raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
 
-    @msFlatDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+    if dInfo.hyperv_connection
+      @msFlatDisk_file = MSCommon.connect_to_hyperv(dInfo)
+    else
+      @msFlatDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+    end
   end
 
   def d_read(pos, len)

--- a/gems/pending/disk/modules/VhdxDisk.rb
+++ b/gems/pending/disk/modules/VhdxDisk.rb
@@ -615,13 +615,12 @@ module VhdxDisk
   end
 
   def connect_to_hyperv(hyperv_connection)
-    raise "Connection to HyperV Server Not Supported Yet"
-    # connection  = @hyperv_connection = hyperv_connection
-    # hyperv_disk = MiqHyperVDisk.new(connection[:host],
-    #                                 connection[:user],
-    #                                 connection[:password],
-    #                                 connection[:port])
-    # hyperv_disk.open(@file_name)
-    # hyperv_disk
+    connection  = @hyperv_connection = hyperv_connection
+    hyperv_disk = MiqHyperVDisk.new(connection[:host],
+                                    connection[:user],
+                                    connection[:password],
+                                    connection[:port])
+    hyperv_disk.open(@file_name)
+    hyperv_disk
   end
 end

--- a/gems/pending/disk/modules/VhdxDiskProbe.rb
+++ b/gems/pending/disk/modules/VhdxDiskProbe.rb
@@ -1,5 +1,7 @@
 # encoding: US-ASCII
 
+require 'Scvmm/miq_hyperv_disk'
+
 VHDX_DISK      = "VhdxDisk"
 VHDX_SIGNATURE = "vhdxfile"
 
@@ -31,10 +33,9 @@ module VhdxDiskProbe
   end
 
   def self.connect_to_hyperv(ostruct)
-    raise "Connection to HyperV Server Not Supported Yet"
-    # connection  = ostruct.hyperv_connection
-    # hyperv_disk = MiqHyperVDisk.new(connection[:host], connection[:user], connection[:password], connection[:port])
-    # hyperv_disk.open(ostruct.fileName)
-    # hyperv_disk
+    connection  = ostruct.hyperv_connection
+    hyperv_disk = MiqHyperVDisk.new(connection[:host], connection[:user], connection[:password], connection[:port])
+    hyperv_disk.open(ostruct.fileName)
+    hyperv_disk
   end
 end

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -20,10 +20,10 @@ class MiqWinRM
   end
 
   def run_powershell_script(script)
-    $log.debug "Running powershell script on #{hostname} as #{username}:\n#{script}"
+    $log.debug "Running powershell script on #{hostname} as #{username}:\n#{script}" unless $log.nil?
     @connection.run_powershell_script(script)
   rescue WinRM::WinRMAuthorizationError
-    $log.info "Error Logging In to #{hostname} using user \"#{username}\""
+    $log.info "Error Logging In to #{hostname} using user \"#{username}\"" unless $log.nil?
     raise
   end
 

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -4,12 +4,12 @@ class MiqWinRM
   attr_reader :uri, :username, :password, :hostname, :port, :connection
 
   def initialize
-    @port    = 5985
+    @port = 5985
     require 'uri'
   end
 
   def build_uri
-    uri          = URI::HTTP.build(:port => @port, :path => "/wsman", :host => @hostname)
+    uri = URI::HTTP.build(:port => @port, :path => "/wsman", :host => @hostname)
     uri.to_s
   end
 
@@ -17,7 +17,6 @@ class MiqWinRM
     raise "no Username defined" if options[:user].nil?
     raise "no Password defined" if options[:pass].nil?
     raise "no Hostname defined" if options[:hostname].nil?
-
     @username    = options[:user]
     @password    = options[:pass]
     @hostname    = options[:hostname]
@@ -28,9 +27,9 @@ class MiqWinRM
 
   def run_powershell_script(script)
     @connection.run_powershell_script(script)
-    rescue WinRM::WinRMAuthorizationError
-      $log.info "Error Logging In to #{hostname} using user \"#{username}\""
-      raise
+  rescue WinRM::WinRMAuthorizationError
+    $log.info "Error Logging In to #{hostname} using user \"#{username}\""
+    raise
   end
 
   private
@@ -44,6 +43,7 @@ class MiqWinRM
     # Please note - the webmock gem depends on gssapi too and prints out the
     # above warning when rspec tests are run.
     # silence_warnings { require 'winrm' }
+
     WinRM::WinRMWebService.new(uri, :ssl, :user => user, :pass => pass, :disable_sspi => true)
   end
 end

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -1,0 +1,49 @@
+require 'winrm'
+
+class MiqWinRM
+  attr_reader :uri, :username, :password, :hostname, :port, :connection
+
+  def initialize
+    @port    = 5985
+    require 'uri'
+  end
+
+  def build_uri
+    uri          = URI::HTTP.build(:port => @port, :path => "/wsman", :host => @hostname)
+    uri.to_s
+  end
+
+  def connect(options = {})
+    raise "no Username defined" if options[:user].nil?
+    raise "no Password defined" if options[:pass].nil?
+    raise "no Hostname defined" if options[:hostname].nil?
+
+    @username    = options[:user]
+    @password    = options[:pass]
+    @hostname    = options[:hostname]
+    @port        = options[:port] unless options[:port].nil?
+    @uri         = build_uri
+    @connection  = raw_connect(@username, @password, @uri)
+  end
+
+  def run_powershell_script(script)
+    @connection.run_powershell_script(script)
+    rescue WinRM::WinRMAuthorizationError
+      $log.info "Error Logging In to #{hostname} using user \"#{username}\""
+      raise
+  end
+
+  private
+
+  def raw_connect(user, pass, uri)
+    # HACK: WinRM depends on the gssapi gem for encryption purposes.
+    # The gssapi code outputs the following warning:
+    #   WARNING: Could not load IOV methods. Check your GSSAPI C library for an update
+    #   WARNING: Could not load AEAD methods. Check your GSSAPI C library for an update
+    # After much googling, this warning is considered benign and can be ignored.
+    # Please note - the webmock gem depends on gssapi too and prints out the
+    # above warning when rspec tests are run.
+    # silence_warnings { require 'winrm' }
+    WinRM::WinRMWebService.new(uri, :ssl, :user => user, :pass => pass, :disable_sspi => true)
+  end
+end

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -14,18 +14,13 @@ class MiqWinRM
   end
 
   def connect(options = {})
-    raise "no Username defined" if options[:user].nil?
-    raise "no Password defined" if options[:pass].nil?
-    raise "no Hostname defined" if options[:hostname].nil?
-    @username    = options[:user]
-    @password    = options[:pass]
-    @hostname    = options[:hostname]
-    @port        = options[:port] unless options[:port].nil?
-    @uri         = build_uri
-    @connection  = raw_connect(@username, @password, @uri)
+    validate_options(options)
+    @uri        = build_uri
+    @connection = raw_connect(@username, @password, @uri)
   end
 
   def run_powershell_script(script)
+    $log.debug "Running powershell script on #{hostname} as #{username}:\n#{script}"
     @connection.run_powershell_script(script)
   rescue WinRM::WinRMAuthorizationError
     $log.info "Error Logging In to #{hostname} using user \"#{username}\""
@@ -33,6 +28,16 @@ class MiqWinRM
   end
 
   private
+
+  def validate_options(options)
+    raise "no Username defined" if options[:user].nil?
+    raise "no Password defined" if options[:pass].nil?
+    raise "no Hostname defined" if options[:hostname].nil?
+    @username = options[:user]
+    @password = options[:pass]
+    @hostname = options[:hostname]
+    @port     = options[:port] unless options[:port].nil?
+  end
 
   def raw_connect(user, pass, uri)
     # HACK: WinRM depends on the gssapi gem for encryption purposes.

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -60,16 +60,6 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
         end
       end
 
-      context "with a non-vmware vm, " do
-        before(:each) do
-          @vm.vendor = "Microsoft"
-          @vm.save
-        end
-        it "should return no servers" do
-          expect(@vm.miq_server_proxies).to be_empty
-        end
-      end
-
       context "with repository vm(a vm without a host), " do
         before(:each) do
           @vm.host = nil


### PR DESCRIPTION
See the summary - "What Works and What Doesn't" at the bottom.

Add a new MiqDisk Disk Module to handle the VHDX virtual disk
format supported by the new version of Hyper-V and SCVMM.

Get Hard disk information for VMs managed
by SCVMM from the SCVMM and Hyper-V host via powershell
functions.

Read the hard disk from the Hyper-V host.

Gets the vhd, host, vhd type from the Hyper-V Host.
Opens and reads the vhd on the Hyper-V host.

This supports both VHDX files via the new VHDXDisk disk module
and the older VHD files via the existing disk modules.  Support
for communicating to Hyper-V via miq_hyperv_disk was added
to the VHD modules.

The Microsoft Provider has been extended to allow SSA scans to be
run in addition to the MiqDisk, MiqVm, and Scvmm gems/pending code.

Enhancements still required:

1) Currently Snapshots are created using VMNAME__EVM_SNAPSHOT
as the snapshot name.  An enhancement will add the date/time into the
snapshot name.

2) Caching has been implemented in the miq_hyperv_disk code which
allows the VHD and VHDX disk modules to communicate to Hyper-V
to read the files.  We need to continue to look at this caching to speed this
up as much as possible.

3) Virtual disk files residing on network-mapped drives on the Hyper-V server, seen
as starting with \\ rather than a drive letter when the inventory is taken from the server,
show up in the database with a NULL datastore ID.  These files currently fail SSA
because of this NULL ID.   https://github.com/ManageIQ/manageiq/issues/5383
describes this issue.  In addition to handling the parsing the code in MiqScvmmVm::getCfg
needs to handle this situation.  it currently does not.

4) Certain VMs seem to timeout after looping doing I/O for an inordinate amount of time while
local copies of the same VM VHD files run extremely quickly.  Further investigation is needed;
this may be related to the caching item in #2 above.

What Works And What Doesn't - 
1) SSA works on local copies of VHD and VHDX disks and their checkpoints.
2) SSA works  on remote copies of VHD and VHDX disks and their checkpoints residing on Hyper-V servers, except some larger disks may time out based on network bandwidth and possibly one other unresolved issue.
3) Hyper-V VMs with virtual disks residing on network-mapped drives starting with "\\" will not currently work.

@roliveri @Fryguy @chessbyte Please Review

By the way - an update to this old comment - this all works at this point.