### PR TITLE
Drop INPUT/FORWARD packets not whitelisted in the firewall setup

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -161,6 +161,14 @@ open-vm-tools
 
 %post --log=/root/anaconda-post.log
 
+# Drop packets for INPUT/FORWARD that aren't whitelisted in the firewall setup
+for IPT in /etc/sysconfig/iptables /etc/sysconfig/iptables.old ; do
+  if [ -f $IPT ] ; then
+     sed -i "s/INPUT ACCEPT/INPUT DROP/g" $IPT
+     sed -i "s/FORWARD ACCEPT/FORWARD DROP/g" $IPT
+  fi
+done
+
 www_root="/var/www"
 app_root="$www_root/miq"
 


### PR DESCRIPTION
The kickstart firewall command does not provide the ability to drop INPUT and FORWARD by default so we we must do it in the post install section.

https://bugzilla.redhat.com/show_bug.cgi?id=1182654

**Before** (cf9f8924d685)
We accepted all INPUT packets.  We allowed icmp, loopback and whitelisted
ports we use.  Any other INPUT ports were logged and dropped.

We accepted all FORWARD packets.

**After this commit**
We drop all INPUT packets by default excluding icmp, loopback,
and whitelisted ports we use.

We drop all FORWARD packets.

OUTPUT packets have NOT been changed, we accept them.
[skip ci]