### PR TITLE
Containers UI - fix container provider rel names and tooltip in left accordion

### DIFF
--- a/vmdb/app/views/layouts/listnav/_container_group.html.haml
+++ b/vmdb/app/views/layouts/listnav/_container_group.html.haml
@@ -17,7 +17,7 @@
 
         - if role_allows(:feature => "ems_container_show") && !@record.ext_management_system.nil?
           %li
-            = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
+            = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.ext_management_system.name}",
                 {:controller => "ems_container", :action => 'show', :id => @record.ext_management_system.id.to_s},
-                {:title => _("Show this Container Groups parent %s") % ui_lookup(:table => "ems_container")},
+                {:title => _("Show this container group's parent %s") % ui_lookup(:table => "ems_container")},
                 '/images/icons/16/link_external.gif')

--- a/vmdb/app/views/layouts/listnav/_container_node.html.haml
+++ b/vmdb/app/views/layouts/listnav/_container_node.html.haml
@@ -17,8 +17,8 @@
 
         - if role_allows(:feature => "ems_container_show") && !@record.ext_management_system.nil?
           %li
-            = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
+            = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.ext_management_system.name}",
                 {:controller => "ems_container", :action => 'show', :id => @record.ext_management_system.id.to_s},
-                {:title => _("Show this Container Nodes parent %s") % ui_lookup(:table => "ems_container")},
+                {:title => _("Show this container node's parent %s") % ui_lookup(:table => "ems_container")},
                 '/images/icons/16/link_external.gif')
 

--- a/vmdb/app/views/layouts/listnav/_container_service.html.haml
+++ b/vmdb/app/views/layouts/listnav/_container_service.html.haml
@@ -17,7 +17,7 @@
 
         - if role_allows(:feature => "ems_container_show") && !@record.ext_management_system.nil?
           %li
-            = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
+            = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.ext_management_system.name}",
                 {:controller => "ems_container", :action => 'show', :id => @record.ext_management_system.id.to_s},
-                {:title => _("Show this Container Services parent %s") % ui_lookup(:table => "ems_container")},
+                {:title => _("Show this container service's parent %s") % ui_lookup(:table => "ems_container")},
                 '/images/icons/16/link_external.gif')

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -949,8 +949,8 @@ en:
       ems_folders:                 Folders
       ems_infra:                   Infrastructure Provider
       ems_infras:                  Infrastructure Providers
-      ems_container:               Provider
-      ems_containers:              Providers
+      ems_container:               Containers Provider
+      ems_containers:              Containers Providers
       evm_owner:                   EVM Owner
       ext_management_system:       Cloud/Infrastructure Provider
       ext_management_systems:      Cloud/Infrastructure Providers


### PR DESCRIPTION
The translation for ext_management_systems reads as "Cloud/Infrastructure Provider" which is incorrect since we also have now containers.
Hence, updated translation file, fixed the provider name to be taken from the ems_container key and changed the phrase in tooltip not to contain capital letters.