### PR TITLE
Log a warning for uneditable automate instances

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -358,6 +358,7 @@ module MiqAeMethodService
       dom, _, _, _ = MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(path)
       domain = MiqAeDomain.find_by_fqname(dom, false)
       return false unless domain
+      $log.warn "path=#{path.inspect} : is not editable" unless domain.editable?
       domain.editable?
     end
   end


### PR DESCRIPTION
The automate methods
$evm.instance_delete
$evm.instance_update
$evm.instance_create

Have been returning a false for uneditable instances and the
caller can check the return value and log an error. Based on
the request from this ticket we will now log a warning if the
instance is not editable

https://bugzilla.redhat.com/show_bug.cgi?id=1212411