### PR TITLE
FIX #2486 Kubernetes provider - service - port was changed to ports

### DIFF
--- a/vmdb/app/helpers/container_service_helper/textual_summary.rb
+++ b/vmdb/app/helpers/container_service_helper/textual_summary.rb
@@ -7,14 +7,16 @@ module ContainerServiceHelper::TextualSummary
     items = %w(
       namespace
       name
-      port
       creation_timestamp
       resource_version
       session_affinity
-      portal_ip
-      protocol
-      container_port)
+      portal_ip)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
+  def textual_group_port_configs
+    items = ContainerServicePortConfig.where(:container_service_id => @record.id)
+    items.collect { |m| textual_port_config(m) }.flatten.compact
   end
 
   def textual_group_relationships
@@ -33,10 +35,6 @@ module ContainerServiceHelper::TextualSummary
     {:label => "Name", :value => @record.name}
   end
 
-  def textual_port
-    {:label => "Port", :value => @record.port}
-  end
-
   def textual_creation_timestamp
     {:label => "Creation Timestamp", :value => format_timezone(@record.creation_timestamp)}
   end
@@ -53,12 +51,15 @@ module ContainerServiceHelper::TextualSummary
     {:label => "Portal IP", :value => @record.portal_ip}
   end
 
-  def textual_protocol
-    {:label => "Protocol", :value => @record.protocol}
-  end
+  def textual_port_config(port_conf)
+    name = port_conf.name
 
-  def textual_container_port
-    {:label => "Container Port", :value => @record.container_port}
+    name = _("<Unnamed>") if name.blank?
+
+    {
+      :label => name,
+      :value => "#{port_conf.protocol} port #{port_conf.port} to pods on target port:'#{port_conf.target_port}'"
+    }
   end
 
   def textual_ems

--- a/vmdb/app/models/container_service.rb
+++ b/vmdb/app/models/container_service.rb
@@ -6,6 +6,7 @@ class ContainerService < ActiveRecord::Base
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_and_belongs_to_many :container_groups
+  has_many :container_service_port_configs, :dependent => :destroy
   has_many :labels, :class_name => CustomAttribute, :as => :resource, :conditions => {:section => "labels"}
   has_many :selector_parts, :class_name => CustomAttribute, :as => :resource, :conditions => {:section => "selectors"}
 end

--- a/vmdb/app/models/container_service_port_config.rb
+++ b/vmdb/app/models/container_service_port_config.rb
@@ -1,0 +1,3 @@
+class ContainerServicePortConfig < ActiveRecord::Base
+  belongs_to :container_service
+end

--- a/vmdb/app/models/ems_refresh/save_inventory_container.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_container.rb
@@ -95,7 +95,8 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(:container_services, ems, hashes, deletes, [:ems_ref],
-                         [:labels, :selector_parts], [:container_groups])
+                         [:labels, :selector_parts, :container_service_port_configs], [:container_groups])
+
     store_ids_for_new_records(ems.container_services, hashes, :ems_ref)
   end
 
@@ -146,6 +147,20 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(:container_port_configs, container_definition, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(container_definition.container_port_configs, hashes, :ems_ref)
+  end
+
+  def save_container_service_port_configs_inventory(container_service, hashes, target = nil)
+    return if hashes.nil?
+
+    container_service.container_service_port_configs(true)
+    deletes = if target.kind_of?(ExtManagementSystem)
+                container_service.container_service_port_configs.dup
+              else
+                []
+              end
+
+    save_inventory_multi(:container_service_port_configs, container_service, hashes, deletes, [:ems_ref])
+    store_ids_for_new_records(container_service.container_service_port_configs, hashes, :ems_ref)
   end
 
   def save_containers_inventory(container_group, hashes, target = nil)

--- a/vmdb/app/views/container_service/_main.html.haml
+++ b/vmdb/app/views/container_service/_main.html.haml
@@ -2,5 +2,6 @@
 .row
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => { :title => _("Properties"), :items => textual_group_properties }
+    = render :partial => "shared/summary/textual", :locals => { :title => _("Port Configurations"), :items => textual_group_port_configs }
     = render :partial => "shared/summary/textual", :locals => { :title => _("Relationships"), :items => textual_group_relationships }
 

--- a/vmdb/db/migrate/20150405141637_remove_port_config_from_container_service.rb
+++ b/vmdb/db/migrate/20150405141637_remove_port_config_from_container_service.rb
@@ -1,0 +1,55 @@
+class RemovePortConfigFromContainerService < ActiveRecord::Migration
+  class ContainerService < ActiveRecord::Base
+    has_many :container_service_port_configs,
+             :class_name => "RemovePortConfigFromContainerService::ContainerServicePortConfig"
+  end
+
+  class ContainerServicePortConfig < ActiveRecord::Base
+    belongs_to :container_service,
+               :class_name => "RemovePortConfigFromContainerService::ContainerService"
+  end
+
+  def up
+    create_table :container_service_port_configs do |t|
+      t.string     :ems_ref
+      t.string     :name
+      t.integer    :port
+      t.string     :target_port
+      t.string     :protocol
+      t.belongs_to :container_service, :type => :bigint
+    end
+
+    say_with_time("Moving container_service port records to container_service_port_config table") do
+      ContainerService.all.each do |service|
+        ContainerServicePortConfig.create!(
+            :ems_ref              => "#{service.ems_ref}_#{service.port}_#{service.container_port}",
+            :port                 => service.port,
+            :protocol             => service.protocol,
+            :target_port          => service.container_port,
+            :container_service_id => service.id
+        )
+      end
+    end
+
+    remove_column :container_services, :port
+    remove_column :container_services, :protocol
+    remove_column :container_services, :container_port
+  end
+
+  def down
+    add_column :container_services, :port, :integer
+    add_column :container_services, :protocol, :string
+    add_column :container_services, :container_port, :integer
+
+    say_with_time("Moving container service port config records back to container service") do
+      ContainerService.all.each do |service|
+        port_config = service.container_service_port_configs.first
+        service.update_attributes!(:port           => port_config.port,
+                                   :protocol       => port_config.protocol,
+                                   :container_port => port_config.target_port)
+      end
+    end
+
+    drop_table :container_service_port_configs
+  end
+end

--- a/vmdb/spec/migrations/20150405141637_remove_port_config_from_container_service_spec.rb
+++ b/vmdb/spec/migrations/20150405141637_remove_port_config_from_container_service_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150405141637_remove_port_config_from_container_service.rb")
+
+describe RemovePortConfigFromContainerService do
+  let(:container_service_stub)             { migration_stub(:ContainerService) }
+  let(:container_service_port_config_stub) { migration_stub(:ContainerServicePortConfig) }
+
+  migration_context :up do
+    it 'Moves port, protocol and host(target)-port to container_service_port_config table' do
+      service = container_service_stub.create!(:ems_ref        => "test_ref",
+                                               :name           => "test_service",
+                                               :protocol       => "TCP",
+                                               :port           => 1111,
+                                               :container_port => 2222)
+      migrate
+      pconfig = container_service_port_config_stub.where(:container_service_id => service.id).first
+      pconfig.protocol.should    == "TCP"
+      pconfig.port.should        == 1111
+      pconfig.target_port.should == "2222" # container_port:integer turns into target_port:string
+
+    end
+  end
+
+  migration_context :down do
+    it 'Moves port, protocol and target_port back to container_service table' do
+      service = container_service_stub.create!(:ems_ref => "test_ref",
+                                               :name    => "test_service")
+      container_service_port_config_stub.create!(:container_service_id => service.id,
+                                                 :protocol             => "TCP",
+                                                 :port                 => 1111,
+                                                 :target_port          => "2222")
+      migrate
+      service.reload
+      service.protocol.should       == "TCP"
+      service.port.should           == 1111
+      service.container_port.should == 2222
+    end
+  end
+end

--- a/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/kubernetes_refresher.yml
+++ b/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/kubernetes_refresher.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:27 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -32,18 +32,18 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/pods",
-            "resourceVersion": "1645"
+            "resourceVersion": "598"
           },
           "items": [
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-40yp7",
+                "name": "monitoring-heapster-controller-39o8t",
                 "generateName": "monitoring-heapster-controller-",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/pods/monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "325",
-                "creationTimestamp": "2015-04-13T08:30:05Z",
+                "selfLink": "/api/v1beta3/namespaces/default/pods/monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "171",
+                "creationTimestamp": "2015-04-20T09:28:50Z",
                 "labels": {
                   "name": "heapster",
                   "uses": "monitoring-influxdb"
@@ -60,7 +60,9 @@ http_interactions:
                     "gcePersistentDisk": null,
                     "gitRepo": null,
                     "secret": null,
-                    "nfs": null
+                    "nfs": null,
+                    "iscsi": null,
+                    "glusterfs": null
                   }
                 ],
                 "containers": [
@@ -102,15 +104,14 @@ http_interactions:
                     "status": "True"
                   }
                 ],
