### PR TITLE
[WIP] Refactor: move orchestration stack operations from provider to stack classes

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -154,21 +154,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def stack_create(stack_name, template, options = {})
-    cloud_formation.stacks.create(stack_name, template.content, options).stack_id
-  rescue => err
-    _log.error "stack=[#{stack_name}], error: #{err}"
-    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
-  end
-
-  def stack_status(stack_name, _stack_id, _options = {})
-    stack = cloud_formation.stacks[stack_name]
-    return stack.status, stack.status_reason if stack
-  rescue => err
-    _log.error "stack=[#{stack_name}], error: #{err}"
-    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
-  end
-
   def orchestration_template_validate(template)
     cloud_formation.validate_template(template.content)[:message]
   rescue => err

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -1,13 +1,45 @@
 class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::OrchestrationStack
-  def raw_update_stack(options)
-    ext_management_system.with_provider_connection(:service => "CloudFormation") do |connection|
-      connection.stacks[name].update(options)
+  require_dependency 'manageiq/providers/amazon/cloud_manager/orchestration_stack/status'
+
+  def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
+    orchestration_manager.with_provider_connection(:service => "CloudFormation") do |service|
+      service.stacks.create(stack_name, template.content, options).stack_id
     end
+  rescue => err
+    _log.error "stack=[#{stack_name}], error: #{err}"
+    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+  end
+
+  def raw_update_stack(options)
+    ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
+      service.stacks[name].update(options)
+    end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
   end
 
   def raw_delete_stack
-    ext_management_system.with_provider_connection(:service => "CloudFormation") do |connection|
-      connection.stacks[name].delete
+    ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
+      service.stacks[name].try(:delete)
     end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+  end
+
+  def raw_status
+    ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
+      raw_stack = service.stacks[name]
+      klass = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status
+      klass.new(raw_stack.status, raw_stack.status_reason)
+    end
+  rescue => err
+    if err.to_s =~ /[S|s]tack.+does not exist/
+      raise MiqException::MiqOrchestrationStackNotExistError, "#{name} does not exist on #{ext_management_system.name}"
+    end
+
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status < ::OrchestrationStack::Status
+  def succeeded?
+    status.downcase == "create_complete"
+  end
+
+  def failed?
+    status.downcase =~ /failed$/
+  end
+
+  def rollbacked?
+    status.downcase == "rollback_complete"
+  end
+
+  def deleted?
+    status.downcase == "delete_complete"
+  end
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -1,17 +1,52 @@
 class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ::OrchestrationStack
+  require_dependency 'manageiq/providers/openstack/cloud_manager/orchestration_stack/status'
+
+  def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
+    create_options = {:stack_name => stack_name, :template => template.content}.merge(options).except(:cloud_tenant)
+    connection_options = {:service => "Orchestration"}.merge(options.slice(:cloud_tenant))
+    orchestration_manager.with_provider_connection(connection_options) do |service|
+      service.stacks.new.save(create_options)["id"]
+    end
+  rescue => err
+    _log.error "stack=[#{stack_name}], error: #{err}"
+    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+  end
+
   def raw_update_stack(options)
     connection_options = {:service => "Orchestration"}
     connection_options.merge!(:tenant_name => cloud_tenant.name) if cloud_tenant
-    ext_management_system.with_provider_connection(connection_options) do |connection|
-      connection.stacks.get(name, ems_ref).save(options)
+    ext_management_system.with_provider_connection(connection_options) do |service|
+      service.stacks.get(name, ems_ref).save(options)
     end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
   end
 
   def raw_delete_stack
     options = {:service => "Orchestration"}
     options.merge!(:tenant_name => cloud_tenant.name) if cloud_tenant
-    ext_management_system.with_provider_connection(options) do |connection|
-      connection.stacks.get(name, ems_ref).delete
+    ext_management_system.with_provider_connection(options) do |service|
+      service.stacks.get(name, ems_ref).try(:delete)
     end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+  end
