### PR TITLE
Service dialog enhancements.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
@@ -1,92 +1,89 @@
-# CatalogBundleInitialization.rb
 #
-# Author: Kevin Morey <kmorey@redhat.com>
-# License: GPL v3
-#
-# Notes: This method Performs the following functions:
+# Description: This method Performs the following functions:
 # 1. YAML load the Service Dialog Options from @task.get_option(:parsed_dialog_options))
 # 2. Set the name of the service
 # 3. Set tags on the service
 # 5. Pass down any dialog options and tags to child catalog items pointing to CatalogItemInitialization
+# Important - The dialog_parser automate method has to run prior to this in order to populate the dialog information.
 #
+def log_and_update_message(level, msg, update_message = false)
+  $evm.log(level, "#{msg}")
+  @task.message = msg if @task && (update_message || level == 'error')
+end
+
+# Loop through all tags from the dialog and create the categories and tags automatically
+def create_tags(category, single_value, tag)
+  log_and_update_message(:info, "Processing create_tags...", true)
+  # Convert to lower case and replace all non-word characters with underscores
+  category_name = category.to_s.downcase.gsub(/\W/, '_')
+  tag_name = tag.to_s.downcase.gsub(/\W/, '_')
+
+  # if the category exists else create it
+  unless $evm.execute('category_exists?', category_name)
+    log_and_update_message(:info, "Category #{category_name} doesn't exist, creating category")
+    $evm.execute('category_create', :name         => category_name,
+                                    :single_value => single_value,
+                                    :description  => "#{category}")
+  end
+  # if the tag exists else create it
+  unless $evm.execute('tag_exists?', category_name, tag_name)
+    log_and_update_message(:info, "Adding new tag #{tag_name} in Category #{category_name}")
+    $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
+  end
+  log_and_update_message(:info, "Processing create_tags...Complete", true)
+end
+
+def override_service_attribute(dialogs_options_hash, attr_name)
+  service_attr_name = "service_#{attr_name}".to_sym
+
+  log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...", true)
+  attr_value = dialogs_options_hash.fetch(service_attr_name, nil)
+  attr_value = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if attr_name == 'name' && attr_value.nil?
+
+  log_and_update_message(:info, "Setting service attribute: #{attr_name} to: #{attr_value}")
+  @service.send("#{attr_name}=", attr_value)
+
+  log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...Complete", true)
+end
+
+def process_tag(tag_category, tag_value)
+  return if tag_value.blank?
+  create_tags(tag_category, true, tag_value)
+  $evm.log(:info, "Assigning Tag: {#{tag_category} => tag: #{tag_value}} to Service: #{@service.name}")
+  @service.tag_assign("#{tag_category}/#{tag_value}")
+end
+
+# service_tagging - tag the service with tags in dialogs_tags_hash[0]
+def tag_service(dialogs_tags_hash)
+  log_and_update_message(:info, "Processing tag_service...", true)
+
+  # Look for tags with a sequence_id of 0 to tag the service
+  dialogs_tags_hash.fetch(0, {}).each do |key, value|
+    log_and_update_message(:info, "Processing tag: #{key.inspect} value: #{value.inspect}")
+    tag_category = key.downcase
+    Array.wrap(value).each do |tag_entry|
+      process_tag(tag_category, tag_entry.downcase)
+    end
+  end
+  log_and_update_message(:info, "Processing tag_service...Complete", true)
+end
+
+def parsed_dialog_information
+  # get parsed dialog options and tags from the task
+  dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
+  dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
+
+  if dialog_options_hash.blank? && dialog_tags_hash.blank?
+    log(:error, "Error loading dialog options")
+    exit MIQ_ABORT
+  end
+
+  log_and_update_message(:info, "dialog_options: #{dialog_options_hash.inspect}")
+  log_and_update_message(:info, "tag_options: #{dialog_tags_hash.inspect}")
+  return dialog_options_hash, dialog_tags_hash
+end
+
 begin
-  def log_and_update_message(level, msg, update_message = false)
-    $evm.log(level, "#{msg}")
-    @task.message = msg if @task && (update_message || level == 'error')
-  end
-
-  # Loop through all tags from the dialog and create the categories and tags automatically
-  def create_tags(category, single_value, tag)
-    log_and_update_message(:info, "Processing create_tags...", true)
-    # Convert to lower case and replace all non-word characters with underscores
-    category_name = category.to_s.downcase.gsub(/\W/, '_')
-    tag_name = tag.to_s.downcase.gsub(/\W/, '_')
-
-    # if the category exists else create it
-    unless $evm.execute('category_exists?', category_name)
-      log_and_update_message(:info, "Category #{category_name} doesn't exist, creating category")
-      $evm.execute('category_create', :name         => category_name,
-                                      :single_value => single_value,
-                                      :description  => "#{category}")
-    end
-    # if the tag exists else create it
-    unless $evm.execute('tag_exists?', category_name, tag_name)
-      log_and_update_message(:info, "Adding new tag #{tag_name} in Category #{category_name}")
-      $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
-    end
-    log_and_update_message(:info, "Processing create_tags...Complete", true)
-  end
-
-  def override_service_attribute(dialogs_options_hash, attr_name)
-    service_attr_name = "service_#{attr_name}".to_sym
-
-    log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...", true)
-    attr_value = dialogs_options_hash.fetch(service_attr_name, nil)
-    attr_value = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if attr_name == 'name' && attr_value.nil?
-
-    log_and_update_message(:info, "Setting service attribute: #{attr_name} to: #{attr_value}")
-    @service.send("#{attr_name}=", attr_value)
-
-    log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...Complete", true)
-  end
-
-  def process_tag(tag_category, tag_value)
-    return if tag_value.blank?
-    create_tags(tag_category, true, tag_value)
-    $evm.log(:info, "Assigning Tag: {#{tag_category} => tag: #{tag_value}} to Service: #{@service.name}")
-    @service.tag_assign("#{tag_category}/#{tag_value}")
-  end
-
-  # service_tagging - tag the service with tags in dialogs_tags_hash[0]
-  def tag_service(dialogs_tags_hash)
-    log_and_update_message(:info, "Processing tag_service...", true)
-
-    # Look for tags with a sequence_id of 0 to tag the service
-    dialogs_tags_hash.fetch(0, {}).each do |key, value|
-      log_and_update_message(:info, "Processing tag: #{key.inspect} value: #{value.inspect}")
-      tag_category = key.downcase
-      Array.wrap(value).each do |tag_entry|
-        process_tag(tag_category, tag_entry.downcase)
-      end
-    end
-    log_and_update_message(:info, "Processing tag_service...Complete", true)
-  end
-
-  def parsed_dialog_information
-    # get parsed dialog options and tags from the task
-    dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
-    dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
-
-    if dialog_options_hash.blank? && dialog_tags_hash.blank?
-      log(:error, "Error loading dialog options")
-      exit MIQ_ABORT
-    end
-
-    log_and_update_message(:info, "dialog_options: #{dialog_options_hash.inspect}")
-    log_and_update_message(:info, "tag_options: #{dialog_tags_hash.inspect}")
-    return dialog_options_hash, dialog_tags_hash
-  end
-
   @task = $evm.root['service_template_provision_task']
 
   @service = @task.destination

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
@@ -1,131 +1,107 @@
+# CatalogBundleInitialization.rb
 #
