### PR TITLE
Foreman parents

### DIFF
--- a/vmdb/app/models/configuration_location.rb
+++ b/vmdb/app/models/configuration_location.rb
@@ -1,5 +1,6 @@
 class ConfigurationLocation < ActiveRecord::Base
   belongs_to :provisioning_manager
+  belongs_to :parent, :class_name => 'ConfigurationLocation'
 
   alias_attribute :display_name, :title
 end

--- a/vmdb/app/models/configuration_organization.rb
+++ b/vmdb/app/models/configuration_organization.rb
@@ -1,5 +1,6 @@
 class ConfigurationOrganization < ActiveRecord::Base
   belongs_to :provisioning_manager
+  belongs_to :parent, :class_name => 'ConfigurationOrganization'
 
   alias_attribute :display_name, :title
 end

--- a/vmdb/app/models/configuration_profile.rb
+++ b/vmdb/app/models/configuration_profile.rb
@@ -4,6 +4,7 @@ class ConfigurationProfile < ActiveRecord::Base
 
   acts_as_miq_taggable
   belongs_to :configuration_manager
+  belongs_to :parent, :class_name => 'ConfigurationProfile'
   has_and_belongs_to_many :configuration_locations, :join_table => :configuration_locations_configuration_profiles
   has_and_belongs_to_many :configuration_organizations, :join_table => :configuration_organizations_configuration_profiles
 end

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -152,7 +152,7 @@ module EmsRefresh
             :type        => type,
             :name        => m["name"],
           }.tap do |h|
-            h[extra_field] = m[extra_field] if extra_field
+            h[extra_field.to_sym] = m[extra_field] if extra_field
           end
         end
       end

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -89,6 +89,7 @@ module EmsRefresh
           {
             :type                           => "ConfigurationProfileForeman",
             :manager_ref                    => profile["id"].to_s,
+            :parent_ref                     => (profile["ancestry"] || "").split("/").last.presence,
             :name                           => profile["name"],
             :description                    => profile["title"],
             :operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -65,11 +65,11 @@ module EmsRefresh
       end
 
       def location_inv_to_hashes(locations)
-        basic_hash(locations || tax_refs, "ConfigurationLocation", "title")
+        backfill_parent_ref(basic_hash(locations || tax_refs, "ConfigurationLocation", "title"))
       end
 
       def organization_inv_to_hashes(organizations)
-        basic_hash(organizations || tax_refs, "ConfigurationOrganization", "title")
+        backfill_parent_ref(basic_hash(organizations || tax_refs, "ConfigurationOrganization", "title"))
       end
 
       def operating_system_flavors_inv_to_hashes(flavors_inv, indexes)
@@ -153,9 +153,22 @@ module EmsRefresh
             :type        => type,
             :name        => m["name"],
           }.tap do |h|
+            h[:parent_ref] = (m["ancestry"] || "").split("/").last.presence if m.key?("ancestry")
             h[extra_field.to_sym] = m[extra_field] if extra_field
           end
         end
