### PR TITLE
OpenstackInfra hostname for nova compute hosts

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_infra.rb
@@ -133,7 +133,7 @@ module EmsRefresh
           :vmm_vendor           => 'RedHat',
           :vmm_product          => identify_product(indexed_resources, host.instance_uuid),
           :ipaddress            => ip_address,
-          :hostname             => ip_address,
+          :hostname             => cloud_host_attributes.try(:[], :host_name) || ip_address,
           :mac_address          => identify_primary_mac_address(host, indexed_servers),
           :ipmi_address         => identify_ipmi_address(host),
           :power_state          => lookup_power_state(host.power_state),


### PR DESCRIPTION
We can obtain hostname of nova compute hosts from Openstack
Cloud nova API call. If it's not there, IP will be used.