### PR TITLE
Silently ignore archived VMs during refresh

### DIFF
--- a/vmdb/app/models/ems_refresh.rb
+++ b/vmdb/app/models/ems_refresh.rb
@@ -70,11 +70,13 @@ module EmsRefresh
             when t.respond_to?(:manager)               then t.manager
             else                                            t
             end
+      next if ems.nil? # archived Vm
       ems.kind_of?(EmsVmware) ? "vc" : ems.emstype.to_s
     end
 
     # Do the refreshes
     groups.each do |g, group_targets|
+      next if g.nil?
       self::Refreshers.const_get("#{g.to_s.camelize}Refresher").refresh(group_targets)
     end
   end

--- a/vmdb/spec/models/ems_refresh_spec.rb
+++ b/vmdb/spec/models/ems_refresh_spec.rb
@@ -64,4 +64,28 @@ describe EmsRefresh do
       described_class.get_ar_objects(pairs).should match_array([ems1, ems2])
     end
   end
+
+  context ".refresh" do
+    it "accepts VMs" do
+      ems = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
+      vm1 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems)
+      vm2 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware2", :ext_management_system => ems)
+      EmsRefresh::Refreshers::VcRefresher.should_receive(:refresh).with([vm1, vm2])
+      EmsRefresh.refresh([
+        [vm1.class, vm1.id],
+        [vm2.class, vm2.id],
+      ])
+    end
+
+    it "ignores an EMS-less (archived) VM" do
+      ems = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
+      vm1 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems)
+      vm2 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware2", :ext_management_system => nil)
+      EmsRefresh::Refreshers::VcRefresher.should_receive(:refresh).with([vm1])
+      EmsRefresh.refresh([
+        [vm1.class, vm1.id],
+        [vm2.class, vm2.id],
+      ])
+    end
+  end
 end


### PR DESCRIPTION
This restores behaviour that seems to have gradually faded between 068485e33e7244299d8bbbd4496a50986ce4f23a (lost the comment) and 3abfa1dd9e134667e2b58abbd20830762aaa250b (broke nil handling).

But now we have tests!

https://bugzilla.redhat.com/show_bug.cgi?id=1211249