### PR TITLE
Openstack infra host authentication by parent status

### DIFF
--- a/vmdb/app/models/mixins/authentication_mixin.rb
+++ b/vmdb/app/models/mixins/authentication_mixin.rb
@@ -56,6 +56,7 @@ module AuthenticationMixin
   end
 
   def authentication_status
+    return authentication_status_by_parent if self.respond_to?(:authentication_status_by_parent) && !authentication_status_by_parent.blank?
     ordered_auths = authentication_userid_passwords.sort_by(&:status_severity)
     ordered_auths.last.try(:status) || "None"
   end

--- a/vmdb/db/migrate/20150401114510_add_authentication_status_by_parent_to_hosts.rb
+++ b/vmdb/db/migrate/20150401114510_add_authentication_status_by_parent_to_hosts.rb
@@ -1,0 +1,5 @@
+class AddAuthenticationStatusByParentToHosts < ActiveRecord::Migration
+  def change
+    add_column :hosts, :authentication_status_by_parent, :string
+  end
+end


### PR DESCRIPTION
just last 2 commits are relevant, rest are dependencies

OpenstackInfra Auth is stored on Provider level. We need to track
if authentication of each host passed correctly. Before we have
some general inheritance of Auth, this is the simplest way how to
do it.
