### PR TITLE
Link between stack and resources

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack_common/orchestration_stacks.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_common/orchestration_stacks.rb
@@ -165,6 +165,7 @@ module EmsRefresh
           child_stacks = []
           resources = raw_resources.collect do |resource|
             physical_id = resource['physical_resource_id']
+            @resource_to_stack[physical_id] = stack.id
             # TODO(lsmola) this condition doesn't apply for OpenStack, resource is nested stack when it has child
             # resources nested resources will be solved in followup PR. There is 'rel' => 'nested' in links, when
             # resource has children.

--- a/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
@@ -14,6 +14,7 @@ module EmsRefresh
         @data              = {}
         @data_index        = {}
         @host_hash_by_name = {}
+        @resource_to_stack = {}
 
         @known_flavors = Set.new
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1212534

During openstack refresh, stack and its resources, namely instances, networks, and security groups, were not associated. 

With this fix, stacks are refreshed before other resources, and a hash from stack's resource id to stack stores the mapping. When refresh the resources, they are connected to theirs stack based on the hash.