### PR TITLE
Show ip address of ui transactions in logs

### DIFF
--- a/vmdb/config/initializers/ad_show_ips.rb
+++ b/vmdb/config/initializers/ad_show_ips.rb
@@ -1,0 +1,7 @@
+module ActionDispatch
+  class RemoteIp
+    def proxies
+      /^127\.0\.0\.1$/
+    end
+  end
+end


### PR DESCRIPTION
All client ip addresses show up as 127.0.0.1
This makes changes to properly set remote_id

The fetching of static files (e.g.: .js, .css)
still display 127.0.0.1, but those are not as important

This is in response to:
- https://github.com/rails/rails/issues/5223


https://bugzilla.redhat.com/show_bug.cgi?id=1056278

/cc @jrafanie @Fryguy changes to `production.log`