### PR TITLE
Openstack infra set host auth status

### DIFF
--- a/vmdb/app/helpers/host_helper/textual_summary.rb
+++ b/vmdb/app/helpers/host_helper/textual_summary.rb
@@ -504,7 +504,7 @@ module HostHelper::TextualSummary
   end
 
   def textual_authentications
-    authentications = @record.authentication_userid_passwords
+    authentications = @record.authentication_userid_passwords + @record.authentication_key_pairs
     return [{:label => "Default Authentication", :title => "None", :value => "None"}] if authentications.blank?
 
     authentications.collect do |auth|
@@ -514,6 +514,7 @@ module HostHelper::TextualSummary
         when "ipmi"; "IPMI"
         when "remote";  "Remote Login"
         when "ws"; "Web Services"
+        when "ssh_keypair"; "SSH keypair"
         else;           "<Unknown>"
         end
 

--- a/vmdb/app/models/host_openstack_infra.rb
+++ b/vmdb/app/models/host_openstack_infra.rb
@@ -24,10 +24,52 @@ class HostOpenstackInfra < Host
     return rl_user, rl_password, su_user, su_password, {:key_data => auth_key}
   end
 
+  def get_parent_keypair(type = nil)
+    self.ext_management_system.try(:authentication_best_fit, type)
+  end
+
   def auth_user_keypair(type = nil)
     # HostOpenstackInfra is using auth key set on ext_management_system level, not individual hosts
-    cred = self.try(:ext_management_system).try(:authentication_best_fit, type)
+    cred = self.get_parent_keypair(type)
     return nil if cred.nil? || cred.userid.blank?
     [cred.userid, cred.auth_key]
+  end
+
+  def authentication_status
+    self.authentication_type(:ssh_keypair).try(:status) || "None"
+  end
+
+  def update_ssh_auth_status!
+    unless cred = self.authentication_type(:ssh_keypair)
+      # Creating just Auth status placeholder, the credentials are stored in parent, that is EmsOpenstackInfra in this
+      # case. We will create Auth per Host where we will store just state
+      # TODO(lsmola) this should be done as auth inheritance, where we can override credentials on lower level, but
+      # it needs to be designed first
+      cred = AuthKeyPairOpenstackInfra.new(:name => "#{self.class.name} #{self.name}", :authtype => :ssh_keypair,
+                                           :resource_id => id, :resource_type => 'Host')
+    end
+
+    begin
+      verified = self.verify_credentials_with_ssh
+    rescue StandardError, NotImplementedError
+      verified = false
+      $log.warn("MIQ(HostOpenstackInfra-verify_credentials_with_ssh_keypair): #{$!.inspect}")
+    end
+
+    if verified
+      cred.status = 'Valid'
+      cred.save
+    else
+      parent_keypair = self.get_parent_keypair(:ssh_keypair)
+      if self.hostname && parent_keypair && parent_keypair.authtype == 'ssh_keypair'
+        # The credentials on parent exists and hostname is set and we are not able to verify, go to error state
+        cred.status = 'Error'
+        cred.save
+      else
+        # Parent credentials do not exists, set None, but do not save. It will be saved as part of host, only if cred
+        # already existed, so it will change state to none when parent keypair was deleted or host was powered down
+        cred.status = 'None'
+      end
+    end
   end
 end


### PR DESCRIPTION
Auth status of the Host
Auth status of the host, modeled by creating Authentication per Host, that will hold status of the last auth. And sing Authentication on Provider level for holding credentials. This should be step forward to inheritance of auth.