### PR TITLE
Do not copy service resource if the resource is nil

### DIFF
--- a/vmdb/app/models/service_template.rb
+++ b/vmdb/app/models/service_template.rb
@@ -71,7 +71,7 @@ class ServiceTemplate < ActiveRecord::Base
     self.service_resources.each do |sr|
       nh = sr.attributes.dup
       %W{id created_at updated_at service_template_id}.each {|key| nh.delete(key)}
-      svc.add_resource(sr.resource, nh)
+      svc.add_resource(sr.resource, nh) unless sr.resource.nil?
     end
 
     parent_svc.add_resource!(svc) unless parent_svc.nil?

--- a/vmdb/app/models/service_template_orchestration.rb
+++ b/vmdb/app/models/service_template_orchestration.rb
@@ -1,6 +1,13 @@
 class ServiceTemplateOrchestration < ServiceTemplate
   include ServiceOrchestrationMixin
 
+  before_save :remove_invalid_resource
+
+  def remove_invalid_resource
+    # remove the resource from both memory and table
+    service_resources.delete_if { |r| r.destroy unless r.resource(true) }
+  end
+
   def create_subtasks(_parent_service_task, _parent_service)
     # no sub task is needed for this service
     []

--- a/vmdb/spec/models/service_template_orchestration_spec.rb
+++ b/vmdb/spec/models/service_template_orchestration_spec.rb
@@ -36,6 +36,15 @@ describe ServiceTemplateOrchestration do
 
       service_template.orchestration_template.should be_nil
     end
+
+    it "clears invalid orchestration template" do
+      service_template.orchestration_template = first_orch_template
+      first_orch_template.delete
+
+      service_template.save!
+      service_template.reload
+      service_template.orchestration_template.should be_nil
+    end
   end
 
   context "#orchestration_manager" do
@@ -63,6 +72,15 @@ describe ServiceTemplateOrchestration do
       service_template.orchestration_manager = ems_openstack
       service_template.orchestration_manager = nil
 
+      service_template.orchestration_manager.should be_nil
+    end
+
+    it "clears invalid orchestration manager" do
+      service_template.orchestration_manager = ems_amazon
+      ems_amazon.delete
+
+      service_template.save!
+      service_template.reload
       service_template.orchestration_manager.should be_nil
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1207865

This bug was caused by the service resource of the service template pointing to a no longer existing resource. When a service template creates a service, it duplicates its service resources to the new service. The invalid service resource entry results in a NilClass error. The fix is to skip such entries.

The debugging process discovered another related issue. The ems provider (orchestration manager) stored as a service resource for the service template was removed by user. The user assigned another orchestration manager to this service template. It turned out its service resources now have two managers. 

https://github.com/ManageIQ/manageiq/blob/master/vmdb/app/models/mixins/service_orchestration_mixin.rb

The above mixin adds has_many orchestration_managers through service_resources. The getter excludes any invalid orchestration_managers. The setter uses `replace` method, which does not replace any invalid orchestration_managers either. Leaving these invalid entries in service_resources does not cause other problems rather than the copying issue fixed here. I am not sure whether we need to force to remove them in the mixin code. We could do the cleaning work either in the getter or setter, either way we need to directly work on the service resource model, not elegant solution. Looking for advices.
