### PR TITLE
Associate nested stacks with provider

### DIFF
--- a/vmdb/app/models/ems_cloud.rb
+++ b/vmdb/app/models/ems_cloud.rb
@@ -10,8 +10,9 @@ class EmsCloud < ExtManagementSystem
   has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
-  has_many :orchestration_stacks,          :foreign_key => :ems_id, :dependent => :destroy
   has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
+
+  include HasManyOrchestrationStackMixin
 
   # Development helper method for Rails console for opening a browser to the EMS.
   #

--- a/vmdb/app/models/ems_openstack_infra.rb
+++ b/vmdb/app/models/ems_openstack_infra.rb
@@ -1,9 +1,8 @@
 class EmsOpenstackInfra < EmsInfra
   include EmsOpenstackMixin
+  include HasManyOrchestrationStackMixin
 
   before_save :ensure_parent_provider
-
-  has_many :orchestration_stacks, :foreign_key => :ems_id, :dependent => :destroy
 
   def cloud_tenants
     CloudTenant.where(:ems_id => provider.try(:cloud_ems).try(:collect, &:id).try(:uniq))

--- a/vmdb/app/models/mixins/has_many_orchestration_stack_mixin.rb
+++ b/vmdb/app/models/mixins/has_many_orchestration_stack_mixin.rb
@@ -1,0 +1,14 @@
+module HasManyOrchestrationStackMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :orchestration_stacks,
+             :foreign_key => :ems_id,
+             :dependent   => :destroy
+
+    has_many :direct_orchestration_stacks,
+             :foreign_key => :ems_id,
+             :conditions  => OrchestrationStack.arel_table[:ancestry].eq(nil).to_sql,
+             :class_name  => "OrchestrationStack"
+  end
+end

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -86,6 +86,8 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
     @ems.vms.size.should                  == 27
     @ems.miq_templates.size.should        == 19
     @ems.orchestration_stacks.size.should == 2
+
+    @ems.direct_orchestration_stacks.size.should == 1
   end
 
   def assert_specific_flavor


### PR DESCRIPTION
### Original Proposal:
Before method `orchestration_stacks` returned all stacks including nested.
Now method `orchestration_stacks` returns stacks only at root level.
Introduce new method `orchestration_stacks_with_nested` which returns all stacks.


### After review comments:
Add method `direct_orchestration_stacks` to providers to return first level stacks only. This is inline with other models with similar needs.
Move `has_many` `orchestration_stacks` and `direct_orchestration_stacks` to a mixin so that it can be shared by `EmsCloud` and `EmsOpenstackInfra`