### PR TITLE
store the model type on the stack

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -160,10 +160,11 @@ module EmsCommon
     assert_privileges("#{model.to_s.underscore}_new")
     return unless load_edit("ems_edit__new")
     get_form_vars
+    _model = model # render blocks instance eval, so cache the value on the stack
     case params[:button]
     when "cancel"
       render :update do |page|
-        page.redirect_to :action=>'show_list', :flash_msg=>_("Add of new %s was cancelled by the user") % ui_lookup(:model=>model.to_s)
+        page.redirect_to :action=>'show_list', :flash_msg=>_("Add of new %s was cancelled by the user") % ui_lookup(:model=>_model.to_s)
       end
     when "add"
       if @edit[:new][:emstype].blank?

--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -283,10 +283,11 @@ module EmsCommon
 
   def update_button_cancel
     session[:edit] = nil  # clean out the saved info
+    _model = model
     render :update do |page|
       page.redirect_to(:action => @lastaction, :id => @ems.id, :display => session[:ems_display],
                        :flash_msg => _("Edit of %{model} \"%{name}\" was cancelled by the user") %
-                       {:model => ui_lookup(:model => model.to_s), :name => @ems.name})
+                       {:model => ui_lookup(:model => _model.to_s), :name => @ems.name})
     end
   end
   private :update_button_cancel

--- a/vmdb/spec/controllers/ems_infra_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_infra_controller_spec.rb
@@ -8,6 +8,15 @@ describe EmsInfraController do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
+    it "can use the cancel button on create" do
+      controller.instance_variable_set(:@edit, {:new => {},
+                                                :key => "ems_edit__new"})
+      session[:edit] = assigns(:edit)
+      controller.stub(:drop_breadcrumb)
+      post :create, :button => "cancel"
+      expect(response.status).to eq(200)
+    end
+
     it "when VM Right Size Recommendations is pressed" do
       controller.should_receive(:vm_right_size)
       post :button, :pressed => "vm_right_size", :format => :js


### PR DESCRIPTION
the render block is instance evaled, so it doesn't have access to the
controller.  We store the model on the stack so that we don't need
access to the instance in the render block.

Fixes Bug 1207313

https://bugzilla.redhat.com/show_bug.cgi?id=1207313

/cc @dclarizio 