### PR TITLE
Miscellaneus fixes for containers collection

### DIFF
--- a/vmdb/app/models/container_definition.rb
+++ b/vmdb/app/models/container_definition.rb
@@ -1,5 +1,5 @@
 class ContainerDefinition < ActiveRecord::Base
   # :name, :image, :image_pull_policy, :memory, :cpu
   belongs_to :container_group
-  has_many :container_port_configs
+  has_many :container_port_configs, :dependent => :destroy
 end

--- a/vmdb/app/models/container_group.rb
+++ b/vmdb/app/models/container_group.rb
@@ -4,8 +4,8 @@ class ContainerGroup < ActiveRecord::Base
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :restart_policy, :dns_policy
 
-  has_many :containers
-  has_many :container_definitions
+  has_many :containers, :dependent => :destroy
+  has_many :container_definitions, :dependent => :destroy
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :labels, :class_name => CustomAttribute, :as => :resource, :conditions => {:section => "labels"}
   belongs_to :container_node

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -180,39 +180,39 @@ module EmsRefresh::Parsers
 
     def parse_container_definition(container_def, pod_id)
       new_result = {
-        :ems_ref           => "#{pod_id}_#{container_def["name"]}_#{container_def["image"]}",
-        :name              => container_def["name"],
-        :image             => container_def["image"],
-        :image_pull_policy => container_def["imagePullPolicy"],
-        :memory            => container_def["memory"],
+        :ems_ref           => "#{pod_id}_#{container_def.name}_#{container_def.image}",
+        :name              => container_def.name,
+        :image             => container_def.image,
+        :image_pull_policy => container_def.imagePullPolicy,
+        :memory            => container_def.memory,
          # https://github.com/GoogleCloudPlatform/kubernetes/blob/0b801a91b15591e2e6e156cf714bfb866807bf30/pkg/api/v1beta3/types.go#L815
-        :cpu_cores         => container_def["cpu"].to_f / 1000
+        :cpu_cores         => container_def.cpu.to_f / 1000
       }
-      ports = container_def["ports"]
+      ports = container_def.ports
       new_result[:container_port_configs] = Array(ports).collect do |port_entry|
-        parse_container_port_config(port_entry, pod_id, container_def["name"])
+        parse_container_port_config(port_entry, pod_id, container_def.name)
       end
       new_result
     end
 
     def parse_container(container, pod_id)
       {
-        :ems_ref       => "#{pod_id}_#{container["name"]}_#{container["image"]}",
-        :name          => container["name"],
-        :image         => container["image"],
-        :restart_count => container["restartCount"],
-        :container_id  => container["containerID"]
+        :ems_ref       => "#{pod_id}_#{container.name}_#{container.image}",
+        :name          => container.name,
+        :image         => container.image,
+        :restart_count => container.restartCount,
+        :container_id  => container.containerID
       }
       # TODO, state
     end
 
     def parse_container_port_config(port_config, pod_id, container_name)
       {
-        :ems_ref   => "#{pod_id}_#{container_name}_#{port_config["containerPort"]}_#{port_config["hostPort"]}_#{port_config["protocol"]}",
-        :port      => port_config["containerPort"],
-        :host_port => port_config["hostPort"],
-        :protocol  => port_config["protocol"],
-        :name      => port_config["name"]
+        :ems_ref   => "#{pod_id}_#{container_name}_#{port_config.containerPort}_#{port_config.hostPort}_#{port_config.protocol}",
+        :port      => port_config.containerPort,
+        :host_port => port_config.hostPort,
+        :protocol  => port_config.protocol,
+        :name      => port_config.name
       }
     end
 

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -101,14 +101,15 @@ module EmsRefresh::Parsers
 
       new_result.merge!(
         :restart_policy => pod.spec.restartPolicy,
-        :dns_policy     => pod.spec.dnsPolicy
+        :dns_policy     => pod.spec.dnsPolicy,
+        :container_node => nil
       )
-      if pod.spec.respond_to?(:host)
+
+      unless pod.spec.host.nil?
         new_result[:container_node] = @data_index.fetch_path(
           :container_nodes, :by_name, pod.spec.host)
-      else
-        new_result[:container_node] = nil
       end
+
       # TODO, map volumes
       # TODO, podIP
       containers = pod.spec.containers

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -98,15 +98,9 @@ module EmsRefresh::Parsers
     def parse_pod(pod)
       # pod in kubernetes is container group in manageiq
       new_result = parse_base_item(pod)
-      # TODO: remove hash support when old versions are not in use anymore
-      #       https://github.com/GoogleCloudPlatform/kubernetes/issues/3607
-      if pod.spec.restartPolicy.kind_of?(Hash)
-        pod_restart_policy = pod.spec.restartPolicy.keys.first.to_s
-      else
-        pod_restart_policy = pod.spec.restartPolicy
-      end
+
       new_result.merge!(
-        :restart_policy => pod_restart_policy,
+        :restart_policy => pod.spec.restartPolicy,
         :dns_policy     => pod.spec.dnsPolicy
       )
       if pod.spec.respond_to?(:host)


### PR DESCRIPTION
This pull request includes:

* align with Kubernetes API so that we can collect containers information again (`pod.status.info` is now `pod.status.containerStatuses` introduced in https://github.com/GoogleCloudPlatform/kubernetes/pull/5915)
* `containers`, `container_definitions` and `container_port_configs` are now destroyed when a `container_group` is destroyed, avoiding to leave orphaned records
* dropping the `restartPolicy` backward compatibility (we are now tracking Kubernetes 8d94c43e)
* generic code cleanups thanks to kubeclient 0.1.10
