### PR TITLE
Convert the Database Diagnostics form to Angular

### DIFF
--- a/vmdb/app/assets/javascripts/application.js
+++ b/vmdb/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 //= require jquery_overrides
 //= require miq_angular_application
 //= require services/miq_service
+//= require services/miq_db_backup_service
 //= require directives/miqrequired
 //= require directives/checkchange
 //= require directives/verifypasswd
@@ -12,6 +13,7 @@
 //= require controllers/provider_foreman/provider_foreman_form_controller
 //= require controllers/repository/repository_form_controller
 //= require controllers/schedule/schedule_form_controller
+//= require controllers/ops/diagnostics_database_form_controller
 //= require miq_application
 //= require miq_dynatree_replacement
 //= require dialog_import_export

--- a/vmdb/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/vmdb/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -1,0 +1,90 @@
+miqAngularApplication.controller('diagnosticsDatabaseFormController', ['$http', '$scope', '$attrs', 'miqService', 'miqDBBackupService', function($http, $scope, $attrs, miqService, miqDBBackupService) {
+    var init = function() {
+
+        $scope.diagnosticsDatabaseModel = {
+          action_typ: 'db_backup',
+          backup_schedule_type: '',
+          depot_name: '',
+          uri: '',
+          uri_prefix: '',
+          log_protocol: '',
+          log_userid: '',
+          log_password: '',
+          log_verify: ''
+        };
+        $scope.afterGet = true;
+        $scope.modelCopy = angular.copy( $scope.diagnosticsDatabaseModel );
+        $scope.dbBackupFormFieldChangedUrl = $attrs.dbBackupFormFieldChangedUrl;
+        $scope.submitUrl = $attrs.submitUrl;
+
+        miqAngularApplication.$scope = $scope;
+
+        $scope.$watch("diagnosticsDatabaseModel.depot_name", function() {
+            $scope.form = $scope.angularForm;
+            $scope.miqService = miqService;
+            $scope.miqDBBackupService = miqDBBackupService;
+        });
+    };
+
+    $scope.backupScheduleTypeChanged = function() {
+      if($scope.diagnosticsDatabaseModel.backup_schedule_type == '') {
+        $scope.diagnosticsDatabaseModel.depot_name = '';
+        $scope.diagnosticsDatabaseModel.uri = '';
+        $scope.diagnosticsDatabaseModel.uri_prefix = '';
+        $scope.diagnosticsDatabaseModel.log_userid = '';
+        $scope.diagnosticsDatabaseModel.log_password = '';
+        $scope.diagnosticsDatabaseModel.log_verify = '';
+        $scope.diagnosticsDatabaseModel.log_protocol = '';
+        return;
+      }
+
+      miqService.sparkleOn();
+
+      url = $scope.dbBackupFormFieldChangedUrl;
+      $http.post(url + $scope.diagnosticsDatabaseModel.backup_schedule_type).success(function(data) {
+        $scope.diagnosticsDatabaseModel.depot_name = data.depot_name;
+        $scope.diagnosticsDatabaseModel.uri = data.uri;
+        $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
+        $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
+        $scope.diagnosticsDatabaseModel.log_password = data.log_password;
+        $scope.diagnosticsDatabaseModel.log_verify = data.log_verify;
+
+        if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
+          $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
+        else
+          $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
+
+        $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
+
+        miqService.sparkleOff();
+      });
+    };
+
+    $scope.showSubmitButton = function() {
+      return true;
+    }
+
+    $scope.isBasicInfoValid = function() {
+        if($scope.angularForm.depot_name.$valid &&
+            $scope.angularForm.uri.$valid &&
+            $scope.angularForm.log_userid.$valid &&
+            $scope.angularForm.log_password.$valid &&
+            $scope.angularForm.log_verify.$valid)
+            return true;
+        else
+            return false;
+    };
+
+    $scope.submitButtonClicked = function(confirm_msg) {
+      if (confirm(confirm_msg)) {
+        miqService.sparkleOn();
+        url = $scope.submitUrl;
+        miqService.miqAjaxButton(url, true);
+      }
+    };
+
+    init();
+}]);
+
+
+

