### PR TITLE
foreman associations for manager and system

### DIFF
--- a/vmdb/app/models/configuration_profile.rb
+++ b/vmdb/app/models/configuration_profile.rb
@@ -7,4 +7,7 @@ class ConfigurationProfile < ActiveRecord::Base
   belongs_to :parent, :class_name => 'ConfigurationProfile'
   has_and_belongs_to_many :configuration_locations, :join_table => :configuration_locations_configuration_profiles
   has_and_belongs_to_many :configuration_organizations, :join_table => :configuration_organizations_configuration_profiles
+
+  has_many :configured_systems
+  alias_method :manager, :configuration_manager
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configuration_profile.rb
@@ -1,6 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceConfigurationProfile < MiqAeServiceModelBase
-    expose :configuration_manager,        :association => true
+    expose :manager,                      :association => true
     expose :parent,                       :association => true
+    expose :configured_systems,           :association => true
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_configured_system.rb
@@ -1,6 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceConfiguredSystem < MiqAeServiceModelBase
-    expose :configuration_manager,   :association => true
+    expose :manager,                 :association => true
     expose :configuration_profile,   :association => true
     expose :computer_system,         :association => true
   end


### PR DESCRIPTION
1. use manager to make all foreman more consistent.
2. expose configuration_profile has_many configured_systems