### PR TITLE
Added type to disabled buttons.

### DIFF
--- a/vmdb/app/views/layouts/_form_buttons.html.haml
+++ b/vmdb/app/views/layouts/_form_buttons.html.haml
@@ -82,8 +82,8 @@
           = button_tag(_("Verify"),
             :class => "btn btn-primary btn-disabled",
             :title => _("All fields are needed to perform verification of Database Settings"))
-        = button_tag(_("Save"),  :class => "btn btn-primary btn-disabled")
-        = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+        = button_tag(_("Save"),  :class => "btn btn-primary btn-disabled", :type => 'button')
+        = button_tag(_("Reset"), :class => "btn btn-default btn-disabled", :type => 'button')
 
         - unless  @layout == "configuration" || @layout == "ops" || @layout == "chargeback" || @layout == "miq_ae_class"
           = button_tag(t = _("Cancel"),


### PR DESCRIPTION
Having button_tag to disable buttons with no type inside form_tag was still leaving button as clickable and causing an error when clicking on disabled buttons in My settings area.

https://bugzilla.redhat.com/show_bug.cgi?id=1211241

@dclarizio @epwinchell please review