### PR TITLE
MiqPassword: Don't auto load legacy keys (v0/v1)

### DIFF
--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -76,8 +76,14 @@ module FixAuth
       FixDatabaseYml.run({:hardcode => options[:password]}.merge(run_options))
     end
 
-    def run
+    def set_passwords
       MiqPassword.key_root = cert_dir if cert_dir
+      MiqPassword.add_legacy_key("v0_key", :v0)
+      MiqPassword.add_legacy_key("v1_key", :v1)
+    end
+
+    def run
+      set_passwords
 
       generate_password if options[:key]
       fix_database_yml if options[:databaseyml]


### PR DESCRIPTION
Currently, we load any encryption key we can find.
Now that we are migrating users to using more secure keys, this extra convenience is a problem.

The goal is to not auto load these keys, but only load them while migrating via `fix_auth.rb`

https://bugzilla.redhat.com/show_bug.cgi?id=1200424