### PR TITLE
Infra explorer tree specs

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1842,7 +1842,7 @@ class ApplicationController < ActionController::Base
   private :get_view_process_search_text
 
   def perpage_key(dbname)
-   %w(job miqtask).include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
+    %w(job miqtask).include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
   end
   private :perpage_key
 

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1789,11 +1789,14 @@ class ApplicationController < ActionController::Base
   end
 
   def get_view_calculate_gtl_type(db_sym)
-    gtl_type = @settings[:views][db_sym] unless ['scanitemset', 'miqschedule', 'pxeserver', 'customizationtemplate'].include?(db_sym.to_s)
+    gtl_type = @settings.fetch_path(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
+
     # Force list view for certain types and areas
     gtl_type = 'list' if ['filesystems', 'registry_items', 'chargeback_rates', 'miq_request'].include?(@listicon)
     gtl_type = 'list' if gtl_type.nil?
     gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
+
+    gtl_type ||= 'grid' # return a sane default
     gtl_type
   end
   private :get_view_calculate_gtl_type
@@ -1839,7 +1842,7 @@ class ApplicationController < ActionController::Base
   private :get_view_process_search_text
 
   def perpage_key(dbname)
-   ["job", "miqtask"].include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
+   %w(job miqtask).include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
   end
   private :perpage_key
 
@@ -1916,12 +1919,7 @@ class ApplicationController < ActionController::Base
     view.sortby = [view.col_order[@sortcol]]      # Set sortby array in the view
     view.order = @sortdir.downcase == "desc" ? "Descending" : "Ascending" # Normalize sort order
 
-    @items_per_page = if ["job", "miqtask"].include?(dbname)
-                        @settings[:perpage][:job_task]
-                      else
-                        # Get per page for this gtl type
-                        controller_name.downcase == "miq_policy" ? ONE_MILLION : @settings[:perpage][PERPAGE_TYPES[@gtl_type]]
-                      end
+    @items_per_page = controller_name.downcase == "miq_policy" ? ONE_MILLION : get_view_pages_perpage(dbname)
     @items_per_page = ONE_MILLION if 'vm' == db_sym.to_s && controller_name == 'service'
 
     @current_page = options[:page] || (params[:page].nil? ? 1 : params[:page].to_i)
@@ -2003,14 +2001,21 @@ class ApplicationController < ActionController::Base
   end
   private :get_view_filter
 
+  def get_view_pages_perpage(dbname)
+    perpage = 10 # return a sane default
+    return perpage unless @settings.key?(:perpage)
+
+    key = perpage_key(dbname)
+    perpage = @settings[:perpage][key] if key && @settings[:perpage].key?(key)
+
+    perpage
+  end
+  private :get_view_pages_perpage
+
   # Create the pages hash and return with the view
   def get_view_pages(dbname, view)
     pages = {
-      :perpage => if ["job", "miqtask"].include?(dbname)
-                    @settings[:perpage][:job_task] # Set per page separate for job/task
-                  else
-                    @settings[:perpage][PERPAGE_TYPES[@gtl_type]]
-                  end,
+      :perpage => get_view_pages_perpage(dbname),
       :current => params[:page].nil? ? 1 : params[:page].to_i,
       :items   => view.extras[:auth_count] || view.extras[:total_count]
     }

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1851,7 +1851,7 @@ module ApplicationHelper
   TRUNC_TO = 10
   def truncate_for_quad(value)
     return value if value.to_s.length < TRUNC_AT
-    case @settings[:display][:quad_truncate]
+    case @settings.fetch_path(:display, :quad_truncate)
     when "b"  # Old version, used first x chars followed by ...
       return value[0...TRUNC_TO] + "..."
     when "f"  # Chop off front

--- a/vmdb/app/views/layouts/quadicon/_vm_or_template.html.haml
+++ b/vmdb/app/views/layouts/quadicon/_vm_or_template.html.haml
@@ -1,4 +1,4 @@
-- if @settings[:quadicons][item.class.base_model.name.underscore.to_sym]
+- if @settings.fetch_path(:quadicons, item.class.base_model.name.underscore.to_sym)
   .flobj
     %img{:src => "/images/icons/#{size}/base.png", :width => size, :height => size}
   .flobj{:class => "a#{size}"}

--- a/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -20,9 +20,7 @@ describe VmInfraController do
       session[:sandboxes] = {
         "vm_infra" => {
           :trees => {
-            :vandt_tree => {
-              :active_node => "v-#{vm.id}" # need this?
-            }
+            :vandt_tree => {}
           },
           :active_tree => :vandt_tree
         }
@@ -42,9 +40,7 @@ describe VmInfraController do
       session[:sandboxes] = {
         "vm_infra" => {
           :trees => {
-            :vms_filter_tree => {
-              #:active_node => "v-#{vm.id}" # need this?
-            }
+            :vms_filter_tree => {}
           },
           :active_tree => :vms_filter_tree
         }
@@ -64,9 +60,7 @@ describe VmInfraController do
       session[:sandboxes] = {
         "vm_infra" => {
           :trees => {
-            :templates_filter_tree => {
-              #:active_node => "v-#{vm.id}" # need this?
-            }
+            :templates_filter_tree => {}
           },
           :active_tree => :templates_filter_tree
         }

--- a/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -13,10 +13,10 @@ describe VmInfraController do
   end
 
   context "VMs & Templates #tree_select" do
-    it "renders VM and Template grid for vandt_tree root node" do
+    it "renders VM and Template list for vandt_tree root node" do
       vm = FactoryGirl.create(:vm_vmware)
 
-      session[:settings] = {:views => { :vmortemplate => 'grid' }, :perpage => {:grid => 10}}
+      session[:settings] = {}
       session[:sandboxes] = {
         "vm_infra" => {
           :trees => {
@@ -29,20 +29,16 @@ describe VmInfraController do
       }
       post :tree_select, :id => 'root', :format => :js
 
-      response.should render_template('layouts/gtl/_grid')
+      response.should render_template('layouts/gtl/_list')
       expect(response.status).to eq(200)
     end
   end
 
   context "VMs #tree_select" do
-    it "renders grid with VMS for vms_filter_tree root node" do
+    it "renders list with VMS for vms_filter_tree root node" do
       FactoryGirl.create(:vm_vmware)
 
-      session[:settings] = {
-        :views     => {:vminfra => 'grid'},
-        :perpage   => {:grid => 10},
-        :quadicons => {}
-      }
+      session[:settings] = {}
       session[:sandboxes] = {
         "vm_infra" => {
           :trees => {
@@ -55,20 +51,16 @@ describe VmInfraController do
       }
       post :tree_select, :id => 'root', :format => :js
 
-      response.should render_template('layouts/gtl/_grid')
+      response.should render_template('layouts/gtl/_list')
       expect(response.status).to eq(200)
     end
   end
 
   context "Templates #tree_select" do
-    it "renders grid with templates for templates_filter_tree root node" do
+    it "renders list with templates for templates_filter_tree root node" do
       FactoryGirl.create(:template_vmware)
 
-      session[:settings] = {
-        :views     => {:templateinfra => 'grid'},
-        :perpage   => {:grid => 10},
-        :quadicons => {}
-      }
+      session[:settings] = {}
       session[:sandboxes] = {
         "vm_infra" => {
           :trees => {
@@ -81,7 +73,7 @@ describe VmInfraController do
       }
       post :tree_select, :id => 'root', :format => :js
 
-      response.should render_template('layouts/gtl/_grid')
+      response.should render_template('layouts/gtl/_list')
       expect(response.status).to eq(200)
     end
   end

--- a/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+
+describe VmInfraController do
+  render_views
+  before :each do
+    set_user_privileges
+    FactoryGirl.create(:vmdb_database)
+    EvmSpecHelper.create_guid_miq_server_zone
+    expect(MiqServer.my_guid).to be
+    expect(MiqServer.my_server).to be
+
+    session[:userid] = User.current_user.userid
+  end
+
+  context "VMs & Templates #tree_select" do
+    it "renders VM and Template grid for vandt_tree root node" do
+      vm = FactoryGirl.create(:vm_vmware)
+
+      session[:settings] = {:views => { :vmortemplate => 'grid' }, :perpage => {:grid => 10}}
+      session[:sandboxes] = {
+        "vm_infra" => {
+          :trees => {
+            :vandt_tree => {
+              :active_node => "v-#{vm.id}" # need this?
+            }
+          },
+          :active_tree => :vandt_tree
+        }
+      }
+      post :tree_select, :id => 'root', :format => :js
+
+      response.should render_template('layouts/gtl/_grid')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "VMs #tree_select" do
+    it "renders grid with VMS for vms_filter_tree root node" do
+      FactoryGirl.create(:vm_vmware)
+
+      session[:settings] = {
+        :views     => {:vminfra => 'grid'},
+        :perpage   => {:grid => 10},
+        :quadicons => {}
+      }
+      session[:sandboxes] = {
+        "vm_infra" => {
+          :trees => {
+            :vms_filter_tree => {
+              #:active_node => "v-#{vm.id}" # need this?
+            }
+          },
+          :active_tree => :vms_filter_tree
+        }
+      }
+      post :tree_select, :id => 'root', :format => :js
+
+      response.should render_template('layouts/gtl/_grid')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "Templates #tree_select" do
+    it "renders grid with templates for templates_filter_tree root node" do
+      FactoryGirl.create(:template_vmware)
+
+      session[:settings] = {
+        :views     => {:templateinfra => 'grid'},
+        :perpage   => {:grid => 10},
+        :quadicons => {}
+      }
+      session[:sandboxes] = {
+        "vm_infra" => {
+          :trees => {
+            :templates_filter_tree => {
+              #:active_node => "v-#{vm.id}" # need this?
+            }
+          },
+          :active_tree => :templates_filter_tree
+        }
+      }
+      post :tree_select, :id => 'root', :format => :js
+
+      response.should render_template('layouts/gtl/_grid')
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -14,7 +14,7 @@ describe VmInfraController do
 
   context "VMs & Templates #tree_select" do
     it "renders VM and Template list for vandt_tree root node" do
-      vm = FactoryGirl.create(:vm_vmware)
+      FactoryGirl.create(:vm_vmware)
 
       session[:settings] = {}
       session[:sandboxes] = {


### PR DESCRIPTION
Implement some specs for Infra explorer trees.

Provide some sane defaults for some session settings.
    
The goal of this is to provide basic coverage for explorers in both Cloud and Infra so that we can safely carry on with the changes that implement the `Feature`s and `TreeBuilder`s what would allow us to implement the explorer views including trees and accordions in a declarative way.