### PR TITLE
Remove IP Address information from hover text

### DIFF
--- a/vmdb/app/views/layouts/quadicon/_ext_management_system.html.haml
+++ b/vmdb/app/views/layouts/quadicon/_ext_management_system.html.haml
@@ -43,7 +43,7 @@
     %img{:src => "/images/icons/#{size}/reflection.png", :width => size, :height => size}
 - else
   .flobj
-    - t = [h(item.name), h(item.hostname), h(item.ipaddress), h(item.last_refresh_status.titleize)]
-    %a{:href => url_for_record(item), :title => _("Name: %s | Host Name: %s | IP Address: %s | Refresh Status: %s") % t}
+    - t = [h(item.name), h(item.hostname), h(item.last_refresh_status.titleize)]
+    %a{:href => url_for_record(item), :title => _("Name: %s | Host Name: %s | Refresh Status: %s") % t}
       %img{:src => "/images/icons/#{size}/reflection.png", :width => size, :height => size}
 

--- a/vmdb/spec/views/layouts/quadicon/_ext_management_system.html.haml_spec.rb
+++ b/vmdb/spec/views/layouts/quadicon/_ext_management_system.html.haml_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+include ApplicationHelper
+
+describe "rendering quadicons of ext_management_system" do
+  before(:each) do
+    @settings = {:quadicons => {:ems => true}}
+    @item = FactoryGirl.build(:ems_infra)
+    @item.stub(:hosts).and_return(%w(foo bar))
+    @item.stub(:image_name).and_return("foo")
+    @layout = "ems_infra"
+  end
+
+  it "doesn't display IP Address in the tooltip" do
+    render :partial => "layouts/quadicon/ext_management_system",
+           :locals  => {:size => "72",
+                        :typ  => "grid",
+                        :item => @item}
+    expect(rendered).not_to match(/IP Address/)
+  end
+
+  it "displays Host Name in the tooltip" do
+    render :partial => "layouts/quadicon/ext_management_system",
+           :locals  => {:size => "72",
+                        :typ  => "grid",
+                        :item => @item}
+    expect(rendered).to match(/Host Name/)
+  end
+
+end


### PR DESCRIPTION
As a part of https://github.com/ManageIQ/manageiq/issues/2127

Only Found IP Address in hover text of ext_management_system quadicon