### PR TITLE
Fix #2054 Added limited persistency to replication controllers

### DIFF
--- a/vmdb/app/models/container_replication_controller.rb
+++ b/vmdb/app/models/container_replication_controller.rb
@@ -1,0 +1,7 @@
+class ContainerReplicationController < ActiveRecord::Base
+  include CustomAttributeMixin
+
+  belongs_to  :ext_management_system, :foreign_key => "ems_id"
+  has_many :labels, :class_name => CustomAttribute, :as => :resource, :conditions => {:section => "labels"}
+  has_many :selector_parts, :class_name => CustomAttribute, :as => :resource, :conditions => {:section => "selectors"}
+end

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -2,6 +2,7 @@ class EmsKubernetes < EmsContainer
   has_many :container_nodes,                      :foreign_key => :ems_id, :dependent => :destroy
   has_many :container_groups,                     :foreign_key => :ems_id, :dependent => :destroy
   has_many :container_services,                   :foreign_key => :ems_id, :dependent => :destroy
+  has_many :container_replication_controllers,    :foreign_key => :ems_id, :dependent => :destroy
 
   default_value_for :port, 6443
 

--- a/vmdb/app/models/ems_refresh/save_inventory_container.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_container.rb
@@ -1,7 +1,8 @@
 module EmsRefresh::SaveInventoryContainer
   def save_ems_container_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
-    child_keys = [:container_nodes, :container_groups, :container_services]
+    child_keys = [:container_nodes, :container_groups, :container_services, :container_replication_controllers]
+
     # Save and link other subsections
     child_keys.each do |k|
       send("save_#{k}_inventory", ems, hashes[k], target)
@@ -28,6 +29,21 @@ module EmsRefresh::SaveInventoryContainer
 
   def save_computer_system_inventory(container_node, hash, _target = nil)
     save_inventory_single(:computer_system, container_node, hash, [:hardware])
+  end
+
+  def save_container_replication_controllers_inventory(ems, hashes, target = nil)
+    return if hashes.nil?
+    target = ems if target.nil?
+
+    ems.container_replication_controllers(true)
+    deletes = if target.kind_of?(ExtManagementSystem)
+                ems.container_replication_controllers.dup
+              else
+                []
+              end
+    save_inventory_multi(:container_replication_controllers, ems, hashes, deletes, [:ems_ref],
+                         [:labels, :selector_parts])
+    store_ids_for_new_records(ems.container_replication_controllers, hashes, :ems_ref)
   end
 
   def save_container_services_inventory(ems, hashes, target = nil)

--- a/vmdb/db/migrate/20150319115040_create_replication_controllers.rb
+++ b/vmdb/db/migrate/20150319115040_create_replication_controllers.rb
@@ -1,0 +1,18 @@
+class CreateReplicationControllers < ActiveRecord::Migration
+  def up
+    create_table :container_replication_controllers do |t|
+      t.string     :ems_ref
+      t.string     :name
+      t.timestamp  :creation_timestamp
+      t.belongs_to :ems, :type => :bigint
+      t.string     :resource_version
+      t.string     :namespace
+      t.integer    :replicas
+      t.integer    :current_replicas
+    end
+  end
+
+  def down
+    drop_table :container_replication_controllers
+  end
+end


### PR DESCRIPTION
The patch does not persist pod templates,
only the basic properties of replication controllers.