### PR TITLE
Satisfy CORS for the API to be consumable from a browser.

### DIFF
--- a/vmdb/app/controllers/api_controller.rb
+++ b/vmdb/app/controllers/api_controller.rb
@@ -4,6 +4,17 @@ class ApiController < ApplicationController
   class BadRequestError           < StandardError; end
   class UnsupportedMediaTypeError < StandardError; end
 
+  def handle_options_request
+    head(:ok) if request.request_method == "OPTIONS"
+  end
+
+  after_filter :set_access_control_headers
+  def set_access_control_headers
+    headers['Access-Control-Allow-Origin'] = '*'
+    headers['Access-Control-Allow-Headers'] = 'origin, content-type, authorization, x-auth-token'
+    headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH'
+  end
+
   # Order *Must* be from most generic to most specific
   ERROR_MAPPING = {
     StandardError                            => :internal_server_error,
@@ -58,7 +69,7 @@ class ApiController < ApplicationController
   extend ApiHelper::ErrorHandler::ClassMethods
   respond_to :json
   rescue_from_api_errors
-  before_filter :require_api_user_or_token
+  before_filter :require_api_user_or_token, :except => [:handle_options_request]
 
   TAG_NAMESPACE = "/managed"
 
@@ -84,7 +95,7 @@ class ApiController < ApplicationController
   # not have these. They would instead dealing with the /api/auth
   # mechanism.
   #
-  skip_before_filter :verify_authenticity_token, :only => [:show, :update, :destroy]
+  skip_before_filter :verify_authenticity_token, :only => [:show, :update, :destroy, :handle_options_request]
 
   delegate :base_config, :version_config, :collection_config, :to => self
 

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1886,6 +1886,8 @@ Vmdb::Application.routes.draw do
   get '/api/*suffix'   => 'api#show',    :format => 'json'
   match '/api/*suffix' => 'api#update',  :format => 'json', :via => [:post, :put, :patch]
   match '/api/*suffix' => 'api#destroy', :format => 'json', :via => [:delete]
+  # OPTIONS requests for REST API pre-flight checks
+  match '/api/*path', :controller => 'api', :action => 'handle_options_request', :constraints => {:method => 'OPTIONS'}
 
   CONTROLLER_ACTIONS.each do |controller_name, controller_actions|
 


### PR DESCRIPTION
We want to be able to consume the API from a web browse.

To do so we need to support CORS. http://en.wikipedia.org/wiki/Cross-origin_resource_sharing

Here is a initial hack to make that work.

Clone an example from here: https://github.com/martinpovolny/manageiq-api-example