### PR TITLE
Connect to the Ems' hostname, not ipaddress.

### DIFF
--- a/vmdb/lib/workers/ems_refresh_core_worker.rb
+++ b/vmdb/lib/workers/ems_refresh_core_worker.rb
@@ -24,7 +24,7 @@ class EmsRefreshCoreWorker < WorkerBase
   end
 
   def log_prefix
-    @log_prefix ||= "MIQ(#{self.class.name}) EMS [#{@ems.ipaddress}] as [#{@ems.authentication_userid}]"
+    @log_prefix ||= "MIQ(#{self.class.name}) EMS [#{@ems.hostname}] as [#{@ems.authentication_userid}]"
   end
 
   def before_exit(message, exit_code)
@@ -63,7 +63,7 @@ class EmsRefreshCoreWorker < WorkerBase
 
     tid = Thread.new do
       begin
-        @vim = MiqVimCoreUpdater.new(@ems.ipaddress, @ems.authentication_userid, @ems.authentication_password)
+        @vim = MiqVimCoreUpdater.new(@ems.hostname, @ems.authentication_userid, @ems.authentication_password)
         @vim.monitorUpdates { |*u| @queue.enq(u) }
       rescue Handsoap::Fault => err
         if ( @exit_requested && (err.code == "ServerFaultCode") && (err.reason == "The task was canceled by a user.") )

--- a/vmdb/lib/workers/event_catcher_vmware.rb
+++ b/vmdb/lib/workers/event_catcher_vmware.rb
@@ -4,7 +4,7 @@ class EventCatcherVmware < EventCatcher
   def event_monitor_handle
     require 'VMwareWebService/MiqVimEventMonitor'
     @event_monitor_handle ||= MiqVimEventMonitor.new(
-                                @ems.ipaddress,
+                                @ems.hostname,
                                 @ems.authentication_userid,
                                 @ems.authentication_password,
                                 nil,


### PR DESCRIPTION
Now that Ems's ipaddress is not exposed, these workers fail to start because
they try to connect to a nil ipaddress.  These need to use the hostname field.

Fixes some of the fallout UI changes in #2127

cc @Fryguy @brandondunne this fixes the awful errors I was seeing when workers were starting:

```
MIQ(EmsRefreshCoreWorker) EMS [] as [administrator] Thread aborted because [Node (search=<//n1:RetrieveServiceContentResponse> namespace=<{"n1"=>"urn:vim2"}>) not found in XML document...
...
[----] E, [2015-04-08T18:08:16.795072 #7867:33e710c] ERROR -- : /var/www/miq/lib/VMwareWebService/VimService.rb:1182:in `parse_response'
/var/www/miq/lib/VMwareWebService/VimService.rb:883:in `retrieveServiceContent'
/var/www/miq/lib/VMwareWebService/VimService.rb:21:in `initialize'
/var/www/miq/lib/VMwareWebService/MiqVimClientBase.rb:33:in `initialize'
/var/www/miq/lib/VMwareWebService/MiqVimCoreUpdater.rb:11:in `initialize'
/var/www/miq/vmdb/lib/workers/ems_refresh_core_worker.rb:66:in `new'
/var/www/miq/vmdb/lib/workers/ems_refresh_core_worker.rb:66:in `block in start_updater'
```


```
ERROR -- : MIQ(EventCatcherVmware) EMS [] as [administrator] Event Monitor Thread aborted because [Node (search=<//n1:RetrieveServiceContentResponse> namespace=<{"n1"=>"urn:vim2"}>) not found in XML document...
...
[----] E, [2015-04-08T18:08:21.306915 #7874:2bc1400] ERROR -- : /var/www/miq/lib/VMwareWebService/VimService.rb:1182:in `parse_response'
/var/www/miq/lib/VMwareWebService/VimService.rb:883:in `retrieveServiceContent'
/var/www/miq/lib/VMwareWebService/VimService.rb:21:in `initialize'
/var/www/miq/lib/VMwareWebService/MiqVimClientBase.rb:33:in `initialize'
/var/www/miq/lib/VMwareWebService/MiqVimInventory.rb:23:in `initialize'
/var/www/miq/lib/VMwareWebService/MiqVimEventMonitor.rb:7:in `initialize'
/var/www/miq/vmdb/lib/workers/event_catcher_vmware.rb:6:in `new'
```
