### PR TITLE
[api] Supporting service catalog creation with no action

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -45,6 +45,7 @@ class ApiController < ApplicationController
   include_concern 'Events'
   include_concern 'ProvisionRequests'
   include_concern 'RequestTasks'
+  include_concern 'ServiceCatalogs'
   include_concern 'ServiceRequests'
   include_concern 'Software'
   include_concern 'ServiceTemplates'

--- a/vmdb/app/controllers/api_controller/service_catalogs.rb
+++ b/vmdb/app/controllers/api_controller/service_catalogs.rb
@@ -1,0 +1,13 @@
+class ApiController
+  module ServiceCatalogs
+    #
+    # Support service catalog creation with no action, straight
+    # post being "create" in addition of "add" for keeping v1.0 compatibility.
+    #
+    # Simply leveraging the generic add_resource method.
+    #
+    def create_resource_service_catalogs(type, id, data = {})
+      add_resource(type, id, data)
+    end
+  end
+end

--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -502,6 +502,8 @@
     - :service_templates
     :collection_actions:
       :post:
+      - :name: create
+        :identifier: st_catalog_new
       - :name: add
         :identifier: st_catalog_new
       - :name: edit

--- a/vmdb/spec/requests/api/service_catalogs_spec.rb
+++ b/vmdb/spec/requests/api/service_catalogs_spec.rb
@@ -1,6 +1,7 @@
 #
 # Rest API Request Tests - Service Catalogs specs
 #
+# - Creating single new service catalog   /api/service_catalogs                 POST
 # - Creating single new service catalog   /api/service_catalogs                 action "add"
 # - Creating multiple service catalogs    /api/service_catalogs                 action "add"
 # - Edit a service catalog                /api/service_catalogs/:id             action "edit"
@@ -41,6 +42,14 @@ describe ApiController do
       expect_request_forbidden
     end
 
+    it "rejects resource creation via create action without appropriate role" do
+      api_basic_authorize
+
+      run_post(service_catalogs_url, "name" => "sample service catalog")
+
+      expect_request_forbidden
+    end
+
     it "rejects resource creation with id specified" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :add)
 
@@ -53,6 +62,20 @@ describe ApiController do
       api_basic_authorize collection_action_identifier(:service_catalogs, :add)
 
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
+
+      expect_request_success
+      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
+
+      sc_id = @result["results"].first["id"]
+
+      expect(ServiceTemplateCatalog.find(sc_id)).to be_true
+    end
+
+    it "supports single resource creation via create action" do
+      api_basic_authorize collection_action_identifier(:service_catalogs, :add)
+
+      run_post(service_catalogs_url, "name" => "sample service catalog")
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)


### PR DESCRIPTION
- Extending v1.0 behavior for v2.0 compatibility
- Supporting no action service catalog creation (i.e. "create") when posting to /api/service_catalogs
- Keeping "add" action for v1.0 compatibility
- Adding spec.

https://trello.com/c/WxBF5lrT/39-api-enhancements-to-v1-0-api