### PR TITLE
Foreman parent configuration tags

### DIFF
--- a/vmdb/app/models/configuration_profile.rb
+++ b/vmdb/app/models/configuration_profile.rb
@@ -8,4 +8,9 @@ class ConfigurationProfile < ActiveRecord::Base
   has_and_belongs_to_many :configuration_locations, :join_table => :configuration_locations_configuration_profiles
   has_and_belongs_to_many :configuration_organizations, :join_table => :configuration_organizations_configuration_profiles
   has_and_belongs_to_many :configuration_tags
+
+  def all_tags
+    tag_hash = configuration_tags.index_by(&:class)
+    parent ? tag_hash.reverse_merge(parent.all_tags) : tag_hash
+  end
 end

--- a/vmdb/app/models/configuration_tag.rb
+++ b/vmdb/app/models/configuration_tag.rb
@@ -7,4 +7,6 @@ class ConfigurationTag < ActiveRecord::Base
   belongs_to :manager
   has_and_belongs_to_many :configured_systems
   has_and_belongs_to_many :configuration_profiles
+
+  validates :name, :presence => true
 end

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -18,4 +18,9 @@ class ConfiguredSystem < ActiveRecord::Base
   def name
     hostname
   end
+
+  def all_tags
+    tag_hash = configuration_tags.index_by(&:class)
+    configuration_profile ? tag_hash.reverse_merge(configuration_profile.all_tags) : tag_hash
+  end
 end

--- a/vmdb/spec/models/configuration_profile_spec.rb
+++ b/vmdb/spec/models/configuration_profile_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+
+describe ConfigurationProfile do
+  subject { described_class.new }
+
+  describe "#all_tags" do
+    let(:cd) { ConfigurationDomain.new(:name => "cd") }
+    let(:cr) { ConfigurationRealm.new(:name => "cr") }
+    let(:cr2) { ConfigurationRealm.new(:name => "cr2") }
+
+    it "defaults to no tags" do
+      expect(subject.all_tags).to eq({})
+    end
+
+    it "reads tags" do
+      subject.configuration_tags << cd
+      subject.configuration_tags << cr
+      expect(subject.all_tags).to eq(
+        ConfigurationRealm  => cr,
+        ConfigurationDomain => cd,
+      )
+    end
+
+    context "with a parent" do
+      let(:parent) { subject.build_parent }
+
+      it "supports empty parents" do
+        subject.configuration_tags << cr
+        expect(subject.all_tags).to eq(
+          ConfigurationRealm => cr
+        )
+      end
+
+      it "loads tags from parent" do
+        parent.build_parent
+        parent.configuration_tags << cr
+        expect(subject.all_tags).to eq(
+          ConfigurationRealm => cr
+        )
+      end
+
+      it "leverages tags from child" do
+        subject.configuration_tags << cr
+        parent.configuration_tags << cr2
+        expect(subject.all_tags).to eq(
+          ConfigurationRealm => cr
+        )
+      end
+
+      context "and a parent" do
+        let(:parent_parent) { parent.build_parent }
+        it "loads tags from parent parent" do
+          parent.configuration_tags << cd
+          parent_parent.configuration_tags << cr
+          expect(subject.all_tags).to eq(
+            ConfigurationRealm  => cr,
+            ConfigurationDomain => cd,
+          )
+        end
+
+        it "loads respects hierarchy" do
+          parent.configuration_tags << cr
+          parent_parent.configuration_tags << cr2
+          parent_parent.configuration_tags << cd
+          expect(subject.all_tags).to eq(
+            ConfigurationRealm  => cr,
+            ConfigurationDomain => cd,
+          )
+        end
+      end
+    end
+  end
+end

--- a/vmdb/spec/models/configured_system_spec.rb
+++ b/vmdb/spec/models/configured_system_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe ConfiguredSystem do
+  subject { described_class.new }
+
+  describe "#all_tags" do
+    let(:cd) { ConfigurationDomain.new(:name => "cd") }
+    let(:cr) { ConfigurationRealm.new(:name => "cr") }
+    let(:cr2) { ConfigurationRealm.new(:name => "cr2") }
+
+    it "defaults to no tags" do
+      expect(subject.all_tags).to eq({})
+    end
+
+    it "reads tags" do
+      subject.configuration_tags << cd
+      subject.configuration_tags << cr
+      expect(subject.all_tags).to eq(
+        ConfigurationDomain => cd,
+        ConfigurationRealm  => cr
+      )
+    end
+
+    context "with a profile" do
+      let(:profile) { subject.build_configuration_profile }
+
+      it "loads tags from profile" do
+        profile.configuration_tags << cr
+        expect(subject.all_tags).to eq(
+          ConfigurationRealm => cr
+        )
+      end
+
+      it "leverages tags from child" do
+        subject.configuration_tags << cr
+        profile.configuration_tags << cr2
+        expect(subject.all_tags).to eq(
+          ConfigurationRealm => cr
+        )
+      end
+
+      context "and a parent" do
+        let(:parent) { profile.build_parent }
+        it "loads tags from profile profile" do
+          profile.configuration_tags << cd
+          parent.configuration_tags << cr
+          expect(subject.all_tags).to eq(
+            ConfigurationRealm  => cr,
+            ConfigurationDomain => cd,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds configuration tag rollup for foreman configuration profiles and configuration systems.

Do note that the 2 `all_tags` methods are a little different (`parent` vs `configuration_profile`)

/cc @gmcculloug @brandondunne 