### PR TITLE
Proper error message in case the value is required and happens to be blank / nil

### DIFF
--- a/vmdb/app/models/dialog_field_text_box.rb
+++ b/vmdb/app/models/dialog_field_text_box.rb
@@ -40,11 +40,12 @@ class DialogFieldTextBox < DialogField
   def validate(dialog_tab, dialog_group)
     return if !required? && value.blank?
 
+    return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is required" if required? && value.blank?
+
     case validator_type
     when 'regex'
       return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.match(/#{validator_rule}/)
     end
-    super
   end
 
   def script_error_values

--- a/vmdb/spec/models/dialog_field_text_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_box_spec.rb
@@ -106,6 +106,12 @@ describe DialogFieldTextBox do
         df.validator_rule = ''
         df.validate(dt, dg).should == 'tab/group/test field is required'
       end
+
+      it "should return an error when a required value is nil" do
+        df.value = nil
+        df.validator_rule = nil
+        df.validate(dt, dg).should == 'tab/group/test field is required'
+      end
     end
   end
 


### PR DESCRIPTION
We need to filter out cases when the dialog field value is required
and happens to be blank / nil, before we proceed with value.match
(which would throw an undefined method exception).

https://bugzilla.redhat.com/show_bug.cgi?id=1206675