### PR TITLE
Add OrchestrationStack.process_tasks

### DIFF
--- a/vmdb/app/models/configuration_manager_foreman.rb
+++ b/vmdb/app/models/configuration_manager_foreman.rb
@@ -1,4 +1,5 @@
 class ConfigurationManagerForeman < ConfigurationManager
+  include ProcessTasksMixin
   delegate :authentication_check,
            :authentication_status,
            :authentication_status_ok?,
@@ -9,29 +10,5 @@ class ConfigurationManagerForeman < ConfigurationManager
 
   def self.ems_type
     "foreman_configuration".freeze
-  end
-
-  def self.process_tasks(options)
-    raise "No ids given to process_tasks" if options[:ids].blank?
-    if options[:task] == "refresh_ems"
-      refresh_ems(options[:ids])
-      create_audit_event(options)
-    else
-      options[:userid] ||= "system"
-      unknown_task_exception(options)
-      invoke_tasks_queue(options)
-    end
-  end
-
-  def self.create_audit_event(options)
-    msg = "'#{options[:task]}' initiated for #{options[:ids].length} #{ui_lookup(:table => 'ext_management_systems').pluralize}"
-    AuditEvent.success(:event        => options[:task],
-                       :target_class => base_class.name,
-                       :userid       => options[:userid],
-                       :message      => msg)
-  end
-
-  def self.unknown_task_exception(options)
-    raise "Unknown task, #{options[:task]}" unless instance_methods.collect(&:to_s).include?(options[:task])
   end
 end

--- a/vmdb/app/models/mixins/process_tasks_mixin.rb
+++ b/vmdb/app/models/mixins/process_tasks_mixin.rb
@@ -1,0 +1,123 @@
+module ProcessTasksMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Processes tasks received from the UI and queues them
+    def process_tasks(options)
+      raise "No ids given to process_tasks" if options[:ids].blank?
+      if options[:task] == "refresh_ems" && respond_to?("refresh_ems")
+        refresh_ems(options[:ids])
+        msg = "'#{options[:task]}' initiated for "\
+              "#{options[:ids].length} #{ui_lookup(:table => base_class.name).pluralize}"
+        task_audit_event(:success, options, :message => msg)
+      else
+        exception_if_task_unknown(options)
+        options[:userid] ||= "system"
+        invoke_tasks_queue(options)
+      end
+    end
+
+    def invoke_tasks_queue(options)
+      MiqQueue.put(:class_name => name, :method_name => "invoke_tasks", :args => [options])
+    end
+
+    # Performs tasks received from the UI via the queue
+    def invoke_tasks(options)
+      local, remote = partition_ids_by_remote_region(options[:ids])
+      invoke_tasks_local(options.merge(:ids => local)) unless local.empty?
+
+      # TODO: invoke_tasks_remote currently is only implemented by VmOrTemplate.
+      # it can be refactored to be generalized like invoke_tasks_local
+      invoke_tasks_remote(options.merge(:ids => remote)) if !remote.empty? && respond_to?("invoke_tasks_remote")
+    end
+
+    def invoke_tasks_local(options)
+      options[:invoke_by] = task_invoked_by(options)
+      args = task_arguments(options)
+
+      instances, tasks = validate_tasks(options)
+
+      instances.each_with_index do |instance, idx|
+        task = MiqTask.where(:id => tasks[idx]).first
+
+        if task && task.status == "Error"
+          task_audit_event(:failure, options, :target_id => instance.id, :message => task.message)
+          task.state_finished
+          next
+        end
+
+        invoke_task_local(task, instance, options, args)
+
+        msg = "#{instance.name}: '#{options[:task]}' initiated"
+        task_audit_event(:success, options, :target_id => instance.id, :message => msg)
+        task.update_status("Queued", "Ok", "Task has been queued") if task
+      end
+    end
+
+    # default: invoked by task, can be overridden
+    def task_invoked_by(_options)
+      :task
+    end
+
+    # default: only handles retirement, can be overridden
+    def task_arguments(options)
+      options[:task] == 'retire_now' ? [options[:userid]] : []
+    end
+
+    # default implementation, can be overridden
+    def invoke_task_local(task, instance, options, args)
+      cb = {
+        :class_name  => task.class.to_s,
+        :instance_id => task.id,
+        :method_name => :queue_callback,
+        :args        => ["Finished"]
+      } if task
+
+      MiqQueue.put(
+        :class_name   => name,
+        :instance_id  => instance.id,
+        :method_name  => options[:task],
+        :args         => args,
+        :miq_callback => cb
+      )
+    end
+
+    # Helper method for invoke_tasks, to determine the instances and the tasks associated
+    def validate_tasks(options)
+      tasks = []
+
+      instances = base_class.where(:id => options[:ids]).order("lower(name)").to_a
+      return instances, tasks unless options[:invoke_by] == :task # jobs will be used instead of tasks for feedback
+
+      instances.each do |instance|
+        # create a task for each instance
+        task = MiqTask.create(:name => "#{instance.name}: '#{options[:task]}'", :userid => options[:userid])
+        tasks.push(task.id)
+
+        validate_task(task, instance, options)
+      end
+      return instances, tasks
+    end
+
+    # default: validate retirement, can be overridden
+    def validate_task(task, instance, options)
+      return true unless options[:task] == "retire_now" && instance.retired?
+      task.error("#{instance.name} is already retired")
+      false
+    end
+
+    def task_audit_event(event, task_options, audit_options)
+      options =
+        {
+          :event        => task_options[:task],
+          :target_class => base_class.name,
+          :userid       => task_options[:userid],
+        }.merge(audit_options)
+      AuditEvent.send(event, options)
+    end
+
+    def exception_if_task_unknown(options)
+      raise "Unknown task, #{options[:task]}" unless instance_methods.collect(&:to_s).include?(options[:task])
+    end
+  end
+end

