### PR TITLE
Bump ovirt to prevent an exception on logging.

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -32,7 +32,7 @@ gem "log4r",                "=1.1.8",        :require => false
 gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
-gem "ovirt",                "~>0.4.0",       :require => false
+gem "ovirt",                "~>0.4.1",       :require => false
 gem "kubeclient",           ">=0.1.7",       :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false


### PR DESCRIPTION
https://github.com/ManageIQ/ovirt/pull/25
https://github.com/ManageIQ/ovirt/pull/26

Fixes an error in dev testing: undefined method `url' for nil:NilClass