+
+  def raw_status
+    ems = ext_management_system
+    ems.with_provider_connection(:service => "Orchestration") do |service|
+      raw_stack = service.stacks.get(name, ems_ref)
+      raise MiqException::MiqOrchestrationStackNotExistError, "#{name} does not exist on #{ems.name}" unless raw_stack
+
+      klass = ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Status
+      klass.new(raw_stack.stack_status, raw_stack.stack_status_reason)
+    end
+  rescue MiqException::MiqOrchestrationStackNotExistError
+    raise
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Status < ::OrchestrationStack::Status
+  def succeeded?
+    status.downcase == "create_complete"
+  end
+
+  def failed?
+    status.downcase =~ /failed$/
+  end
+
+  def rollbacked?
+    status.downcase == "rollback_complete"
+  end
+
+  def deleted?
+    status.downcase == "delete_complete"
+  end
+end

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -134,22 +134,6 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     [:userid, :password]
   end
 
-  def stack_create(stack_name, template, options = {})
-    create_options = {:stack_name => stack_name, :template => template.content}.merge(options.except(:tenant_name))
-    openstack_handle.orchestration_service(options[:tenant_name]).stacks.new.save(create_options)["id"]
-  rescue => err
-    _log.error "stack=[#{stack_name}], error: #{err}"
-    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
-  end
-
-  def stack_status(stack_name, stack_id, options = {})
-    stack = openstack_handle.orchestration_service(options[:tenant_name]).stacks.get(stack_name, stack_id)
-    return stack.stack_status, stack.stack_status_reason if stack
-  rescue => err
-    _log.error "stack=[#{stack_name}], error: #{err}"
-    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
-  end
-
   def orchestration_template_validate(template)
     openstack_handle.orchestration_service.templates.validate(:template => template.content)
     nil

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -41,34 +41,45 @@ class OrchestrationStack < ActiveRecord::Base
     cloud_networks.size
   end
 
-  # @param options [Hash] what to update for the stack. Option keys and values are:
-  #   :template (String, URI, S3::S3Object, Object) - A new stack template.
-  #     This may be provided in a number of formats including:
-  #       a String, containing the template in CFN or HOT format.
-  #       a URL String pointing to the document in S3.
-  #       a URI object pointing to the document in S3.
-  #       an S3::S3Object which contains the template.
-  #       an Object which responds to #to_json and returns the template.
-  #   :parameters (Hash) - A hash that specifies the input parameters of the new stack.
-  def raw_update_stack(_options)
+  def self.create_stack(orchestration_manager, stack_name, template, options = {})
+    klass = orchestration_manager.class::OrchestrationStack
+    ems_ref = klass.raw_create_stack(orchestration_manager, stack_name, template, options)
+
+    klass.create(:name                   => stack_name,
+                 :ems_ref                => ems_ref,
+                 :status                 => 'CREATE_IN_PROGRESS',
+                 :ext_management_system  => orchestration_manager,
+                 :orchestration_template => template)
+  end
+
+  def self.raw_create_stack(_orchestration_manager, _stack_name, _template, _options = {})
+    raise NotImplementedError, "raw_create_stack must be implemented in a subclass"
+  end
+
+  def raw_update_stack(_options = {})
     raise NotImplementedError, "raw_update_stack must be implemented in a subclass"
+  end
+
+  def update_stack(options = {})
+    raw_update_stack(options)
   end
 
   def raw_delete_stack
     raise NotImplementedError, "raw_delete_stack must be implemented in a subclass"
   end
 
+  def delete_stack
+    raw_delete_stack
+  end
+
   def raw_status
-    options = {}
-    options.merge!(:tenant_name => cloud_tenant.name) if cloud_tenant
-    ext_management_system.stack_status(name, ems_ref, options)
+    raise NotImplementedError, "raw_status must be implemented in a subclass"
   end
 
   def raw_exists?
