### PR TITLE
Kerberos SSO with Invalid credentials spins login screen forever.

### DIFF
--- a/system/COPY/var/www/html/proxy_pages/invalid_sso_credentials.js
+++ b/system/COPY/var/www/html/proxy_pages/invalid_sso_credentials.js
@@ -1,4 +1,23 @@
-Element.update("flash_div", "Error: Invalid Single Sign-On credentials")
-$("flash_div").show()
+var msg = "Invalid Single Sign-On credentials"
+$('#flash_msg_div').text("");
+
+var outerMost = $("<div id='flash_text_div' onclick=$('#flash_msg_div').text(''); title='Click to remove messages'>");
+var txt = $('<strong>' + msg + '</strong>');
+
+var outerBox = $('<div class="alert alert-danger">');
+var innerSpan = $('<span class="pficon-layered">');
+var icon1 = $('<span class="pficon pficon-error-octagon">');
+var icon2 = $('<span class="pficon pficon-warning-exclamation">');
+
+$(innerSpan).append(icon1);
+$(innerSpan).append(icon2);
+
+$(outerBox).append(innerSpan);
+$(outerBox).append(txt);
+$(outerMost).append(outerBox);
+$(outerMost).appendTo($("#flash_msg_div"));
+
+$('#flash_msg_div').show()
+
 miqSparkle(false)
 miqEnableLoginFields(true);

--- a/system/COPY/var/www/html/proxy_pages/invalid_sso_credentials.js
+++ b/system/COPY/var/www/html/proxy_pages/invalid_sso_credentials.js
@@ -1,23 +1,6 @@
-var msg = "Invalid Single Sign-On credentials"
-$('#flash_msg_div').text("");
-
-var outerMost = $("<div id='flash_text_div' onclick=$('#flash_msg_div').text(''); title='Click to remove messages'>");
-var txt = $('<strong>' + msg + '</strong>');
-
-var outerBox = $('<div class="alert alert-danger">');
-var innerSpan = $('<span class="pficon-layered">');
-var icon1 = $('<span class="pficon pficon-error-octagon">');
-var icon2 = $('<span class="pficon pficon-warning-exclamation">');
-
-$(innerSpan).append(icon1);
-$(innerSpan).append(icon2);
-
-$(outerBox).append(innerSpan);
-$(outerBox).append(txt);
-$(outerMost).append(outerBox);
-$(outerMost).appendTo($("#flash_msg_div"));
-
-$('#flash_msg_div').show()
-
+$('#invalid_sso_credentials_flash').click(function() {
+  $(this).text('');
+});
+$('#invalid_sso_credentials_flash').show()
 miqSparkle(false)
 miqEnableLoginFields(true);

--- a/vmdb/app/views/dashboard/login.html.haml
+++ b/vmdb/app/views/dashboard/login.html.haml
@@ -9,6 +9,13 @@
       .form-horizontal#login_div
         = render(:partial => "layouts/spinner", 
                  :locals  => {:login => true})
+        #invalid_sso_credentials_flash(style="display: none;")
+          #flash_text_div(title="Click to remove message")
+            .alert.alert-danger
+              %span.pficon-layered
+                %span.pficon.pficon-error-octagon
+                %span.pficon.pficon-warning-exclamation
+              %strong=_("Invalid Single Sign-On credentials")
         = render :partial => "layouts/flash_msg"
         .form-group
           %label.col-sm-3.col-md-3.control-label=_('Username')


### PR DESCRIPTION
Upon invalid kerberos SSO, the error javascript comes to us from outside
the application /, namely proxy_pages/invalid_sso_credentials.js

The javascript in that is no longer compatible with the later UI bits
for flash messages.

https://bugzilla.redhat.com/show_bug.cgi?id=1213014