### PR TITLE
Require ovirt gem instead of rhevm_inventory

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -32,7 +32,7 @@ gem "log4r",                "=1.1.8",        :require => false
 gem "memoist",              "~>0.11.0",      :require => false
 gem "more_core_extensions", "~>1.2.0",       :require => false
 gem "nokogiri",             "~>1.5.0",       :require => false
-gem "ovirt",                "~>0.4.1",       :require => false
+gem "ovirt",                "~>0.4.2",       :require => false
 gem "kubeclient",           ">=0.1.11",      :require => false
 gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",      :require => false

--- a/lib/metadata/MIQExtract/MIQExtract.rb
+++ b/lib/metadata/MIQExtract/MIQExtract.rb
@@ -23,7 +23,7 @@ require 'Win32EventLog'
 require 'LinuxUsers'
 require 'LinuxPackages'
 require 'LinuxInitProcs'
-require 'LinuxSystemd'
+require 'LinuxSystemd'
 require 'LinuxOSInfo'
 require 'VmScanProfiles'
 require 'MiqVim'
@@ -232,8 +232,8 @@ class MIQExtract
 		when "Windows"
 			MiqWin32::Services.new(c, @systemFs).to_xml(node)
 		when "Linux"
-      MiqLinux::Systemd.new(@systemFs).toXml(node) if MiqLinux::Systemd.detected?(@systemFs)
-      MiqLinux::InitProcs.new(@systemFs).toXml(node)
+      MiqLinux::Systemd.new(@systemFs).toXml(node) if MiqLinux::Systemd.detected?(@systemFs)
+      MiqLinux::InitProcs.new(@systemFs).toXml(node)
 		end
 
 		doc
@@ -441,7 +441,7 @@ class MIQExtract
       miqVimHost[:password_decrypt] = MiqPassword.decrypt(miqVimHost[:password])
 
       begin
-        require 'rhevm_inventory'
+        require 'ovirt'
         ems_opt = {
           :server     => miqVimHost[:address],
           :username   => miqVimHost[:username],


### PR DESCRIPTION
The functionality of rhevm_inventory has been moved into the ovirt gem,
require the proper gem accordingly.

Some bad end of line characters were also removed

https://bugzilla.redhat.com/show_bug.cgi?id=1205247