-                "host": "dhcp-0-202.tlv.redhat.com",
                 "hostIP": "10.35.0.202",
-                "podIP": "172.17.0.7",
+                "podIP": "172.17.0.10",
                 "containerStatuses": [
                   {
                     "name": "heapster",
                     "state": {
                       "running": {
-                        "startedAt": "2015-04-13T08:30:10Z"
+                        "startedAt": "2015-04-20T09:29:36Z"
                       }
                     },
                     "lastState": {},
@@ -118,20 +119,20 @@ http_interactions:
                     "restartCount": 0,
                     "image": "kubernetes/heapster:v0.9",
                     "imageID": "docker://204dbb8fac26ee36633185b0781f8f10a544ada8fdd7e9832706db67d6249ee6",
-                    "containerID": "docker://87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71"
+                    "containerID": "docker://6e6119478fe1a60b751f52b39bcaab97015575ac797d7a810bb5804370bd7351"
                   }
                 ]
               }
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua",
+                "name": "monitoring-influx-grafana-controller-rnzju",
                 "generateName": "monitoring-influx-grafana-controller-",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/pods/monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "1640",
-                "creationTimestamp": "2015-04-13T08:30:05Z",
+                "selfLink": "/api/v1beta3/namespaces/default/pods/monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "178",
+                "creationTimestamp": "2015-04-20T09:28:50Z",
                 "labels": {
                   "name": "influxGrafana"
                 }
@@ -198,15 +199,14 @@ http_interactions:
                     "status": "True"
                   }
                 ],
-                "host": "dhcp-0-202.tlv.redhat.com",
                 "hostIP": "10.35.0.202",
-                "podIP": "172.17.0.8",
+                "podIP": "172.17.0.9",
                 "containerStatuses": [
                   {
                     "name": "grafana",
                     "state": {
                       "running": {
-                        "startedAt": "2015-04-13T08:30:12Z"
+                        "startedAt": "2015-04-20T09:29:39Z"
                       }
                     },
                     "lastState": {},
@@ -214,13 +214,13 @@ http_interactions:
                     "restartCount": 0,
                     "image": "kubernetes/heapster_grafana:v0.5",
                     "imageID": "docker://550cea8112c607e1a66ccf021ab75b8fbbb04cf171c8e39ccb7f300995ed60ed",
-                    "containerID": "docker://f9ae296270fe8891f74060006f00ddf247be7f771511a783ca0564bd0469de3a"
+                    "containerID": "docker://7996e009081d7fe9a579b973d282d178c009e6f231590f8f08d71c1ee793fe6c"
                   },
                   {
                     "name": "influxdb",
                     "state": {
                       "running": {
-                        "startedAt": "2015-04-13T08:30:11Z"
+                        "startedAt": "2015-04-20T09:29:36Z"
                       }
                     },
                     "lastState": {},
@@ -228,7 +228,7 @@ http_interactions:
                     "restartCount": 0,
                     "image": "kubernetes/heapster_influxdb:v0.3",
                     "imageID": "docker://514b330600afe3ed9f948f65fab7593b374075d194c65263fe3bafc43820fdad",
-                    "containerID": "docker://af741769b650a408f4a65d2d27043912b6d57e5e2a721faeb7a93a1989eef0c6"
+                    "containerID": "docker://997c6a36aec6677fb1d5ae37ed89e483b49798fab4648ccfb21cea3be1cf63d9"
                   }
                 ]
               }
