### PR TITLE
Dialog field readonly

### DIFF
--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -876,6 +876,7 @@ module MiqAeCustomizationController::Dialogs
     copy_checkbox_field_param.call(:past_dates)
     copy_checkbox_field_param.call(:reconfigurable)
     copy_checkbox_field_param.call(:dynamic)
+    copy_checkbox_field_param.call(:read_only)
 
     [:data_typ, :required, :sort_by, :sort_by, :sort_order].each { |key| copy_field_param.call(key) }
 
@@ -895,6 +896,7 @@ module MiqAeCustomizationController::Dialogs
 
       if @edit[:field_typ] != params[:field_typ]
         @edit[:field_dynamic] = key[:dynamic] = false
+        @edit[:field_read_only] = key[:read_only] = false
 
         if params[:field_typ].include?("TextBox")
           @edit[:field_protected]      = key[:protected] = false
@@ -1027,6 +1029,7 @@ module MiqAeCustomizationController::Dialogs
         :field_typ            => field[:typ],
         :field_dynamic        => field[:dynamic],
         :field_default_value  => field[:default_value],
+        :field_read_only      => field[:read_only],
         :field_reconfigurable => field[:reconfigurable],
         :field_required       => field[:required]
       )
@@ -1141,7 +1144,8 @@ module MiqAeCustomizationController::Dialogs
               :order          => field.order,
               :name           => f.name,
               :reconfigurable => f.reconfigurable,
-              :dynamic        => f.dynamic
+              :dynamic        => f.dynamic,
+              :read_only      => f.read_only
             }
 
             if dynamic_field?(fld)
@@ -1243,6 +1247,7 @@ module MiqAeCustomizationController::Dialogs
                     :name           => field[:name],
                     :reconfigurable => field[:reconfigurable],
                     :dynamic        => field[:dynamic],
+                    :read_only      => field[:read_only],
                     :display        => :edit
                   }
 

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -84,6 +84,27 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
+  def radio_options(field, url, value)
+    tag_options = {
+      :type     => 'radio',
+      :id       => field.id,
+      :value    => value,
+      :name     => field.name,
+      :checked  => field.default_value.to_s == value.to_s ? '' : nil
+    }
+
+    extra_options = {
+      :onclick  => remote_function(
+        :with     => "miqSerializeForm(this)",
+        :url      => url,
+        :loading  => "miqSparkle(true);",
+        :complete => "miqSparkle(false);"
+      )
+    }
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
   private
 
   def add_options_unless_read_only(options_to_add, options_to_add_to, field)

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -20,11 +20,11 @@ module ApplicationHelper::Dialogs
   end
 
   def hour_select_options(value)
-    options_for_select(Array.new(24) {|i| i.to_s.rjust(2, '0')}, value)
+    options_for_select(Array.new(24) { |i| i.to_s.rjust(2, '0') }, value)
   end
 
   def minute_select_options(value)
-    options_for_select(Array.new(59) {|i| i.to_s.rjust(2, '0')}, value)
+    options_for_select(Array.new(59) { |i| i.to_s.rjust(2, '0') }, value)
   end
 
   def textbox_tag_options(field, url)
@@ -86,11 +86,11 @@ module ApplicationHelper::Dialogs
 
   def radio_options(field, url, value)
     tag_options = {
-      :type     => 'radio',
-      :id       => field.id,
-      :value    => value,
-      :name     => field.name,
-      :checked  => field.default_value.to_s == value.to_s ? '' : nil
+      :type    => 'radio',
+      :id      => field.id,
+      :value   => value,
+      :name    => field.name,
+      :checked => field.default_value.to_s == value.to_s ? '' : nil
     }
 
     extra_options = {

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -40,6 +40,17 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
+  def checkbox_tag_options(field, url)
+    tag_options = {:class => "dynamic-checkbox-#{field.id}"}
+    extra_options = {
+      "data-miq_sparkle_on"       => true,
+      "data-miq_sparkle_off"      => true,
+      "data-miq_observe_checkbox" => {:url => url}.to_json
+    }
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
   private
 
   def add_options_unless_read_only(options_to_add, options_to_add_to, field)

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -1,5 +1,4 @@
 module ApplicationHelper::Dialogs
-
   def dialog_dropdown_select_values(field, selected_value, category_tags = nil)
     values = []
     if !field.required
@@ -20,4 +19,23 @@ module ApplicationHelper::Dialogs
     category && category[:single_value]
   end
 
+  def textbox_tag_options(field, url)
+    tag_options = {
+      :maxlength => 50,
+      :class     => "dynamic-text-box-#{field.id}"
+    }
+    extra_options = {"data-miq_observe" => {:interval => '.5', :url => url}.to_json}
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
+  private
+
+  def add_options_unless_read_only(options_to_add, options_to_add_to, field)
+    if field.read_only
+      options_to_add_to.merge!(:disabled => true, :title => "This element is disabled because it is read only")
+    else
+      options_to_add_to.merge!(options_to_add)
+    end
+  end
 end

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -73,6 +73,17 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
+  def drop_down_options(field, url)
+    tag_options = {:class => "dynamic-drop-down-#{field.id}"}
+    extra_options = {
+      "data-miq_sparkle_on"  => true,
+      "data-miq_sparkle_off" => true,
+      "data-miq_observe"     => {:url => url}.to_json
+    }
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
   private
 
   def add_options_unless_read_only(options_to_add, options_to_add_to, field)

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -19,6 +19,14 @@ module ApplicationHelper::Dialogs
     category && category[:single_value]
   end
 
+  def hour_select_options(value)
+    options_for_select(Array.new(24) {|i| i.to_s.rjust(2, '0')}, value)
+  end
+
+  def minute_select_options(value)
+    options_for_select(Array.new(59) {|i| i.to_s.rjust(2, '0')}, value)
+  end
+
   def textbox_tag_options(field, url)
     tag_options = {
       :maxlength => 50,
@@ -47,6 +55,20 @@ module ApplicationHelper::Dialogs
       "data-miq_sparkle_off"      => true,
       "data-miq_observe_checkbox" => {:url => url}.to_json
     }
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
+  def date_tag_options(field, url)
+    tag_options = {:class => "css1 dynamic-date-#{field.id}", :readonly => "true"}
+    extra_options = {"data-miq_observe_date" => {:url => url}.to_json}
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
+  def time_tag_options(field, url, hour_or_min)
+    tag_options = {:class => "dynamic-date-#{hour_or_min}-#{field.id}"}
+    extra_options = {"data-miq_observe" => {:url => url}.to_json}
 
     add_options_unless_read_only(extra_options, tag_options, field)
   end

--- a/vmdb/app/helpers/application_helper/dialogs.rb
+++ b/vmdb/app/helpers/application_helper/dialogs.rb
@@ -29,6 +29,17 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only(extra_options, tag_options, field)
   end
 
+  def textarea_tag_options(field, url)
+    tag_options = {
+      :class     => "dynamic-text-area-#{field.id}",
+      :maxlength => 8192,
+      :size      => "50x6"
+    }
+    extra_options = {"data-miq_observe" => {:interval => '.5', :url => url}.to_json}
+
+    add_options_unless_read_only(extra_options, tag_options, field)
+  end
+
   private
 
   def add_options_unless_read_only(options_to_add, options_to_add_to, field)

--- a/vmdb/app/models/dialog_field_check_box.rb
+++ b/vmdb/app/models/dialog_field_check_box.rb
@@ -1,5 +1,5 @@
 class DialogFieldCheckBox < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(required)
+  AUTOMATE_VALUE_FIELDS = %w(required read_only)
 
   def checked?
     value == "t"

--- a/vmdb/app/models/dialog_field_date_control.rb
+++ b/vmdb/app/models/dialog_field_date_control.rb
@@ -1,5 +1,5 @@
 class DialogFieldDateControl < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(show_past_dates)
+  AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only)
 
   include TimezoneMixin
 

