### PR TITLE
Fixed links for VMs/Instances displayed under Service Summary Screen

### DIFF
--- a/vmdb/app/controllers/service_controller.rb
+++ b/vmdb/app/controllers/service_controller.rb
@@ -281,7 +281,6 @@ class ServiceController < ApplicationController
       @right_cell_text = _("%{model} \"%{name}\"") % {:name=>@record.name, :model=>ui_lookup(:model=>TreeBuilder.get_model_for_prefix(@nodetype))}
       @no_checkboxes = true
       @gtl_type = "grid"
-      @embedded = !role_allows(:feature => "vm_show")
       @items_per_page = ONE_MILLION
       @view, @pages = get_view(Vm, :parent=>@record, :parent_method => :all_vms, :all_pages=>true)  # Get the records (into a view) and the paginator
     else      # Get list of child Catalog Items/Services of this node

--- a/vmdb/app/controllers/vm_infra_controller.rb
+++ b/vmdb/app/controllers/vm_infra_controller.rb
@@ -56,7 +56,7 @@ class VmInfraController < ApplicationController
     if role_allows(:feature => "vandt_accord")
       set_active_elements_authorized_user('vandt_tree', 'vandt', true, VmOrTemplate, id)
     elsif role_allows(:feature => "#{prefix}_filter_accord")
-      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", false, nil)
+      set_active_elements_authorized_user("#{prefix}_filter_tree", "#{prefix}_filter", false, nil, id)
     else
       if (prefix == "vms" && role_allows(:feature => "vms_instances_filter_accord")) ||
         (prefix == "templates" && role_allows(:feature => "templates_images_filter_accord"))

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2720,5 +2720,56 @@ module ApplicationHelper
     %w(vm_cloud vm_infra vm_or_template).include?(controller_name)
   end
 
+  def vm_quad_link_attributes(record)
+    attributes = vm_cloud_attributes(record) if record.kind_of?(VmCloud)
+    attributes ||= vm_infra_attributes(record) if record.kind_of?(VmInfra)
+    attributes
+  end
+
+  def vm_cloud_attributes(record)
+    attributes = vm_cloud_explorer_accords_attributes(record)
+    attributes ||= service_workload_attributes(record)
+    attributes
+  end
+
+  def vm_cloud_explorer_accords_attributes(record)
+    if role_allows(:feature => "instances_accord") || role_allows(:feature => "instances_filter_accord")
+      attributes = {}
+      attributes[:link] = true
+      attributes[:controller] = "vm_cloud"
+      attributes[:action] = "show"
+      attributes[:id] = record.id
+    end
+    attributes
+  end
+
+  def vm_infra_attributes(record)
+    attributes = vm_infra_explorer_accords_attributes(record)
+    attributes ||= service_workload_attributes(record)
+    attributes
+  end
+
+  def vm_infra_explorer_accords_attributes(record)
+    if role_allows(:feature => "vandt_accord") || role_allows(:feature => "vms_filter_accord")
+      attributes = {}
+      attributes[:link] = true
+      attributes[:controller] = "vm_infra"
+      attributes[:action] = "show"
+      attributes[:id] = record.id
+    end
+    attributes
+  end
+
+  def service_workload_attributes(record)
+    attributes = {}
+    if role_allows(:feature => "vms_instances_filter_accord")
+      attributes[:link] = true
+      attributes[:controller] = "vm_or_template"
+      attributes[:action] = "explorer"
+      attributes[:id] = "v-#{record.id}"
+    end
+    attributes
+  end
+
   attr_reader :big_iframe
 end

--- a/vmdb/app/views/layouts/_quadicon.html.haml
+++ b/vmdb/app/views/layouts/_quadicon.html.haml
@@ -10,7 +10,7 @@
   - db = item.kind_of?(ExtManagementSystem) ? model_for_ems(item).name : item.class.base_model.name
 - if mode == :text
   - # Rendering the text link, not the quadicon
-  = render :partial => "layouts/quadicon/quadicon_text", :locals => {:db => db, :truncate_length => 13, :row => row}
+  = render :partial => "layouts/quadicon/quadicon_text", :locals => {:db => db, :truncate_length => 13, :row => row, :item => item}
 - elsif item
   - # Render the quad icon
   - if typ == :listnav

--- a/vmdb/app/views/layouts/quadicon/_quadicon_text.html.haml
+++ b/vmdb/app/views/layouts/quadicon/_quadicon_text.html.haml
@@ -43,11 +43,17 @@
       - else
         - name = row['name']
       - if request.parameters[:controller] == "service" && @view.db == "Vm"
-        = link_to(truncate_for_quad(name),
-          {:controller => "vm_or_template", :action => 'show', :id => to_cid(row['id'])},
-          :title                 => name,
-          "data-miq_sparkle_on"  => true,
-          "data-miq_sparkle_off" => true)
+        - attributes = vm_quad_link_attributes(item)
+        - if attributes[:link]
+          - @record = item
+          = link_to(truncate_for_quad(name),
+            {:controller => attributes[:controller], :action => attributes[:action], :id => attributes[:id]},
+             :title                 => name,
+             "data-miq_sparkle_on"  => true,
+             "data-miq_sparkle_off" => true)
+        - else
+          %a{:title => h(name)}
+          = truncate_for_quad(name)
       - else
         = link_to(truncate_for_quad(name),
           {:action => 'x_show', :id => to_cid(row['id'])},

--- a/vmdb/app/views/layouts/quadicon/_vm_or_template.html.haml
+++ b/vmdb/app/views/layouts/quadicon/_vm_or_template.html.haml
@@ -57,10 +57,15 @@
     - if !@embedded || @showlinks
       - if @explorer
         - if request.parameters[:controller] == "service" && @view.db == "Vm"
-          = link_to(image_tag("/images/icons/#{size}/reflection.png", :width => size, :height => size, :title => h(item.name)),
-            {:controller => "vm_infra", :action => 'show', :id => to_cid(item.id)},
-            "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true)
+          - attributes = vm_quad_link_attributes(item)
+          - if attributes[:link]
+            = link_to(image_tag("/images/icons/#{size}/reflection.png", :width => size, :height => size, :title => h(item.name)),
+              {:controller => attributes[:controller], :action => attributes[:action], :id => attributes[:id]},
+               "data-miq_sparkle_on"  => true,
+               "data-miq_sparkle_off" => true)
+          - else
+            %a{:title => h(item.name)}
+            %img{:src => "/images/icons/#{size}/reflection.png", :width => size, :height => size}
         - else
           = link_to(image_tag("/images/icons/#{size}/reflection.png", :width => size, :height => size, :title => h(item.name)),
             {:action => 'x_show', :id => to_cid(item.id)},


### PR DESCRIPTION
The links for VMs or Instances that are displayed under Service Summary Screen have to be disabled/enabled based on what features the user has access to.
For e.g. if the user is not entitled to view VMs, then the link that would redirect to VM Summary screen (from Service Summary screen) should not be available to the user.

https://bugzilla.redhat.com/show_bug.cgi?id=1190293