### PR TITLE
Don't hide skipped assets during precompile.

### DIFF
--- a/vmdb/lib/vmdb/productization.rb
+++ b/vmdb/lib/vmdb/productization.rb
@@ -34,7 +34,7 @@ module Vmdb
           resolved = resolved.relative_path_from(Rails.root) if resolved.to_s.start_with?(Rails.root.to_s)
           if include
             puts "+ #{resolved}"
-          elsif ENV["DEBUG_PRECOMPILE"]
+          elsif
             puts "- #{resolved}"
           end
 


### PR DESCRIPTION
It's hard to know your assets are being skipped because we don't print it by default.