### PR TITLE
compare drift issues

### DIFF
--- a/vmdb/app/views/layouts/_compare.html.haml
+++ b/vmdb/app/views/layouts/_compare.html.haml
@@ -2,12 +2,10 @@
 - if @compare.nil?
   = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}
 - else
-  #compare_grid_div{:style => "width: #{@winW - 250}px; height:auto; cursor:hand;"}
+  #compare_grid_div{:style => "width: #{@winW - 250}; height: #{center_div_height + 150}px; cursor: hand; overflow-x: auto; overflow-y: auto;"}
     = render :partial => 'layouts/slickgrid',
              :locals  => { :grid_id        => "compare_grid_div",
                            :grid_name      => "compare_grid",
                            :grid_rows_json => @temp[:grid_rows_json],
                            :grid_cols_json => @temp[:grid_cols_json],
-                           :autosize       => true,
-                           :set_sizes      => true,
-                           :skin           => "miq" }
+                           :autoheight     => false }

--- a/vmdb/app/views/layouts/_drift.html.haml
+++ b/vmdb/app/views/layouts/_drift.html.haml
@@ -4,12 +4,10 @@
 - if @compare.nil?
   = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}
 - else
-  #drift_grid_div{:style => "width: #{w}px; height: auto; cursor:hand;"}
+  #drift_grid_div{:style => "width: #{w}; height: #{center_div_height + 150}px; cursor: hand; overflow-x: auto; overflow-y: auto;"}
     = render :partial => 'layouts/slickgrid',
              :locals  => { :grid_id        => "drift_grid_div",
                            :grid_name      => "drift_grid",
                            :grid_rows_json => @temp[:grid_rows_json],
                            :grid_cols_json => @temp[:grid_cols_json],
-                           :autosize       => true,
-                           :set_sizes      => true,
-                           :skin           => "miq"}
+                           :autoheight     => false}

--- a/vmdb/app/views/layouts/_slickgrid.html.haml
+++ b/vmdb/app/views/layouts/_slickgrid.html.haml
@@ -1,11 +1,12 @@
 :javascript
   var columns = #{grid_cols_json};
   var data = #{grid_rows_json};
+  var autoheight = #{autoheight}
 
   var options = {
     enableCellNavigation: true,
     enableColumnReorder: false,
-    autoHeight: true,
+    autoHeight: autoheight,
     fullWidthRows: false,
     rowHeight: 34,
     enableAsyncPostRender: true,


### PR DESCRIPTION
header was not scrolling to the end of the table, cutting off last few compared items
* header is now vertically static (like it was before slick grids) for easier comparisons

#1574

Old:
![screen shot 2015-04-08 at 1 33 18 pm](https://cloud.githubusercontent.com/assets/1287144/7051142/0aaee134-ddf4-11e4-8370-dd19fbbabf61.png)

New:
![screen shot 2015-04-08 at 1 35 30 pm](https://cloud.githubusercontent.com/assets/1287144/7051155/2734ada2-ddf4-11e4-8129-649ac9014405.png)
