### PR TITLE
fix_auth helper method

### DIFF
--- a/system/LINK/bin/fix_auth
+++ b/system/LINK/bin/fix_auth
@@ -1,0 +1,5 @@
+#!/bin/bash
+# description: ManageIQ fix_auth launcher
+
+cd /var/www/miq/vmdb
+bundle exec ruby tools/fix_auth.rb "$@"


### PR DESCRIPTION
the instructions required of users is too complex
when asking them to fix the passwords in their database.
This allows then to type fix_auth from anywhere on the appliance

before:
```bash
cd /var/www/miq/vmdb ; bundle exec ruby tools/fix_auth.rb SOME_OPTIONS
```

now:

```
fix_auth SOME_OPTIONS
```

/cc @jrafanie 