### PR TITLE
Always do a refresh even if the stack creation status is failed

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -7,43 +7,71 @@ def refresh_provider(service)
   provider = service.orchestration_manager
 
   $evm.log("info", "Refreshing provider #{provider.name}")
+  old_date = provider.last_refresh_date
+  $evm.set_state_var('provider_last_refresh', old_date)
   provider.refresh
 end
 
-$evm.log("info", "Check orchestration provisioned")
+def refresh_may_have_completed?(service)
+  provider = service.orchestration_manager
+  provider.last_refresh_date > $evm.get_state_var('provider_last_refresh')
+end
 
-service = $evm.root["service_template_provision_task"].destination
-
-if $evm.state_var_exist? 'stack_deployed'
-  # check whether refresh completed
-  stack = $evm.vmdb('orchestration_stack').find_by_ems_ref(service.stack_ems_ref)
-
-  $evm.log("info", "Check refresh status of stack (#{service.stack_name})")
-  if stack
-    $evm.root['ae_result'] = 'ok'
-    stack.add_to_service(service)
-    $evm.log("info", "Stack (#{stack.name}, id = #{stack.id}) has been added to vmdb")
-  else
-    $evm.root['ae_result']         = 'retry'
-    $evm.root['ae_retry_interval'] = '30.seconds'
-  end
-else
+def check_deployed(service)
+  $evm.log("info", "Check orchestration deployed")
   # check whether the stack deployment completed
   status, reason = service.orchestration_stack_status
   case status.downcase
   when 'create_complete'
-    refresh_provider(service)
-    $evm.set_state_var('stack_deployed', true)
-    $evm.root['ae_result']         = 'retry'
-    $evm.root['ae_retry_interval'] = '30.seconds'
-  when 'rollback_complete'
-    $evm.root['ae_result'] = 'error'
-    $evm.root['ae_reason'] = 'Stack creation has been rolled back'
-  when /failed$/
+    $evm.root['ae_result'] = 'ok'
+  when 'rollback_complete', /failed$/
     $evm.root['ae_result'] = 'error'
     $evm.root['ae_reason'] = reason
   else
+    # deployment not done yet in provider
     $evm.root['ae_result']         = 'retry'
     $evm.root['ae_retry_interval'] = '1.minute'
+    return
   end
+
+  $evm.log("info", "Stack deployment finished. Status: #{$evm.root['ae_result']}, reason: #{$evm.root['ae_reason']}")
+
+  return unless service.stack_ems_ref
+  $evm.set_state_var('deploy_result', $evm.root['ae_result'])
+  $evm.set_state_var('deploy_reason', $evm.root['ae_reason'])
+
+  refresh_provider(service)
+
+  $evm.root['ae_result']         = 'retry'
+  $evm.root['ae_retry_interval'] = '30.seconds'
+end
+
+def check_refreshed(service)
+  $evm.log("info", "Check refresh status of stack (#{service.stack_name})")
+
+  # check whether refresh has completed, and add stack to service if applicable
+  # look for stack in vmdb if stack was successfully deployed
+  # otherwise check provider's last refresh time stamp because the stack may not exist in provider
+
+  stack = $evm.vmdb('orchestration_stack').find_by_ems_ref(service.stack_ems_ref)
+  if stack
+    $evm.root['ae_result'] = $evm.get_state_var('deploy_result')
+    $evm.root['ae_reason'] = $evm.get_state_var('deploy_reason')
+    stack.add_to_service(service)
+    $evm.log("info", "Stack (#{stack.name}, id = #{stack.id}) has been added to VMDB")
+  elsif $evm.get_state_var('deploy_result') == 'ok' || !refresh_may_have_completed?(service)
+    $evm.root['ae_result']         = 'retry'
+    $evm.root['ae_retry_interval'] = '30.seconds'
+  else
+    $evm.root['ae_result'] = 'error'
+    $evm.root['ae_reason'] = $evm.get_state_var('deploy_reason')
+    $evm.log("info", "Refresh completed. No new stack was found")
+  end
+end
+
+service = $evm.root["service_template_provision_task"].destination
+if $evm.state_var_exist?('provider_last_refresh')
+  check_refreshed(service)
+else
+  check_deployed(service)
 end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -26,9 +26,9 @@ object:
       scope: 
       description: 
       condition: 
-      on_entry: update_serviceprovision_status(status => 'Processing Pre1')
-      on_exit: update_serviceprovision_status(status => 'Processed Pre1')
-      on_error: update_serviceprovision_status(status => 'Error Processing Pre1')
+      on_entry: update_serviceprovision_status(status => 'Processing Preprovision')
+      on_exit: update_serviceprovision_status(status => 'Processed Preprovision')
+      on_error: update_serviceprovision_status(status => 'Error Processing Preprovision')
       max_retries: '100'
       max_time: 
   - field:
@@ -126,8 +126,8 @@ object:
       scope: 
       description: 
       condition: 
-      on_entry: update_serviceprovision_status(status => 'Creating Service')
-      on_exit: update_serviceprovision_status(status => 'Creating Service')
+      on_entry: update_serviceprovision_status(status => 'Creating Stack')
+      on_exit: update_serviceprovision_status(status => 'Creating Stack')
       on_error: update_serviceprovision_status(status => '${/#ae_reason}')
       max_retries: '100'
       max_time: 
@@ -147,7 +147,7 @@ object:
       description: 
       condition: 
       on_entry: 
-      on_exit: update_serviceprovision_status(status => 'Creating Service')
+      on_exit: update_serviceprovision_status(status => 'Creating Stack')
       on_error: update_serviceprovision_status(status => '${/#ae_reason}')
       max_retries: '100'
       max_time: 


### PR DESCRIPTION
When a stack creation failed, the stack may remained in the provider. Before we did not do provider refresh and add the stack to service_resources table.

With this fix, we should always do a refresh and add the failed stack to service_resources table. Therefore when a service is retired, the resulting failed stack can be retired also.

However the provider may not always keep the failed stack. The refresh may or may not get the failed stack from the provider. In order to determine whether the refresh has completed, in this fix we rely on monitoring the change of the provider's `last_refresh_date`. This is not always safe the time stamp may change by another refresh request from other party. A better solution is to introduce a new column `last_refresh_start_date`, which can be done by anther PR. 

Included in this PR are also some wording changes for state machine status.