--- a/vmdb/app/models/orchestration_stack.rb
+++ b/vmdb/app/models/orchestration_stack.rb
@@ -3,6 +3,7 @@ class OrchestrationStack < ActiveRecord::Base
   include NewWithTypeStiMixin
   include ReportableMixin
   include AsyncDeleteMixin
+  include ProcessTasksMixin
   include_concern 'RetirementManagement'
 
   acts_as_miq_taggable

--- a/vmdb/app/models/service.rb
+++ b/vmdb/app/models/service.rb
@@ -17,6 +17,7 @@ class Service < ActiveRecord::Base
   include OwnershipMixin
   include CustomAttributeMixin
   include NewWithTypeStiMixin
+  include ProcessTasksMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'
@@ -80,69 +81,6 @@ class Service < ActiveRecord::Base
     self.direct_vms + self.indirect_vms
   end
   alias :vms :all_vms
-
-  # Processes tasks received from the UI and queues them
-  def self.process_tasks(options)
-    raise "No ids given to process_tasks" if options[:ids].blank?
-    raise "Unknown task, #{options[:task]}" unless self.instance_methods.collect(&:to_s).include?(options[:task])
-    options[:userid] ||= "system"
-    self.invoke_tasks_queue(options)
-  end
-
-  def self.invoke_tasks_queue(options)
-    MiqQueue.put(:class_name => self.name, :method_name => "invoke_tasks", :args => [options])
-  end
-
-  # Performs tasks received from the UI via the queue
-  def self.invoke_tasks(options)
-    local, remote = self.partition_ids_by_remote_region(options[:ids])
-    self.invoke_tasks_local(options.merge(:ids => local)) unless local.empty?
-  end
-
-  def self.invoke_tasks_local(options)
-    options[:invoke_by] = :task
-    args = options[:task] == 'retire_now' ? [options[:userid]] : []
-
-    services, tasks = self.validate_tasks(options)
-
-    audit = {:event => options[:task], :target_class => self.name, :userid => options[:userid]}
-
-    services.each_with_index do |service, idx|
-      task = MiqTask.find_by_id(tasks[idx])
-
-      if task && task.status == "Error"
-        AuditEvent.failure(audit.merge(:target_id => service.id, :message => task.message))
-        task.state_finished
-        next
-      end
-
-      cb = { :class_name => task.class.to_s, :instance_id => task.id, :method_name => :queue_callback, :args => ["Finished"] } if task
-
-      MiqQueue.put(:class_name => self.name, :instance_id => service.id, :method_name => options[:task], :args => args, :miq_callback => cb)
-      AuditEvent.success(audit.merge(:target_id => service.id, :message => "#{service.name}: '#{options[:task]}' successfully initiated"))
-      task.update_status("Queued", "Ok", "Task has been queued") if task
-    end
-  end
-
-  # Helper method for invoke_tasks, to determine the services and the tasks associated
-  def self.validate_tasks(options)
-    tasks = []
-
-    services = self.find_all_by_id(options[:ids], :order => "lower(name)")
-    return services, tasks unless options[:invoke_by] == :task # jobs will be used instead of tasks for feedback
-
-    services.each do |service|
-      # create a task instance for each VM
-      task = MiqTask.create(:name => "#{service.name}: '" + options[:task] + "'", :userid => options[:userid])
-      tasks.push(task.id)
-
-      if options[:task] == "retire_now" && service.retired?
-        task.error("#{service.name}: Service is already retired")
-        next
-      end
-    end
-    return services, tasks
-  end
 
   def start
     self.raise_request_start_event

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -404,11 +404,13 @@ class VmOrTemplate < ActiveRecord::Base
     end
     true
   end
