### PR TITLE
Add logging and a null logger

### DIFF
--- a/lib/manageiq_foreman/lib/manageiq_foreman.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman.rb
@@ -1,11 +1,12 @@
+require "manageiq_foreman/logging"
 require "manageiq_foreman/version"
 
 require 'apipie-bindings'
 
-require "manageiq_foreman/paged_response"
 require "manageiq_foreman/connection"
-require "manageiq_foreman/inventory"
 require "manageiq_foreman/host"
+require "manageiq_foreman/inventory"
+require "manageiq_foreman/paged_response"
 
 module ManageiqForeman
 end

--- a/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
@@ -1,5 +1,6 @@
 module ManageiqForeman
   class Connection
+    include ManageiqForeman::Logging
     # some foreman servers don't have locations or organizations, just return nil
     ALLOW_404 = [:locations, :organizations]
     attr_accessor :connection_attrs
@@ -43,6 +44,7 @@ module ManageiqForeman
     # filter: "page" => 2, "per_page" => 50, "search" => "field=value", "value"
     def fetch(resource, action = :index, filter = {})
       action, filter = :index, action if action.kind_of?(Hash)
+      logger.info("#{self.class.name}##{__method__} Calling Apipie Resource: #{resource.inspect} Action: #{action.inspect} Params: #{dump_hash(filter)}")
       PagedResponse.new(@api.resource(resource).action(action).call(filter))
     rescue RestClient::ResourceNotFound
       raise unless ALLOW_404.include?(resource)

--- a/lib/manageiq_foreman/lib/manageiq_foreman/logging.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/logging.rb
@@ -1,0 +1,23 @@
+require "manageiq_foreman/null_logger"
+
+module ManageiqForeman
+  extend self
+  attr_accessor :logger
+
+  module Logging
+    def logger
+      ManageiqForeman.logger ||= NullLogger.new
+    end
+
+    def logger=(new_logger)
+      ManageiqForeman.logger = new_logger
+    end
+
+    def dump_hash(hash)
+      filtered_keys = ["root_pass"]
+      new_hash = hash.dup
+      filtered_keys.each { |k| new_hash[k] = "<FILTERED>" }
+      new_hash.inspect
+    end
+  end
+end

--- a/lib/manageiq_foreman/lib/manageiq_foreman/null_logger.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/null_logger.rb
@@ -1,0 +1,11 @@
+require 'logger'
+
+module ManageiqForeman
+  class NullLogger < Logger
+    def initialize(*_args)
+    end
+
+    def add(*_args, &_block)
+    end
+  end
+end

--- a/vmdb/app/models/ems_refresh/refreshers/foreman_refresher.rb
+++ b/vmdb/app/models/ems_refresh/refreshers/foreman_refresher.rb
@@ -1,6 +1,3 @@
-require 'manageiq_foreman'
-require 'manageiq_foreman/inventory'
-
 module EmsRefresh
   module Refreshers
     class ForemanRefresher

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
@@ -1,4 +1,3 @@
-require 'manageiq_foreman'
 module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
   def log_provider_options
     $log.info("MIQ(#{self.class.name}##{__method__}) Provisioning [#{source.name}]")

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/state_machine.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/state_machine.rb
@@ -1,4 +1,3 @@
-require 'manageiq_foreman'
 module MiqProvisionTaskConfiguredSystemForeman::StateMachine
   def run_provision
     validate_source

--- a/vmdb/app/models/provider_foreman.rb
+++ b/vmdb/app/models/provider_foreman.rb
@@ -22,6 +22,7 @@ class ProviderForeman < Provider
 
   def self.raw_connect(base_url, username, password, verify_ssl)
     require 'manageiq_foreman'
+    ManageiqForeman.logger ||= $log
     ManageiqForeman::Connection.new(
       :base_url   => base_url,
       :username   => username,

--- a/vmdb/lib/vmdb/logging.rb
+++ b/vmdb/lib/vmdb/logging.rb
@@ -106,9 +106,6 @@ module Vmdb
     def self.configure_external_loggers
       require 'awesome_spawn'
       AwesomeSpawn.logger = $log
-
-      require 'manageiq_foreman'
-      ManageiqForeman.logger = $log
     end
     private_class_method :configure_external_loggers
 

--- a/vmdb/lib/vmdb/logging.rb
+++ b/vmdb/lib/vmdb/logging.rb
@@ -106,6 +106,9 @@ module Vmdb
     def self.configure_external_loggers
       require 'awesome_spawn'
       AwesomeSpawn.logger = $log
+
+      require 'manageiq_foreman'
+      ManageiqForeman.logger = $log
     end
     private_class_method :configure_external_loggers
 


### PR DESCRIPTION
Provider interactions with Foreman are mysterious.  Add logging to ManageiqForeman to help with debugging provider interactions.