### PR TITLE
WeakRef's can stand in for recycled objects so skip logging it.

### DIFF
--- a/vmdb/lib/workers/worker_base.rb
+++ b/vmdb/lib/workers/worker_base.rb
@@ -448,7 +448,7 @@ class WorkerBase
     types = Hash.new { |h, k| h[k] = Hash.new(0) }
     ObjectSpace.each_object do |obj|
       types[obj.class][:count] += 1
-      next if obj.kind_of?(DRbObject)
+      next if obj.kind_of?(DRbObject) || obj.kind_of?(WeakRef)
       if obj.respond_to?(:length)
         len = obj.length
         if len.kind_of?(Numeric)


### PR DESCRIPTION
Fixes:
```
WeakRef::RefError: Invalid Reference - probably recycled
  from (irb):5:in `respond_to?'
  from (irb):5:in `block in irb_binding'
  from (irb):2:in `each_object'
```

If a user configured log_top_ruby_objects_on_heartbeat in their worker settings (vmdb.tmpl.yml), the workers fail to log the breakdown of ruby objects by type with this error.