### PR TITLE
Added a name method that returns description.

### DIFF
--- a/vmdb/app/models/orchestration_stack_output.rb
+++ b/vmdb/app/models/orchestration_stack_output.rb
@@ -3,4 +3,6 @@ class OrchestrationStackOutput < ActiveRecord::Base
 
   belongs_to :stack, :class_name => "OrchestrationStack"
   include ReportableMixin
+
+  alias_attribute :name, :key
 end


### PR DESCRIPTION
Added a name method that returns description since orchestration_stack_outputs table doesn't have name field.
Common code that builds breadcrumbs expects record to have name.

https://bugzilla.redhat.com/show_bug.cgi?id=1206016

@bzwei @gmcculloug please review.
@dclarizio please review
This cannot be tested in UI until https://github.com/ManageIQ/manageiq/pull/2442 is merged