### PR TITLE
Create OpenstackInfra specific charts

### DIFF
--- a/vmdb/app/controllers/application_controller/performance.rb
+++ b/vmdb/app/controllers/application_controller/performance.rb
@@ -542,16 +542,7 @@ module ApplicationController::Performance
 
   # Load a chart layout from YML
   def perf_get_chart_layout(layout, fname = nil)
-    if fname
-      charts = YAML::load(File.open("#{CHARTS_LAYOUTS_FOLDER}/#{layout}/#{fname}.yaml"))
-    else
-      charts = YAML::load(File.open("#{CHARTS_LAYOUTS_FOLDER}/#{layout}.yaml"))
-    end
-    charts.delete_if do |c|
-      c.is_a?(Hash) && c[:applies_to_method] && @perf_record &&
-        @perf_record.respond_to?(c[:applies_to_method]) &&
-        !@perf_record.send(c[:applies_to_method].to_sym)
-    end
+    charts = ChartsLayoutService.layout(@perf_record, CHARTS_LAYOUTS_FOLDER, layout, fname)
     @perf_options[:index] = nil unless @perf_options[:index].nil? || charts[@perf_options[:index].to_i]
     return charts
   end

--- a/vmdb/app/services/charts_layout_service.rb
+++ b/vmdb/app/services/charts_layout_service.rb
@@ -1,0 +1,47 @@
+class ChartsLayoutService
+  def self.layout(perf_record, charts_folder, layout, fname = nil)
+    self.new(perf_record, charts_folder, layout, fname).layout
+  end
+
+  def initialize(perf_record, charts_folder, layout, fname = nil)
+    # DB record that has the charts, e.g. Host, EmsCluster, etc.
+    @perf_record   = perf_record
+    # Main folder of charts layouts
+    @charts_folder = charts_folder
+    # Name of the layout dir or file
+    @layout        = layout
+    # Optional name of the file in the layout directory, usually it's name of the base class
+    @fname         = fname
+  end
+
+  def layout
+    charts = build_charts
+    charts.delete_if do |c|
+      c.kind_of?(Hash) && c[:applies_to_method] && @perf_record &&
+        @perf_record.respond_to?(c[:applies_to_method]) &&
+        !@perf_record.send(c[:applies_to_method].to_sym)
+    end
+  end
+
+  private
+
+  def build_charts
+    YAML::load(File.open(find_chart_path))
+  end
+
+  def find_chart_path
+    if @fname
+      # First check if there is file for specific class of the @perf_record
+      path = chart_path(@layout, @perf_record.class.name)
+      return path if File.exist?(path)
+      # Fallback to fname, which is usually base class of the @perf_record
+      chart_path(@layout, @fname)
+    else
+      chart_path(@layout)
+    end
+  end
+
+  def chart_path(*base)
+    File.join(@charts_folder, *base) + '.yaml'
+  end
+end

--- a/vmdb/product/charts/layouts/daily_perf_charts/HostOpenstackInfra.yaml
+++ b/vmdb/product/charts/layouts/daily_perf_charts/HostOpenstackInfra.yaml
@@ -1,0 +1,97 @@
+# Host Daily performance chart layouts
+--- 
+- :title: CPU (Mhz)
+  :type: Line
+  :columns:
+  - cpu_usagemhz_rate_average
+  - max_derived_cpu_available
+  - max_derived_cpu_reserved
+  - min_cpu_usagemhz_rate_average
+  - max_cpu_usagemhz_rate_average
+  - trend_max_cpu_usagemhz_rate_average
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top VMs on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :trends:
+  - max_derived_cpu_reserved:Projected to hit reserve
+  - max_derived_cpu_available:Projected to hit available
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - max_derived_memory_available
+  - max_derived_memory_reserved
+  - min_derived_memory_used
+  - max_derived_memory_used
+  - trend_max_derived_memory_used
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top VMs on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :trends:
+  - max_derived_memory_reserved:Projected to hit reserve
+  - max_derived_memory_available:Projected to hit available
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Disk I/O (blocks per second)
+  :type: Line
+  :columns:
+  - disk_usage_rate_average
+  - min_disk_usage_rate_average
+  - max_disk_usage_rate_average
+  - trend_max_disk_usage_rate_average
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top VMs on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Network I/O (datagrams per second)
+  :type: Line
+  :columns:
+  - net_usage_rate_average
+  - min_net_usage_rate_average
+  - max_net_usage_rate_average
+  - trend_max_net_usage_rate_average
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top VMs on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Virtual Machines
+  :type: StackedArea
+  :columns:
+  - derived_vm_count_on
+  - derived_vm_count_off
+  :menu: 
+  - Chart-Current-Hourly:Hourly for this day
+  - Display-VMs-on:VMs that were running
+  - Display-VMs-off:VMs that were stopped

