### PR TITLE
Add more examples in preprovision and postprovision for orchstration provisioning

### DIFF
--- a/vmdb/app/models/service_orchestration.rb
+++ b/vmdb/app/models/service_orchestration.rb
@@ -31,6 +31,10 @@ class ServiceOrchestration < Service
     save_options
   end
 
+  def orchestration_stack
+    service_resources.find { |sr| sr.resource.kind_of?(OrchestrationStack) }
+  end
+
   private
 
   def build_stack_options_from_dialog

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.rb
@@ -1,0 +1,19 @@
+#
+# Description: This method examines the orchestration stack provisioned
+#
+def dump_stack_outputs(stack)
+  $evm.log("info", "Outputs from stack #{stack.name}")
+  stack.outputs.each do |output|
+    $evm.log("info", "Key #{output.key}, value #{output.value}")
+  end
+end
+
+$evm.log("info", "Starting Orchestration Post-Provisioning")
+
+service = $evm.root["service_template_provision_task"].destination
+stack = service.orchestration_stack
+
+# You can add logic to process the stack object in VMDB
+# For example, dump all outputs from the stack
+#
+# dump_stack_outputs(stack)

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: postprovision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/preprovision.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/preprovision.rb
@@ -15,3 +15,12 @@ $evm.log("info", "template = #{service.orchestration_template.name}(#{service.or
 $evm.log("info", "stack name = #{service.stack_name}")
 # Caution: stack_options may contain passwords.
 # $evm.log("info", "stack options = #{service.stack_options.inspect}")
+
+# Example how to programmatically modify stack options:
+# service.stack_name = 'new_name'
+# stack_options = service.stack_options
+# stack_options[:disable_rollback] = false
+# stack_options[:timeout_mins] = 2 # this option is provider dependent
+# stack_options[:parameters]['flavor'] = 'm1.small'
+# # Important: set stack_options
+# service.stack_options = stack_options

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/postprovision.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/postprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: postprovision
+    inherits: 
+    description: postprovision
+  fields:
+  - execute:
+      value: postprovision

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -158,7 +158,7 @@ object:
       datatype: string
       priority: 8
       owner: 
-      default_value: 
+      default_value: /Cloud/Orchestration/Provisioning/StateMachines/Methods/PostProvision
       substitute: true
       message: create
       visibility: 

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service_orchestration.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service_orchestration.rb
@@ -9,6 +9,7 @@ module MiqAeMethodService
     expose :stack_options=
     expose :orchestration_stack_status
     expose :deploy_orchestration_stack
+    expose :orchestration_stack
 
     def orchestration_template=(template)
       if template && !template.kind_of?(MiqAeMethodService::MiqAeServiceOrchestrationTemplate)


### PR DESCRIPTION
Add example how to modify stack options and for orchestration provisioning
Also add postprovision step to examine stack outputs

This does not affect the current provisioning workflow but to show the user what more they can do with the user script.