### PR TITLE
Removed api version from kubernetes provider

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -33,7 +33,7 @@ gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
 gem "ovirt",                "~>0.4.0",       :require => false
-gem "kubeclient",           ">=0.1.4",       :require => false
+gem "kubeclient",           ">=0.1.7",       :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false

--- a/lib/kubernetes/events/kubernetes_event_monitor.rb
+++ b/lib/kubernetes/events/kubernetes_event_monitor.rb
@@ -1,12 +1,11 @@
 class KubernetesEventMonitor
-  def initialize(api_endpoint, api_version)
+  def initialize(api_endpoint)
     @api_endpoint = api_endpoint
-    @api_version = api_version
   end
 
   def inventory
     require 'kubeclient'
-    @inventory ||= Kubeclient::Client.new(@api_endpoint, @api_version)
+    @inventory ||= Kubeclient::Client.new(@api_endpoint)
   end
 
   def watcher(version = nil)

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -11,10 +11,10 @@ class EmsKubernetes < EmsContainer
     @description ||= "Kubernetes".freeze
   end
 
-  def self.raw_connect(hostname, port, api_version)
+  def self.raw_connect(hostname, port)
     require 'kubeclient'
     api_endpoint = raw_api_endpoint(hostname, port)
-    Kubeclient::Client.new(api_endpoint, api_version)
+    Kubeclient::Client.new(api_endpoint)
   end
 
   def self.raw_api_endpoint(hostname, port)
@@ -26,7 +26,7 @@ class EmsKubernetes < EmsContainer
   end
 
   def connect(_options = {})
-    self.class.raw_connect(hostname, port, api_version)
+    self.class.raw_connect(hostname, port)
   end
 
   def self.event_monitor_class

--- a/vmdb/lib/workers/event_catcher_kubernetes.rb
+++ b/vmdb/lib/workers/event_catcher_kubernetes.rb
@@ -4,8 +4,7 @@ class EventCatcherKubernetes < EventCatcher
   def event_monitor_handle
     require 'kubernetes/events/kubernetes_event_monitor'
     @event_monitor_handle ||= KubernetesEventMonitor.new(
-      @ems.api_endpoint,
-      @ems.api_version
+      @ems.api_endpoint
     )
   end
 


### PR DESCRIPTION
api_version has now a default value in kubeclient, there's no need to
pass it.