### PR TITLE
Convert the Ems' string port column to an integer provided to URI.

### DIFF
--- a/vmdb/lib/workers/event_catcher_redhat.rb
+++ b/vmdb/lib/workers/event_catcher_redhat.rb
@@ -3,13 +3,17 @@ require 'workers/event_catcher'
 class EventCatcherRedhat < EventCatcher
   def event_monitor_handle
     require 'ovirt_provider/events/ovirt_event_monitor'
-    @event_monitor_handle ||= OvirtEventMonitor.new(
+    @event_monitor_handle ||= OvirtEventMonitor.new(event_monitor_options)
+  end
+
+  def event_monitor_options
+    {
       :server     => @ems.ipaddress,
-      :port       => @ems.port,
+      :port       => @ems.port.blank? ? nil : @ems.port.to_i,
       :username   => @ems.authentication_userid,
       :password   => @ems.authentication_password,
-      :verify_ssl => false,
-    )
+      :verify_ssl => false
+    }
   end
 
   def reset_event_monitor_handle

--- a/vmdb/spec/lib/workers/event_catcher_redhat_spec.rb
+++ b/vmdb/spec/lib/workers/event_catcher_redhat_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+require "workers/event_catcher_redhat"
+
+describe EventCatcherRedhat do
+  context "#event_monitor_options" do
+    let(:ems)     { FactoryGirl.create(:ems_redhat, :ipaddress => "1.1.1.1") }
+    let(:catcher) { described_class.new(:ems_id => ems) }
+
+    before do
+      EmsRedhat.any_instance.stub(:authentication_check => true)
+      WorkerBase.any_instance.stub(:worker_initialization)
+    end
+
+    it "numeric port" do
+      ems.update_attributes(:port => 123)
+      expect(catcher.event_monitor_options).to have_attributes(:port => 123)
+    end
+
+    it "nil port" do
+      ems.update_attributes(:port => nil)
+      expect(catcher.event_monitor_options).to have_attributes(:port => nil)
+    end
+  end
+end


### PR DESCRIPTION
Fixes [URI::InvalidComponentError]: bad component(expected port component): 443

From here:
lib/ovirt_provider/events/ovirt_event_monitor.rb:26:in `each_batch'
vmdb/lib/workers/event_catcher_redhat.rb:34:in `monitor_events'
vmdb/lib/workers/event_catcher.rb:99:in `block in start_event_monitor'