--- a/vmdb/app/models/dialog_field_date_time_control.rb
+++ b/vmdb/app/models/dialog_field_date_time_control.rb
@@ -1,5 +1,5 @@
 class DialogFieldDateTimeControl < DialogFieldDateControl
-  AUTOMATE_VALUE_FIELDS = %w(show_past_dates)
+  AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only)
 
   def automate_output_value
     return nil unless @value

--- a/vmdb/app/models/dialog_field_radio_button.rb
+++ b/vmdb/app/models/dialog_field_radio_button.rb
@@ -27,7 +27,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
       @value = default_value
     end
 
-    {:refreshed_values => refreshed_values, :checked_value => @value}
+    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only}
   end
 
   private

--- a/vmdb/app/models/dialog_field_sorted_item.rb
+++ b/vmdb/app/models/dialog_field_sorted_item.rb
@@ -49,7 +49,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def normalize_automate_values(automate_hash)
-    %w(sort_by sort_order data_type default_value required).each do |key|
+    %w(sort_by sort_order data_type default_value required read_only).each do |key|
       send("#{key}=", automate_hash[key]) if automate_hash.key?(key)
     end
 

--- a/vmdb/app/models/dialog_field_text_area_box.rb
+++ b/vmdb/app/models/dialog_field_text_area_box.rb
@@ -1,3 +1,3 @@
 class DialogFieldTextAreaBox < DialogFieldTextBox
-  AUTOMATE_VALUE_FIELDS = %w(required)
+  AUTOMATE_VALUE_FIELDS = %w(required read_only)
 end

--- a/vmdb/app/models/dialog_field_text_box.rb
+++ b/vmdb/app/models/dialog_field_text_box.rb
@@ -49,7 +49,7 @@ class DialogFieldTextBox < DialogField
   end
 
   def sample_text
-    dynamic ? "Sample Text" : value
+    dynamic ? "Sample Text" : (value || default_value)
   end
 
   def normalize_automate_values(automate_hash)

--- a/vmdb/app/models/dialog_field_text_box.rb
+++ b/vmdb/app/models/dialog_field_text_box.rb
@@ -1,5 +1,5 @@
 class DialogFieldTextBox < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(protected required validator_rule validator_type)
