### PR TITLE
[api] Changing to action response signatures for service template assigns/unassigns

### DIFF
--- a/vmdb/app/controllers/api_controller/policies.rb
+++ b/vmdb/app/controllers/api_controller/policies.rb
@@ -76,7 +76,7 @@ class ApiController
       end
 
       add_parent_href_to_result(result)
-      add_policy_to_result(result, ctype, policy)
+      add_subcollection_resource_to_result(result, ctype, policy)
       log_result(result)
       result
     end

--- a/vmdb/app/controllers/api_controller/service_templates.rb
+++ b/vmdb/app/controllers/api_controller/service_templates.rb
@@ -9,28 +9,23 @@ class ApiController
       object ? klass.where(:service_template_catalog_id => object.id) : {}
     end
 
-    def service_templates_assign_resource(object, _type, id = nil, _data = nil)
-      klass = collection_config[:service_templates][:klass].constantize
-      st    = klass.find(id)
-      stcid = st.service_template_catalog_id
-      if stcid
-        raise BadRequestError, "Service Template #{id} is already assigned to Service Catalog #{stcid}"
-      else
-        st.update_attributes(:service_template_catalog_id => object.id)
+    def service_templates_assign_resource(object, type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for Assigning a #{type} resource" unless id
+
+      service_template_subcollection_action(type, id) do |st|
+        api_log_info("Assigning #{service_template_ident(st)}")
+
+        assign_service_template(object, st)
       end
     end
 
-    def service_templates_unassign_resource(object, _type, id = nil, _data = nil)
-      klass = collection_config[:service_templates][:klass].constantize
-      st    = klass.find(id)
-      stcid = st.service_template_catalog_id
-      if stcid
-        if stcid != object.id
-          raise BadRequestError,
-                "Service Template #{id} is not currently assigned to Service Catalog #{stcid}"
-        else
-          st.update_attributes(:service_template_catalog_id => nil)
-        end
+    def service_templates_unassign_resource(object, type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for Unassigning a #{type} resource" unless id
+
+      service_template_subcollection_action(type, id) do |st|
+        api_log_info("Unassigning #{service_template_ident(st)}")
+
+        unassign_service_template(object, st)
       end
     end
 
@@ -64,6 +59,55 @@ class ApiController
 
       request.call_automate_event_queue("request_created")
       request
+    end
+
+    private
+
+    def service_template_ident(st)
+      "Service Template id:#{st.id} name:'#{st.name}'"
+    end
+
+    def service_template_subcollection_action(type, id)
+      klass = collection_config[:service_templates][:klass].constantize
+      result =
+        begin
+          st = resource_search(id, type, klass)
+          yield(st) if block_given?
+        rescue => err
+          action_result(false, err.to_s)
+        end
+      add_subcollection_resource_to_result(result, type, st) if st
+      add_parent_href_to_result(result)
+      log_result(result)
+      result
+    end
+
+    def assign_service_template(object, st)
+      stcid = st.service_template_catalog_id
+      if stcid
+        action_result(stcid == object.id, "Service Template #{st.id} is currently assigned to Service Catalog #{stcid}")
+      else
+        object.service_templates << st
+        action_result(true, "Assigning #{service_template_ident(st)}")
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def unassign_service_template(object, st)
+      stcid = st.service_template_catalog_id
+      if stcid
+        if stcid != object.id
+          action_result(false, "Service Template #{st.id} is not currently assigned to Service Catalog #{stcid}")
+        else
+          object.service_templates -= Array.wrap(st)
+          action_result(true, "Unassigning #{service_template_ident(st)}")
+        end
+      else
+        action_result(true, "Service Template #{st.id} is not currently assigned to a Service Catalog")
+      end
+    rescue => err
+      action_result(false, err)
     end
   end
 end

--- a/vmdb/app/helpers/api_helper/results.rb
+++ b/vmdb/app/helpers/api_helper/results.rb
@@ -33,10 +33,11 @@ module ApiHelper
       hash
     end
 
-    def add_policy_to_result(hash, ctype, policy)
-      return hash if policy.blank?
-      hash["#{ctype.to_s.singularize}_id".to_sym]   = policy.id
-      hash["#{ctype.to_s.singularize}_href".to_sym] = "#{@req[:base]}#{@req[:prefix]}/#{ctype}/#{policy.id}"
+    def add_subcollection_resource_to_result(hash, ctype, object)
+      return hash if object.blank?
+      ctype_pref = ctype.to_s.singularize
+      hash["#{ctype_pref}_id".to_sym]   = object.id
+      hash["#{ctype_pref}_href".to_sym] = "#{@req[:base]}#{@req[:prefix]}/#{ctype}/#{object.id}"
       hash
     end
 

--- a/vmdb/spec/requests/api/service_catalogs_spec.rb
+++ b/vmdb/spec/requests/api/service_catalogs_spec.rb
@@ -237,7 +237,8 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id), gen_request(:assign, "href" => service_templates_url(999_999)))
 
-      expect_resource_not_found
+      expect_request_success
+      expect_results_to_match_hash("results", [{"success" => false, "href" => service_catalogs_url(sc.id)}])
     end
 
     it "supports assign requests" do
@@ -249,6 +250,11 @@ describe ApiController do
       run_post(sc_templates_url(sc.id), gen_request(:assign, "href" => service_templates_url(st.id)))
 
       expect_request_success
+      expect_results_to_match_hash("results", [{"success"               => true,
+                                                "href"                  => service_catalogs_url(sc.id),
+                                                "service_template_id"   => st.id,
+                                                "service_template_href" => /^.*#{service_templates_url(st.id)}$/,
+                                                "message"               => /assigning/i}])
       expect(sc.reload.service_templates.pluck(:id)).to eq([st.id])
     end
 
@@ -263,6 +269,11 @@ describe ApiController do
       run_post(sc_templates_url(sc.id), gen_request(:unassign, "href" => service_templates_url(st1.id)))
 
       expect_request_success
+      expect_results_to_match_hash("results", [{"success"               => true,
+                                                "href"                  => service_catalogs_url(sc.id),
+                                                "service_template_id"   => st1.id,
+                                                "service_template_href" => /^.*#{service_templates_url(st1.id)}$/,
+                                                "message"               => /unassigning/i}])
       expect(sc.reload.service_templates.pluck(:id)).to eq([st2.id])
     end
   end


### PR DESCRIPTION

- Extending v1.0 for compatibility to v2.0
- Updated service catalog assign and unassign service templates to return action signature including success, parent href as well as service_template id and href.
- Updated spec.

https://trello.com/c/WxBF5lrT/39-api-enhancements-to-v1-0-api