### PR TITLE
Eager loading

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1486,7 +1486,7 @@ module VmCommon
       if x_node == "root"
         # TODO: potential to move this into a model with a scope built into it
         options[:where_clause] =
-          ["vms.type IN (?)", VmInfra::SUBCLASSES + TemplateInfra::SUBCLASSES] if x_active_tree == :vandt_tree
+          ["vms.type IN (?)", VmInfra.subclasses.collect(&:name) + TemplateInfra.subclasses.collect(&:name)] if x_active_tree == :vandt_tree
         process_show_list(options)  # Get all VMs & Templates
         # :model=>ui_lookup(:models=>"VmOrTemplate"))
         # TODO: Change ui_lookup/dictionary to handle VmOrTemplate, returning VMs And Templates
@@ -1494,7 +1494,7 @@ module VmCommon
       else
         if TreeBuilder.get_model_for_prefix(@nodetype) == "Hash"
           options[:where_clause] =
-            ["vms.type IN (?)", VmInfra::SUBCLASSES + TemplateInfra::SUBCLASSES] if x_active_tree == :vandt_tree
+            ["vms.type IN (?)", VmInfra.subclasses.collect(&:name) + TemplateInfra.subclasses.collect(&:name)] if x_active_tree == :vandt_tree
           if id == "orph"
             options[:where_clause] = MiqExpression.merge_where_clauses(options[:where_clause], VmOrTemplate::ORPHANED_CONDITIONS)
             process_show_list(options)

--- a/vmdb/app/models/auth_key_pair_cloud.rb
+++ b/vmdb/app/models/auth_key_pair_cloud.rb
@@ -1,12 +1,3 @@
 class AuthKeyPairCloud < AuthPrivateKey
-  SUBCLASSES = [
-    "AuthKeyPairAmazon",
-    "AuthKeyPairOpenstack",
-  ]
-
   has_and_belongs_to_many :vms, :join_table => :key_pairs_vms, :foreign_key => :authentication_id
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-AuthKeyPairCloud::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/auth_private_key.rb
+++ b/vmdb/app/models/auth_private_key.rb
@@ -1,10 +1,2 @@
 class AuthPrivateKey < Authentication
-  SUBCLASSES = [
-    'AuthKeyPairCloud',
-    'AuthKeyPairOpenstackInfra',
-  ]
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-AuthPrivateKey::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/availability_zone_openstack.rb
+++ b/vmdb/app/models/availability_zone_openstack.rb
@@ -1,9 +1,2 @@
 class AvailabilityZoneOpenstack < AvailabilityZone
