### PR TITLE
Openstack infra backend for OpenStack components

### DIFF
--- a/lib/metadata/linux/LinuxUtils.rb
+++ b/lib/metadata/linux/LinuxUtils.rb
@@ -140,5 +140,32 @@ module MiqLinux
          :running           => parts[3] == 'running'}
       end.compact!
     end
+
+    def self.parse_openstack_status(lines)
+      lines.to_s.split("\n")
+        .slice_before do |line|
+        # get section for each OpenStack service
+        line.start_with?('== ') && line.end_with?(' ==')
+      end.map do |section|
+        {
+          # OpenStack service section name
+          'name'     => section.first.gsub('=', '').strip,
+          # get array of services
+          'services' => section[1..-1].map do |service_line|
+            # split service line by :, ( and ) and strip white space from results
+            service_line.split(/[:\(\)]/).map(&:strip)
+          end.map do |service|
+            {
+              'name'    => service.first,
+              'active'  => service[1] == 'active',
+              'enabled' => !(service[2] =~ /disabled/)
+            }
+          end
+        }
+      end.reject do |service|
+        # we omit Keystone users section
+        service['name'] == 'Keystone users'
+      end
+    end
   end
 end

--- a/lib/spec/metadata/linux/LinuxUtils_spec.rb
+++ b/lib/spec/metadata/linux/LinuxUtils_spec.rb
@@ -1,0 +1,94 @@
+require "spec_helper"
+
+$LOAD_PATH.push(File.expand_path(File.join(File.dirname(__FILE__), %w(.. .. .. metadata linux))))
+require 'LinuxUtils'
+
+describe MiqLinux::Utils do
+  describe '#parse_openstack_status' do
+    let(:text) do
+      <<EOS
+== Nova services ==
+openstack-nova-api:                     active
+openstack-nova-cert:                    inactive  (disabled on boot)
+openstack-nova-compute:                 active
+openstack-nova-network:                 inactive  (disabled on boot)
+openstack-nova-scheduler:               active
+openstack-nova-conductor:               active
+== Glance services ==
+openstack-glance-api:                   active
+openstack-glance-registry:              active
+== Keystone service ==
+openstack-keystone:                     active
+== Horizon service ==
+openstack-dashboard:                    active
+== neutron services ==
+neutron-server:                         active
+neutron-dhcp-agent:                     active
+neutron-l3-agent:                       inactive  (disabled on boot)
+neutron-metadata-agent:                 inactive  (disabled on boot)
+neutron-openvswitch-agent:              active
+== Swift services ==
+openstack-swift-proxy:                  active
+openstack-swift-account:                active
+openstack-swift-container:              active
+openstack-swift-object:                 active
+== Ceilometer services ==
+openstack-ceilometer-api:               active
+openstack-ceilometer-central:           active
+openstack-ceilometer-compute:           inactive  (disabled on boot)
+openstack-ceilometer-collector:         active
+openstack-ceilometer-alarm-notifier:    active
+openstack-ceilometer-alarm-evaluator:   active
+openstack-ceilometer-notification:      active
+== Heat services ==
+openstack-heat-api:                     active
+openstack-heat-api-cfn:                 active
+openstack-heat-api-cloudwatch:          active
+openstack-heat-engine:                  active
+== Support services ==
+mysqld:                                 inactive  (disabled on boot)
+openvswitch:                            active
+dbus:                                   active
+rabbitmq-server:                        active
+memcached:                              active
+== Keystone users ==
+Warning keystonerc not sourced
+EOS
+    end
+    let(:subject) { MiqLinux::Utils.parse_openstack_status(text) }
+
+    it "should return Array" do
+      should be_a Array
+    end
+
+    # we omit Keystone users section
+    it "should have 9 OpenStack services" do
+      subject.count.should be_equal 9
+    end
+
+    %w(Nova Glance Keystone Swift neutron Ceilometer Heat Support).map do |service|
+      it "should have contain correct OpenStack #{service} service" do
+        subject.select { |service_hash| service_hash['name'].include?(service) }.count.should be_equal 1
+      end
+    end
+
+    describe "Nova services" do
+      let(:subject) do
+        MiqLinux::Utils.parse_openstack_status(text).select { |service| service['name'].include?('Nova') }
+          .first['services']
+      end
+
+      it "should have 6 services total" do
+        subject.count.should be_equal 6
+      end
+
+      it "should have 4 active services" do
+        subject.select { |service| service['active'] }.count.should be_equal 4
+      end
+
+      it "should have 2 inactive services" do
+        subject.select { |service| !service['active'] }.count.should be_equal 2
+      end
+    end
+  end
+end

