### PR TITLE
Populate OrchestrationStackResource's name attribute at refresh

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/ec2.rb
+++ b/vmdb/app/models/ems_refresh/parsers/ec2.rb
@@ -518,6 +518,7 @@ module EmsRefresh::Parsers
       uid = resource[:physical_resource_id]
       new_result = {
         :ems_ref                => uid,
+        :name                   => resource[:logical_resource_id],
         :logical_resource       => resource[:logical_resource_id],
         :physical_resource      => uid,
         :resource_category      => resource[:resource_type],

--- a/vmdb/app/models/ems_refresh/parsers/openstack_common/orchestration_stacks.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_common/orchestration_stacks.rb
@@ -102,6 +102,7 @@ module EmsRefresh
           uid = resource['physical_resource_id']
           new_result = {
             :ems_ref                => uid,
+            :name                   => resource['resource_name'],
             :logical_resource       => resource['logical_resource_id'],
             :physical_resource      => uid,
             :resource_category      => resource['resource_type'],

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -473,6 +473,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
 
     # assert one of the resource models
     resources[3].should have_attributes(
+      :name                   => "WebServer",
       :logical_resource       => "WebServer",
       :physical_resource      => "i-b98fdd57",
       :resource_category      => "AWS::EC2::Instance",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1213570

For OpenStack heat stack resource, `name` is copied from `resource_name` field
For AWS CloudFormation stack resource, there is no corresponding name field. `logic_resource_name` is copied instead. 