### PR TITLE
Use existing fixture to test template dialog generation

### DIFF
--- a/vmdb/spec/controllers/catalog_controller_spec.rb
+++ b/vmdb/spec/controllers/catalog_controller_spec.rb
@@ -345,7 +345,7 @@ describe CatalogController do
 
   context "#service_dialog_create_from_ot" do
     before(:each) do
-      @ot = FactoryGirl.create(:orchestration_template_with_content)
+      @ot = FactoryGirl.create(:orchestration_template_cfn_with_content)
       @dialog_label = "New Dialog 01"
       session[:edit] = {
         :new    => {:dialog_name => @dialog_label},

--- a/vmdb/spec/factories/orchestration_template.rb
+++ b/vmdb/spec/factories/orchestration_template.rb
@@ -17,15 +17,13 @@ FactoryGirl.define do
     stacks { [FactoryGirl.create(:orchestration_stack)] }
   end
 
-  factory :orchestration_template_with_content, :parent => :orchestration_template do
-    type 'OrchestrationTemplateCfn'
-    content '{'\
-            '"Description" : "Description",'\
-            '"Parameters" : {'\
-            '    "KeyName" : {'\
-            '      "Description" : "Description",'\
-            '      "Type" : "String",'\
-            '      "Default": "Description"'\
-            '}}}'
+  factory :orchestration_template_cfn_with_content, :parent => :orchestration_template_cfn do
+    content File.read('spec/fixtures/orchestration_templates/cfn_parameters.json')
+  end
+
+  factory :orchestration_template_hot_with_content,
+          :parent => :orchestration_template,
+          :class  => OrchestrationTemplateHot do
+    content File.read('spec/fixtures/orchestration_templates/hot_parameters.yml')
   end
 end

--- a/vmdb/spec/models/orchestration_template_cfn_spec.rb
+++ b/vmdb/spec/models/orchestration_template_cfn_spec.rb
@@ -9,17 +9,9 @@ describe OrchestrationTemplateCfn do
     end
   end
 
-  let(:sample) do
-    'spec/fixtures/orchestration_templates/cfn_parameters.json'
-  end
-
-  let(:valid_template) do
-    OrchestrationTemplateCfn.new(:content => IO.read(sample))
-  end
+  let(:valid_template) { FactoryGirl.create(:orchestration_template_cfn_with_content) }
 
   context "when a raw template in JSON format is given" do
-
-
     it "parses parameters from a template" do
       groups = valid_template.parameter_groups
       groups.size.should == 1

--- a/vmdb/spec/models/orchestration_template_hot_spec.rb
+++ b/vmdb/spec/models/orchestration_template_hot_spec.rb
@@ -9,9 +9,7 @@ describe OrchestrationTemplateHot do
     end
   end
 
-  let(:sample) { 'spec/fixtures/orchestration_templates/hot_parameters.yml' }
-
-  let(:valid_template) { OrchestrationTemplateHot.new(:content => IO.read(sample)) }
+  let(:valid_template) { FactoryGirl.create(:orchestration_template_hot_with_content) }
 
   context "when a raw template in YAML format is given" do
     it "parses parameters from a template" do

--- a/vmdb/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/vmdb/spec/services/orchestration_template_dialog_service_spec.rb
@@ -3,10 +3,7 @@ require "spec_helper"
 describe OrchestrationTemplateDialogService do
   let(:dialog_service) { described_class.new }
 
-  let(:template) do
-    file = 'spec/fixtures/orchestration_templates/hot_parameters.yml'
-    OrchestrationTemplateHot.new(:content => IO.read(file))
-  end
+  let(:template) { FactoryGirl.create(:orchestration_template_hot_with_content) }
 
   describe "#create_dialog" do
     it "creates a dialog with stack basic info and parameters" do


### PR DESCRIPTION
We already have a sample template with parameters that can be used to generate a dialog for testing purpose. There is no need to recreate another template for the same purpose in factories.