### PR TITLE
performance: report derived logical cpu

### DIFF
--- a/vmdb/app/models/metric/processing.rb
+++ b/vmdb/app/models/metric/processing.rb
@@ -2,6 +2,8 @@ module Metric::Processing
   DERIVED_COLS = [
     :derived_cpu_available,
     :derived_cpu_reserved,
+    :derived_logicalcpus_used,
+    :derived_logicalcpus_available,
     :derived_host_count_off,
     :derived_host_count_on,
     :derived_memory_available,
@@ -22,6 +24,7 @@ module Metric::Processing
     ts = attrs[:timestamp] if ts.nil?
     state = obj.vim_performance_state_for_ts(ts)
     total_cpu = state.total_cpu || 0
+    logical_cpus = state.logical_cpus || 0
     total_mem = state.total_mem || 0
     result = {}
 
@@ -29,7 +32,13 @@ module Metric::Processing
       dummy, group, typ, mode = col.to_s.split("_")
       case typ
       when "available"
-        result[col] = group == "cpu" ? total_cpu : total_mem
+        if group == "cpu"
+          result[col] = total_cpu
+        elsif group == "memory"
+          result[col] = total_mem
+        elsif group == "logicalcpus"
+          result[col] = logical_cpus
+        end
       when "allocated"
         method = col.to_s.split("_")[1..-1].join("_")
         result[col] = state.send(method) if state.respond_to?(method)
@@ -38,6 +47,10 @@ module Metric::Processing
           result[col] = ( attrs[:cpu_usage_rate_average]     / 100 * total_cpu ) unless (total_cpu == 0 || attrs[:cpu_usage_rate_average].nil?)
         elsif group == "memory"
           result[col] = ( attrs[:mem_usage_absolute_average] / 100 * total_mem ) unless (total_mem == 0  || attrs[:mem_usage_absolute_average].nil?)
+        elsif group == "logicalcpus"
+          unless logical_cpus == 0 || attrs[:cpu_usage_rate_average].nil?
+            result[col] = (attrs[:cpu_usage_rate_average] / 100 * logical_cpus)
+          end
         else
           method = col.to_s.split("_")[1..-1].join("_")
           result[col] = state.send(method) if state.respond_to?(method)

--- a/vmdb/app/models/vim_performance_state.rb
+++ b/vmdb/app/models/vim_performance_state.rb
@@ -15,6 +15,7 @@ class VimPerformanceState < ActiveRecord::Base
     :tag_names,
     :numvcpus,
     :total_cpu,
+    :logical_cpus,
     :total_mem,
     :reserve_cpu,
     :reserve_mem,
@@ -29,6 +30,7 @@ class VimPerformanceState < ActiveRecord::Base
   # => assoc_ids
   # => total_memory
   # => total_cpu
+  # => logical_cpus
   # => reserve_memory
   # => reserve_cpu
   # => vm_count_on      (derive from assoc_ids)
@@ -53,6 +55,7 @@ class VimPerformanceState < ActiveRecord::Base
     state.parent_ems_cluster_id = self.capture_parent_cluster(obj)
     state.numvcpus = self.capture_numvcpus(obj)
     state.total_cpu = self.capture_total(obj, :cpu_speed)
+    state.logical_cpus = self.capture_logical_cpus(obj)
     state.total_mem = self.capture_total(obj, :memory)
     state.reserve_cpu = self.capture_reserve(obj, :cpu_reserve)
     state.reserve_mem = self.capture_reserve(obj, :memory_reserve)
@@ -190,5 +193,14 @@ class VimPerformanceState < ActiveRecord::Base
     # depending on the name :numvcpus
     # A larger patch should be done outside of a z-stream release
     return obj.hardware.logical_cpus
+  end
+
+  def self.capture_logical_cpus(obj)
+    # FIXME: this should probably include capture_numvcpus
+    if obj.respond_to?(:hardware) && obj.hardware
+      return obj.hardware.logical_cpus
+    elsif obj.respond_to?(:container_node) && obj.container_node.hardware
+      return obj.container_node.hardware.logical_cpus
+    end
   end
 end

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -149,6 +149,8 @@ en:
       EmsClusterPerformance:
         cpu_usage_rate_average:                                                CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)
         derived_cpu_available:                                                 CPU - Total Installed - Sum of Child Hosts (MHz)
