### PR TITLE
containers: use ssl and align with kubernetes entities in openshift

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -33,7 +33,7 @@ gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
 gem "ovirt",                "~>0.4.1",       :require => false
-gem "kubeclient",           ">=0.1.8",       :require => false
+gem "kubeclient",           ">=0.1.10",      :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false

--- a/lib/kubernetes/events/kubernetes_event_monitor.rb
+++ b/lib/kubernetes/events/kubernetes_event_monitor.rb
@@ -6,6 +6,9 @@ class KubernetesEventMonitor
   def inventory
     require 'kubeclient'
     @inventory ||= Kubeclient::Client.new(@api_endpoint)
+    # TODO: support real authentication using certificates
+    @inventory.ssl_options(:verify_ssl => OpenSSL::SSL::VERIFY_NONE)
+    @inventory
   end
 
   def watcher(version = nil)

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -14,11 +14,14 @@ class EmsKubernetes < EmsContainer
   def self.raw_connect(hostname, port)
     require 'kubeclient'
     api_endpoint = raw_api_endpoint(hostname, port)
-    Kubeclient::Client.new(api_endpoint)
+    kube = Kubeclient::Client.new(api_endpoint)
+    # TODO: support real authentication using certificates
+    kube.ssl_options(:verify_ssl => OpenSSL::SSL::VERIFY_NONE)
+    kube
   end
 
   def self.raw_api_endpoint(hostname, port)
-    URI::HTTP.build(:host => hostname, :port => port.to_i, :path => "/api")
+    URI::HTTPS.build(:host => hostname, :port => port.to_i, :path => "/api")
   end
 
   def api_endpoint

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -3,6 +3,8 @@ class EmsKubernetes < EmsContainer
   has_many :container_groups,                     :foreign_key => :ems_id, :dependent => :destroy
   has_many :container_services,                   :foreign_key => :ems_id, :dependent => :destroy
 
+  default_value_for :port, 6443
+
   def self.ems_type
     @ems_type ||= "kubernetes".freeze
   end
@@ -21,7 +23,7 @@ class EmsKubernetes < EmsContainer
   end
 
   def self.raw_api_endpoint(hostname, port)
-    URI::HTTPS.build(:host => hostname, :port => port.to_i, :path => "/api")
+    URI::HTTPS.build(:host => hostname, :port => port.to_i)
   end
 
   def api_endpoint

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -147,12 +147,13 @@ module EmsRefresh::Parsers
       end
 
       entity.subsets.each do |subset|
-        subset.fetch('addresses', []).each do |address|
-          target_ref = address['targetRef']
-          next if target_ref.nil? || target_ref['kind'] != 'Pod'
+        (subset.addresses || []).each do |address|
+          next if address.targetRef.nil? || address.targetRef.kind != 'Pod'
           cg = @data_index.fetch_path(
-            :container_groups, :by_namespace_and_name, target_ref['namespace'],
-            target_ref['name'])
+            :container_groups, :by_namespace_and_name,
+            # namespace is overriden in more_core_extensions and hence needs
+            # a non method access
+            address.targetRef["table"][:namespace], address.targetRef.name)
           new_result[:container_groups] << cg unless cg.nil?
         end
       end
@@ -238,7 +239,7 @@ module EmsRefresh::Parsers
         :name               => item.metadata.name,
         # namespace is overriden in more_core_extensions and hence needs
         # a non method access
-        :namespace          => item.metadata[:namespace],
+        :namespace          => item.metadata["table"][:namespace],
         :creation_timestamp => item.metadata.creationTimestamp,
         :resource_version   => item.metadata.resourceVersion
       }

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -138,24 +138,14 @@ module EmsRefresh::Parsers
       new_result = parse_base_item(entity)
       new_result[:container_groups] = []
 
-      # TODO: remove once kubernetes api v1beta3/v1.0 will be stable
-      if !entity.respond_to?(:subsets) || entity.subsets.nil?
-        $log.warn("your kubernetes endpoints are not providing subsets, " \
-                  "please upgrade, see https://github.com/" \
-                  "GoogleCloudPlatform/kubernetes/pull/5939")
-        return new_result
-      end
-
-      entity.subsets.each do |subset|
-        (subset.addresses || []).each do |address|
-          next if address.targetRef.nil? || address.targetRef.kind != 'Pod'
-          cg = @data_index.fetch_path(
-            :container_groups, :by_namespace_and_name,
-            # namespace is overriden in more_core_extensions and hence needs
-            # a non method access
-            address.targetRef["table"][:namespace], address.targetRef.name)
-          new_result[:container_groups] << cg unless cg.nil?
-        end
+      (entity.endpoints || []).each do |endpoint|
+        next unless endpoint.targetRef.try(:kind) == 'Pod'
+        cg = @data_index.fetch_path(
+          :container_groups, :by_namespace_and_name,
+          # namespace is overriden in more_core_extensions and hence needs
+          # a non method access
+          endpoint.targetRef["table"][:namespace], endpoint.targetRef.name)
+        new_result[:container_groups] << cg unless cg.nil?
       end
 
       new_result

--- a/vmdb/spec/models/ems_kubernetes_spec.rb
+++ b/vmdb/spec/models/ems_kubernetes_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 describe EmsKubernetes do
   it ".raw_api_endpoint (ipv6)" do
-    expect(described_class.raw_api_endpoint("::1", 123).to_s).to eq "https://[::1]:123/api"
+    expect(described_class.raw_api_endpoint("::1", 123).to_s).to eq "https://[::1]:123"
   end
 end

--- a/vmdb/spec/models/ems_kubernetes_spec.rb
+++ b/vmdb/spec/models/ems_kubernetes_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 describe EmsKubernetes do
   it ".raw_api_endpoint (ipv6)" do
-    expect(described_class.raw_api_endpoint("::1", 123).to_s).to eq "http://[::1]:123/api"
+    expect(described_class.raw_api_endpoint("::1", 123).to_s).to eq "https://[::1]:123/api"
   end
 end


### PR DESCRIPTION
This patch switches to use https for the kubernetes connection. All the provides already defined in the database will stop working as they'll probably need to update the port (from 8080 to 6443). Since we're still in a development phase this shouldn't be a problem (not worth a migration script) provided that all the developers are aware of it.