-    status, _reason = raw_status
-    status.nil? || status.downcase == 'delete_complete' ? false : true
-  rescue => err
-    return false if err.to_s =~ /[S|s]tack.+does not exist/
-    raise
+    rstatus = raw_status
+    rstatus && !rstatus.deleted?
+  rescue MiqException::MiqOrchestrationStackNotExistError
+    false
   end
 end

--- a/app/models/orchestration_stack/status.rb
+++ b/app/models/orchestration_stack/status.rb
@@ -1,0 +1,46 @@
+class OrchestrationStack
+  class Status
+    attr_accessor :status
+    attr_accessor :reason
+
+    def initialize(status, reason)
+      self.status = status
+      self.reason = reason
+    end
+
+    def succeeded?
+      false
+    end
+
+    def failed?
+      false
+    end
+
+    def rollbacked?
+      false
+    end
+
+    def deleted?
+      false
+    end
+
+    # in a non-transitional state
+    def completed?
+      succeeded? || failed? || rollbacked? || deleted?
+    end
+
+    def normalized_status
+      return ['transient', reason || status] unless completed?
+
+      if succeeded?
+        ['create_complete', reason || 'OK']
+      elsif rollbacked?
+        ['rollback_complete', reason || 'Stack was rolled back']
+      elsif deleted?
+        ['delete_complete', reason || 'Stack was deleted']
+      else
+        ['failed', reason || 'Stack creation failed']
+      end
+    end
+  end
+end

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -8,8 +8,8 @@ task = $evm.root["service_template_provision_task"]
 service = task.destination
 
 begin
-  ems_ref = service.deploy_orchestration_stack
-  $evm.log("info", "Stack #{service.stack_name} with reference id (#{ems_ref}) is being created")
+  stack = service.deploy_orchestration_stack
+  $evm.log("info", "Stack #{service.stack_name} with reference id (#{stack.ems_ref}) is being created")
 rescue => err
   $evm.root['ae_result'] = 'error'
   $evm.root['ae_reason'] = err.message

--- a/gems/pending/util/miq-exception.rb
+++ b/gems/pending/util/miq-exception.rb
@@ -106,4 +106,7 @@ module MiqException
   class MiqOrchestrationProvisionError < Error; end
   class MiqOrchestrationStatusError < Error; end
   class MiqOrchestrationValidationError < Error; end
+  class MiqOrchestrationUpdateError < Error; end
+  class MiqOrchestrationDeleteError < Error; end
+  class MiqOrchestrationStackNotExistError < Error; end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
@@ -11,9 +11,9 @@ module MiqAeMethodService
     expose :cloud_networks,         :association => true
     expose :orchestration_template, :association => true
     expose :ext_management_system,  :association => true
+    expose :ems_ref
     expose :raw_delete_stack
     expose :raw_update_stack
-    expose :raw_status
     expose :raw_exists?
 
     def add_to_service(service)
@@ -27,6 +27,12 @@ module MiqAeMethodService
       object_send(:destroy)
       @object = nil
       true
+    end
+
+    def normalized_live_status
+      @object.raw_status.try(:normalized_status)
+    rescue MiqException::MiqOrchestrationStackNotExistError => err
+      ['not_exist', err.message]
     end
   end
 end

--- a/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
@@ -34,14 +34,14 @@ describe "Orchestration check_provisioned Method Validation" do
   end
 
   it "considers rollback as provision error" do
-    ServiceOrchestration.any_instance.stub(:orchestration_stack_status) { ['ROLLBACK_COMPLETE', nil] }
+    ServiceOrchestration.any_instance.stub(:orchestration_stack_status) { ['ROLLBACK_COMPLETE', 'Stack was rolled back'] }
     ws.root['ae_result'].should == 'error'
     ws.root['ae_reason'].should == 'Stack was rolled back'
   end
 
   it "refreshes the provider and waits for it to complete" do
     ServiceOrchestration.any_instance.stub(:orchestration_stack_status) { ['CREATE_COMPLETE', nil] }
