### PR TITLE
Add todos so these storage models can use hostname.

### DIFF
--- a/vmdb/app/models/miq_smis_agent.rb
+++ b/vmdb/app/models/miq_smis_agent.rb
@@ -23,6 +23,7 @@ class MiqSmisAgent < StorageManager
   default_value_for :agent_type, DEFAULT_AGENT_TYPE
 
   def connect
+    # TODO: Use hostname, not ipaddress
     @conn = SmisClient.new(ipaddress, *self.auth_user_pwd(:default))
     return @conn
   end
@@ -53,6 +54,7 @@ class MiqSmisAgent < StorageManager
     pendingAgents = []
 
     agents.each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "MiqSmisAgent.update_smis: Checking agent: #{agent.ipaddress}"
       connectFailed = false
       begin
@@ -97,6 +99,7 @@ class MiqSmisAgent < StorageManager
         agent.save
         updated = true
       rescue Exception => err
+        # TODO: Log hostname, not ipaddress
         $log.error "MiqSmisAgent.update_smis: agent: #{agent.ipaddress} - #{err}"
         $log.error err.backtrace.join("\n")
         agent.last_update_status = STORAGE_UPDATE_FAILED
@@ -149,6 +152,7 @@ class MiqSmisAgent < StorageManager
 
   def self.update_stats
     self.find(:all, :conditions => {:agent_type => 'SMIS'}).each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "MiqSmisAgent.update_stats Agent: #{agent.ipaddress}"
 
       begin
@@ -195,6 +199,7 @@ class MiqSmisAgent < StorageManager
 
   def self.update_status
     self.find(:all, :conditions => {:agent_type => 'SMIS'}).each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "MiqSmisAgent.update_status Agent: #{agent.ipaddress}"
 
       begin

--- a/vmdb/app/models/netapp_rcu.rb
+++ b/vmdb/app/models/netapp_rcu.rb
@@ -14,6 +14,7 @@ class NetappRcu < StorageManager
     ra = []
     EmsVmware.where(:zone_id => zoneId).each do |vc|
       begin
+        # TODO: Use hostname, not ipaddress
         rcu = RcuClientBase.new(vc.ipaddress, *vc.auth_user_pwd(:default))
         rcu.getMoref("", "")
       rescue => err
@@ -26,6 +27,7 @@ class NetappRcu < StorageManager
 
   def self.add_from_ems(ems)
     raise "NetappRcu.add_from_ems: unsupported ems type: #{ems.type}" unless ems.kind_of?(EmsVmware)
+    # TODO: Use hostname, not ipaddress
     add(ems.ipaddress,
       ems.authentication_userid(:default),
       ems.authentication_password(:default),
@@ -41,14 +43,18 @@ class NetappRcu < StorageManager
   def self.get_rcu_for_object(obj)
     return nil unless obj.respond_to?(:ext_management_system)
     return nil unless (ems = obj.ext_management_system)
+
+    # TODO: Use hostname, not ipaddress
     return self.find_by_ipaddress(ems.ipaddress)
   end
 
   def rcu_client
+    # TODO: Use hostname, not ipaddress
     @rcuClient ||= RcuClientBase.new(self.ipaddress, self.authentication_userid, self.authentication_password)
   end
 
   def add_controller(ipaddress, username, password, hostname=nil, name=nil, rcuData={})
+    # TODO: Use hostname, not ipaddress
     c = NetappRemoteService.add(ipaddress, username, password, NetappRemoteService::DEFAULT_AGENT_TYPE, zone_id, hostname, name)
     controllers << c unless controllers.include?(c)
 
@@ -59,6 +65,7 @@ class NetappRcu < StorageManager
     cRcuData[:ssl]      ||= rcuData[:ssl]
 
     unless cRcuData[:aggregates] && cRcuData[:volumes]
+      # TODO: Use hostname, not ipaddress
       unless (oss = NetappRemoteService.find_controller_by_ip(ipaddress))
         $log.info "NetappRcu.add_controller: could not find controller #{ipaddress}"
       else
@@ -72,6 +79,7 @@ class NetappRcu < StorageManager
   end
 
   def get_controller_by_ipaddress(ip)
+    # TODO: Use hostname, not ipaddress
     controllers.find_by_ipaddress(ip)
   end
 
@@ -79,6 +87,7 @@ class NetappRcu < StorageManager
     controllers.find_by_name(name)
   end
 
+  # TODO: Use hostname, not ipaddress
   def set_current_controller_by_ipaddress(ip)
     @currentController = controllers.find_by_ipaddress(ip)
     @currentControllerSpec = nil
@@ -102,6 +111,7 @@ class NetappRcu < StorageManager
 
   def controller_spec
     @currentControllerSpec ||= RcuHash.new("ControllerSpec") do |cs|
+      # TODO: Use hostname, not ipaddress
       cs.ipAddress = current_controller.ipaddress
       cs.username  = current_controller.authentication_userid
       cs.password  = current_controller.authentication_password

--- a/vmdb/app/models/netapp_remote_service.rb
+++ b/vmdb/app/models/netapp_remote_service.rb
@@ -25,6 +25,8 @@ class NetappRemoteService < StorageManager
 
   def connect
     self.class.initialize_class_for_client
+
+    # TODO: Use hostname, not ipaddress
     @ontapClient = OntapClient.new(ipaddress, *self.auth_user_pwd(:default))
     @nmaClient = @ontapClient.conn
     return @ontapClient
@@ -178,6 +180,7 @@ class NetappRemoteService < StorageManager
 
     agent_query.update_all(:last_update_status => STORAGE_UPDATE_PENDING)
     agent_query.find_each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "NetappRemoteService.update_ontap: Checking agent: #{agent.ipaddress}"
       begin
         agent.connect
@@ -196,6 +199,7 @@ class NetappRemoteService < StorageManager
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_IN_PROGRESS)
       agent.managed_elements.update_all(:last_update_status => STORAGE_UPDATE_AGENT_OK_NO_INSTANCE)
 