--- a/vmdb/app/assets/javascripts/services/miq_db_backup_service.js
+++ b/vmdb/app/assets/javascripts/services/miq_db_backup_service.js
@@ -1,0 +1,45 @@
+miqAngularApplication.service('miqDBBackupService', function() {
+
+  this.logProtocolNotSelected = function(model) {
+    if(model.log_protocol == '')
+      return true;
+    else
+      return false;
+    };
+
+  this.logProtocolSelected = function(model) {
+    if(model.log_protocol != '')
+      return true;
+    else
+      return false;
+  };
+
+  this.logProtocolChanged = function(model) {
+    if(model.log_protocol == 'Network File System')
+      model.uri_prefix = 'nfs';
+    else
+      model.uri_prefix = 'smb';
+  };
+
+  this.sambaBackup = function(model) {
+    if(model.log_protocol == 'Samba')
+      return true;
+    else
+      return false;
+    };
+
+  this.dbRequired = function(model, value) {
+    return this.logProtocolSelected(model) &&
+           (this.isModelValueNil(value));
+  };
+
+  this.sambaRequired = function(model, value) {
+    return this.sambaBackup(model) &&
+           (this.isModelValueNil(value));
+  };
+
+  this.isModelValueNil = function(value) {
+    return value == null || value == '';
+  };
+
+});

--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -177,7 +177,7 @@ class OpsController < ApplicationController
     @temp[:x_edit_buttons_locals] = set_form_locals if @in_a_form
     @collapse_c_cell = @in_a_form || @pages ? false : true
     @sb[:center_tb_filename] = center_toolbar_filename
-    session[:changed] = @edit[:new] != @edit[:current].config
+    session[:changed] = @edit[:new] != @edit[:current].try(:config) if @edit
     render :layout => "explorer"
   end
 

--- a/vmdb/app/views/ops/_diagnostics_database_tab.html.haml
+++ b/vmdb/app/views/ops/_diagnostics_database_tab.html.haml
@@ -1,82 +1,118 @@
-- if @sb[:active_tab] == "diagnostics_database"
-  -# created div with different name so database validation flash message can be shown in it's own box
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "database"}
+- @angularForm = true
 
-  %h3= _("Basic Info")
-  %table.style1
-    %tr
-      %td.key= _("Type")
-      %td.wide= h(@database[:display_name])
-    %tr
-      %td.key= _("Hostname")
-      %td.wide= h(@database[:host])
-    %tr
-      %td.key= _("Database Name")
-      %td.wide= h(@database[:database])
-    %tr
-      %td.key= _("Username")
-      %td.wide= h(@database[:username])
+%form#form_div(name                                  = "angularForm"
+               ng-controller                         = "diagnosticsDatabaseFormController"
+               ng-show                               = "afterGet"
+               data-db-backup-form-field-changed-url = "/#{controller_name}/db_backup_form_field_changed/"
+               data-submit-url                       = "/#{controller_name}/db_backup/")
+  - if @sb[:active_tab] == "diagnostics_database"
+    -# created div with different name so database validation flash message can be shown in it's own box
+    = render :partial => "layouts/flash_msg", :locals => {:div_num => "database"}
 
-  - if DatabaseBackup.backup_supported?
-    - url = url_for(:action => 'db_backup_form_field_changed')
-    %hr/
-    %h3= _("Run a Database Backup Now")
-    %fieldset
-      %h3= _("Backup Schedules")
-      %table.style1
-        %tr
-          %td.key= _("Fetch settings from a schedule")
-          %td.wide
-            - if @edit[:backup_schedules].length < 1
-              = _("No Backup Schedules are defined")
-            - else
-              - default_option = [_("<Choose>"), nil]
-              - schedules_ary = Array(@edit[:backup_schedules].invert)
-              - schedules_ary.sort_by! { |name, _id| name }
-              - options = options_for_select([default_option] + schedules_ary, @edit[:selected_backup_schedule])
-
-              = select_tag('backup_schedule', options, "data-miq_observe" => {:url => url}.to_json)
-
-    = render :partial => "layouts/edit_log_depot_settings",        |
-      :locals       => {:action => "db_backup_form_field_changed", |
-      :validate_url => "log_depot_validate",                       |
-      :div_num      => "validate"}                                 |
-
-    %table{:width => "100%"}
-      %tr
-        %td{:align => "right"}
-          #submit_on{:style => "display: none"}
-            - caption = _("Run a Database Backup Now")
-            - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
-
-            = link_to(submit, {:action => 'db_backup'},                                          |
-              "data-miq_sparkle_on" => true,                                                     |
-              :confirm              => _("Are you sure you want to Run a Database Backup Now?"), |
-              :remote               => true,                                                     |
-              :title                => caption)                                                  |
-
-          #submit_off
-            - caption = _("No Backup Schedules are defined")
-            = button_tag(_("Submit"),                   |
-              :class => "btn btn-primary btn-disabled", |
-              :alt   => caption,                        |
-              :title => caption)                        |
-
-  - if DatabaseBackup.gc_supported?
-    %hr/
-    %h3= _("Run Database Garbage Collection Now")
+    %h3= _("Basic Info")
     %table.style1
       %tr
