### PR TITLE
Avoid NilClass error when no parameters in a template

### DIFF
--- a/vmdb/app/models/orchestration_template_cfn.rb
+++ b/vmdb/app/models/orchestration_template_cfn.rb
@@ -10,7 +10,7 @@ class OrchestrationTemplateCfn < OrchestrationTemplate
 
   def parameters
     raw_parameters = JSON.load(content)["Parameters"]
-    raw_parameters.collect do |key, val|
+    (raw_parameters || {}).collect do |key, val|
       parameter = OrchestrationTemplate::OrchestrationParameter.new(
         :name          => key,
         :label         => key.titleize,

--- a/vmdb/app/models/orchestration_template_hot.rb
+++ b/vmdb/app/models/orchestration_template_hot.rb
@@ -24,7 +24,7 @@ class OrchestrationTemplateHot < OrchestrationTemplate
 
   def parameters(content_hash = nil)
     content_hash = YAML.load(content) unless content_hash
-    content_hash["parameters"].collect do |key, val|
+    (content_hash["parameters"] || {}).collect do |key, val|
       OrchestrationTemplate::OrchestrationParameter.new(
         :name          => key,
         :label         => val.key?('label') ? val['label'] : key.titleize,

--- a/vmdb/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/vmdb/spec/services/orchestration_template_dialog_service_spec.rb
@@ -5,6 +5,8 @@ describe OrchestrationTemplateDialogService do
 
   let(:template) { FactoryGirl.create(:orchestration_template_hot_with_content) }
 
+  let(:empty_template) { FactoryGirl.create(:orchestration_template_cfn) }
+
   describe "#create_dialog" do
     it "creates a dialog with stack basic info and parameters" do
       dialog = dialog_service.create_dialog("test", template)
@@ -18,13 +20,18 @@ describe OrchestrationTemplateDialogService do
       tabs.size.should == 1
       assert_stack_tab(tabs[0])
     end
+
+    it "creates a dialog from a template without parameters" do
+      dialog = dialog_service.create_dialog("test", empty_template)
+
+      tabs = dialog.dialog_tabs
+      assert_tab_attributes(tabs[0])
+      assert_stack_group(tabs[0].dialog_groups[0])
+    end
   end
 
   def assert_stack_tab(tab)
-    tab.should have_attributes(
-      :label   => "Basic Information",
-      :display => "edit"
-    )
+    assert_tab_attributes(tab)
 
     groups = tab.dialog_groups
     groups.size.should == 3
@@ -32,6 +39,13 @@ describe OrchestrationTemplateDialogService do
     assert_stack_group(groups[0])
     assert_parameter_group1(groups[1])
     assert_parameter_group2(groups[2])
+  end
+
+  def assert_tab_attributes(tab)
+    tab.should have_attributes(
+      :label   => "Basic Information",
+      :display => "edit"
+    )
   end
 
   def assert_stack_group(group)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1212466

When a dialog is created from a template that has no parameters section, the NilClass error is raised. The fix is to feed an empty hash if no parameters are found.

The resulting dialog has a parameters group with no controls. I think it is acceptable, but let's discuss.
![empty_parameters](https://cloud.githubusercontent.com/assets/7047579/7184399/0dbcf22a-e42b-11e4-9fcb-aa415c0d4f25.png)
 