### PR TITLE
Fixed association links when switching to grid/tile views

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -256,6 +256,8 @@ module ApplicationHelper
     when "MiqWorker"
       controller = request.parameters[:controller]
       action = "diagnostics_worker_selected"
+    when "CloudNetwork", "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource"
+      controller = request.parameters[:controller]
     else
       controller = db.underscore
     end


### PR DESCRIPTION
Fixed to build correct url for records when switching to grid/tile views on sub-lists from Orchestration Stack summary.

https://bugzilla.redhat.com/show_bug.cgi?id=1206263

@dclarizio please review.