### PR TITLE
Properly reflect starting/stopping status for EC2 instances

### DIFF
--- a/vmdb/app/models/vm_amazon.rb
+++ b/vmdb/app/models/vm_amazon.rb
@@ -92,10 +92,12 @@ class VmAmazon < VmCloud
 
   def self.calculate_power_state(raw_power_state)
     case raw_power_state
-    when "running"                  then "on"
-    when "shutting_down", "pending" then "suspended"
-    when "terminated"               then "terminated"
-    else                                 "off"
+    when "running"       then "on"
+    when "powering_up"   then "powering_up"
+    when "shutting_down" then "powering_down"
+    when "pending"       then "suspended"
+    when "terminated"    then "terminated"
+    else                      "off"
     end
   end
 end

--- a/vmdb/app/models/vm_amazon/operations/power.rb
+++ b/vmdb/app/models/vm_amazon/operations/power.rb
@@ -10,12 +10,12 @@ module VmAmazon::Operations::Power
   def raw_start
     with_provider_object(&:start)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "pending") # show state as suspended
+    self.update_attributes!(:raw_power_state => "powering_up")
   end
 
   def raw_stop
     with_provider_object(&:stop)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "pending") # show state as suspended
+    self.update_attributes!(:raw_power_state => "shutting_down")
   end
 end


### PR DESCRIPTION
We have the right icons, so we should use them: they're far more informative than pretending it's paused.

https://bugzilla.redhat.com/show_bug.cgi?id=1029690