### PR TITLE
use the Rails router for path parsing

### DIFF
--- a/vmdb/app/controllers/api_controller/parser.rb
+++ b/vmdb/app/controllers/api_controller/parser.rb
@@ -11,18 +11,18 @@ class ApiController
       path_split = @req[:path].split('/')
       @req[:prefix]        = "/#{path_split[1]}"           # /api
       @req[:version]       = @version                      # Default API Version
-      cidx                 = 2                             # collection starts @ index 2
-      if path_split[2]
-        ver = path_split[2]
+      if params[:version]
+        ver = params[:version]
         if ver.match(version_config[:regex])               # v#.# version signature
           @req[:version]   = ver[1..-1]                    # Switching API Version
           @req[:prefix]    = "#{@req[:prefix]}/#{ver}"     # /api/v#.#
-          cidx            += 1
         end
       end
 
-      @req[:collection],    @req[:c_id] = path_split[cidx..cidx + 1]
-      @req[:subcollection], @req[:s_id] = path_split[cidx + 2..cidx + 3]
+      @req[:collection]    = params[:collection]
+      @req[:c_id]          = params[:c_id]
+      @req[:subcollection] = params[:subcollection]
+      @req[:s_id]          = params[:s_id]
 
       log_api_request
     end

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1934,12 +1934,13 @@ Vmdb::Application.routes.draw do
   root :to => 'dashboard#login'
 
   # Enablement for the REST API
-  get '/api'           => 'api#show',    :format => 'json'
-  get '/api/*suffix'   => 'api#show',    :format => 'json'
-  match '/api/*suffix' => 'api#update',  :format => 'json', :via => [:post, :put, :patch]
-  match '/api/*suffix' => 'api#destroy', :format => 'json', :via => [:delete]
   # OPTIONS requests for REST API pre-flight checks
   match '/api/*path'   => 'api#handle_options_request', :via => [:options]
+  get '/api(/:version)'           => 'api#show',    :format => 'json', :version => /v\d.*/
+
+  get    '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#show',    :format => 'json', :version => /v\d.*/
+  match  '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#update',  :format => 'json', :via => [:post, :put, :patch], :version => /v\d.*/
+  delete '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#destroy', :format => 'json', :version => /v\d.*/
 
   CONTROLLER_ACTIONS.each do |controller_name, controller_actions|
 


### PR DESCRIPTION
The Rails router can be configured with path parameters (parameters
which are embedded in the path).  If we configure the API routes to use
path parameters, then we can eliminate the path parsing code in the API
controller

/cc @abellotti 