### PR TITLE
appliance_console don't error before db configured

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -166,12 +166,13 @@ loop do
   begin
     ip = Env["IP"]
     # Because it takes a few seconds, get the database information once in the outside loop
-    dbhost, dbtype, database = ApplianceConsole::Utilities.db_host_type_database
+    configured = ApplianceConsole::DatabaseConfiguration.configured?
+    dbhost, dbtype, database = ApplianceConsole::Utilities.db_host_type_database if configured
 
     clear_screen
 
     say("#{I18n.t("product.name")} Virtual Appliance\n")
-    say("To administer this appliance, browse to https://#{ip}\n") if ApplianceConsole::DatabaseConfiguration.configured?
+    say("To administer this appliance, browse to https://#{ip}\n") if configured
     if $MIQDEBUG
       $MIQDEBUG_FILES.each { |f| puts "Modified #{(Time.now - File.mtime(f)).to_i / 60} minutes ago - #{f}" }
     end
@@ -505,6 +506,7 @@ Date and Time Configuration
           if database_configuration.activate
             database_configuration.post_activation
             say("\nConfiguration activated successfully.\n")
+            dbhost, dbtype, database = ApplianceConsole::Utilities.db_host_type_database
             press_any_key
           else
             say("\nConfiguration activation failed!\n")


### PR DESCRIPTION
1. don't display an error in logs when db not configured yet
2. don't require logout to display configured database information

/cc @jvlcek @jrafanie 