### PR TITLE
VmCommon#set_checked_items - should not try to remove a trailing | when it's not there

### DIFF
--- a/vmdb/app/controllers/vm_common.rb
+++ b/vmdb/app/controllers/vm_common.rb
@@ -1245,8 +1245,7 @@ module VmCommon
     if params[:all_checked]
       ids = params[:all_checked].split(',')
       ids.each do |id|
-        id = id.split('-')
-        id = id[1].slice(0,id[1].length-1)
+        id = id.split('-')[1]
         session[:checked_items].push(id) unless session[:checked_items].include?(id)
       end
     end


### PR DESCRIPTION
The ids used to have a trailing |, removed in 4ecc3af8

https://bugzilla.redhat.com/show_bug.cgi?id=1206142