-    ServiceOrchestration.any_instance.stub(:stack_ems_ref) { stack_ems_ref }
+    ServiceOrchestration.any_instance.stub(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_amazon) }
     ManageIQ::Providers::Amazon::CloudManager.any_instance.should_receive(:refresh_ems)
     ws.root['ae_result'].should == 'retry'
   end
@@ -51,8 +51,7 @@ describe "Orchestration check_provisioned Method Validation" do
   end
 
   it "completes check_provisioned step when refresh is done" do
-    ServiceOrchestration.any_instance.stub(:stack_ems_ref) { stack_ems_ref }
-    FactoryGirl.create(:orchestration_stack, :ems_ref => stack_ems_ref)
+    ems_amazon.update_attributes(:last_refresh_date => Time.now + 100)
     ws_with_refresh_started.root['ae_result'].should == deploy_result
   end
 end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -2,6 +2,12 @@ FactoryGirl.define do
   factory :orchestration_stack do
   end
 
+  factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack"do
+  end
+
+  factory :orchestration_stack_openstack, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack"do
+  end
+
   factory :orchestration_stack_openstack_infra, :class => "ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack" do
     after :create do |x|
       x.parameters << FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_orchestration_stack_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_orchestration_stack_spec.rb
@@ -18,5 +18,20 @@ module MiqAeServiceOrchestrationStackSpec
         expect { service_stack.add_to_service('wrong type') }.to raise_error
       end
     end
+
+    context "normalized_live_status" do
+      it "gets the live status of the stack and normalizes the status" do
+        status = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status.new('CREATING', nil)
+        OrchestrationStack.any_instance.stub(:raw_status) { status }
+
+        service_stack.normalized_live_status.should == ['transient', "CREATING"]
+      end
+
+      it "shows the status as not_exist for non-existing stacks" do
+        OrchestrationStack.any_instance.stub(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'test failure' }
+
+        service_stack.normalized_live_status.should == ['not_exist', 'test failure']
+      end
+    end
   end
 end

--- a/spec/models/orchestration_stack/status_amazon_spec.rb
+++ b/spec/models/orchestration_stack/status_amazon_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require_dependency 'manageiq/providers/amazon/cloud_manager/orchestration_stack/status'
+
+describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status do
+  it 'parses CREATE_COMPLETE' do
+    status = described_class.new('CREATE_COMPLETE', '')
+    status.completed?.should  be_true
+    status.succeeded?.should  be_true
+    status.failed?.should     be_false
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['create_complete', '']
+  end
+
+  it 'parses ROLLBACK_COMPLETE' do
+    status = described_class.new('ROLLBACK_COMPLETE', nil)
+    status.completed?.should  be_true
+    status.succeeded?.should  be_false
+    status.failed?.should     be_false
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_true
+    status.normalized_status.should == ['rollback_complete', 'Stack was rolled back']
+  end
+
+  it 'parses DELETE_COMPLETE' do
+    status = described_class.new('DELETE_COMPLETE', nil)
+    status.completed?.should  be_true
+    status.succeeded?.should  be_false
+    status.failed?.should     be_false
+    status.deleted?.should    be_true
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['delete_complete', 'Stack was deleted']
+  end
+
+  it 'parses ROLLBACK_FAILED' do
+    status = described_class.new('ROLLBACK_FAILED', nil)
+    status.completed?.should  be_true
+    status.succeeded?.should  be_false
+    status.failed?.should     be_true
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['failed', 'Stack creation failed']
+  end
+
+  it 'parses transient status' do
+    status = described_class.new('CREATING', nil)
+    status.completed?.should  be_false
+    status.succeeded?.should  be_false
+    status.failed?.should     be_false
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['transient', 'CREATING']
+  end
+end

