### PR TITLE
Removed reason code from service model code.

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -24,10 +24,6 @@ module MiqAeMethodService
     end
     association :approvers
 
-    def reason
-      ar_method { @object.miq_approvals.collect { |a| (a.state == 'denied') ? a.reason : nil }.compact.join("; ") }
-    end
-
     def set_message(value)
       object_send(:update_attribute, :message, value)
     end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -112,7 +112,7 @@ module MiqAeServiceMiqRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].reason"
       @ae_method.update_attributes(:data => method)
       reason = invoke_ae.root(@ae_result_key)
-      reason.should == ""
+      reason.should be_nil
 
       wilma          = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'wilma',  :email => 'wilma@bedrock.gov')
       betty          = FactoryGirl.create(:user, :name => 'Betty Rubble',     :userid => 'betty',  :email => 'betty@bedrock.gov')


### PR DESCRIPTION
The reason code is defined as a virtual column in the
Active Record models, use that method instead of using
the one from service model

https://bugzilla.redhat.com/show_bug.cgi?id=1210469