+        derived_logicalcpus_used:                                              CPU - Usage of Logical CPUs
+        derived_logicalcpus_available:                                         CPU - Number of Logical CPUs
         disk_usage_rate_average:                                               Disk I/O - Aggregate of Avg for Child Hosts (KBps)
         max_cpu_usage_rate_average:                                            CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)
         max_cpu_usage_rate_average_avg_over_time_period:                       CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg (%)
@@ -180,6 +182,8 @@ en:
 
       HostPerformance:
         derived_cpu_available: CPU - Total Installed - from Host Analysis (MHz)
+        derived_logicalcpus_used: CPU - Usage of Logical CPUs
+        derived_logicalcpus_available: CPU - Number of Logical CPUs
 
       StoragePerformance:
         max_derived_storage_total: Disk Space Max Total
@@ -199,6 +203,8 @@ en:
         cpu_used_delta_summation:      CPU - Time Used (ms)
         cpu_wait_delta_summation:      CPU - Time Spent in Wait State (ms)
         derived_cpu_available:         CPU - Total - from VM Analysis (MHz)
+        derived_logicalcpus_used:      CPU - Usage of Logical CPUs
+        derived_logicalcpus_available: CPU - Number of Logical CPUs
         derived_cpu_reserved:          CPU - Reserved (MHz)
         derived_memory_available:      Memory - Total Allocated (MB)
         derived_memory_reserved:       Memory - Reserved (MB)
@@ -296,6 +302,8 @@ en:
       depend_on_service: Depends on Service
       derived_cpu_available: CPU Total Installed
       derived_cpu_reserved: CPU - Available (MHz)
+      derived_logicalcpus_used: CPU - Usage of Logical CPUs
+      derived_logicalcpus_available: CPU - Number of Logical CPUs
       derived_host_count_off: State - Number of Hosts Powered Off  - Hourly Count / Daily Avg
       derived_host_count_on: State - Number of Hosts Powered On  - Hourly Count / Daily Avg
       derived_memory_available: Memory - Total Allocated for Child VMs (MB)

--- a/vmdb/db/migrate/20150410083237_add_logicalcpus_derived_metrics.rb
+++ b/vmdb/db/migrate/20150410083237_add_logicalcpus_derived_metrics.rb
@@ -1,0 +1,9 @@
+class AddLogicalcpusDerivedMetrics < ActiveRecord::Migration
+  def change
+    # metrics_xx and metrics_rollups_xx automatically inherit this change
+    add_column :metrics, :derived_logicalcpus_used, :float
+    add_column :metric_rollups, :derived_logicalcpus_used, :float
+    add_column :metrics, :derived_logicalcpus_available, :integer
+    add_column :metric_rollups, :derived_logicalcpus_available, :integer
+  end
+end

--- a/vmdb/product/charts/miq_reports/vim_perf_daily.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_daily.yaml
@@ -30,6 +30,8 @@ cols:
 - min_cpu_usage_rate_average
 - max_cpu_usage_rate_average
 - trend_max_cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -96,6 +98,8 @@ col_order:
 - min_cpu_usage_rate_average
 - max_cpu_usage_rate_average
 - trend_max_cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -158,6 +162,8 @@ headers:
 - Min % Used
 - Max % Used
 - Trend Max % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - ! '% Idle'
 - ! '% Used'

--- a/vmdb/product/charts/miq_reports/vim_perf_daily_cloud.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_daily_cloud.yaml
@@ -30,6 +30,8 @@ cols:
 - min_cpu_usage_rate_average
 - max_cpu_usage_rate_average
 - trend_max_cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -96,6 +98,8 @@ col_order:
 - min_cpu_usage_rate_average
 - max_cpu_usage_rate_average
 - trend_max_cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -158,6 +162,8 @@ headers:
 - Min % Used
 - Max % Used
 - Trend Max % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - ! '% Idle'
 - ! '% Used'