--- a/spec/models/orchestration_stack/status_openstack_spec.rb
+++ b/spec/models/orchestration_stack/status_openstack_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require_dependency 'manageiq/providers/openstack/cloud_manager/orchestration_stack/status'
+
+describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Status do
+  it 'parses CREATE_COMPLETE' do
+    status = described_class.new('CREATE_COMPLETE', '')
+    status.completed?.should  be_true
+    status.succeeded?.should  be_true
+    status.failed?.should     be_false
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['create_complete', '']
+  end
+
+  it 'parses ROLLBACK_COMPLETE' do
+    status = described_class.new('ROLLBACK_COMPLETE', nil)
+    status.completed?.should  be_true
+    status.succeeded?.should  be_false
+    status.failed?.should     be_false
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_true
+    status.normalized_status.should == ['rollback_complete', 'Stack was rolled back']
+  end
+
+  it 'parses DELETE_COMPLETE' do
+    status = described_class.new('DELETE_COMPLETE', nil)
+    status.completed?.should  be_true
+    status.succeeded?.should  be_false
+    status.failed?.should     be_false
+    status.deleted?.should    be_true
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['delete_complete', 'Stack was deleted']
+  end
+
+  it 'parses ROLLBACK_FAILED' do
+    status = described_class.new('ROLLBACK_FAILED', nil)
+    status.completed?.should  be_true
+    status.succeeded?.should  be_false
+    status.failed?.should     be_true
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['failed', 'Stack creation failed']
+  end
+
+  it 'parses transient status' do
+    status = described_class.new('CREATING', nil)
+    status.completed?.should  be_false
+    status.succeeded?.should  be_false
+    status.failed?.should     be_false
+    status.deleted?.should    be_false
+    status.rollbacked?.should be_false
+    status.normalized_status.should == ['transient', 'CREATING']
+  end
+end

