### PR TITLE
Returning therubyracer to the appliance.

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -77,8 +77,6 @@ gem 'spice-html5-rails'
 # Only add gems here that we do not need on an appliance.
 #
 unless ENV['APPLIANCE']
-  gem 'therubyracer'
-
   group :development do
     gem "ruby-prof",                    :require => false
 
@@ -87,6 +85,7 @@ unless ENV['APPLIANCE']
     gem "gettext",          "3.1.4",    :require => false
     # used for finding translations inside HAML
     gem 'ruby_parser',                  :require => false
+    gem 'therubyracer'
   end
 
   group :test do

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -13,6 +13,7 @@ gem 'jquery-rails', "=2.1.4"
 
 gem "sprockets-sass",  "~>1.2.0"
 gem "sprockets-less",  "~>0.6.1"
+gem 'therubyracer'
 gem 'less-rails'
 
 # Vendored and required
@@ -85,7 +86,6 @@ unless ENV['APPLIANCE']
     gem "gettext",          "3.1.4",    :require => false
     # used for finding translations inside HAML
     gem 'ruby_parser',                  :require => false
-    gem 'therubyracer'
   end
 
   group :test do


### PR DESCRIPTION
When less-rails was added, it depends on less, which needs
therubyracer, we can't use nodejs for the v8 engine