### PR TITLE
[wip] foreman refresh: use object refs instead of ids

### DIFF
--- a/vmdb/app/models/ems_refresh/save_inventory_configuration.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_configuration.rb
@@ -27,10 +27,9 @@ module EmsRefresh
       # these records are cross referenced to the hashes
       # get the id out and store in this record
       hashes.each do |hash|
-        hash[:configuration_profile_id] = hash.fetch_path(:configuration_profile, :id)
+        hash[:configuration_profile] = hash.fetch_path(:configuration_profile, :ar_object)
       end
-      save_inventory_assoc(:configured_systems, manager, hashes, delete_missing_records, [:manager_ref], nil,
-                           [:configuration_profile])
+      save_inventory_assoc(:configured_systems, manager, hashes, delete_missing_records, [:manager_ref])
     end
   end
 end

--- a/vmdb/app/models/ems_refresh/save_inventory_helper.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_helper.rb
@@ -1,5 +1,5 @@
 module EmsRefresh::SaveInventoryHelper
-  def save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys = [], extra_keys = [])
+  def save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys = [], extra_keys = [], store_ref = false)
     deletes = deletes.to_a # make sure to load the association if it's an association
     child_keys, extra_keys, remove_keys = self.save_inventory_prep(child_keys, extra_keys)
 
@@ -9,6 +9,7 @@ module EmsRefresh::SaveInventoryHelper
     hashes.each do |h|
       found = save_inventory_with_findkey(type, parent, h.except(*remove_keys), deletes, new_records, record_index, record_index_columns, find_key)
       save_child_inventory(found, h, child_keys)
+      h[:ar_object] = found if store_ref
     end
 
     # Delete the items no longer found
@@ -114,8 +115,7 @@ module EmsRefresh::SaveInventoryHelper
   def save_inventory_assoc(type, parent, hashes, target, find_key, child_keys = [], extra_keys = [])
     deletes = relation_values(parent, type, target)
 
-    save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys, extra_keys)
-    store_ids_for_new_records(parent.send(type), hashes, find_key)
+    save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys, extra_keys, true)
   end
 
   # We need to determine our intent:

--- a/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_provisioning.rb
@@ -27,11 +27,10 @@ module EmsRefresh
       delete_missing_records = target.nil? || manager == target
       hashes.each do |hash|
         if hash[:customization_scripts]
-          hash[:customization_script_ids] = hash[:customization_scripts].map { |cp| cp[:id] }
+          hash[:customization_scripts] = hash[:customization_scripts].map { |cp| cp[:ar_object] }
         end
       end
-      save_inventory_assoc(:operating_system_flavors, manager, hashes, delete_missing_records, [:manager_ref], nil,
-                           [:customization_scripts])
+      save_inventory_assoc(:operating_system_flavors, manager, hashes, delete_missing_records, [:manager_ref])
     end
 
     def save_configuration_locations_inventory(manager, hashes, target)


### PR DESCRIPTION
Save inventory converts a hash to a collection of active record objects.
Sometimes one of these collections links to another.

pseudo code for linking records:

```ruby
  save_inventory_multi(code_lookup_hash, :find_id => [:ems_ref])
  store_ids_for_new_records(code_lookup_hash, :find_id => [:ems_ref])
  target_hash.each {|tgt| tgt[:code_id] = code_lookup_hash.detect {|c| c.ems_ref == tgt[:code_ref]}[:id]}
  save_inventory_multi(target_hash, :ignore => :code_ref)
```

If it is a self reference:

```ruby
  save_inventory_multi(obj, :hosts, target_hash, :find_id => [:ems_ref], :ignore => :parent)
  store_ids_for_new_records(obj.hosts, target_hash, :find_id => [:ems_ref])
  obj.hosts.each do |o|
    o.update_attributes(:parent_id => target_hash[o.id][:parent][:id])
  end
```

New suggested code is to just store the active record reference in the hash instead of the id:

1. no need to saving the record first
2. no need to `store_ids_for_new_records` which loops through all active record objects for lookup.
3. use the active record association rather than using the id.
4. only 1 line change in core code.
5. No need to change any existing code, but it would make sense to leverage it.

Gave example how this affects foreman. We have another PR #2440 that leverages this

/cc @gmcculloug @brandondunne @Fryguy 