### PR TITLE
[api] Enhancement of /api/providers to support Foreman

### DIFF
--- a/lib/cfme_client/bin/rest_api.rb
+++ b/lib/cfme_client/bin/rest_api.rb
@@ -72,7 +72,7 @@ actions              = methods.keys
 methods_needing_data = %w(put post patch)
 scriptdir_actions    = %w(ls run)
 sub_commands         = actions + %w(edit vi) + scriptdir_actions
-api_parameters       = %w(expand attributes limit offset sort_by sort_order filter by_tag)
+api_parameters       = %w(expand attributes limit offset sort_by sort_order filter by_tag provider_class)
 multi_params         = %w(filter)
 
 opts = Trollop.options do

--- a/vmdb/app/controllers/api_controller/action.rb
+++ b/vmdb/app/controllers/api_controller/action.rb
@@ -3,8 +3,7 @@ class ApiController
     private
 
     def api_action(type, id, options = {})
-      cspec = collection_config[type]
-      klass = cspec[:klass].constantize
+      klass = collection_class(type)
 
       result = yield(klass) if block_given?
 

--- a/vmdb/app/controllers/api_controller/generic.rb
+++ b/vmdb/app/controllers/api_controller/generic.rb
@@ -42,7 +42,7 @@ class ApiController
     #
     def add_resource(type, _id, data)
       cspec = collection_config[type]
-      klass = cspec[:klass].constantize
+      klass = collection_class(type)
       if data.key?("id") || data.key?("href")
         raise BadRequestError,
               "Resource id or href should not be specified for creating a new #{type} resource"
@@ -62,16 +62,14 @@ class ApiController
     end
 
     def edit_resource(type, id, data)
-      cspec = collection_config[type]
-      klass = cspec[:klass].constantize
+      klass = collection_class(type)
       resource = resource_search(id, type, klass)
       resource.update_attributes(data.except(*ID_ATTRS))
       resource
     end
 
     def delete_resource(type, id = nil, _data = nil)
-      cspec = collection_config[type]
-      klass = cspec[:klass].constantize
+      klass = collection_class(type)
       id  ||= @req[:c_id]
       raise BadRequestError, "Must specify and id for deleting a #{type} resource" unless id
       api_log_info("Deleting #{type} id #{id}")
@@ -80,8 +78,7 @@ class ApiController
     end
 
     def retire_resource(type, id, data = nil)
-      cspec = collection_config[type]
-      klass = cspec[:klass].constantize
+      klass = collection_class(type)
       if id
         msg = "Retiring #{type} id #{id}"
         resource = resource_search(id, type, klass)

--- a/vmdb/app/controllers/api_controller/manager.rb
+++ b/vmdb/app/controllers/api_controller/manager.rb
@@ -21,8 +21,11 @@ class ApiController
 
     def parent_resource_obj
       type  = @req[:collection].to_sym
-      klass = collection_config[type][:klass].constantize
-      resource_search(@req[:c_id], type, klass)
+      resource_search(@req[:c_id], type, collection_class(type))
+    end
+
+    def collection_class(type)
+      (@collection_klasses[type.to_sym] || collection_config[type.to_sym][:klass]).constantize
     end
 
     def put_resource(type, id)

--- a/vmdb/app/controllers/api_controller/parser.rb
+++ b/vmdb/app/controllers/api_controller/parser.rb
@@ -42,6 +42,8 @@ class ApiController
     end
 
     def validate_api_request
+      validate_optional_collection_classes
+
       # API Version Validation
       if @req[:version]
         vname = @req[:version]
@@ -63,6 +65,20 @@ class ApiController
       end
 
       validate_api_parameters
+    end
+
+    def validate_optional_collection_classes
+      @collection_klasses = {}  # Default all to config classes
+      param = params['provider_class']
+      return unless param.present?
+
+      raise BadRequestError, "Unsupported provider_class #{param} specified" if param != "provider"
+      %w(tags policies policy_profiles).each do |cname|
+        if @req[:subcollection] == cname || expand?(cname)
+          raise BadRequestError, "Management of #{cname} is unsupported for the Provider class"
+        end
+      end
+      @collection_klasses[:providers] = "Provider"
     end
 
     def validate_api_action