+  private_class_method :validate_task
 
   # override
   def self.task_invoked_by(options)
     %w(scan sync).include?(options[:task]) ? :job : super
   end
+  private_class_method :task_invoked_by
 
   # override
   def self.task_arguments(options)
@@ -423,6 +425,7 @@ class VmOrTemplate < ActiveRecord::Base
       super
     end
   end
+  private_class_method :task_arguments
 
   def powerops_callback(task_id, status, msg, result, queue_item)
     if queue_item.last_exception.kind_of?(MiqException::MiqVimBrokerUnavailable)

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -25,6 +25,7 @@ class VmOrTemplate < ActiveRecord::Base
   include WebServiceAttributeMixin
 
   include EventMixin
+  include ProcessTasksMixin
 
   has_many :ems_custom_attributes, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute", :conditions => "source = 'VC'"
 
@@ -368,29 +369,59 @@ class VmOrTemplate < ActiveRecord::Base
     MiqEvent.raise_evm_event(self, event, inputs)
   end
 
-  # Processes tasks received from the UI and queues them
-  def self.process_tasks(options)
-    raise "No ids given to process_tasks" if options[:ids].blank?
-    if options[:task] == "refresh_ems"
-      self.refresh_ems(options[:ids])
-      AuditEvent.success(:event => options[:task], :target_class => self.base_class.name, :userid => options[:userid],
-        :message => "'#{options[:task]}' successfully initiated for #{ApplicationController.new.pluralize(options[:ids].length,"VM")}")
-    else
-      raise "Unknown task, #{options[:task]}" unless self.instance_methods.collect(&:to_s).include?(options[:task])
-      options[:userid] ||= "system"
-      self.invoke_tasks_queue(options)
+  # override
+  def self.validate_task(task, vm, options)
+    return false unless super
+    return false if options[:task] == "destroy" ||  options[:task] == "check_compliance_queue"
+    return false if vm.has_required_host?
+
+    # VM has no host or storage affiliation
+    if vm.storage.nil?
+      task.error("#{vm.name}: There is no owning Host or #{ui_lookup(:table => "storages")} for this VM, "\
+                 "'#{options[:task]}' is not allowed")
+      return false
     end
+
+    # VM belongs to a storage/repository location
+    # TODO: The following never gets run since the invoke tasks invokes it as a job, and only tasks get to this point ?
+    unless %w(scan sync).include?(options[:task])
+      task.error("#{vm.name}: There is no owning Host for this VM, '#{options[:task]}' is not allowed")
+      return false
+    end
+    current = VMDB::Config.new("vmdb")      # Get the vmdb configuration settings
+    spid = current.config[:repository_scanning][:defaultsmartproxy]
+    if spid.nil?                          # No repo scanning SmartProxy configured
+      task.error("#{vm.name}: No Default Repository SmartProxy is configured, contact your EVM administrator")
+      return false
+    elsif MiqProxy.exists?(spid) == false
+      task.error("#{vm.name}: The Default Repository SmartProxy no longer exists, contact your EVM Administrator")
+      return false
+    end
+    if MiqProxy.find(spid).state != "on"                     # Repo scanning host iagent s not running
+      task.error("#{vm.name}: The Default Repository SmartProxy, '#{sp.name}', is not running. "\
+                 "'#{options[:task]}' not attempted")
+      return false
+    end
+    true
   end
 
