### PR TITLE
External Authentication Fails with Domains with special characters.

### DIFF
--- a/lib/appliance_console/external_httpd_configuration.rb
+++ b/lib/appliance_console/external_httpd_configuration.rb
@@ -186,10 +186,10 @@ EOS
       def configure_sssd_domain(config, domain)
         ldap_user_extra_attrs = LDAP_ATTRS.keys.join(", ")
         if config.include?("ldap_user_extra_attrs = ")
-          pattern = "[domain/#{domain}](\n.*)+ldap_user_extra_attrs = (.*)"
+          pattern = "[domain/#{Regexp.escape(domain)}](\n.*)+ldap_user_extra_attrs = (.*)"
           config[/#{pattern}/, 2] = ldap_user_extra_attrs
         else
-          pattern = "[domain/#{domain}].*(\n)"
+          pattern = "[domain/#{Regexp.escape(domain)}].*(\n)"
           config[/#{pattern}/, 1] = "\nldap_user_extra_attrs = #{ldap_user_extra_attrs}\n"
         end
       end


### PR DESCRIPTION
When domains have special characters in them, the external authentication
configuration would fail with an error similar to the following:

  Configuring IPA (may take a minute) ...
  Configuring the IPA Client ...
  Configuring pam ...
  Configuring sssd ...
     Failed to Configure External Authentication - empty range in char class: /[domain\/my-test.domain].*(
  )/

When the appliance console updates the SSSD configuration, it uses regular
expression to find patterns. The problem is that the dash character has special meaning
to Regexp and needed to be properly escaped.

https://bugzilla.redhat.com/show_bug.cgi?id=1207451