### PR TITLE
Changed Provision Order pull down to be independent pull down.

### DIFF
--- a/vmdb/app/views/catalog/_form_resources_info.html.haml
+++ b/vmdb/app/views/catalog/_form_resources_info.html.haml
@@ -57,7 +57,7 @@
                     = h(@edit[:new][:selected_resources].length)
                   - else
                     = select_tag("provision_index_#{i}_#{k}",
-                      options_for_select(Array.new(@edit[:new][:rsc_groups].length) {|j| j+1}, (sr[:provision_index]+1).to_s),
+                      options_for_select(Array.new(@edit[:new][:provision_order].length) {|j| j+1}, (sr[:provision_index]+1).to_s),
                       "data-miq_sparkle_on" => true,
                       "data-miq_observe" => {:url => url}.to_json)
                 - start_action_values = [_('Do Nothing'), _('Power On')]


### PR DESCRIPTION
Previously Provision Order pull down was tied to Action Order pull down and only showed entries same as in Action Order pull down, changed it to be a separate pull down and have one extra entry than already assigned Provision Order.

https://bugzilla.redhat.com/show_bug.cgi?id=1207895

@gmcculloug please test.
@dclarizio please test/review.