### PR TITLE
Openstack infra UI for openstack components

### DIFF
--- a/vmdb/app/views/host/_main.html.haml
+++ b/vmdb/app/views/host/_main.html.haml
@@ -14,3 +14,4 @@
     = render :partial => "shared/summary/textual", :locals => { :title => _("Custom Attributes"), :items => textual_group_miq_custom_attributes }
     = render :partial => "shared/summary/textual", :locals => { :title => _("VC Custom Attributes"), :items => textual_group_ems_custom_attributes }
     = render :partial => "shared/summary/textual", :locals => { :title => _("Authentication Status"), :items => textual_group_authentications }
+    = render :partial => "shared/summary/textual_multilink", :locals => { :title => _("OpenStack Status"), :items => textual_group_openstack_status }


### PR DESCRIPTION
UI for OpenStack components UI.

Adding the whole block named openstack status, each TD has link leading to filtered list of services or configuration

![image](https://cloud.githubusercontent.com/assets/1737058/7229497/a826f3d8-e764-11e4-9f80-823c2e948b01.png)