-  # Performs tasks received from the UI via the queue
-  def self.invoke_tasks(options)
-    local, remote = self.partition_ids_by_remote_region(options[:ids])
-    self.invoke_tasks_local(options.merge(:ids => local)) unless local.empty?
-    self.invoke_tasks_remote(options.merge(:ids => remote)) unless remote.empty?
+  # override
+  def self.task_invoked_by(options)
+    %w(scan sync).include?(options[:task]) ? :job : super
   end
 
-  def self.invoke_tasks_queue(options)
-    MiqQueue.put(:class_name => self.name, :method_name => "invoke_tasks", :args => [options])
+  # override
+  def self.task_arguments(options)
+    case options[:task]
+    when "scan", "sync" then
+      [options[:userid]]
+    when "remove_snapshot", "revert_to_snapshot" then
+      [options[:snap_selected]]
+    when "create_snapshot" then
+      [options[:name], options[:description], options[:memory]]
+    else
+      super
+    end
   end
 
   def powerops_callback(task_id, status, msg, result, queue_item)
@@ -406,63 +437,40 @@ class VmOrTemplate < ActiveRecord::Base
     (VMDB::Config.new('vmdb').config.fetch_path(:management_system, :power_operation_expiration) || 10.minutes).to_i_with_method.seconds.from_now.utc
   end
 
-  def self.invoke_tasks_local(options)
-    case options[:task]
-    when "scan", "sync" then
-      options[:invoke_by] = :job
-      args = [options[:userid]]
-    when "remove_snapshot", "revert_to_snapshot" then
-      options[:invoke_by] = :task
-      args = [options[:snap_selected]]
-    when "create_snapshot" then
-      options[:invoke_by] = :task
-      args = [options[:name], options[:description], options[:memory]]
-    when "retire_now" then
-      options[:invoke_by] = :task
-      args = [options[:userid]]
-    else
-      options[:invoke_by] = :task
-      args = []
+  # override
+  def self.invoke_task_local(task, vm, options, args)
+    cb = nil
+    if task
+      cb =
+        if POWER_OPS.include?(options[:task])
+          {
+            :class_name  => vm.class.base_class.name,
+            :instance_id => vm.id,
+            :method_name => :powerops_callback,
+            :args        => [task.id]
+          }
+        else
+          {
+            :class_name  => task.class.to_s,
+            :instance_id => task.id,
+            :method_name => :queue_callback,
+            :args        => ["Finished"]
+          }
+        end
     end
 
-    vms, tasks = self.validate_tasks(options)
-
-    audit = {:event => options[:task], :target_class => self.base_class.name, :userid => options[:userid]}
-
-    vms.each_with_index do |vm, idx|
-      task = MiqTask.find_by_id(tasks[idx])
-
-      if task && task.status == "Error"
-        AuditEvent.failure(audit.merge(:target_id => vm.id, :message => task.message))
-        task.state_finished
-        next
-      end
-
-      cb = nil
-      if task
-        cb =
-          if POWER_OPS.include?(options[:task])
-            {:class_name => vm.class.base_class.name, :instance_id => vm.id, :method_name => :powerops_callback, :args => [task.id]}
-          else
-            {:class_name => task.class.to_s, :instance_id => task.id, :method_name => :queue_callback, :args => ["Finished"]}
-          end
-      end
-
-      role = options[:invoke_by] == :job ? "smartstate" : "ems_operations"
-      role = nil if options[:task] == "destroy"
-      MiqQueue.put(
-        :class_name   => self.base_class.name,
-        :instance_id  => vm.id,
-        :method_name  => options[:task],
-        :args         => args,
-        :miq_callback => cb,
-        :zone         => vm.my_zone,
-        :role         => role,
-        :expires_on   => POWER_OPS.include?(options[:task]) ? powerops_expiration : nil
-      )
-      AuditEvent.success(audit.merge(:target_id => vm.id, :message => "#{vm.name}: '#{options[:task]}' successfully initiated"))
-      task.update_status("Queued", "Ok", "Task has been queued") if task
-    end
+    role = options[:invoke_by] == :job ? "smartstate" : "ems_operations"
+    role = nil if options[:task] == "destroy"
+    MiqQueue.put(
+      :class_name   => base_class.name,
+      :instance_id  => vm.id,
+      :method_name  => options[:task],
+      :args         => args,
+      :miq_callback => cb,
+      :zone         => vm.my_zone,
+      :role         => role,
+      :expires_on   => POWER_OPS.include?(options[:task]) ? powerops_expiration : nil
+    )
   end
 
   def self.invoke_tasks_remote(options)