+# Author: Kevin Morey <kmorey@redhat.com>
+# License: GPL v3
 #
-# Description: This method sets the dialog optioms in the destination service and service catalog items.
-# 1. Look for all Service Dialog Options in the service_template_provision_task.dialog_options
-#    (i.e. Options that come from a Service Dialog)
-# 2. Any Service dialog option keys that match the regular expression /^tag_0_(.*)/i will be used to
-#    tag the destination Service
-# 3. Service dialog option keys that match the regular expression /^(option|tag)_(\d*)_(.*)/
-#    (I.e. <option_type>_<sequence_id>_variable,  option_0_vm_memory, tag_1_environment) are sorted
-#    by sequence_id into an options_hash[sequence_id] and then distributed to the appropriate
-#    child catalog items. For example, a sequence_id of 0 means that all catalog items will inhereit
-#    these variables. A sequence_id of 1 means that the variable is only intended for a catalog item
-#    with a group index of 1.
-# 4. Service dialog option keys that do NOT match the regular expression are then inserted into the
-#    options_hash[0] for all catalog items.
+# Notes: This method Performs the following functions:
+# 1. YAML load the Service Dialog Options from @task.get_option(:parsed_dialog_options))
+# 2. Set the name of the service
+# 3. Set tags on the service
+# 5. Pass down any dialog options and tags to child catalog items pointing to CatalogItemInitialization
 #
-# Inputs: $evm.root['service_template_provision_task'].dialog_options
-#
-
-# Description: Look for service dialog variables in the root object that start with "dialog_option_[0-9]",
-def get_options_hash(dialog_options)
-  # Setup regular expression for service dialog tags
-  options_regex = /^(dialog_option|dialog_tag)_(\d*)_(.*)/i
-  options_hash = {}
-
-  # Loop through all of the options and build an options_hash from them
-  dialog_options.each do |k, v|
-
-    option_key = k.downcase.to_sym
-    if options_regex =~ k
-      sequence_id = Regexp.last_match[2].to_i
-
-      unless v.blank?
-        $evm.log("info", "Adding sequence_id:<#{sequence_id}> option_key:<#{option_key.inspect}> v:<#{v.inspect}> to options_hash")
-        if options_hash.key?(sequence_id)
-          options_hash[sequence_id][option_key] = v
-        else
-          options_hash[sequence_id] = {option_key => v}
-        end
-      end
-    else
-      # If options_regex does not match then stuff dialog options into options_hash[0]
-      sequence_id = 0
-      unless v.nil?
-        $evm.log("info", "Adding sequence_id:<#{sequence_id}> option_key:<#{option_key.inspect}> v:<#{v.inspect}> to options_hash")
-        if options_hash.key?(sequence_id)
-          options_hash[sequence_id][option_key] = v
-        else
-          options_hash[sequence_id] = {option_key => v}
-        end
-      end
-    end # if options_regex =~ k
-  end # dialog_options.each do
-  $evm.log("info", "Inspecting options_hash:<#{options_hash.inspect}>")
-  options_hash
-end
-
-# Description: Look for tags with a sequence_id of 0 and tag the parent service
-def tag_parent_service(service, options_hash)
-  # Setup regular expression for service dialog tags
-  tags_regex = /^dialog_tag_0_(.*)/i
-
-  # Look for tags with a sequence_id of 0 to tag the destination Service
-  options_hash[0].each do |k, v|
-    $evm.log("info", "Processing Tag Key:<#{k.inspect}> Value:<#{v.inspect}>")
-    if tags_regex =~ k
-      # Convert key to symbol
-      tag_category = Regexp.last_match[1]
-      tag_value = v.downcase
-      unless tag_value.blank?
-        $evm.log("info", "Adding tag_category:<#{tag_category.inspect}> value:<#{tag_value.inspect}> to Service:<#{service.name}>")
-        service.tag_assign("#{tag_category}/#{tag_value}")
-      end
-    end # if tags_regex
-  end # options_hash[0].each
-end
-
-# Get the task object from root
-service_template_provision_task = $evm.root['service_template_provision_task']
-
-# Get destination service object
-service = service_template_provision_task.destination
-$evm.log("info", "Detected Service:<#{service.name}> Id:<#{service.id}>")
-
-# Get dialog options from options hash
-# I.e. {:dialog=>{"option_0_myvar"=>"myprefix", "option_1_vservice_workers"=>"2", "tag_0_environment"=>"test", "tag_0_location"=>"paris",
-# "option_2_vm_memory"=>"2048", "option_0_vlan"=>"Internal", "option_1_cores_per_socket"=>"1"}}
-dialog_options = service_template_provision_task.dialog_options
-$evm.log("info", "Inspecting Dialog Options:<#{dialog_options.inspect}>")
-
-# Get options_hash
-options_hash = get_options_hash(dialog_options)
-
-# Tag Parent Service
-tag_parent_service(service, options_hash)
-
-# Process Child Services
-service_template_provision_task.miq_request_tasks.each do |t|
-  # Child Service
-  child_service = t.destination
-  # Service Bundle Resource
-  child_service_resource = t.service_resource
-
-  # Increment the provision_index number since the child resource starts with a zero
-  group_idx = child_service_resource.provision_index + 1
-  $evm.log("info", "Child service name:<#{child_service.name}> group_idx:<#{group_idx}>")
-
-  # Create dialog options hash variable
-  dialog_options_hash = {}
-
-  # Set all dialog options pertaining to the catalog item plus any options destined for the catalog bundle
-  unless options_hash[0].nil?
-    unless options_hash[group_idx].nil?
-      # Merge child options with global options if any
-      dialog_options_hash = options_hash[0].merge(options_hash[group_idx])
-    else
-      dialog_options_hash = options_hash[0]
-    end
-  else # unless options_hash[0].nil?
-    unless options_hash[group_idx].nil?
-      dialog_options_hash = options_hash[group_idx]
-    end
+begin
+  def log_and_update_message(level, msg, update_message = false)
+    $evm.log(level, "#{msg}")
+    @task.message = msg if @task && (update_message || level == 'error')
   end
 
-  # Pass down dialog options to catalog items
-  dialog_options_hash.each do |k, v|
-    $evm.log("info", "Adding Dialog Option:<{#{k.inspect} => #{v.inspect}}> to Child Service:<#{child_service.name}>")
-    t.set_dialog_option(k, v)
+  # Loop through all tags from the dialog and create the categories and tags automatically
+  def create_tags(category, single_value, tag)
+    log_and_update_message(:info, "Processing create_tags...", true)
+    # Convert to lower case and replace all non-word characters with underscores
+    category_name = category.to_s.downcase.gsub(/\W/, '_')
+    tag_name = tag.to_s.downcase.gsub(/\W/, '_')
+
+    # if the category exists else create it
+    unless $evm.execute('category_exists?', category_name)
+      log_and_update_message(:info, "Category #{category_name} doesn't exist, creating category")
+      $evm.execute('category_create', :name         => category_name,
+                                      :single_value => single_value,
+                                      :description  => "#{category}")
+    end
+    # if the tag exists else create it
+    unless $evm.execute('tag_exists?', category_name, tag_name)
+      log_and_update_message(:info, "Adding new tag #{tag_name} in Category #{category_name}")
+      $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
+    end
+    log_and_update_message(:info, "Processing create_tags...Complete", true)
   end