--- a/vmdb/product/charts/layouts/daily_tag_charts/HostOpenstackInfra.yaml
+++ b/vmdb/product/charts/layouts/daily_tag_charts/HostOpenstackInfra.yaml
@@ -1,0 +1,58 @@
+# Host Daily performance by tag chart layouts
+---
+- :title: CPU (Mhz)
+  :type: Line
+  :columns:
+  - cpu_usagemhz_rate_average
+  :menu:
+  - Chart-Current-Hourly:Hourly on this day
+  - Chart-VMs-topday:Top VMs for <cat> on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-bytag:VMs for <cat> that were running
+
+- :title: Virtual Machine CPU Ready (Percent)
+  :type: Line
+  :columns:
+  - v_pct_cpu_ready_delta_summation
+  :menu:
+  - Chart-Current-Hourly:Hourly on this day
+  - Chart-VMs-topday:Top VMs for <cat> on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-bytag:VMs for <cat> that were running
+#  :max_value: 100.4
+  :decimals: 1
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  :menu:
+  - Chart-Current-Hourly:Hourly on this day
+  - Chart-VMs-topday:Top VMs for <cat> on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-bytag:VMs for <cat> that were running
+
+- :title: Disk I/O (blocks per second)
+  :type: Line
+  :columns:
+  - disk_usage_rate_average
+  :menu:
+  - Chart-Current-Hourly:Hourly on this day
+  - Chart-VMs-topday:Top VMs for <cat> on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-bytag:VMs for <cat> that were running
+
+- :title: Network I/O (datagrams per second)
+  :type: Line
+  :columns:
+  - net_usage_rate_average
+  :menu:
+  - Chart-Current-Hourly:Hourly on this day
+  - Chart-VMs-topday:Top VMs for <cat> on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-bytag:VMs for <cat> that were running

--- a/vmdb/product/charts/layouts/hourly_perf_charts/HostOpenstackInfra.yaml
+++ b/vmdb/product/charts/layouts/hourly_perf_charts/HostOpenstackInfra.yaml
@@ -1,0 +1,75 @@
+# Host Hourly performance chart layouts
+--- 
+- :title: CPU (Mhz)
+  :type: Line
+  :columns:
+  - cpu_usagemhz_rate_average
+  - derived_cpu_available
+  - derived_cpu_reserved
+  :menu:
+  - Chart-Vms-tophour:Top VMs during this hour
+  - Chart-Current-Daily:Back to daily
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available
+  - derived_memory_reserved
+  :menu:
+  - Chart-Vms-tophour:Top VMs during this hour
+  - Chart-Current-Daily:Back to daily
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Disk I/O (blocks per second)
+  :type: Line
+  :columns:
+  - disk_usage_rate_average
+  :menu:
+  - Chart-Vms-tophour:Top VMs during this hour
+  - Chart-Current-Daily:Back to daily
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Network I/O (datagrams per second)
+  :type: Line
+  :columns:
+  - net_usage_rate_average
+  :menu:
+  - Chart-Vms-tophour:Top VMs during this hour
+  - Chart-Current-Daily:Back to daily
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2: 
+    :type: Line
+    :title: VMs
+    :columns: 
+    - derived_vm_count_on
+
+- :title: Virtual Machines
+  :type: StackedArea
+  :columns:
+  - derived_vm_count_on
+  - derived_vm_count_off
+  :menu: 
+  - Chart-Current-Daily:Back to daily
+  - Display-VMs-on:VMs that were running
+  - Display-VMs-off:VMs that were stopped

