### PR TITLE
Removed GTL view buttons from sublists and made default gtl type as list

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1780,13 +1780,8 @@ class ApplicationController < ActionController::Base
 
   def get_view_calculate_gtl_type(db_sym)
     gtl_type = @settings.fetch_path(:views, db_sym) unless %w(scanitemset miqschedule pxeserver customizationtemplate).include?(db_sym.to_s)
-
-    # Force list view for certain types and areas
-    gtl_type = 'list' if ['filesystems', 'registry_items', 'chargeback_rates', 'miq_request'].include?(@listicon)
-    gtl_type = 'list' if gtl_type.nil?
     gtl_type = 'grid' if ['vm'].include?(db_sym.to_s) && request.parameters[:controller] == 'service'
-
-    gtl_type ||= 'grid' # return a sane default
+    gtl_type ||= 'list' # return a sane default
     gtl_type
   end
   private :get_view_calculate_gtl_type

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2615,8 +2615,8 @@ module ApplicationHelper
 
   def render_gtl_view_tb?
     GTL_VIEW_LAYOUTS.include?(@layout) && @gtl_type && !@tagitems &&
-    !@ownershipitems && !@retireitems && !@politems && !@new_policy &&
-    !@in_a_form
+      !@ownershipitems && !@retireitems && !@politems && !@in_a_form &&
+      %w(show show_list).include?(params[:action])
   end
 
   def update_url_parms(url_parm)

--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -167,14 +167,13 @@ module UiConstants
   # Default UI settings
   DEFAULT_SETTINGS = {
     :quadicons => { # Show quad icons, by resource type
-      :service        =>  true,
-      :ems            =>  true,
-      :ems_cloud      =>  true,
-      :host           =>  true,
-      :miq_template   =>  true,
-      :storage        =>  true,
-      :vm             =>  true,
-      :hostitem       =>  true,
+      :service      => true,
+      :ems          => true,
+      :ems_cloud    => true,
+      :host         => true,
+      :miq_template => true,
+      :storage      => true,
+      :vm           => true
     },
     :views => { # List view setting, by resource type
       :availabilityzone      => "list",
@@ -197,7 +196,6 @@ module UiConstants
       :filesystem            => "list",
       :flavor                => "list",
       :host                  => "grid",
-      :hostitem              => "list",
       :job                   => "list",
       :miqaction             => "list",
       :miqaeclass            => "list",

--- a/vmdb/app/views/configuration/_ui_1.html.haml
+++ b/vmdb/app/views/configuration/_ui_1.html.haml
@@ -14,7 +14,6 @@
             - [[role_allows(:feature => "ems_infra_show_list"), ui_lookup(:table => "ems_infra"),          "ems"],
                [role_allows(:feature => "ems_cloud_show_list"), ui_lookup(:table => "ems_cloud"),          "ems_cloud"],
                [role_allows(:feature => "host_show_list"),      _("Host"),                                 "host"],
-               [false,                                          _("Host Item"),                            "hostitem"],
                [role_allows(:feature => "storage_show_list"),   ui_lookup(:table => "storages"),           "storage"],
                [true,                                           _("VM"),                                   "vm"],
                [true,                                           _("Template"),                             "miq_template"]].each do |icons_checkbox|

--- a/vmdb/app/views/configuration/_ui_2.html.haml
+++ b/vmdb/app/views/configuration/_ui_2.html.haml
@@ -129,10 +129,6 @@
                   %td.key= _('Hosts')
                   %td
                     %ul#toolbars= render_view_buttons(:host, @edit[:new][:views][:host])
-                %tr
-                  %td.key= _('Host Items')
-                  %td
-                    %ul#toolbars= render_view_buttons(:hostitem, @edit[:new][:views][:hostitem])
               - if role_allows(:feature => "vandt_accord")      ||
               -    role_allows(:feature => "vms_filter_accord")
                 %tr

--- a/vmdb/app/views/layouts/_x_view_buttons.html.haml
+++ b/vmdb/app/views/layouts/_x_view_buttons.html.haml
@@ -7,18 +7,3 @@
     = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "blank_view_tb"}
   - elsif %w(report).include?(@layout)
     = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => @report ? "report_view_tb" : "blank_view_tb"}
-  - else
-    - if ["ems_cloud",    "ems_infra",    "resource_pool",   "policy_profile",
-          "offline",      "retired",      "templates",       "ontap_file_share",
-          "repository",   "policy_group", "event",           "snia_local_file_system",
-          "storage",      "service",      "policy",           "ontap_logical_disk",
-          "action",       "scan_profile", "ems_cluster",     "ontap_storage_volume",
-          "miq_schedule", "vm",           "storage_manager", "ontap_storage_system",
-          "host",         "condition",    "cim_base_storage_extent"].include?(@layout) && @gtl_type && !@tagitems && !@ownershipitems && !@retireitems && !@politems && !@new_policy && !@in_a_form
-      = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "gtl_view_tb"}
-    - elsif %w(vm host ems_cluster).include?(@layout) && %(compare_miq compare_compress).include?(@lastaction)
-      = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "compare_view_tb"}
-    - elsif @lastaction == "drift"
-      = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "drift_view_tb"}
-    - elsif !["all_tasks","all_ui_tasks","timeline","diagnostics","my_tasks","my_ui_tasks","miq_server","services","usage"].include?(@layout) && !@layout.starts_with?("miq_request") && !@treesize_buttons && @display == "main" && @showtype == "main" && !@in_a_for
-      = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "x_summary_view_tb"}

--- a/vmdb/spec/controllers/application_controller_spec.rb
+++ b/vmdb/spec/controllers/application_controller_spec.rb
@@ -109,4 +109,29 @@ describe ApplicationController do
       result.should eq([1, 2, 3, 4])
     end
   end
+
+  context "#render_gtl_view_tb?" do
+    before do
+      controller.instance_variable_set(:@layout, "host")
+      controller.instance_variable_set(:@gtl_type, "list")
+    end
+
+    it "returns true for list views" do
+      controller.instance_variable_set(:@_params, :action => "show_list")
+      result = controller.send(:render_gtl_view_tb?)
+      result.should eq(true)
+    end
+
+    it "returns true for list views when navigating thru relationships" do
+      controller.instance_variable_set(:@_params, :action => "show")
+      result = controller.send(:render_gtl_view_tb?)
+      result.should eq(true)
+    end
+
+    it "returns false for sub list views" do
+      controller.instance_variable_set(:@_params, :action => "host_services")
+      result = controller.send(:render_gtl_view_tb?)
+      result.should eq(false)
+    end
+  end
 end


### PR DESCRIPTION
- Deleted unused code from x_view_buttons view, this code is already in view_buttons view for classic screens.
- Changed default gtl type for sublist screens to be list view, this also fixes and issue in BZ 1211364 where quad text link was incorrect.
- Added spec test for render_gtl_view_tb? method

https://bugzilla.redhat.com/show_bug.cgi?id=1211125

@dclarizio as discussed removed hostitem setting and removed GTL view buttons from all sublist views and made default GTL view type as 'list'. This PR also fixes a high pri. blocker: https://bugzilla.redhat.com/show_bug.cgi?id=1211364 