### PR TITLE
Destroying an OpenStack VM should not set `state` attr

### DIFF
--- a/vmdb/app/models/vm_openstack/operations.rb
+++ b/vmdb/app/models/vm_openstack/operations.rb
@@ -5,6 +5,6 @@ module VmOpenstack::Operations
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless self.ext_management_system
     with_provider_object(&:destroy)
-    self.update_attributes!(:state => "suspended")
+    self.update_attributes!(:raw_power_state => "SUSPENDED")
   end
 end

--- a/vmdb/spec/models/vm_openstack_spec.rb
+++ b/vmdb/spec/models/vm_openstack_spec.rb
@@ -47,4 +47,21 @@ describe VmOpenstack do
       include_examples "Vm operation is available when powered on"
     end
   end
+
+  context "when detroyed" do
+    let(:ems) { FactoryGirl.create(:ems_openstack) }
+    let(:provider_object) do
+      double("vm_openstack_provider_object", :destroy => nil).as_null_object
+    end
+    let(:vm)  { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
+
+    it "sets the raw_power_state and not state" do
+      # when destorying a VM, the power state will momentarily be set to
+      # suspended while the provider deals with the "destroy" operation
+      expect(vm).to receive(:with_provider_object).and_yield(provider_object)
+      vm.raw_destroy
+      vm.raw_power_state.should == "SUSPENDED"
+      vm.state.should == "suspended"
+    end
+  end
 end


### PR DESCRIPTION
The `state` attribute on VMs is read only and used purely as a normalization layer in order to display a common state for all different types of VMs.

When VMs are destroyed (or, otherwise acted upon), the appliance will set a temporary power state in order to reflect the impending change that's been submitted to the provider.  The change submitted to the provider is handled largely asynchronously with any updates from the change coming in the form of events received after the fact.

The temporary power state change when destroying OpenStack VMs was trying to set the state attribute.  By changing that to the `raw_power_state` attribute, the power state is updated and reflected in the read only `state` attribute.

https://bugzilla.redhat.com/show_bug.cgi?id=1212052