### PR TITLE
Openstack infra UI for openstack components cluster aggregate

### DIFF
--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -508,7 +508,8 @@ module ApplicationController::CiProcessing
 
     # Build the vm detail gtl view
   def show_details(db, options={})  # Pass in the db, parent vm is in @vm
-    association    = options[:association] || nil
+    association = options[:association]
+    conditions  = options[:conditions]
     # generate the grid/tile/list url to come back here when gtl buttons are pressed
     @gtl_url       = "/#{@db}/#{@listicon.pluralize}/#{@record.id.to_s}?"
     @showtype      = "details"
@@ -518,6 +519,7 @@ module ApplicationController::CiProcessing
     @view, @pages = get_view(db,
                             :parent=>@record,
                             :association=>association,
+                            :conditions => conditions,
                             :dbname=>"#{@db}item")  # Get the records into a view & paginator
 
     if @explorer # In explorer?
@@ -1895,7 +1897,7 @@ module ApplicationController::CiProcessing
     @edit[:new][owner] != @edit[:current][owner]
   end
 
-  def show_association(action, display_name, listicon, method, klass, association = nil)
+  def show_association(action, display_name, listicon, method, klass, association = nil, conditions =nil)
     # Ajax request means in explorer, or if current explorer is one of the explorer controllers
     @explorer = true if request.xml_http_request? && explorer_controller?
     if @explorer  # Save vars for tree history array
@@ -1931,9 +1933,9 @@ module ApplicationController::CiProcessing
                       :url  => "/#{controller_name}/#{action}/#{@record.id}")
       @listicon = listicon
       if association.nil?
-        show_details(klass)
+        show_details(klass, :conditions => conditions)
       else
-        show_details(klass, :association => association )
+        show_details(klass, :association => association, :conditions => conditions)
       end
     end
   end

--- a/vmdb/app/controllers/ems_cluster_controller.rb
+++ b/vmdb/app/controllers/ems_cluster_controller.rb
@@ -61,8 +61,10 @@ class EmsClusterController < ApplicationController
       end
 
     when "hosts"
-      drop_breadcrumb( {:name=>@ems_cluster.name+" (All Hosts)", :url=>"/ems_cluster/show/#{@ems_cluster.id}?display=hosts"} )
-      @view, @pages = get_view(Host, :parent=>@ems_cluster) # Get the records (into a view) and the paginator
+      label, condition, breadcrumb_suffix = hosts_subsets
+
+      drop_breadcrumb( {:name => label, :url => "/ems_cluster/show/#{@ems_cluster.id}?display=hosts#{breadcrumb_suffix}"} )
+      @view, @pages = get_view(Host, :parent=>@ems_cluster, :conditions => condition) # Get the records (into a view) and the paginator
       @showtype = "hosts"
       if @view.extras[:total_count] && @view.extras[:auth_count] &&
           @view.extras[:total_count] > @view.extras[:auth_count]
@@ -260,6 +262,34 @@ class EmsClusterController < ApplicationController
   end
 
   private ############################
+
+  def hosts_subsets
+    condition         = nil
+    label             = @ems_cluster.name + _(" (All Hosts)")
+    breadcrumb_suffix = ""
+
+    host_service_group_name = params[:host_service_group_name]
+    if host_service_group_name
+      case params[:status]
+        when 'running'
+          hosts_filter =  @ems_cluster.host_ids_with_running_service_group(host_service_group_name)
+          label     = _("Hosts with running %s") % host_service_group_name
+        when 'failed'
+          hosts_filter =  @ems_cluster.host_ids_with_failed_service_group(host_service_group_name)
+          label     = _("Hosts with failed %s") % host_service_group_name
+        when 'all'
+          hosts_filter = @ems_cluster.host_ids_with_service_group(host_service_group_name)
+          label     = _("All Hosts with %s") % host_service_group_name
+      end
+
+      if hosts_filter
+        condition = ["hosts.id IN (#{hosts_filter.to_sql})"]
+        breadcrumb_suffix = "&host_service_group_name=#{host_service_group_name}&status=#{params[:status]}"
+      end
+    end
+
+    return label, condition, breadcrumb_suffix
+  end
 
   # Build the tree object to display the ems_cluster datacenter info
   def build_dc_tree

--- a/vmdb/app/models/ems_cluster_openstack_infra.rb
+++ b/vmdb/app/models/ems_cluster_openstack_infra.rb
@@ -13,4 +13,38 @@ class EmsClusterOpenstackInfra < EmsCluster
   def direct_vm_ids
     direct_vms.collect(&:id)
   end