+  AUTOMATE_VALUE_FIELDS = %w(protected required validator_rule validator_type read_only)
 
   def value
     @value = values_from_automate if dynamic && @value.blank?

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -42,11 +42,6 @@
           %td
             = check_box_tag('field_dynamic', '1', @edit[:field_dynamic], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
-      %tr
-        %td.key=_('Read only')
-        %td
-          = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
-
   - unless @edit[:field_typ].nil?
     %fieldset
       %h3=_('Options')
@@ -109,6 +104,10 @@
               = check_box_tag('field_required', 'true',
                 @edit[:field_required],
                 "data-miq_observe_checkbox" => {:url => url}.to_json)
+          %tr
+            %td.key=_('Read only')
+            %td
+              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
           - if @edit[:field_typ].include?('TextBox')
             %tr
               %td.key=_('Validator Type')
@@ -130,32 +129,15 @@
 
         - elsif %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
           %tr
+            %td.key=_('Read only')
+            %td
+              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+          %tr
             %td.key=_('Show Past Dates')
             %td
               = check_box_tag("field_past_dates", "1",
                 @edit[:field_past_dates],
                 "data-miq_observe_checkbox" => {:url => url}.to_json)
-
-        - elsif @edit[:field_dynamic] == true
-          %tr
-            %td.key=_('Entry Point (NS/Cls/Inst)')
-            %td.wide
-              = text_field_tag('field_entry_point',
-                @edit[:field_entry_point],
-                :onFocus => 'miqShowAE_Tree("field_entry_point");miqButtons(false, "automate");')
-          %tr
-            %td.key=_('Show Refresh Button')
-            %td
-              = check_box_tag('field_show_refresh_button', '1',
-                @edit[:field_show_refresh_button],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
-          - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
-            %tr
-              %td.key=_('Load Values on Init')
-              %td
-                = check_box_tag('field_load_on_init', '1',
-                  @edit[:field_load_on_init],
-                  'data-miq_observe_checkbox' => {:url => url}.to_json)
 
         - elsif %w(DialogFieldDropDownList DialogFieldRadioButton).include?(@edit[:field_typ])
           %tr
@@ -165,6 +147,10 @@
                 options_for_select([[_("True"), true], [_("False"), false]], @edit[:field_required].to_s),
                 "data-miq_sparkle_on" => true,
                 "data-miq_observe" => {:url => url}.to_json)
+          %tr
+            %td.key=_('Read only')
+            %td
+              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
           %tr
             %td.key=_('Default Value')
             %td
@@ -235,6 +221,10 @@
               = check_box_tag('field_required', 'true',
                 @edit[:field_required],
                 "data-miq_observe_checkbox" => {:url => url}.to_json)
+          %tr
+            %td.key=_('Read only')
+            %td
+              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
   - if @edit[:field_typ] =~ /Drop|Radio/ && !@edit[:field_dynamic]
     = render :partial => 'field_values', :locals=>{:entry=>nil}

--- a/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/vmdb/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -42,6 +42,11 @@
           %td
             = check_box_tag('field_dynamic', '1', @edit[:field_dynamic], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
+      %tr
+        %td.key=_('Read only')
+        %td
+          = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+
   - unless @edit[:field_typ].nil?
     %fieldset
       %h3=_('Options')

--- a/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field.html.haml
@@ -36,16 +36,14 @@
         - if edit
           - if field.single_value?
             - select_values = dialog_dropdown_select_values(field, wf.value(field.name), category_tags)
-            = select_tag(field.name, options_for_select(select_values, wf.value(field.name)),
-                         "data-miq_sparkle_on"  => true,
-                         "data-miq_sparkle_off" => true,
-                         "data-miq_observe"     => {:url => url}.to_json)
+            = select_tag(field.name,
+                         options_for_select(select_values, wf.value(field.name)),
+                         drop_down_options(field, url))
           - else
-            = select_tag(field.name, options_for_select(category_tags, wf.value(field.name)),
-                         :multiple              => true,
-                         "data-miq_sparkle_on"  => true,
-                         "data-miq_sparkle_off" => true,
-                         "data-miq_observe"     => {:url => url}.to_json)
+            = select_tag(field.name,
+                         options_for_select(category_tags, wf.value(field.name)),
+                         drop_down_options(field, url).merge(:multiple => true))
+
         - else
           - value = wf.value(field.name) || ''
           - classification_ids = value.split(',')

--- a/vmdb/app/views/shared/dialogs/_dialog_field_check_box.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field_check_box.haml
@@ -1,9 +1,4 @@
-= check_box_tag(field.name, "1", field.checked?,
-                :disabled                   => !edit,
-                :class                      => "dynamic-checkbox-#{field.id}",
-                "data-miq_sparkle_on"       => true,
-                "data-miq_sparkle_off"      => true,
-                "data-miq_observe_checkbox" => {:url => url}.to_json)
+= check_box_tag(field.name, "1", field.checked?, {:disabled => !edit}.merge(checkbox_tag_options(field, url)))
 
 - if field.dynamic && field.show_refresh_button?
   = button_tag('Refresh', :id => "refresh-dynamic-checkbox-#{field.id}", :class => "btn btn-default")

--- a/vmdb/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.haml
@@ -1,35 +1,22 @@
 - if field.type == "DialogFieldDateControl"
   - if edit
-    = text_field_tag("miq_date__#{field.name}",
-                     field.value,
-                     :class                  => "css1 dynamic-date-#{field.id}",
-                     :readonly               => "true",
-                     "data-miq_observe_date" => {:url => url}.to_json)
+    = text_field_tag("miq_date__#{field.name}", field.value, date_tag_options(field, url))
   - else
     = field.value
 
 - if field.type == "DialogFieldDateTimeControl"
   - date_val = field.refresh_json_value
   - if edit
-    = text_field_tag("miq_date__#{field.name}",
-                     date_val[:date],
-                     :class                  => "css1 dynamic-date-#{field.id}",
-                     :readonly               => "true",
-                     "data-miq_observe_date" => {:url => url}.to_json)
+    = text_field_tag("miq_date__#{field.name}", date_val[:date], date_tag_options(field, url))
   - else
     = date_val[:date]
 
   &nbsp;at&nbsp;
   - if edit
-    = select_tag("start_hour",
-                 options_for_select(Array.new(24) {|i| i.to_s.rjust(2, '0')}, date_val[:hour]),
-                 :class => "dynamic-date-hour-#{field.id}",
-                 "data-miq_observe" => {:url => url}.to_json)
+    = select_tag("start_hour", hour_select_options(date_val[:hour]), time_tag_options(field, url, "hour"))
     = ':'
-    = select_tag("start_min",
-                 options_for_select(Array.new(59) {|i| i.to_s.rjust(2, '0')}, date_val[:min]),
-                 :class => "dynamic-date-min-#{field.id}",
-                 "data-miq_observe" => {:url => url}.to_json)
+    = select_tag("start_min", minute_select_options(date_val[:min]), time_tag_options(field, url, "min"))
+
   - else
     = "#{date_val[:hour].rjust(2, '0')}:#{date_val[:min].rjust(2, '0')}"
   &nbsp;

--- a/vmdb/app/views/shared/dialogs/_dialog_field_drop_down_list.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field_drop_down_list.haml
@@ -1,11 +1,7 @@
 - if edit
   - if field.values.length > 1
     - select_values = field.values.collect(&:reverse)
-    = select_tag(field.name, options_for_select(select_values, field.default_value),
-                 :class                 => "dynamic-drop-down-#{field.id}",
-                 "data-miq_sparkle_on"  => true,
-                 "data-miq_sparkle_off" => true,
-                 "data-miq_observe"     => {:url => url}.to_json)
+    = select_tag(field.name, options_for_select(select_values, field.default_value), drop_down_options(field, url))
 
   - else
     = h(field.values[0].last) if !field.values.empty?

--- a/vmdb/app/views/shared/dialogs/_dialog_field_radio_button.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field_radio_button.haml
@@ -4,16 +4,8 @@
       - values = field.values
       - values = [['', "<#{_('None')}>"]] + values if !field.required && !field.dynamic
       - values.each_with_index do |rb, i|
-        %input{:type     => 'radio',
-               :id       => field.id,
-               :value    => rb[0],
-               :name     => field.name,
-               :checked  => field.default_value.to_s == rb[0].to_s ? '' : nil,
-               :onclick  => remote_function(:with     => 'miqSerializeForm(this)',
-                                            :url      => { :action => 'dialog_field_changed',
-                                                           :id     => "#{(@edit && @edit[:rec_id]) || "new"}"},
-                                            :loading  => "miqSparkle(true);",
-                                            :complete => "miqSparkle(false);")}
+
+        %input{radio_options(field, url, rb[0])}
         %label.dynamic-radio-label= rb[1]
 
   - else
@@ -44,12 +36,18 @@
           if (data.values.checked_value === value[0].toString()) {
             radio += 'checked="" ';
           }
-          radio += 'onclick="' + "#{remote_function(
-            :with     => 'miqSerializeForm(this)',
-            :url      => {:action => 'dialog_field_changed', :id => (@edit && @edit[:rec_id]) || 'new'},
-            :loading  => 'miqSparkle(true);',
-            :complete => 'miqSparkle(false);'
-          )}" + '"';
+
+          if (data.values.read_only === true) {
+            radio += 'title="This element is disabled because it is read only" ';
+            radio += 'disabled=true ';
+          } else {
+            radio += 'onclick="' + "#{remote_function(
+              :with     => 'miqSerializeForm(this)',
+              :url      => {:action => 'dialog_field_changed', :id => (@edit && @edit[:rec_id]) || 'new'},
+              :loading  => 'miqSparkle(true);',
+              :complete => 'miqSparkle(false);'
+            )}" + '"';
+          }
           radio += '/> ';
           radio += $('<label></label>').addClass('dynamic-radio-label').text(value[1]).prop('outerHTML');
           radio += ' ';

