### PR TITLE
Make the Gemfile's location known from anywhere on appliances.

### DIFF
--- a/system/LINK/etc/default/evm_bundler
+++ b/system/LINK/etc/default/evm_bundler
@@ -2,6 +2,7 @@
 
 export BUNDLE_WITHOUT=test:metric_fu:development
 export BUNDLE_JOBS=1
+export BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile
 
 # This is an environment variable we set in one place in the event
 # we want to use --local, --deployment, etc.


### PR DESCRIPTION
Make the Gemfile's location known from anywhere on appliances.

Bundler binstubs residing outside of /var/www/miq/vmdb/bin can't find 
the application's Gemfile without this environment variable set.

https://bugzilla.redhat.com/show_bug.cgi?id=1207842

[skip ci]