### PR TITLE
Nil out OperatingSystem, Ptable and Medium on the ConfiguredSystem

### DIFF
--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/options_helper.rb
@@ -4,12 +4,12 @@ module MiqProvisionTaskConfiguredSystemForeman::OptionsHelper
   end
 
   def merge_provider_options_from_automate
-    phase_context[:provider_options].merge!(get_option(:provider_options) || {}).delete_nils
+    phase_context[:provider_options].merge!(get_option(:provider_options) || {})
     dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Merged Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
   end
 
   def prepare_provider_options
-    h = {"hostgroup_id" => dest_configuration_profile.manager_ref}
+    h = {"hostgroup_id" => dest_configuration_profile.manager_ref, "medium_id" => nil, "operatingsystem_id" => nil, "ptable_id" => nil}
     h["name"]      = options[:hostname]                           if options[:hostname]
     h["ip"]        = options[:ip_addr]                            if options[:ip_addr]
     h["root_pass"] = MiqPassword.decrypt(options[:root_password]) if options[:root_password]


### PR DESCRIPTION
Provisioning will not use these values from the Hostgroup unless they are nilled out.

https://bugzilla.redhat.com/show_bug.cgi?id=1213145

Unfortunately this removes the ability of the automate user to remove keys from the hash being sent across for this provisioning type.  We could possibly introduce a separate option which would be an array of key paths that the users would like to remove, or a better option (in my opinion) would be to return the raw hash to automate, let them modify it and return it back to us.
@gmcculloug Any thoughts?