--- a/vmdb/app/views/shared/dialogs/_dialog_field_text_area_box.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field_text_area_box.haml
@@ -1,10 +1,5 @@
 - if edit
-  = text_area_tag(field.name,
-                  field.value,
-                  :class             => "dynamic-text-area-#{field.id}",
-                  :maxlength         => 8192,
-                  :size              => "50x6",
-                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  = text_area_tag(field.name, field.value, textarea_tag_options(field, url))
 - else
   = h(field.value)
 

--- a/vmdb/app/views/shared/dialogs/_dialog_field_text_box.haml
+++ b/vmdb/app/views/shared/dialogs/_dialog_field_text_box.haml
@@ -1,14 +1,8 @@
 - if edit
   - if field.protected?
-    = password_field_tag(field.name + "__protected", field.value,
-                         :maxlength         => 50,
-                         :class             => "dynamic-text-box-#{field.id}",
-                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    = password_field_tag(field.name + "__protected", field.value, textbox_tag_options(field, url))
   - else
-    = text_field_tag(field.name, field.value,
-                     :maxlength         => 50,
-                     :class             => "dynamic-text-box-#{field.id}",
-                     "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    = text_field_tag(field.name, field.value, textbox_tag_options(field, url))
 
   - if field.dynamic && field.show_refresh_button?
     = button_tag('Refresh', :id => "refresh-dynamic-text-field-#{field.id}", :class => "btn btn-default")

--- a/vmdb/db/migrate/20150312081342_add_read_only_to_dialog_fields.rb
+++ b/vmdb/db/migrate/20150312081342_add_read_only_to_dialog_fields.rb
@@ -1,0 +1,5 @@
+class AddReadOnlyToDialogFields < ActiveRecord::Migration
+  def change
+    add_column :dialog_fields, :read_only, :boolean
+  end
+end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -117,5 +117,61 @@ describe ApplicationHelper do
         end
       end
     end
+
+    describe "#date_tag_options" do
+      let(:dialog_field) { active_record_instance_double("DialogField", :id => "100", :read_only => read_only) }
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        it "returns the tag options with a disabled true" do
+          expect(helper.date_tag_options(dialog_field, "url")).to eq({
+            :class    => "css1 dynamic-date-100",
+            :readonly => "true",
+            :disabled => true,
+            :title    => "This element is disabled because it is read only"
+          })
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        it "returns the tag options with a few data-miq attributes" do
+          expect(helper.date_tag_options(dialog_field, "url")).to eq({
+            :class                  => "css1 dynamic-date-100",
+            :readonly               => "true",
+            "data-miq_observe_date" => "{\"url\":\"url\"}"
+          })
+        end
+      end
+    end
+
+    describe "#time_tag_options" do
+      let(:dialog_field) { active_record_instance_double("DialogField", :id => "100", :read_only => read_only) }
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        it "returns the tag options with a disabled true" do
+          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq({
+            :class    => "dynamic-date-hour_or_min-100",
+            :disabled => true,
+            :title    => "This element is disabled because it is read only"
+          })
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        it "returns the tag options with a few data-miq attributes" do
+          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq({
+            :class             => "dynamic-date-hour_or_min-100",
+            "data-miq_observe" => "{\"url\":\"url\"}"
+          })
+        end
+      end
+    end
   end
 end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -88,5 +88,34 @@ describe ApplicationHelper do
         end
       end
     end
+
+    describe "#checkbox_tag_options" do
+      let(:dialog_field) { active_record_instance_double("DialogField", :id => "100", :read_only => read_only) }
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        it "returns the tag options with a disabled true" do
+          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq({
+            :class    => "dynamic-checkbox-100",
+            :disabled => true,
+            :title    => "This element is disabled because it is read only"
+          })
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        it "returns the tag options with a few data-miq attributes" do
+          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq({
+            :class                      => "dynamic-checkbox-100",
+            "data-miq_sparkle_on"       => true,
+            "data-miq_sparkle_off"      => true,
+            "data-miq_observe_checkbox" => "{\"url\":\"url\"}"
+          })
+        end
+      end
+    end
   end
 end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -57,5 +57,36 @@ describe ApplicationHelper do
         end
       end
     end
+
+    describe "#textarea_tag_options" do
+      let(:dialog_field) { active_record_instance_double("DialogField", :id => "100", :read_only => read_only) }
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        it "returns the tag options with a disabled true" do
+          expect(helper.textarea_tag_options(dialog_field, "url")).to eq({
+            :class     => "dynamic-text-area-100",
+            :maxlength => 8192,
+            :size      => "50x6",
+            :disabled  => true,
+            :title     => "This element is disabled because it is read only"
+          })
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        it "returns the tag options with a data-miq-observe" do
+          expect(helper.textarea_tag_options(dialog_field, "url")).to eq({
+            :class             => "dynamic-text-area-100",
+            :maxlength         => 8192,
+            :size              => "50x6",
+            "data-miq_observe" => "{\"interval\":\".5\",\"url\":\"url\"}"
+          })
+        end
+      end
+    end
   end
 end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -36,12 +36,12 @@ describe ApplicationHelper do
         let(:read_only) { true }
 
         it "returns the tag options with a disabled true" do
-          expect(helper.textbox_tag_options(dialog_field, "url")).to eq({
+          expect(helper.textbox_tag_options(dialog_field, "url")).to eq(
             :maxlength => 50,
             :class     => "dynamic-text-box-100",
             :disabled  => true,
             :title     => "This element is disabled because it is read only"
-          })
+          )
         end
       end
 
@@ -49,11 +49,11 @@ describe ApplicationHelper do
         let(:read_only) { false }
 
         it "returns the tag options with a data-miq-observe" do
-          expect(helper.textbox_tag_options(dialog_field, "url")).to eq({
+          expect(helper.textbox_tag_options(dialog_field, "url")).to eq(
             :maxlength         => 50,
             :class             => "dynamic-text-box-100",
             "data-miq_observe" => "{\"interval\":\".5\",\"url\":\"url\"}"
-          })
+          )
         end
       end
     end
@@ -65,13 +65,13 @@ describe ApplicationHelper do
         let(:read_only) { true }
 
         it "returns the tag options with a disabled true" do
-          expect(helper.textarea_tag_options(dialog_field, "url")).to eq({
+          expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
             :class     => "dynamic-text-area-100",
             :maxlength => 8192,
             :size      => "50x6",
             :disabled  => true,
             :title     => "This element is disabled because it is read only"
-          })
+          )
         end
       end
 
@@ -79,12 +79,12 @@ describe ApplicationHelper do
         let(:read_only) { false }
 
         it "returns the tag options with a data-miq-observe" do
-          expect(helper.textarea_tag_options(dialog_field, "url")).to eq({
+          expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
             :class             => "dynamic-text-area-100",
             :maxlength         => 8192,
             :size              => "50x6",
             "data-miq_observe" => "{\"interval\":\".5\",\"url\":\"url\"}"
-          })
+          )
         end
       end
     end
@@ -96,11 +96,11 @@ describe ApplicationHelper do
         let(:read_only) { true }
 
         it "returns the tag options with a disabled true" do
-          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq({
+          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq(
             :class    => "dynamic-checkbox-100",
             :disabled => true,
             :title    => "This element is disabled because it is read only"
-          })
+          )
         end
       end
 
@@ -108,12 +108,12 @@ describe ApplicationHelper do
         let(:read_only) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq({
+          expect(helper.checkbox_tag_options(dialog_field, "url")).to eq(
             :class                      => "dynamic-checkbox-100",
             "data-miq_sparkle_on"       => true,
             "data-miq_sparkle_off"      => true,
             "data-miq_observe_checkbox" => "{\"url\":\"url\"}"
-          })
+          )
         end
       end
     end
@@ -125,12 +125,12 @@ describe ApplicationHelper do
         let(:read_only) { true }
 
         it "returns the tag options with a disabled true" do
-          expect(helper.date_tag_options(dialog_field, "url")).to eq({
+          expect(helper.date_tag_options(dialog_field, "url")).to eq(
             :class    => "css1 dynamic-date-100",
             :readonly => "true",
             :disabled => true,
             :title    => "This element is disabled because it is read only"
-          })
+          )
         end
       end
 
@@ -138,11 +138,11 @@ describe ApplicationHelper do
         let(:read_only) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.date_tag_options(dialog_field, "url")).to eq({
+          expect(helper.date_tag_options(dialog_field, "url")).to eq(
             :class                  => "css1 dynamic-date-100",
             :readonly               => "true",
             "data-miq_observe_date" => "{\"url\":\"url\"}"
-          })
+          )
         end
       end
     end
