### PR TITLE
Updated miq_request.user_message to set miq_request.message attribute.

### DIFF
--- a/vmdb/app/models/mixins/miq_request_mixin.rb
+++ b/vmdb/app/models/mixins/miq_request_mixin.rb
@@ -17,6 +17,7 @@ module MiqRequestMixin
   def user_message=(msg)
     options[:user_message] = msg
     update_attribute(:options, options)
+    update_attributes(:message => msg) unless msg.blank?
   end
 
   def self.get_option_last(key, from)

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 module MiqAeServiceServiceTemplateProvisionRequestSpec
   describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest do
-
     let(:service_service_template_provision_request) do
       MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest.find(@service_template_provision_request.id)
     end
@@ -27,14 +26,24 @@ module MiqAeServiceServiceTemplateProvisionRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_request'].approve('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
       MiqRequest.any_instance.should_receive(:approve).with(approver, reason).once
-      invoke_ae.root(@ae_result_key).should  be_true
+      invoke_ae.root(@ae_result_key).should be_true
     end
 
     it "#user_message" do
       service_service_template_provision_request.user_message = "fred"
 
+      expect(@service_template_provision_request.reload.message).to eq("fred")
       expect(@service_template_provision_request.reload.options[:user_message]).to eq("fred")
     end
 
+    it "#user_message reset" do
+      service_service_template_provision_request.user_message = "fred"
+      expect(@service_template_provision_request.reload.message).to eq("fred")
+      expect(@service_template_provision_request.reload.options[:user_message]).to eq("fred")
+
+      service_service_template_provision_request.user_message = ""
+      expect(@service_template_provision_request.reload.message).to eq("fred")
+      expect(@service_template_provision_request.reload.options[:user_message]).to be_blank
+    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
@@ -29,7 +29,18 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
     it "#user_message" do
       service_service_template_provision_task.user_message = "fred"
 
+      expect(@service_template_provision_task.reload.message).to eq("fred")
       expect(@service_template_provision_task.reload.options[:user_message]).to eq("fred")
+    end
+
+    it "#user_message reset" do
+      service_service_template_provision_task.user_message = "fred"
+      expect(@service_template_provision_task.reload.message).to eq("fred")
+      expect(@service_template_provision_task.reload.options[:user_message]).to eq("fred")
+
+      service_service_template_provision_task.user_message = ""
+      expect(@service_template_provision_task.reload.message).to eq("fred")
+      expect(@service_template_provision_task.reload.options[:user_message]).to be_blank
     end
 
     context "#status" do


### PR DESCRIPTION
Set "Last Message" for miq_request immediately when setting the user message. 

The following RFE had given users the ability to override the default messaging used in service state machine processing. 
https://bugzilla.redhat.com/show_bug.cgi?id=1161253

Since the miq_request.user_message method sets the "Last Message" only for state machine error conditions and/or the finished state, long running state machines would not report correct "Last Message" until the end of the state machine.

Changed the user_message= method to set the miq_request.message to report an  accurate "Last Message" status during state machine processing.   

https://bugzilla.redhat.com/show_bug.cgi?id=1196369