### PR TITLE
ID's need a class qualifier MiqAeClass or MiqAeNamespace

### DIFF
--- a/vmdb/app/models/miq_ae_class.rb
+++ b/vmdb/app/models/miq_ae_class.rb
@@ -155,8 +155,7 @@ class MiqAeClass < ActiveRecord::Base
 
   def self.waypoint_ids_for_state_machines
     MiqAeClass.all.select(&:state_machine?).each_with_object([]) do |klass, ids|
-      ids << klass.id
-      next if ids.include?(klass.ae_namespace.id)
+      ids << "#{klass.class.name}::#{klass.id}"
       sub_namespaces(klass.ae_namespace, ids)
     end
   end
@@ -165,8 +164,8 @@ class MiqAeClass < ActiveRecord::Base
 
   def self.sub_namespaces(ns_obj, ids)
     loop do
-      break if ns_obj.nil? || ids.include?(ns_obj.id)
-      ids << ns_obj.id
+      break if ns_obj.nil? || ids.include?("#{ns_obj.class.name}::#{ns_obj.id}")
+      ids << "#{ns_obj.class.name}::#{ns_obj.id}"
       ns_obj = ns_obj.parent
     end
   end

--- a/vmdb/app/presenters/tree_builder_ae_class.rb
+++ b/vmdb/app/presenters/tree_builder_ae_class.rb
@@ -44,6 +44,8 @@ class TreeBuilderAeClass  < TreeBuilder
 
   def filter_ae_objects(objects)
     return objects unless @sb[:cached_waypoint_ids]
-    objects.select { |obj| @sb[:cached_waypoint_ids].include?(obj.id) }
+    klass_name = objects.first.class.name
+    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
+    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
   end
 end

--- a/vmdb/spec/models/miq_ae_class_spec.rb
+++ b/vmdb/spec/models/miq_ae_class_spec.rb
@@ -320,8 +320,8 @@ describe MiqAeClass do
       create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
       ns_fqnames = %w(FRED FRED/A FRED/A/B FRED/A/B/C FREDDY FREDDY/C FREDDY/C/D FREDDY/C/D/E)
       class_fqnames = %w(/FRED/A/B/C/CLASS1 /FREDDY/C/D/E/CLASS2)
-      ids = ns_fqnames.collect { |ns| MiqAeNamespace.find_by_fqname(ns, false).id }
-      ids += class_fqnames.collect { |cls| MiqAeClass.find_by_fqname(cls).id }
+      ids = ns_fqnames.collect { |ns| "MiqAeNamespace::#{MiqAeNamespace.find_by_fqname(ns, false).id}" }
+      ids += class_fqnames.collect { |cls| "MiqAeClass::#{MiqAeClass.find_by_fqname(cls).id}" }
       MiqAeClass.waypoint_ids_for_state_machines.should match_array(ids)
     end
 


### PR DESCRIPTION
Fixes #2542

When collecting ID's from 2 of the automate tables
MiqAeNamespace and MiqAeClass, we might get the same ids.
Prefix'ed the classname to the ids as a discriminator.