-  $evm.log("info", "Inspecting Child Service:<#{child_service.name}> Dialog Options:<#{t.dialog_options.inspect}>")
+
+  def override_service_attribute(dialogs_options_hash, attr_name)
+    service_attr_name = "service_#{attr_name}".to_sym
+
+    log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...", true)
+    attr_value = dialogs_options_hash.fetch(service_attr_name, nil)
+    attr_value = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if attr_name == 'name' && attr_value.nil?
+
+    log_and_update_message(:info, "Setting service attribute: #{attr_name} to: #{attr_value}")
+    @service.send("#{attr_name}=", attr_value)
+
+    log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...Complete", true)
+  end
+
+  def process_tag(tag_category, tag_value)
+    return if tag_value.blank?
+    create_tags(tag_category, true, tag_value)
+    $evm.log(:info, "Assigning Tag: {#{tag_category} => tag: #{tag_value}} to Service: #{@service.name}")
+    @service.tag_assign("#{tag_category}/#{tag_value}")
+  end
+
+  # service_tagging - tag the service with tags in dialogs_tags_hash[0]
+  def tag_service(dialogs_tags_hash)
+    log_and_update_message(:info, "Processing tag_service...", true)
+
+    # Look for tags with a sequence_id of 0 to tag the service
+    dialogs_tags_hash.fetch(0, {}).each do |key, value|
+      log_and_update_message(:info, "Processing tag: #{key.inspect} value: #{value.inspect}")
+      tag_category = key.downcase
+      Array.wrap(value).each do |tag_entry|
+        process_tag(tag_category, tag_entry.downcase)
+      end
+    end
+    log_and_update_message(:info, "Processing tag_service...Complete", true)
+  end
+
+  def parsed_dialog_information
+    # get parsed dialog options and tags from the task
+    dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
+    dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
+
+    if dialog_options_hash.blank? && dialog_tags_hash.blank?
+      log(:error, "Error loading dialog options")
+      exit MIQ_ABORT
+    end
+
+    log_and_update_message(:info, "dialog_options: #{dialog_options_hash.inspect}")
+    log_and_update_message(:info, "tag_options: #{dialog_tags_hash.inspect}")
+    return dialog_options_hash, dialog_tags_hash
+  end
+
+  @task = $evm.root['service_template_provision_task']
+
+  @service = @task.destination
+  log_and_update_message(:info, "Service: #{@service.name} id: #{@service.id} tasks: #{@task.miq_request_tasks.count}")
+
+  dialog_options_hash, dialog_tags_hash = parsed_dialog_information
+
+  override_service_attribute(dialog_options_hash.fetch(0, {}), "name")
+
+  override_service_attribute(dialog_options_hash.fetch(0, {}), "description")
+
+  tag_service(dialog_tags_hash)
+
+rescue => err
+  log_and_update_message(:error, "[#{err}]\n#{err.backtrace.join("\n")}")
+  @task.finished("#{err}") if @task
+  exit MIQ_ABORT
 end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -1,126 +1,234 @@
+# CatalogItemInitialization.rb
 #
-# Description: Tag service and set provison options based on service dialog entries.
-# 1. Look for all Service Dialog Options in the service_template_provision_task.dialog_options
-#    (i.e. Dialog options that came from either a Catalog Bundle Service or a Service Dialog)
-# 2. Service dialog option keys that match the regular expression /^tag_\d*_(.*)/i
-#    (I.e. <tag>_<sequence_id>_variable,  tag_0_function, tag_1_environment) will be used to
-#    tag the destination Catalog Item Service and any subordinate miq_provision tasks
-# 3. The remaining Service Dialog Option keys are simply passed into the subordinate
-#    miq_provision object. I.e. option_0_vm_memory => 2048
+# Author: Kevin Morey <kmorey@redhat.com>
+# License: GPL v3
 #
-# Inputs: $evm.root['service_template_provision_task'].dialog_options
+# Description: This method Performs the following functions:
+# 1. YAML load the Service Dialog Options from @task.get_option(:parsed_dialog_options))
+# 2. Set the name of the service
+# 3. Set tags on the service
+# 5. Override miq_provision task with any options and tags
 #
+begin
+  def log_and_update_message(level, msg, update_message = false)
+    $evm.log(level, "#{msg}")
+    @task.message = msg if @task && (update_message || level == 'error')
+  end
 
-# Look for service dialog variables in the dialog options hash that start with "tag_[0-9]",
-def get_tags_hash(dialog_options)
-  # Setup regular expression for service dialog tags
-  tags_regex = /^dialog_tag_\d*_(.*)/
+  # Loop through all tags from the dialog and create the categories and tags automatically
+  def create_tags(category, single_value, tag)
+    # Convert to lower case and replace all non-word characters with underscores
+    category_name = category.to_s.downcase.gsub(/\W/, '_')
+    tag_name = tag.to_s.downcase.gsub(/\W/, '_')
+    # if the category exists else create it
+    unless $evm.execute('category_exists?', category_name)
+      log_and_update_message(:info, "Creating Category: {#{category_name} => #{category}}")
+      $evm.execute('category_create', :name         => category_name,
+                                      :single_value => single_value,
+                                      :description  => "#{category}")
+    end
+    # if the tag exists else create it
+    return if $evm.execute('tag_exists?', category_name, tag_name)
+    log_and_update_message(:info, "Creating tag: {#{tag_name} => #{tag}}")
+    $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
+  end
 
-  tags_hash = {}
-
-  # Loop through all of the tags and build an options_hash from them
-  dialog_options.each do |k, v|
-    if tags_regex =~ k
-      # Convert key to symbol
-      tag_category = Regexp.last_match[1].to_sym
-      tag_value = v.downcase
-
-      unless tag_value.blank?
-        $evm.log("info", "Adding category:<#{tag_category.inspect}> tag:<#{tag_value.inspect}> to tags_hash")
-        tags_hash[tag_category] = tag_value
+  def create_category_and_tags_if_necessary(dialog_tags_hash)
+    dialog_tags_hash.each do |category, tag|
+      Array.wrap(tag).each do |tag_entry|
+        create_tags(category, true, tag_entry)
       end
     end
   end
-  $evm.log("info", "Inspecting tags_hash:<#{tags_hash.inspect}>")
-  tags_hash
-end
 
-# Look for service dialog variables in the dialog options hash that start with "option_[0-9]",
-def get_options_hash(dialog_options)
-  # Setup regular expression for service dialog tags
-  options_regex = /^dialog_option_\d*_(.*)/
-  options_hash = {}
+  def override_service_name(dialog_options_hash)
+    log_and_update_message(:info, "Processing override_service_name...", true)
+    new_service_name = dialog_options_hash.fetch(:service_name, nil)
+    new_service_name = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if new_service_name.blank?
 
