### PR TITLE
SCVMM - Correctly handle VMs without snapshots

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -309,7 +309,6 @@ module EmsRefresh::Parsers
 
     def process_snapshots(p)
       result = []
-      last_restored_snapshot = p[:LastRestoredVMCheckpoint]
       p[:VMCheckpoints].each do |snapshot_hash|
         s = snapshot_hash[:Props]
         new_result = {
@@ -320,7 +319,7 @@ module EmsRefresh::Parsers
           :name        => s[:Name],
           :description => s[:description],
           :create_time => s[:AddedTime],
-          :current     => s[:CheckpointID] == last_restored_snapshot[:Props][:CheckpointID],
+          :current     => s[:CheckpointID] == p[:LastRestoredCheckpointID]
         }
         result << new_result
       end


### PR DESCRIPTION
Up to this point, we have used the SCVMM Virtual Machine property 'LastRestoredVMCheckpoint' to determine if a given checkpoint (snapshot) is current. However, depending on the version of SCVMM, it can be nil if no checkpoints were ever created for a given VM and therefore can cause the SCVMM parser to bomb out.
Instead, we should query the LastRestoredCheckpointID to determine if a
checkpoint is current which is set to either:
The most current checkpoint OR the Virtual machine ID if no checkpoints are present.

https://bugzilla.redhat.com/show_bug.cgi?id=1213939