+      end
+
+      def backfill_parent_ref(collection)
+        collection.each do |rec|
+          rec[:parent_ref] = derive_parent_ref(rec, collection) unless rec.key?(:parent_ref)
+        end
+      end
+
+      # title = parent_title/name. we do this in reverse
+      def derive_parent_ref(rec, collection)
+        parent_title = (rec[:title] || "").sub(/\/?#{rec[:name]}/, "").presence
+        collection.detect { |c| c[:title].to_s == parent_title }.try(:[], :manager_ref) if parent_title
       end
     end
   end

--- a/vmdb/app/models/ems_refresh/save_inventory_configuration.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_configuration.rb
@@ -20,6 +20,8 @@ module EmsRefresh
     def save_configuration_profiles_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
       save_inventory_assoc(:configuration_profiles, manager, hashes, delete_missing_records, [:manager_ref])
+
+      link_children_references(manager.configuration_profiles)
     end
 
     def save_configured_systems_inventory(manager, hashes, target)

--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -109,6 +109,13 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
+  def link_children_references(records)
+    records.each do |rec|
+      parent = records.detect { |r| r.manager_ref == rec.parent_ref } if rec.parent_ref.present?
+      rec.update_attributes(:parent_id => parent.try(:id))
+    end
+  end
+
   # most of the refresh_inventory_multi calls follow the same pattern
   # this pulls it out
   def save_inventory_assoc(type, parent, hashes, target, find_key, child_keys = [], extra_keys = [])

--- a/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
@@ -37,11 +37,13 @@ module EmsRefresh
     def save_configuration_locations_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
       save_inventory_assoc(:configuration_locations, manager, hashes, delete_missing_records, [:manager_ref])
+      link_children_references(manager.configuration_locations)
     end
 
     def save_configuration_organizations_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
       save_inventory_assoc(:configuration_organizations, manager, hashes, delete_missing_records, [:manager_ref])
+      link_children_references(manager.configuration_organizations)
     end
   end
 end

--- a/vmdb/db/migrate/20150323004436_add_locations_parent.rb
+++ b/vmdb/db/migrate/20150323004436_add_locations_parent.rb
@@ -1,0 +1,10 @@
+class AddLocationsParent < ActiveRecord::Migration
+  def change
+    add_column :configuration_locations, :parent_id, :bigint
+    add_column :configuration_locations, :parent_ref, :string
+    add_column :configuration_organizations, :parent_id, :bigint
+    add_column :configuration_organizations, :parent_ref, :string
+    add_column :configuration_profiles, :parent_id, :bigint
+    add_column :configuration_profiles, :parent_ref, :string
+  end
+end

--- a/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
+++ b/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
@@ -36,6 +36,8 @@ describe EmsRefresh::Parsers::Foreman do
       }, {
         "id"                 => 9,
         "name"               => "hg9",
+        "title"              => "hg8",
+        "ancestry"           => "8",
         "description"        => "t",
         "operatingsystem_id" => 20,
         "medium_id"          => 10,
@@ -93,6 +95,26 @@ describe EmsRefresh::Parsers::Foreman do
   # end
 
   describe "#configuration_inv_to_hashes" do
+
+    it "links parents by ancestry" do
+      result = parser.configuration_inv_to_hashes(
+        :operating_system_flavors => flavors,
+        :media                    => media,
+        :ptables                  => ptables,
+        :hostgroups               => hostgroups,
+        :hosts                    => hosts,
+        :locations                => locations,
+        :organizations            => organizations,
+      )
+
+      # linked off of ancestry
+      profiles = result[:configuration_profiles]
+      parent = profiles.detect { |r| r[:manager_ref].to_s == "8" }
+      child  = profiles.detect { |r| r[:manager_ref].to_s == "9" }
+
+      expect(child[:parent_ref]).to eq(parent[:manager_ref])
+    end
+
     it "doesnt need provisioning_refresh" do
       result = parser.configuration_inv_to_hashes(
         :operating_system_flavors => flavors,

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_locations_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_locations_spec.rb
@@ -58,8 +58,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     child = orgs.first
     parent = orgs.last
     expect(child).to have_attributes(
-      :title => "Infra/ProviderRefreshSpecOrganization/ProviderRefreshSpecChildOrganization",
-      :name  => "ProviderRefreshSpecChildOrganization",
+      :title     => "Infra/ProviderRefreshSpecOrganization/ProviderRefreshSpecChildOrganization",
+      :name      => "ProviderRefreshSpecChildOrganization",
+      :parent_id => parent.id,
     )
     expect(parent).to have_attributes(
       :title => "Infra/ProviderRefreshSpecOrganization",
@@ -72,8 +73,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     child = locs.first
     parent = locs.last
     expect(child).to have_attributes(
-      :title => "ProviderRefreshSpec-Location/ProviderRefreshSpec-ChildLocation",
-      :name  => "ProviderRefreshSpec-ChildLocation",
+      :title     => "ProviderRefreshSpec-Location/ProviderRefreshSpec-ChildLocation",
+      :name      => "ProviderRefreshSpec-ChildLocation",
+      :parent_id => parent.id,
     )
     expect(parent).to have_attributes(
       :title => "ProviderRefreshSpec-Location",

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -109,11 +109,13 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
 
   def assert_configuration_profile_child
     child  = configuration_manager.configuration_profiles.where(:name => 'ProviderRefreshSpec-ChildHostGroup').first
+    parent = configuration_manager.configuration_profiles.where(:name => 'ProviderRefreshSpec-HostGroup').first
     expect(child).to have_attributes(
       :type        => "ConfigurationProfileForeman",
       :name        => "ProviderRefreshSpec-ChildHostGroup",
       :description => "ProviderRefreshSpec-HostGroup/ProviderRefreshSpec-ChildHostGroup",
       :manager_ref => "14",
+      :parent_id   => parent.id,
     )
     expect(child.operating_system_flavor).to     eq(mine(osfs))    # inherited from parent
     expect(child.customization_script_medium).to eq(mine(media))   # inherited from parent


### PR DESCRIPTION
This sets `parent` field in the foreman tables: `configuration_location`, `configuration_organization`, and `configuration_profile`.

The `configuration_profile` can leverage the `ancestry` field that comes over the api. It is of the form `/grandparent_id/parent_id`.

Currently `configuration_location` and `configuration_organization` do not pass the `ancestry` field but pass `title` over the rest api. (A PR is open in foreman for passing this in the future). It is of the form `grandparent_name/parent_name/child_name`. Or `parent_title/child_name`. This is trivial to match.

The `parent_ref()` parses either of these fields to produce the `parent_ref` and is setup to leverage `ancestry` when the value does start coming across the wire.

/cc @gmcculloug @brandondunne 