### PR TITLE
Not sure why but query_start can be nil, so return 0 in that case.

### DIFF
--- a/vmdb/app/models/vmdb_database_connection.rb
+++ b/vmdb/app/models/vmdb_database_connection.rb
@@ -71,6 +71,8 @@ class VmdbDatabaseConnection < ActiveRecord::Base
   end
 
   def wait_time_ms
+    return 0 if query_start.nil?
+
     (Time.now - query_start).to_i
   end
 

--- a/vmdb/spec/models/vmdb_database_connection_spec.rb
+++ b/vmdb/spec/models/vmdb_database_connection_spec.rb
@@ -74,6 +74,12 @@ describe VmdbDatabaseConnection do
     expect(setting.wait_time).to be_kind_of(Fixnum)
   end
 
+  it 'wait_time_ms defaults to 0 on nil query_start' do
+    conn = VmdbDatabaseConnection.first
+    conn.stub(:query_start => nil)
+    expect(conn.wait_time_ms).to eq 0
+  end
+
   [
     :address,
     :application,


### PR DESCRIPTION
We've had a sporadic test failure, see #2115 and possibly related #2105 where it appears that occasionally `pg_stat_activity.query_start` is null.  @tenderlove and I couldn't track it down to figure why but considering this method is called to draw a graph in our UI for DB introspection, it should be a fair enough choice to return 0 in these rare cases.  At least until we figure out why `query_start` is null in these instances.

Fixes #2115