### PR TITLE
add display of relationship to container group in container node and container service UI

### DIFF
--- a/vmdb/app/helpers/container_node_helper/textual_summary.rb
+++ b/vmdb/app/helpers/container_node_helper/textual_summary.rb
@@ -10,7 +10,7 @@ module ContainerNodeHelper::TextualSummary
   end
 
   def textual_group_relationships
-    items = %w(ems)
+    items = %w(ems container_groups)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
@@ -70,5 +70,11 @@ module ContainerNodeHelper::TextualSummary
   def textual_identity_infra
     {:label => "Infrastructure Machine ID", :value =>
       @record.identity_infra.nil?  ? "N/A" : @record.identity_infra}
+  end
+
+  def textual_container_groups
+    num_of_container_groups = @record.number_of(:container_groups)
+    label = ui_lookup(:tables => "container_groups")
+    {:label => label, :image => "container_group", :value => num_of_container_groups}
   end
 end

--- a/vmdb/app/helpers/container_service_helper/textual_summary.rb
+++ b/vmdb/app/helpers/container_service_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    items = %w(ems)
+    items = %w(ems container_groups)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
   #
@@ -71,5 +71,11 @@ module ContainerServiceHelper::TextualSummary
       h[:link]  = url_for(:controller => 'ems_container', :action => 'show', :id => ems)
     end
     h
+  end
+
+  def textual_container_groups
+    num_of_container_groups = @record.number_of(:container_groups)
+    label = ui_lookup(:tables => "container_groups")
+    {:label => label, :image => "container_group", :value => num_of_container_groups}
   end
 end


### PR DESCRIPTION
this change adds just the info on the main entity page, it's not clickable to lead to the other sub tabs.
the patch also doesn't include the left pane accordion relationships