@@ -154,11 +154,11 @@ describe ApplicationHelper do
         let(:read_only) { true }
 
         it "returns the tag options with a disabled true" do
-          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq({
+          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq(
             :class    => "dynamic-date-hour_or_min-100",
             :disabled => true,
             :title    => "This element is disabled because it is read only"
-          })
+          )
         end
       end
 
@@ -166,10 +166,10 @@ describe ApplicationHelper do
         let(:read_only) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq({
+          expect(helper.time_tag_options(dialog_field, "url", "hour_or_min")).to eq(
             :class             => "dynamic-date-hour_or_min-100",
             "data-miq_observe" => "{\"url\":\"url\"}"
-          })
+          )
         end
       end
     end
@@ -181,11 +181,11 @@ describe ApplicationHelper do
         let(:read_only) { true }
 
         it "returns the tag options with a disabled true" do
-          expect(helper.drop_down_options(dialog_field, "url")).to eq({
+          expect(helper.drop_down_options(dialog_field, "url")).to eq(
             :class    => "dynamic-drop-down-100",
             :disabled => true,
             :title    => "This element is disabled because it is read only"
-          })
+          )
         end
       end
 
@@ -193,12 +193,12 @@ describe ApplicationHelper do
         let(:read_only) { false }
 
         it "returns the tag options with a few data-miq attributes" do
