### PR TITLE
miq-file.rb cleanup

### DIFF
--- a/lib/disk/modules/MiqLargeFile.rb
+++ b/lib/disk/modules/MiqLargeFile.rb
@@ -1,18 +1,16 @@
 require 'rubygems'
-#gem 'Platform'
 require 'platform'
-$:.push("../../util")
-require 'miq-system'
+require_relative '../../util/miq-system'
 
 if Platform::IMPL == :linux
 	if MiqSystem.arch == :x86
-		require 'MiqLargeFileLinux'
+		require_relative 'MiqLargeFileLinux'
 	elsif MiqSystem.arch == :x86_64
-		require 'MiqBlockDevOps'
-		require 'RawBlockIO'
+		require_relative 'MiqBlockDevOps'
+		require_relative 'RawBlockIO'
 	end
 elsif Platform::OS == :win32
-	require 'MiqLargeFileWin32'
+	require_relative 'MiqLargeFileWin32'
 end
 
 module MiqLargeFile
@@ -55,12 +53,12 @@ module MiqLargeFile
     		File.stat(@file_name).blockdev?
     	end
     end
-	
+
     class MiqLargeFileOther < File
         def write (buf, len)
             super(buf)
         end
-      
+
         def size
             return self.stat.size unless self.stat.blockdev?
 			return MiqBlockDevOps.blkgetsize64(self.fileno)

--- a/lib/util/extensions/miq-file.rb
+++ b/lib/util/extensions/miq-file.rb
@@ -26,17 +26,17 @@ class File
       buffer = " " * 255
       returnSize = Win32API.new("kernel32" , "GetShortPathNameA" , 'ppl'  , 'L').Call(longName ,  buffer , size )
       a = ""
-      a = a + buffer[0...returnSize]        
+      a = a + buffer[0...returnSize]
       return a
     else
       return longName
     end
   end
-  
+
   def self.normalize(path)
     File.expand_path(path.gsub(/\\/,"/"))
   end
-  
+
   def self.splitpath(path)
     ext = File.extname(path)
     return File.dirname(path), File.basename(path, ext), ext

--- a/lib/util/extensions/miq-file.rb
+++ b/lib/util/extensions/miq-file.rb
@@ -1,13 +1,10 @@
-$:.push("#{File.dirname(__FILE__)}/../../disk/modules")
-$:.push("#{File.dirname(__FILE__)}/..")
-
 require 'rubygems'
 require 'platform'
-require "Win32API" if Platform::OS == :win32
-require 'MiqLargeFile'
-require 'runcmd'
 require 'uri'
-require 'MiqSockUtil'
+require "Win32API" if Platform::OS == :win32
+require_relative '../../disk/modules/MiqLargeFile'
+require_relative '../runcmd'
+require_relative '../MiqSockUtil'
 
 class File
   def self.paths_equal?(f1, f2)

--- a/lib/util/extensions/miq-file.rb
+++ b/lib/util/extensions/miq-file.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'platform'
 require 'uri'
-require "Win32API" if Platform::OS == :win32
+require 'win32/file' if Platform::OS == :win32
 require_relative '../../disk/modules/MiqLargeFile'
 require_relative '../runcmd'
 require_relative '../MiqSockUtil'
@@ -9,29 +9,15 @@ require_relative '../MiqSockUtil'
 class File
   def self.paths_equal?(f1, f2)
     if Platform::OS == :win32
-      # Note: The file needs to exist and be accessable for getShortFileName to work.
-      f1 = File.getShortFileName(f1).downcase
-      f2 = File.getShortFileName(f2).downcase
+      f1 = File.short_path(f1).downcase
+      f2 = File.short_path(f2).downcase
     end
 
-    File.expand_path(f1).gsub("\\","/") == File.expand_path(f2).gsub("\\","/")
-  end
-
-  def self.getShortFileName(longName)
-    if Platform::OS == :win32
-      size = 255
-      buffer = " " * 255
-      returnSize = Win32API.new("kernel32" , "GetShortPathNameA" , 'ppl'  , 'L').Call(longName ,  buffer , size )
-      a = ""
-      a = a + buffer[0...returnSize]
-      return a
-    else
-      return longName
-    end
+    File.normalize(f1) == File.normalize(f2)
   end
 
   def self.normalize(path)
-    File.expand_path(path.gsub(/\\/,"/"))
+    File.expand_path(path.tr("\\", "/"))
   end
 
   def self.splitpath(path)

--- a/lib/util/win32/miq-powershell-daemon.rb
+++ b/lib/util/win32/miq-powershell-daemon.rb
@@ -1,8 +1,6 @@
-$:.push("#{File.dirname(__FILE__)}")
-$:.push("#{File.dirname(__FILE__)}/..")
-require 'miq-powershell'
-require 'miq-process'
-require 'miq-password'
+require_relative 'miq-powershell'
+require_relative '../miq-process'
+require_relative '../miq-password'
 
 module MiqPowerShell
   class Daemon
@@ -201,13 +199,14 @@ module MiqPowerShell
 
     def self.get_log_dir
       return nil unless Platform::OS == :win32
+      require 'win32/file'
       ps_log_dir = $miqHostCfg ? $miqHostCfg.miqLogs : nil
       unless ps_log_dir.blank?
         ps_log_dir = File.join(ps_log_dir, "ps_log")
         Dir.mkdir(ps_log_dir, 0755) if !File.directory?(ps_log_dir)
       end
       return nil if ps_log_dir.blank?
-      File.getShortFileName(ps_log_dir)
+      File.short_path(ps_log_dir)
     end
 
     def get_log_dir


### PR DESCRIPTION
This is just the first part of cleaning up this file. This PR does some minor formatting (stripping ^M characters) and replaces $LOAD_PATH mangling with require_relative.

As a rule, I don't think any library should every mess with $LOAD_PATH outside of testing/futzing because it could cause problems with 3rd party libs, and slows down require statements because Ruby is now searching more load paths.