-        %td= _("Press submit to start the Database Vacuum process")
-    %table{:width => "100%"}
+        %td.key= _("Type")
+        %td.wide= h(@database[:display_name])
       %tr
-        %td{:align => "right"}
-          #gc_submit_on
-            - caption = _("Run Database Garbage Collection Now")
-            - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
+        %td.key= _("Hostname")
+        %td.wide= h(@database[:host])
+      %tr
+        %td.key= _("Database Name")
+        %td.wide= h(@database[:database])
+      %tr
+        %td.key= _("Username")
+        %td.wide= h(@database[:username])
 
-            = link_to(submit, {:action => 'db_gc_collection'},                                             |
-              "data-miq_sparkle_on" => true,                                                               |
-              :confirm              => _("Are you sure you want to Run Database Garbage Collection Now?"), |
-              :remote               => true,                                                               |
-              :title                => caption)                                                            |
+    - if DatabaseBackup.backup_supported?
+      %hr/
+      %h3= _("Run a Database Backup Now")
+      %fieldset
+        %h3= _("Backup Schedules")
+        %table.style1
+          %tr
+            %td.key= _("Fetch settings from a schedule")
+            %td.wide
+              - if @backup_schedules.length < 1
+                = _("No Backup Schedules are defined")
+              - else
+                - default_option = [_("<Choose>"), nil]
+                - schedules_ary = Array(@backup_schedules.invert)
+                - schedules_ary.sort_by! { |name, _id| name }
+                - options = options_for_select([default_option] + schedules_ary)
+
+                = select_tag('backup_schedule_type',
+                             options,
+                             "ng-model"    => "diagnosticsDatabaseModel.backup_schedule_type",
+                             "ng-change"   => "backupScheduleTypeChanged()",
+                             "checkchange" => "log_protocol,depot_name,uri,log_userid,log_password,log_verify")
+
+
+      %fieldset
+        %h3
+          = _("Database Backup Settings")
+        %table.style1
+          %tr
+            %td.key
+              = _("Type")
+            %td.wide
+              - default_option = [_("<No Depot>"), nil]
+              = select_tag('log_protocol', options_for_select([default_option] + @database_backup_options_for_select),
+                          "ng-model"       => "diagnosticsDatabaseModel.log_protocol",
+                          "ng-change"      => "miqDBBackupService.logProtocolChanged(diagnosticsDatabaseModel)",
+                          "ng-required"    => "miqDBBackupService.logProtocolNotSelected(diagnosticsDatabaseModel)",
+                          "checkchange"    => "")
+          = render :partial => "layouts/angular/edit_log_depot_settings_angular",
+                         :locals  => {:ng_show             => "miqDBBackupService.logProtocolSelected(diagnosticsDatabaseModel)",
+                                      :ng_reqd_depot_name  => "miqDBBackupService.dbRequired(diagnosticsDatabaseModel, diagnosticsDatabaseModel.depot_name)",
+                                      :ng_model_depot_name => "diagnosticsDatabaseModel.depot_name",
+                                      :ng_reqd_uri         => "miqDBBackupService.dbRequired(diagnosticsDatabaseModel, diagnosticsDatabaseModel.uri)",
+                                      :ng_model_uri        => "diagnosticsDatabaseModel.uri",
+                                      :ng_model_uri_prefix => "diagnosticsDatabaseModel.uri_prefix",
+                                      :uri_prefix_display  =>  "{{diagnosticsDatabaseModel.uri_prefix}}://"}
+          = render :partial => "layouts/angular/auth_credentials_angular",
+                         :locals  => {:ng_show           => "miqDBBackupService.sambaBackup(diagnosticsDatabaseModel)",
+                                      :ng_model          => "diagnosticsDatabaseModel",
+                                      :ng_reqd_userid    => "miqDBBackupService.sambaRequired(diagnosticsDatabaseModel, diagnosticsDatabaseModel.log_userid)",
+                                      :ng_reqd_password  => "miqDBBackupService.sambaRequired(diagnosticsDatabaseModel, diagnosticsDatabaseModel.log_password)",
+                                      :ng_reqd_verify    => "miqDBBackupService.sambaRequired(diagnosticsDatabaseModel, diagnosticsDatabaseModel.log_verify)",
+                                      :validate_url      => "log_depot_edit",
+                                      :id                => nil,
+                                      :valtype           => "log",
+                                      :basic_info_needed => true}
+          %input(type="hidden" value="db_backup" name="action_typ")
+      %table{:width => "100%"}
+        %tr
+          %td{:align => "right"}
+            - caption = _("Run a Database Backup Now")
+            - confirm = _("Are you sure you want to Run a Database Backup Now?")
+            = button_tag(_("Submit"),
+                         :class        => "btn btn-primary",
+                         :title        => caption,
+                         "ng-class"    => "{'btn-disabled': !angularForm.$valid}",
+                         "ng-disabled" => "!miqService.saveable(angularForm)",
+                         "ng-show"     => true,
+                         "ng-click"    => "submitButtonClicked('#{confirm}')",
+                         )
+
+    - if DatabaseBackup.gc_supported?
+      %hr/
+      %h3= _("Run Database Garbage Collection Now")
+      %table.style1
+        %tr
+          %td= _("Press submit to start the Database Vacuum process")
+      %table{:width => "100%"}
+        %tr
+          %td{:align => "right"}
+            #gc_submit_on
+              - caption = _("Run Database Garbage Collection Now")
+              - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
+
+              = link_to(submit, {:action => 'db_gc_collection'},                                             |
+                "data-miq_sparkle_on" => true,                                                               |
+                :confirm              => _("Are you sure you want to Run Database Garbage Collection Now?"), |
+                :remote               => true,                                                               |
+                :title                => caption)                                                            |
+
+:javascript
+  angular.bootstrap(jQuery('#form_div'), ['miqAngularApplication']);

