### PR TITLE
Fixed link to Stacks from listnav on Cloud Provider Summary screen.

### DIFF
--- a/vmdb/app/views/layouts/listnav/_ems_cloud.html.haml
+++ b/vmdb/app/views/layouts/listnav/_ems_cloud.html.haml
@@ -60,5 +60,4 @@
           = li_link_if_nonzero(:count => @record.number_of(:orchestration_stacks),
             :record_id                => @record.id,
             :display                  => 'orchestration_stacks',
-            :tables                   => 'orchestration_stack',
-            :controller               => 'orchestration_stack')
+            :tables                   => 'orchestration_stack')


### PR DESCRIPTION
Dont need to set the controller in the link, it should go to show method in ems_cloud controller

https://bugzilla.redhat.com/show_bug.cgi?id=1211489

@dclarizio please review.