### PR TITLE
Fix tree view calculation for infra clusters

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -438,18 +438,8 @@ class ApplicationController < ActionController::Base
   end
 
   def build_vm_host_array
-    @temp[:tree_hosts] = []
-    @temp[:tree_vms]   = []
-    if !@sb[:tree_hosts].blank?
-      @sb[:tree_hosts].each do |h|
-        @temp[:tree_hosts].push(Host.find_by_id(h))
-      end
-    end
-    if !@sb[:tree_vms].blank?
-      @sb[:tree_vms].each do |v|
-        @temp[:tree_vms].push(Vm.find_by_id(v))
-      end
-    end
+    @temp[:tree_hosts] = (@sb[:tree_hosts_hash] || {}).collect { |k,_| Host.find_by_id(k) }
+    @temp[:tree_vms]   = (@sb[:tree_vms_hash]   || {}).collect { |k,_| Vm.find_by_id(k) }
   end
 
   # Show the current widget report in pdf format
@@ -2549,11 +2539,9 @@ class ApplicationController < ActionController::Base
     @sb[:detail_sortcol] = @detail_sortcol
     @sb[:detail_sortdir] = @detail_sortdir
 
-    @sb[:tree_hosts] = nil if @sb[:tree_hosts] &&
-      (!%w{ems_folders descendant_vms}.include?(params[:display]) &&
+    @sb[:tree_hosts_hash] = nil if (!%w{ems_folders descendant_vms}.include?(params[:display]) &&
         !%w{treesize tree_autoload_dynatree tree_autoload_quads}.include?(params[:action]))
-    @sb[:tree_vms] = nil if @sb[:tree_vms] &&
-      (!%w{ems_folders descendant_vms}.include?(params[:display]) &&
+    @sb[:tree_vms_hash] = nil if (!%w{ems_folders descendant_vms}.include?(params[:display]) &&
         !%w{treesize tree_autoload_dynatree tree_autoload_quads}.include?(params[:action]))
 
     # Set/clear sandbox (@sb) per controller in the session object

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -438,8 +438,8 @@ class ApplicationController < ActionController::Base
   end
 
   def build_vm_host_array
-    @temp[:tree_hosts] = (@sb[:tree_hosts_hash] || {}).collect { |k,_| Host.find_by_id(k) }
-    @temp[:tree_vms]   = (@sb[:tree_vms_hash]   || {}).collect { |k,_| Vm.find_by_id(k) }
+    @temp[:tree_hosts] = Host.where(:id => (@sb[:tree_hosts_hash] || {}).keys)
+    @temp[:tree_vms]   = Vm.where(  :id => (@sb[:tree_vms_hash]   || {}).keys)
   end
 
   # Show the current widget report in pdf format

--- a/vmdb/app/controllers/ems_cluster_controller.rb
+++ b/vmdb/app/controllers/ems_cluster_controller.rb
@@ -262,8 +262,8 @@ class EmsClusterController < ApplicationController
 
   # Build the tree object to display the ems_cluster datacenter info
   def build_dc_tree
-    @sb[:tree_hosts]  = []                    # Capture all Host ids in the tree
-    @sb[:tree_vms]    = []                    # Capture all VM ids in the tree
+    @sb[:tree_hosts]    = []                    # Capture all Host ids in the tree
+    @sb[:tree_vms_hash] = {}                    # Capture all VM ids in the tree
     @sb[:cl_id] = @ems_cluster.id if @ems_cluster   # do not want to store cl object in session hash, need to get record incase coming from treesize to rebuild refreshed tree
     if !@ems_cluster
       @ems_cluster = EmsCluster.find(@sb[:cl_id])

--- a/vmdb/app/controllers/ems_cluster_controller.rb
+++ b/vmdb/app/controllers/ems_cluster_controller.rb
@@ -39,6 +39,7 @@ class EmsClusterController < ApplicationController
                       :url=>"/ems_cluster/show/#{@ems_cluster.id}?display=descendant_vms&treestate=true"})
       @showtype = "config"
       build_dc_tree
+      build_vm_host_array
 
     when "all_vms"
       drop_breadcrumb( {:name=>@ems_cluster.name+" (All VMs)", :url=>"/ems_cluster/show/#{@ems_cluster.id}?display=all_vms"} )

--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -512,8 +512,8 @@ module EmsCommon
     # Build the datacenter JSON object
     @sb[:vat] = false if params[:action] != "treesize"        #need to set this, to remember vat, treesize doesnt pass in param[:vat]
     vat = params[:vat] ? true : (@sb[:vat] ? true : false)    #use @sb[:vat] when coming from treesize