-          expect(helper.drop_down_options(dialog_field, "url")).to eq({
+          expect(helper.drop_down_options(dialog_field, "url")).to eq(
             :class                 => "dynamic-drop-down-100",
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             "data-miq_observe"     => "{\"url\":\"url\"}"
-          })
+          )
         end
       end
     end
@@ -222,7 +222,7 @@ describe ApplicationHelper do
           let(:value) { "some_value" }
 
           it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+            expect(helper.radio_options(dialog_field, "url", value)).to eq(
               :type     => "radio",
               :id       => "100",
               :value    => "some_value",
@@ -230,7 +230,7 @@ describe ApplicationHelper do
               :checked  => '',
               :disabled => true,
               :title    => "This element is disabled because it is read only"
-            })
+            )
           end
         end
 
@@ -238,7 +238,7 @@ describe ApplicationHelper do
           let(:value) { "bogus" }
 
           it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+            expect(helper.radio_options(dialog_field, "url", value)).to eq(
               :type     => "radio",
               :id       => "100",
               :value    => "bogus",
@@ -246,7 +246,7 @@ describe ApplicationHelper do
               :checked  => nil,
               :disabled => true,
               :title    => "This element is disabled because it is read only"
-            })
+            )
           end
         end
       end
@@ -258,14 +258,14 @@ describe ApplicationHelper do
           let(:value) { "some_value" }
 
           it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+            expect(helper.radio_options(dialog_field, "url", value)).to eq(
               :type    => "radio",
               :id      => "100",
               :value   => "some_value",
               :name    => "field_name",
               :checked => '',
               :onclick => "$.ajax({beforeSend:function(request){miqSparkle(true);}, complete:function(request){miqSparkle(false);}, data:miqSerializeForm(this), dataType:'script', type:'post', url:'url'})"
-            })
+            )
           end
         end
 
@@ -273,14 +273,14 @@ describe ApplicationHelper do
           let(:value) { "bogus" }
 
           it "returns the tag options with a disabled true and checked" do
-            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+            expect(helper.radio_options(dialog_field, "url", value)).to eq(
               :type    => "radio",
               :id      => "100",
               :value   => "bogus",
               :name    => "field_name",
               :checked => nil,
               :onclick => "$.ajax({beforeSend:function(request){miqSparkle(true);}, complete:function(request){miqSparkle(false);}, data:miqSerializeForm(this), dataType:'script', type:'post', url:'url'})"
-            })
+            )
           end
         end
       end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -202,5 +202,88 @@ describe ApplicationHelper do
         end
       end
     end
