### PR TITLE
bump kubeclient version to limit recursiveopenstruct version

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -33,7 +33,7 @@ gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
 gem "ovirt",                "~>0.4.1",       :require => false
-gem "kubeclient",           ">=0.1.10",      :require => false
+gem "kubeclient",           ">=0.1.11",      :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false
 gem "Platform",             "=0.4.0",        :require => false


### PR DESCRIPTION
Bumped kubeclient version since there was a need to freeze recursiveopenstruct gem dependency version on 0.6.1. 
(due to potential regressions in the version released today that cause travis to start failing - 0.6.2)