--- a/vmdb/app/controllers/api_controller/policies.rb
+++ b/vmdb/app/controllers/api_controller/policies.rb
@@ -6,12 +6,12 @@ class ApiController
 
     def policies_query_resource(object)
       return {} unless object
-      policy_profile_klass = collection_config[:policy_profiles][:klass].constantize
+      policy_profile_klass = collection_class(:policy_profiles)
       (object.kind_of?(policy_profile_klass)) ? object.members : object_policies(object)
     end
 
     def policy_profiles_query_resource(object)
-      policy_profile_klass = collection_config[:policy_profiles][:klass].constantize
+      policy_profile_klass = collection_class(:policy_profiles)
       object ? object.get_policies.select { |p| p.kind_of?(policy_profile_klass) } : {}
     end
 
@@ -49,7 +49,7 @@ class ApiController
     end
 
     def object_policies(object)
-      policy_klass = collection_config[:policies][:klass].constantize
+      policy_klass = collection_class(:policies)
       object.get_policies.select { |p| p.kind_of?(policy_klass) }
     end
 
@@ -82,7 +82,7 @@ class ApiController
     end
 
     def policy_assign_action(object, ctype, id, data)
-      klass  = collection_config[ctype][:klass].constantize
+      klass  = collection_class(ctype)
       policy = policy_specified(id, data, ctype, klass)
       policy_subcollection_action(ctype, policy) do
         api_log_info("Assigning #{policy_ident(ctype, policy)}")
@@ -91,7 +91,7 @@ class ApiController
     end
 
     def policy_unassign_action(object, ctype, id, data)
-      klass  = collection_config[ctype][:klass].constantize
+      klass  = collection_class(ctype)
       policy = policy_specified(id, data, ctype, klass)
       policy_subcollection_action(ctype, policy) do
         api_log_info("Unassigning #{policy_ident(ctype, policy)}")
@@ -100,7 +100,7 @@ class ApiController
     end
 
     def policy_resolve_action(object, ctype, id, data)
-      klass  = collection_config[ctype][:klass].constantize
+      klass  = collection_class(ctype)
       policy = policy_specified(id, data, ctype, klass)
       policy_subcollection_action(ctype, policy) do
         api_log_info("Resolving #{policy_ident(ctype, policy)}")

--- a/vmdb/app/controllers/api_controller/providers.rb
+++ b/vmdb/app/controllers/api_controller/providers.rb
@@ -20,8 +20,7 @@ class ApiController
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
       raise BadRequestError, "Provider type cannot be updated" if data.key?(TYPE_ATTR)
 
-      klass = collection_config[:providers][:klass].constantize
-      provider = resource_search(id, type, klass)
+      provider = resource_search(id, type, collection_class(:providers))
       edit_provider(provider, data)
     end
 
@@ -68,8 +67,7 @@ class ApiController
     end
 
     def create_provider(data)
-      klass = collection_config[:providers][:klass].constantize
-      provider_klass = fetch_provider_klass(klass, data)
+      provider_klass = fetch_provider_klass(collection_class(:providers), data)
       create_data    = fetch_provider_data(provider_klass, data, :requires_zone => true)
       provider       = provider_klass.create!(create_data)
       update_provider_authentication(provider, data)

--- a/vmdb/app/controllers/api_controller/request_tasks.rb
+++ b/vmdb/app/controllers/api_controller/request_tasks.rb
@@ -4,7 +4,7 @@ class ApiController
     # Tasks/Request Tasks Subcollection Supporting Methods
     #
     def request_tasks_query_resource(object)
-      klass = collection_config[:request_tasks][:klass].constantize
+      klass = collection_class(:request_tasks)
       object ? klass.where(:miq_request_id => object.id) : {}
     end
 

--- a/vmdb/app/controllers/api_controller/service_requests.rb
+++ b/vmdb/app/controllers/api_controller/service_requests.rb
@@ -4,7 +4,7 @@ class ApiController
     # Service Requests Subcollection Supporting Methods
     #
     def service_requests_query_resource(object)
-      klass = collection_config[:service_requests][:klass].constantize
+      klass = collection_class(:service_requests)
       object ? klass.where(:source_id => object.id) : {}
     end
   end