+      # TODO: Log hostname, not ipaddress
       begin
         agent.update_ontap
         $log.info "NetappRemoteService.update_ontap: agent: #{agent.ipaddress} STORAGE_UPDATE_OK"
@@ -223,6 +227,7 @@ class NetappRemoteService < StorageManager
     statistic_time ||= Time.now.utc
 
     self.agent_query(nrsIds).find_each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "NetappRemoteService.update_metrics Agent: #{agent.ipaddress} Start..."
 
       begin
@@ -245,6 +250,7 @@ class NetappRemoteService < StorageManager
 
   def self.rollup_hourly_metrics(rollup_time, nrsIds=[])
     self.agent_query(nrsIds).find_each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "NetappRemoteService.rollup_hourly_metrics Agent: #{agent.ipaddress} Start..."
 
       begin
@@ -260,6 +266,7 @@ class NetappRemoteService < StorageManager
   end
 
   def rollup_hourly_metrics(rollup_time)
+    # TODO: Log hostname, not ipaddress
     $log.info "NetappRemoteService.rollup_hourly_metrics Agent: #{self.ipaddress}, rollup_time: #{rollup_time}"
     topMe = self.top_managed_elements.first
     topMe.elements_with_metrics.each do |se|
@@ -281,6 +288,7 @@ class NetappRemoteService < StorageManager
     end
 
     self.agent_query(nrsIds).find_each do |agent|
+      # TODO: Log hostname, not ipaddress
       $log.info "NetappRemoteService.rollup_daily_metrics Agent: #{agent.ipaddress}, TZ: #{time_profile.tz} Start..."
 
       begin
@@ -296,6 +304,7 @@ class NetappRemoteService < StorageManager
   end
 
   def rollup_daily_metrics(rollup_time, time_profile)
+    # TODO: Log hostname, not ipaddress
     $log.info "NetappRemoteService.rollup_daily_metrics Agent: #{self.ipaddress}, rollup_time: #{rollup_time}, TZ: #{time_profile.tz}"
     topMe = self.top_managed_elements.first
     topMe.elements_with_metrics.each do |se|

--- a/vmdb/app/models/snia_file_share.rb
+++ b/vmdb/app/models/snia_file_share.rb
@@ -315,6 +315,7 @@ class SniaFileShare < MiqCimInstance
     nrs                = storage_system.storage_managers.first
     raise "Could not find manager entry for NetApp filer: #{self.evm_display_name}" if nrs.nil?
 
+    # TODO: Log hostname, not ipaddress
     $log.info("#{log_prefix} Found service entry for NetApp filer: #{self.evm_display_name} -> #{nrs.ipaddress}")
 
     # Add the ESX hosts to the root hosts list for the NFS share.

--- a/vmdb/app/models/storage_manager.rb
+++ b/vmdb/app/models/storage_manager.rb
@@ -42,6 +42,7 @@ class StorageManager < ActiveRecord::Base
   end
 
   def self.add(ipaddress, username, password, agent_type, zone_id=nil, hostname=nil, name=nil)
+    # TODO: Use hostname, not ipaddress
     agent = self.where(:ipaddress => ipaddress, :agent_type => agent_type).first
     unless (agent)
       agent = self.new
@@ -53,6 +54,7 @@ class StorageManager < ActiveRecord::Base
 
       if username
         auth = Authentication.new
+        # TODO: Use hostname, not ipaddress
         auth.name     = "#{self.name} #{ipaddress}"
         auth.authtype   = "default"
         auth.userid     = username


### PR DESCRIPTION
All of the main communication is now using hostname column, not ipaddress.

https://trello.com/c/vw2LAn8T/26-ipv6-insight-default-to-hostname-ipv6

Please review and merge @roliveri 