@@ -497,64 +505,9 @@ class VmOrTemplate < ActiveRecord::Base
         next
       end
 
-      AuditEvent.success(
-        :event        => options[:task],
-        :target_class => self.base_class.name,
-        :userid       => options[:userid],
-        :message      => "'#{options[:task]}' successfully initiated for remote VMs: #{ids.sort.inspect}"
-      )
+      msg = "'#{options[:task]}' successfully initiated for remote VMs: #{ids.sort.inspect}"
+      task_audit_event(:success, options, :message => msg)
     end
-  end
-
-  # Helper method for invoke_tasks, to determine the vms and the tasks associated
-  def self.validate_tasks(options)
-    tasks = []
-
-    vms = base_class.where(:id => options[:ids]).order("lower(name)").to_a
-    return vms, tasks unless options[:invoke_by] == :task # jobs will be used instead of tasks for feedback
-
-    vms.each do |vm|
-      # create a task instance for each VM
-      task = MiqTask.create(:name => "#{vm.name}: '" + options[:task] + "'", :userid => options[:userid])
-      tasks.push(task.id)
-
-      next if options[:task] == "destroy" ||  options[:task] == "check_compliance_queue"
-
-      if options[:task] == "retire_now" && vm.retired?
-        task.error("#{vm.name}: Vm is already retired")
-        next
-      end
-
-      next if vm.has_required_host?
-
-      # VM has no host or storage affiliation
-      if vm.storage.nil?
-        task.error("#{vm.name}: There is no owning Host or #{ui_lookup(:table => "storages")} for this VM, '" + options[:task] + "' is not allowed")
-        next
-      end
-
-      # VM belongs to a storage/repository location
-      # TODO: The following never gets run since the invoke tasks invokes it as a job, and only tasks get to this point ?
-      unless ["scan", "sync"].include?(options[:task])
-        task.error("#{vm.name}: There is no owning Host for this VM, '#{options[:task]}' is not allowed")
-        next
-      end
-      current = VMDB::Config.new("vmdb")      # Get the vmdb configuration settings
-      spid = current.config[:repository_scanning][:defaultsmartproxy]
-      if spid == nil                          # No repo scanning SmartProxy configured
-        task.error("#{vm.name}: No Default Repository SmartProxy is configured, contact your EVM administrator")
-        next
-      elsif MiqProxy.exists?(spid) == false
-        task.error("#{vm.name}: The Default Repository SmartProxy no longer exists, contact your EVM Administrator")
-        next
-      end
-      sp = MiqProxy.find(spid)
-      if sp.state != "on"                     # Repo scanning host iagent s not running
-        task.error("#{vm.name}: The Default Repository SmartProxy, '#{sp.name}', is not running '" + options[:task] + "' not attempted")
-        next
-      end
-    end
-    return vms, tasks
   end
 
   def scan_data_current?

