### PR TITLE
fix_auth --v2 should result in v2 == true

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -41,7 +41,7 @@ gem "rubyzip",              "=0.9.5",        :require => false  # TODO: Review 0
 gem "rufus-lru",            "~>1.0.3",       :require => false
 gem "uuidtools",            "~>2.1.3",       :require => false
 gem "sass",                 "3.1.20",        :require => false
-gem "trollop",              "~>1.16.2",      :require => false
+gem "trollop",              "~>2.0",      :require => false
 gem "psych",                "~>2.0.12"
 gem "apipie-bindings",      "~>0.0.12",      :require => false
 

--- a/vmdb/spec/tools/fix_auth/cli_spec.rb
+++ b/vmdb/spec/tools/fix_auth/cli_spec.rb
@@ -64,5 +64,19 @@ describe FixAuth::Cli do
              .options.slice(:db, :databaseyml, :key)
       expect(opts).to eq(:db => true, :databaseyml => true, :key => true)
     end
+
+    describe "v2" do
+      it "defaults to true" do
+        expect(described_class.new.parse(%w()).options[:v2]).to be_true
+      end
+
+      it "allows v2 to be passed" do
+        expect(described_class.new.parse(%w(--v2)).options[:v2]).to be_true
+      end
+
+      it "allows v2 to be negative" do
+        expect(described_class.new.parse(%w(--no-v2)).options[:v2]).to be_false
+      end
+    end
   end
 end


### PR DESCRIPTION
Having trouble with a bad v2 key in my database.
Couldn't get `fix_auth` to fix it.

Turns out older versions of `trollop` make this flag negative.
So `fix_auth` no longer works like our documentation.

/cc @jrafanie @Fryguy 