--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1741,6 +1741,13 @@ class Host < ActiveRecord::Base
             task.update_status("Active", "Ok", "Refreshing FS Files") if task
             Benchmark.realtime_block(:refresh_fs_files) { self.refresh_fs_files(ssu) }
 
+            # refresh_openstack_services should run after refresh_services and refresh_fs_files
+            if self.respond_to?(:refresh_openstack_services)
+              $log.info("#{log_header} Refreshing OpenStack Services for #{log_target}")
+              task.update_status("Active", "Ok", "Refreshing OpenStack Services") if task
+              Benchmark.realtime_block(:refresh_openstack_services) { refresh_openstack_services(ssu) }
+            end
+
             self.save
           end
         rescue Net::SSH::HostKeyMismatch

--- a/vmdb/app/models/host_openstack_infra.rb
+++ b/vmdb/app/models/host_openstack_infra.rb
@@ -88,6 +88,15 @@ class HostOpenstackInfra < Host
         # associate SystemService record with OpenstackHostServiceGroup
         host_service_group_openstack.system_services = sys_services
 
+        # find Filesystem records by host
+        # filter Filesystem records by names
+        # we assume that /etc/<service name>* is good enough pattern
+        dir_name = "/etc/#{host_service_group_openstack.name.downcase.gsub(/\sservice.*/, '')}"
+
+        matcher = Filesystem.arel_table[:name].matches("#{dir_name}%")
+        files = filesystems.where(matcher)
+        host_service_group_openstack.filesystems = files
+
         # save all changes
         host_service_group_openstack.save
       end

--- a/vmdb/app/models/host_openstack_infra.rb
+++ b/vmdb/app/models/host_openstack_infra.rb
@@ -1,6 +1,8 @@
 class HostOpenstackInfra < Host
   belongs_to :availability_zone
 
+  has_many   :host_service_group_openstacks, :foreign_key => :host_id, :dependent => :destroy
+
   # TODO(lsmola) for some reason UI can't handle joined table cause there is hardcoded somewhere that it selects
   # DISTINCT id, with joined tables, id needs to be prefixed with table name. When this is figured out, replace
   # cloud tenant with rails relations
@@ -71,5 +73,27 @@ class HostOpenstackInfra < Host
         cred.status = 'None'
       end
     end
+  end
+
+  def refresh_openstack_services(ssu)
+    openstack_status = ssu.shell_exec("openstack-status")
+    services = MiqLinux::Utils.parse_openstack_status(openstack_status)
+    self.host_service_group_openstacks = services.map do |service|
+      # find OpenstackHostServiceGroup records by host and name and initialize if not found
+      host_service_group_openstacks.where(:name => service['name'])
+        .first_or_initialize.tap do |host_service_group_openstack|
+        # find SystemService records by host
+        # filter SystemService records by names from openstack-status results
+        sys_services = system_services.where(:name => service['services'].map { |ser| ser['name'] })
+        # associate SystemService record with OpenstackHostServiceGroup
+        host_service_group_openstack.system_services = sys_services
+
+        # save all changes
+        host_service_group_openstack.save
+      end
+    end
+  rescue => err
+    $log.log_backtrace(err)
+    raise err
   end
 end

