### PR TITLE
Fix deprecation warning regarding Fog::Connection

### DIFF
--- a/lib/openstack/openstack_handle/identity_delegate.rb
+++ b/lib/openstack/openstack_handle/identity_delegate.rb
@@ -15,7 +15,7 @@ module OpenstackHandle
     def visible_tenants
       response = Handle.try_connection do |scheme, connection_options|
         url = Handle.url(@os_handle.address, @os_handle.port, scheme, "/v2.0/tenants")
-        connection = Fog::Connection.new(url, false, connection_options)
+        connection = Fog::Core::Connection.new(url, false, connection_options)
         response = connection.request(
           :expects => [200, 204],
           :headers => {'Content-Type' => 'application/json',


### PR DESCRIPTION
@blomquisg Please review.

This should remove the following warning we see in the specs: `[fog][DEPRECATION] Fog::Connection is deprecated use Fog::Core::Connection instead (/home/travis/build/ManageIQ/manageiq/lib/openstack/openstack_handle/identity_delegate.rb:19:in 'block in visible_tenants')`