### PR TITLE
Changed to use Classification id instead of a name in the hash

### DIFF
--- a/vmdb/app/controllers/application_controller/tags.rb
+++ b/vmdb/app/controllers/application_controller/tags.rb
@@ -109,7 +109,7 @@ module ApplicationController::Tags
     return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}","replace_cell__explorer")
 
     if params[:tag_cat]
-      @edit[:cat] = Classification.find_by_name(params[:tag_cat])
+      @edit[:cat] = Classification.find_by_id(params[:tag_cat])
       tag_edit_build_entries_pulldown
     elsif params[:tag_add]
       @edit[:new][:assignments].push(params[:tag_add].to_i)
@@ -392,9 +392,9 @@ module ApplicationController::Tags
     cats.delete_if{ |c| c.read_only? || c.entries.length == 0}  # Remove categories that are read only or have no entries
     cats.each do |c|
         if c.single_value?
-          @categories[c.description + " *"] = c.name
+          @categories[c.description + " *"] = c.id
         else
-          @categories[c.description] = c.name
+          @categories[c.description] = c.id
         end
     end
 

--- a/vmdb/app/views/layouts/_tag_edit.html.haml
+++ b/vmdb/app/views/layouts/_tag_edit.html.haml
@@ -8,8 +8,8 @@
         %th
           = _("Select a customer tag to assign:")
         %th
-          - @categories.each do | cat_key, cat_val |
-            - if session[:assigned_filters].include?(cat_val.downcase)
+          - @categories.each do | cat_key, _ |
+            - if session[:assigned_filters].include?(cat_key.downcase)
               - @categories.delete(cat_key)
           = select_tag("tag_cat",
             options_for_select(@categories.sort, @edit[:cat].name),

--- a/vmdb/spec/controllers/application_controller/tags_spec.rb
+++ b/vmdb/spec/controllers/application_controller/tags_spec.rb
@@ -33,4 +33,56 @@ describe ApplicationController  do
       end
     end
   end
+
+  context "tag_edit_build_screen" do
+    def add_entry(cat, options)
+      raise "entries can only be added to classifications" unless cat.category?
+      # Inherit from parent classification
+      options.merge!(:read_only    => cat.read_only,
+                     :syntax       => cat.syntax,
+                     :single_value => cat.single_value,
+                     :ns           => cat.ns)
+      options.merge!(:parent_id => cat.id) # Ugly way to set up a child
+      FactoryGirl.create(:classification, options)
+    end
+
+    # creating record in different region
+    def update_record_region(record)
+      record.update_column(:id, record.id + MiqRegion.rails_sequence_factor)
+    end
+
+    # convert record id into region id
+    def convert_to_region_id(id)
+      MiqRegion.id_to_region(id)
+    end
+
+    before(:each) do
+      # setup classification/entries with same name in different regions
+      clergy = FactoryGirl.create(:classification, :description => "Clergy")
+      add_entry(clergy, :name => "bishop", :description => "Bishop")
+
+      # add another classification with different description,
+      # then change description to be same as above after updating region id of record
+      clergy2 = FactoryGirl.create(:classification, :description => "Clergy2")
+      update_record_region(clergy2)
+      clergy2.update_column(:description, "Clergy")
+
+      clergy_bishop2 = add_entry(clergy2, :name => "bishop", :description => "Bishop")
+      update_record_region(clergy_bishop2)
+
+      Classification.stub(:my_region_number).and_return(convert_to_region_id(clergy_bishop2.id))
+      @st = FactoryGirl.create(:service_template, :name => 'foo')
+    end
+
+    it "region id of classification/entries should match" do
+      # only classification/entries from same region should be returned
+      controller.instance_variable_set(:@edit, :new => {})
+      controller.instance_variable_set(:@tagging, 'ServiceTemplate')
+      controller.instance_variable_set(:@object_ids, [@st.id])
+      session[:assigned_filters] = {:Test => %w("Entry1 Entry2)}
+
+      controller.send(:tag_edit_build_screen)
+      convert_to_region_id(assigns(:categories)['Clergy']).should eq(convert_to_region_id(assigns(:entries)['Bishop']))
+    end
+  end
 end


### PR DESCRIPTION
- Changed code to look up Classification by id, and also store id and descrition in the Hash that is being used to build a pull down on the tagging screen to make sure Classification & Entries are both from same region.
- Added spec tests to verify changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1134568

@fryguy @dclarizio please review.