### PR TITLE
Provide a limited ability for OpenStack refresh to skip item types

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack.rb
@@ -179,6 +179,7 @@ module EmsRefresh::Parsers
 
     def process_collection(collection, key, &block)
       @data[key] ||= []
+      return if @options[:inventory_ignore] && @options[:inventory_ignore].include?(key)
       collection.each { |item| process_collection_item(item, key, &block) }
     end
 


### PR DESCRIPTION
Documenting this in the config file seems likely to make it too enticing; as a quick fix, it's not really as universal as it would first appear. To wit: while it works for our immediate situation (needing to skip `:cloud_volumes` and `:cloud_volume_snapshots`), it would have no effect on (for example) `:firewall_rules`, and would actively break for `:security_groups`.

Not to mention the likelihood of someone assuming such an option will work equally in other providers, where it would in fact be ignored completely.

With the above limitations in mind, to use, configure:

```yaml
ems_refresh:
  openstack:
    :inventory_ignore:
      - :cloud_volumes
      - :cloud_volume_snapshots
```

https://bugzilla.redhat.com/show_bug.cgi?id=1209711