--- a/vmdb/product/charts/layouts/realtime_perf_charts/HostOpenstackInfra.yaml
+++ b/vmdb/product/charts/layouts/realtime_perf_charts/HostOpenstackInfra.yaml
@@ -1,0 +1,66 @@
+# Real time performance chart layouts
+--- 
+- :title: CPU (Mhz)
+  :type: Line
+  :columns:
+  - cpu_usagemhz_rate_average
+  - derived_cpu_available
+#  :menu:
+#  - Chart-Vms-tophour:Top VMs during this hour
+#  - Chart-Current-Daily:Back to daily
+#  - Timeline-Current-Hourly:Hourly events on this Host
+#  - Display-VMs-on:VMs that were running
+#  :chart2:
+#    :type: Line
+#    :title: VMs
+#    :columns:
+#    - derived_vm_count_on
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available
+#  :menu:
+#  - Chart-Vms-tophour:Top VMs during this hour
+#  - Chart-Current-Daily:Back to daily
+#  - Timeline-Current-Hourly:Hourly events on this Host
+#  - Display-VMs-on:VMs that were running
+#  :chart2:
+#    :type: Line
+#    :title: VMs
+#    :columns:
+#    - derived_vm_count_on
+
+- :title: Disk I/O (blocks per second)
+  :type: Line
+  :columns:
+  - disk_usage_rate_average
+#  :menu:
+#  - Chart-Vms-tophour:Top VMs during this hour
+#  - Chart-Current-Daily:Back to daily
+#  - Timeline-Current-Hourly:Hourly events on this Host
+#  - Display-VMs-on:VMs that were running#
+#  :chart2:
+#    :type: Line
+#    :title: VMs
+#    :columns:
+#    - derived_vm_count_on
+
+- :title: Network I/O (datagrams per second)
+  :type: Line
+  :columns:
+  - net_usage_rate_average
+#  :menu:
+#  - Chart-Vms-tophour:Top VMs during this hour
+#  - Chart-Current-Daily:Back to daily
+#  - Timeline-Current-Hourly:Hourly events on this Host
+#  - Display-VMs-on:VMs that were running
+#  :chart2:
+#    :type: Line
+#    :title: VMs
+#    :columns:
+#    - derived_vm_count_on
+
+- :title: Virtual Machines
+  :type: None

--- a/vmdb/spec/services/charts_layout_service_spec.rb
+++ b/vmdb/spec/services/charts_layout_service_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe ChartsLayoutService do
+  let(:host_openstack_infra) { FactoryGirl.create(:host_openstack_infra) }
+  let(:host_redhat) { FactoryGirl.create(:host_redhat) }
+  let(:vm_openstack) { FactoryGirl.create(:vm_openstack) }
+  let(:host_openstack_infra_chart) do
+    YAML::load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'HostOpenstackInfra') + '.yaml'))
+  end
+  let(:host_chart) do
+    YAML::load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host') + '.yaml'))
+  end
+  let(:layout_chart) do
+    YAML::load(File.open(File.join(UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts') + '.yaml'))
+  end
+
+  describe "#layout" do
+    it "returns layout for specific class if exists" do
+      chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
+      chart.should == host_openstack_infra_chart
+    end
+
+    it "returns layout for fname if specific class does not exist" do
+      chart = ChartsLayoutService.layout(host_redhat,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
+      chart.should == host_chart
+    end
+
+    it "returns base layout if fname is missing" do
+      chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts')
+      chart.should == layout_chart
+    end
+  end
+
+  describe "#layout applies_to_method functionality" do
+    it "shows CPU (%) by default for VmOpenstack" do
+      # By default percent is visible and mhz not
+      chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      chart.select { |x| x[:title] == "CPU (%)" }.count.should equal 1
+      chart.select { |x| x[:title] == "CPU (Mhz)" }.count.should equal 0
+    end
+
+    it "shows CPU (Mhz) instead of CPU (%), when applies_to_method methods are changed" do
+      # Stub it so mhz is visible and percent not
+      vm_openstack.stub(:cpu_percent_available?).and_return(false)
+      vm_openstack.stub(:cpu_mhz_available?).and_return(true)
+      chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      chart.select { |x| x[:title] == "CPU (%)" }.count.should equal 0
+      chart.select { |x| x[:title] == "CPU (Mhz)" }.count.should equal 1
+    end
+  end
+end


### PR DESCRIPTION
OpenstackInfra is not using all Host charts and has different
lables of some. Creating specific charts for OpenstackInfra
and allowing grabbing class specific charts in a general
way.