### PR TITLE
removed IPAddr field from new/edit containers provider form

### DIFF
--- a/vmdb/app/views/ems_container/_form_fields.html.haml
+++ b/vmdb/app/views/ems_container/_form_fields.html.haml
@@ -7,13 +7,6 @@
         :maxlength => MAX_HOSTNAME_LEN,
         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %tr
-    %td.key=_('IP Address')
-    %td.wide
-      = text_field_tag("ipaddress",
-        @edit[:new][:ipaddress],
-        :maxlength => 15,
-        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %tr
     %td.key=_('Port')
     %td.wide
       = text_field_tag("port",


### PR DESCRIPTION
As part of the high level desire to drop ipaddress configuration in favor of the hostname detailed in https://github.com/ManageIQ/manageiq/issues/2127 generally and #2228 specifically, this pull request removes the ip address from the new/edit container provider screens