### PR TITLE
Foreman normalize configuration tags

### DIFF
--- a/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/inventory.rb
@@ -19,7 +19,7 @@ module ManageiqForeman
       end
       {
         :hosts      => hosts,
-        :hostgroups => hostgroups.denormalize
+        :hostgroups => hostgroups
       }
     end
 

--- a/vmdb/app/models/configuration_profile.rb
+++ b/vmdb/app/models/configuration_profile.rb
@@ -7,10 +7,4 @@ class ConfigurationProfile < ActiveRecord::Base
   belongs_to :parent, :class_name => 'ConfigurationProfile'
   has_and_belongs_to_many :configuration_locations, :join_table => :configuration_locations_configuration_profiles
   has_and_belongs_to_many :configuration_organizations, :join_table => :configuration_organizations_configuration_profiles
-  has_and_belongs_to_many :configuration_tags
-
-  def all_tags
-    tag_hash = configuration_tags.index_by(&:class)
-    parent ? tag_hash.reverse_merge(parent.all_tags) : tag_hash
-  end
 end

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -1,6 +1,15 @@
 class ConfigurationProfileForeman < ConfigurationProfile
+  belongs_to :parent, :class_name => 'ConfigurationProfileForeman'
   belongs_to :operating_system_flavor
 
   belongs_to :customization_script_ptable
   belongs_to :customization_script_medium
+  has_and_belongs_to_many :configuration_tags,
+                          :join_table  => 'configuration_profiles_configuration_tags',
+                          :foreign_key => :configuration_profile_id
+
+  def all_tags
+    tag_hash = configuration_tags.index_by(&:class)
+    parent ? tag_hash.reverse_merge(parent.all_tags) : tag_hash
+  end
 end

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -13,6 +13,26 @@ class ConfigurationProfileForeman < ConfigurationProfile
     tag_hash.values
   end
 
+  def configuration_architecture
+    tag_hash[configurationArchitecture]
+  end
+
+  def configuration_compute_profile
+    tag_hash[ConfigurationComputeProfile]
+  end
+
+  def configuration_domain
+    tag_hash[ConfigurationDomain]
+  end
+
+  def configuration_environment
+    tag_hash[ConfigurationEnvironment]
+  end
+
+  def configuration_realm
+    tag_hash[ConfigurationRealm]
+  end
+
   def tag_hash
     tag_hash = raw_configuration_tags.index_by(&:class)
     parent ? tag_hash.reverse_merge(parent.tag_hash) : tag_hash

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -15,6 +15,12 @@ class ConfigurationProfileForeman < ConfigurationProfile
                           :class_name  => 'ConfigurationTag',
                           :foreign_key => :configuration_profile_id
 
+  # derived values (to be used by ui)
+  belongs_to :customization_script_ptable
+  belongs_to :customization_script_medium
+  belongs_to :operating_system_flavor
+  virtual_has_many :configuration_tags,  :class_name => 'ConfigurationTag'
+
   delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_compute_profile, :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_domain,          :prefix => true, :allow_nil => true
@@ -23,11 +29,6 @@ class ConfigurationProfileForeman < ConfigurationProfile
   delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
   delegate :name, :to => :customization_script_medium,   :prefix => true, :allow_nil => true
   delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
-
-  virtual_has_many   :configuration_tags,          :class_name => 'ConfigurationTag'
-  virtual_belongs_to :customization_script_ptable, :class_name  => 'CustomizationScriptPtable'
-  virtual_belongs_to :customization_script_medium, :class_name  => 'CustomizationScriptMedium'
-  virtual_belongs_to :operating_system_flavor,     :class_name  => 'OperatingSystemFlavor'
 
   def configuration_tags
     tag_hash.values
@@ -51,18 +52,6 @@ class ConfigurationProfileForeman < ConfigurationProfile
 
   def configuration_realm
     tag_hash[ConfigurationRealm]
-  end
-
-  def operating_system_flavor
-    raw_operating_system_flavor || parent.try(:operating_system_flavor)
-  end
-
-  def customization_script_ptable
-    raw_customization_script_ptable || parent.try(:customization_script_ptable)
-  end
-
-  def customization_script_medium
-    raw_customization_script_medium || parent.try(:customization_script_medium)
   end
 
   def tag_hash

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -1,13 +1,33 @@
 class ConfigurationProfileForeman < ConfigurationProfile
   belongs_to :parent, :class_name => 'ConfigurationProfileForeman'
-  belongs_to :operating_system_flavor
 
-  belongs_to :customization_script_ptable
-  belongs_to :customization_script_medium
+  belongs_to :raw_operating_system_flavor,
+             :class_name  => 'OperatingSystemFlavor'
+
+  belongs_to :raw_customization_script_ptable,
+             :class_name  => 'CustomizationScriptPtable'
+
+  belongs_to :raw_customization_script_medium,
+             :class_name  => 'CustomizationScriptMedium'
+
   has_and_belongs_to_many :raw_configuration_tags,
                           :join_table  => 'configuration_profiles_configuration_tags',
                           :class_name  => 'ConfigurationTag',
                           :foreign_key => :configuration_profile_id
+
+  delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_compute_profile, :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_domain,          :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_environment,     :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_realm,           :prefix => true, :allow_nil => true
+  delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
+  delegate :name, :to => :customization_script_medium,   :prefix => true, :allow_nil => true
+  delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
+
+  virtual_belongs_to :operating_system_flavor,     :class_name  => 'OperatingSystemFlavor'
+  virtual_belongs_to :customization_script_ptable, :class_name  => 'CustomizationScriptPtable'
+  virtual_belongs_to :customization_script_medium, :class_name  => 'CustomizationScriptMedium'
+  virtual_has_many   :configuration_tags,          :class_name => 'ConfigurationTag'
 
   def configuration_tags
     tag_hash.values
@@ -31,6 +51,18 @@ class ConfigurationProfileForeman < ConfigurationProfile
 
   def configuration_realm
     tag_hash[ConfigurationRealm]
+  end
+
+  def operating_system_flavor
+    raw_operating_system_flavor || parent.try(:operating_system_flavor)
+  end
+
+  def customization_script_ptable
+    raw_customization_script_ptable || parent.try(:customization_script_ptable)
+  end
+
+  def customization_script_medium
+    raw_customization_script_medium || parent.try(:customization_script_medium)
   end
 
   def tag_hash

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -24,17 +24,17 @@ class ConfigurationProfileForeman < ConfigurationProfile
   delegate :name, :to => :customization_script_medium,   :prefix => true, :allow_nil => true
   delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
 
-  virtual_belongs_to :operating_system_flavor,     :class_name  => 'OperatingSystemFlavor'
+  virtual_has_many   :configuration_tags,          :class_name => 'ConfigurationTag'
   virtual_belongs_to :customization_script_ptable, :class_name  => 'CustomizationScriptPtable'
   virtual_belongs_to :customization_script_medium, :class_name  => 'CustomizationScriptMedium'
-  virtual_has_many   :configuration_tags,          :class_name => 'ConfigurationTag'
+  virtual_belongs_to :operating_system_flavor,     :class_name  => 'OperatingSystemFlavor'
 
   def configuration_tags
     tag_hash.values
   end
 
   def configuration_architecture
-    tag_hash[configurationArchitecture]
+    tag_hash[ConfigurationArchitecture]
   end
 
   def configuration_compute_profile
@@ -66,7 +66,9 @@ class ConfigurationProfileForeman < ConfigurationProfile
   end
 
   def tag_hash
-    tag_hash = raw_configuration_tags.index_by(&:class)
-    parent ? tag_hash.reverse_merge(parent.tag_hash) : tag_hash
+    @tag_hash ||= begin
+      tag_hash = raw_configuration_tags.index_by(&:class)
+      parent ? tag_hash.reverse_merge(parent.tag_hash) : tag_hash
+    end
   end
 end

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -1,16 +1,16 @@
 class ConfigurationProfileForeman < ConfigurationProfile
   belongs_to :parent, :class_name => 'ConfigurationProfileForeman'
 
-  belongs_to :raw_operating_system_flavor,
+  belongs_to :direct_operating_system_flavor,
              :class_name  => 'OperatingSystemFlavor'
 
-  belongs_to :raw_customization_script_ptable,
+  belongs_to :direct_customization_script_ptable,
              :class_name  => 'CustomizationScriptPtable'
 
-  belongs_to :raw_customization_script_medium,
+  belongs_to :direct_customization_script_medium,
              :class_name  => 'CustomizationScriptMedium'
 