--- a/vmdb/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/vmdb/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -1,0 +1,158 @@
+require "spec_helper"
+
+describe "Service Retirement Management" do
+  before(:each) do
+    @guid = MiqUUID.new_guid
+    MiqServer.stub(:my_guid).and_return(@guid)
+
+    @zone       = FactoryGirl.create(:zone)
+    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
+    MiqServer.stub(:my_server).and_return(@miq_server)
+    @stack = FactoryGirl.create(:orchestration_stack)
+  end
+
+  it "#retirement_check" do
+    MiqAeEvent.should_receive(:raise_evm_event)
+    @stack.update_attributes(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
+    expect(@stack.retirement_last_warn).to be_nil
+    @stack.class.any_instance.should_receive(:retire_now).once
+    @stack.retirement_check
+    @stack.reload
+    expect(@stack.retirement_last_warn).not_to be_nil
+    expect(Time.now.utc - @stack.retirement_last_warn).to be < 30
+  end
+
+  it "#start_retirement" do
+    expect(@stack.retirement_state).to be_nil
+    @stack.start_retirement
+    @stack.reload
+    expect(@stack.retirement_state).to eq("retiring")
+  end
+
+  it "#retire_now" do
+    expect(@stack.retirement_state).to be_nil
+    expect(MiqAeEvent).to receive(:raise_evm_event).once
+    @stack.retire_now
+    @stack.reload
+  end
+
+  it "#retire_now with userid" do
+    expect(@stack.retirement_state).to be_nil
+    event_name = 'request_orchestration_stack_retire'
+    event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
+                  :retirement_initiator => "user", :user_id => "freddy"}
+
+    expect(MiqAeEvent).to receive(:raise_evm_event).with(event_name, @stack, event_hash).once
+
+    @stack.retire_now('freddy')
+    @stack.reload
+  end
+
+  it "#retire_now without userid" do
+    expect(@stack.retirement_state).to be_nil
+    event_name = 'request_orchestration_stack_retire'
+    event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
+                  :retirement_initiator => "system"}
+
+    expect(MiqAeEvent).to receive(:raise_evm_event).with(event_name, @stack, event_hash).once
+
+    @stack.retire_now
+    @stack.reload
+  end
+
+  it "#retire warn" do
+    expect(AuditEvent).to receive(:success).once
+    options = {}
+    options[:warn] = 2.days.to_i
+    @stack.retire(options)
+    @stack.reload
+    expect(@stack.retirement_warn).to eq(options[:warn])
+  end
+
+  it "#retire date" do
+    expect(AuditEvent).to receive(:success).once
+    options = {}
+    options[:date] = Date.today
+    @stack.retire(options)
+    @stack.reload
+    expect(@stack.retires_on).to eq(options[:date])
+  end
+
+  it "#finish_retirement" do
+    expect(@stack.retirement_state).to be_nil
+    @stack.finish_retirement
+    @stack.reload
+    expect(@stack.retired).to be_true
+    expect(@stack.retires_on).to eq(Date.today)
+    expect(@stack.retirement_state).to eq("retired")
+  end
+
+  it "#retiring - false" do
+    expect(@stack.retirement_state).to be_nil
+    expect(@stack.retiring?).to be_false
+  end
+
+  it "#retiring - true" do
+    @stack.update_attributes(:retirement_state => 'retiring')
+    expect(@stack.retiring?).to be_true
+  end
+
+  it "#error_retiring - false" do
+    expect(@stack.retirement_state).to be_nil
+    expect(@stack.error_retiring?).to be_false
+  end
+
+  it "#error_retiring - true" do
+    @stack.update_attributes(:retirement_state => 'error')
+    expect(@stack.error_retiring?).to be_true
+  end
+
+  it "#retires_on - today" do
+    expect(@stack.retirement_due?).to be_false
+    @stack.retires_on = Date.today
+    expect(@stack.retirement_due?).to be_true
+  end
+
+  it "#retires_on - tomorrow" do
+    expect(@stack.retirement_due?).to be_false
+    @stack.retires_on = Date.today + 1
+    expect(@stack.retirement_due?).to be_false
+  end
+
+  it "#retirement_due?" do
+    expect(@stack.retirement_due?).to be_false
+
+    @stack.update_attributes(:retires_on => Date.today + 1.day)
+    expect(@stack.retirement_due?).to be_false
+
+    @stack.update_attributes(:retires_on => Date.today)
+    expect(@stack.retirement_due?).to be_true
+
+    @stack.update_attributes(:retires_on => Date.today - 1.day)
+    expect(@stack.retirement_due?).to be_true
+  end
+
+  it "#raise_retirement_event" do
+    event_name = 'foo'
+    event_hash = {
+      :orchestration_stack  => @stack,
+      :type                 => "OrchestrationStack",
+      :retirement_initiator => "system"
+    }
+    expect(MiqAeEvent).to receive(:raise_evm_event).with(event_name, @stack, event_hash)
+    @stack.raise_retirement_event(event_name)
+  end
+
+  it "#raise_audit_event" do
+    event_name = 'foo'
+    message = 'bar'
+    event_hash = {
+      :target_class => "OrchestrationStack",
+      :target_id    => @stack.id.to_s,
+      :event        => event_name,
+      :message      => message
+    }
+    expect(AuditEvent).to receive(:success).with(event_hash)
+    @stack.raise_audit_event(event_name, message)
+  end
+end


### PR DESCRIPTION
This enables direct retirement of a stack from UI.

the retirement spec test is directly modified from service retirement spec.