-  # Loop through all of the options and build an options_hash from them
-  dialog_options.each do |k, v|
-    if options_regex =~ k
-      option_key = Regexp.last_match[1].to_sym
-      option_value = v
+    log_and_update_message(:info, "Service name: #{new_service_name}")
+    @service.name = new_service_name
+    log_and_update_message(:info, "Processing override_service_name...Complete", true)
+  end
 
-      unless option_value.blank?
-        $evm.log("info", "Adding option_key:<#{option_key.inspect}> option_value:<#{option_value.inspect}> to options_hash")
-        options_hash[option_key] = option_value
-      end
+  def override_service_description(dialog_options_hash)
+    log_and_update_message(:info, "Processing override_service_description...", true)
+    new_service_description = dialog_options_hash.fetch(:service_description, nil)
+    return if new_service_description.blank?
+
+    log_and_update_message(:info, "Service description #{new_service_description}")
+    @service.description = new_service_description
+    log_and_update_message(:info, "Processing override_service_description...Complete", true)
+  end
+
+  def tag_service(dialog_tags_hash)
+    return if dialog_tags_hash.nil?
+
+    log_and_update_message(:info, "Processing tag service...", true)
+
+    dialog_tags_hash.each do |key, value|
+      log_and_update_message(:info, "Processing Tag Key: #{key.inspect}  value: #{value.inspect}")
+      next if value.blank?
+      get_service_tags(key.downcase, value)
+    end
+    log_and_update_message(:info, "Processing tag_service...Complete", true)
+  end
+
+  def get_service_tags(tag_category, tag_value)
+    Array.wrap(tag_value).each do |tag_entry|
+      assign_service_tag(tag_category, tag_entry)
+    end
+  end
+
+  def assign_service_tag(tag_category, tag_value)
+    $evm.log(:info, "Adding tag category: #{tag_category} tag: #{tag_value} to Service: #{@service.name}")
+    @service.tag_assign("#{tag_category}/#{tag_value}")
+  end
+
+  def get_vm_name(dialog_options_hash, prov)
+    log_and_update_message(:info, "Processing get_vm_name", true)
+    new_vm_name = dialog_options_hash.fetch(:vm_name, nil) || dialog_options_hash.fetch(:vm_target_name, nil)
+
+    new_vm_name = prov.get_option(:vm_target_name) if new_vm_name.blank?
+
+    dialog_options_hash[:vm_target_name] = new_vm_name
+    dialog_options_hash[:vm_target_hostname] = new_vm_name
+    dialog_options_hash[:vm_name] = new_vm_name
+    dialog_options_hash[:linux_host_name] = new_vm_name
+    log_and_update_message(:info, "Processing get_vm_name...Complete", true)
+  end
+
+  def service_item_dialog_values(dialogs_options_hash)
+    merged_options_hash = Hash.new { |h, k| h[k] = {} }
+    provision_index = determine_provision_index
+
+    if dialogs_options_hash[0].nil?
+      merged_options_hash = dialogs_options_hash[provision_index] || {}
     else
-      unless v.nil?
-        $evm.log("info", "Adding option:<#{k.to_sym.inspect}> value:<#{v.inspect}> to options_hash")
-        options_hash[k.to_sym] = v
-      end
+      merged_options_hash = dialogs_options_hash[0].merge(dialogs_options_hash[provision_index] || {})
+    end
+    merged_options_hash
+  end
+
+  def service_item_tag_values(dialogs_tags_hash)
+    merged_tags_hash         = Hash.new { |h, k| h[k] = {} }
+    provision_index = determine_provision_index
+
+    # merge dialog_tag_0 stuff with current build
+    if dialogs_tags_hash[0].nil?
+      merged_tags_hash = dialogs_tags_hash[provision_index] || {}
+    else
+      merged_tags_hash = dialogs_tags_hash[0].merge(dialogs_tags_hash[provision_index] || {})
+    end
+    merged_tags_hash
+  end
+
+  def determine_provision_index
+    service_resource = @task.service_resource
+    if service_resource
+      # Increment the provision_index number since the child resource starts with a zero
+      provision_index = service_resource.provision_index ? service_resource.provision_index + 1 : 0
+      log_and_update_message(:info, "Bundle --> Service name: #{@service.name}> provision_index: #{provision_index}")
+    else
+      provision_index = 1
+      log_and_update_message(:info, "Item --> Service name: #{@service.name}> provision_index: #{provision_index}")
+    end
+    provision_index
+  end
+
+  def add_provision_tag(key, value, prov)
+    log_and_update_message(:info, "Adding Tag: {#{key.inspect} => #{value.inspect}} to Provisioning id: #{prov.id}")
+    prov.add_tag(key.to_s.downcase.gsub(/\W/, '_'), value.to_s.downcase.gsub(/\W/, '_'))
+  end
+
+  def get_provision_tags(key, value, prov)
+    Array.wrap(value).each do |tag_entry|
+      add_provision_tag(key, tag_entry.downcase, prov)
     end
   end
-  $evm.log("info", "Inspecting options_hash:<#{options_hash.inspect}>")
-  options_hash
-end
 
-# Look in tags_hash for tags and tag the service
-def tag_service(service, tags_hash)
-  # Look for tags with a sequence_id of 0 to tag the destination Service
-  unless tags_hash.nil?
-    tags_hash.each do |k, v|
-      $evm.log("info", "Adding Tag:<#{k.inspect}/#{v.inspect}> to Service:<#{service.name}>")
-      service.tag_assign("#{k}/#{v}")
+  def tag_provision_task(dialog_tags_hash, prov)
+    dialog_tags_hash.each do |key, value|
+      get_provision_tags(key, value, prov)
     end
   end
