### PR TITLE
[ci skip] skip asset compile on update_start

### DIFF
--- a/vmdb/lib/tasks/evm.rake
+++ b/vmdb/lib/tasks/evm.rake
@@ -28,7 +28,7 @@ namespace :evm do
     EvmApplication.status
   end
 
-  task :update_start => :compile_assets do
+  task :update_start do
     EvmApplication.update_start
   end
 


### PR DESCRIPTION
we are compiling assets when packaging the RPM so we don't need to do
that when doing update_start.

https://bugzilla.redhat.com/show_bug.cgi?id=1211693