--- a/vmdb/spec/factories/host_service_group.rb
+++ b/vmdb/spec/factories/host_service_group.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :host_service_group do
+    sequence(:name) { |n| "host_service_group_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/vmdb/spec/factories/host_service_group_openstack.rb
+++ b/vmdb/spec/factories/host_service_group_openstack.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :host_service_group_openstack do
+    sequence(:name) { |n| "host_service_group_openstack_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/vmdb/spec/factories/system_service.rb
+++ b/vmdb/spec/factories/system_service.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :system_service do
+    sequence(:name) { |n| "system_service_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/vmdb/spec/models/host_openstack_infra_spec.rb
+++ b/vmdb/spec/models/host_openstack_infra_spec.rb
@@ -1,0 +1,161 @@
+require "spec_helper"
+
+describe HostOpenstackInfra do
+  describe "#refresh_openstack_services" do
+    let(:openstack_status_text) do
+      <<-EOT
+== Nova services ==
+openstack-nova-api:                     active
+openstack-nova-cert:                    inactive  (disabled on boot)
+openstack-nova-compute:                 active
+openstack-nova-network:                 inactive  (disabled on boot)
+openstack-nova-scheduler:               active
+openstack-nova-conductor:               active
+== Glance services ==
+openstack-glance-api:                   active
+openstack-glance-registry:              active
+openstack-glance-for-test:              active
+== Keystone service ==
+openstack-keystone:                     active
+      EOT
+    end
+
+    let(:ssu) do
+      double('ssu').tap do |ssu|
+        ssu.should_receive(:shell_exec).with("openstack-status").and_return(openstack_status_text)
+      end
+    end
+
+    let(:host) do
+      FactoryGirl.create(:host_openstack_infra).tap do |host|
+        host.stub(:connect_ssh).and_yield(ssu)
+
+        # create generic SystemService
+        host.system_services << FactoryGirl.create(:system_service)
+        # create OpenStack related SystemService to test against
+        host.system_services << FactoryGirl.create(:system_service, :name => 'openstack-nova-api')
+
+        # create generic Filesystem
+        host.filesystems << FactoryGirl.create(:filesystem)
+        # create OpenStack related Filesystems to test against
+        host.filesystems << FactoryGirl.create(:filesystem, :name => '/etc/nova.conf')
+        host.filesystems << FactoryGirl.create(:filesystem, :name => '/etc/nova/api.conf')
+
+        # create HostServiceGroupOpenstack existing prior to calling HostOpenstackInfra#refresh_openstack_services
+        glance = FactoryGirl.create(:host_service_group_openstack, :name => 'Glance services')
+        # create glance_api and add it to both Host and HostServiceGroupOpenstack objects
+        glance_api = FactoryGirl.create(:system_service, :name => 'openstack-glance-api')
+        glance.system_services << glance_api
+        host.system_services << glance_api
+        # create glance_registry and add it to Host object only
+        glance_registry = FactoryGirl.create(:system_service, :name => 'openstack-glance-registry')
+        host.system_services << glance_registry
+
+        host.host_service_group_openstacks << glance
+
+        # create keystone system service on host
+        host.system_services << FactoryGirl.create(:system_service, :name => 'openstack-keystone')
+      end
+    end
+
+    before do
+      HostServiceGroupOpenstack.create(:host => host, :name => 'Keystone service')
+    end
+
+    context "with stubbed MiqLinux::Utils" do
+      it "makes proper utils calls" do
+        miq_linux_utils_double = double('MiqLinux::Utils')
+        miq_linux_utils_double.should_receive(:parse_openstack_status).with(openstack_status_text).and_return([])
+        stub_const('MiqLinux::Utils', miq_linux_utils_double)
+        host.refresh_openstack_services(ssu)
+      end
+    end
+
+    describe "host_service_group_openstacks names" do
+      subject do
+        host.refresh_openstack_services(ssu)
+        host.host_service_group_openstacks.map(&:name)
+      end
+
+      let(:expected) do
+        [
+          'Nova services',
+          'Glance services',
+          'Keystone service',
+        ]
+      end
+
+      let(:unexpected) do
+        [
+          'Swift services',
+        ]
+      end
+
+      it { should include(*expected) }
+      it { should_not include(*unexpected) }
+    end
+
+    describe "system_services names" do
+      subject do
+        host.refresh_openstack_services(ssu)
+        host.system_services.map(&:name)
+      end
+
+      let(:expected) do
+        [
+          'openstack-nova-api',
+          'openstack-glance-api',
+          'openstack-glance-registry',
+          'openstack-keystone',
+        ]
+      end
+
+      let(:unexpected) do
+        [
+          'openstack-nova-compute', # was not present in Host#system_services
+        ]
+      end
+
+      it { should include(*expected) }
+      it { should_not include(*unexpected) }
+    end
+
+    describe "existing HostServiceGroupOpenstack gets updated" do
+      let(:glance_host_service_group) do
+        host.refresh_openstack_services(ssu)
+        host.host_service_group_openstacks.where(:name => 'Glance services').first
+      end
+
+      describe "system_service names" do
+        subject do
+          glance_host_service_group.system_services.map(&:name)
+        end
+
+        let(:expected) do
+          [
+            'openstack-glance-api',
+            'openstack-glance-registry',
+          ]
+        end
+
+        let(:unexpected) do
+          [
+            'openstack-nova-compute',
+            'openstack-keystone',
+            'openstack-glance-for-test',
+          ]
+        end
+
+        it { should include(*expected) }
+        it { should_not include(*unexpected) }
+      end
+    end
+
+    it "creates association with existing SystemServices" do
+      host.refresh_openstack_services(ssu)
+      # we test if SystemServices with associated HostServiceGroupOpenstacks from current Host
+      # are included among all SystemServices of that host
+      host.system_services.should include(*(host.host_service_group_openstacks.flat_map(&:system_services)))
+    end
+  end
+end


### PR DESCRIPTION
Builds on top of #2554 .

Creates HostOpenstackInfra#refresh_openstack_services.
This is used for getting OpenstackHostServices populated from output of openstack-status CLI on Host.
OpenstackHostService is connected to one or more SystemServices of its Host and to one or more Filesystems of its Host.