@@ -236,7 +236,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:28 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/services
@@ -258,7 +258,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:29 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -269,28 +269,33 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/services",
-            "resourceVersion": "1645"
+            "resourceVersion": "603"
           },
           "items": [
             {
               "metadata": {
                 "name": "kubernetes",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/services/kubernetes",
-                "uid": "ef9ca891-e1b5-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "6",
-                "creationTimestamp": "2015-04-13T08:20:25Z",
+                "selfLink": "/api/v1beta3/namespaces/default/services/kubernetes",
+                "uid": "a36a2858-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "5",
+                "creationTimestamp": "2015-04-20T09:28:43Z",
                 "labels": {
                   "component": "apiserver",
                   "provider": "kubernetes"
                 }
               },
               "spec": {
-                "port": 443,
-                "protocol": "TCP",
+                "ports": [
+                  {
+                    "name": "",
+                    "protocol": "TCP",
+                    "port": 443,
+                    "targetPort": 443
+                  }
+                ],
                 "selector": null,
                 "portalIP": "10.0.0.2",
-                "targetPort": 0,
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -299,21 +304,26 @@ http_interactions:
               "metadata": {
                 "name": "kubernetes-ro",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/services/kubernetes-ro",
-                "uid": "ef98cd2f-e1b5-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "5",
-                "creationTimestamp": "2015-04-13T08:20:25Z",
+                "selfLink": "/api/v1beta3/namespaces/default/services/kubernetes-ro",
+                "uid": "a36e0599-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "6",
+                "creationTimestamp": "2015-04-20T09:28:43Z",
                 "labels": {
                   "component": "apiserver",
                   "provider": "kubernetes"
                 }
               },
               "spec": {
-                "port": 80,
-                "protocol": "TCP",
+                "ports": [
+                  {
+                    "name": "",
+                    "protocol": "TCP",
+                    "port": 80,
+                    "targetPort": 80
+                  }
+                ],
                 "selector": null,
                 "portalIP": "10.0.0.1",
-                "targetPort": 0,
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -322,19 +332,24 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-grafana",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/services/monitoring-grafana",
-                "uid": "497e6b34-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "296",
-                "creationTimestamp": "2015-04-13T08:30:05Z"
+                "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-grafana",
+                "uid": "a7494354-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "22",
+                "creationTimestamp": "2015-04-20T09:28:50Z"
               },
               "spec": {
-                "port": 80,
-                "protocol": "TCP",
+                "ports": [
+                  {
+                    "name": "",
+                    "protocol": "TCP",
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ],
                 "selector": {
                   "name": "influxGrafana"
                 },
-                "portalIP": "10.0.0.189",
-                "targetPort": 8080,
+                "portalIP": "10.0.0.59",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -343,19 +358,24 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-heapster",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/services/monitoring-heapster",
-                "uid": "49981230-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "298",
-                "creationTimestamp": "2015-04-13T08:30:05Z"
+                "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-heapster",
+                "uid": "a75625b8-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "24",
+                "creationTimestamp": "2015-04-20T09:28:50Z"
               },
               "spec": {
-                "port": 80,
-                "protocol": "TCP",
+                "ports": [
+                  {
+                    "name": "",
+                    "protocol": "TCP",
+                    "port": 80,
+                    "targetPort": 8082
+                  }
+                ],
                 "selector": {
                   "name": "heapster"
                 },
-                "portalIP": "10.0.0.42",
-                "targetPort": 8082,
+                "portalIP": "10.0.0.227",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -364,19 +384,24 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-influxdb",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/services/monitoring-influxdb",
-                "uid": "49b6edac-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "302",
-                "creationTimestamp": "2015-04-13T08:30:05Z"
+                "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-influxdb",
+                "uid": "a7641ae9-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "28",
+                "creationTimestamp": "2015-04-20T09:28:50Z"
               },
               "spec": {
-                "port": 80,
-                "protocol": "TCP",
+                "ports": [
+                  {
+                    "name": "",
+                    "protocol": "TCP",
+                    "port": 80,
+                    "targetPort": 8086
+                  }
+                ],
                 "selector": {
                   "name": "influxGrafana"
                 },
-                "portalIP": "10.0.0.38",
-                "targetPort": 8086,
+                "portalIP": "10.0.0.43",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -385,19 +410,24 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-influxdb-ui",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/services/monitoring-influxdb-ui",
-                "uid": "49c23d97-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "306",
-                "creationTimestamp": "2015-04-13T08:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-influxdb-ui",
+                "uid": "a76e689d-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "30",
+                "creationTimestamp": "2015-04-20T09:28:50Z"
               },
               "spec": {
-                "port": 80,
-                "protocol": "TCP",
+                "ports": [
+                  {
+                    "name": "",
+                    "protocol": "TCP",
+                    "port": 80,
+                    "targetPort": 8083
+                  }
+                ],
                 "selector": {
                   "name": "influxGrafana"
                 },
-                "portalIP": "10.0.0.196",
-                "targetPort": 8083,
+                "portalIP": "10.0.0.104",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -405,7 +435,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:29 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/replicationcontrollers
@@ -427,7 +457,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:31 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -438,17 +468,17 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/replicationcontrollers",
-            "resourceVersion": "1645"
+            "resourceVersion": "607"
           },
           "items": [
             {
               "metadata": {
                 "name": "monitoring-heapster-controller",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/replicationcontrollers/monitoring-heapster-controller",
-                "uid": "49880524-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "309",
-                "creationTimestamp": "2015-04-13T08:30:05Z",
+                "selfLink": "/api/v1beta3/namespaces/default/replicationcontrollers/monitoring-heapster-controller",
+                "uid": "a7519595-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "46",
+                "creationTimestamp": "2015-04-20T09:28:50Z",
                 "labels": {
                   "name": "heapster"
                 }
@@ -477,7 +507,9 @@ http_interactions:
                         "gcePersistentDisk": null,
                         "gitRepo": null,
                         "secret": null,
-                        "nfs": null
+                        "nfs": null,
+                        "iscsi": null,
+                        "glusterfs": null
                       }
                     ],
                     "containers": [
@@ -520,10 +552,10 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-influx-grafana-controller",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/replicationcontrollers/monitoring-influx-grafana-controller",
-                "uid": "49a1e047-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "308",
-                "creationTimestamp": "2015-04-13T08:30:05Z",
+                "selfLink": "/api/v1beta3/namespaces/default/replicationcontrollers/monitoring-influx-grafana-controller",
+                "uid": "a75b3f84-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "47",
+                "creationTimestamp": "2015-04-20T09:28:50Z",
                 "labels": {
                   "name": "influxGrafana"
                 }
@@ -602,7 +634,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:31 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/nodes
@@ -624,9 +656,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:33 GMT
       Content-Length:
-      - '1272'
+      - '1555'
     body:
       encoding: UTF-8
       string: |-
@@ -635,16 +667,16 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/nodes",
-            "resourceVersion": "1646"
+            "resourceVersion": "613"
           },
           "items": [
             {
               "metadata": {
                 "name": "dhcp-0-202.tlv.redhat.com",
                 "selfLink": "/api/v1beta3/nodes/dhcp-0-202.tlv.redhat.com",
-                "uid": "f035c16a-e1b5-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "1645",
-                "creationTimestamp": "2015-04-13T08:20:26Z"
+                "uid": "a3d2a008-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "613",
+                "creationTimestamp": "2015-04-20T09:28:44Z"
               },
               "spec": {
                 "externalID": "dhcp-0-202.tlv.redhat.com"
@@ -658,8 +690,8 @@ http_interactions:
                   {
                     "type": "Ready",
                     "status": "True",
-                    "lastProbeTime": "2015-04-13T09:07:46Z",
-                    "lastTransitionTime": "2015-04-13T08:20:26Z",
+                    "lastHeartbeatTime": "2015-04-20T09:32:33Z",
+                    "lastTransitionTime": "2015-04-20T09:28:46Z",
                     "reason": "kubelet is posting ready status"
                   }
                 ],
@@ -672,14 +704,19 @@ http_interactions:
                 "nodeInfo": {
                   "machineID": "8b4806e4334f470aa612265388e4121e",
                   "systemUUID": "8B4806E4-334F-470A-A612-265388E4121E",
-                  "bootID": "8bf324a5-8d03-49ce-8324-14617e6ddec2"
+                  "bootID": "8bf324a5-8d03-49ce-8324-14617e6ddec2",
+                  "kernelVersion": "3.10.0-229.1.2.el7.x86_64",
+                  "osImage": "CentOS Linux 7 (Core)",
+                  "containerRuntimeVersion": "docker://1.5.0-dev",
+                  "kubeletVersion": "v0.14.1-583-g4f0822d5fb10d5",
+                  "KubeProxyVersion": "v0.14.1-583-g4f0822d5fb10d5"
                 }
               }
             }
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:33 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/events
@@ -701,7 +738,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:35 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -712,440 +749,469 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/events",
-            "resourceVersion": "1646"
+            "resourceVersion": "618"
           },
           "items": [
             {
               "metadata": {
-                "name": "dhcp-0-202.tlv.redhat.com.13d4850244e78f5f",
+                "name": "monitoring-heapster-controller-39o8t.13d6aecdc352df13",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/dhcp-0-202.tlv.redhat.com.13d4850244e78f5f",
-                "uid": "f05adcd5-e1b5-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "10",
-                "creationTimestamp": "2015-04-13T08:20:26Z",
-                "deletionTimestamp": "2015-04-13T09:20:26Z"
-              },
-              "involvedObject": {
-                "kind": "Node",
-                "name": "dhcp-0-202.tlv.redhat.com",
-                "uid": "dhcp-0-202.tlv.redhat.com"
-              },
-              "reason": "starting",
-              "message": "Starting kubelet.",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-13T08:20:26Z",
-              "lastTimestamp": "2015-04-13T08:20:26Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-heapster-controller-40yp7.13d485892e7393cf",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-heapster-controller-40yp7.13d485892e7393cf",
-                "uid": "49bad6df-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "304",
-                "creationTimestamp": "2015-04-13T08:30:06Z",
-                "deletionTimestamp": "2015-04-13T09:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aecdc352df13",
+                "uid": "a92b352b-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "41",
+                "creationTimestamp": "2015-04-20T09:28:53Z",
+                "deletionTimestamp": "2015-04-20T10:28:53Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "299"
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "25"
               },
-              "reason": "scheduled",
-              "message": "Successfully assigned monitoring-heapster-controller-40yp7 to dhcp-0-202.tlv.redhat.com",
+              "reason": "failedScheduling",
+              "message": "Error scheduling: no minions available to schedule pods",
               "source": {
                 "component": "scheduler"
               },
-              "firstTimestamp": "2015-04-13T08:30:06Z",
-              "lastTimestamp": "2015-04-13T08:30:06Z",
-              "count": 1
+              "firstTimestamp": "2015-04-20T09:28:50Z",
+              "lastTimestamp": "2015-04-20T09:28:53Z",
+              "count": 3
             },
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-40yp7.13d485894b2b549a",
+                "name": "monitoring-heapster-controller-39o8t.13d6aecf66cd9593",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-heapster-controller-40yp7.13d485894b2b549a",
-                "uid": "4a046471-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "312",
-                "creationTimestamp": "2015-04-13T08:30:06Z",
-                "deletionTimestamp": "2015-04-13T09:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aecf66cd9593",
+                "uid": "ab92d0b7-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "60",
+                "creationTimestamp": "2015-04-20T09:28:57Z",
+                "deletionTimestamp": "2015-04-20T10:28:57Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "301",
-                "fieldPath": "implicitly required container POD"
-              },
-              "reason": "pulled",
-              "message": "Successfully pulled image \"kubernetes/pause:latest\"",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-13T08:30:06Z",
-              "lastTimestamp": "2015-04-13T08:30:06Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-heapster-controller-40yp7.13d48589b32f86cc",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-heapster-controller-40yp7.13d48589b32f86cc",
-                "uid": "4b0ea210-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "317",
-                "creationTimestamp": "2015-04-13T08:30:08Z",
-                "deletionTimestamp": "2015-04-13T09:30:08Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "301",
-                "fieldPath": "implicitly required container POD"
-              },
-              "reason": "created",
-              "message": "Created with docker id d59c7248be04ff32796c62aa6f40b61316fa7a9fb34c11a45ddefb080b0de450",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-13T08:30:08Z",
-              "lastTimestamp": "2015-04-13T08:30:08Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-heapster-controller-40yp7.13d48589d93e6b2a",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-heapster-controller-40yp7.13d48589d93e6b2a",
-                "uid": "4b7017a7-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "318",
-                "creationTimestamp": "2015-04-13T08:30:08Z",
-                "deletionTimestamp": "2015-04-13T09:30:08Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "301",
-                "fieldPath": "implicitly required container POD"
-              },
-              "reason": "started",
-              "message": "Started with docker id d59c7248be04ff32796c62aa6f40b61316fa7a9fb34c11a45ddefb080b0de450",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-13T08:30:08Z",
-              "lastTimestamp": "2015-04-13T08:30:08Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-heapster-controller-40yp7.13d4858a2fdb7e98",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-heapster-controller-40yp7.13d4858a2fdb7e98",
-                "uid": "4c4e3b5d-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "322",
-                "creationTimestamp": "2015-04-13T08:30:10Z",
-                "deletionTimestamp": "2015-04-13T09:30:10Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "301",
-                "fieldPath": "spec.containers{heapster}"
-              },
-              "reason": "created",
-              "message": "Created with docker id 87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-13T08:30:10Z",
-              "lastTimestamp": "2015-04-13T08:30:10Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-heapster-controller-40yp7.13d4858a3d8e1b84",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-heapster-controller-40yp7.13d4858a3d8e1b84",
-                "uid": "4c70da42-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "323",
-                "creationTimestamp": "2015-04-13T08:30:10Z",
-                "deletionTimestamp": "2015-04-13T09:30:10Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-heapster-controller-40yp7",
-                "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "301",
-                "fieldPath": "spec.containers{heapster}"
-              },
-              "reason": "started",
-              "message": "Started with docker id 87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-13T08:30:10Z",
-              "lastTimestamp": "2015-04-13T08:30:10Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d4858937990688",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d4858937990688",
-                "uid": "49d2425f-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "307",
-                "creationTimestamp": "2015-04-13T08:30:06Z",
-                "deletionTimestamp": "2015-04-13T09:30:06Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "303"
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "25"
               },
               "reason": "scheduled",
