### PR TITLE
[api] Updating Rest API Versioning to 2.0.0

### DIFF
--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -1,14 +1,14 @@
 ---
 :base:
   :module: api
-  :name: ManageIQ API
-  :description: ManageIQ REST API
-  :version: '2.0.0-pre'
+  :name: API
+  :description: REST API
+  :version: '2.0.0'
 :version:
   :regex: !ruby/regexp /^v[0-9]+(?>\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?/
   :definitions:
-  - :name: '2.0.0-pre'
-    :ident: 'v2.0.0-pre'
+  - :name: '2.0.0'
+    :ident: 'v2.0.0'
 :method:
   :names:
   - :get


### PR DESCRIPTION
- Updating Versioning to 2.0.0
- Removed ManageIQ string from api.yml

https://bugzilla.redhat.com/show_bug.cgi?id=1210761