### PR TITLE
Added CTRL+SHIFT+X hotkey to hide spinner the development mode

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -10,6 +10,7 @@ MiqBundler.include_gemfile("../lib/Gemfile", binding)
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '=1.2.4'
 gem 'jquery-rails', "=2.1.4"
+gem 'jquery-hotkeys-rails'
 
 gem "sprockets-sass",  "~>1.2.0"
 gem "sprockets-less",  "~>0.6.1"

--- a/vmdb/app/assets/javascripts/application.js
+++ b/vmdb/app/assets/javascripts/application.js
@@ -51,3 +51,4 @@
 //= require codemirror-4.2/lib/codemirror.js
 //= require codemirror-4.2/mode/yaml/yaml.js
 //= require spin
+//= require jquery-hotkeys

--- a/vmdb/app/assets/javascripts/miq_debug.js
+++ b/vmdb/app/assets/javascripts/miq_debug.js
@@ -1,0 +1,2 @@
+// CTRL+SHIFT+X stops the spinner
+$(document).bind('keyup', 'ctrl+shift+x', miqSparkleOff);

--- a/vmdb/app/views/layouts/_global_header.html.haml
+++ b/vmdb/app/views/layouts/_global_header.html.haml
@@ -16,6 +16,8 @@
     = stylesheet_link_tag 'codemirror-4.2/lib/codemirror'
     = render :partial => "stylesheets/template50"
     = javascript_include_tag 'application'
+    - if Rails.env.development?
+      = javascript_include_tag 'miq_debug'
 
     -# HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries
     /[if lt IE 9]

--- a/vmdb/app/views/layouts/application.html.haml
+++ b/vmdb/app/views/layouts/application.html.haml
@@ -8,6 +8,8 @@
       = stylesheet_link_tag 'template'
       = stylesheet_link_tag 'application'
       = javascript_include_tag 'application'
+      - if Rails.env.development?
+        = javascript_include_tag 'miq_debug'
     %body{:style => "overflow: scroll; padding: 0 20px 0 20px !important"}
       = yield
 - else

--- a/vmdb/app/views/layouts/login.html.haml
+++ b/vmdb/app/views/layouts/login.html.haml
@@ -9,6 +9,8 @@
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag 'template'
     = javascript_include_tag 'application'
+    - if Rails.env.development?
+      = javascript_include_tag 'miq_debug'
     - # HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries
     /[if lt IE 9]
       = javascript_include_tag 'html5shiv.min'

--- a/vmdb/app/views/vm_common/console_spice.html.haml
+++ b/vmdb/app/views/vm_common/console_spice.html.haml
@@ -12,6 +12,8 @@
     'spiceHTML5/cursor', 'spiceHTML5/thirdparty/jsbn', 'spiceHTML5/thirdparty/rsa',
     'spiceHTML5/thirdparty/prng4', 'spiceHTML5/thirdparty/rng', 'spiceHTML5/thirdparty/sha1',
     'spiceHTML5/ticket', 'spice-html5'
+    - if Rails.env.development?
+      = javascript_include_tag 'miq_debug'
 
   %body{:style => 'margin: 0px; padding-top: 0px !important;'}
     = link_to('Ctrl-Alt-Del', '#', :id => 'sendCtrlAltDelButton', :class => 'btn btn-default', :onclick => 'sendCtrlAltDel()')

--- a/vmdb/app/views/vm_common/console_vnc.html.haml
+++ b/vmdb/app/views/vm_common/console_vnc.html.haml
@@ -8,6 +8,8 @@
     'novnc/display', 'novnc/keyboard', 'novnc/keysym', 'novnc/keysymdef', 'novnc/logo',
     'novnc/playback', 'novnc/rfb', 'novnc/websock', 'novnc/webutil', 'novnc/web-socket-js/swfobject',
     'novnc/web-socket-js/web_socket', 'novnc-rails', 'miq_novnc'
+    - if Rails.env.development?
+      = javascript_include_tag 'miq_debug'
 
   %body{:style => 'margin: 0px; padding-top: 0px !important;'}
     = link_to('Ctrl-Alt-Del', '#', :id => 'sendCtrlAltDelButton', :class => 'btn btn-default')


### PR DESCRIPTION
The hotkey functionality is provided by jquery-hotkey.
The new miq_debug.js file can be extended with other debugging capabilities in the future