-              "message": "Successfully assigned monitoring-influx-grafana-controller-2toua to dhcp-0-202.tlv.redhat.com",
+              "message": "Successfully assigned monitoring-heapster-controller-39o8t to dhcp-0-202.tlv.redhat.com",
               "source": {
                 "component": "scheduler"
               },
-              "firstTimestamp": "2015-04-13T08:30:06Z",
-              "lastTimestamp": "2015-04-13T08:30:06Z",
+              "firstTimestamp": "2015-04-20T09:28:57Z",
+              "lastTimestamp": "2015-04-20T09:28:57Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d485894b4bed33",
+                "name": "monitoring-heapster-controller-39o8t.13d6aed6b128034c",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d485894b4bed33",
-                "uid": "4a1be4fc-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "314",
-                "creationTimestamp": "2015-04-13T08:30:06Z",
-                "deletionTimestamp": "2015-04-13T09:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed6b128034c",
+                "uid": "be6849c6-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "142",
+                "creationTimestamp": "2015-04-20T09:29:29Z",
+                "deletionTimestamp": "2015-04-20T10:29:29Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "59",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "pulled",
-              "message": "Successfully pulled image \"kubernetes/pause:latest\"",
+              "message": "Successfully pulled image \"gcr.io/google_containers/pause:0.8.0\"",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:06Z",
-              "lastTimestamp": "2015-04-13T08:30:06Z",
+              "firstTimestamp": "2015-04-20T09:29:28Z",
+              "lastTimestamp": "2015-04-20T09:29:28Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d48589f50bf7aa",
+                "name": "monitoring-heapster-controller-39o8t.13d6aed769a3903e",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d48589f50bf7aa",
-                "uid": "4bb74443-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "319",
-                "creationTimestamp": "2015-04-13T08:30:09Z",
-                "deletionTimestamp": "2015-04-13T09:30:09Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed769a3903e",
+                "uid": "c0509481-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "152",
+                "creationTimestamp": "2015-04-20T09:29:32Z",
+                "deletionTimestamp": "2015-04-20T10:29:32Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "59",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "created",
-              "message": "Created with docker id 56e9d758e48e845dfeef6e6d4e7a2735b70547836e8902e4995f5325355a363b",
+              "message": "Created with docker id be2610ef34e18c8468381b4ecac0ef9b3b4eb0b657bba5b15de8d667db959a26",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:09Z",
-              "lastTimestamp": "2015-04-13T08:30:09Z",
+              "firstTimestamp": "2015-04-20T09:29:31Z",
+              "lastTimestamp": "2015-04-20T09:29:31Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d4858a2e04d162",
+                "name": "monitoring-heapster-controller-39o8t.13d6aed776282ead",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d4858a2e04d162",
-                "uid": "4c49126a-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "321",
-                "creationTimestamp": "2015-04-13T08:30:10Z",
-                "deletionTimestamp": "2015-04-13T09:30:10Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed776282ead",
+                "uid": "c0ac1bac-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "154",
+                "creationTimestamp": "2015-04-20T09:29:32Z",
+                "deletionTimestamp": "2015-04-20T10:29:32Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "59",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "started",
-              "message": "Started with docker id 56e9d758e48e845dfeef6e6d4e7a2735b70547836e8902e4995f5325355a363b",
+              "message": "Started with docker id be2610ef34e18c8468381b4ecac0ef9b3b4eb0b657bba5b15de8d667db959a26",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:10Z",
-              "lastTimestamp": "2015-04-13T08:30:10Z",
+              "firstTimestamp": "2015-04-20T09:29:32Z",
+              "lastTimestamp": "2015-04-20T09:29:32Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d4858a718b8a62",
+                "name": "monitoring-heapster-controller-39o8t.13d6aed853d62f2a",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d4858a718b8a62",
-                "uid": "4cf5f639-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "326",
-                "creationTimestamp": "2015-04-13T08:30:11Z",
-                "deletionTimestamp": "2015-04-13T09:30:11Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed853d62f2a",
+                "uid": "c2d17324-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "164",
+                "creationTimestamp": "2015-04-20T09:29:36Z",
+                "deletionTimestamp": "2015-04-20T10:29:36Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "59",
+                "fieldPath": "spec.containers{heapster}"
+              },
+              "reason": "created",
+              "message": "Created with docker id 6e6119478fe1a60b751f52b39bcaab97015575ac797d7a810bb5804370bd7351",
+              "source": {
+                "component": "kubelet",
+                "host": "dhcp-0-202.tlv.redhat.com"
+              },
+              "firstTimestamp": "2015-04-20T09:29:35Z",
+              "lastTimestamp": "2015-04-20T09:29:35Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-heapster-controller-39o8t.13d6aed888a58a6f",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed888a58a6f",
+                "uid": "c36a093b-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "167",
+                "creationTimestamp": "2015-04-20T09:29:37Z",
+                "deletionTimestamp": "2015-04-20T10:29:37Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "59",
+                "fieldPath": "spec.containers{heapster}"
+              },
+              "reason": "started",
+              "message": "Started with docker id 6e6119478fe1a60b751f52b39bcaab97015575ac797d7a810bb5804370bd7351",
+              "source": {
+                "component": "kubelet",
+                "host": "dhcp-0-202.tlv.redhat.com"
+              },
+              "firstTimestamp": "2015-04-20T09:29:36Z",
+              "lastTimestamp": "2015-04-20T09:29:36Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aecdc88a2b10",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aecdc88a2b10",
+                "uid": "a93896eb-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "43",
+                "creationTimestamp": "2015-04-20T09:28:53Z",
+                "deletionTimestamp": "2015-04-20T10:28:53Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "29"
+              },
+              "reason": "failedScheduling",
+              "message": "Error scheduling: no minions available to schedule pods",
+              "source": {
+                "component": "scheduler"
+              },
+              "firstTimestamp": "2015-04-20T09:28:50Z",
+              "lastTimestamp": "2015-04-20T09:28:53Z",
+              "count": 3
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aecf6d323264",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aecf6d323264",
+                "uid": "aba38226-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "63",
+                "creationTimestamp": "2015-04-20T09:28:57Z",
+                "deletionTimestamp": "2015-04-20T10:28:57Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "29"
+              },
+              "reason": "scheduled",
+              "message": "Successfully assigned monitoring-influx-grafana-controller-rnzju to dhcp-0-202.tlv.redhat.com",
+              "source": {
+                "component": "scheduler"
+              },
+              "firstTimestamp": "2015-04-20T09:28:57Z",
+              "lastTimestamp": "2015-04-20T09:28:57Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed6b18e9b97",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed6b18e9b97",
+                "uid": "bea55362-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "144",
+                "creationTimestamp": "2015-04-20T09:29:29Z",
+                "deletionTimestamp": "2015-04-20T10:29:29Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
+                "fieldPath": "implicitly required container POD"
+              },
+              "reason": "pulled",
+              "message": "Successfully pulled image \"gcr.io/google_containers/pause:0.8.0\"",
+              "source": {
+                "component": "kubelet",
+                "host": "dhcp-0-202.tlv.redhat.com"
+              },
+              "firstTimestamp": "2015-04-20T09:29:28Z",
+              "lastTimestamp": "2015-04-20T09:29:28Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed754c7e6b6",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed754c7e6b6",
+                "uid": "bff50754-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "150",
+                "creationTimestamp": "2015-04-20T09:29:31Z",
+                "deletionTimestamp": "2015-04-20T10:29:31Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
+                "fieldPath": "implicitly required container POD"
+              },
+              "reason": "created",
+              "message": "Created with docker id 26c7485bab3c13eaf87d70a36416c6df8211ce0f71f1039b265841e0e857fb69",
+              "source": {
+                "component": "kubelet",
+                "host": "dhcp-0-202.tlv.redhat.com"
+              },
+              "firstTimestamp": "2015-04-20T09:29:31Z",
+              "lastTimestamp": "2015-04-20T09:29:31Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed77213f01e",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed77213f01e",
+                "uid": "c06f170a-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "153",
+                "creationTimestamp": "2015-04-20T09:29:32Z",
+                "deletionTimestamp": "2015-04-20T10:29:32Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
+                "fieldPath": "implicitly required container POD"
+              },
+              "reason": "started",
+              "message": "Started with docker id 26c7485bab3c13eaf87d70a36416c6df8211ce0f71f1039b265841e0e857fb69",
+              "source": {
+                "component": "kubelet",
+                "host": "dhcp-0-202.tlv.redhat.com"
+              },
+              "firstTimestamp": "2015-04-20T09:29:32Z",
+              "lastTimestamp": "2015-04-20T09:29:32Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed84ed2381b",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed84ed2381b",
+                "uid": "c294676b-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "163",
+                "creationTimestamp": "2015-04-20T09:29:36Z",
+                "deletionTimestamp": "2015-04-20T10:29:36Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
                 "fieldPath": "spec.containers{influxdb}"
               },
               "reason": "created",
