### PR TITLE
Automate Export_as issues

### DIFF
--- a/vmdb/app/models/miq_ae_yaml_export.rb
+++ b/vmdb/app/models/miq_ae_yaml_export.rb
@@ -23,7 +23,7 @@ class MiqAeYamlExport
     else
       @domain == ALL_DOMAINS ? write_all_domains : write_domain
     end
-    write_manifest(swap_domain_name(@domain))
+    write_manifest(@options['export_as'].presence || @domain)
   end
 
   def export_level
@@ -250,11 +250,6 @@ class MiqAeYamlExport
       $log.error("#{self.class} Class: <#{klass}> not found in <#{ns_obj.fqname}>.")
       raise MiqAeException::ClassNotFound, "Class: [#{klass}] not found in [#{ns_obj.fqname}]"
     end
-  end
-
-  def swap_domain_name(name)
-    return name if @options['export_as'].blank?
-    name.gsub(/^#{@domain}/, @options['export_as'])
   end
 
   def swap_domain_path(fqname)

--- a/vmdb/app/models/miq_ae_yaml_export.rb
+++ b/vmdb/app/models/miq_ae_yaml_export.rb
@@ -82,7 +82,7 @@ class MiqAeYamlExport
       domain_obj.name = @options['export_as']
     end
     envelope_hash = setup_envelope(domain_obj, DOMAIN_OBJ_TYPE).to_yaml
-    write_export_file('fqname'          => swap_domain_name(domain_obj.name),
+    write_export_file('fqname'          => domain_obj.name,
                       'output_filename' => DOMAIN_YAML_FILENAME,
                       'export_data'     => envelope_hash,
                       'created_on'      => domain_obj.created_on,

--- a/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -718,7 +718,7 @@ describe MiqAeDatastore do
 
   def setup_export_dir
     @export_dir = File.join(Dir.tmpdir, "rspec_export_tests")
-    @export_as  = "barney"
+    @export_as  = "manageiq"*2
     @zip_file   = File.join(Dir.tmpdir, "yaml_model.zip")
     @yaml_file  = File.join(Dir.tmpdir, "yaml_model.yml")
     FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)
@@ -766,6 +766,7 @@ describe MiqAeDatastore do
   end
 
   def create_bogus_zip_file
+    require 'zip/zipfilesystem'
     Zip::ZipFile.open(@zip_file, Zip::ZipFile::CREATE) do |zh|
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")

--- a/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/vmdb/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -718,7 +718,7 @@ describe MiqAeDatastore do
 
   def setup_export_dir
     @export_dir = File.join(Dir.tmpdir, "rspec_export_tests")
-    @export_as  = "manageiq"*2
+    @export_as  = "manageiq" * 2
     @zip_file   = File.join(Dir.tmpdir, "yaml_model.zip")
     @yaml_file  = File.join(Dir.tmpdir, "yaml_model.yml")
     FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)


### PR DESCRIPTION
Automate `Export_as` command could not handle names which start with the same string as the original name.

https://bugzilla.redhat.com/show_bug.cgi?id=1211392