### PR TITLE
Don't build therubyracer into the appliance

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -77,6 +77,8 @@ gem 'spice-html5-rails'
 # Only add gems here that we do not need on an appliance.
 #
 unless ENV['APPLIANCE']
+  gem 'therubyracer'
+
   group :development do
     gem "ruby-prof",                    :require => false
 
@@ -85,7 +87,6 @@ unless ENV['APPLIANCE']
     gem "gettext",          "3.1.4",    :require => false
     # used for finding translations inside HAML
     gem 'ruby_parser',                  :require => false
-    gem 'therubyracer'
   end
 
   group :test do

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -13,7 +13,6 @@ gem 'angularjs-rails', '=1.2.4'
 
 gem "sprockets-sass",  "~>1.2.0"
 gem "sprockets-less",  "~>0.6.1"
-gem 'therubyracer'
 gem 'less-rails'
 
 # Vendored and required
@@ -86,6 +85,7 @@ unless ENV['APPLIANCE']
     gem "gettext",          "3.1.4",    :require => false
     # used for finding translations inside HAML
     gem 'ruby_parser',                  :require => false
+    gem 'therubyracer'
   end
 
   group :test do


### PR DESCRIPTION
therubyracer should not be built into the appliance.

therubyracer was landing in the gemset. @jrafanie informed me it does not
need to be in the appliance.

@jrafanie @kbrock @Fryguy - Please review