-              "message": "Created with docker id af741769b650a408f4a65d2d27043912b6d57e5e2a721faeb7a93a1989eef0c6",
+              "message": "Created with docker id 997c6a36aec6677fb1d5ae37ed89e483b49798fab4648ccfb21cea3be1cf63d9",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:11Z",
-              "lastTimestamp": "2015-04-13T08:30:11Z",
+              "firstTimestamp": "2015-04-20T09:29:35Z",
+              "lastTimestamp": "2015-04-20T09:29:35Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d4858a759ff420",
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed865e5b53e",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d4858a759ff420",
-                "uid": "4d00676e-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "327",
-                "creationTimestamp": "2015-04-13T08:30:11Z",
-                "deletionTimestamp": "2015-04-13T09:30:11Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed865e5b53e",
+                "uid": "c30e765f-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "166",
+                "creationTimestamp": "2015-04-20T09:29:36Z",
+                "deletionTimestamp": "2015-04-20T10:29:36Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
                 "fieldPath": "spec.containers{influxdb}"
               },
               "reason": "started",
-              "message": "Started with docker id af741769b650a408f4a65d2d27043912b6d57e5e2a721faeb7a93a1989eef0c6",
+              "message": "Started with docker id 997c6a36aec6677fb1d5ae37ed89e483b49798fab4648ccfb21cea3be1cf63d9",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:11Z",
-              "lastTimestamp": "2015-04-13T08:30:11Z",
+              "firstTimestamp": "2015-04-20T09:29:36Z",
+              "lastTimestamp": "2015-04-20T09:29:36Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d4858ab406e706",
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed912cd7a49",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d4858ab406e706",
-                "uid": "4da01b6f-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "329",
-                "creationTimestamp": "2015-04-13T08:30:12Z",
-                "deletionTimestamp": "2015-04-13T09:30:12Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed912cd7a49",
+                "uid": "c47cff06-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "173",
+                "creationTimestamp": "2015-04-20T09:29:39Z",
+                "deletionTimestamp": "2015-04-20T10:29:39Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
                 "fieldPath": "spec.containers{grafana}"
               },
               "reason": "created",
