### PR TITLE
kubernetes: api_version was removed in 0.1.8

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -33,7 +33,7 @@ gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
 gem "ovirt",                "~>0.4.1",       :require => false
-gem "kubeclient",           ">=0.1.7",       :require => false
+gem "kubeclient",           ">=0.1.8",       :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false


### PR DESCRIPTION
This patch rectifies a kubeclient update that was recently introduced. The api_version parameter was removed in 0.1.8 (not 0.1.7).