--- a/spec/models/orchestration_stack_amazon_spec.rb
+++ b/spec/models/orchestration_stack_amazon_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
+  let(:ems) { FactoryGirl.create(:ems_amazon) }
+  let(:template) { FactoryGirl.create(:orchestration_template) }
+  let(:orchestration_stack) do
+    FactoryGirl.create(:orchestration_stack_amazon, :ext_management_system => ems, :name => 'test')
+  end
+
+  let(:the_raw_stack) do
+    double.tap do |stack|
+      allow(stack).to receive(:stack_id).and_return('one_id')
+    end
+  end
+
+  let(:raw_stacks) do
+    double.tap do |stacks|
+      handle = double
+      allow(handle).to receive(:stacks).and_return(stacks)
+      allow(ems).to receive(:connect).and_return(handle)
+      allow(stacks).to receive(:[]).with(orchestration_stack.name).and_return(the_raw_stack)
+    end
+  end
+
+  before do
+    raw_stacks
+  end
+
+  describe 'stack operations' do
+    context ".create_stack" do
+      it 'creates a stack' do
+        expect(raw_stacks).to receive(:create).and_return(the_raw_stack)
+
+        stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
+        stack.class.should == described_class
+        stack.name.should == 'mystack'
+        stack.ems_ref.should == the_raw_stack.stack_id
+      end
+
+      it 'catches errors from provider' do
+        expect(raw_stacks).to receive(:create).and_throw('bad request')
+
+        expect { OrchestrationStack.create_stack(ems, 'mystack', template, {}) }.to raise_error(MiqException::MiqOrchestrationProvisionError)
+      end
+    end
+
+    context "#update_stack" do
+      it 'updates the stack' do
+        expect(the_raw_stack).to receive(:update)
+        orchestration_stack.update_stack({})
+      end
+
+      it 'catches errors from provider' do
+        expect(the_raw_stack).to receive(:update).and_throw('bad request')
+        expect { orchestration_stack.update_stack }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+      end
+    end
+
+    context "#delete_stack" do
+      it 'updates the stack' do
+        expect(the_raw_stack).to receive(:delete)
+        orchestration_stack.delete_stack
+      end
+
+      it 'catches errors from provider' do
+        expect(the_raw_stack).to receive(:delete).and_throw('bad request')
+        expect { orchestration_stack.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
+      end
+    end
+  end
+
+  describe 'stack status' do
+    context '#raw_status and #raw_exists' do
+      it 'gets the stack status and reason' do
+        allow(the_raw_stack).to receive(:status).and_return('CREATE_COMPLETE')
+        allow(the_raw_stack).to receive(:status_reason).and_return('complete')
+
+        rstatus = orchestration_stack.raw_status
+        expect(rstatus).to have_attributes(:status => 'CREATE_COMPLETE', :reason => 'complete')
+
+        orchestration_stack.raw_exists?.should be_true
+      end
+
+      it 'parses error message to determine stack not exist' do
+        allow(raw_stacks).to receive(:[]).with(orchestration_stack.name).and_throw("Stack xxx does not exist")
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+
+        orchestration_stack.raw_exists?.should be_false
+      end
+
+      it 'catches errors from provider' do
+        allow(raw_stacks).to receive(:[]).with(orchestration_stack.name).and_throw("bad request")
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+
+        expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+      end
+    end
+  end
+end

--- a/spec/models/orchestration_stack_openstack_spec.rb
+++ b/spec/models/orchestration_stack_openstack_spec.rb
@@ -1,0 +1,106 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+  let(:template) { FactoryGirl.create(:orchestration_template) }
+  let(:orchestration_stack) do
+    FactoryGirl.create(:orchestration_stack_openstack, :ext_management_system => ems, :name => 'test', :ems_ref => 'one_id')
+  end
+
+  let(:the_raw_stack) do
+    double.tap do |stack|
+      allow(stack).to receive(:id).and_return('one_id')
+    end
+  end
+
+  let(:raw_stacks) do
+    double.tap do |stacks|
+      handle = double
+      allow(handle).to receive(:stacks).and_return(stacks)
+      allow(ems).to receive(:connect).and_return(handle)
+      allow(stacks).to receive(:get).with(orchestration_stack.name, orchestration_stack.ems_ref).and_return(the_raw_stack)
+    end
+  end
+
+  before do
+    raw_stacks
+  end
+
+  describe 'stack operations' do
+    context ".create_stack" do
+      let(:the_new_stack) { double }
+
+      before do
+        allow(raw_stacks).to receive(:new).and_return(the_new_stack)
+      end
+
+      it 'creates a stack' do
+        allow(the_new_stack).to receive(:[]).with("id").and_return('new_id')
+        expect(the_new_stack).to receive(:save).and_return(the_new_stack)
+
+        stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
+        stack.class.should == described_class
+        stack.name.should == 'mystack'
+        stack.ems_ref.should == 'new_id'
+      end
+
+      it 'catches errors from provider' do
+        expect(the_new_stack).to receive(:save).and_throw('bad request')
+
+        expect { OrchestrationStack.create_stack(ems, 'mystack', template, {}) }.to raise_error(MiqException::MiqOrchestrationProvisionError)
+      end
+    end
+
+    context "#update_stack" do
+      it 'updates the stack' do
+        expect(the_raw_stack).to receive(:save)
+        orchestration_stack.update_stack({})
+      end
+
+      it 'catches errors from provider' do
+        expect(the_raw_stack).to receive(:save).and_throw('bad request')
+        expect { orchestration_stack.update_stack }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+      end
+    end
+
+    context "#delete_stack" do
+      it 'updates the stack' do
+        expect(the_raw_stack).to receive(:delete)
+        orchestration_stack.delete_stack
+      end
+
+      it 'catches errors from provider' do
+        expect(the_raw_stack).to receive(:delete).and_throw('bad request')
+        expect { orchestration_stack.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
+      end
+    end
+  end
+
+  describe 'stack status' do
+    context '#raw_status and #raw_exists' do
+      it 'gets the stack status and reason' do
+        allow(the_raw_stack).to receive(:stack_status).and_return('CREATE_COMPLETE')
+        allow(the_raw_stack).to receive(:stack_status_reason).and_return('complete')
+
+        rstatus = orchestration_stack.raw_status
+        expect(rstatus).to have_attributes(:status => 'CREATE_COMPLETE', :reason => 'complete')
+
+        orchestration_stack.raw_exists?.should be_true
+      end
+
+      it 'determines stack not exist' do
+        allow(raw_stacks).to receive(:get).with(orchestration_stack.name, orchestration_stack.ems_ref).and_return(nil)
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+
+        orchestration_stack.raw_exists?.should be_false
+      end
+
+      it 'catches errors from provider' do
+        allow(raw_stacks).to receive(:get).with(orchestration_stack.name, orchestration_stack.ems_ref).and_throw("bad request")
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+
+        expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+      end
+    end
+  end
+end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -5,6 +5,7 @@ describe ServiceTemplate do
   let(:template_by_setter) { FactoryGirl.create(:orchestration_template) }
   let(:manager_by_dialog)  { FactoryGirl.create(:ems_amazon) }
   let(:template_by_dialog) { FactoryGirl.create(:orchestration_template) }
+  let(:deployed_stack)     { FactoryGirl.create(:orchestration_stack_amazon) }
 
   let(:dialog_options) do
     {
@@ -30,6 +31,11 @@ describe ServiceTemplate do
     service.orchestration_manager = manager_by_setter
     service.options = {:dialog => dialog_options}
     service
+  end
+
+  let(:service_with_deployed_stack) do
+    service_mix_dialog_setter.add_resource(deployed_stack)
+    service_mix_dialog_setter
   end
 
   context "#stack_name" do
@@ -80,7 +86,8 @@ describe ServiceTemplate do
 
   context '#deploy_orchestration_stack' do
     it 'creates a stack through cloud manager' do
-      ManageIQ::Providers::Amazon::CloudManager.any_instance.stub(:stack_create) do |name, template, opts|
+      ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.stub(:raw_create_stack) do |manager, name, template, opts|
+        manager.should == manager_by_setter
         name.should == 'test123'
         template.should be_kind_of OrchestrationTemplate
         opts.should be_kind_of Hash
@@ -134,21 +141,18 @@ describe ServiceTemplate do
     end
 
     it 'returns current stack status through provider' do
-      ManageIQ::Providers::Amazon::CloudManager.any_instance.stub(:stack_status).and_return(['create_complete', 'no error'])
+      status_obj = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status.new('CREATE_COMPLETE', 'no error')
+      deployed_stack.stub(:raw_status).and_return(status_obj)
 
-      service_mix_dialog_setter.options[:stack_ems_ref] = 'abc'  # simulate stack deployed
-      status, message = service_mix_dialog_setter.orchestration_stack_status
-
+      status, message = service_with_deployed_stack.orchestration_stack_status
       status.should  == 'create_complete'
       message.should == 'no error'
     end
 
     it 'returns an error message when the provider fails to retrieve the status' do
-      ManageIQ::Providers::Amazon::CloudManager.any_instance.stub(:stack_status)
-        .and_raise(MiqException::MiqOrchestrationStatusError, 'test failure')
+      deployed_stack.stub(:raw_status).and_raise(MiqException::MiqOrchestrationStatusError, 'test failure')
 
-      service_mix_dialog_setter.options[:stack_ems_ref] = 'abc'  # simulate stack deployed
-      status, message = service_mix_dialog_setter.orchestration_stack_status
+      status, message = service_with_deployed_stack.orchestration_stack_status
       status.should  == 'check_status_failed'
       message.should == 'test failure'
     end


### PR DESCRIPTION
Provider classes already have methods to create and query status of orchestration stacks. It makes sense to move implementations of updating and deleting stacks to provider. `OrchestrationStack` contains only delegate methods for the operations. Each subclass of `OrchestrationStack` no longer needs to implement these methods.

This PR also expose some of the operations in the miq ae service model

[UPDATE]
After the initial review comments, we decided to do the opposite. Now I have moved all stack operation (create, delete, update, and query status) from provider to `OrchestrationStack` and subclasses.