+
+  def set_option_on_provision_task(dialog_options_hash, prov)
+    dialog_options_hash.each do |key, value|
+      log_and_update_message(:info, "Adding Option: {#{key} => #{value}} to Provisioning id: #{prov.id}")
+      prov.set_option(key.to_s.downcase.gsub(/\W/, '_'), value.to_s.downcase.gsub(/\W/, '_'))
+    end
+  end
+
+  def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, dialog_tags_hash)
+    provision_task.miq_request_tasks.each do |prov|
+      log_and_update_message(:info, "Grandchild Task: #{prov.id} Desc: #{prov.description} type: #{prov.source_type}")
+      get_vm_name(dialog_options_hash, prov)
+      tag_provision_task(dialog_tags_hash, prov)
+      set_option_on_provision_task(dialog_tags_hash, prov)
+    end
+  end
+
+  def pass_dialog_values_to_children(dialog_options_hash, dialog_tags_hash)
+    @task.miq_request_tasks.each do |t|
+      child_service = t.destination
+      log_and_update_message(:info, "Child Service: #{child_service.name}")
+      next if t.miq_request_tasks.nil?
+
+      pass_dialog_values_to_provision_task(t, dialog_options_hash, dialog_tags_hash)
+    end
+  end
+
+  def remove_service
+    log_and_update_message(:info, "Processing remove_service...", true)
+    if @service
+      log_and_update_message(:info, "Removing Service: #{@service.name} id: #{@service.id} due to failure")
+      @service.remove_from_vmdb
+    end
+    log_and_update_message(:info, "Processing remove_service...Complete", true)
+  end
+
+  def merge_dialog_information(dialog_options_hash, dialog_tags_hash)
+    merged_options_hash = service_item_dialog_values(dialog_options_hash)
+    merged_tags_hash = service_item_tag_values(dialog_tags_hash)
+
+    log_and_update_message(:info, "merged_options_hash: #{merged_options_hash.inspect}")
+    log_and_update_message(:info, "merged_tags_hash: #{merged_tags_hash.inspect}")
+    return merged_options_hash, merged_tags_hash
+  end
+
+  def parsed_dialog_information
+    dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
+    dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
+
+    if dialog_options_hash.blank? && dialog_tags_hash.blank?
+      log_and_update_message(:error, "Error loading dialog options")
+      exit MIQ_ABORT
+    end
+    merged_options_hash, merged_tags_hash = merge_dialog_information(dialog_options_hash, dialog_tags_hash)
+    return merged_options_hash, merged_tags_hash
+  end
+
+  @task = $evm.root['service_template_provision_task']
+
+  @service = @task.destination
+  log_and_update_message(:info, "Service: #{@service.name} Id: #{@service.id} Tasks: #{@task.miq_request_tasks.count}")
+
+  dialog_options_hash, dialog_tags_hash = parsed_dialog_information
+
+  override_service_name(dialog_options_hash)
+
+  override_service_description(dialog_options_hash)
+
+  create_category_and_tags_if_necessary(dialog_tags_hash)
+
+  tag_service(dialog_tags_hash)
+
+  pass_dialog_values_to_children(dialog_options_hash, dialog_tags_hash)
+
+rescue => err
+  log_and_update_message(:error, "[#{err}]\n#{err.backtrace.join("\n")}")
+  @task.finished("#{err}") if @task
+  remove_service if @service
+  exit MIQ_ABORT
 end
-
-# Get the task object from root
-service_template_provision_task = $evm.root['service_template_provision_task']
-
-# Get destination service object
-service = service_template_provision_task.destination
-$evm.log("info", "Detected Service:<#{service.name}> Id:<#{service.id}>")
-
-# Get dialog options from options hash
-# {:dialog=>{"option_0_myvar"=>"myprefix", "option_1_vservice_workers"=>"2", "tag_0_environment"=>"test", "tag_0_location"=>"paris",
-# "option_2_vm_memory"=>"2048", "option_0_vlan"=>"Internal", "option_1_cores_per_socket"=>"1"}}
-dialog_options = service_template_provision_task.dialog_options
-$evm.log("info", "Inspecting Dialog Options:<#{dialog_options.inspect}>")
-
-# Get tags_hash
-tags_hash = get_tags_hash(dialog_options)
-
-# Tag Service
-tag_service(service, tags_hash)
-
-# Get options_hash
-options_hash = get_options_hash(dialog_options)
-
-# Process Child Tasks
-service_template_provision_task.miq_request_tasks.each do |t|
-
-  # Process grandchildren service options
-  unless t.miq_request_tasks.nil?
-    grandchild_tasks = t.miq_request_tasks
-    grandchild_tasks.each do |gc|
-      $evm.log("info", "Detected Grandchild Task ID:<#{gc.id}> Description:<#{gc.description}> source type:<#{gc.source_type}>")
-
-      # If child task is provisioning then apply tags and options
-      if gc.source_type == "template"
-        unless tags_hash.nil?
-          tags_hash.each do |k, v|
-            $evm.log("info", "Adding Tag:<#{k.inspect}/#{v.inspect}> to Provisioning ID:<#{gc.id}>")
-            gc.add_tag(k, v)
-          end
-        end
-        unless options_hash.nil?
-          options_hash.each do |k, v|
-            $evm.log("info", "Adding Option:<{#{k.inspect} => #{v.inspect}}> to Provisioning ID:<#{gc.id}>")
-            gc.set_option(k, v)
-          end
-        end
-      else
-        $evm.log("info", "Invalid Source Type:<#{gc.source_type}>. Skipping task ID:<#{gc.id}>")
-      end # if gc.source_type
-    end # grandchild_tasks.each do
-  end # unless t.miq_request_tasks.nil?
-end # service_template_provision_task.miq_request_tasks.each do

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -1,214 +1,211 @@
-# CatalogItemInitialization.rb
-#
-# Author: Kevin Morey <kmorey@redhat.com>
-# License: GPL v3
 #
 # Description: This method Performs the following functions:
 # 1. YAML load the Service Dialog Options from @task.get_option(:parsed_dialog_options))
 # 2. Set the name of the service
 # 3. Set tags on the service
 # 5. Override miq_provision task with any options and tags
+# Important - The dialog_parser automate method has to run prior to this in order to populate the dialog information.
 #
