### PR TITLE
Use underlying refresh_ems impl for foreman

### DIFF
--- a/vmdb/app/models/configuration_manager_foreman.rb
+++ b/vmdb/app/models/configuration_manager_foreman.rb
@@ -34,8 +34,4 @@ class ConfigurationManagerForeman < ConfigurationManager
   def self.unknown_task_exception(options)
     raise "Unknown task, #{options[:task]}" unless instance_methods.collect(&:to_s).include?(options[:task])
   end
-
-  def self.refresh_ems(provider_ids)
-    EmsRefresh.queue_refresh(Array.wrap(provider_ids).collect { |id| [base_class, id] })
-  end
 end


### PR DESCRIPTION
ConfigurationManager for Foreman overrode 'refresh_ems` method. No need since the parent version was more featured.

https://bugzilla.redhat.com/show_bug.cgi?id=1211693

/cc @gmcculloug @brandondunne 