### PR TITLE
Fixed raising policy events for services

### DIFF
--- a/vmdb/app/models/ems_event.rb
+++ b/vmdb/app/models/ems_event.rb
@@ -16,8 +16,6 @@ class EmsEvent < ActiveRecord::Base
   belongs_to :dest_miq_template,   :class_name => "MiqTemplate", :foreign_key => :dest_vm_or_template_id
   belongs_to :dest_host,           :class_name => "Host"
 
-  belongs_to :service
-
   include_concern 'Automate'
   include ReportableMixin
 

--- a/vmdb/app/models/service.rb
+++ b/vmdb/app/models/service.rb
@@ -4,7 +4,6 @@ class Service < ActiveRecord::Base
   belongs_to :service_template               # Template this service was cloned from
   belongs_to :service                        # Parent Service
   has_many :services, :dependent => :destroy # Child services
-  has_many :ems_events
 
   virtual_belongs_to :parent_service
   virtual_has_many   :direct_service_children
@@ -229,29 +228,23 @@ class Service < ActiveRecord::Base
   end
 
   def raise_request_start_event
-    self.raise_event(:request_service_start, "Request Service #{self.name} start")
+    MiqEvent.raise_evm_event(self, :request_service_start)
   end
 
   def raise_started_event
-    self.raise_event(:service_started, "Service #{self.name} started")
+    MiqEvent.raise_evm_event(self, :service_started)
   end
 
   def raise_request_stop_event
-    self.raise_event(:request_service_stop, "Request Service #{self.name} stop")
+    MiqEvent.raise_evm_event(self, :request_service_stop)
   end
 
   def raise_stopped_event
-    self.raise_event(:service_stopped, "Service #{self.name} stopped")
+    MiqEvent.raise_evm_event(self, :service_stopped)
   end
 
   def raise_provisioned_event
-    event = self.ems_events.where(:event_type => "service_provisioned")
-    return event.first unless event.blank?
-    self.raise_event(:service_provisioned, "Service #{self.name} provisioned")
-  end
-
-  def raise_event(event_type, message)
-    EmsEvent.add(nil, {:service_id => self.id, :event_type => event_type, :timestamp => Time.now, :message => message})
+    MiqEvent.raise_evm_event(self, :service_provisioned)
   end
 
   def v_total_vms

--- a/vmdb/db/migrate/20150406141646_remove_service_id_from_ems_events.rb
+++ b/vmdb/db/migrate/20150406141646_remove_service_id_from_ems_events.rb
@@ -1,0 +1,11 @@
+class RemoveServiceIdFromEmsEvents < ActiveRecord::Migration
+  def up
+    remove_index  :ems_events, :service_id
+    remove_column :ems_events, :service_id
+  end
+
+  def down
+    add_column :ems_events, :service_id, :bigint
+    add_index  :ems_events, :service_id
+  end
+end

--- a/vmdb/spec/models/service_spec.rb
+++ b/vmdb/spec/models/service_spec.rb
@@ -19,49 +19,45 @@ describe Service do
     end
 
     it "raise_request_start_event" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_start)
+
       @service.raise_request_start_event
-      EmsEvent.count.should ==1
-      EmsEvent.first.event_type.should == "request_service_start"
     end
 
     it "raise_started_event" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_started)
+
       @service.raise_started_event
-      EmsEvent.count.should ==1
-      EmsEvent.first.event_type.should == "service_started"
     end
 
     it "raise_request_stop_event" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_stop)
+
       @service.raise_request_stop_event
-      EmsEvent.count.should ==1
-      EmsEvent.first.event_type.should == "request_service_stop"
     end
 
     it "raise_stopped_event" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_stopped)
+
       @service.raise_stopped_event
-      EmsEvent.count.should ==1
-      EmsEvent.first.event_type.should == "service_stopped"
     end
 
     it "raise_provisioned_event" do
-      @service.raise_provisioned_event
-      EmsEvent.count.should ==1
-      EmsEvent.first.event_type.should == "service_provisioned"
-    end
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_provisioned)
 
-    it "provisioned event raised once for a service" do
       @service.raise_provisioned_event
-      @service.raise_provisioned_event
-      @service.ems_events.count.should == 1
     end
 
     it "raise_final_process_event start" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_started)
+
       @service.raise_final_process_event('start')
-      EmsEvent.first.event_type.should == "service_started"
     end
 
     it "raise_final_process_event stop" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_stopped)
+
       @service.raise_final_process_event('stop')
-      EmsEvent.first.event_type.should == "service_stopped"
     end
   end
 
@@ -144,20 +140,6 @@ describe Service do
       expect { @service << @service }.to raise_error
     end
 
-    # it "should not allow MiqTemplate resources to be added to the service" do
-    #   template = FactoryGirl.create(:miq_template, :name => "template", :location => "abc/abc.vmtx", :template => true, :vendor => "vmware")
-    #   lambda {@service.add_resource(template)}.should raise_error(RuntimeError)
-    # end
-
-    # it "should not allow ServiceTemplate resources to be added to the service" do
-    #   service_template = FactoryGirl.create(:service_template, :name => "Service Template")
-    #   lambda {@service.add_resource(service_template)}.should raise_error(RuntimeError)
-    # end
-
-    # it "should not allow Host resources to be added to the service" do
-    #   lambda {@service.add_resource(Host.first)}.should raise_error(RuntimeError)
-    # end
-
     it "should set the group index when adding a resource" do
       @service.last_group_index.should equal(0)
       @service.add_resource(Vm.first, :group_idx => 1)
@@ -167,13 +149,15 @@ describe Service do
     end
 
     it "start" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_start)
+
       @service.start
-      EmsEvent.first.event_type.should == "request_service_start"
     end
 
     it "stop" do
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_stop)
+
       @service.stop
-      EmsEvent.first.event_type.should == "request_service_stop"
     end
 
     context "with VM resources" do

--- a/vmdb/spec/models/service_template_provision_task_spec.rb
+++ b/vmdb/spec/models/service_template_provision_task_spec.rb
@@ -84,10 +84,10 @@ describe ServiceTemplateProvisionTask do
       end
 
       it "raise provisioned event" do
+        expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_provisioned)
+
         @task_1_2.destination = @service
         @task_1_2.update_and_notify_parent(:state => "finished", :status => "Ok", :message => "Test Message")
-        @service.ems_events.count.should == 1
-        @service.ems_events.first.event_type.should == "service_provisioned"
       end
     end
   end


### PR DESCRIPTION
EmsEvents are raw events that come from all different providers, like vc, rhevm, openstack, amazon...
Policy events (MiqEvents) are MIQ events that we raise to trigger policies. 
In this case, what we really want is to raise the policy events to kick off the policies.