### PR TITLE
Prefer require "spec_helper" to be consistent with other specs

### DIFF
--- a/vmdb/spec/controllers/sandbox_spec.rb
+++ b/vmdb/spec/controllers/sandbox_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require "spec_helper"
 
 describe Sandbox do
   let(:sb) do

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -93,7 +93,6 @@ end
 #   models.  These tests test the basic service model methods and can be removed
 #   in favor of the same tests against any single one of those classes.
 #
-require "spec_helper"
 #  require "#{File.dirname(__FILE__)}/../lib/engine/miq_ae_service"
 #  require "#{File.dirname(__FILE__)}/../lib/engine/miq_ae_service_model_base"
 #  Dir.new("#{File.dirname(__FILE__)}/../lib/service_models").each { |fname|

--- a/vmdb/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
+++ b/vmdb/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require "spec_helper"
 require Rails.root.join("db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb")
 
 describe FixReplicationOnUpgradeFromVersionFour do

--- a/vmdb/spec/models/miq_report/charting_spec.rb
+++ b/vmdb/spec/models/miq_report/charting_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'spec_helper'))
+require "spec_helper"
 
 describe MiqReport do
   before(:each) do


### PR DESCRIPTION
We should be consistent across all specs with the way we require spec_helper