### PR TITLE
Enable auto-placement for SCVMM provisioning

### DIFF
--- a/vmdb/app/models/miq_provision_microsoft/placement.rb
+++ b/vmdb/app/models/miq_provision_microsoft/placement.rb
@@ -4,11 +4,12 @@ module MiqProvisionMicrosoft::Placement
   protected
 
   def placement
-    if get_option(:placement_auto) == true
-      automatic_placement
-    else
-      manual_placement
-    end
+    host, datastore = placement_auto ? automatic_placement : manual_placement
+
+    options[:dest_host]    = [host.id, host.name]
+    options[:dest_storage] = [datastore.id, datastore.name]
+
+    return host, datastore
   end
 
   private

--- a/vmdb/app/models/miq_provision_microsoft/state_machine.rb
+++ b/vmdb/app/models/miq_provision_microsoft/state_machine.rb
@@ -4,7 +4,10 @@ module MiqProvisionMicrosoft::StateMachine
   end
 
   def determine_placement
-    placement
+    host, datastore = self.placement
+
+    self.options[:dest_host]    = [host.id, host.name]
+    self.options[:dest_storage] = [datastore.id, datastore.name]
 
     signal :prepare_provision
   end

--- a/vmdb/app/models/miq_provision_microsoft/state_machine.rb
+++ b/vmdb/app/models/miq_provision_microsoft/state_machine.rb
@@ -4,10 +4,7 @@ module MiqProvisionMicrosoft::StateMachine
   end
 
   def determine_placement
-    host, datastore = self.placement
-
-    self.options[:dest_host]    = [host.id, host.name]
-    self.options[:dest_storage] = [datastore.id, datastore.name]
+    placement
 
     signal :prepare_provision
   end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
@@ -1,0 +1,35 @@
+#
+# Description: This method is used to find all hosts, datastores that are the least utilized
+#
+
+prov = $evm.root["miq_provision"]
+vm   = prov.vm_template
+raise "VM not specified" if vm.nil?
+
+ems = vm.ext_management_system
+raise "EMS not found for VM [#{vm.name}]" if ems.nil?
+
+# Log space required
+$evm.log("info", "vm=[#{vm.name}], space required=[#{vm.provisioned_storage}]")
+
+host = storage = nil
+min_registered_vms = nil
+prov.eligible_hosts.each do |h|
+  next unless h.power_state == "on"
+  nvms = h.vms.length
+
+  if min_registered_vms.nil? || nvms < min_registered_vms
+    s = h.storages.sort_by(&:free_space).last
+    unless s.nil?
+      host    = h
+      storage = s
+      min_registered_vms = nvms
+    end
+  end
+end
+
+# Set host and storage
+prov.set_host(host) if host
+prov.set_storage(storage) if storage
+
+$evm.log("info", "vm=[#{vm.name}] host=[#{host.try(:name)}] storage=[#{storage.try(:name)}]")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: microsoft_best_fit_least_utilized
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/default.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/default.yaml
@@ -12,3 +12,5 @@ object:
       value: redhat_best_fit_cluster
   - vmware:
       value: vmware_best_fit_least_utilized
+  - microsoft:
+      value: microsoft_best_fit_least_utilized

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -221,7 +221,7 @@
             true: 1
           :description: Choose Automatically
           :required: false
-          :display: :hide
+          :display: :edit
           :default: false
           :data_type: :boolean
         :placement_dc_name:
@@ -237,7 +237,8 @@
             :method: :allowed_hosts
           :auto_select_single: false
           :description: Name
-          :required: false
+          :required_method: :validate_placement
+          :required: true
           :display: :edit
           :data_type: :integer
           :required_description: Host Name
@@ -246,7 +247,8 @@
             :method: :allowed_storages
           :auto_select_single: false
           :description: Name
-          :required: false
+          :required_method: :validate_placement
+          :required: true
           :display: :edit
           :data_type: :integer
           :required_description: Datastore Name

