### PR TITLE
Render all orch. template types consistently

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1880,7 +1880,7 @@ class ApplicationController < ActionController::Base
     # Set up the list view type (grid/tile/list)
     @settings[:views][db_sym] = params[:type] if params[:type]  # Change the list view type, if it's sent in
 
-    @gtl_type = get_view_calculate_gtl_type(db_sym)
+    @gtl_type = get_view_calculate_gtl_type(options[:gtl_dbname] || db_sym)
 
     # Get the view for this db or use the existing one in the session
     view = refresh_view ? get_db_view(db.split("::").last, :association => association, :view_suffix => view_suffix) : session[:view]

--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -1615,7 +1615,7 @@ class CatalogController < ApplicationController
         elsif ["xx-otcfn", "xx-othot"].include?(x_node)
           typ = x_node == "xx-otcfn" ? "OrchestrationTemplateCfn" : "OrchestrationTemplateHot"
           @right_cell_text = _("All %s") % ui_lookup(:models => typ)
-          process_show_list(:model => typ.constantize)
+          process_show_list(:model => typ.constantize, :gtl_dbname => :orchestrationtemplate)
           sync_view_pictures_to_disk(@view) if ["grid", "tile"].include?(@gtl_type)
         else
           if x_active_tree == :stcat_tree


### PR DESCRIPTION
The configured orchestration template list view type should apply
to both CloudFormation & Heat template types.

https://bugzilla.redhat.com/show_bug.cgi?id=1207298