+def log_and_update_message(level, msg, update_message = false)
+  $evm.log(level, "#{msg}")
+  @task.message = msg if @task && (update_message || level == 'error')
+end
+
+# Loop through all tags from the dialog and create the categories and tags automatically
+def create_tags(category, single_value, tag)
+  # Convert to lower case and replace all non-word characters with underscores
+  category_name = category.to_s.downcase.gsub(/\W/, '_')
+  tag_name = tag.to_s.downcase.gsub(/\W/, '_')
+  # if the category exists else create it
+  unless $evm.execute('category_exists?', category_name)
+    log_and_update_message(:info, "Creating Category: {#{category_name} => #{category}}")
+    $evm.execute('category_create', :name         => category_name,
+                                    :single_value => single_value,
+                                    :description  => "#{category}")
+  end
+  # if the tag exists else create it
+  return if $evm.execute('tag_exists?', category_name, tag_name)
+  log_and_update_message(:info, "Creating tag: {#{tag_name} => #{tag}}")
+  $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
+end
+
+def create_category_and_tags_if_necessary(dialog_tags_hash)
+  dialog_tags_hash.each do |category, tag|
+    Array.wrap(tag).each do |tag_entry|
+      create_tags(category, true, tag_entry)
+    end
+  end
+end
+
+def override_service_name(dialog_options_hash)
+  log_and_update_message(:info, "Processing override_service_name...", true)
+  new_service_name = dialog_options_hash.fetch(:service_name, nil)
+  new_service_name = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if new_service_name.blank?
+
+  log_and_update_message(:info, "Service name: #{new_service_name}")
+  @service.name = new_service_name
+  log_and_update_message(:info, "Processing override_service_name...Complete", true)
+end
+
+def override_service_description(dialog_options_hash)
+  log_and_update_message(:info, "Processing override_service_description...", true)
+  new_service_description = dialog_options_hash.fetch(:service_description, nil)
+  return if new_service_description.blank?
+
+  log_and_update_message(:info, "Service description #{new_service_description}")
+  @service.description = new_service_description
+  log_and_update_message(:info, "Processing override_service_description...Complete", true)
+end
+
+def tag_service(dialog_tags_hash)
+  return if dialog_tags_hash.nil?
+
+  log_and_update_message(:info, "Processing tag service...", true)
+
+  dialog_tags_hash.each do |key, value|
+    log_and_update_message(:info, "Processing Tag Key: #{key.inspect}  value: #{value.inspect}")
+    next if value.blank?
+    get_service_tags(key.downcase, value)
+  end
+  log_and_update_message(:info, "Processing tag_service...Complete", true)
+end
+
+def get_service_tags(tag_category, tag_value)
+  Array.wrap(tag_value).each do |tag_entry|
+    assign_service_tag(tag_category, tag_entry)
+  end
+end
+
+def assign_service_tag(tag_category, tag_value)
+  $evm.log(:info, "Adding tag category: #{tag_category} tag: #{tag_value} to Service: #{@service.name}")
+  @service.tag_assign("#{tag_category}/#{tag_value}")
+end
+
+def get_vm_name(dialog_options_hash, prov)
+  log_and_update_message(:info, "Processing get_vm_name", true)
+  new_vm_name = dialog_options_hash.fetch(:vm_name, nil) || dialog_options_hash.fetch(:vm_target_name, nil)
+
+  new_vm_name = prov.get_option(:vm_target_name) if new_vm_name.blank?
+
+  dialog_options_hash[:vm_target_name] = new_vm_name
+  dialog_options_hash[:vm_target_hostname] = new_vm_name
+  dialog_options_hash[:vm_name] = new_vm_name
+  dialog_options_hash[:linux_host_name] = new_vm_name
+  log_and_update_message(:info, "Processing get_vm_name...Complete", true)
+end
+
+def service_item_dialog_values(dialogs_options_hash)
+  merged_options_hash = Hash.new { |h, k| h[k] = {} }
+  provision_index = determine_provision_index
+
+  if dialogs_options_hash[0].nil?
+    merged_options_hash = dialogs_options_hash[provision_index] || {}
+  else
+    merged_options_hash = dialogs_options_hash[0].merge(dialogs_options_hash[provision_index] || {})
+  end
+  merged_options_hash
+end
+
+def service_item_tag_values(dialogs_tags_hash)
+  merged_tags_hash         = Hash.new { |h, k| h[k] = {} }
+  provision_index = determine_provision_index
+
+  # merge dialog_tag_0 stuff with current build
+  if dialogs_tags_hash[0].nil?
+    merged_tags_hash = dialogs_tags_hash[provision_index] || {}
+  else
+    merged_tags_hash = dialogs_tags_hash[0].merge(dialogs_tags_hash[provision_index] || {})
+  end
+  merged_tags_hash
+end
+
+def determine_provision_index
+  service_resource = @task.service_resource
+  if service_resource
+    # Increment the provision_index number since the child resource starts with a zero
+    provision_index = service_resource.provision_index ? service_resource.provision_index + 1 : 0
+    log_and_update_message(:info, "Bundle --> Service name: #{@service.name}> provision_index: #{provision_index}")
+  else
+    provision_index = 1
+    log_and_update_message(:info, "Item --> Service name: #{@service.name}> provision_index: #{provision_index}")
+  end
+  provision_index
+end
+
+def add_provision_tag(key, value, prov)
+  log_and_update_message(:info, "Adding Tag: {#{key.inspect} => #{value.inspect}} to Provisioning id: #{prov.id}")
+  prov.add_tag(key.to_s.downcase.gsub(/\W/, '_'), value.to_s.downcase.gsub(/\W/, '_'))
+end
+
+def get_provision_tags(key, value, prov)
+  Array.wrap(value).each do |tag_entry|
+    add_provision_tag(key, tag_entry.downcase, prov)
+  end
+end
+
+def tag_provision_task(dialog_tags_hash, prov)
+  dialog_tags_hash.each do |key, value|
+    get_provision_tags(key, value, prov)
+  end
+end
+
+def set_option_on_provision_task(dialog_options_hash, prov)
+  dialog_options_hash.each do |key, value|
+    log_and_update_message(:info, "Adding Option: {#{key} => #{value}} to Provisioning id: #{prov.id}")
+    prov.set_option(key.to_s.downcase.gsub(/\W/, '_'), value.to_s.downcase.gsub(/\W/, '_'))
+  end
+end
+
+def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, dialog_tags_hash)
+  provision_task.miq_request_tasks.each do |prov|
+    log_and_update_message(:info, "Grandchild Task: #{prov.id} Desc: #{prov.description} type: #{prov.source_type}")
+    get_vm_name(dialog_options_hash, prov)
+    tag_provision_task(dialog_tags_hash, prov)
+    set_option_on_provision_task(dialog_tags_hash, prov)
+  end
+end
+
+def pass_dialog_values_to_children(dialog_options_hash, dialog_tags_hash)
+  @task.miq_request_tasks.each do |t|
+    child_service = t.destination
+    log_and_update_message(:info, "Child Service: #{child_service.name}")
+    next if t.miq_request_tasks.nil?
+
+    pass_dialog_values_to_provision_task(t, dialog_options_hash, dialog_tags_hash)
+  end
+end
+
+def remove_service
+  log_and_update_message(:info, "Processing remove_service...", true)
+  if @service
+    log_and_update_message(:info, "Removing Service: #{@service.name} id: #{@service.id} due to failure")
+    @service.remove_from_vmdb
+  end
+  log_and_update_message(:info, "Processing remove_service...Complete", true)
+end
+
+def merge_dialog_information(dialog_options_hash, dialog_tags_hash)
+  merged_options_hash = service_item_dialog_values(dialog_options_hash)
+  merged_tags_hash = service_item_tag_values(dialog_tags_hash)
+
+  log_and_update_message(:info, "merged_options_hash: #{merged_options_hash.inspect}")
+  log_and_update_message(:info, "merged_tags_hash: #{merged_tags_hash.inspect}")
+  return merged_options_hash, merged_tags_hash
+end
+
+def parsed_dialog_information
+  dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
+  dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
+
+  if dialog_options_hash.blank? && dialog_tags_hash.blank?
+    log_and_update_message(:error, "Error loading dialog options")
+    exit MIQ_ABORT
+  end
+  merged_options_hash, merged_tags_hash = merge_dialog_information(dialog_options_hash, dialog_tags_hash)
+  return merged_options_hash, merged_tags_hash
+end
+
 begin