+
+    describe "#radio_options" do
+      let(:dialog_field) do
+        active_record_instance_double(
+          "DialogField",
+          :default_value => "some_value",
+          :name          => "field_name",
+          :id            => "100",
+          :read_only     => read_only,
+          :value         => value
+        )
+      end
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        context "when the current value is equal to the default value" do
+          let(:value) { "some_value" }
+
+          it "returns the tag options with a disabled true and checked" do
+            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+              :type     => "radio",
+              :id       => "100",
+              :value    => "some_value",
+              :name     => "field_name",
+              :checked  => '',
+              :disabled => true,
+              :title    => "This element is disabled because it is read only"
+            })
+          end
+        end
+
+        context "when the current value is not equal to the default value" do
+          let(:value) { "bogus" }
+
+          it "returns the tag options with a disabled true and checked" do
+            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+              :type     => "radio",
+              :id       => "100",
+              :value    => "bogus",
+              :name     => "field_name",
+              :checked  => nil,
+              :disabled => true,
+              :title    => "This element is disabled because it is read only"
+            })
+          end
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        context "when the current value is equal to the default value" do
+          let(:value) { "some_value" }
+
+          it "returns the tag options with a disabled true and checked" do
+            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+              :type    => "radio",
+              :id      => "100",
+              :value   => "some_value",
+              :name    => "field_name",
+              :checked => '',
+              :onclick => "$.ajax({beforeSend:function(request){miqSparkle(true);}, complete:function(request){miqSparkle(false);}, data:miqSerializeForm(this), dataType:'script', type:'post', url:'url'})"
+            })
+          end
+        end
+
+        context "when the current value is not equal to the default value" do
+          let(:value) { "bogus" }
+
+          it "returns the tag options with a disabled true and checked" do
+            expect(helper.radio_options(dialog_field, "url", value)).to eq({
+              :type    => "radio",
+              :id      => "100",
+              :value   => "bogus",
+              :name    => "field_name",
+              :checked => nil,
+              :onclick => "$.ajax({beforeSend:function(request){miqSparkle(true);}, complete:function(request){miqSparkle(false);}, data:miqSerializeForm(this), dataType:'script', type:'post', url:'url'})"
+            })
+          end
+        end
+      end
+    end
   end
 end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -173,5 +173,34 @@ describe ApplicationHelper do
         end
       end
     end
+
+    describe "#drop_down_options" do
+      let(:dialog_field) { active_record_instance_double("DialogField", :id => "100", :read_only => read_only) }
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        it "returns the tag options with a disabled true" do
+          expect(helper.drop_down_options(dialog_field, "url")).to eq({
+            :class    => "dynamic-drop-down-100",
+            :disabled => true,
+            :title    => "This element is disabled because it is read only"
+          })
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        it "returns the tag options with a few data-miq attributes" do
+          expect(helper.drop_down_options(dialog_field, "url")).to eq({
+            :class                 => "dynamic-drop-down-100",
+            "data-miq_sparkle_on"  => true,
+            "data-miq_sparkle_off" => true,
+            "data-miq_observe"     => "{\"url\":\"url\"}"
+          })
+        end
+      end
+    end
   end
 end

--- a/vmdb/spec/helpers/application_helper/dialogs_spec.rb
+++ b/vmdb/spec/helpers/application_helper/dialogs_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe ApplicationHelper do
-
   context "::Dialogs" do
     describe "#dialog_dropdown_select_values" do
 
@@ -27,6 +26,35 @@ describe ApplicationHelper do
         @field.required = true
         values = helper.dialog_dropdown_select_values(@field, "cat")
         values.should == @val_array_reversed
+      end
+    end
+
+    describe "#textbox_tag_options" do
+      let(:dialog_field) { active_record_instance_double("DialogField", :id => "100", :read_only => read_only) }
+
+      context "when the field is read_only" do
+        let(:read_only) { true }
+
+        it "returns the tag options with a disabled true" do
+          expect(helper.textbox_tag_options(dialog_field, "url")).to eq({
+            :maxlength => 50,
+            :class     => "dynamic-text-box-100",
+            :disabled  => true,
+            :title     => "This element is disabled because it is read only"
+          })
+        end
+      end
+
+      context "when the dialog field is not read only" do
+        let(:read_only) { false }
+
+        it "returns the tag options with a data-miq-observe" do
+          expect(helper.textbox_tag_options(dialog_field, "url")).to eq({
+            :maxlength         => 50,
+            :class             => "dynamic-text-box-100",
+            "data-miq_observe" => "{\"interval\":\".5\",\"url\":\"url\"}"
+          })
+        end
       end
     end
   end

--- a/vmdb/spec/models/dialog_field_check_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_check_box_spec.rb
@@ -78,8 +78,9 @@ describe DialogFieldCheckBox do
     let(:dialog_field) { described_class.new }
     let(:automate_hash) do
       {
-        "value"    => value,
-        "required" => true
+        "value"     => value,
+        "required"  => true,
+        "read_only" => true
       }
     end
 
@@ -90,6 +91,10 @@ describe DialogFieldCheckBox do
 
       it "sets the required" do
         expect(dialog_field.required).to be_true
+      end
+
+      it "sets the read_only" do
+        expect(dialog_field.read_only).to be_true
       end
     end
 

--- a/vmdb/spec/models/dialog_field_date_control_spec.rb
+++ b/vmdb/spec/models/dialog_field_date_control_spec.rb
@@ -60,7 +60,8 @@ describe DialogFieldDateControl do
     let(:automate_hash) do
       {
         "value"           => value,
-        "show_past_dates" => true
+        "show_past_dates" => true,
+        "read_only"       => true
       }
     end
 
@@ -75,6 +76,10 @@ describe DialogFieldDateControl do
 
       it "sets the show_past_dates" do
         expect(dialog_field.show_past_dates).to be_true
+      end
+
+      it "sets the read_only" do
+        expect(dialog_field.read_only).to be_true
       end
     end
 

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -144,8 +144,8 @@ describe DialogFieldRadioButton do
       let(:refreshed_values_from_automate) { [%w(123 123), %w(456 456)] }
 
       it "returns the list of refreshed values and checked value as a hash" do
