### PR TITLE
Fix module collision and concern

### DIFF
--- a/vmdb/app/models/miq_ui_worker.rb
+++ b/vmdb/app/models/miq_ui_worker.rb
@@ -36,5 +36,5 @@ class MiqUiWorker < MiqWorker
     end
   end
 
-  include WebServerWorkerMixin
+  include MiqWebServerWorkerMixin
 end

--- a/vmdb/app/models/miq_web_service_worker.rb
+++ b/vmdb/app/models/miq_web_service_worker.rb
@@ -26,5 +26,5 @@ class MiqWebServiceWorker < MiqWorker
     end
   end
 
-  include WebServerWorkerMixin
+  include MiqWebServerWorkerMixin
 end

--- a/vmdb/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/vmdb/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -1,5 +1,5 @@
 require 'miq_apache'
-module WebServerWorkerMixin
+module MiqWebServerWorkerMixin
   extend ActiveSupport::Concern
 
   BINDING_ADDRESS = Rails.env.production? ? "127.0.0.1" : "0.0.0.0"

--- a/vmdb/lib/workers/mixins/web_server_worker_mixin.rb
+++ b/vmdb/lib/workers/mixins/web_server_worker_mixin.rb
@@ -1,4 +1,6 @@
 module WebServerWorkerMixin
+  extend ActiveSupport::Concern
+
   included do
     self.wait_for_worker_monitor = false
   end

--- a/vmdb/spec/lib/workers/ui_worker_spec.rb
+++ b/vmdb/spec/lib/workers/ui_worker_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+
+require "workers/ui_worker"
+
+describe UiWorker do
+  it ".wait_for_worker_monitor?" do
+    expect(described_class.wait_for_worker_monitor?).to be_false
+  end
+end

--- a/vmdb/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe WebServerWorkerMixin do
+describe MiqWebServerWorkerMixin do
   it "build_uri (ipv6)" do
     test_class = Class.new do
-      include WebServerWorkerMixin
+      include MiqWebServerWorkerMixin
     end
 
     test_class.stub(:binding_address => "::1")


### PR DESCRIPTION
* Rename worker model mixin to be consistent with worker models.

* The module name was accidentally duplicated so the Concern was missed.

    Add `extend ActiveSupport::Concern` to fix `wrong number of arguments (0 for 1) (ArgumentError)`

    Follow up to: #2386
    https://bugzilla.redhat.com/show_bug.cgi?id=1205407

cc @matthewd @Fryguy @movitto @bronaghs 