### PR TITLE
Non UI workers can't send email bodies

### DIFF
--- a/vmdb/app/mailers/generic_mailer.rb
+++ b/vmdb/app/mailers/generic_mailer.rb
@@ -1,3 +1,4 @@
+require 'haml-rails'
 class GenericMailer < ActionMailer::Base
 
   def self.deliver(method, options = {})


### PR DESCRIPTION
Only the UI worker had the require 'haml-rails' so emails sent from
the UI had the body, but if a non ui worker like automate sent the
email it wont have the body. The specs have the require 'haml-rails'
so they always worked.

https://bugzilla.redhat.com/show_bug.cgi?id=1209557