### PR TITLE
Only serialize a single changed field to send transaction.

### DIFF
--- a/vmdb/app/assets/javascripts/miq_application.js
+++ b/vmdb/app/assets/javascripts/miq_application.js
@@ -1650,3 +1650,7 @@ function miqSerializeForm(element) {
   return $('#' + element).find('input,select,textarea').serialize();
 }
 
+function miqSerializeField(element, field_name) {
+  return $("#" + element + " :input[id=" + field_name + "]").serialize();
+}
+

--- a/vmdb/app/views/miq_request/_prov_field.html.haml
+++ b/vmdb/app/views/miq_request/_prov_field.html.haml
@@ -443,7 +443,7 @@
             - field_hash[:values].each do |f|
               - checked = options[field] && options[field][0] ==  f[0]
               - current_div = "#{@edit[:new][:current_tab_key]}_div"
-              - onclick = remote_function(:with => "miqSerializeForm('#{current_div}')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
+              - onclick = remote_function(:with => "miqSerializeField('#{current_div}', '#{field_id}')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
               %input{:type => "radio", :id => field_id, :value => f[0], :name => field_id, :checked => checked, :onclick => disabled ? "" : onclick}
               = f[1]
           - else


### PR DESCRIPTION
Added new JS function that only send up a single field that is changed to send up in AJAX transaction, sending up the whole div with all fields in it was causing to reset some of the values on the screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1209847

@dclarizio please review/test