-  has_and_belongs_to_many :raw_configuration_tags,
+  has_and_belongs_to_many :direct_configuration_tags,
                           :join_table  => 'configuration_profiles_configuration_tags',
                           :class_name  => 'ConfigurationTag',
                           :foreign_key => :configuration_profile_id
@@ -56,7 +56,7 @@ class ConfigurationProfileForeman < ConfigurationProfile
 
   def tag_hash
     @tag_hash ||= begin
-      tag_hash = raw_configuration_tags.index_by(&:class)
+      tag_hash = direct_configuration_tags.index_by(&:class)
       parent ? tag_hash.reverse_merge(parent.tag_hash) : tag_hash
     end
   end

--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -4,12 +4,17 @@ class ConfigurationProfileForeman < ConfigurationProfile
 
   belongs_to :customization_script_ptable
   belongs_to :customization_script_medium
-  has_and_belongs_to_many :configuration_tags,
+  has_and_belongs_to_many :raw_configuration_tags,
                           :join_table  => 'configuration_profiles_configuration_tags',
+                          :class_name  => 'ConfigurationTag',
                           :foreign_key => :configuration_profile_id
 
-  def all_tags
-    tag_hash = configuration_tags.index_by(&:class)
-    parent ? tag_hash.reverse_merge(parent.all_tags) : tag_hash
+  def configuration_tags
+    tag_hash.values
+  end
+
+  def tag_hash
+    tag_hash = raw_configuration_tags.index_by(&:class)
+    parent ? tag_hash.reverse_merge(parent.tag_hash) : tag_hash
   end
 end

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -5,10 +5,8 @@ class ConfiguredSystem < ActiveRecord::Base
   acts_as_miq_taggable
   belongs_to :configuration_manager
   belongs_to :configuration_profile
-  belongs_to :operating_system_flavor
   has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
 
-  delegate :name,                      :to => :operating_system_flavor, :prefix => true, :allow_nil => true
   delegate :name,                      :to => :provider,                :prefix => true, :allow_nil => true
   delegate :my_zone, :provider, :zone, :to => :manager
 

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -7,7 +7,6 @@ class ConfiguredSystem < ActiveRecord::Base
   belongs_to :configuration_profile
   belongs_to :operating_system_flavor
   has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
-  has_and_belongs_to_many :configuration_tags
 
   delegate :name,                      :to => :operating_system_flavor, :prefix => true, :allow_nil => true
   delegate :name,                      :to => :provider,                :prefix => true, :allow_nil => true
@@ -17,10 +16,5 @@ class ConfiguredSystem < ActiveRecord::Base
 
   def name
     hostname
-  end
-
-  def all_tags
-    tag_hash = configuration_tags.index_by(&:class)
-    configuration_profile ? tag_hash.reverse_merge(configuration_profile.all_tags) : tag_hash
   end
 end

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -4,13 +4,13 @@ class ConfiguredSystemForeman < ConfiguredSystem
   belongs_to :configuration_profile, :class_name => 'ConfigurationProfileForeman'
   belongs_to :configuration_location
   belongs_to :configuration_organization
-  belongs_to :raw_operating_system_flavor,
+  belongs_to :direct_operating_system_flavor,
              :class_name  => 'OperatingSystemFlavor'
-  belongs_to :raw_customization_script_medium,
+  belongs_to :direct_customization_script_medium,
              :class_name => "CustomizationScriptMedium"
-  belongs_to :raw_customization_script_ptable,
+  belongs_to :direct_customization_script_ptable,
              :class_name => "CustomizationScriptPtable"
-  has_and_belongs_to_many :raw_configuration_tags,
+  has_and_belongs_to_many :direct_configuration_tags,
                           :join_table  => 'configuration_tags_configured_systems',
                           :class_name  => 'ConfigurationTag',
                           :foreign_key => :configured_system_id
@@ -62,7 +62,7 @@ class ConfiguredSystemForeman < ConfiguredSystem
 
   def tag_hash
     @tag_hash ||= begin
-      tag_hash = raw_configuration_tags.index_by(&:class)
+      tag_hash = direct_configuration_tags.index_by(&:class)
       configuration_profile ? tag_hash.reverse_merge(configuration_profile.tag_hash) : tag_hash
     end
   end

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -22,6 +22,26 @@ class ConfiguredSystemForeman < ConfiguredSystem
     tag_hash.values
   end
 
+  def configuration_architecture
+    tag_hash[configurationArchitecture]
+  end
+
+  def configuration_compute_profile
+    tag_hash[ConfigurationComputeProfile]
+  end
+
+  def configuration_domain
+    tag_hash[ConfigurationDomain]
+  end
+
+  def configuration_environment
+    tag_hash[ConfigurationEnvironment]
+  end
+
+  def configuration_realm
+    tag_hash[ConfigurationRealm]
+  end
+
   def tag_hash
     tag_hash = raw_configuration_tags.index_by(&:class)
     configuration_profile ? tag_hash.reverse_merge(configuration_profile.tag_hash) : tag_hash

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -1,16 +1,25 @@
 class ConfiguredSystemForeman < ConfiguredSystem
   include ProviderObjectMixin
 
+  belongs_to :configuration_profile, :class_name => 'ConfigurationProfileForeman'
   belongs_to :configuration_location
   belongs_to :configuration_organization
   belongs_to :customization_script_medium
   belongs_to :customization_script_ptable
+  has_and_belongs_to_many :configuration_tags,
+                          :join_table  => 'configuration_tags_configured_systems',
+                          :foreign_key => :configured_system_id
 
   delegate :name, :to => :configuration_location,     :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_organization, :prefix => true, :allow_nil => true
 
   def provider_object(connection = nil)
     (connection || connection_source.connect).host(manager_ref)
+  end
+
+  def all_tags
+    tag_hash = configuration_tags.index_by(&:class)
+    configuration_profile ? tag_hash.reverse_merge(configuration_profile.all_tags) : tag_hash
   end
 
   private

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -4,15 +4,32 @@ class ConfiguredSystemForeman < ConfiguredSystem
   belongs_to :configuration_profile, :class_name => 'ConfigurationProfileForeman'
   belongs_to :configuration_location
   belongs_to :configuration_organization
-  belongs_to :customization_script_medium
-  belongs_to :customization_script_ptable
+  belongs_to :raw_operating_system_flavor,
+             :class_name  => 'OperatingSystemFlavor'
+  belongs_to :raw_customization_script_medium,
+             :class_name => "CustomizationScriptMedium"
+  belongs_to :raw_customization_script_ptable,
+             :class_name => "CustomizationScriptPtable"
   has_and_belongs_to_many :raw_configuration_tags,
                           :join_table  => 'configuration_tags_configured_systems',
                           :class_name  => 'ConfigurationTag',
                           :foreign_key => :configured_system_id
 
-  delegate :name, :to => :configuration_location,     :prefix => true, :allow_nil => true
-  delegate :name, :to => :configuration_organization, :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_location,        :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_organization,    :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_compute_profile, :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_domain,          :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_environment,     :prefix => true, :allow_nil => true
+  delegate :name, :to => :configuration_realm,           :prefix => true, :allow_nil => true
+  delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
+  delegate :name, :to => :customization_script_medium,   :prefix => true, :allow_nil => true
+  delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
+
+  virtual_belongs_to :operating_system_flavor,     :class_name  => 'OperatingSystemFlavor'
+  virtual_belongs_to :customization_script_ptable, :class_name  => 'CustomizationScriptPtable'
+  virtual_belongs_to :customization_script_medium, :class_name  => 'CustomizationScriptMedium'
+  virtual_has_many   :configuration_tags,          :class_name => 'ConfigurationTag'
 
   def provider_object(connection = nil)
     (connection || connection_source.connect).host(manager_ref)
@@ -40,6 +57,18 @@ class ConfiguredSystemForeman < ConfiguredSystem
 
   def configuration_realm
     tag_hash[ConfigurationRealm]
+  end
+
+  def operating_system_flavor
+    raw_operating_system_flavor || configuration_profile.try(:operating_system_flavor)
+  end
+
+  def customization_script_medium
+    raw_customization_script_medium || configuration_profile.try(:customization_script_medium)
+  end
+
+  def customization_script_ptable
+    raw_customization_script_ptable || configuration_profile.try(:customization_script_ptable)
   end
 
   def tag_hash

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -40,7 +40,7 @@ class ConfiguredSystemForeman < ConfiguredSystem
   end
 
   def configuration_architecture
-    tag_hash[configurationArchitecture]
+    tag_hash[ConfigurationArchitecture]
   end
 
   def configuration_compute_profile
@@ -72,8 +72,10 @@ class ConfiguredSystemForeman < ConfiguredSystem
   end
 
   def tag_hash