+
+  ############################################33
+  # OpenStack status aggregate methods
+  def service_groups
+    self.hosts.joins(:host_service_groups)
+  end
+
+  def service_group_services
+    self.hosts.joins(:host_service_groups => :system_services)
+  end
+
+  def service_group_names
+    service_groups.group('host_service_groups.name').select('host_service_groups.name')
+  end
+
+  def service_group_services_running
+    service_group_services.where(SystemService.running_systemd_services_condition)
+  end
+
+  def service_group_services_failed
+    service_group_services.where(SystemService.failed_systemd_services_condition)
+  end
+
+  def host_ids_with_running_service_group(service_group_name)
+    service_group_services_running.where('host_service_groups.name' => service_group_name).select('DISTINCT hosts.id')
+  end
+
+  def host_ids_with_failed_service_group(service_group_name)
+    service_group_services_failed.where('host_service_groups.name' => service_group_name).select('DISTINCT hosts.id')
+  end
+
+  def host_ids_with_service_group(service_group_name)
+    service_group_services.where('host_service_groups.name' => service_group_name).select('DISTINCT hosts.id')
+  end
 end

--- a/vmdb/app/models/filesystem.rb
+++ b/vmdb/app/models/filesystem.rb
@@ -15,6 +15,10 @@ class Filesystem < ActiveRecord::Base
   virtual_column :contents,           :type => :string,  :uses => {:binary_blob => :binary_blob_parts}
   virtual_column :contents_available, :type => :boolean, :uses => :binary_blob
 
+  def self.host_service_group_condition(host_service_group_id)
+    arel_table[:host_service_group_id].eq(host_service_group_id)
+  end
+
   def self.add_elements(miq_set, scan_item, parent, xmlNode)
     options = {}
     options[:miq_set_id]   = miq_set.id   unless miq_set.nil?

--- a/vmdb/app/models/host_service_group_openstack.rb
+++ b/vmdb/app/models/host_service_group_openstack.rb
@@ -1,12 +1,20 @@
 class HostServiceGroupOpenstack < HostServiceGroup
   def running_system_services_condition
     # UI can't do arel relations, so I need to expose conditions
-    ["systemd_active= ? AND systemd_sub=?", 'active', 'running']
+    SystemService.running_systemd_services_condition
   end
 
   def failed_system_services_condition
     # UI can't do arel relations, so I need to expose conditions
-    ["(systemd_active= ? OR systemd_sub=?)", 'failed', 'failed']
+    SystemService.failed_systemd_services_condition
+  end
+
+  def host_service_group_system_services_condition
+    SystemService.host_service_group_condition(self.id)
+  end
+
+  def host_service_group_filesystems_condition
+    Filesystem.host_service_group_condition(self.id)
   end
 
   def running_system_services

--- a/vmdb/app/models/system_service.rb
+++ b/vmdb/app/models/system_service.rb
@@ -33,6 +33,18 @@ class SystemService < ActiveRecord::Base
     "4" =>    "Disabled"
   }
 
+  def self.running_systemd_services_condition
+    arel_table[:systemd_active].eq('active').and(arel_table[:systemd_sub].eq('running'))
+  end
+
+  def self.failed_systemd_services_condition
+    arel_table[:systemd_active].eq('failed').or(arel_table[:systemd_sub].eq('failed'))
+  end
+
+  def self.host_service_group_condition(host_service_group_id)
+    arel_table[:host_service_group_id].eq(host_service_group_id)
+  end
+
   def self.add_elements(parent, xmlNode)
     add_missing_elements(parent, xmlNode, "services")
   end

--- a/vmdb/app/views/ems_cluster/_main.html.haml
+++ b/vmdb/app/views/ems_cluster/_main.html.haml
@@ -9,3 +9,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for VMs"), :items => textual_group_vm_totals}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Configuration"), :items => textual_group_configuration}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}
+    = render :partial => "shared/summary/textual_multilink", :locals => { :title => _("OpenStack Status"), :items => textual_group_openstack_status }

--- a/vmdb/app/views/shared/summary/_textual_multilink.html.haml
+++ b/vmdb/app/views/shared/summary/_textual_multilink.html.haml
@@ -1,0 +1,21 @@
+- if items
+  %table.table.table-bordered.table-hover.table-striped
+    %thead
+      %tr
+        %th{:colspan => "100"}
+          = title
+    %tbody
+      - items.each do |item|
+        %tr{:class => 'no-hover'}
+          %td{:class => 'hover'}
+            - if item[:image]
+              %img{:src => "/images/icons/new/#{item[:image]}.png"}
+            = item[:value]
+          - item[:sub_items].each do |sub_item|
+            %td{:class => sub_item[:link] ? 'hover' : '',
+                :style => sub_item[:link] ? 'cursor: pointer; cursor: hand;' : '',
+                :title => sub_item[:title],
+                :onclick => sub_item[:link] ? "DoNav('#{sub_item[:link]}');" : ""}
+              - unless sub_item[:image].blank?
+                %img{:src => "/images/icons/new/#{sub_item[:image]}.png"}
+              = sub_item[:value]


### PR DESCRIPTION
Just last patch relevant, adding aggregate view of openstack status in cluster

Adding the whole block OpenStack Status. Each TD leads to the list of filtered hosts according to status of service.

![image](https://cloud.githubusercontent.com/assets/1737058/7229530/052ae5ee-e765-11e4-862a-7464ecc4be73.png)
