### PR TITLE
Reset Save/Reset buttons when going to OPS controller.

### DIFF
--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -177,7 +177,7 @@ class OpsController < ApplicationController
     @temp[:x_edit_buttons_locals] = set_form_locals if @in_a_form
     @collapse_c_cell = @in_a_form || @pages ? false : true
     @sb[:center_tb_filename] = center_toolbar_filename
-
+    session[:changed] = @edit[:new] != @edit[:current].config
     render :layout => "explorer"
   end
 


### PR DESCRIPTION
Sometimes Reset/Save buttons are enabled when going to Configuration/Configure screen, clicking on links/nodes it prompts for Abandon changes? even tho nothing was changed.

@dclarizio please review/test.

Steps to recreate:

1. Go to an Infrastructure Provider, edit a provider make changes on the screen once Save/Reset buttons are enabled without cancelling the form jump to Configuration/Configure screen.
2. Try to click on nodes in the tree or links in navigation bar, that will prompt for Abandon changes? even tho there are no changes on screen.
