### PR TITLE
Fixed compressed icons within Bootstrap table columns

### DIFF
--- a/vmdb/app/assets/stylesheets/patternfly_overrides.less
+++ b/vmdb/app/assets/stylesheets/patternfly_overrides.less
@@ -188,7 +188,6 @@ li.brand-white-label.whitelabeled {
 
 table.table tbody td img {
   height: 20px;
-  padding-right: 5px
 }
 
 .table > thead > tr > th {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1201140

Old
![screen shot 2015-04-21 at 2 53 05 pm](https://cloud.githubusercontent.com/assets/1287144/7260156/2939d8b0-e836-11e4-9657-584f04defde0.png)

New
![screen shot 2015-04-21 at 2 51 54 pm](https://cloud.githubusercontent.com/assets/1287144/7260143/0af96942-e836-11e4-9432-a6939a9ceec4.png)
