### PR TITLE
OpenStack Host Services Schema changes

### DIFF
--- a/vmdb/app/models/filesystem.rb
+++ b/vmdb/app/models/filesystem.rb
@@ -5,6 +5,7 @@ class Filesystem < ActiveRecord::Base
   belongs_to :resource, :polymorphic => true
   belongs_to :miq_set    #ScanItemSet
   belongs_to :scan_item
+  belongs_to :host_service_group
 
   has_one :binary_blob, :as => :resource, :dependent => :destroy
 

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -82,6 +82,8 @@ class Host < ActiveRecord::Base
 
   has_one                   :miq_cim_instance, :as => :vmdb_obj, :dependent => :destroy
 
+  has_many                  :host_service_groups, :dependent => :destroy
+
   serialize                 :settings
 
   # TODO: Remove all callers of address

--- a/vmdb/app/models/host_service_group.rb
+++ b/vmdb/app/models/host_service_group.rb
@@ -1,0 +1,11 @@
+class HostServiceGroup < ActiveRecord::Base
+  has_many :filesystems, :dependent => :nullify
+  has_many :system_services, :dependent => :nullify
+  belongs_to :host
+
+  SUBCLASSES = %w(
+    HostServiceGroupOpenstack
+  )
+end
+
+HostServiceGroup::SUBCLASSES.each { |c| require_dependency Rails.root.join("app", "models", "#{c.underscore}.rb").to_s }

--- a/vmdb/app/models/host_service_group_openstack.rb
+++ b/vmdb/app/models/host_service_group_openstack.rb
@@ -1,0 +1,2 @@
+class HostServiceGroupOpenstack < HostServiceGroup
+end

--- a/vmdb/app/models/system_service.rb
+++ b/vmdb/app/models/system_service.rb
@@ -3,6 +3,7 @@ class SystemService < ActiveRecord::Base
   belongs_to :vm,           :foreign_key => :vm_or_template_id
   belongs_to :miq_template, :foreign_key => :vm_or_template_id
   belongs_to :host
+  belongs_to :host_service_group
 
   serialize :dependencies, Hash
 

--- a/vmdb/db/migrate/20150409145038_add_host_service_group_to_system_services.rb
+++ b/vmdb/db/migrate/20150409145038_add_host_service_group_to_system_services.rb
@@ -1,0 +1,6 @@
+class AddHostServiceGroupToSystemServices < ActiveRecord::Migration
+  def change
+    add_column :system_services, :host_service_group_id, :bigint
+    add_index :system_services, :host_service_group_id
+  end
+end

--- a/vmdb/db/migrate/20150409145147_add_host_service_group_to_filesystems.rb
+++ b/vmdb/db/migrate/20150409145147_add_host_service_group_to_filesystems.rb
@@ -1,0 +1,6 @@
+class AddHostServiceGroupToFilesystems < ActiveRecord::Migration
+  def change
+    add_column :filesystems, :host_service_group_id, :bigint
+    add_index :filesystems, :host_service_group_id
+  end
+end

--- a/vmdb/db/migrate/20150409145739_create_host_service_groups.rb
+++ b/vmdb/db/migrate/20150409145739_create_host_service_groups.rb
@@ -1,0 +1,13 @@
+class CreateHostServiceGroups < ActiveRecord::Migration
+  def up
+    create_table :host_service_groups do |t|
+      t.string     :name
+      t.string     :type
+      t.belongs_to :host, :type => :bigint
+    end
+  end
+
+  def down
+    drop_table :host_service_groups
+  end
+end


### PR DESCRIPTION
This schema change is needed for future work on HostServiceGroup models.

Simply put HostServiceGroup is group of SystemServices running on one Host.
For example with OpenStack services - "Nova" would be HostServiceGroup and it would contain these SystemServices: "nova-api", "nova-compute", "nova-scheduler", "nova-conductor", ...

Implementation for OpenStack Infra services running on HostOpenstackInfra is #2560 

Adds migration for creating openstack_host_services table.
Adds migration for creating openstack_host_service_id column in hosts
table with index for it.
Adds migration for creating openstack_host_service_id column in
system_services table with index for it.
Adds model OpenstackHostService with associations to Host and
SystemService models.