### PR TITLE
Correct event name from request_vm_stop to request_vm_poweroff

### DIFF
--- a/vmdb/app/models/vm_or_template/operations/power.rb
+++ b/vmdb/app/models/vm_or_template/operations/power.rb
@@ -12,7 +12,7 @@ module VmOrTemplate::Operations::Power
   end
 
   def stop
-    raw_stop unless policy_prevented?(:request_vm_stop)
+    raw_stop unless policy_prevented?(:request_vm_poweroff)
   end
 
   # Suspend saves the state of the VM to disk and shuts it down


### PR DESCRIPTION
request_vm_stop is not a valid event name

https://bugzilla.redhat.com/show_bug.cgi?id=1207788