-    tag_hash = raw_configuration_tags.index_by(&:class)
-    configuration_profile ? tag_hash.reverse_merge(configuration_profile.tag_hash) : tag_hash
+    @tag_hash ||= begin
+      tag_hash = raw_configuration_tags.index_by(&:class)
+      configuration_profile ? tag_hash.reverse_merge(configuration_profile.tag_hash) : tag_hash
+    end
   end
 
   private

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -6,8 +6,9 @@ class ConfiguredSystemForeman < ConfiguredSystem
   belongs_to :configuration_organization
   belongs_to :customization_script_medium
   belongs_to :customization_script_ptable
-  has_and_belongs_to_many :configuration_tags,
+  has_and_belongs_to_many :raw_configuration_tags,
                           :join_table  => 'configuration_tags_configured_systems',
+                          :class_name  => 'ConfigurationTag',
                           :foreign_key => :configured_system_id
 
   delegate :name, :to => :configuration_location,     :prefix => true, :allow_nil => true
@@ -17,9 +18,13 @@ class ConfiguredSystemForeman < ConfiguredSystem
     (connection || connection_source.connect).host(manager_ref)
   end
 
-  def all_tags
-    tag_hash = configuration_tags.index_by(&:class)
-    configuration_profile ? tag_hash.reverse_merge(configuration_profile.all_tags) : tag_hash
+  def configuration_tags
+    tag_hash.values
+  end
+
+  def tag_hash
+    tag_hash = raw_configuration_tags.index_by(&:class)
+    configuration_profile ? tag_hash.reverse_merge(configuration_profile.tag_hash) : tag_hash
   end
 
   private

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -15,6 +15,12 @@ class ConfiguredSystemForeman < ConfiguredSystem
                           :class_name  => 'ConfigurationTag',
                           :foreign_key => :configured_system_id
 
+  # derived values (to be used by ui)
+  belongs_to :customization_script_ptable
+  belongs_to :customization_script_medium
+  belongs_to :operating_system_flavor
+  virtual_has_many :configuration_tags,  :class_name => 'ConfigurationTag'
+
   delegate :name, :to => :configuration_location,        :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_organization,    :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true
@@ -25,11 +31,6 @@ class ConfiguredSystemForeman < ConfiguredSystem
   delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
   delegate :name, :to => :customization_script_medium,   :prefix => true, :allow_nil => true
   delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
-
-  virtual_belongs_to :operating_system_flavor,     :class_name  => 'OperatingSystemFlavor'
-  virtual_belongs_to :customization_script_ptable, :class_name  => 'CustomizationScriptPtable'
-  virtual_belongs_to :customization_script_medium, :class_name  => 'CustomizationScriptMedium'
-  virtual_has_many   :configuration_tags,          :class_name => 'ConfigurationTag'
 
   def provider_object(connection = nil)
     (connection || connection_source.connect).host(manager_ref)
@@ -57,18 +58,6 @@ class ConfiguredSystemForeman < ConfiguredSystem
 
   def configuration_realm
     tag_hash[ConfigurationRealm]
-  end
-
-  def operating_system_flavor
-    raw_operating_system_flavor || configuration_profile.try(:operating_system_flavor)
-  end
-
-  def customization_script_medium
-    raw_customization_script_medium || configuration_profile.try(:customization_script_medium)
-  end
-
-  def customization_script_ptable
-    raw_customization_script_ptable || configuration_profile.try(:customization_script_ptable)
   end
 
   def tag_hash

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -155,6 +155,11 @@ module EmsRefresh
               }
             end
             rollup(p, ancestor_values)
+
+            invalid = []
+            invalid << "location" if p[:configuration_location_ids].empty?
+            invalid << "organization" if p[:configuration_organization_ids].empty?
+            $log.warn "Foreman hostgroup #{p[:name]} missing: #{invalid.join(", ")}" unless invalid.empty?
           end
           indexes[:profiles] = add_ids(profiles)
         end
@@ -198,6 +203,10 @@ module EmsRefresh
               :customization_script_ptable_id => s[:direct_customization_script_ptable_id].presence ||
                                                  parent[:customization_script_ptable_id].presence,
             )
+            invalid = []
+            invalid << "location" if s[:configuration_location_id].nil?
+            invalid << "organization" if s[:configuration_organization_id].nil?
+            $log.warn "Foreman host #{s[:hostname]} missing: #{invalid.join(", ")}" unless invalid.empty?
           end
         end
       end

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -123,23 +123,23 @@ module EmsRefresh
       def configuration_profile_inv_to_hashes(recs, indexes)
         recs.collect do |profile|
           {
-            :type                           => "ConfigurationProfileForeman",
-            :manager_ref                    => profile["id"].to_s,
-            :parent_ref                     => (profile["ancestry"] || "").split("/").last.presence,
-            :name                           => profile["name"],
-            :description                    => profile["title"],
-            :raw_configuration_tag_ids      => [
+            :type                               => "ConfigurationProfileForeman",
+            :manager_ref                        => profile["id"].to_s,
+            :parent_ref                         => (profile["ancestry"] || "").split("/").last.presence,
+            :name                               => profile["name"],
+            :description                        => profile["title"],
+            :raw_configuration_tag_ids          => [
               id_lookup(indexes[:architectures], profile["architecture_id"]),
               id_lookup(indexes[:compute_profiles], profile["compute_profile_id"]),
               id_lookup(indexes[:domains], profile["domain_id"]),
               id_lookup(indexes[:environments], profile["environment_id"]),
               id_lookup(indexes[:realms], profile["realm_id"]),
             ].compact,
-            :operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),
-            :customization_script_medium_id => id_lookup(indexes[:media], profile["medium_id"]),
-            :customization_script_ptable_id => id_lookup(indexes[:ptables], profile["ptable_id"]),
-            :configuration_location_ids     => ids_lookup(indexes[:locations], profile["locations"] || tax_refs),
-            :configuration_organization_ids => ids_lookup(indexes[:organizations], profile["organizations"] || tax_refs),
+            :raw_operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),
+            :raw_customization_script_medium_id => id_lookup(indexes[:media], profile["medium_id"]),
+            :raw_customization_script_ptable_id => id_lookup(indexes[:ptables], profile["ptable_id"]),
+            :configuration_location_ids         => ids_lookup(indexes[:locations], profile["locations"] || tax_refs),
+            :configuration_organization_ids     => ids_lookup(indexes[:organizations], profile["organizations"] || tax_refs),
           }
         end.tap do |profiles|
           indexes[:profiles] = add_ids(profiles)
