### PR TITLE
Lock down compiled gems

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -22,16 +22,16 @@ gem "binary_struct",        "~> 2.0",        :require => false
 gem "excon",                "~>0.40",        :require => false
 gem "ezcrypto",             "=0.7",          :require => false
 gem "facade",               "~>1.0.5",       :require => false  # Used by util/pathname2.rb
-gem "ffi",                  "~>1.9.3",       :require => false
+gem "ffi",                  "=1.9.8",        :require => false
 gem "ffi-vix_disk_lib",     "~>1.0.1",       :require => false  # used by lib/VixDiskLib
 gem "fog",                  "~>1.28.0",      :require => false
 gem "httpclient",           "~>2.5.3",       :require => false
-gem "io-extra",             "~>1.2.8",       :require => false
+gem "io-extra",             "=1.2.8",        :require => false
 gem "linux_admin",          ">=0.10", "<1",  :require => false
 gem "log4r",                "=1.1.8",        :require => false
 gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
-gem "nokogiri",             "~>1.5.0",       :require => false
+gem "nokogiri",             "=1.5.11",       :require => false
 gem "ovirt",                "~>0.4.1",       :require => false
 gem "kubeclient",           ">=0.1.8",       :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
@@ -42,7 +42,7 @@ gem "rufus-lru",            "~>1.0.3",       :require => false
 gem "uuidtools",            "~>2.1.3",       :require => false
 gem "sass",                 "3.1.20",        :require => false
 gem "trollop",              "~>1.16.2",      :require => false
-gem "psych",                "~>2.0.12"
+gem "psych",                "=2.0.13"
 gem "apipie-bindings",      "~>0.0.12",      :require => false
 
 # qpid group is needed to gate the inclusion of qpid_messaging gem on platforms

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -13,7 +13,7 @@ gem 'jquery-rails', "=2.1.4"
 
 gem "sprockets-sass",  "~>1.2.0"
 gem "sprockets-less",  "~>0.6.1"
-gem 'therubyracer'
+gem 'therubyracer',    "=0.12.1"
 gem 'less-rails'
 
 # Vendored and required
@@ -39,8 +39,8 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "default_value_for",              "~>2.0.3"
-gem "thin",                           "~>1.3.1"  # Used by rails server through rack
-gem "bcrypt-ruby",                    "~> 3.0.1"
+gem "thin",                           "=1.3.1"  # Used by rails server through rack
+gem "bcrypt-ruby",                    "=3.0.1"
 gem 'outfielding-jqplot-rails',       "= 1.0.8"
 gem 'secure_headers'
 # Needed by the REST API
@@ -53,16 +53,18 @@ gem "ancestry",                       "~>1.2.4",      :require => false
 gem "aws-sdk",                        "~>1.56.0",     :require => false
 gem 'dalli',                          "~>2.2.1",      :require => false
 gem "elif",                           "=0.1.0",       :require => false
+gem "eventmachine",                   "=1.0.7",       :require => false
 gem "haml",                           "~>4.0.5",      :require => false
 gem 'haml-rails',                     "~> 0.4",       :require => false
 gem "inifile",                        "~>3.0",        :require => false
+gem "json",                           "=1.8.2",       :require => false
 gem "logging",                        "~>1.6.1",      :require => false  # Ziya depends on this
 gem "net-ping",                       "~>1.7.4",      :require => false
 gem "net-sftp",                       "~>2.0.5",      :require => false
 gem "net-ssh",                        "~>2.9.1",      :require => false
 gem "open4",                          "~>1.3.0",      :require => false
 gem "ovirt_metrics",                  "~>1.0.1",      :require => false
-gem "pg",                             "~>0.12.2",     :require => false
+gem "pg",                             "=0.12.2",      :require => false
 gem "rack",                           "~>1.4.1",      :require => false
 
 gem "ruby-progressbar",               "~>0.0.10",     :require => false


### PR DESCRIPTION
I want to lock down the versions of the compiled gems for the build.

eventmachine and json are compiled gems that were not in our Gemfiles but were pulled
in as dependencies. I added them to vmdb/Gemfile but am not sure if this is the best location.

@kbrock @brandondunne @Fryguy @jrafanie Please review

Thank you! JoeV