### PR TITLE
Fix backup depots

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -543,7 +543,7 @@ class ApplicationController < ActionController::Base
         PxeServer.verify_depot_settings(settings)
       else
         msg = 'Depot Settings successfuly validated'
-        MiqSchedule.verify_depot_hash(settings)
+        MiqSchedule.new.verify_file_depot(settings)
       end
     rescue StandardError => bang
       add_flash(_("Error during '%s': ") % "Validate" << bang.message, :error)

--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -270,7 +270,7 @@ class OpsController < ApplicationController
   end
 
   def set_log_depot_vars
-    if (settings = @schedule.depot_hash).present?
+    if (settings = @schedule.file_depot.try(:depot_hash)).present?
       log_depot_get_form_vars_from_settings(settings)
     else
       log_depot_reset_form_vars

--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -330,11 +330,19 @@ module OpsController::Diagnostics
       end
       return
     end
-    settings = {:uri      => params[:uri_prefix] + "://" + params[:uri],
-                :username => params[:log_userid],
-                :password => params[:log_password],
-                :name     => params[:depot_name]}
-      @schedule.depot_hash=(settings) if MiqSchedule.verify_depot_hash(settings)
+
+    # only verify_depot_hash if anything has changed in depot settings
+    if [:uri_prefix, :uri, :log_userid, :log_password].any? { |param| @edit[:new][param] != @edit[:current][param] }
+      @schedule.verify_depot_hash(
+        :uri        => "#{@edit[:new][:uri_prefix]}://#{@edit[:new][:uri]}",
+        :uri_prefix => @edit[:new][:uri_prefix],
+        :username   => @edit[:new][:log_userid],
+        :password   => @edit[:new][:log_password],
+        :name       => @edit[:new][:depot_name],
+        :save       => true,
+      )
+    end
+
     schedule_set_record_vars(@schedule)
     schedule_validate?(@schedule)
     if @schedule.valid? && !flash_errors? && @schedule.save

--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -295,8 +295,8 @@ module OpsController::Diagnostics
 
   def db_backup_form_field_changed
     schedule = MiqSchedule.find_by_id(params[:id])