-  def log_and_update_message(level, msg, update_message = false)
-    $evm.log(level, "#{msg}")
-    @task.message = msg if @task && (update_message || level == 'error')
-  end
-
-  # Loop through all tags from the dialog and create the categories and tags automatically
-  def create_tags(category, single_value, tag)
-    # Convert to lower case and replace all non-word characters with underscores
-    category_name = category.to_s.downcase.gsub(/\W/, '_')
-    tag_name = tag.to_s.downcase.gsub(/\W/, '_')
-    # if the category exists else create it
-    unless $evm.execute('category_exists?', category_name)
-      log_and_update_message(:info, "Creating Category: {#{category_name} => #{category}}")
-      $evm.execute('category_create', :name         => category_name,
-                                      :single_value => single_value,
-                                      :description  => "#{category}")
-    end
-    # if the tag exists else create it
-    return if $evm.execute('tag_exists?', category_name, tag_name)
-    log_and_update_message(:info, "Creating tag: {#{tag_name} => #{tag}}")
-    $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
-  end
-
-  def create_category_and_tags_if_necessary(dialog_tags_hash)
-    dialog_tags_hash.each do |category, tag|
-      Array.wrap(tag).each do |tag_entry|
-        create_tags(category, true, tag_entry)
-      end
-    end
-  end
-
-  def override_service_name(dialog_options_hash)
-    log_and_update_message(:info, "Processing override_service_name...", true)
-    new_service_name = dialog_options_hash.fetch(:service_name, nil)
-    new_service_name = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if new_service_name.blank?
-
-    log_and_update_message(:info, "Service name: #{new_service_name}")
-    @service.name = new_service_name
-    log_and_update_message(:info, "Processing override_service_name...Complete", true)
-  end
-
-  def override_service_description(dialog_options_hash)
-    log_and_update_message(:info, "Processing override_service_description...", true)
-    new_service_description = dialog_options_hash.fetch(:service_description, nil)
-    return if new_service_description.blank?
-
-    log_and_update_message(:info, "Service description #{new_service_description}")
-    @service.description = new_service_description
-    log_and_update_message(:info, "Processing override_service_description...Complete", true)
-  end
-
-  def tag_service(dialog_tags_hash)
-    return if dialog_tags_hash.nil?
-
-    log_and_update_message(:info, "Processing tag service...", true)
-
-    dialog_tags_hash.each do |key, value|
-      log_and_update_message(:info, "Processing Tag Key: #{key.inspect}  value: #{value.inspect}")
-      next if value.blank?
-      get_service_tags(key.downcase, value)
-    end
-    log_and_update_message(:info, "Processing tag_service...Complete", true)
-  end
-
-  def get_service_tags(tag_category, tag_value)
-    Array.wrap(tag_value).each do |tag_entry|
-      assign_service_tag(tag_category, tag_entry)
-    end
-  end
-
-  def assign_service_tag(tag_category, tag_value)
-    $evm.log(:info, "Adding tag category: #{tag_category} tag: #{tag_value} to Service: #{@service.name}")
-    @service.tag_assign("#{tag_category}/#{tag_value}")
-  end
-
-  def get_vm_name(dialog_options_hash, prov)
-    log_and_update_message(:info, "Processing get_vm_name", true)
-    new_vm_name = dialog_options_hash.fetch(:vm_name, nil) || dialog_options_hash.fetch(:vm_target_name, nil)
-
-    new_vm_name = prov.get_option(:vm_target_name) if new_vm_name.blank?
-
-    dialog_options_hash[:vm_target_name] = new_vm_name
-    dialog_options_hash[:vm_target_hostname] = new_vm_name
-    dialog_options_hash[:vm_name] = new_vm_name
-    dialog_options_hash[:linux_host_name] = new_vm_name
-    log_and_update_message(:info, "Processing get_vm_name...Complete", true)
-  end
-
-  def service_item_dialog_values(dialogs_options_hash)
-    merged_options_hash = Hash.new { |h, k| h[k] = {} }
-    provision_index = determine_provision_index
-
-    if dialogs_options_hash[0].nil?
-      merged_options_hash = dialogs_options_hash[provision_index] || {}
-    else
-      merged_options_hash = dialogs_options_hash[0].merge(dialogs_options_hash[provision_index] || {})
-    end
-    merged_options_hash
-  end
-
-  def service_item_tag_values(dialogs_tags_hash)
-    merged_tags_hash         = Hash.new { |h, k| h[k] = {} }
-    provision_index = determine_provision_index
-
-    # merge dialog_tag_0 stuff with current build
-    if dialogs_tags_hash[0].nil?
-      merged_tags_hash = dialogs_tags_hash[provision_index] || {}
-    else
-      merged_tags_hash = dialogs_tags_hash[0].merge(dialogs_tags_hash[provision_index] || {})
-    end
-    merged_tags_hash
-  end
-
-  def determine_provision_index
-    service_resource = @task.service_resource
-    if service_resource
-      # Increment the provision_index number since the child resource starts with a zero
-      provision_index = service_resource.provision_index ? service_resource.provision_index + 1 : 0
-      log_and_update_message(:info, "Bundle --> Service name: #{@service.name}> provision_index: #{provision_index}")
-    else
-      provision_index = 1
-      log_and_update_message(:info, "Item --> Service name: #{@service.name}> provision_index: #{provision_index}")
-    end
-    provision_index
-  end
-
-  def add_provision_tag(key, value, prov)
-    log_and_update_message(:info, "Adding Tag: {#{key.inspect} => #{value.inspect}} to Provisioning id: #{prov.id}")
-    prov.add_tag(key.to_s.downcase.gsub(/\W/, '_'), value.to_s.downcase.gsub(/\W/, '_'))
-  end
-
-  def get_provision_tags(key, value, prov)
-    Array.wrap(value).each do |tag_entry|
-      add_provision_tag(key, tag_entry.downcase, prov)
-    end
-  end
-
-  def tag_provision_task(dialog_tags_hash, prov)
-    dialog_tags_hash.each do |key, value|
-      get_provision_tags(key, value, prov)
-    end
-  end
-
-  def set_option_on_provision_task(dialog_options_hash, prov)
-    dialog_options_hash.each do |key, value|
-      log_and_update_message(:info, "Adding Option: {#{key} => #{value}} to Provisioning id: #{prov.id}")
-      prov.set_option(key.to_s.downcase.gsub(/\W/, '_'), value.to_s.downcase.gsub(/\W/, '_'))
-    end
-  end
-
-  def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, dialog_tags_hash)
-    provision_task.miq_request_tasks.each do |prov|
-      log_and_update_message(:info, "Grandchild Task: #{prov.id} Desc: #{prov.description} type: #{prov.source_type}")
-      get_vm_name(dialog_options_hash, prov)
-      tag_provision_task(dialog_tags_hash, prov)
-      set_option_on_provision_task(dialog_tags_hash, prov)
-    end
-  end
-
-  def pass_dialog_values_to_children(dialog_options_hash, dialog_tags_hash)
-    @task.miq_request_tasks.each do |t|
-      child_service = t.destination
-      log_and_update_message(:info, "Child Service: #{child_service.name}")
-      next if t.miq_request_tasks.nil?
-
-      pass_dialog_values_to_provision_task(t, dialog_options_hash, dialog_tags_hash)
-    end
-  end
-
-  def remove_service
-    log_and_update_message(:info, "Processing remove_service...", true)
-    if @service
-      log_and_update_message(:info, "Removing Service: #{@service.name} id: #{@service.id} due to failure")
-      @service.remove_from_vmdb
-    end
-    log_and_update_message(:info, "Processing remove_service...Complete", true)
-  end
-
-  def merge_dialog_information(dialog_options_hash, dialog_tags_hash)
-    merged_options_hash = service_item_dialog_values(dialog_options_hash)
-    merged_tags_hash = service_item_tag_values(dialog_tags_hash)
-
-    log_and_update_message(:info, "merged_options_hash: #{merged_options_hash.inspect}")
-    log_and_update_message(:info, "merged_tags_hash: #{merged_tags_hash.inspect}")
-    return merged_options_hash, merged_tags_hash
-  end
-
-  def parsed_dialog_information
-    dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
-    dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
-
-    if dialog_options_hash.blank? && dialog_tags_hash.blank?
-      log_and_update_message(:error, "Error loading dialog options")
-      exit MIQ_ABORT
-    end
-    merged_options_hash, merged_tags_hash = merge_dialog_information(dialog_options_hash, dialog_tags_hash)
-    return merged_options_hash, merged_tags_hash
-  end
-
   @task = $evm.root['service_template_provision_task']
 
   @service = @task.destination

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -1,0 +1,108 @@
+
+def vmdb_object_from_array_entry(entry)
+  model, id = entry.split("::")
+  $evm.vmdb(model, id.to_i) if model && id
+end
+
+def parent_task(task)
+  return task if task.miq_request_task.nil?
+  parent_task(task.miq_request_task)
+end
+
+def add_hash_value(sequence_id, option_key, value, hash)
+  $evm.log("info", "Adding seq_id: #{sequence_id} key: #{option_key} value: #{value} ")
+  hash[sequence_id][option_key] = value
+end
+
+def process_comma_separated_object_array(sequence_id, option_key, value, hash)
+  return if value.nil?
+  options_value_array = []
+  value.split(",").each do |entry|
+    vmdb_obj = vmdb_object_from_array_entry(entry.to_s)
+    next if vmdb_obj.nil?
+    options_value_array << vmdb_obj.name
+  end
+  hash[sequence_id][option_key] = options_value_array
+end
+
+def option_hash_value(dialog_key, dialog_value, options_hash)
+  return false unless /^dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+  add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, options_hash)
+  true
+end
+
+def option_array_value(dialog_key, dialog_value, options_hash)
+  return false unless /^array::dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+  process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, options_hash)
+  true
+end
+
+def tag_hash_value(dialog_key, dialog_value, tags_hash)
+  return false unless /^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+  add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, tags_hash)
+  true
+end
+
+def tag_array_value(dialog_key, dialog_value, tags_hash)
+  return false unless /^array::dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+  process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, tags_hash)
+  true
+end
+
+def generic_dialog_value(dialog_key, dialog_value, options_hash)
+  return false unless /^dialog_(?<option_key>.*)/i =~ dialog_key
+  add_hash_value(0, option_key.to_sym, dialog_value, options_hash)
+  true
+end
+
+def parse_dialog_entries(dialog_options)
+  options_hash        = Hash.new { |h, k| h[k] = {} }
+  tags_hash           = Hash.new { |h, k| h[k] = {} }
+
+  dialog_options.each do |key, value|
+    next if value.blank?
+
+    option_hash_value(key, value, options_hash) ||
+      option_array_value(key, value, options_hash) ||
+      tag_hash_value(key, value, tags_hash) ||
+      tag_array_value(key, value, tags_hash) ||
+      generic_dialog_value(key, value, options_hash)
+  end
+  return options_hash, tags_hash
+end
+
+def parent_task_dialog_information
+  bundle_task = parent_task(@task)
+  if bundle_task.nil?
+    $evm.log('error', "Unable to locate Dialog information")
+    exit MIQ_ABORT
+  end
+
+  $evm.log('info', "Current task has empty dialogs, getting dialog information from parent task")
+  options_hash = YAML.load(bundle_task.get_option(:parsed_dialog_options))
+  tags_hash = YAML.load(bundle_task.get_option(:parsed_dialog_tags))
+  return options_hash, tags_hash
+end
+
+def save_parsed_dialog_information(options_hash, tags_hash)
+  @task.set_option(:parsed_dialog_options, YAML.dump(options_hash))
+  @task.set_option(:parsed_dialog_tags, YAML.dump(tags_hash))
+  $evm.log('info', "parsed_dialog_options: #{@task.get_option(:parsed_dialog_options).inspect}")
+  $evm.log('info', "parsed_dialog_tags: #{@task.get_option(:parsed_dialog_tags).inspect}")
+end
+
+@task = $evm.root['service_template_provision_task']
+
+dialog_entries = @task.dialog_options
+
+$evm.log('info', "dialog_options: #{dialog_entries.inspect}")
+
+options_hash, tags_hash = parse_dialog_entries(dialog_entries)
+
+if options_hash.blank? && tags_hash.blank?
+  options_hash, tags_hash = parent_task_dialog_information
+else
+  $evm.log('info', "Current task has dialog information")
+end
+
+save_parsed_dialog_information(options_hash, tags_hash)

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: dialog_parser
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/dialogparser.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/dialogparser.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DialogParser
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: dialog_parser

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/catalogbundleinitialization.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/catalogbundleinitialization.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - pre1:
+      value: "/Service/Provisioning/StateMachines/Methods/DialogParser"
   - pre2:
       value: "/Service/Provisioning/StateMachines/Methods/CatalogBundleInitialization"

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/catalogiteminitialization.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/catalogiteminitialization.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - pre1:
+      value: "/Service/Provisioning/StateMachines/Methods/DialogParser"
   - pre2:
       value: "/Service/Provisioning/StateMachines/Methods/CatalogItemInitialization"