@@ -149,26 +149,26 @@ module EmsRefresh
       def configured_system_inv_to_hashes(recs, indexes)
         recs.collect do |cs|
           {
-            :type                           => "ConfiguredSystemForeman",
-            :manager_ref                    => cs["id"].to_s,
-            :hostname                       => cs["name"],
-            :configuration_profile          => id_lookup(indexes[:profiles], cs["hostgroup_id"]),
-            :operating_system_flavor_id     => id_lookup(indexes[:flavors], cs["operatingsystem_id"]),
-            :customization_script_medium_id => id_lookup(indexes[:media], cs["medium_id"]),
-            :customization_script_ptable_id => id_lookup(indexes[:ptables], cs["ptable_id"]),
-            :raw_configuration_tag_ids      => [
+            :type                               => "ConfiguredSystemForeman",
+            :manager_ref                        => cs["id"].to_s,
+            :hostname                           => cs["name"],
+            :configuration_profile              => id_lookup(indexes[:profiles], cs["hostgroup_id"]),
+            :raw_operating_system_flavor_id     => id_lookup(indexes[:flavors], cs["operatingsystem_id"]),
+            :raw_customization_script_medium_id => id_lookup(indexes[:media], cs["medium_id"]),
+            :raw_customization_script_ptable_id => id_lookup(indexes[:ptables], cs["ptable_id"]),
+            :raw_configuration_tag_ids          => [
               id_lookup(indexes[:architectures], cs["architecture_id"]),
               id_lookup(indexes[:compute_profiles], cs["compute_profile_id"]),
               id_lookup(indexes[:domains], cs["domain_id"]),
               id_lookup(indexes[:environments], cs["environment_id"]),
               id_lookup(indexes[:realms], cs["realm_id"])].compact,
-            :last_checkin                   => cs["last_compile"],
-            :build_state                    => cs["build"] ? "pending" : nil,
-            :ipaddress                      => cs["ip"],
-            :mac_address                    => cs["mac"],
-            :ipmi_present                   => cs["sp_ip"].present?,
-            :configuration_location_id      => id_lookup(indexes[:locations], cs["location_id"] || 0),
-            :configuration_organization_id  => id_lookup(indexes[:organizations], cs["organization_id"] || 0),
+            :last_checkin                       => cs["last_compile"],
+            :build_state                        => cs["build"] ? "pending" : nil,
+            :ipaddress                          => cs["ip"],
+            :mac_address                        => cs["mac"],
+            :ipmi_present                       => cs["sp_ip"].present?,
+            :configuration_location_id          => id_lookup(indexes[:locations], cs["location_id"] || 0),
+            :configuration_organization_id      => id_lookup(indexes[:organizations], cs["organization_id"] || 0),
           }
         end
       end

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -128,7 +128,7 @@ module EmsRefresh
             :parent_ref                     => (profile["ancestry"] || "").split("/").last.presence,
             :name                           => profile["name"],
             :description                    => profile["title"],
-            :configuration_tag_ids          => [
+            :raw_configuration_tag_ids      => [
               id_lookup(indexes[:architectures], profile["architecture_id"]),
               id_lookup(indexes[:compute_profiles], profile["compute_profile_id"]),
               id_lookup(indexes[:domains], profile["domain_id"]),
@@ -156,7 +156,7 @@ module EmsRefresh
             :operating_system_flavor_id     => id_lookup(indexes[:flavors], cs["operatingsystem_id"]),
             :customization_script_medium_id => id_lookup(indexes[:media], cs["medium_id"]),
             :customization_script_ptable_id => id_lookup(indexes[:ptables], cs["ptable_id"]),
-            :configuration_tag_ids          => [
+            :raw_configuration_tag_ids      => [
               id_lookup(indexes[:architectures], cs["architecture_id"]),
               id_lookup(indexes[:compute_profiles], cs["compute_profile_id"]),
               id_lookup(indexes[:domains], cs["domain_id"]),

--- a/vmdb/app/models/ems_refresh/parsers/foreman.rb
+++ b/vmdb/app/models/ems_refresh/parsers/foreman.rb
@@ -123,23 +123,23 @@ module EmsRefresh
       def configuration_profile_inv_to_hashes(recs, indexes)
         recs.collect do |profile|
           {
-            :type                               => "ConfigurationProfileForeman",
-            :manager_ref                        => profile["id"].to_s,
-            :parent_ref                         => (profile["ancestry"] || "").split("/").last.presence,
-            :name                               => profile["name"],
-            :description                        => profile["title"],
-            :raw_configuration_tag_ids          => [
+            :type                                  => "ConfigurationProfileForeman",
+            :manager_ref                           => profile["id"].to_s,
+            :parent_ref                            => (profile["ancestry"] || "").split("/").last.presence,
+            :name                                  => profile["name"],
+            :description                           => profile["title"],
+            :direct_configuration_tag_ids          => [
               id_lookup(indexes[:architectures], profile["architecture_id"]),
               id_lookup(indexes[:compute_profiles], profile["compute_profile_id"]),
               id_lookup(indexes[:domains], profile["domain_id"]),
               id_lookup(indexes[:environments], profile["environment_id"]),
               id_lookup(indexes[:realms], profile["realm_id"]),
             ].compact,
-            :raw_operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),
-            :raw_customization_script_medium_id => id_lookup(indexes[:media], profile["medium_id"]),
-            :raw_customization_script_ptable_id => id_lookup(indexes[:ptables], profile["ptable_id"]),
-            :configuration_location_ids         => ids_lookup(indexes[:locations], profile["locations"] || tax_refs),
-            :configuration_organization_ids     => ids_lookup(indexes[:organizations], profile["organizations"] || tax_refs),
+            :direct_operating_system_flavor_id     => id_lookup(indexes[:flavors], profile["operatingsystem_id"]),
+            :direct_customization_script_medium_id => id_lookup(indexes[:media], profile["medium_id"]),
+            :direct_customization_script_ptable_id => id_lookup(indexes[:ptables], profile["ptable_id"]),
+            :configuration_location_ids            => ids_lookup(indexes[:locations], profile["locations"] || tax_refs),
+            :configuration_organization_ids        => ids_lookup(indexes[:organizations], profile["organizations"] || tax_refs),
           }
         end.tap do |profiles|
           # populate profiles with rolled up values
@@ -147,9 +147,9 @@ module EmsRefresh
             # pull back a few fields that are to be merged
             ancestor_values = family_tree(profiles, p).map do |hash|
               {
-                :operating_system_flavor_id     => hash[:raw_operating_system_flavor_id],
-                :customization_script_medium_id => hash[:raw_customization_script_medium_id],
-                :customization_script_ptable_id => hash[:raw_customization_script_ptable_id],
+                :operating_system_flavor_id     => hash[:direct_operating_system_flavor_id],
+                :customization_script_medium_id => hash[:direct_customization_script_medium_id],
+                :customization_script_ptable_id => hash[:direct_customization_script_ptable_id],
               }
             end
             rollup(p, ancestor_values)
@@ -161,37 +161,37 @@ module EmsRefresh
       def configured_system_inv_to_hashes(recs, indexes)
         recs.collect do |cs|
           {
-            :type                               => "ConfiguredSystemForeman",
-            :manager_ref                        => cs["id"].to_s,
-            :hostname                           => cs["name"],
-            :configuration_profile              => id_lookup(indexes[:profiles], cs["hostgroup_id"]),
-            :raw_operating_system_flavor_id     => id_lookup(indexes[:flavors], cs["operatingsystem_id"]),
-            :raw_customization_script_medium_id => id_lookup(indexes[:media], cs["medium_id"]),
-            :raw_customization_script_ptable_id => id_lookup(indexes[:ptables], cs["ptable_id"]),
-            :raw_configuration_tag_ids          => [
+            :type                                  => "ConfiguredSystemForeman",
+            :manager_ref                           => cs["id"].to_s,
+            :hostname                              => cs["name"],
+            :configuration_profile                 => id_lookup(indexes[:profiles], cs["hostgroup_id"]),
+            :direct_operating_system_flavor_id     => id_lookup(indexes[:flavors], cs["operatingsystem_id"]),
+            :direct_customization_script_medium_id => id_lookup(indexes[:media], cs["medium_id"]),
+            :direct_customization_script_ptable_id => id_lookup(indexes[:ptables], cs["ptable_id"]),
+            :direct_configuration_tag_ids          => [
               id_lookup(indexes[:architectures], cs["architecture_id"]),
               id_lookup(indexes[:compute_profiles], cs["compute_profile_id"]),
               id_lookup(indexes[:domains], cs["domain_id"]),
               id_lookup(indexes[:environments], cs["environment_id"]),
               id_lookup(indexes[:realms], cs["realm_id"])].compact,
-            :last_checkin                       => cs["last_compile"],
-            :build_state                        => cs["build"] ? "pending" : nil,
-            :ipaddress                          => cs["ip"],
-            :mac_address                        => cs["mac"],
-            :ipmi_present                       => cs["sp_ip"].present?,
-            :configuration_location_id          => id_lookup(indexes[:locations], cs["location_id"] || 0),
-            :configuration_organization_id      => id_lookup(indexes[:organizations], cs["organization_id"] || 0),
+            :last_checkin                          => cs["last_compile"],
+            :build_state                           => cs["build"] ? "pending" : nil,
+            :ipaddress                             => cs["ip"],
+            :mac_address                           => cs["mac"],
+            :ipmi_present                          => cs["sp_ip"].present?,
+            :configuration_location_id             => id_lookup(indexes[:locations], cs["location_id"] || 0),
+            :configuration_organization_id         => id_lookup(indexes[:organizations], cs["organization_id"] || 0),
           }
         end.tap do |systems|
           # if the system doesn't have a value, use the rolled up profile value
           systems.each do |s|
             parent = s[:configuration_profile] || {}
             s.merge!(
-              :operating_system_flavor_id     => s[:raw_operating_system_flavor_id].presence ||
+              :operating_system_flavor_id     => s[:direct_operating_system_flavor_id].presence ||
                                                  parent[:operating_system_flavor_id].presence,
-              :customization_script_medium_id => s[:raw_customization_script_medium_id].presence ||
+              :customization_script_medium_id => s[:direct_customization_script_medium_id].presence ||
                                                  parent[:customization_script_medium_id].presence,
-              :customization_script_ptable_id => s[:raw_customization_script_ptable_id].presence ||
+              :customization_script_ptable_id => s[:direct_customization_script_ptable_id].presence ||
                                                  parent[:customization_script_ptable_id].presence,
             )
           end

--- a/vmdb/db/migrate/20150414201314_update_foreman_raw_attributes.rb
+++ b/vmdb/db/migrate/20150414201314_update_foreman_raw_attributes.rb
@@ -1,0 +1,11 @@
+class UpdateForemanRawAttributes < ActiveRecord::Migration
+  def change
+    rename_column :configured_systems, :operating_system_flavor_id,     :raw_operating_system_flavor_id
+    rename_column :configured_systems, :customization_script_medium_id, :raw_customization_script_medium_id
+    rename_column :configured_systems, :customization_script_ptable_id, :raw_customization_script_ptable_id
+
+    rename_column :configuration_profiles, :operating_system_flavor_id,     :raw_operating_system_flavor_id
+    rename_column :configuration_profiles, :customization_script_medium_id, :raw_customization_script_medium_id
+    rename_column :configuration_profiles, :customization_script_ptable_id, :raw_customization_script_ptable_id
+  end
+end

--- a/vmdb/db/migrate/20150414201314_update_foreman_raw_attributes.rb
+++ b/vmdb/db/migrate/20150414201314_update_foreman_raw_attributes.rb
@@ -1,11 +1,11 @@
 class UpdateForemanRawAttributes < ActiveRecord::Migration
   def change
-    rename_column :configured_systems, :operating_system_flavor_id,     :raw_operating_system_flavor_id
-    rename_column :configured_systems, :customization_script_medium_id, :raw_customization_script_medium_id
-    rename_column :configured_systems, :customization_script_ptable_id, :raw_customization_script_ptable_id
+    rename_column :configured_systems, :operating_system_flavor_id,     :direct_operating_system_flavor_id
+    rename_column :configured_systems, :customization_script_medium_id, :direct_customization_script_medium_id
+    rename_column :configured_systems, :customization_script_ptable_id, :direct_customization_script_ptable_id
 
-    rename_column :configuration_profiles, :operating_system_flavor_id,     :raw_operating_system_flavor_id
-    rename_column :configuration_profiles, :customization_script_medium_id, :raw_customization_script_medium_id
-    rename_column :configuration_profiles, :customization_script_ptable_id, :raw_customization_script_ptable_id
+    rename_column :configuration_profiles, :operating_system_flavor_id,     :direct_operating_system_flavor_id
+    rename_column :configuration_profiles, :customization_script_medium_id, :direct_customization_script_medium_id
+    rename_column :configuration_profiles, :customization_script_ptable_id, :direct_customization_script_ptable_id
   end
 end

--- a/vmdb/db/migrate/20150417162811_update_foreman_derived_values.rb
+++ b/vmdb/db/migrate/20150417162811_update_foreman_derived_values.rb
@@ -1,0 +1,11 @@
+class UpdateForemanDerivedValues < ActiveRecord::Migration
+  def change
+    add_column :configured_systems, :operating_system_flavor_id,     :bigint
+    add_column :configured_systems, :customization_script_medium_id, :bigint
+    add_column :configured_systems, :customization_script_ptable_id, :bigint
+
+    add_column :configuration_profiles, :operating_system_flavor_id,     :bigint
+    add_column :configuration_profiles, :customization_script_medium_id, :bigint
+    add_column :configuration_profiles, :customization_script_ptable_id, :bigint
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_location.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_location.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceConfigurationLocation < MiqAeServiceModelBase
+    expose :provisioning_manager,         :association => true
+    expose :parent,                       :association => true
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_organization.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_organization.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceConfigurationOrganization < MiqAeServiceModelBase
+    expose :provisioning_manager,         :association => true
+    expose :parent,                       :association => true
+  end
+end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile.rb
@@ -1,6 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceConfigurationProfile < MiqAeServiceModelBase
-    expose :configuration_manager,       :association => true
-    expose :configuration_tags,          :association => true
+    expose :configuration_manager,        :association => true
+    expose :parent,                       :association => true
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile_foreman.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile_foreman.rb
@@ -1,5 +1,13 @@
 module MiqAeMethodService
   class MiqAeServiceConfigurationProfileForeman < MiqAeServiceConfigurationProfile
+    expose :parent,                            :association => true
+
+    expose :raw_configuration_tags,            :association => true
+    expose :raw_customization_script_ptable,   :association => true
+    expose :raw_customization_script_medium,   :association => true
+    expose :raw_operating_system_flavors,      :association => true
+
+    expose :configuration_tags,                :association => true
     expose :customization_script_ptable,       :association => true
     expose :customization_script_medium,       :association => true
     expose :operating_system_flavors,          :association => true

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile_foreman.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile_foreman.rb
@@ -2,10 +2,10 @@ module MiqAeMethodService
   class MiqAeServiceConfigurationProfileForeman < MiqAeServiceConfigurationProfile
     expose :parent,                            :association => true
 
-    expose :raw_configuration_tags,            :association => true
-    expose :raw_customization_script_ptable,   :association => true
-    expose :raw_customization_script_medium,   :association => true
-    expose :raw_operating_system_flavors,      :association => true
+    expose :direct_configuration_tags,            :association => true
+    expose :direct_customization_script_ptable,   :association => true
+    expose :direct_customization_script_medium,   :association => true
+    expose :direct_operating_system_flavors,      :association => true
 
     expose :configuration_tags,                :association => true
     expose :customization_script_ptable,       :association => true

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system.rb
@@ -2,7 +2,6 @@ module MiqAeMethodService
   class MiqAeServiceConfiguredSystem < MiqAeServiceModelBase
     expose :configuration_manager,   :association => true
     expose :configuration_profile,   :association => true
-    expose :operating_system_flavor, :association => true
-    expose :configuration_tags,      :association => true
+    expose :computer_system,         :association => true
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system_foreman.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system_foreman.rb
@@ -1,4 +1,15 @@
 module MiqAeMethodService
   class MiqAeServiceConfiguredSystemForeman < MiqAeServiceConfiguredSystem
+    expose :configuration_profile,           :association => true
+    expose :configuration_location,          :association => true
+    expose :operating_system_flavor,         :association => true
+    expose :customization_script_media,      :association => true
+    expose :customization_script_ptable,     :association => true
+    expose :configuration_tags,              :association => true
+
+    expose :raw_operating_system_flavor,     :association => true
+    expose :raw_customization_script_media,  :association => true
+    expose :raw_customization_script_ptable, :association => true
+    expose :raw_configuration_tags,          :association => true
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system_foreman.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system_foreman.rb
@@ -7,9 +7,9 @@ module MiqAeMethodService
     expose :customization_script_ptable,     :association => true
     expose :configuration_tags,              :association => true
 
-    expose :raw_operating_system_flavor,     :association => true
-    expose :raw_customization_script_media,  :association => true
-    expose :raw_customization_script_ptable, :association => true
-    expose :raw_configuration_tags,          :association => true
+    expose :direct_operating_system_flavor,     :association => true
+    expose :direct_customization_script_media,  :association => true
+    expose :direct_customization_script_ptable, :association => true
+    expose :direct_configuration_tags,          :association => true
   end
 end

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe ConfigurationProfile do
+describe ConfigurationProfileForeman do
   subject { described_class.new }
 
   describe "#all_tags" do

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -47,11 +47,11 @@ describe ConfigurationProfileForeman do
         )
       end
 
-      context "and a parent" do
-        let(:parent_parent) { parent.build_parent }
-        it "loads tags from parent parent" do
+      context "and a grandparent" do
+        let(:grandparent) { parent.build_parent }
+        it "loads tags from grandparent" do
           parent.configuration_tags << cd
-          parent_parent.configuration_tags << cr
+          grandparent.configuration_tags << cr
           expect(subject.all_tags).to eq(
             ConfigurationRealm  => cr,
             ConfigurationDomain => cd,
@@ -60,8 +60,8 @@ describe ConfigurationProfileForeman do
 
         it "loads respects hierarchy" do
           parent.configuration_tags << cr
-          parent_parent.configuration_tags << cr2
-          parent_parent.configuration_tags << cd
+          grandparent.configuration_tags << cr2
+          grandparent.configuration_tags << cd
           expect(subject.all_tags).to eq(
             ConfigurationRealm  => cr,
             ConfigurationDomain => cd,

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -3,69 +3,54 @@ require "spec_helper"
 describe ConfigurationProfileForeman do
   subject { described_class.new }
 
-  describe "#all_tags" do
+  describe "#configuration_tags" do
     let(:cd) { ConfigurationDomain.new(:name => "cd") }
     let(:cr) { ConfigurationRealm.new(:name => "cr") }
     let(:cr2) { ConfigurationRealm.new(:name => "cr2") }
 
     it "defaults to no tags" do
-      expect(subject.all_tags).to eq({})
+      expect(subject.configuration_tags).to eq([])
     end
 
     it "reads tags" do
-      subject.configuration_tags << cd
-      subject.configuration_tags << cr
-      expect(subject.all_tags).to eq(
-        ConfigurationRealm  => cr,
-        ConfigurationDomain => cd,
-      )
+      subject.raw_configuration_tags << cd
+      subject.raw_configuration_tags << cr
+      expect(subject.configuration_tags).to match_array([cr, cd])
     end
 
     context "with a parent" do
       let(:parent) { subject.build_parent }
 
       it "supports empty parents" do
-        subject.configuration_tags << cr
-        expect(subject.all_tags).to eq(
-          ConfigurationRealm => cr
-        )
+        subject.raw_configuration_tags << cr
+        expect(subject.configuration_tags).to eq([cr])
       end
 
       it "loads tags from parent" do
         parent.build_parent
-        parent.configuration_tags << cr
-        expect(subject.all_tags).to eq(
-          ConfigurationRealm => cr
-        )
+        parent.raw_configuration_tags << cr
+        expect(subject.configuration_tags).to eq([cr])
       end
 
       it "leverages tags from child" do
-        subject.configuration_tags << cr
-        parent.configuration_tags << cr2
-        expect(subject.all_tags).to eq(
-          ConfigurationRealm => cr
-        )
+        subject.raw_configuration_tags << cr
+        parent.raw_configuration_tags << cr2
+        expect(subject.configuration_tags).to eq([cr])
       end
 
       context "and a grandparent" do
         let(:grandparent) { parent.build_parent }
         it "loads tags from grandparent" do
-          parent.configuration_tags << cd
-          grandparent.configuration_tags << cr
-          expect(subject.all_tags).to eq(
-            ConfigurationRealm  => cr,
-            ConfigurationDomain => cd,
-          )
+          parent.raw_configuration_tags << cd
+          grandparent.raw_configuration_tags << cr
+          expect(subject.configuration_tags).to eq([cr, cd])
         end
 
         it "loads respects hierarchy" do
-          parent.configuration_tags << cr
-          grandparent.configuration_tags << cr2
-          grandparent.configuration_tags << cd
-          expect(subject.all_tags).to eq(
-            ConfigurationRealm  => cr,
-            ConfigurationDomain => cd,
-          )
+          parent.raw_configuration_tags << cr
+          grandparent.raw_configuration_tags << cr2
+          grandparent.raw_configuration_tags << cd
+          expect(subject.configuration_tags).to eq([cr, cd])
         end
       end
     end

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -24,8 +24,15 @@ describe ConfigurationProfileForeman do
     it "reads tag helpers" do
       subject.raw_configuration_tags << cd
       subject.raw_configuration_tags << cr
+      subject.raw_configuration_tags << ConfigurationArchitecture.new(:name => "CA")
+      subject.raw_configuration_tags << ConfigurationComputeProfile.new(:name => "CC")
+      subject.raw_configuration_tags << ConfigurationEnvironment.new(:name => "CE")
+
       expect(subject.configuration_domain).to eq(cd)
       expect(subject.configuration_realm).to eq(cr)
+      expect(subject.configuration_architecture).not_to be_nil
+      expect(subject.configuration_compute_profile).not_to be_nil
+      expect(subject.configuration_environment).not_to be_nil
     end
 
     context "with a parent" do
@@ -91,6 +98,35 @@ describe ConfigurationProfileForeman do
           expect(subject.configuration_domain).to eq(cd)
           expect(subject.configuration_realm).to eq(cr)
         end
+      end
+    end
+  end
+
+  describe "inherited attributes" do
+    it "defaults to nil" do
+      expect(subject.operating_system_flavor).to be_nil
+      expect(subject.customization_script_medium).to be_nil
+      expect(subject.customization_script_ptable).to be_nil
+    end
+
+    it "loads attributes with nil parent" do
+      subject.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
+      subject.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
+      subject.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
+      expect(subject.operating_system_flavor).not_to be_nil
+      expect(subject.customization_script_medium).not_to be_nil
+      expect(subject.customization_script_ptable).not_to be_nil
+    end
+
+    context "with a parent" do
+      let(:parent) { subject.build_parent }
+      it "loads attributes from parent" do
+        parent.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
+        parent.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
+        parent.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
+        expect(subject.operating_system_flavor).not_to be_nil
+        expect(subject.customization_script_medium).not_to be_nil
+        expect(subject.customization_script_ptable).not_to be_nil
       end
     end
   end

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -12,10 +12,20 @@ describe ConfigurationProfileForeman do
       expect(subject.configuration_tags).to eq([])
     end
 
+    it { expect(subject.configuration_realm).to eq(nil) }
+
     it "reads tags" do
       subject.raw_configuration_tags << cd
       subject.raw_configuration_tags << cr
       expect(subject.configuration_tags).to match_array([cr, cd])
+      expect(subject.raw_configuration_tags).to match_array([cr, cd])
+    end
+
+    it "reads tag helpers" do
+      subject.raw_configuration_tags << cd
+      subject.raw_configuration_tags << cr
+      expect(subject.configuration_domain).to eq(cd)
+      expect(subject.configuration_realm).to eq(cr)
     end
 
     context "with a parent" do
@@ -27,9 +37,14 @@ describe ConfigurationProfileForeman do
       end
 
       it "loads tags from parent" do
-        parent.build_parent
         parent.raw_configuration_tags << cr
         expect(subject.configuration_tags).to eq([cr])
+        expect(subject.raw_configuration_tags).to eq([])
+      end
+
+      it "loads tags from parent helpers" do
+        parent.raw_configuration_tags << cr
+        expect(subject.configuration_realm).to eq(cr)
       end
 
       it "leverages tags from child" do
@@ -38,12 +53,27 @@ describe ConfigurationProfileForeman do
         expect(subject.configuration_tags).to eq([cr])
       end
 
+      it "leverages tags from child helpers" do
+        subject.raw_configuration_tags << cr
+        parent.raw_configuration_tags << cr2
+        expect(subject.configuration_realm).to eq(cr)
+      end
+
       context "and a grandparent" do
         let(:grandparent) { parent.build_parent }
+
         it "loads tags from grandparent" do
           parent.raw_configuration_tags << cd
           grandparent.raw_configuration_tags << cr
-          expect(subject.configuration_tags).to eq([cr, cd])
+          expect(subject.configuration_tags).to match_array([cr, cd])
+          expect(subject.raw_configuration_tags).to eq([])
+        end
+
+        it "loads tags from grandparent helpers" do
+          parent.raw_configuration_tags << cd
+          grandparent.raw_configuration_tags << cr
+          expect(subject.configuration_domain).to eq(cd)
+          expect(subject.configuration_realm).to eq(cr)
         end
 
         it "loads respects hierarchy" do
@@ -51,6 +81,15 @@ describe ConfigurationProfileForeman do
           grandparent.raw_configuration_tags << cr2
           grandparent.raw_configuration_tags << cd
           expect(subject.configuration_tags).to eq([cr, cd])
+          expect(subject.raw_configuration_tags).to eq([])
+        end
+
+        it "loads respects hierarchy helpers" do
+          parent.raw_configuration_tags << cr
+          grandparent.raw_configuration_tags << cr2
+          grandparent.raw_configuration_tags << cd
+          expect(subject.configuration_domain).to eq(cd)
+          expect(subject.configuration_realm).to eq(cr)
         end
       end
     end

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -101,33 +101,4 @@ describe ConfigurationProfileForeman do
       end
     end
   end
-
-  describe "inherited attributes" do
-    it "defaults to nil" do
-      expect(subject.operating_system_flavor).to be_nil
-      expect(subject.customization_script_medium).to be_nil
-      expect(subject.customization_script_ptable).to be_nil
-    end
-
-    it "loads attributes with nil parent" do
-      subject.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
-      subject.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
-      subject.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
-      expect(subject.operating_system_flavor).not_to be_nil
-      expect(subject.customization_script_medium).not_to be_nil
-      expect(subject.customization_script_ptable).not_to be_nil
-    end
-
-    context "with a parent" do
-      let(:parent) { subject.build_parent }
-      it "loads attributes from parent" do
-        parent.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
-        parent.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
-        parent.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
-        expect(subject.operating_system_flavor).not_to be_nil
-        expect(subject.customization_script_medium).not_to be_nil
-        expect(subject.customization_script_ptable).not_to be_nil
-      end
-    end
-  end
 end

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -15,18 +15,18 @@ describe ConfigurationProfileForeman do
     it { expect(subject.configuration_realm).to eq(nil) }
 
     it "reads tags" do
-      subject.raw_configuration_tags << cd
-      subject.raw_configuration_tags << cr
+      subject.direct_configuration_tags << cd
+      subject.direct_configuration_tags << cr
       expect(subject.configuration_tags).to match_array([cr, cd])
-      expect(subject.raw_configuration_tags).to match_array([cr, cd])
+      expect(subject.direct_configuration_tags).to match_array([cr, cd])
     end
 
     it "reads tag helpers" do
-      subject.raw_configuration_tags << cd
-      subject.raw_configuration_tags << cr
-      subject.raw_configuration_tags << ConfigurationArchitecture.new(:name => "CA")
-      subject.raw_configuration_tags << ConfigurationComputeProfile.new(:name => "CC")
-      subject.raw_configuration_tags << ConfigurationEnvironment.new(:name => "CE")
+      subject.direct_configuration_tags << cd
+      subject.direct_configuration_tags << cr
+      subject.direct_configuration_tags << ConfigurationArchitecture.new(:name => "CA")
+      subject.direct_configuration_tags << ConfigurationComputeProfile.new(:name => "CC")
+      subject.direct_configuration_tags << ConfigurationEnvironment.new(:name => "CE")
 
       expect(subject.configuration_domain).to eq(cd)
       expect(subject.configuration_realm).to eq(cr)
@@ -39,30 +39,30 @@ describe ConfigurationProfileForeman do
       let(:parent) { subject.build_parent }
 
       it "supports empty parents" do
-        subject.raw_configuration_tags << cr
+        subject.direct_configuration_tags << cr
         expect(subject.configuration_tags).to eq([cr])
       end
 
       it "loads tags from parent" do
-        parent.raw_configuration_tags << cr
+        parent.direct_configuration_tags << cr
         expect(subject.configuration_tags).to eq([cr])
-        expect(subject.raw_configuration_tags).to eq([])
+        expect(subject.direct_configuration_tags).to eq([])
       end
 
       it "loads tags from parent helpers" do
-        parent.raw_configuration_tags << cr
+        parent.direct_configuration_tags << cr
         expect(subject.configuration_realm).to eq(cr)
       end
 
       it "leverages tags from child" do
-        subject.raw_configuration_tags << cr
-        parent.raw_configuration_tags << cr2
+        subject.direct_configuration_tags << cr
+        parent.direct_configuration_tags << cr2
         expect(subject.configuration_tags).to eq([cr])
       end
 
       it "leverages tags from child helpers" do
-        subject.raw_configuration_tags << cr
-        parent.raw_configuration_tags << cr2
+        subject.direct_configuration_tags << cr
+        parent.direct_configuration_tags << cr2
         expect(subject.configuration_realm).to eq(cr)
       end
 
@@ -70,31 +70,31 @@ describe ConfigurationProfileForeman do
         let(:grandparent) { parent.build_parent }
 
         it "loads tags from grandparent" do
-          parent.raw_configuration_tags << cd
-          grandparent.raw_configuration_tags << cr
+          parent.direct_configuration_tags << cd
+          grandparent.direct_configuration_tags << cr
           expect(subject.configuration_tags).to match_array([cr, cd])
-          expect(subject.raw_configuration_tags).to eq([])
+          expect(subject.direct_configuration_tags).to eq([])
         end
 
         it "loads tags from grandparent helpers" do
-          parent.raw_configuration_tags << cd
-          grandparent.raw_configuration_tags << cr
+          parent.direct_configuration_tags << cd
+          grandparent.direct_configuration_tags << cr
           expect(subject.configuration_domain).to eq(cd)
           expect(subject.configuration_realm).to eq(cr)
         end
 
         it "loads respects hierarchy" do
-          parent.raw_configuration_tags << cr
-          grandparent.raw_configuration_tags << cr2
-          grandparent.raw_configuration_tags << cd
+          parent.direct_configuration_tags << cr
+          grandparent.direct_configuration_tags << cr2
+          grandparent.direct_configuration_tags << cd
           expect(subject.configuration_tags).to eq([cr, cd])
-          expect(subject.raw_configuration_tags).to eq([])
+          expect(subject.direct_configuration_tags).to eq([])
         end
 
         it "loads respects hierarchy helpers" do
-          parent.raw_configuration_tags << cr
-          grandparent.raw_configuration_tags << cr2
-          grandparent.raw_configuration_tags << cd
+          parent.direct_configuration_tags << cr
+          grandparent.direct_configuration_tags << cr2
+          grandparent.direct_configuration_tags << cd
           expect(subject.configuration_domain).to eq(cd)
           expect(subject.configuration_realm).to eq(cr)
         end

--- a/vmdb/spec/models/configured_system_foreman_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman_spec.rb
@@ -59,33 +59,4 @@ describe ConfiguredSystemForeman do
       end
     end
   end
-
-  describe "inherited attributes" do
-    it "defaults to nil" do
-      expect(subject.operating_system_flavor).to be_nil
-      expect(subject.customization_script_medium).to be_nil
-      expect(subject.customization_script_ptable).to be_nil
-    end
-
-    it "loads attributes with nil profile" do
-      subject.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
-      subject.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
-      subject.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
-      expect(subject.operating_system_flavor).not_to be_nil
-      expect(subject.customization_script_medium).not_to be_nil
-      expect(subject.customization_script_ptable).not_to be_nil
-    end
-
-    context "with a profile" do
-      let(:profile) { subject.build_configuration_profile }
-      it "loads attributes from profile" do
-        profile.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
-        profile.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
-        profile.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
-        expect(subject.operating_system_flavor).not_to be_nil
-        expect(subject.customization_script_medium).not_to be_nil
-        expect(subject.customization_script_ptable).not_to be_nil
-      end
-    end
-  end
 end

--- a/vmdb/spec/models/configured_system_foreman_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman_spec.rb
@@ -13,18 +13,18 @@ describe ConfiguredSystemForeman do
     end
 
     it "reads tags" do
-      subject.raw_configuration_tags << cd
-      subject.raw_configuration_tags << cr
+      subject.direct_configuration_tags << cd
+      subject.direct_configuration_tags << cr
       expect(subject.configuration_tags).to match_array([cr, cd])
-      expect(subject.raw_configuration_tags).to match_array([cr, cd])
+      expect(subject.direct_configuration_tags).to match_array([cr, cd])
     end
 
     it "reads tag helpers" do
-      subject.raw_configuration_tags << cd
-      subject.raw_configuration_tags << cr
-      subject.raw_configuration_tags << ConfigurationArchitecture.new(:name => "CA")
-      subject.raw_configuration_tags << ConfigurationComputeProfile.new(:name => "CC")
-      subject.raw_configuration_tags << ConfigurationEnvironment.new(:name => "CE")
+      subject.direct_configuration_tags << cd
+      subject.direct_configuration_tags << cr
+      subject.direct_configuration_tags << ConfigurationArchitecture.new(:name => "CA")
+      subject.direct_configuration_tags << ConfigurationComputeProfile.new(:name => "CC")
+      subject.direct_configuration_tags << ConfigurationEnvironment.new(:name => "CE")
 
       expect(subject.configuration_domain).to eq(cd)
       expect(subject.configuration_realm).to eq(cr)
@@ -39,21 +39,21 @@ describe ConfiguredSystemForeman do
       let(:profile) { subject.build_configuration_profile }
 
       it "loads tags from profile" do
-        profile.raw_configuration_tags << cr
+        profile.direct_configuration_tags << cr
         expect(subject.configuration_tags).to eq([cr])
       end
 
       it "leverages tags from child" do
-        subject.raw_configuration_tags << cr
-        profile.raw_configuration_tags << cr2
+        subject.direct_configuration_tags << cr
+        profile.direct_configuration_tags << cr2
         expect(subject.configuration_tags).to eq([cr])
       end
 
       context "and a parent" do
         let(:parent) { profile.build_parent }
         it "loads tags from profile profile" do
-          profile.raw_configuration_tags << cd
-          parent.raw_configuration_tags << cr
+          profile.direct_configuration_tags << cd
+          parent.direct_configuration_tags << cr
           expect(subject.configuration_tags).to match_array([cr, cd])
         end
       end

--- a/vmdb/spec/models/configured_system_foreman_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe ConfiguredSystem do
+describe ConfiguredSystemForeman do
   subject { described_class.new }
 
   describe "#all_tags" do

--- a/vmdb/spec/models/configured_system_foreman_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman_spec.rb
@@ -15,7 +15,24 @@ describe ConfiguredSystemForeman do
     it "reads tags" do
       subject.raw_configuration_tags << cd
       subject.raw_configuration_tags << cr
-      expect(subject.configuration_tags).to match_array([cd, cr])
+      expect(subject.configuration_tags).to match_array([cr, cd])
+      expect(subject.raw_configuration_tags).to match_array([cr, cd])
+    end
+
+    it "reads tag helpers" do
+      subject.raw_configuration_tags << cd
+      subject.raw_configuration_tags << cr
+      subject.raw_configuration_tags << ConfigurationArchitecture.new(:name => "CA")
+      subject.raw_configuration_tags << ConfigurationComputeProfile.new(:name => "CC")
+      subject.raw_configuration_tags << ConfigurationEnvironment.new(:name => "CE")
+
+      expect(subject.configuration_domain).to eq(cd)
+      expect(subject.configuration_realm).to eq(cr)
+      expect(subject.configuration_architecture).not_to be_nil
+      expect(subject.configuration_compute_profile).not_to be_nil
+      expect(subject.configuration_environment).not_to be_nil
+
+      expect(subject.configuration_tags.size).to eq(5)
     end
 
     context "with a profile" do
@@ -39,6 +56,35 @@ describe ConfiguredSystemForeman do
           parent.raw_configuration_tags << cr
           expect(subject.configuration_tags).to match_array([cr, cd])
         end
+      end
+    end
+  end
+
+  describe "inherited attributes" do
+    it "defaults to nil" do
+      expect(subject.operating_system_flavor).to be_nil
+      expect(subject.customization_script_medium).to be_nil
+      expect(subject.customization_script_ptable).to be_nil
+    end
+
+    it "loads attributes with nil profile" do
+      subject.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
+      subject.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
+      subject.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
+      expect(subject.operating_system_flavor).not_to be_nil
+      expect(subject.customization_script_medium).not_to be_nil
+      expect(subject.customization_script_ptable).not_to be_nil
+    end
+
+    context "with a profile" do
+      let(:profile) { subject.build_configuration_profile }
+      it "loads attributes from profile" do
+        profile.raw_operating_system_flavor = OperatingSystemFlavor.new(:name => "osf")
+        profile.raw_customization_script_medium = CustomizationScriptMedium.new(:name => "csm")
+        profile.raw_customization_script_ptable = CustomizationScriptPtable.new(:name => "csp")
+        expect(subject.operating_system_flavor).not_to be_nil
+        expect(subject.customization_script_medium).not_to be_nil
+        expect(subject.customization_script_ptable).not_to be_nil
       end
     end
   end

--- a/vmdb/spec/models/configured_system_foreman_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman_spec.rb
@@ -3,51 +3,41 @@ require "spec_helper"
 describe ConfiguredSystemForeman do
   subject { described_class.new }
 
-  describe "#all_tags" do
+  describe "#configuration_tags" do
     let(:cd) { ConfigurationDomain.new(:name => "cd") }
     let(:cr) { ConfigurationRealm.new(:name => "cr") }
     let(:cr2) { ConfigurationRealm.new(:name => "cr2") }
 
     it "defaults to no tags" do
-      expect(subject.all_tags).to eq({})
+      expect(subject.configuration_tags).to eq([])
     end
 
     it "reads tags" do
-      subject.configuration_tags << cd
-      subject.configuration_tags << cr
-      expect(subject.all_tags).to eq(
-        ConfigurationDomain => cd,
-        ConfigurationRealm  => cr
-      )
+      subject.raw_configuration_tags << cd
+      subject.raw_configuration_tags << cr
+      expect(subject.configuration_tags).to match_array([cd, cr])
     end
 
     context "with a profile" do
       let(:profile) { subject.build_configuration_profile }
 
       it "loads tags from profile" do
-        profile.configuration_tags << cr
-        expect(subject.all_tags).to eq(
-          ConfigurationRealm => cr
-        )
+        profile.raw_configuration_tags << cr
+        expect(subject.configuration_tags).to eq([cr])
       end
 
       it "leverages tags from child" do
-        subject.configuration_tags << cr
-        profile.configuration_tags << cr2
-        expect(subject.all_tags).to eq(
-          ConfigurationRealm => cr
-        )
+        subject.raw_configuration_tags << cr
+        profile.raw_configuration_tags << cr2
+        expect(subject.configuration_tags).to eq([cr])
       end
 
       context "and a parent" do
         let(:parent) { profile.build_parent }
         it "loads tags from profile profile" do
-          profile.configuration_tags << cd
-          parent.configuration_tags << cr
-          expect(subject.all_tags).to eq(
-            ConfigurationRealm  => cr,
-            ConfigurationDomain => cd,
-          )
+          profile.raw_configuration_tags << cd
+          parent.raw_configuration_tags << cr
+          expect(subject.configuration_tags).to match_array([cr, cd])
         end
       end
     end

--- a/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
+++ b/vmdb/spec/models/ems_refresh/parsers/foreman_spec.rb
@@ -95,7 +95,6 @@ describe EmsRefresh::Parsers::Foreman do
   # end
 
   describe "#configuration_inv_to_hashes" do
-
     it "links parents by ancestry" do
       result = parser.configuration_inv_to_hashes(
         :operating_system_flavors => flavors,

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -137,9 +137,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(child.customization_script_ptable).to eq(mine(ptables)) # declared
     expect(child.configuration_locations).to     eq([default_location])
     expect(child.configuration_organizations).to eq([default_organization])
-    expect(child.raw_operating_system_flavor).to     be_nil
-    expect(child.raw_customization_script_medium).to be_nil
-    expect(child.raw_customization_script_ptable).to eq(mine(ptables))
+    expect(child.direct_operating_system_flavor).to     be_nil
+    expect(child.direct_customization_script_medium).to be_nil
+    expect(child.direct_customization_script_ptable).to eq(mine(ptables))
   end
 
   def assert_configuration_profile_parent
@@ -155,9 +155,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(parent.customization_script_ptable).to be_nil          # blank
     expect(parent.configuration_locations).to     eq([default_location])
     expect(parent.configuration_organizations).to eq([default_organization])
-    expect(parent.raw_operating_system_flavor).to     eq(mine(osfs))
-    expect(parent.raw_customization_script_medium).to eq(mine(media))
-    expect(parent.raw_customization_script_ptable).to be_nil
+    expect(parent.direct_operating_system_flavor).to     eq(mine(osfs))
+    expect(parent.direct_customization_script_medium).to eq(mine(media))
+    expect(parent.direct_customization_script_ptable).to be_nil
   end
 
   def assert_configured_system
@@ -177,9 +177,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(system.configuration_location).to      eq(default_location)
     expect(system.configuration_organization).to  eq(default_organization)
     expect(system.configuration_profile).to       eq(child)
-    expect(system.raw_operating_system_flavor).to     eq(mine(osfs))
-    expect(system.raw_customization_script_medium).to eq(mine(media))
-    expect(system.raw_customization_script_ptable).to eq(mine(ptables))
+    expect(system.direct_operating_system_flavor).to     eq(mine(osfs))
+    expect(system.direct_customization_script_medium).to eq(mine(media))
+    expect(system.direct_customization_script_ptable).to eq(mine(ptables))
   end
 
   private

--- a/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/foreman_refresher_spec.rb
@@ -137,6 +137,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(child.customization_script_ptable).to eq(mine(ptables)) # declared
     expect(child.configuration_locations).to     eq([default_location])
     expect(child.configuration_organizations).to eq([default_organization])
+    expect(child.raw_operating_system_flavor).to     be_nil
+    expect(child.raw_customization_script_medium).to be_nil
+    expect(child.raw_customization_script_ptable).to eq(mine(ptables))
   end
 
   def assert_configuration_profile_parent
@@ -152,6 +155,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(parent.customization_script_ptable).to be_nil          # blank
     expect(parent.configuration_locations).to     eq([default_location])
     expect(parent.configuration_organizations).to eq([default_organization])
+    expect(parent.raw_operating_system_flavor).to     eq(mine(osfs))
+    expect(parent.raw_customization_script_medium).to eq(mine(media))
+    expect(parent.raw_customization_script_ptable).to be_nil
   end
 
   def assert_configured_system
@@ -171,6 +177,9 @@ describe EmsRefresh::Refreshers::ForemanRefresher do
     expect(system.configuration_location).to      eq(default_location)
     expect(system.configuration_organization).to  eq(default_organization)
     expect(system.configuration_profile).to       eq(child)
+    expect(system.raw_operating_system_flavor).to     eq(mine(osfs))
+    expect(system.raw_customization_script_medium).to eq(mine(media))
+    expect(system.raw_customization_script_ptable).to eq(mine(ptables))
   end
 
   private


### PR DESCRIPTION
`configuration_tags` returns a collection of tags.
But it is now the merge of parent tags.
This logic is specific for foreman.

/cc @brandondunne @gmcculloug 