### PR TITLE
Alert validation fix: don't fail on MiqExpression

### DIFF
--- a/vmdb/app/controllers/miq_policy_controller/alerts.rb
+++ b/vmdb/app/controllers/miq_policy_controller/alerts.rb
@@ -534,7 +534,7 @@ module MiqPolicyController::Alerts
     if alert.options[:notifications][:automate]
       add_flash(_("%s is required") % "Event Name", :error) if alert.options[:notifications][:automate][:event_name].blank?
     end
-    if alert.expression[:eval_method] == 'event_threshold'
+    if alert.expression.is_a?(Hash) && alert.expression[:eval_method] == 'event_threshold'
       add_flash(_("%s is required") % "Event to Check", :error) if alert.expression[:options][:event_types].blank?
     end
 


### PR DESCRIPTION
alert.expression may be nil, MiqExpression or Hash, the "Event to Check" check is relevant only if Hash
(introduced in 2e48432)

https://bugzilla.redhat.com/show_bug.cgi?id=1213553