### PR TITLE
[WIP] we need to resolve the hostname and set it on host discovery

### DIFF
--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1244,15 +1244,21 @@ class Host < ActiveRecord::Base
   def detect_discovered_hypervisor(ost, ipaddr)
     log_header = 'MIQ(Host.detect_discovered_hypervisor)'
     find_method = :find_by_ipaddress
+
+    # TODO: break this apart, we probably want to only do the namelookup for hyperv, esx
+    hostname = Socket.getaddrinfo(ipaddr, nil)[0][2]
+
     if ost.hypervisor.include?(:hyperv)
       self.name        = "Microsoft Hyper-V (#{ipaddr})"
       self.type        = "HostMicrosoft"
       self.ipaddress   = ipaddr
+      self.hostname    = hostname
       self.vmm_vendor  = "microsoft"
       self.vmm_product = "Hyper-V"
     elsif ost.hypervisor.include?(:esx)
       self.name        = "VMware ESX Server (#{ipaddr})"
       self.ipaddress   = ipaddr
+      self.hostname    = hostname
       self.vmm_vendor  = "vmware"
       self.vmm_product = "Esx"
       if self.has_credentials?(:ws)


### PR DESCRIPTION
**Problem** Now that #2127's main UI tasks have completed, the UI and backend for host/ems no longer use/display ipaddress field.  Therefore, when we do host discovery, we need to resolve the hostname from the discovered ipaddress.