### PR TITLE
Polymorphic Association for Container Node

### DIFF
--- a/vmdb/app/models/container_node.rb
+++ b/vmdb/app/models/container_node.rb
@@ -1,6 +1,7 @@
 class ContainerNode < ActiveRecord::Base
   include ReportableMixin
   # :name, :uid, :creation_timestamp, :resource_version
-  belongs_to  :ext_management_system, :foreign_key => "ems_id"
-  has_many :container_groups
+  belongs_to :ext_management_system, :foreign_key => "ems_id"
+  has_many   :container_groups
+  belongs_to :lives_on, :polymorphic => true
 end

--- a/vmdb/db/migrate/20150402133252_add_container_node_cross_provider_association.rb
+++ b/vmdb/db/migrate/20150402133252_add_container_node_cross_provider_association.rb
@@ -1,0 +1,11 @@
+class AddContainerNodeCrossProviderAssociation < ActiveRecord::Migration
+  def up
+    add_column :container_nodes, :lives_on_type, :string
+    add_column :container_nodes, :lives_on_id,   :bigint
+  end
+
+  def down
+    remove_column :container_nodes, :lives_on_type
+    remove_column :container_nodes, :lives_on_id
+  end
+end


### PR DESCRIPTION
Adding polymorphic relationship to `container_node`
    
This polymorphic association will allow container nodes to "live on" an arbitrary entity belonging to another provider.
    
The purpose for this association is to capture the idea that Kubernetes Container Nodes are actually running inside a VM or Physical host owned by another provider.

At the moment the association is one direction only: from the `container_node` to the entity it lives on.  When we better understand which entities need to be associated with container nodes, and how we plan on presenting this relationship in the UI, we can add the reverse relationship; namely `has_many :container_nodes, :as => :lives_on`.

https://trello.com/c/4wkBDSS6/128-5-containernode-cross-provider-associations