### PR TITLE
Routes.rb: Add missing routes to the catalog routes

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -172,6 +172,7 @@ Vmdb::Application.routes.draw do
         show
       ),
       :post => %w(
+        ab_group_reorder
         accordion_select
         ae_tree_select
         ae_tree_select_discard
@@ -183,6 +184,7 @@ Vmdb::Application.routes.draw do
         get_ae_tree_edit_key
         group_create
         group_form_field_changed
+        group_reorder_field_changed
         group_update
         identify_catalog
         orchestration_template_add

--- a/vmdb/spec/routing/catalog_routing_spec.rb
+++ b/vmdb/spec/routing/catalog_routing_spec.rb
@@ -22,6 +22,7 @@ describe 'routes for CatalogController' do
   end
 
   %w(
+    ab_group_reorder
     accordion_select
     ae_tree_select
     ae_tree_select_discard
@@ -35,6 +36,7 @@ describe 'routes for CatalogController' do
     get_ae_tree_edit_key
     group_create
     group_form_field_changed
+    group_reorder_field_changed
     group_update
     identify_catalog
     orchestration_template_add


### PR DESCRIPTION
Added routes for reordering groups/buttons action in Catalog items

https://bugzilla.redhat.com/show_bug.cgi?id=1213853