### PR TITLE
Added Authentication tab back for Cloud/Infra provider from screens.

### DIFF
--- a/vmdb/app/views/shared/views/ems_common/_form.html.haml
+++ b/vmdb/app/views/shared/views/ems_common/_form.html.haml
@@ -67,7 +67,9 @@
             :maxlength         => 6,
             :size              => 6,
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-
+  - unless @ems.kind_of?(EmsContainer)
+    %hr
+      = render :partial => "/layouts/multi_auth_credentials", :locals  => {:record => @ems}
   - if @edit[:ems_id].nil?
     %table{:width => "100%"}
       %tr


### PR DESCRIPTION
@dclarizio please review, this was removed by commit: bd634791 in https://github.com/ManageIQ/manageiq/pull/2443 Authentication tab should be only hidden for Container Providers.