-              "message": "Created with docker id f9ae296270fe8891f74060006f00ddf247be7f771511a783ca0564bd0469de3a",
+              "message": "Created with docker id 7996e009081d7fe9a579b973d282d178c009e6f231590f8f08d71c1ee793fe6c",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:12Z",
-              "lastTimestamp": "2015-04-13T08:30:12Z",
+              "firstTimestamp": "2015-04-20T09:29:39Z",
+              "lastTimestamp": "2015-04-20T09:29:39Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-2toua.13d4858ab7a76b2d",
+                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed92033e11b",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/events/monitoring-influx-grafana-controller-2toua.13d4858ab7a76b2d",
-                "uid": "4da96d57-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "330",
-                "creationTimestamp": "2015-04-13T08:30:12Z",
-                "deletionTimestamp": "2015-04-13T09:30:12Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed92033e11b",
+                "uid": "c4d843ae-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "174",
+                "creationTimestamp": "2015-04-20T09:29:39Z",
+                "deletionTimestamp": "2015-04-20T10:29:39Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-2toua",
-                "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                "apiVersion": "v1beta1",
-                "resourceVersion": "305",
+                "name": "monitoring-influx-grafana-controller-rnzju",
+                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "62",
                 "fieldPath": "spec.containers{grafana}"
               },
               "reason": "started",