--- a/vmdb/spec/javascripts/controllers/ops/diagnostics_database_form_controller_spec.js
+++ b/vmdb/spec/javascripts/controllers/ops/diagnostics_database_form_controller_spec.js
@@ -1,0 +1,145 @@
+describe('diagnosticsDatabaseFormController', function() {
+  var $scope, $controller, $httpBackend, miqService;
+
+  beforeEach(module('miqAngularApplication'));
+
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
+
+  miqService = _miqService_;
+  spyOn(miqService, 'miqFlash');
+  spyOn(miqService, 'miqAjaxButton');
+  spyOn(miqService, 'sparkleOn');
+  spyOn(miqService, 'sparkleOff');
+  $scope = $rootScope.$new();
+  $scope.diagnosticsDatabaseModel = { depot_name:   '',
+                                      uri:          '',
+                                      uri_prefix:   '',
+                                      log_userid:   '',
+                                      log_password: '',
+                                      log_verify:   ''
+                                    };
+
+  $httpBackend = _$httpBackend_;
+
+  $controller = _$controller_('diagnosticsDatabaseFormController',
+                              {$scope: $scope,
+                               $attrs: {'dbBackupFormFieldChangedUrl': '/ops/db_backup_form_field_changed/'},
+                               miqService: miqService
+                              });
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('when the diagnostics database form loads', function() {
+    it('sets the depot_name to blank', function () {
+      expect($scope.diagnosticsDatabaseModel.depot_name).toEqual('');
+    });
+
+    it('sets the uri to blank', function () {
+      expect($scope.diagnosticsDatabaseModel.uri).toEqual('');
+    });
+
+    it('sets the uri_prefix to blank', function () {
+      expect($scope.diagnosticsDatabaseModel.uri_prefix).toEqual('');
+    });
+
+    it('sets the log_userid to blank', function () {
+      expect($scope.diagnosticsDatabaseModel.log_userid).toEqual('');
+    });
+
+    it('sets the log_password to blank', function () {
+      expect($scope.diagnosticsDatabaseModel.log_verify).toEqual('');
+    });
+
+    it('sets the log_password to blank', function () {
+      expect($scope.diagnosticsDatabaseModel.log_verify).toEqual('');
+    });
+  });
+
+  describe('when user selects a nfs backup db schedule from dropdown', function() {
+    var diagnosticsDBFormResponse = {
+      depot_name:   'my_nfs_depot',
+      uri:          'nfs://nfs_location',
+      uri_prefix:   'nfs',
+      log_userid:   null,
+      log_password: null,
+      log_verify:   null
+    };
+
+    beforeEach(inject(function() {
+      $httpBackend.whenPOST('/ops/db_backup_form_field_changed/12345').respond(200, diagnosticsDBFormResponse);
+      $scope.diagnosticsDatabaseModel.backup_schedule_type = '12345';
+      $scope.backupScheduleTypeChanged();
+      $httpBackend.flush();
+    }));
+
+    it('sets the depot_name to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.depot_name).toEqual('my_nfs_depot');
+    });
+
+    it('sets the uri to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.uri).toEqual('nfs://nfs_location');
+    });
+
+    it('sets the uri_prefix to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.uri_prefix).toEqual('nfs');
+    });
+
+    it('sets the log_userid to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.log_userid).toBeNull();
+    });
+
+    it('sets the log_password to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.log_password).toBeNull();
+    });
+
+    it('sets the log_verify to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.log_verify).toBeNull();
+    });
+  });
+
+  describe('when user selects a samba backup db schedule from dropdown', function() {
+    var diagnosticsDBFormResponse = {
+      depot_name:   'my_samba_depot',
+      uri:          'smb://smb_location',
+      uri_prefix:   'smb',
+      log_userid:   'admin',
+      log_password: 'smartvm',
+      log_verify:   'smartvm'
+    };
+
+    beforeEach(inject(function() {
+      $httpBackend.whenPOST('/ops/db_backup_form_field_changed/123456').respond(200, diagnosticsDBFormResponse);
+      $scope.diagnosticsDatabaseModel.backup_schedule_type = '123456';
+      $scope.backupScheduleTypeChanged();
+      $httpBackend.flush();
+    }));
+
+    it('sets the depot_name to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.depot_name).toEqual('my_samba_depot');
+    });
+
+    it('sets the uri to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.uri).toEqual('smb://smb_location');
+    });
+
+    it('sets the uri_prefix to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.uri_prefix).toEqual('smb');
+    });
+
+    it('sets the log_userid to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.log_userid).toEqual('admin');
+    });
+
+    it('sets the log_password to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.log_password).toEqual('smartvm');
+    });
+
+    it('sets the log_verify to the value returned from the http request', function () {
+      expect($scope.diagnosticsDatabaseModel.log_verify).toEqual('smartvm');
+    });
+  });
+});

--- a/vmdb/spec/javascripts/support/jasmine.yml
+++ b/vmdb/spec/javascripts/support/jasmine.yml
@@ -17,7 +17,9 @@ src_files:
   - javascripts/miq_application.js
   - javascripts/miq_angular_application.js
   - javascripts/services/miq_service.js
+  - javascripts/services/miq_db_backup_service.js
   - javascripts/services/timer_option_service.js
+  - javascripts/controllers/ops/diagnostics_database_form_controller.js
   - javascripts/controllers/schedule/schedule_form_controller.js
   - javascripts/controllers/repository/repository_form_controller.js
   - javascripts/directives/repository/valid_unc_path.js


### PR DESCRIPTION
The Database Diagnostics form shares common code with the Schedule Editor form.
When the Schedule Editor form was converted to Angular, we got rid of all the ```@edit``` usages that the Schedule Editor form was using.
Therefore the database Diagnostics form had to follow suit and had to be converted to Angular as well owing to the common code between the two forms.

https://bugzilla.redhat.com/show_bug.cgi?id=1206204