--- a/vmdb/product/charts/miq_reports/vim_perf_hourly.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_hourly.yaml
@@ -24,6 +24,8 @@ cols:
 - derived_cpu_available
 - derived_cpu_reserved
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -50,6 +52,8 @@ col_order:
 - derived_cpu_available
 - derived_cpu_reserved
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -73,6 +77,8 @@ headers:
 - Available
 - Reserved
 - Avg % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - ! '% Idle'
 - ! '% Used'

--- a/vmdb/product/charts/miq_reports/vim_perf_hourly_cloud.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_hourly_cloud.yaml
@@ -24,6 +24,8 @@ cols:
 - derived_cpu_available
 - derived_cpu_reserved
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -50,6 +52,8 @@ col_order:
 - derived_cpu_available
 - derived_cpu_reserved
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -73,6 +77,8 @@ headers:
 - Available
 - Reserved
 - Avg % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - ! '% Idle'
 - ! '% Used'

--- a/vmdb/product/charts/miq_reports/vim_perf_realtime.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_realtime.yaml
@@ -23,6 +23,8 @@ cols:
 - cpu_usagemhz_rate_average
 - derived_cpu_available
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -41,6 +43,8 @@ col_order:
 - cpu_usagemhz_rate_average
 - derived_cpu_available
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
@@ -56,6 +60,8 @@ headers:
 - Avg Used
 - Available
 - Avg % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - ! '% Idle'
 - ! '% Used'

--- a/vmdb/product/charts/miq_reports/vim_perf_tag_daily.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_tag_daily.yaml
@@ -22,6 +22,8 @@ cols:
 - timestamp
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - derived_memory_used
 - disk_usage_rate_average
@@ -41,6 +43,8 @@ col_order:
 - timestamp
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - derived_memory_used
 - disk_usage_rate_average
@@ -57,6 +61,8 @@ headers:
 - Date/Time
 - Avg Used
 - Avg % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - Avg Used
 - Avg I/O

--- a/vmdb/product/charts/miq_reports/vim_perf_tag_hourly.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_tag_hourly.yaml
@@ -22,6 +22,8 @@ cols:
 - timestamp
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - derived_memory_used
 - disk_usage_rate_average
@@ -36,6 +38,8 @@ col_order:
 - timestamp
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - derived_memory_used
 - disk_usage_rate_average
@@ -47,6 +51,8 @@ headers:
 - Date/Time
 - Avg Used
 - Avg % Used
+- Used Cores
+- Total Cores
 - ! '% Ready'
 - Avg Used
 - Avg I/O

--- a/vmdb/product/charts/miq_reports/vim_perf_topday.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_topday.yaml
@@ -25,6 +25,8 @@ cols:
 - resource_name
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - derived_memory_used
 - disk_usage_rate_average
@@ -46,6 +48,8 @@ col_order:
 - resource_name
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - v_pct_cpu_ready_delta_summation
 - derived_memory_used
 - disk_usage_rate_average
@@ -65,6 +69,8 @@ headers:
 - Avg CPU Used
 - Avg CPU % Used
 - Avg % CPU Ready
+- Used Cores
+- Total Cores
 - Avg RAM Used
 - Avg Disk I/O
 - Avg Net I/O

--- a/vmdb/product/charts/miq_reports/vim_perf_tophour.yaml
+++ b/vmdb/product/charts/miq_reports/vim_perf_tophour.yaml
@@ -23,6 +23,8 @@ cols:
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
 - v_pct_cpu_ready_delta_summation
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - derived_memory_used
 - disk_usage_rate_average
 - net_usage_rate_average
@@ -44,6 +46,8 @@ col_order:
 - cpu_usagemhz_rate_average
 - cpu_usage_rate_average
 - v_pct_cpu_ready_delta_summation
+- derived_logicalcpus_used
+- derived_logicalcpus_available
 - derived_memory_used
 - disk_usage_rate_average
 - net_usage_rate_average
@@ -59,6 +63,8 @@ headers:
 - Avg CPU Used
 - Avg CPU % Used
 - Avg % CPU Ready
+- Used Cores
+- Total Cores
 - Avg RAM Used
 - Avg Disk I/O
 - Avg Net I/O


### PR DESCRIPTION
It is important to store the number of logical cpu used by an entity (container/vm/etc.) so that it's possible to compare it with other ones running on other hosts (with possibly different core counts).