-    settings = schedule ? schedule.depot_hash : nil
-    uri_settings = settings[:uri].split("://")
+    settings = schedule.file_depot.try(:depot_hash) || {}
+    uri_settings = settings[:uri].to_s.split("://")
     render :json => {:depot_name   => settings[:name],
                      :uri          => uri_settings[1],
                      :uri_prefix   => uri_settings[0],
@@ -329,18 +329,6 @@ module OpsController::Diagnostics
         page << "miqSparkle(false);"
       end
       return
-    end
-
-    # only verify_depot_hash if anything has changed in depot settings
-    if [:uri_prefix, :uri, :log_userid, :log_password].any? { |param| @edit[:new][param] != @edit[:current][param] }
-      @schedule.verify_depot_hash(
-        :uri        => "#{@edit[:new][:uri_prefix]}://#{@edit[:new][:uri]}",
-        :uri_prefix => @edit[:new][:uri_prefix],
-        :username   => @edit[:new][:log_userid],
-        :password   => @edit[:new][:log_password],
-        :name       => @edit[:new][:depot_name],
-        :save       => true,
-      )
     end
 
     schedule_set_record_vars(@schedule)

--- a/vmdb/app/controllers/ops_controller/settings/schedules.rb
+++ b/vmdb/app/controllers/ops_controller/settings/schedules.rb
@@ -553,12 +553,14 @@ module OpsController::Settings::Schedules
       end
     else
       schedule.filter = nil
-      schedule.depot_hash = {
-        :uri      => "#{params[:uri_prefix]}://#{params[:uri]}",
-        :username => params[:log_userid],
-        :password => params[:log_password],
-        :name     => params[:depot_name]
-      }
+      MiqSchedule.verify_file_depot(
+        :name       => params[:depot_name],
+        :password   => params[:log_password],
+        :username   => params[:log_username],
+        :uri        => "#{params[:uri_prefix]}://#{params[:uri]}",
+        :uri_prefix => params[:uri_prefix],
+        :save       => true,
+      )
     end
   end
 

--- a/vmdb/app/controllers/ops_controller/settings/schedules.rb
+++ b/vmdb/app/controllers/ops_controller/settings/schedules.rb
@@ -53,11 +53,6 @@ module OpsController::Settings::Schedules
       # when we have a version of Rails that supports detecting changes on serialized
       # fields
       old_schedule_attributes = schedule.attributes.clone
-      old_schedule_attributes.merge("depot_hash" => {:uri      => schedule.depot_hash[:uri],
-                                                     :username => schedule.depot_hash[:username],
-                                                     :password => schedule.depot_hash[:password],
-                                                     :name     => schedule.depot_hash[:name]
-                                                    }) if schedule.depot_hash
       old_schedule_attributes.merge("filter" => old_schedule_attributes["filter"].try(:to_human))
       old_schedule_attributes.merge("run_at" => {:start_time => schedule.run_at[:start_time],
                                                  :tz         => schedule.run_at[:tz],
@@ -92,7 +87,7 @@ module OpsController::Settings::Schedules
       # This is only because ops_controller tries to set form locals, otherwise we should not use the @edit variable
       @edit = {:sched_id => @schedule.id}
 
-      settings = @schedule.depot_hash
+      settings = @schedule.file_depot.try(:depot_hash) || {}
       unless settings[:uri].nil?
         @protocol = DatabaseBackup.supported_depots[settings[:uri].split('://')[0]]
         @uri_prefix = settings[:uri].split('://')[0]
@@ -121,8 +116,7 @@ module OpsController::Settings::Schedules
       action_type = schedule.towhat.downcase + "_" + schedule.sched_action[:method]
     elsif schedule_db_backup?(schedule)
       action_type = schedule.sched_action[:method]
-
-      settings = schedule.depot_hash
+      settings    = schedule.file_depot.try(:depot_hash) || {}
 
       unless settings[:uri].nil?
         uri_prefix = settings[:uri].split('://')[0]
@@ -553,10 +547,10 @@ module OpsController::Settings::Schedules
       end
     else
       schedule.filter = nil
-      MiqSchedule.verify_file_depot(
+      schedule.verify_file_depot(
         :name       => params[:depot_name],
         :password   => params[:log_password],
-        :username   => params[:log_username],
+        :username   => params[:log_userid],
         :uri        => "#{params[:uri_prefix]}://#{params[:uri]}",
         :uri_prefix => params[:uri_prefix],
         :save       => true,

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -25,6 +25,7 @@ class FileDepot < ActiveRecord::Base
   end
 
   def depot_hash=(hsh = {})
+    deprecate_method(__method__, "attributes and authentications of the instance")
     return if hsh == depot_hash
     update_authentication(:default => {:userid   => hsh[:username],
                                        :password => hsh[:password]})
@@ -33,6 +34,7 @@ class FileDepot < ActiveRecord::Base
   end
 
   def depot_hash
+    deprecate_method(__method__, "attributes and authentications of the instance")
     {:username => authentication_userid,
      :uri      => uri,
      :password => authentication_password,
@@ -41,5 +43,15 @@ class FileDepot < ActiveRecord::Base
 
   def upload_file(file)
     @file = file
+  end
+
+  private
+
+  def deprecate_method(method, instead)
+    unless Rails.env.production?
+      msg = "[DEPRECATION] #{method} method is deprecated.  Please use #{instead} instead.  At #{caller[1]}"
+      $log.warn msg
+      warn msg
+    end
   end
 end

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -2,7 +2,8 @@ class FileDepot < ActiveRecord::Base
   include NewWithTypeStiMixin
   include AuthenticationMixin
   belongs_to            :resource, :polymorphic => true
-  has_many              :miq_servers, :foreign_key => :log_file_depot_id, :dependent => :nullify
+  has_many              :miq_schedules, :dependent => :nullify
+  has_many              :miq_servers,   :dependent => :nullify, :foreign_key => :log_file_depot_id
   has_many              :log_files
   validates_presence_of :uri
 

--- a/vmdb/app/models/file_depot.rb
+++ b/vmdb/app/models/file_depot.rb
@@ -1,7 +1,6 @@
 class FileDepot < ActiveRecord::Base
   include NewWithTypeStiMixin
   include AuthenticationMixin
-  belongs_to            :resource, :polymorphic => true
   has_many              :miq_schedules, :dependent => :nullify
   has_many              :miq_servers,   :dependent => :nullify, :foreign_key => :log_file_depot_id
   has_many              :log_files

--- a/vmdb/app/models/file_depot_ftp.rb
+++ b/vmdb/app/models/file_depot_ftp.rb
@@ -12,8 +12,7 @@ class FileDepotFtp < FileDepot
   end
 
   def self.validate_settings(settings)
-    depot = new(:uri => settings[:uri])
-    depot.with_connection(:username => settings[:username], :password => settings[:password]) { |c| c.last_response }
+    new(:uri => settings[:uri]).verify_credentials(nil, settings.slice(:username, :password))
   end
 
   def upload_file(file)
@@ -46,8 +45,8 @@ class FileDepotFtp < FileDepot
     $log.info("#{log_header(__method__)} Removing log file [#{destination_file}]...complete")
   end
 
-  def verify_credentials(_auth_type = nil)
-    with_connection(&:last_response)
+  def verify_credentials(_auth_type = nil, cred_hash = nil)
+    with_connection(cred_hash, &:last_response)
   rescue
     false
   end

--- a/vmdb/app/models/file_depot_smb.rb
+++ b/vmdb/app/models/file_depot_smb.rb
@@ -8,4 +8,8 @@ class FileDepotSmb < FileDepot
     raise "Depot Settings validation failed with error: #{res.last}" unless res.first
     res
   end
+
+  def verify_credentials(_auth_type = nil, cred_hash = nil)
+    self.class.validate_settings(cred_hash.merge(:uri => uri))
+  end
 end

--- a/vmdb/app/models/miq_schedule.rb
+++ b/vmdb/app/models/miq_schedule.rb
@@ -12,8 +12,9 @@ class MiqSchedule < ActiveRecord::Base
   virtual_column :v_zone_name,     :type => :string, :uses => :zone
   virtual_column :next_run_on,     :type => :datetime
 
-  belongs_to  :zone
-  belongs_to  :miq_search
+  belongs_to :file_depot
+  belongs_to :miq_search
+  belongs_to :zone
 
   scope :in_zone, lambda { |zone_name|
     includes(:zone).where("zones.name" => zone_name)

--- a/vmdb/app/models/miq_schedule.rb
+++ b/vmdb/app/models/miq_schedule.rb
@@ -303,36 +303,24 @@ class MiqSchedule < ActiveRecord::Base
     end
   end
 
-  def validate_file_depot
+  def validate_file_depot  # TODO: Do we need this if the validations are on the FileDepot classes?
     if self.sched_action.kind_of?(Hash) && self.sched_action[:method] == "db_backup" && self.file_depot
       errors.add(:file_depot, "is missing credentials") if !file_depot.uri.to_s.starts_with?("nfs") && file_depot.missing_credentials?
       errors.add(:file_depot, "is missing uri") if file_depot.uri.blank?
     end
   end
 
-  def self.verify_depot_hash(hsh)
-    prefix      = hsh[:uri].split("://").first
-    depot_class = Object.const_get(FileDepot.supported_protocols[prefix])
-    return true unless depot_class.requires_credentials?
-
-    begin
-      depot_class.validate_settings(hsh)
-    rescue => err
-      $log.error("Miq(Schedule.verify_depot_hash) #{err.message}.")
-      false
+  def verify_file_depot(params)  # TODO: This logic belongs in the UI, not sure where
+    depot_class = FileDepot.supported_protocols[params[:uri_prefix]]
+    depot       = file_depot.class.name == depot_class ? file_depot : build_file_depot(:type => depot_class)
+    depot.name  = params[:name]
+    depot.uri   = params[:uri]
+    if params[:save]
+      file_depot.save!
+      file_depot.update_authentication(:default => {:userid => params[:username], :password => params[:password]}) if (params[:username] || params[:password]) && depot.class.requires_credentials?
+    else
+      depot.verify_credentials(nil, params.slice(:username, :password)) if depot.class.requires_credentials?
     end
-  end
-
-  def depot_hash=(hsh = {})
-    hsh            ||= {}
-    depot            = self.file_depot(:include => :authentications) || self.build_file_depot
-    depot.depot_hash = hsh
-  end
-
-  def depot_hash
-    depot        = self.file_depot(:include => :authentications)
-    depot_hash   = depot.depot_hash if depot
-    depot_hash ||= {}
   end
 
   def next_interval_time

--- a/vmdb/app/models/miq_schedule.rb
+++ b/vmdb/app/models/miq_schedule.rb
@@ -2,7 +2,6 @@ class MiqSchedule < ActiveRecord::Base
   validates_uniqueness_of :name, :scope => [:userid, :towhat]
   validates_presence_of   :name, :description, :towhat, :run_at
   validate                :validate_run_at, :validate_file_depot
-  has_one                 :file_depot, :as => :resource, :dependent => :destroy
 
   include ReportableMixin
 

--- a/vmdb/app/models/zone.rb
+++ b/vmdb/app/models/zone.rb
@@ -12,7 +12,6 @@ class Zone < ActiveRecord::Base
   has_many :miq_servers
   has_many :active_miq_servers, :class_name => "MiqServer", :conditions => {:status => MiqServer::STATUSES_ACTIVE}
   has_many :ext_management_systems
-  has_many :file_depots, :dependent => :destroy, :as => :resource
   has_many :miq_groups, :as => :resource
   has_many :miq_schedules, :dependent => :destroy
   has_many :storage_managers

--- a/vmdb/db/migrate/20150330214408_add_file_depot_id_to_miq_schedule.rb
+++ b/vmdb/db/migrate/20150330214408_add_file_depot_id_to_miq_schedule.rb
@@ -1,0 +1,39 @@
+class AddFileDepotIdToMiqSchedule < ActiveRecord::Migration
+  class MiqSchedule < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    def file_depot
+      FileDepot.where(:id => file_depot_id).first
+    end
+  end
+
+  class FileDepot < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    def resource
+      MiqSchedule.where(:id => resource_id).first
+    end
+  end
+
+  def up
+    add_column :miq_schedules, :file_depot_id, :bigint
+
+    say_with_time "Updating Schedules with file depots" do
+      FileDepot.where(:resource_type => "MiqSchedule").each { |depot| depot.resource.update_attributes(:file_depot_id => depot.id) if depot.resource }
+    end
+
+    remove_column :file_depots, :resource_id
+    remove_column :file_depots, :resource_type
+  end
+
+  def down
+    add_column :file_depots, :resource_id,   :bigint
+    add_column :file_depots, :resource_type, :string
+
+    say_with_time "Updating Schedules with file depots" do
+      MiqSchedule.all.each { |schedule| schedule.file_depot.update_attributes(:resource_type => "MiqSchedule", :resource_id => schedule.id) if schedule.file_depot }
+    end
+
+    remove_column :miq_schedules, :file_depot_id
+  end
+end

--- a/vmdb/spec/controllers/ops_controller_spec.rb
+++ b/vmdb/spec/controllers/ops_controller_spec.rb
@@ -126,17 +126,10 @@ describe OpsController do
                                                          :tz         => "UTC",
                                                          :interval   => {:unit => "once", :value => ""}
                                                         })
-      file_depot = FactoryGirl.create(:file_depot,
-                                      :name          => "test_depot",
-                                      :resource_id   => miq_schedule.id,
-                                      :resource_type => "MiqSchedule",
-                                      :uri           => "nfs://test_location"
-      )
-
       post :db_backup,
            :backup_schedule => miq_schedule.id,
-           :uri             => file_depot.uri,
-           :uri_prefix      => file_depot.uri.split("://")[0],
+           :uri             => "nfs://test_location",
+           :uri_prefix      => "nfs",
            :action_typ      => "db_backup",
            :format          => :js
       expect(response.status).to eq(200)

--- a/vmdb/spec/factories/file_depot_ftp.rb
+++ b/vmdb/spec/factories/file_depot_ftp.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory(:file_depot_ftp, :class => "FileDepotFtp", :parent => :file_depot) { uri "ftp://somehost/export" }
+  factory :file_depot_ftp_with_authentication, :parent => :file_depot_ftp do
+    after(:create) { |x| x.authentications << FactoryGirl.create(:authentication) }
+  end
+end

--- a/vmdb/spec/migrations/20150330214408_add_file_depot_id_to_miq_schedule_spec.rb
+++ b/vmdb/spec/migrations/20150330214408_add_file_depot_id_to_miq_schedule_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150330214408_add_file_depot_id_to_miq_schedule")
+
+describe AddFileDepotIdToMiqSchedule do
+  let(:depot_stub)    { migration_stub(:FileDepot) }
+  let(:schedule_stub) { migration_stub(:MiqSchedule) }
+
+  migration_context :up do
+    it "up" do
+      schedule = schedule_stub.create!
+      depot    = depot_stub.create!(:resource_type => "MiqSchedule", :resource_id => schedule.id)
+
+      migrate
+
+      expect(schedule.reload.file_depot_id).to eq(depot.id)
+    end
+  end
+
+  migration_context :down do
+    it "down" do
+      depot    = depot_stub.create!
+      schedule = schedule_stub.create!(:file_depot_id => depot.id)
+
+      migrate
+
+      expect(depot.reload.resource_id).to   eq(schedule.id)
+      expect(depot.reload.resource_type).to eq("MiqSchedule")
+    end
+  end
+end

--- a/vmdb/spec/models/miq_schedule_spec.rb
+++ b/vmdb/spec/models/miq_schedule_spec.rb
@@ -1,14 +1,9 @@
 require "spec_helper"
 
 describe MiqSchedule do
+  before { EvmSpecHelper.create_guid_miq_server_zone }
   context 'with schedule infrastructure and valid run_ats' do
     before(:each) do
-      @zone  = FactoryGirl.create(:zone)
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid)
-      MiqServer.my_server_clear_cache
-
       @valid_run_ats =  [ {:start_time => "2010-07-08 04:10:00 Z", :interval => { :unit => "daily", :value => "1"  } },
         {:start_time => "2010-07-08 04:10:00 Z", :interval => { :unit => "once" } } ]
     end

--- a/vmdb/spec/models/miq_schedule_spec.rb
+++ b/vmdb/spec/models/miq_schedule_spec.rb
@@ -483,18 +483,6 @@ describe MiqSchedule do
       end
     end
 
-    it "should verify_depot_hash with good hash and FileDepot.verify_depot_hash good" do
-      @depot_hash = {:uri => "smb://dev005.manageiq.com/share1", :username => "samba_one", :password => "Zug-drep5s" }
-      FileDepotSmb.stub(:validate_settings).and_return(true)
-      MiqSchedule.verify_depot_hash(@depot_hash).should be_true
-    end
-
-    it "should verify_depot_hash with good hash and FileDepot.verify_depot_hash bad" do
-      @depot_hash = {:uri => "smb://dev005.manageiq.com/share1", :username => "samba_one", :password => "Zug-drep5s" }
-      FileDepotSmb.stub(:validate_settings).and_return(false)
-      MiqSchedule.verify_depot_hash(@depot_hash).should_not be_true
-    end
-
     context "valid db_gc unsaved schedule, run_adhoc_db_gc" do
       before(:each) do
         @task_id = MiqSchedule.run_adhoc_db_gc(:userid => "admin", :aggressive => true)
@@ -755,7 +743,6 @@ describe MiqSchedule do
 
       it "should do nothing if setting the depot_hash to it's existing values" do
         @valid_schedules.each do |sch|
-          FileDepot.should_receive(:verify_depot_hash).never
           before = sch.depot_hash
           sch.depot_hash = before
           sch.save
@@ -764,7 +751,6 @@ describe MiqSchedule do
 
       it "should update the file depot and it's authentication if the depot_hash is changed but not actually test the depot" do
         @valid_schedules.each do |sch|
-          FileDepot.should_receive(:verify_depot_hash).never
           before = sch.depot_hash
           before[:uri] = "smb://someotherhost/share1"
           before[:username] = "test1"


### PR DESCRIPTION
Change MiqSchedule to leverage file_depot relationship rather than "resource_id" and "resource_type" on the FileDepot, allowing the UI to build an associated file_depot when building or editing a MiqSchedule.
https://bugzilla.redhat.com/show_bug.cgi?id=1205898