### PR DESCRIPTION
Service Dialog Enhancements

*Created single copy of parsing code in separate automate method. 
*Normalized Dialog information provided to Service provision state machine methods.
*Added clarity by the separation of dialog options and tags.  
*Add tag_control support.
*Ability to override the service_name, service_description and vm_name.
*Service cleanup for failed service provision.

The catalogbundleinitialization and catalogiteminitialization automate methods had duplicated parsing code and had issues where tagging and options setting was not working correctly.   
Created new dialog_parser automate method to be executed prior to catalogbundleinitialization and catalogiteminitialization methods to provide consolidated and configurable dialog parsing.

Sample parser method output:
dialog_options_hash: {1=>{:stuff=>"this is for items 1 only - FINAL TEST"}, 2=>{:stuff=>"option2 stuff"}, 3=>{:stuff=>"option 3"}, 0=>{:global_value=>"global value"}}
dialog_tags_hash: {0=>{:location=>"location"}, 2=>{:stuff=>"tag 2"}, 3=>{:stuff=>"tag_3_stuff"}}

The parsed dialog information is stored in YAML format in the options hash of the request task and is copied from the request task to the child task when the catalog item is processed. The information is stored in the options hash using the parsed_dialog_options and parsed_tag_options keys.

Tag control support input format:
Array::dialog_option_1_department3"=>"Classification::41,Classification::42,Classification::43,Classification::44"
Parsed Results: department3=>["accounting", "automotive", "communication"]}

CatalogBundleinitialization and catalogiteminitialization method changes:
Methods use normalized dialog information stored in options hash.
parsed_dialog_options: {1=>{:stuff=>"this is for items 1 only - FINAL TEST"}, 2=>{:stuff=>"option2 stuff"}, 3=>{:stuff=>"option 3"}, 0=>{:global_value=>"global value"}}
parsed_tag_options: {0=>{:location=>"location"}, 2=>{:stuff=>"tag 2"}, 3=>{:stuff=>"tag_3_stuff"}}
The zero key entries are global and passed to all service items.  The non-zero key entries are applied to the service item that have a matching provision index.  Service item 1 will have options for 0 and 1, service item 2 will have options for 0 and 2, …..

Pass dialog_value of “service_name” to override the service name:         
Pass dialog_value of “service_description” to override the service description:  
Pass dialog_value of “vm_name” or “vm_target_name" to override the VM name:               

https://bugzilla.redhat.com/show_bug.cgi?id=1184267