--- a/vmdb/app/controllers/api_controller/service_templates.rb
+++ b/vmdb/app/controllers/api_controller/service_templates.rb
@@ -5,7 +5,7 @@ class ApiController
     #
 
     def service_templates_query_resource(object)
-      klass = collection_config[:service_templates][:klass].constantize
+      klass = collection_class(:service_templates)
       object ? klass.where(:service_template_catalog_id => object.id) : {}
     end
 
@@ -30,7 +30,7 @@ class ApiController
     end
 
     def service_templates_order_resource(_object, _type, id = nil, data = nil)
-      klass = collection_config[:service_templates][:klass].constantize
+      klass = collection_class(:service_templates)
       st    = klass.find(id)
 
       requester_id     = @auth_user
@@ -68,7 +68,7 @@ class ApiController
     end
 
     def service_template_subcollection_action(type, id)
-      klass = collection_config[:service_templates][:klass].constantize
+      klass = collection_class(:service_templates)
       result =
         begin
           st = resource_search(id, type, klass)

--- a/vmdb/app/controllers/api_controller/tags.rb
+++ b/vmdb/app/controllers/api_controller/tags.rb
@@ -47,7 +47,7 @@ class ApiController
 
     def tag_specified(id, data)
       if id.to_i > 0
-        klass  = collection_config[:tags][:klass].constantize
+        klass  = collection_class(:tags)
         tagobj = klass.find(id)
         return tag_path_to_spec(tagobj.name).merge(:id => tagobj.id)
       end
@@ -69,7 +69,7 @@ class ApiController
     def parse_tag_from_href(data)
       href = data["href"]
       tag  = if href && href.match(%r{^.*/tags/[0-9]+$})
-               klass = collection_config[:tags][:klass].constantize
+               klass = collection_class(:tags)
                klass.find(href.split('/').last)
              end
       tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}

--- a/vmdb/app/helpers/api_helper/renderer.rb
+++ b/vmdb/app/helpers/api_helper/renderer.rb
@@ -4,8 +4,7 @@ module ApiHelper
     # Helper proc for rendering a collection of type specified.
     #
     def render_collection_type(type, id, is_subcollection = false)
-      cspec = collection_config[type]
-      klass = cspec[:klass].constantize
+      klass = collection_class(type)
       opts  = {
         :name               => type.to_s,
         :is_subcollection   => is_subcollection,
@@ -98,7 +97,7 @@ module ApiHelper
       return reftype unless resource.respond_to?(:attributes)
 
       rclass = resource.class
-      if collection_config.fetch_path(type.to_sym, :klass).constantize != rclass
+      if collection_class(type) != rclass
         matched_type, _ = collection_config.detect do |_collection, spec|
           spec[:klass] && spec[:klass].constantize == rclass
         end

--- a/vmdb/spec/requests/api/providers_spec.rb
+++ b/vmdb/spec/requests/api/providers_spec.rb
@@ -47,6 +47,27 @@ describe ApiController do
     Vmdb::Application
   end
 
+  describe "Providers actions on Provider class" do
+    it "rejects requests with invalid provider_class" do
+      api_basic_authorize
+
+      run_get providers_url, :provider_class => "bad_class"
+
+      expect_bad_request(/unsupported/i)
+    end
+
+    it "supports requests with valid provider_class" do
+      api_basic_authorize
+
+      FactoryGirl.build(:provider_foreman)
+      run_get providers_url, :provider_class => "provider", :expand => "resources"
+
+      klass = Provider
+      expect_query_result(:providers, klass.count, klass.count)
+      expect_result_resources_to_include_data("resources", "name" => klass.pluck(:name))
+    end
+  end
+
   describe "Providers create" do
     it "rejects creation without appropriate role" do
       api_basic_authorize


### PR DESCRIPTION
- This enhancement allows the /api/providers CRUD & refresh to work with the new Provider class (i.e. Foreman)
- Support parameter provider_class == "provider" instead of the default ExtManagementSystem.
- Updated Provider class to support: supported_subclasses, managers, refresh_ems
- Added rspecs to test support of provider_class

https://trello.com/c/zsAoy9PP/115-api-provider-actions