--- a/vmdb/spec/automation/unit/method_validation/scvmm_microsoft_best_fit_least_utilized_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/scvmm_microsoft_best_fit_least_utilized_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+describe "SCVMM microsoft_best_fit_least_utilized" do
+  let(:ws) do
+    MiqAeEngine.instantiate("/System/Request/Call_Instance_With_Message?" \
+                            "namespace=Infrastructure/VM/Provisioning&class=Placement" \
+                            "&instance=default&message=microsoft&" \
+                            "MiqProvision::miq_provision=#{miq_provision.id}")
+  end
+  let(:vm_template) do
+    FactoryGirl.create(:template_microsoft,
+                       :name                  => "template1",
+                       :ext_management_system => FactoryGirl.create(:ems_microsoft_with_authentication))
+  end
+  let(:miq_provision) do
+    FactoryGirl.create(:miq_provision_microsoft,
+                       :options => {:src_vm_id      => vm_template.id,
+                                    :placement_auto => [true, 1]},
+                       :state   => 'active',
+                       :status  => 'Ok')
+  end
+
+  let(:host)    { FactoryGirl.create(:host_microsoft, :power_state => "on") }
+  let(:storage) { FactoryGirl.create(:storage) }
+
+  context "provision task object" do
+    it "without host or storage will not set placement values" do
+      ws.root
+      miq_provision.reload
+
+      expect(miq_provision.options[:placement_host_name]).to be_nil
+      expect(miq_provision.options[:placement_ds_name]).to   be_nil
+    end
+
+    context "with an eligible host" do
+      before do
+        host_struct = MiqHashStruct.new(:id               => host.id,
+                                        :evm_object_class => host.class.base_class.name.to_sym)
+        MiqProvisionMicrosoftWorkflow.any_instance.stub(:allowed_hosts).and_return([host_struct])
+      end
+
+      it "without storage will not set placement values" do
+        ws.root
+        miq_provision.reload
+
+        expect(miq_provision.options[:placement_host_name]).to be_nil
+        expect(miq_provision.options[:placement_ds_name]).to   be_nil
+      end
+
+      context "with storage" do
+        before do
+          host.storages << storage
+          storage_struct = MiqHashStruct.new(:id               => storage.id,
+                                             :evm_object_class => storage.class.base_class.name.to_sym)
+          MiqProvisionMicrosoftWorkflow.any_instance.stub(:allowed_storages).and_return([storage_struct])
+        end
+
+        it "will set placement values" do
+          ws.root
+          miq_provision.reload
+
+          expect(miq_provision.options[:placement_host_name]).to eq([host.id, host.name])
+          expect(miq_provision.options[:placement_ds_name]).to   eq([storage.id, storage.name])
+        end
+
+        it "will not set placement values when placement_auto is false" do
+          miq_provision.update_attributes(:options => miq_provision.options.merge(:placement_auto => [false, 0]))
+          ws.root
+          miq_provision.reload
+
+          expect(miq_provision.options[:placement_host_name]).to be_nil
+          expect(miq_provision.options[:placement_ds_name]).to   be_nil
+        end
+      end
+    end
+  end
+end

--- a/vmdb/spec/models/miq_provision_microsoft/placement_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft/placement_spec.rb
@@ -32,9 +32,24 @@ describe MiqProvisionMicrosoft do
       check
     end
 
+    it "#automatic_placement" do
+      @task.should_receive(:get_most_suitable_host_and_storage).and_return([@host, @storage])
+      @task.options[:placement_auto] = true
+      check
+    end
+
+    it "automate returns nothing" do
+      @task.options[:placement_host_name] = @host.id
+      @task.options[:placement_ds_name]   = @storage.id
+      @task.should_receive(:get_most_suitable_host_and_storage).and_return([nil, nil])
+      @task.options[:placement_auto] = true
+      check
+    end
+
     def check
-      @task.send(:placement)
-      @task.options[:dest_host].should eql([@host.id, @host.name])
+      host, storage = @task.send(:placement)
+      host.should eql(@host)
+      storage.should eql(@storage)
     end
   end
 end


### PR DESCRIPTION
Added automate script to pick host/storage based on least utilized values.  (Based on the VMware best_fit_least_utilized method.)
Update dialog to show "Choose Automatically" field and mark host/storage as required fields

Depends on PR #2785.