### PR TITLE
fix_auth and migrations support dbs before 5/2013

### DIFF
--- a/vmdb/lib/tasks/evm_dba.rake
+++ b/vmdb/lib/tasks/evm_dba.rake
@@ -306,5 +306,12 @@ namespace :evm do
       end
     end
 
+    # loads the v1 key into the enviroment
+    task :environmentlegacykey => :environment do
+      MiqPassword.add_legacy_key('v0_key', :v0)
+      MiqPassword.add_legacy_key('v1_key')
+    end
   end
 end
+
+Rake::Task["db:migrate"].enhance(["evm:db:environmentlegacykey"])

--- a/vmdb/tools/fix_auth/auth_model.rb
+++ b/vmdb/tools/fix_auth/auth_model.rb
@@ -82,6 +82,8 @@ module FixAuth
       end
 
       def run(options = {})
+        return if available_columns.empty?
+        puts "fixing #{table_name}.#{available_columns.join(", ")}"
         contenders(options[:v2]).each do |r|
           fix_passwords(r, options)
           if options[:verbose]

--- a/vmdb/tools/fix_auth/fix_auth.rb
+++ b/vmdb/tools/fix_auth/fix_auth.rb
@@ -62,7 +62,6 @@ module FixAuth
         begin
           ActiveRecord::Base.establish_connection(db_attributes(database)) if please_establish_connection
           models.each do |model|
-            puts "fixing #{model.table_name}.#{model.password_columns.join(", ")}"
             model.run(run_options)
           end
         ensure

--- a/vmdb/tools/fix_auth/models.rb
+++ b/vmdb/tools/fix_auth/models.rb
@@ -15,7 +15,8 @@ module FixAuth
   class FixMiqDatabase < ActiveRecord::Base
     include FixAuth::AuthModel
     self.table_name = "miq_databases"
-    self.password_columns = %w(registration_http_proxy_server session_secret_token csrf_secret_token)
+    self.password_columns = %w(registration_http_proxy_server registration_http_proxy_password
+                               session_secret_token csrf_secret_token)
 
     def self.hardcode(old_value, _new_value)
       super(old_value, SecureRandom.hex(64))


### PR DESCRIPTION
older databases had fields encrypted with v1_key keys.
vmdb migrations no longer knows about v1 keys.
fix_auth did not know about these older columns
So both fix_auth and migrations were failing.

This fixes up migrations to be able to properly migrate an older database.
`fix_auth` can then be run to update any database fields that are not up to date.

https://bugzilla.redhat.com/show_bug.cgi?id=1217532

/cc @brandondunne @jrafanie @Fryguy 