### PR TITLE
Don't eager require therubyracer/less-rails

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -13,8 +13,8 @@ gem 'jquery-rails', "=2.1.4"
 
 gem "sprockets-sass",  "~>1.2.0"
 gem "sprockets-less",  "~>0.6.1"
-gem 'therubyracer'
-gem 'less-rails'
+gem 'therubyracer', :require => false
+gem 'less-rails',   :require => false
 
 # Vendored and required
 # TODO: Fix AWS tests now that our api specs and the soap4r 1.6.0 specs pass on 1.8.7/1.9.3


### PR DESCRIPTION
require 'less' by itself consumes 500+ MB of virtual memory per process.
However, we only need less/less-rails to precompile less assets into css.
In production mode, we should have all of the less assets precompiled so
there's no need to take this 500 MB hit.

https://bugzilla.redhat.com/show_bug.cgi?id=1215285