### PR TITLE
Add provisioning attributes to provider hash

### DIFF
--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
@@ -1,8 +1,7 @@
 require 'manageiq_foreman'
 module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
   def log_provider_options
-    log_header = "MIQ(#{self.class.name}##{__method__})"
-    $log.info("#{log_header} Provisioning [#{source.name}]")
+    $log.info("MIQ(#{self.class.name}##{__method__}) Provisioning [#{source.name}]")
   end
 
   def merge_provider_options_from_automate

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
@@ -12,7 +12,6 @@ module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
 
   def prepare_provider_options
     phase_context[:provider_options] = {
-      "id"           => source.manager_ref,
       "hostgroup_id" => dest_configuration_profile.manager_ref,
     }
     dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Default Provider Options: ", $log, :info)

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
@@ -6,7 +6,7 @@ module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
 
   def merge_provider_options_from_automate
     phase_context[:provider_options].merge!(get_option(:provider_options) || {}).delete_nils
-    dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Merged Provider Options: ", $log, :info)
+    dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Merged Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
   end
 
   def prepare_provider_options
@@ -15,7 +15,7 @@ module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
     h["ip"]        = options[:ip_addr]                            if options[:ip_addr]
     h["root_pass"] = MiqPassword.decrypt(options[:root_password]) if options[:root_password]
     phase_context[:provider_options] = h
-    dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Default Provider Options: ", $log, :info)
+    dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Default Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
   end
 
   def validate_source

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
@@ -11,9 +11,11 @@ module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
   end
 
   def prepare_provider_options
-    phase_context[:provider_options] = {
-      "hostgroup_id" => dest_configuration_profile.manager_ref,
-    }
+    h = {"hostgroup_id" => dest_configuration_profile.manager_ref}
+    h["name"]      = options[:hostname]                           if options[:hostname]
+    h["ip"]        = options[:ip_addr]                            if options[:ip_addr]
+    h["root_pass"] = MiqPassword.decrypt(options[:root_password]) if options[:root_password]
+    phase_context[:provider_options] = h
     dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Default Provider Options: ", $log, :info)
   end
 


### PR DESCRIPTION
- Protect "root_pass" field from being dumped to the log
- Update each attribute individually, rescue failures and re-raise better exceptions to aid field troubleshooting
- Pass remaining fields from "Customize" tab to the manager