-        expect(dialog_field_radio_button.refresh_json_value("456")).to eq(
-          :refreshed_values => refreshed_values_from_automate, :checked_value => "456"
+        expect(dialog_field_radio_button.refresh_json_value("123")).to eq(
+          {:refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil}
         )
       end
     end
@@ -155,7 +155,7 @@ describe DialogFieldRadioButton do
 
       it "returns the list of refreshed values and checked (default) value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("321")).to eq(
-          :refreshed_values => refreshed_values_from_automate, :checked_value => "123"
+          {:refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil}
         )
       end
     end

--- a/vmdb/spec/models/dialog_field_radio_button_spec.rb
+++ b/vmdb/spec/models/dialog_field_radio_button_spec.rb
@@ -145,7 +145,7 @@ describe DialogFieldRadioButton do
 
       it "returns the list of refreshed values and checked value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("123")).to eq(
-          {:refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil}
+          :refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil
         )
       end
     end
@@ -155,7 +155,7 @@ describe DialogFieldRadioButton do
 
       it "returns the list of refreshed values and checked (default) value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("321")).to eq(
-          {:refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil}
+          :refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil
         )
       end
     end

--- a/vmdb/spec/models/dialog_field_serializer_spec.rb
+++ b/vmdb/spec/models/dialog_field_serializer_spec.rb
@@ -31,6 +31,7 @@ describe DialogFieldSerializer do
         "label"                   => "label",
         "load_values_on_init"     => false,
         "position"                => 1,
+        "read_only"               => false,
         "validator_type"          => "validator_type",
         "validator_rule"          => "validator_rule",
         "reconfigurable"          => nil

--- a/vmdb/spec/models/dialog_field_sorted_item_spec.rb
+++ b/vmdb/spec/models/dialog_field_sorted_item_spec.rb
@@ -30,6 +30,7 @@ describe DialogFieldSortedItem do
         "data_type"     => "datatype",
         "default_value" => "default",
         "required"      => true,
+        "read_only"     => true,
         "values"        => values
       }
     end
@@ -56,7 +57,11 @@ describe DialogFieldSortedItem do
       end
 
       it "sets the required" do
-        expect(dialog_field.required).to eq(true)
+        expect(dialog_field.required).to be_true
+      end
+
+      it "sets the read_only" do
+        expect(dialog_field.read_only).to be_true
       end
     end
 

--- a/vmdb/spec/models/dialog_field_text_area_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_area_box_spec.rb
@@ -10,6 +10,7 @@ describe DialogFieldTextAreaBox do
         "value"          => value,
         "protected"      => true,
         "required"       => true,
+        "read_only"      => true,
         "validator_rule" => "rule",
         "validator_type" => "regex"
       }
@@ -33,7 +34,11 @@ describe DialogFieldTextAreaBox do
       end
 
       it "sets the required" do
-        expect(dialog_field.required).to eq(true)
+        expect(dialog_field.required).to be_true
+      end
+
+      it "sets the read_only" do
+        expect(dialog_field.read_only).to be_true
       end
     end
 

--- a/vmdb/spec/models/dialog_field_text_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_box_spec.rb
@@ -168,6 +168,7 @@ describe DialogFieldTextBox do
         "value"          => value,
         "protected"      => true,
         "required"       => true,
+        "read_only"      => true,
         "validator_type" => "regex",
         "validator_rule" => "rule"
       }
@@ -184,6 +185,10 @@ describe DialogFieldTextBox do
 
       it "sets the required" do
         expect(dialog_field.required).to be_true
+      end
+
+      it "sets the read_only" do
+        expect(dialog_field.read_only).to be_true
       end
 
       it "sets the validator type" do

--- a/vmdb/spec/models/dialog_field_text_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_box_spec.rb
@@ -221,6 +221,7 @@ describe DialogFieldTextBox do
 
     context "when the dialog is dynamic" do
       let(:dynamic) { true }
+      let(:value) { "somevalue" }
 
       it "returns 'Sample Text'" do
         expect(dialog_field.sample_text).to eq("Sample Text")

--- a/vmdb/spec/models/dialog_field_text_box_spec.rb
+++ b/vmdb/spec/models/dialog_field_text_box_spec.rb
@@ -217,7 +217,7 @@ describe DialogFieldTextBox do
   end
 
   describe "#sample_text" do
-    let(:dialog_field) { described_class.new(:dynamic => dynamic, :value => "defaultvalue") }
+    let(:dialog_field) { described_class.new(:dynamic => dynamic, :value => value, :default_value => "defaultvalue") }
 
     context "when the dialog is dynamic" do
       let(:dynamic) { true }
@@ -230,8 +230,20 @@ describe DialogFieldTextBox do
     context "when the dialog is not dynamic" do
       let(:dynamic) { false }
 
-      it "returns the value" do
-        expect(dialog_field.sample_text).to eq("defaultvalue")
+      context "when the dialog has a value" do
+        let(:value) { "somevalue" }
+
+        it "returns the value" do
+          expect(dialog_field.sample_text).to eq("somevalue")
+        end
+      end
+
+      context "when the dialog does not have a value" do
+        let(:value) { nil }
+
+        it "returns the default value" do
+          expect(dialog_field.sample_text).to eq("defaultvalue")
+        end
       end
     end
   end


### PR DESCRIPTION
This adds a read_only column to all dialog fields. It then does not allow the user to change the values of the dialog_field by disabling them as well as not sending a request when they change (so, even if the user goes into the source and un-disables the field). It also adds a small title that explains why the field is disabled.

https://trello.com/c/WYpk2dN3

/cc @gmcculloug 