### PR TITLE
GTL buttons shouldn't show on Catalog Item editor screen

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -1677,7 +1677,7 @@ class CatalogController < ApplicationController
             build_toolbar_buttons_and_xml("summary_view_tb")
           end
         else
-          build_toolbar_buttons_and_xml("x_gtl_view_tb")
+          build_toolbar_buttons_and_xml("x_gtl_view_tb") unless @in_a_form
         end
       when :svccat_tree, :stcat_tree, :ot_tree
         build_toolbar_buttons_and_xml("x_gtl_view_tb") unless record_showing || @in_a_form


### PR DESCRIPTION
@dclarizio please review/test.

Before fix:
![before_fix_catalog_item_editor](https://cloud.githubusercontent.com/assets/3450808/6927085/f89368d0-d7b8-11e4-8936-e1a00deed339.png)

After fix:
![after_fix_catalog_item_editor](https://cloud.githubusercontent.com/assets/3450808/6927088/fc9f9c46-d7b8-11e4-894e-d6fd45069a04.png)