-              "message": "Started with docker id f9ae296270fe8891f74060006f00ddf247be7f771511a783ca0564bd0469de3a",
+              "message": "Started with docker id 7996e009081d7fe9a579b973d282d178c009e6f231590f8f08d71c1ee793fe6c",
               "source": {
                 "component": "kubelet",
                 "host": "dhcp-0-202.tlv.redhat.com"
               },
-              "firstTimestamp": "2015-04-13T08:30:12Z",
-              "lastTimestamp": "2015-04-13T08:30:12Z",
+              "firstTimestamp": "2015-04-20T09:29:39Z",
+              "lastTimestamp": "2015-04-20T09:29:39Z",
               "count": 1
             }
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:36 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/endpoints
@@ -1167,7 +1233,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:38 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -1178,23 +1244,31 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/endpoints",
-            "resourceVersion": "1646"
+            "resourceVersion": "625"
           },
           "items": [
             {
               "metadata": {
                 "name": "kubernetes",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/endpoints/kubernetes",
-                "uid": "efa65825-e1b5-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "8",
-                "creationTimestamp": "2015-04-13T08:20:25Z"
+                "selfLink": "/api/v1beta3/namespaces/default/endpoints/kubernetes",
+                "uid": "a37316f5-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "7",
+                "creationTimestamp": "2015-04-20T09:28:43Z"
               },
-              "protocol": "TCP",
-              "endpoints": [
+              "subsets": [
                 {
-                  "ip": "10.35.0.202",
-                  "port": 6443
+                  "addresses": [
+                    {
+                      "IP": "10.35.0.202"
+                    }
+                  ],
+                  "ports": [
+                    {
+                      "port": 6443,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
               ]
             },
@@ -1202,16 +1276,24 @@ http_interactions:
               "metadata": {
                 "name": "kubernetes-ro",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/endpoints/kubernetes-ro",
-                "uid": "efa27967-e1b5-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "7",
-                "creationTimestamp": "2015-04-13T08:20:25Z"
+                "selfLink": "/api/v1beta3/namespaces/default/endpoints/kubernetes-ro",
+                "uid": "a376f279-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "8",
+                "creationTimestamp": "2015-04-20T09:28:43Z"
               },
-              "protocol": "TCP",
-              "endpoints": [
+              "subsets": [
                 {
-                  "ip": "10.35.0.202",
-                  "port": 7080
+                  "addresses": [
+                    {
+                      "IP": "10.35.0.202"
+                    }
+                  ],
+                  "ports": [
+                    {
+                      "port": 7080,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
               ]
             },
@@ -1219,23 +1301,31 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-grafana",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/endpoints/monitoring-grafana",
-                "uid": "49f60fec-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "1646",
-                "creationTimestamp": "2015-04-13T08:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-grafana",
+                "uid": "a9c9c6d0-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "193",
+                "creationTimestamp": "2015-04-20T09:28:54Z"
               },
-              "protocol": "TCP",
-              "endpoints": [
+              "subsets": [
                 {
-                  "ip": "172.17.0.8",
-                  "port": 8080,
-                  "targetRef": {
-                    "kind": "Pod",
-                    "namespace": "default",
-                    "name": "monitoring-influx-grafana-controller-2toua",
-                    "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                    "resourceVersion": "1640"
-                  }
+                  "addresses": [
+                    {
+                      "IP": "172.17.0.9",
+                      "targetRef": {
+                        "kind": "Pod",
+                        "namespace": "default",
+                        "name": "monitoring-influx-grafana-controller-rnzju",
+                        "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                        "resourceVersion": "178"
+                      }
+                    }
+                  ],
+                  "ports": [
+                    {
+                      "port": 8080,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
               ]
             },
@@ -1243,23 +1333,31 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-heapster",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/endpoints/monitoring-heapster",
-                "uid": "4a03bc06-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "336",
-                "creationTimestamp": "2015-04-13T08:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-heapster",
+                "uid": "aa7edaf0-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "194",
+                "creationTimestamp": "2015-04-20T09:28:55Z"
               },
-              "protocol": "TCP",
-              "endpoints": [
+              "subsets": [
                 {
-                  "ip": "172.17.0.7",
-                  "port": 8082,
-                  "targetRef": {
-                    "kind": "Pod",
-                    "namespace": "default",
-                    "name": "monitoring-heapster-controller-40yp7",
-                    "uid": "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-                    "resourceVersion": "325"
-                  }
+                  "addresses": [
+                    {
+                      "IP": "172.17.0.10",
+                      "targetRef": {
+                        "kind": "Pod",
+                        "namespace": "default",
+                        "name": "monitoring-heapster-controller-39o8t",
+                        "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                        "resourceVersion": "171"
+                      }
+                    }
+                  ],
+                  "ports": [
+                    {
+                      "port": 8082,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
               ]
             },
@@ -1267,23 +1365,31 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-influxdb",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/endpoints/monitoring-influxdb",
-                "uid": "4a0df38f-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "1598",
-                "creationTimestamp": "2015-04-13T08:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-influxdb",
+                "uid": "aada66e1-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "196",
+                "creationTimestamp": "2015-04-20T09:28:56Z"
               },
-              "protocol": "TCP",
-              "endpoints": [
+              "subsets": [
                 {
-                  "ip": "172.17.0.8",
-                  "port": 8086,
-                  "targetRef": {
-                    "kind": "Pod",
-                    "namespace": "default",
-                    "name": "monitoring-influx-grafana-controller-2toua",
-                    "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                    "resourceVersion": "1592"
-                  }
+                  "addresses": [
+                    {
+                      "IP": "172.17.0.9",
+                      "targetRef": {
+                        "kind": "Pod",
+                        "namespace": "default",
+                        "name": "monitoring-influx-grafana-controller-rnzju",
+                        "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                        "resourceVersion": "178"
+                      }
+                    }
+                  ],
+                  "ports": [
+                    {
+                      "port": 8086,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
               ]
             },
@@ -1291,30 +1397,38 @@ http_interactions:
               "metadata": {
                 "name": "monitoring-influxdb-ui",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/%7Bnamespaces%7D/endpoints/monitoring-influxdb-ui",
-                "uid": "4a23229e-e1b7-11e4-b7dc-001a4a5f4a02",
-                "resourceVersion": "1599",
-                "creationTimestamp": "2015-04-13T08:30:06Z"
+                "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-influxdb-ui",
+                "uid": "ab35f567-e73f-11e4-b613-001a4a5f4a02",
+                "resourceVersion": "197",
+                "creationTimestamp": "2015-04-20T09:28:56Z"
               },
-              "protocol": "TCP",
-              "endpoints": [
+              "subsets": [
                 {
-                  "ip": "172.17.0.8",
-                  "port": 8083,
-                  "targetRef": {
-                    "kind": "Pod",
-                    "namespace": "default",
-                    "name": "monitoring-influx-grafana-controller-2toua",
-                    "uid": "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-                    "resourceVersion": "1592"
-                  }
+                  "addresses": [
+                    {
+                      "IP": "172.17.0.9",
+                      "targetRef": {
+                        "kind": "Pod",
+                        "namespace": "default",
+                        "name": "monitoring-influx-grafana-controller-rnzju",
+                        "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                        "resourceVersion": "178"
+                      }
+                    }
+                  ],
+                  "ports": [
+                    {
+                      "port": 8083,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:38 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/namespaces
@@ -1336,9 +1450,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Apr 2015 09:07:46 GMT
+      - Mon, 20 Apr 2015 09:32:40 GMT
       Content-Length:
-      - '564'
+      - '563'
     body:
       encoding: UTF-8
       string: |-
@@ -1347,16 +1461,16 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/namespaces",
-            "resourceVersion": "1647"
+            "resourceVersion": "630"
           },
           "items": [
             {
               "metadata": {
                 "name": "default",
                 "selfLink": "/api/v1beta3/namespaces/default",
-                "uid": "ef94940d-e1b5-11e4-b7dc-001a4a5f4a02",
+                "uid": "a3653796-e73f-11e4-b613-001a4a5f4a02",
                 "resourceVersion": "4",
-                "creationTimestamp": "2015-04-13T08:20:25Z"
+                "creationTimestamp": "2015-04-20T09:28:43Z"
               },
               "spec": {
                 "finalizers": [
@@ -1370,5 +1484,5 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 13 Apr 2015 09:07:46 GMT
+  recorded_at: Mon, 20 Apr 2015 09:32:40 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
port, container_port and protocol moved to a new model (container_service_port_config) to accommodate the changes to kubernetes listed here: [GoogleCloudPlatform/kubernetes/pull/6182](https://github.com/GoogleCloudPlatform/kubernetes/pull/6182)
This patch also migrates existing data.