-  SUBCLASSES = %w{
-    AvailabilityZoneOpenstackNull
-  }
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-AvailabilityZoneOpenstack::SUBCLASSES.each {|c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/cim_computer_system.rb
+++ b/vmdb/app/models/cim_computer_system.rb
@@ -36,8 +36,6 @@ class CimComputerSystem < MiqCimInstance
   virtual_has_many  :vms,         :class_name => 'Vm'
   virtual_has_many  :hosts,         :class_name => 'Host'
 
-  MODEL_SUBCLASSES  = [ 'OntapStorageSystem' ]
-
   CcsToBse            = CimProfiles.storage_system_to_base_storage_extent
   CcsToVm             = CimProfiles.storage_system_to_virtual_machine
   CcsToDatastores         = CimProfiles.storage_system_to_datastore
@@ -351,7 +349,3 @@ class CimComputerSystem < MiqCimInstance
     return true
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-# conditions that are generated on queries against this class.
-CimComputerSystem::MODEL_SUBCLASSES.each { |sc| require_dependency File.join(Rails.root, 'app', 'models', sc.underscore + '.rb')}

--- a/vmdb/app/models/cim_logical_disk.rb
+++ b/vmdb/app/models/cim_logical_disk.rb
@@ -32,8 +32,6 @@ class CimLogicalDisk < CimStorageExtent
   virtual_has_many  :hosts,                 :class_name => 'Host'
   virtual_belongs_to  :storage_system,            :class_name => 'CimComputerSystem'
 
-  MODEL_SUBCLASSES  = [ 'OntapLogicalDisk' ]
-
   LogicalDiskToBaseSe         = CimProfiles.storage_extent_to_base_storage_extent
   LogicalDiskToFileShare        = CimProfiles.logical_disk_to_file_share
   LogicalDiskToDatastores       = CimProfiles.logical_disk_to_datastore
@@ -263,9 +261,4 @@ class CimLogicalDisk < CimStorageExtent
   def is_based_on_underlying_redundancy?
     property('IsBasedOnUnderlyingRedundancy')
   end
-
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-# conditions that are generated on queries against this class.
-CimLogicalDisk::MODEL_SUBCLASSES.each { |sc| require_dependency File.join(Rails.root, 'app', 'models', sc.underscore + '.rb')}

--- a/vmdb/app/models/cim_storage_extent.rb
+++ b/vmdb/app/models/cim_storage_extent.rb
@@ -42,15 +42,6 @@ class CimStorageExtent < MiqCimInstance
   virtual_has_many  :hosts,           :class_name => 'Host'
   virtual_belongs_to  :storage_system,      :class_name => 'CimComputerSystem'
 
-  MODEL_SUBCLASSES  = [
-    'CimLogicalDisk',
-    'CimStorageVolume',
-    'OntapConcreteExtent',
-    'OntapFlexVolExtent',
-    'OntapPlexExtent',
-    'OntapRaidGroupExtent'
-  ]
-
   SeToBaseSe          = CimProfiles.storage_extent_to_base_storage_extent
   SeToTopSe         = CimProfiles.base_storage_extent_to_top_storage_extent
   SeToStorageSystem     = CimAssociations.CIM_StorageExtent_TO_CIM_ComputerSystem
@@ -241,9 +232,4 @@ class CimStorageExtent < MiqCimInstance
   def primordial?
     property('Primordial')
   end
-
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-# conditions that are generated on queries against this class.
-CimStorageExtent::MODEL_SUBCLASSES.each { |sc| require_dependency File.join(Rails.root, 'app', 'models', sc.underscore + '.rb')}

--- a/vmdb/app/models/cim_storage_volume.rb
+++ b/vmdb/app/models/cim_storage_volume.rb
@@ -27,8 +27,6 @@ class CimStorageVolume < CimStorageExtent
   virtual_has_many  :hosts,                 :class_name => 'Host'
   virtual_belongs_to  :storage_system,            :class_name => 'CimComputerSystem'
 
-  MODEL_SUBCLASSES  = [ 'OntapStorageVolume' ]
-
   StorageVolumeToBaseSe       = CimProfiles.storage_extent_to_base_storage_extent
   StorageVolumeToVirtualDisk      = CimProfiles.storage_volume_to_virtual_disk
   StorageVolumeToVm         = CimProfiles.storage_volume_to_virtual_machine
@@ -220,10 +218,4 @@ class CimStorageVolume < CimStorageExtent
   def correlatable_id
     self.name
   end
-
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-# conditions that are generated on queries against this class.
-CimStorageVolume::MODEL_SUBCLASSES.each { |sc| require_dependency File.join(Rails.root, 'app', 'models', sc.underscore + '.rb')}
-

--- a/vmdb/app/models/configuration_manager.rb
+++ b/vmdb/app/models/configuration_manager.rb
@@ -6,7 +6,3 @@ class ConfigurationManager < ExtManagementSystem
     false
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-VMDB::Util.eager_load_subclasses('ConfigurationManager')

--- a/vmdb/app/models/ems_cloud.rb
+++ b/vmdb/app/models/ems_cloud.rb
@@ -1,9 +1,4 @@
 class EmsCloud < ExtManagementSystem
-  SUBCLASSES = %w{
-    EmsAmazon
-    EmsOpenstack
-  }
-
   has_many :availability_zones,            :foreign_key => :ems_id, :dependent => :destroy
   has_many :flavors,                       :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_tenants,                 :foreign_key => :ems_id, :dependent => :destroy
@@ -27,7 +22,3 @@ class EmsCloud < ExtManagementSystem
     MiqSystem.open_browser(browser_url)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-EmsCloud::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/ems_cluster.rb
+++ b/vmdb/app/models/ems_cluster.rb
@@ -1,10 +1,5 @@
 class EmsCluster < ActiveRecord::Base
   include NewWithTypeStiMixin
-
-  SUBCLASSES = %w(
-    EmsClusterOpenstackInfra
-  )
-
   include_concern 'CapacityPlanning'
   include ReportableMixin
   include EventMixin
@@ -402,7 +397,3 @@ class EmsCluster < ActiveRecord::Base
     ext_management_system.class == EmsOpenstackInfra
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-EmsCluster::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/ems_container.rb
+++ b/vmdb/app/models/ems_container.rb
@@ -1,13 +1,5 @@
 class EmsContainer < ExtManagementSystem
-  SUBCLASSES = %w(
-    EmsKubernetes
-  )
-
   def self.supported_subclasses
     subclasses
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-EmsContainer::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/ems_infra.rb
+++ b/vmdb/app/models/ems_infra.rb
@@ -1,11 +1,4 @@
 class EmsInfra < ExtManagementSystem
-  SUBCLASSES = %w{
-    EmsMicrosoft
-    EmsOpenstackInfra
-    EmsRedhat
-    EmsVmware
-  }
-
   #
   # ems_timeouts is a general purpose proc for obtaining
   # read and open timeouts for any ems type and optional service.
@@ -46,9 +39,4 @@ class EmsInfra < ExtManagementSystem
     path = [:ems, :ems_redhat, :service, :read_timeout]
     cfg.merge_from_template_if_missing(*path)
   end
-
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-EmsInfra::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/ext_management_system.rb
+++ b/vmdb/app/models/ext_management_system.rb
@@ -1,12 +1,4 @@
 class ExtManagementSystem < ActiveRecord::Base
-  SUBCLASSES = %w(
-    ConfigurationManager
-    EmsInfra
-    EmsCloud
-    EmsContainer
-    ProvisioningManager
-  )
-
   def self.types
     leaf_subclasses.collect(&:ems_type)
   end
@@ -443,7 +435,3 @@ class ExtManagementSystem < ActiveRecord::Base
     end
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-ExtManagementSystem::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -43,6 +43,3 @@ class FileDepot < ActiveRecord::Base
     @file = file
   end
 end
-
-# load all plugins
-# VMDB::Util.eager_load_subclasses('FileDepot')

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -45,4 +45,4 @@ class FileDepot < ActiveRecord::Base
 end
 
 # load all plugins
-VMDB::Util.eager_load_subclasses('FileDepot')
+# VMDB::Util.eager_load_subclasses('FileDepot')

--- a/vmdb/app/models/host_service_group.rb
+++ b/vmdb/app/models/host_service_group.rb
@@ -2,10 +2,4 @@ class HostServiceGroup < ActiveRecord::Base
   has_many :filesystems, :dependent => :nullify
   has_many :system_services, :dependent => :nullify
   belongs_to :host
-
-  SUBCLASSES = %w(
-    HostServiceGroupOpenstack
-  )
 end
-
-HostServiceGroup::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/host_vmware.rb
+++ b/vmdb/app/models/host_vmware.rb
@@ -61,7 +61,3 @@ class HostVmware < Host
     end
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Dir.glob(Rails.root.join("app", "models", "host_vmware_*.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision.rb
+++ b/vmdb/app/models/miq_provision.rb
@@ -31,7 +31,6 @@ class MiqProvision < MiqProvisionTask
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
-  SUBCLASSES            = %w(MiqProvisionCloud MiqProvisionRedhat MiqProvisionVmware MiqProvisionMicrosoft)
   SUPPORTED_EMS_CLASSES = %w(EmsVmware EmsRedhat EmsAmazon EmsOpenstack EmsMicrosoft)
 
   def self.base_model
@@ -92,7 +91,3 @@ class MiqProvision < MiqProvisionTask
     "#{title} from [#{prov_obj.vm_template.name}] to [#{vm_name}]"
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvision::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_provision_cloud.rb
+++ b/vmdb/app/models/miq_provision_cloud.rb
@@ -1,10 +1,4 @@
 class MiqProvisionCloud < MiqProvision
-
-  SUBCLASSES = %w{
-    MiqProvisionAmazon
-    MiqProvisionOpenstack
-  }
-
   include_concern 'Cloning'
   include_concern 'OptionsHelper'
   include_concern 'Placement'
@@ -15,7 +9,3 @@ class MiqProvisionCloud < MiqProvision
     "Vm"
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvisionCloud::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_provision_cloud_workflow.rb
+++ b/vmdb/app/models/miq_provision_cloud_workflow.rb
@@ -1,11 +1,6 @@
 class MiqProvisionCloudWorkflow < MiqProvisionVirtWorkflow
   include CloudInitTemplateMixin
 
-  SUBCLASSES = %w{
-    MiqProvisionAmazon
-    MiqProvisionOpenstack
-  }
-
   def allowed_availability_zones(options={})
     source = load_ar_obj(get_source_vm)
     ems = source.try(:ext_management_system)
@@ -120,7 +115,3 @@ class MiqProvisionCloudWorkflow < MiqProvisionVirtWorkflow
     load_ar_obj(obj)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvisionCloudWorkflow::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}_workflow.rb").to_s }

--- a/vmdb/app/models/miq_provision_configured_system_workflow.rb
+++ b/vmdb/app/models/miq_provision_configured_system_workflow.rb
@@ -11,7 +11,3 @@ class MiqProvisionConfiguredSystemWorkflow < MiqProvisionWorkflow
     MiqProvisionConfiguredSystemRequest
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Dir.glob(File.join(File.dirname(__FILE__), "miq_provision_configured_system_*_workflow.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision_infra_workflow.rb
+++ b/vmdb/app/models/miq_provision_infra_workflow.rb
@@ -1,10 +1,4 @@
 class MiqProvisionInfraWorkflow < MiqProvisionVirtWorkflow
-  SUBCLASSES = %w{
-    MiqProvisionRedhatWorkflow
-    MiqProvisionVmwareWorkflow
-    MiqProvisionMicrosoftWorkflow
-  }
-
   def set_or_default_hardware_field_values(vm)
     update_values = {
       :vm_memory      => vm.hardware.memory_cpu.to_s,
@@ -60,7 +54,3 @@ class MiqProvisionInfraWorkflow < MiqProvisionVirtWorkflow
     super(message, extra_attrs)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvisionInfraWorkflow::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_provision_microsoft.rb
+++ b/vmdb/app/models/miq_provision_microsoft.rb
@@ -3,7 +3,3 @@ class MiqProvisionMicrosoft < MiqProvision
   include_concern 'Placement'
   include_concern 'StateMachine'
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Dir.glob(Rails.root.join("app", "models", "miq_provision_microsoft_*.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision_redhat.rb
+++ b/vmdb/app/models/miq_provision_redhat.rb
@@ -13,7 +13,3 @@ class MiqProvisionRedhat < MiqProvision
     self.destination.with_provider_object { |rhevm_vm| return rhevm_vm }
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Dir.glob(Rails.root.join("app", "models", "miq_provision_redhat_*.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision_request.rb
+++ b/vmdb/app/models/miq_provision_request.rb
@@ -131,7 +131,3 @@ class MiqProvisionRequest < MiqRequest
     "vm"
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Dir.glob(Rails.root.join("app", "models", "miq_provision_request_*.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision_task.rb
+++ b/vmdb/app/models/miq_provision_task.rb
@@ -6,7 +6,6 @@ class MiqProvisionTask < MiqRequestTask
   validates_inclusion_of :state, :in => %w(pending queued active provisioned finished), :message => "should be pending, queued, active, provisioned or finished"
 
   AUTOMATE_DRIVES = true
-  SUBCLASSES      = %w(MiqProvision MiqProvisionTaskConfiguredSystemForeman)
 
   def self.base_model
     MiqProvisionTask
@@ -16,7 +15,3 @@ class MiqProvisionTask < MiqRequestTask
     signal :run_provision
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvisionTask::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_provision_virt_workflow.rb
+++ b/vmdb/app/models/miq_provision_virt_workflow.rb
@@ -1,11 +1,6 @@
 require 'active_support/deprecation'
 
 class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
-  SUBCLASSES = %w{
-    MiqProvisionCloudWorkflow
-    MiqProvisionInfraWorkflow
-  }
-
   def auto_placement_enabled?
     get_value(@values[:placement_auto])
   end
@@ -1320,7 +1315,3 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     switches
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvisionVirtWorkflow::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_provision_vmware.rb
+++ b/vmdb/app/models/miq_provision_vmware.rb
@@ -15,9 +15,4 @@ class MiqProvisionVmware < MiqProvision
     else                            ""
     end
   end
-
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Dir.glob(Rails.root.join("app", "models", "miq_provision_vmware_*.rb")).each { |f| require_dependency f }

--- a/vmdb/app/models/miq_provision_workflow.rb
+++ b/vmdb/app/models/miq_provision_workflow.rb
@@ -1,9 +1,4 @@
 class MiqProvisionWorkflow < MiqRequestWorkflow
-  SUBCLASSES = %w{
-    MiqProvisionConfiguredSystemWorkflow
-    MiqProvisionVirtWorkflow
-  }
-
   def self.base_model
     MiqProvisionWorkflow
   end
@@ -63,7 +58,3 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
     true
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqProvisionWorkflow::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_request_task.rb
+++ b/vmdb/app/models/miq_request_task.rb
@@ -10,12 +10,12 @@ class MiqRequestTask < ActiveRecord::Base
   belongs_to :miq_request_task
 
   serialize   :phase_context, Hash
-  serialize   :options, Hash
+  serialize   :options,       Hash
 
   default_value_for :phase_context, {}
-  default_value_for :options, {}
+  default_value_for :options,       {}
 
-  validates_inclusion_of :status,         :in => %w{ Ok Warn Error Timeout }
+  validates_inclusion_of :status, :in => %w{ Ok Warn Error Timeout }
 
   include MiqRequestMixin
 
@@ -197,5 +197,19 @@ class MiqRequestTask < ActiveRecord::Base
       update_and_notify_parent(:state => "finished", :status => "Error", :message => message)
       return
     end
+  end
+
+  private
+
+  def validate_request_type
+    errors.add(:request_type, "should be #{request_class::REQUEST_TYPES.join(", ")}") unless request_class::REQUEST_TYPES.include?(request_type)
+  end
+
+  def validate_state
+    errors.add(:state, "should be #{valid_states.join(", ")}") unless valid_states.include?(state)
+  end
+
+  def valid_states
+    %w(pending finished) + request_class::ACTIVE_STATES
   end
 end

--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -2,13 +2,6 @@ require 'enumerator'
 require 'miq-hash_struct'
 
 class MiqRequestWorkflow
-  SUBCLASSES = %w(
-    MiqHostProvisionWorkflow
-    MiqProvisionWorkflow
-    ResourceActionWorkflow
-    VmMigrateWorkflow
-  )
-
   attr_accessor :dialogs, :requester, :values, :last_vm_id
 
   def self.automate_dialog_request
@@ -1523,7 +1516,3 @@ class MiqRequestWorkflow
     end
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqRequestWorkflow::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/miq_template.rb
+++ b/vmdb/app/models/miq_template.rb
@@ -1,9 +1,4 @@
 class MiqTemplate < VmOrTemplate
-  SUBCLASSES = %w{
-    TemplateInfra
-    TemplateCloud
-  }
-
   default_scope { where(:template => true) }
 
   include_concern 'Operations'
@@ -44,7 +39,3 @@ class MiqTemplate < VmOrTemplate
 
   def active?; false; end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-MiqTemplate::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/provider.rb
+++ b/vmdb/app/models/provider.rb
@@ -5,10 +5,6 @@ class Provider < ActiveRecord::Base
   include AsyncDeleteMixin
   include EmsRefresh::Manager
 
-  SUBCLASSES = %w(
-    ProviderForeman
-  )
-
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
 
@@ -58,7 +54,3 @@ class Provider < ActiveRecord::Base
     end
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Provider::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/provisioning_manager.rb
+++ b/vmdb/app/models/provisioning_manager.rb
@@ -14,7 +14,3 @@ class ProvisioningManager < ExtManagementSystem
     false
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-VMDB::Util.eager_load_subclasses('ProvisioningManager')

--- a/vmdb/app/models/service_reconfigure_task.rb
+++ b/vmdb/app/models/service_reconfigure_task.rb
@@ -1,14 +1,9 @@
 class ServiceReconfigureTask < MiqRequestTask
   include ReportableMixin
 
-  validates_inclusion_of :request_type,
-                         :in      => request_class::REQUEST_TYPES,
-                         :message => "should be #{request_class::REQUEST_TYPES.join(", ")}"
-  validates_inclusion_of :state,
-                         :in      => %w(pending finished) + request_class::ACTIVE_STATES,
-                         :message => "should be pending, #{request_class::ACTIVE_STATES.join(", ")} or finished"
+  validate :validate_request_type, :validate_state
 
-  AUTOMATE_DRIVES  = true
+  AUTOMATE_DRIVES = true
 
   def self.base_model
     ServiceReconfigureTask

--- a/vmdb/app/models/service_template_provision_task.rb
+++ b/vmdb/app/models/service_template_provision_task.rb
@@ -1,12 +1,11 @@
 class ServiceTemplateProvisionTask < MiqRequestTask
   include ReportableMixin
 
-  validates_inclusion_of :request_type, :in => self.request_class::REQUEST_TYPES,                          :message => "should be #{self.request_class::REQUEST_TYPES.join(", ")}"
-  validates_inclusion_of :state,        :in => %w{ pending provisioned finished } + self.request_class::ACTIVE_STATES, :message => "should be pending, #{self.request_class::ACTIVE_STATES.join(", ")} or finished"
+  validate :validate_request_type, :validate_state
 
   virtual_belongs_to :service_resource, :class_name => "ServiceResource"
 
-  AUTOMATE_DRIVES  = true
+  AUTOMATE_DRIVES = true
 
   def self.base_model
     ServiceTemplateProvisionTask
@@ -201,4 +200,9 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     service.raise_provisioned_event unless service.nil?
   end
 
+  private
+
+  def valid_states
+    super + ["provisioned"]
+  end
 end

--- a/vmdb/app/models/snia_file_share.rb
+++ b/vmdb/app/models/snia_file_share.rb
@@ -35,8 +35,6 @@ class SniaFileShare < MiqCimInstance
   virtual_has_many  :hosts,           :class_name => 'Host'
   virtual_belongs_to  :storage_system,      :class_name => 'CimComputerSystem'
 
-  MODEL_SUBCLASSES  = [ 'OntapFileShare' ]
-
   FileShareToBaseSe       = CimProfiles.file_share_to_base_storage_extent
   FileShareToVirtualDisk      = CimProfiles.file_share_to_virtual_disk
   FileShareToVm         = CimProfiles.file_share_to_virtual_machine
@@ -387,8 +385,3 @@ class SniaFileShare < MiqCimInstance
   end
 
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-# conditions that are generated on queries against this class.
-SniaFileShare::MODEL_SUBCLASSES.each { |sc| require_dependency File.join(Rails.root, 'app', 'models', sc.underscore + '.rb')}
-

--- a/vmdb/app/models/template_cloud.rb
+++ b/vmdb/app/models/template_cloud.rb
@@ -1,9 +1,4 @@
 class TemplateCloud < MiqTemplate
-  SUBCLASSES = %w{
-    TemplateAmazon
-    TemplateOpenstack
-  }
-
   default_value_for :cloud, true
 
   private
@@ -12,7 +7,3 @@ class TemplateCloud < MiqTemplate
     MiqEvent.raise_evm_event(self, "vm_template", :vm => self)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-TemplateCloud::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/template_infra.rb
+++ b/vmdb/app/models/template_infra.rb
@@ -1,11 +1,4 @@
 class TemplateInfra < MiqTemplate
-  SUBCLASSES = %w{
-    TemplateMicrosoft
-    TemplateRedhat
-    TemplateVmware
-    TemplateXen
-  }
-
   default_value_for :cloud, false
 
   def self.eligible_for_provisioning
@@ -18,7 +11,3 @@ class TemplateInfra < MiqTemplate
     MiqEvent.raise_evm_event(self, "vm_template", :vm => self, :host => host)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-TemplateInfra::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/vm.rb
+++ b/vmdb/app/models/vm.rb
@@ -1,9 +1,4 @@
 class Vm < VmOrTemplate
-  SUBCLASSES = %w{
-    VmInfra
-    VmCloud
-  }
-
   default_scope { where(:template => false) }
 
   include_concern 'Operations'
@@ -81,7 +76,3 @@ class Vm < VmOrTemplate
   end
 
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-Vm::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/vm_cloud.rb
+++ b/vmdb/app/models/vm_cloud.rb
@@ -1,9 +1,4 @@
 class VmCloud < Vm
-  SUBCLASSES = %w{
-    VmAmazon
-    VmOpenstack
-  }
-
   belongs_to :availability_zone
   belongs_to :flavor
   belongs_to :cloud_network
@@ -38,7 +33,3 @@ class VmCloud < Vm
     MiqEvent.raise_evm_event(self, "vm_create", :vm => self)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-VmCloud::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/vm_infra.rb
+++ b/vmdb/app/models/vm_infra.rb
@@ -1,11 +1,4 @@
 class VmInfra < Vm
-  SUBCLASSES = %w{
-    VmMicrosoft
-    VmRedhat
-    VmVmware
-    VmXen
-  }
-
   default_value_for :cloud, false
 
   # Show certain non-generic charts
@@ -55,7 +48,3 @@ class VmInfra < Vm
     MiqEvent.raise_evm_event(self, "vm_create", :vm => self, :host => host)
   end
 end
-
-# Preload any subclasses of this class, so that they will be part of the
-#   conditions that are generated on queries against this class.
-VmInfra::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/vm_migrate_task.rb
+++ b/vmdb/app/models/vm_migrate_task.rb
@@ -3,10 +3,9 @@ class VmMigrateTask < MiqRequestTask
 
   include ReportableMixin
 
-  validates_inclusion_of :request_type, :in => self.request_class::REQUEST_TYPES,                          :message => "should be #{self.request_class::REQUEST_TYPES.join(", ")}"
-  validates_inclusion_of :state,        :in => %w{ pending finished } + self.request_class::ACTIVE_STATES, :message => "should be pending, #{self.request_class::ACTIVE_STATES.join(", ")} or finished"
+  validate :validate_request_type, :validate_state
 
-  AUTOMATE_DRIVES  = true
+  AUTOMATE_DRIVES = true
 
   def self.base_model
     VmMigrateTask

--- a/vmdb/app/models/vm_reconfigure_task.rb
+++ b/vmdb/app/models/vm_reconfigure_task.rb
@@ -3,10 +3,9 @@ class VmReconfigureTask < MiqRequestTask
 
   include ReportableMixin
 
-  validates_inclusion_of :request_type, :in => self.request_class::REQUEST_TYPES,                          :message => "should be #{self.request_class::REQUEST_TYPES.join(", ")}"
-  validates_inclusion_of :state,        :in => %w{ pending finished } + self.request_class::ACTIVE_STATES, :message => "should be pending, #{self.request_class::ACTIVE_STATES.join(", ")} or finished"
+  validate :validate_request_type, :validate_state
 
-  AUTOMATE_DRIVES  = false
+  AUTOMATE_DRIVES = false
 
   def self.base_model
     VmReconfigureTask

--- a/vmdb/lib/extensions/as_const_missing_with_sti.rb
+++ b/vmdb/lib/extensions/as_const_missing_with_sti.rb
@@ -1,0 +1,90 @@
+module AsConstMissingWithSti
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :const_missing, :sti
+  end
+
+  # Rails +const_missing+ only loads the requested constant and any of its
+  # parents. However, when using STI and having class hierarchies that are
+  # several levels deep, ActiveRecord requires that all descendants of a
+  # model are loaded to generate the correct query. Additionally, the
+  # methods +subclasses+ and +descendants+ require that all descendants of
+  # a model are loaded in order to work as expected.
+  #
+  # Example:
+  #   Given a class hierarchy of:
+  #
+  #     class Aaa < ActiveRecord::Base; end
+  #     class Bbb < Aaa; end
+  #     class Ccc < Bbb; end
+  #
+  #   Without this change, the following queries will be generated:
+  #
+  #     Aaa.count
+  #     # SELECT COUNT(*) FROM "aaas"
+  #     Bbb.count
+  #     # SELECT COUNT(*) FROM "aaas" WHERE "aaas"."type" IN ('Bbb')
+  #     Ccc.count
+  #     # SELECT COUNT(*) FROM "aaas" WHERE "aaas"."type" IN ('Ccc')
+  #
+  #   The 'Bbb' query is incorrect since +const_missing+ does not load the
+  #   child objects.
+  #   With this change, the following queries will be generated:
+  #
+  #     Aaa.count
+  #     # SELECT COUNT(*) FROM "aaas"
+  #     Bbb.count
+  #     # SELECT COUNT(*) FROM "aaas" WHERE "aaas"."type" IN ('Bbb', 'Ccc')
+  #     Ccc.count
+  #     # SELECT COUNT(*) FROM "aaas" WHERE "aaas"."type" IN ('Ccc')
+  #
+  def const_missing_with_sti(constant)
+    const_missing_without_sti(constant).tap do
+      AsConstMissingWithSti.class_inheritance_relationships[constant.to_s].each { |c| AsConstMissingWithSti.load_subclass(c) }
+    end
+  end
+
+  private
+
+  ClassInheritanceRelationship = Struct.new(:subclass, :file_path)
+
+  def self.class_inheritance_relationships
+    @class_inheritance_relationships ||= begin
+      relats = Hash.new { |h, k| h[k] = [] }
+      Dir.glob(Rails.root.join("app/models/*.rb")).each_with_object(relats) do |file, h|
+        File.foreach(file) do |l|
+          match = l.match(/^\s*class\s+(\w+)\s*<\s*(\w+)/)
+          next unless match
+
+          child, parent = match.values_at(1, 2)
+          h[parent].push(ClassInheritanceRelationship.new(child, File.expand_path(file)))
+        end
+      end
+    end
+  end
+
+  def self.clear_class_inheritance_relationships
+    @class_inheritance_relationships = nil
+  end
+
+  def self.load_subclass(relat)
+    Object.const_get(relat.subclass) unless ActiveSupport::Dependencies.loaded.include?(relat.file_path.sub(/\.rb\z/, ''))
+  end
+end
+
+module AsDependenciesClearWithSti
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :clear, :sti
+  end
+
+  def clear_with_sti
+    AsConstMissingWithSti.clear_class_inheritance_relationships
+    clear_without_sti
+  end
+end
+
+ActiveSupport::Dependencies::ModuleConstMissing.send(:include, AsConstMissingWithSti)
+ActiveSupport::Dependencies.send(:include, AsDependenciesClearWithSti)

--- a/vmdb/lib/report_formatter/timeline.rb
+++ b/vmdb/lib/report_formatter/timeline.rb
@@ -105,7 +105,7 @@ module ReportFormatter
           ems_cloud = false
           if rec[:ems_id] && ExtManagementSystem.exists?(rec[:ems_id])
             ems = ExtManagementSystem.find(rec[:ems_id])
-            ems_cloud =  true if EmsCloud::SUBCLASSES.include?(ems.class.name)
+            ems_cloud =  true if ems.kind_of?(EmsCloud)
           end
           if rec[:vm_name] && !ems_cloud             # Create the title using VM name
             e_title = rec[:vm_name]

--- a/vmdb/lib/vmdb/util.rb
+++ b/vmdb/lib/vmdb/util.rb
@@ -1,18 +1,5 @@
 module VMDB
   module Util
-    # load all subclasses recursively
-    def self.eager_load_subclasses(klass)
-      ActiveSupport::Dependencies.autoload_paths.each do |root|
-        Dir.glob(File.join(root, "#{klass.underscore}_*.rb")).sort.each do |file|
-          name = File.basename(file, '.*')
-          if name =~ /^#{klass.underscore}_[^_]*$/  # filter out sub-subclasses
-            require_dependency file
-          end
-        end
-        const_get(klass).subclasses.each { |k| eager_load_subclasses(k.name) }
-      end
-    end
-
     def self.http_proxy_uri
       proxy = VMDB::Config.new("vmdb").config[:http_proxy] || {}
       return nil unless proxy[:host]

--- a/vmdb/spec/controllers/application_controller/tags_spec.rb
+++ b/vmdb/spec/controllers/application_controller/tags_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ApplicationController  do
   describe "#get_tagdata" do
-    let(:record) { Host.new; instance_double("Host") }
+    let(:record) { active_record_instance_double("Host") }
 
     before do
       session[:userid] = "testuser"

--- a/vmdb/spec/controllers/dashboard_controller_spec.rb
+++ b/vmdb/spec/controllers/dashboard_controller_spec.rb
@@ -20,7 +20,7 @@ describe DashboardController do
   end
 
   context "#validate_user" do
-    let(:server) { instance_double("MiqServer", :logon_status => :ready) }
+    let(:server) { active_record_instance_double("MiqServer", :logon_status => :ready) }
 
     before do
       MiqServer.stub(:my_server).with(true).and_return(server)

--- a/vmdb/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -257,7 +257,7 @@ describe MiqAeCustomizationController do
   describe "#upload_import_file" do
     include_context "valid session"
 
-    let(:dialog_import_service) { instance_double("DialogImportService") }
+    let(:dialog_import_service) { auto_loaded_instance_double("DialogImportService") }
 
     before do
       bypass_rescue
@@ -371,7 +371,7 @@ describe MiqAeCustomizationController do
   describe "#import_service_dialogs" do
     include_context "valid session"
 
-    let(:dialog_import_service) { instance_double("DialogImportService") }
+    let(:dialog_import_service) { auto_loaded_instance_double("DialogImportService") }
     let(:params) { {:import_file_upload_id => "123", :dialogs_to_import => ["potato"]} }
 
     before do
@@ -388,9 +388,7 @@ describe MiqAeCustomizationController do
     end
 
     context "when the import file upload exists" do
-      let(:import_file_upload) do
-        instance_double("ImportFileUpload")
-      end
+      let(:import_file_upload) { active_record_instance_double("ImportFileUpload") }
 
       before do
         dialog_import_service.stub(:import_service_dialogs)
@@ -445,7 +443,7 @@ describe MiqAeCustomizationController do
     include_context "valid session"
 
     let(:params) { {:import_file_upload_id => "123"} }
-    let(:dialog_import_service) { instance_double("DialogImportService") }
+    let(:dialog_import_service) { auto_loaded_instance_double("DialogImportService") }
 
     before do
       bypass_rescue
@@ -490,7 +488,7 @@ describe MiqAeCustomizationController do
   describe "#export_service_dialogs" do
     include_context "valid session"
 
-    let(:dialog_yaml_serializer) { instance_double("DialogYamlSerializer") }
+    let(:dialog_yaml_serializer) { auto_loaded_instance_double("DialogYamlSerializer") }
     let(:dialogs) { [active_record_instance_double("Dialog")] }
     let(:params) { {:service_dialogs => service_dialogs} }
 

--- a/vmdb/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -24,7 +24,7 @@ describe MiqAeToolsController do
     include_context "valid session"
 
     let(:params) { {:import_file_upload_id => "123"} }
-    let(:automate_import_service) { instance_double("AutomateImportService") }
+    let(:automate_import_service) { auto_loaded_instance_double("AutomateImportService") }
 
     before do
       bypass_rescue
@@ -51,7 +51,7 @@ describe MiqAeToolsController do
   describe "#automate_json" do
     include_context "valid session"
 
-    let(:automate_import_json_serializer) { instance_double("AutomateImportJsonSerializer") }
+    let(:automate_import_json_serializer) { auto_loaded_instance_double("AutomateImportJsonSerializer") }
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload") }
     let(:params) { {:import_file_upload_id => "123"} }
 
@@ -91,7 +91,7 @@ describe MiqAeToolsController do
     end
 
     context "when the selected namespaces is not nil" do
-      let(:automate_import_service) { instance_double("AutomateImportService") }
+      let(:automate_import_service) { auto_loaded_instance_double("AutomateImportService") }
       let(:selected_namespaces) { ["datastore/namespace", "datastore/namespace/test"] }
 
       before do
@@ -214,7 +214,7 @@ Methods updated/added: 10
     end
 
     context "when an upload file is given" do
-      let(:automate_import_service) { instance_double("AutomateImportService") }
+      let(:automate_import_service) { auto_loaded_instance_double("AutomateImportService") }
       let(:params) { {:upload => {:file => upload_file}} }
       let(:upload_file) { fixture_file_upload(Rails.root.join("spec/fixtures/files/import_automate.yml"), "text/yml") }
 

--- a/vmdb/spec/controllers/miq_policy_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_policy_controller_spec.rb
@@ -9,7 +9,7 @@ describe MiqPolicyController do
     include_context "valid session"
 
     let(:params) { {:import_file_upload_id => 123, :commit => commit} }
-    let(:miq_policy_import_service) { instance_double("MiqPolicyImportService") }
+    let(:miq_policy_import_service) { auto_loaded_instance_double("MiqPolicyImportService") }
 
     before do
       MiqPolicyImportService.stub(:new).and_return(miq_policy_import_service)
@@ -79,7 +79,7 @@ describe MiqPolicyController do
             fixture_file_upload(Rails.root.join("spec/fixtures/files/import_policies.yml"), "text/yml")
           end
 
-          let(:miq_policy_import_service) { instance_double("MiqPolicyImportService") }
+          let(:miq_policy_import_service) { auto_loaded_instance_double("MiqPolicyImportService") }
 
           before do
             MiqPolicyImportService.stub(:new).and_return(miq_policy_import_service)

--- a/vmdb/spec/controllers/report_controller_spec.rb
+++ b/vmdb/spec/controllers/report_controller_spec.rb
@@ -914,7 +914,7 @@ describe ReportController do
   describe "#upload_widget_import_file" do
     include_context "valid session"
 
-    let(:widget_import_service) { instance_double("WidgetImportService") }
+    let(:widget_import_service) { auto_loaded_instance_double("WidgetImportService") }
 
     before do
       bypass_rescue
@@ -1050,7 +1050,7 @@ describe ReportController do
     include_context "valid session"
 
     let(:params) { {:import_file_upload_id => "123"} }
-    let(:widget_import_service) { instance_double("WidgetImportService") }
+    let(:widget_import_service) { auto_loaded_instance_double("WidgetImportService") }
 
     before do
       bypass_rescue
@@ -1077,7 +1077,7 @@ describe ReportController do
   describe "#import_widgets" do
     include_context "valid session"
 
-    let(:widget_import_service) { instance_double("WidgetImportService") }
+    let(:widget_import_service) { auto_loaded_instance_double("WidgetImportService") }
     let(:params) { {:import_file_upload_id => "123", :widgets_to_import => ["potato"]} }
 
     before do
@@ -1094,9 +1094,7 @@ describe ReportController do
     end
 
     context "when the import file upload exists" do
-      let(:import_file_upload) do
-        instance_double("ImportFileUpload")
-      end
+      let(:import_file_upload) { active_record_instance_double("ImportFileUpload") }
 
       before do
         widget_import_service.stub(:import_widgets)

--- a/vmdb/spec/lib/tasks/dialogs_spec.rb
+++ b/vmdb/spec/lib/tasks/dialogs_spec.rb
@@ -5,7 +5,7 @@ describe "dialogs" do
   let(:task_path) { "lib/tasks/dialogs" }
 
   describe "import", :type => :rake_task do
-    let(:dialog_import_helper) { instance_double("TaskHelpers::DialogImportHelper") }
+    let(:dialog_import_helper) { auto_loaded_instance_double("TaskHelpers::DialogImportHelper") }
 
     before do
       TaskHelpers::DialogImportHelper.stub(:new).and_return(dialog_import_helper)
@@ -22,7 +22,7 @@ describe "dialogs" do
   end
 
   describe "export", :type => :rake_task do
-    let(:dialog_exporter) { instance_double("TaskHelpers::DialogExporter") }
+    let(:dialog_exporter) { auto_loaded_instance_double("TaskHelpers::DialogExporter") }
 
     before do
       TaskHelpers::DialogExporter.stub(:new).and_return(dialog_exporter)

--- a/vmdb/spec/models/automate_import_json_serializer_spec.rb
+++ b/vmdb/spec/models/automate_import_json_serializer_spec.rb
@@ -1,11 +1,10 @@
 require "spec_helper"
-require "miq_ae_yaml_import_zipfs"
 
 describe AutomateImportJsonSerializer do
   let(:automate_import_json_serializer) { described_class.new }
 
   describe "#serialize" do
-    let(:miq_ae_yaml_import_zipfs) { instance_double("MiqAeYamlImportZipfs") }
+    let(:miq_ae_yaml_import_zipfs) { auto_loaded_instance_double("MiqAeYamlImportZipfs") }
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload") }
     let(:binary_blob) { active_record_instance_double("BinaryBlob") }
 

--- a/vmdb/spec/models/dialog_field_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_field_serializer_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe DialogFieldSerializer do
-  let(:resource_action_serializer) { instance_double("ResourceActionSerializer") }
+  let(:resource_action_serializer) { auto_loaded_instance_double("ResourceActionSerializer") }
   let(:dialog_field_serializer) { described_class.new(resource_action_serializer) }
 
   describe "#serialize" do

--- a/vmdb/spec/models/dialog_group_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_group_serializer_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
 
 describe DialogGroupSerializer do
-  let(:dialog_field_serializer) { instance_double("DialogFieldSerializer") }
-
+  let(:dialog_field_serializer) { auto_loaded_instance_double("DialogFieldSerializer") }
   let(:dialog_group_serializer) { described_class.new(dialog_field_serializer) }
 
   describe "#serialize" do

--- a/vmdb/spec/models/dialog_spec.rb
+++ b/vmdb/spec/models/dialog_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Dialog do
   describe ".seed" do
-    let(:dialog_import_service) { instance_double("DialogImportService") }
+    let(:dialog_import_service) { auto_loaded_instance_double("DialogImportService") }
     let(:test_file_path) { Rails.root.join("spec/fixtures/files/dialogs") }
     let(:all_yaml_files) { test_file_path.join("{,*/**/}*.{yaml,yml}") }
 

--- a/vmdb/spec/models/dialog_tab_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_tab_serializer_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
 
 describe DialogTabSerializer do
-  let(:dialog_group_serializer) { instance_double("DialogGroupSerializer") }
-
+  let(:dialog_group_serializer) { auto_loaded_instance_double("DialogGroupSerializer") }
   let(:dialog_tab_serializer) { described_class.new(dialog_group_serializer) }
 
   describe "#serialize" do

--- a/vmdb/spec/models/dialog_yaml_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_yaml_serializer_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
-require "dialog_tab_serializer"
 
 describe DialogYamlSerializer do
-  let(:dialog_tab_serializer) { instance_double("DialogTabSerializer") }
-
+  let(:dialog_tab_serializer) { auto_loaded_instance_double("DialogTabSerializer") }
   let(:dialog_yaml_serializer) { described_class.new(dialog_tab_serializer) }
 
   describe "#serialize" do

--- a/vmdb/spec/models/dynamic_dialog_field_value_processor_spec.rb
+++ b/vmdb/spec/models/dynamic_dialog_field_value_processor_spec.rb
@@ -27,7 +27,7 @@ describe DynamicDialogFieldValueProcessor do
     end
 
     context "when there is no error delivering to automate from dialog field" do
-      let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspaceRuntime") }
+      let(:workspace) { auto_loaded_instance_double("MiqAeEngine::MiqAeWorkspaceRuntime") }
       let(:workspace_attributes) do
         double(
           :attributes => {

--- a/vmdb/spec/models/miq_ae_datastore_spec.rb
+++ b/vmdb/spec/models/miq_ae_datastore_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'miq_ae_yaml_import_zipfs'
 include AutomationSpecHelper
 
 describe MiqAeDatastore do
@@ -113,7 +112,7 @@ describe MiqAeDatastore do
 
   describe "restore" do
 
-    let(:miq_ae_yaml_import_zipfs)  { instance_double("MiqAeYamlImportZipfs") }
+    let(:miq_ae_yaml_import_zipfs)  { auto_loaded_instance_double("MiqAeYamlImportZipfs") }
     let(:dummy_zipfile) { File.expand_path(File.join(File.dirname(__FILE__), "/miq_ae_datastore/data/dummy.zip")) }
 
     before do

--- a/vmdb/spec/models/miq_provision_spec.rb
+++ b/vmdb/spec/models/miq_provision_spec.rb
@@ -147,7 +147,7 @@ describe MiqProvision do
     it "workflow should be called with placement_auto = false and skip_dialog_load = true" do
       prov     = FactoryGirl.build(:miq_provision)
       host     = active_record_instance_double('Host', :id => 1, :name => 'my_host')
-      workflow = instance_double("MiqProvisionWorkflow", :allowed_hosts => [host])
+      workflow = auto_loaded_instance_double("MiqProvisionWorkflow", :allowed_hosts => [host])
 
       prov.should_receive(:eligible_resource_lookup).and_return(host)
 

--- a/vmdb/spec/models/miq_widget_spec.rb
+++ b/vmdb/spec/models/miq_widget_spec.rb
@@ -464,7 +464,7 @@ describe MiqWidget do
 
   context "#generate_content_options" do
     let(:widget) { described_class.new }
-    let(:content_option_generator) { instance_double("MiqWidget::ContentOptionGenerator") }
+    let(:content_option_generator) { auto_loaded_instance_double("MiqWidget::ContentOptionGenerator") }
     let(:group) { "group" }
     let(:users) { "users" }
 
@@ -480,7 +480,7 @@ describe MiqWidget do
 
   context "#generate_content" do
     let(:widget) { described_class.new(:miq_task => miq_task) }
-    let(:content_generator) { instance_double("MiqWidget::ContentGenerator") }
+    let(:content_generator) { auto_loaded_instance_double("MiqWidget::ContentGenerator") }
     let(:klass) { "klass" }
     let(:userids) { "userids" }
     let(:timezones) { "timezones" }

--- a/vmdb/spec/services/automate_import_service_spec.rb
+++ b/vmdb/spec/services/automate_import_service_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "miq_ae_yaml_import_zipfs"
 
 describe AutomateImportService do
   let(:automate_import_service) { described_class.new }
@@ -32,9 +31,7 @@ describe AutomateImportService do
   describe "#import_datastore" do
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload", :binary_blob => binary_blob) }
     let(:binary_blob) { active_record_instance_double("BinaryBlob", :binary => "binary") }
-
-    let(:miq_ae_import) { instance_double("MiqAeYamlImportZipfs", :import_stats => "import stats") }
-
+    let(:miq_ae_import) { auto_loaded_instance_double("MiqAeYamlImportZipfs", :import_stats => "import stats") }
     let(:removable_entry) { double(:name => "carrot/something_else/namespace.yaml") }
     let(:removable_class_entry) { double(:name => "carrot/something_else.class/class.yaml") }
 

--- a/vmdb/spec/services/dialog_import_service_spec.rb
+++ b/vmdb/spec/services/dialog_import_service_spec.rb
@@ -4,8 +4,8 @@ require "dialog_import_validator"
 
 describe DialogImportService do
   let(:dialog_import_service) { described_class.new(dialog_field_importer, dialog_import_validator) }
-  let(:dialog_field_importer) { instance_double("DialogFieldImporter") }
-  let(:dialog_import_validator) { instance_double("DialogImportValidator") }
+  let(:dialog_field_importer) { auto_loaded_instance_double("DialogFieldImporter") }
+  let(:dialog_import_validator) { auto_loaded_instance_double("DialogImportValidator") }
 
   shared_context "DialogImportService dialog setup" do
     let(:dialog_fields) do

--- a/vmdb/spec/services/privilege_checker_service_spec.rb
+++ b/vmdb/spec/services/privilege_checker_service_spec.rb
@@ -37,7 +37,7 @@ describe PrivilegeCheckerService do
 
       context "when the session has not timed out" do
         let(:last_trans_time) { Time.current }
-        let(:server) { instance_double("MiqServer", :logon_status => logon_status) }
+        let(:server) { active_record_instance_double("MiqServer", :logon_status => logon_status) }
 
         before do
           MiqServer.stub(:my_server).with(true).and_return(server)

--- a/vmdb/spec/services/widget_import_service_spec.rb
+++ b/vmdb/spec/services/widget_import_service_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe WidgetImportService do
   let(:widget_import_service) { described_class.new(widget_import_validator) }
-  let(:widget_import_validator) { instance_double("WidgetImportValidator") }
+  let(:widget_import_validator) { auto_loaded_instance_double("WidgetImportValidator") }
 
   before do
     MiqServer.stub(:my_server).and_return(active_record_instance_double("MiqServer", :zone_id => 1))

--- a/vmdb/spec/support/controller_spec_helper.rb
+++ b/vmdb/spec/support/controller_spec_helper.rb
@@ -45,8 +45,8 @@ module ControllerSpecHelper
   end
 
   shared_context "valid session" do
-    let(:privilege_checker_service) { instance_double("PrivilegeCheckerService", :valid_session?  => true) }
-    let(:request_referer_service)   { instance_double("RequestRefererService",   :allowed_access? => true) }
+    let(:privilege_checker_service) { auto_loaded_instance_double("PrivilegeCheckerService", :valid_session?  => true) }
+    let(:request_referer_service)   { auto_loaded_instance_double("RequestRefererService",   :allowed_access? => true) }
 
     before do
       controller.stub(:set_user_time_zone)

--- a/vmdb/spec/support/rspec_fire.rb
+++ b/vmdb/spec/support/rspec_fire.rb
@@ -6,6 +6,13 @@ module RSpec::Fire
     double_name.constantize.new
     instance_double(double_name, stubs)
   end
+
+  # rspec-fire does not detect classes that are autoloaded, so we load
+  # the constant using constantize leveraging +const_missing+
+  def auto_loaded_instance_double(double_name, stubs = {})
+    double_name.constantize
+    instance_double(double_name, stubs)
+  end
 end
 
 RSpec::Fire.configure do |config|

--- a/vmdb/spec/task_helpers/dialog_exporter_spec.rb
+++ b/vmdb/spec/task_helpers/dialog_exporter_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
 
 describe TaskHelpers::DialogExporter do
-  let(:dialog_yaml_serializer) { instance_double("DialogYamlSerializer") }
-
+  let(:dialog_yaml_serializer) { auto_loaded_instance_double("DialogYamlSerializer") }
   let(:dialog_exporter) { described_class.new(dialog_yaml_serializer) }
 
   describe "#export" do

--- a/vmdb/spec/task_helpers/dialog_import_helper_spec.rb
+++ b/vmdb/spec/task_helpers/dialog_import_helper_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe TaskHelpers::DialogImportHelper do
-  let(:dialog_import_service) { instance_double("DialogImportService") }
+  let(:dialog_import_service) { auto_loaded_instance_double("DialogImportService") }
   let(:dialog_import_helper) { described_class.new(dialog_import_service) }
 
   describe "#import" do


### PR DESCRIPTION
Moved all eager loading of STI trees to ActiveSupport::Dependencies.const_missing
We have a lot of problems with STI trees not being fully loaded since we do not eager load everything (especially in development mode). In addition that requires developers to remember to require all subclasses (and only direct subclasses) of their new models (and to do it properly). As you can see from the deletions, this is widely problematic. This is a hack on const_missing which is admittedly dirty, but at least puts all logic in one place. Hooking const_missing also allows Rails model reloading when changing files in dev mode to work properly (where an initializer approach would not work).

https://bugzilla.redhat.com/show_bug.cgi?id=1207259