### PR TITLE
Destroy parent provider when destroying EmsOpenstackInfra

### DIFF
--- a/vmdb/app/models/ems_openstack_infra.rb
+++ b/vmdb/app/models/ems_openstack_infra.rb
@@ -2,6 +2,7 @@ class EmsOpenstackInfra < EmsInfra
   include EmsOpenstackMixin
 
   before_save :ensure_parent_provider
+  before_destroy :destroy_parent_provider
 
   has_many :orchestration_stacks, :foreign_key => :ems_id, :dependent => :destroy
 
@@ -27,6 +28,10 @@ class EmsOpenstackInfra < EmsInfra
     else
       self.provider = ProviderOpenstack.create!(attributes)
     end
+  end
+
+  def destroy_parent_provider
+    provider.try(:destroy)
   end
 
   def self.ems_type

--- a/vmdb/app/models/provider_openstack.rb
+++ b/vmdb/app/models/provider_openstack.rb
@@ -2,12 +2,11 @@ class ProviderOpenstack < Provider
   has_one :infra_ems,
           :foreign_key => "provider_id",
           :class_name  => "EmsOpenstackInfra",
-          :dependent   => :destroy,
           :autosave    => true
   has_many :cloud_ems,
            :foreign_key => "provider_id",
            :class_name  => "EmsOpenstack",
-           :dependent   => :destroy,
+           :dependent   => :nullify,
            :autosave    => true
 
   validates :name, :presence => true, :uniqueness => true

--- a/vmdb/spec/models/ems_openstack_infra_spec.rb
+++ b/vmdb/spec/models/ems_openstack_infra_spec.rb
@@ -44,4 +44,35 @@ describe EmsOpenstackInfra do
     end
   end
 
+  context "provider_hooks" do
+    before :each do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+    end
+
+    it "creates related ProviderOpenstack after creating EmsOpenstackInfra" do
+      @ems.provider.name.should equal @ems.name
+      @ems.provider.zone.should == @ems.zone
+      ProviderOpenstack.count.should equal 1
+    end
+
+    it "destroys related ProviderOpenstack after destroying EmsOpenstackInfra" do
+      ProviderOpenstack.count.should equal 1
+      @ems.destroy
+      ProviderOpenstack.count.should equal 0
+    end
+
+    it "related EmsOpenstack nullifies relation to ProviderOpenstack on EmsOpenstackInfra destroy" do
+      # add ems_cloud relation to @ems
+      @ems_cloud = FactoryGirl.create(:ems_openstack_with_authentication)
+      @ems.provider.cloud_ems << @ems_cloud
+
+      # compare they both use the same provider
+      @ems_cloud.provider.should == @ems.provider
+
+      # destroy ems and see the relation of ems_cloud to provider nullified
+      @ems.destroy
+      ProviderOpenstack.count.should equal 0
+      @ems_cloud.reload.provider.should be_nil
+    end
+  end
 end


### PR DESCRIPTION
Destroy parent provider when destroying EmsOpenstackInfra, also
nullify relations to cloud. Until we have some management of
the Providers, this should be the way how it works.