-    @sb[:tree_hosts] = []                    # Capture all Host ids in the tree
-    @sb[:tree_vms] = []                      # Capture all VM ids in the tree
+    @sb[:tree_hosts_hash] = {} # Capture all Host ids in the tree
+    @sb[:tree_vms_hash]   = {} # Capture all VM ids in the tree
     # do not want to store ems object in session hash,
     # need to get record incase coming from treesize to rebuild refreshed tree
     @sb[:ems_id] = @ems.id if @ems
@@ -542,6 +542,7 @@ module EmsCommon
     else
       session[:tree_name] = "dc_tree"
     end
+    build_vm_host_array if %w{show treesize}.include?(params[:action])
   end
 
   # Add the children of a node that is being expanded (autoloaded)

--- a/vmdb/app/controllers/host_controller.rb
+++ b/vmdb/app/controllers/host_controller.rb
@@ -573,7 +573,7 @@ class HostController < ApplicationController
   def build_network_tree
     @tree_vms = []                   # Capture all VM ids in the tree
     host_node = TreeNodeBuilder.generic_tree_node(
-      "h_#{@host.id}|",
+      "h_#{@host.id}",
       @host.name,
       "host.png",
       "Host: #{@host.name}",
@@ -587,7 +587,7 @@ class HostController < ApplicationController
   def add_host_branch
     @host.switches.collect do |s|
       switch_node = TreeNodeBuilder.generic_tree_node(
-        "s_#{s.id}|",
+        "s_#{s.id}",
         s.name,
         "switch.png",
         "Switch: #{s.name}"
@@ -603,7 +603,7 @@ class HostController < ApplicationController
   def add_guest_devices(switch)
     switch.guest_devices.collect do |p|
       TreeNodeBuilder.generic_tree_node(
-        "n_#{p.id}|",
+        "n_#{p.id}",
         p.device_name,
         "pnic.png",
         "Physical NIC: #{p.device_name}"
@@ -614,7 +614,7 @@ class HostController < ApplicationController
   def add_lans(switch)
     switch.lans.collect do |l|
       lan_node = TreeNodeBuilder.generic_tree_node(
-        "l_#{l.id}|",
+        "l_#{l.id}",
         l.name,
         "lan.png",
         "Port Group: #{l.name}"
@@ -635,7 +635,7 @@ class HostController < ApplicationController
           image = "#{v.current_state.downcase}.png"
         end
         TreeNodeBuilder.generic_tree_node(
-          "v-#{v.id}|",
+          "v-#{v.id}",
           v.name,
           image,
           "VM: #{v.name} (Click to view)"
@@ -647,7 +647,7 @@ class HostController < ApplicationController
   # Build the tree object to display the host storage adapter info
   def build_sa_tree
     host_node = TreeNodeBuilder.generic_tree_node(
-      "h_#{@host.id}|",
+      "h_#{@host.id}",
       @host.name,
       "host.png",
       "Host: #{@host.name}",
@@ -664,7 +664,7 @@ class HostController < ApplicationController
   def storage_adapters_node
     @host.hardware.storage_adapters.collect do |storage_adapter|
       storage_adapter_node = TreeNodeBuilder.generic_tree_node(
-          "sa_#{storage_adapter.id}|",
+          "sa_#{storage_adapter.id}",
           storage_adapter.device_name,
           "sa_#{storage_adapter.controller_type.downcase}.png",
           "#{storage_adapter.controller_type} Storage Adapter: #{storage_adapter.device_name}",
@@ -682,7 +682,7 @@ class HostController < ApplicationController
       name = name + " (#{scsi_target.iscsi_name})" unless scsi_target.iscsi_name.blank?
       target_text = name.blank? ? "[empty]" : name
       target_node = TreeNodeBuilder.generic_tree_node(
-          "t_#{scsi_target.id}|",
+          "t_#{scsi_target.id}",
           target_text,
           "target_scsi.png",
           "Target: #{target_text}",
@@ -696,7 +696,7 @@ class HostController < ApplicationController
   def add_miq_scsi_luns_nodes(target)
     target.miq_scsi_luns.collect do |l|
       TreeNodeBuilder.generic_tree_node(
-        "l_#{l.id}|",
+        "l_#{l.id}",
         l.canonical_name,
         "lun.png",
         "LUN: #{l.canonical_name}",

--- a/vmdb/app/controllers/resource_pool_controller.rb
+++ b/vmdb/app/controllers/resource_pool_controller.rb
@@ -212,9 +212,9 @@ class ResourcePoolController < ApplicationController
 
   # Build the tree object to display the resource_pool datacenter info
   def build_dc_tree
-      @sb[:tree_hosts] = Array.new                    # Capture all Host ids in the tree
-      @sb[:tree_vms]   = Array.new                    # Capture all VM ids in the tree
-      @sb[:rp_id] = @record.id if @record                 # do not want to store ems object in session hash, need to get record incase coming from treesize to rebuild refreshed tree
+      @sb[:tree_hosts_hash] = {} # Capture all Host ids in the tree
+      @sb[:tree_vms_hash]   = {} # Capture all VM ids in the tree
+      @sb[:rp_id] = @record.id if @record # do not want to store ems object in session hash, need to get record incase coming from treesize to rebuild refreshed tree
       if !@record
         @record = ResourcePool.find(@sb[:rp_id])
       end

--- a/vmdb/app/views/layouts/_dc_tree_quads.html.haml
+++ b/vmdb/app/views/layouts/_dc_tree_quads.html.haml
@@ -1,31 +1,27 @@
-#dc_tree_quads_div
+#dc_tree_quads_div{:style => 'position: fixed; top: 50%; left: 50%'}
   -# Create divs for each Host to display as the mouse hovers over each Host node
   - @temp[:tree_hosts].each do |h|
-    #outer
-      #inner
-        %div{:id => "h-#{to_cid(h.id)}", :style => 'display:none; z-index:10; width: 72px; height: 72px;'}
-          %div{:style => 'margin-left: -70px;'}
-            = render(:partial => 'layouts/quadicon',
-                     :locals  => {:mode => :icon,
-                                  :item => h,
-                                  :typ  => :listnav,
-                                  :size => 72})
-            %center{:style => 'color:#000;'}
-              = h(h.product_name)
-              %br/
-              = h(h.service_pack)
+    %div{:id => "h-#{to_cid(h.id)}", :style => 'display:none; z-index:10; width: 72px; height: 72px;'}
+      %div{:style => 'margin-left: -70px;'}
+        = render(:partial => 'layouts/quadicon',
+                 :locals  => {:mode => :icon,
+                              :item => h,
+                              :typ  => :listnav,
+                              :size => 72})
+        %center{:style => 'color:#000;'}
+          = h(h.product_name)
+          %br/
+          = h(h.service_pack)
   -# Create divs for each VM to display as the mouse hovers over each VM node
   - @temp[:tree_vms].each do |v|
-    #outer
-      #inner
-        %div{:id => "v-#{to_cid(v.id)}", :style => 'display:none; z-index:10; width: 72px; height: 72px;'}
-          %div{:style => 'margin-left: -70px;'}
-            = render(:partial => 'layouts/quadicon',
-                     :locals  => {:mode => :icon,
-                                 :item => v,
-                                 :typ => :listnav,
-                                 :size => 72})
-            %center{:style => 'color:#000;'}
-              = h(v.product_name)
-              %br/
-              = h(v.service_pack)
+    %div{:id => "v-#{to_cid(v.id)}", :style => 'display:none; z-index:10; width: 72px; height: 72px;'}
+      %div{:style => 'margin-left: -70px;'}
+        = render(:partial => 'layouts/quadicon',
+                 :locals  => {:mode => :icon,
+                             :item => v,
+                             :typ => :listnav,
+                             :size => 72})
+        %center{:style => 'color:#000;'}
+          = h(v.product_name)
+          %br/
+          = h(v.service_pack)

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -532,6 +532,8 @@ Vmdb::Application.routes.draw do
         tag_edit_form_field_changed
         tagging_edit
         tl_chooser
+        tree_autoload_dynatree
+        tree_autoload_quads
         wait_for_task
       ) +
         adv_search_post +

--- a/vmdb/spec/routing/ems_cluster_routing_spec.rb
+++ b/vmdb/spec/routing/ems_cluster_routing_spec.rb
@@ -124,4 +124,20 @@ describe EmsClusterController do
       expect(post("/ems_cluster/show_list")).to route_to("ems_cluster#show_list")
     end
   end
+
+  describe '#tree_autoload_dynatree' do
+    it 'routes with POST' do
+      expect(
+        post("/#{controller_name}/tree_autoload_dynatree")
+      ).to route_to("#{controller_name}#tree_autoload_dynatree")
+    end
+  end
+
+  describe '#tree_autoload_quads' do
+    it 'routes with POST' do
+      expect(
+        post("/#{controller_name}/tree_autoload_quads")
+      ).to route_to("#{controller_name}#tree_autoload_quads")
+    end
+  end
 end


### PR DESCRIPTION
Fix for:

https://bugzilla.redhat.com/show_bug.cgi?id=1207641

Ping @h-kataria : moving the line that you seem to have added
Ping @epwinchell : edited a partial to show the quadicons but I lack the aesthetic skill, please check

Changes:
* update a partial so that the quadicons are displayed even when there are many items in the tree
* add missing routes
* prevent `build_vm_host_array` from being called over and over until the HTTP request times out during the recursive calculation of the tree
* replace arrays with hashes and `includes?` with `key?` for cached VMs and Hosts
