### PR TITLE
Add event monitor class for OpenStack

### DIFF
--- a/vmdb/app/models/ems_openstack.rb
+++ b/vmdb/app/models/ems_openstack.rb
@@ -123,4 +123,8 @@ class EmsOpenstack < EmsCloud
     $log.debug err.backtrace.join("\n") if $log.debug?
     raise
   end
+
+  def self.event_monitor_class
+    MiqEventCatcherOpenstack
+  end
 end

--- a/vmdb/app/models/mixins/ems_openstack_mixin.rb
+++ b/vmdb/app/models/mixins/ems_openstack_mixin.rb
@@ -53,7 +53,7 @@ module EmsOpenstackMixin
   def event_monitor_options
     @event_monitor_options ||= begin
       opts = {:hostname => self.hostname}
-      opts[:port] = MiqEventCatcherOpenstack.worker_settings[:amqp_port]
+      opts[:port] = event_monitor_class.worker_settings[:amqp_port]
       if self.has_authentication_type? :amqp
         # authentication_userid/password will happily return the "default"
         # userid/password if this ems has no amqp auth configured

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_grizzly_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_grizzly_spec.rb
@@ -67,7 +67,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
     SystemService.count.should       == 0
 
     Relationship.count.should        == 13
-    MiqQueue.count.should            == 19
+    MiqQueue.count.should            == 20
   end
 
   def assert_ems

--- a/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
@@ -69,7 +69,7 @@ describe EmsRefresh::Refreshers::OpenstackRefresher do
     SystemService.count.should       == 0
 
     Relationship.count.should        == 10
-    MiqQueue.count.should            == 17
+    MiqQueue.count.should            == 18
   end
 
   def assert_ems


### PR DESCRIPTION
This class is defined in every Provider and is missing for OpenStack. That can lead to exceptional behaviour.


It is most probably a bug cause many places rely on that class being there, unless somebody
removed it for a reason. We need to dig up in the code history