### PR TITLE
Changes to display appropriate Host/Cluster titles in UI.

### DIFF
--- a/vmdb/app/controllers/application_controller/automate.rb
+++ b/vmdb/app/controllers/application_controller/automate.rb
@@ -107,7 +107,7 @@ module ApplicationController::Automate
     end
     if @edit[:new][:target_class]
       @resolve[:new][:target_class] = Hash[*@resolve[:target_classes].flatten][@edit[:new][:target_class]]
-      target_class = @resolve[:target_classes].detect { |ui_name, _| @edit[:new][:target_class] == ui_name }.last
+      target_class = @resolve[:target_classes].detect { |ui_name, _| @edit[:new][:target_class] == ui_name }.first
       targets = target_class.constantize.all
       @resolve[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
       @resolve[:new][:target_id] = nil

--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -828,10 +828,10 @@ module ApplicationController::CiProcessing
   end
 
   def set_discover_title(type, controller)
-    controller_table = ui_lookup(:tables=>controller)
     if type == "hosts"
-      return controller_table
+      return ui_lookup(:host_types => "hosts")
     else
+      controller_table = ui_lookup(:tables => controller)
       if controller == "ems_cloud"
         return "Amazon #{controller_table}"
       else

--- a/vmdb/app/controllers/application_controller/explorer.rb
+++ b/vmdb/app/controllers/application_controller/explorer.rb
@@ -597,7 +597,10 @@ module ApplicationController::Explorer
       else
         objects = Array.new
         if ems_clusters.count > 0 || non_clustered_hosts.count > 0
-          objects.push({:id=>"folder_c_xx-#{to_cid(object.id)}", :text=>ui_lookup(:tables=>"ems_cluster"), :image=>"folder", :tip=>"#{ui_lookup(:tables=>"ems_clusters")} (Click to open)"})
+          objects.push(:id    => "folder_c_xx-#{to_cid(object.id)}",
+                       :text  => ui_lookup(:ems_cluster_types => "cluster"),
+                       :image => "folder",
+                       :tip   => "#{ui_lookup(:ems_cluster_types => "cluster")} (Click to open)")
         end
         return objects
       end

--- a/vmdb/app/controllers/ems_cluster_controller.rb
+++ b/vmdb/app/controllers/ems_cluster_controller.rb
@@ -265,7 +265,7 @@ class EmsClusterController < ApplicationController
 
   def hosts_subsets
     condition         = nil
-    label             = @ems_cluster.name + _(" (All Hosts)")
+    label             = @ems_cluster.name + _(" (All %s)" % title_for_hosts)
     breadcrumb_suffix = ""
 
     host_service_group_name = params[:host_service_group_name]
@@ -279,7 +279,7 @@ class EmsClusterController < ApplicationController
           label     = _("Hosts with failed %s") % host_service_group_name
         when 'all'
           hosts_filter = @ems_cluster.host_ids_with_service_group(host_service_group_name)
-          label     = _("All Hosts with %s") % host_service_group_name
+          label     = _("All %s with %s") % [title_for_hosts, host_service_group_name]
       end
 
       if hosts_filter
@@ -289,6 +289,10 @@ class EmsClusterController < ApplicationController
     end
 
     return label, condition, breadcrumb_suffix
+  end
+
+  def breadcrumb_name
+    title_for_clusters
   end
 
   # Build the tree object to display the ems_cluster datacenter info

--- a/vmdb/app/controllers/ems_cluster_controller.rb
+++ b/vmdb/app/controllers/ems_cluster_controller.rb
@@ -265,7 +265,7 @@ class EmsClusterController < ApplicationController
 
   def hosts_subsets
     condition         = nil
-    label             = @ems_cluster.name + _(" (All %s)" % title_for_hosts)
+    label             = _("%s (All %s)" % [@ems_cluster.name, title_for_hosts])
     breadcrumb_suffix = ""
 
     host_service_group_name = params[:host_service_group_name]

--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -138,8 +138,8 @@ module EmsCommon
         @bottom_msg = "* You are not authorized to view " + pluralize(@view.extras[:total_count] - @view.extras[:auth_count], "other " + ui_lookup(:table=>"storages")) + " on this " + ui_lookup(:table=>@table_name)
       end
     elsif @display == "ems_clusters"
-      drop_breadcrumb({:name => "#{@ems.name} (All #{title_for_clusters})",
-                       :url  => "/#{@table_name}/show/#{@ems.id}?display=ems_clusters"})
+      drop_breadcrumb(:name => "#{@ems.name} (All #{title_for_clusters})",
+                      :url  => "/#{@table_name}/show/#{@ems.id}?display=ems_clusters")
       @view, @pages = get_view(EmsCluster, :parent=>@ems) # Get the records (into a view) and the paginator
       if @view.extras[:total_count] && @view.extras[:auth_count] &&
           @view.extras[:total_count] > @view.extras[:auth_count]

--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -138,7 +138,8 @@ module EmsCommon
         @bottom_msg = "* You are not authorized to view " + pluralize(@view.extras[:total_count] - @view.extras[:auth_count], "other " + ui_lookup(:table=>"storages")) + " on this " + ui_lookup(:table=>@table_name)
       end
     elsif @display == "ems_clusters"
-      drop_breadcrumb( {:name=>@ems.name+" (All Clusters)", :url=>"/#{@table_name}/show/#{@ems.id}?display=ems_clusters"} )
+      drop_breadcrumb({:name => "#{@ems.name} (All #{title_for_clusters})",
+                       :url  => "/#{@table_name}/show/#{@ems.id}?display=ems_clusters"})
       @view, @pages = get_view(EmsCluster, :parent=>@ems) # Get the records (into a view) and the paginator
       if @view.extras[:total_count] && @view.extras[:auth_count] &&
           @view.extras[:total_count] > @view.extras[:auth_count]

--- a/vmdb/app/controllers/host_controller.rb
+++ b/vmdb/app/controllers/host_controller.rb
@@ -620,6 +620,10 @@ class HostController < ApplicationController
 
   private ############################
 
+  def breadcrumb_name
+    title_for_hosts
+  end
+
   # Build the tree object to display the host network info
   def build_network_tree
     @tree_vms = []                   # Capture all VM ids in the tree

--- a/vmdb/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -110,9 +110,17 @@ module MiqAeCustomizationController::CustomButtons
         @resolve[:new][:target_class] = @sb[:target_classes].invert[@nodetype[0].split('-').last]
       else
         #selected button is under assigned folder
-        @resolve[:new][:target_class] = @sb[:target_classes].invert[@nodetype[1]]
+        kls = case @nodetype[1]
+              when "Host"
+                ui_lookup(:host_types => "host")
+              when "EmsCluster"
+                ui_lookup(:ems_cluster_types => "cluster")
+              else
+                @nodetype[1]
+              end
+        @resolve[:new][:target_class] = @sb[:target_classes].invert[kls]
       end
-      @right_cell_text = _("%{model} \"%{name}\"") % {:model=>"Button", :name=>@temp[:custom_button].name}
+      @right_cell_text = _("%{model} \"%{name}\"") % {:model => "Button", :name => @temp[:custom_button].name}
     else                # assigned buttons node/folder
       @sb[:applies_to_class] = @nodetype[1]
       @record = CustomButtonSet.find(from_cid(nodeid.last))

--- a/vmdb/app/controllers/resource_pool_controller.rb
+++ b/vmdb/app/controllers/resource_pool_controller.rb
@@ -53,7 +53,8 @@ class ResourcePoolController < ApplicationController
       end
 
     when "clusters"
-      drop_breadcrumb( {:name=>@record.name+" (All Clusters)", :url=>"/resource_pool/show/#{@record.id}?display=clusters"} )
+      drop_breadcrumb({:name => "#{@record.name} (All #{title_for_clusters})",
+                       :url  => "/resource_pool/show/#{@record.id}?display=clusters"})
       @view, @pages = get_view(EmsCluster, :parent=>@record)  # Get the records (into a view) and the paginator
       @showtype = "clusters"
 

--- a/vmdb/app/controllers/resource_pool_controller.rb
+++ b/vmdb/app/controllers/resource_pool_controller.rb
@@ -53,8 +53,8 @@ class ResourcePoolController < ApplicationController
       end
 
     when "clusters"
-      drop_breadcrumb({:name => "#{@record.name} (All #{title_for_clusters})",
-                       :url  => "/resource_pool/show/#{@record.id}?display=clusters"})
+      drop_breadcrumb(:name => "#{@record.name} (All #{title_for_clusters})",
+                      :url  => "/resource_pool/show/#{@record.id}?display=clusters")
       @view, @pages = get_view(EmsCluster, :parent=>@record)  # Get the records (into a view) and the paginator
       @showtype = "clusters"
 

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1573,7 +1573,10 @@ module ApplicationHelper
     if layout.blank?  # no layout, leave title alone
     elsif ["configuration", "dashboard", "chargeback", "about"].include?(layout)
       title += ": #{layout.titleize}"
-
+    elsif @layout == "ems_cluster"
+      title += ": #{title_for_clusters}"
+    elsif @layout == "host"
+      title += ": #{title_for_hosts}"
     # Specific titles for certain layouts
     elsif layout == "miq_server"
       title += ": Servers"
@@ -2774,6 +2777,48 @@ module ApplicationHelper
       attributes[:id] = "v-#{record.id}"
     end
     attributes
+  end
+
+  def title_for_hosts
+    title_for_host(true)
+  end
+
+  def title_for_host(plural = false)
+    key = case Host.node_types
+          when :non_openstack
+            "host_infra"
+          when :openstack
+            "host_openstack"
+          else
+            "host"
+          end
+    ui_lookup(:host_types => plural ? key.pluralize : key)
+  end
+
+  def title_for_clusters
+    title_for_cluster(true)
+  end
+
+  def title_for_cluster(plural = false)
+    key = case EmsCluster.node_types
+          when :non_openstack
+            "cluster_infra"
+          when :openstack
+            "cluster_openstack"
+          else
+            "cluster"
+          end
+    ui_lookup(:ems_cluster_types => plural ? key.pluralize : key)
+  end
+
+  def title_for_host_record(record)
+    record.openstack_host? ? ui_lookup(:host_types => 'host_openstack') : ui_lookup(:host_types => 'host_infra')
+  end
+
+  def title_for_cluster_record(record)
+    record.openstack_cluster? ?
+      ui_lookup(:ems_cluster_types => 'cluster_openstack') :
+      ui_lookup(:ems_cluster_types => 'cluster_infra')
   end
 
   attr_reader :big_iframe

--- a/vmdb/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -92,7 +92,7 @@ module EmsClusterHelper::TextualSummary
   end
 
   def textual_aggregate_logical_cpus
-    {:label => "Total Host CPU Cores", :value => number_with_delimiter(@record.aggregate_logical_cpus)}
+    {:label => "Total #{title_for_host} CPU Cores", :value => number_with_delimiter(@record.aggregate_logical_cpus)}
   end
 
   def textual_aggregate_vm_memory
@@ -121,9 +121,9 @@ module EmsClusterHelper::TextualSummary
 
   def textual_total_hosts
     num = @record.total_hosts
-    h = {:label => "Hosts", :image => "host", :value => num}
+    h = {:label => title_for_hosts, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")
-      h[:title] = "Show all Hosts"
+      h[:title] = "Show all #{title_for_hosts}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'hosts')
     end
     h
@@ -133,7 +133,7 @@ module EmsClusterHelper::TextualSummary
     num = @record.total_direct_vms
     h = {:label => "Direct VMs", :image => "vm", :value => num}
     if num > 0 && role_allows(:feature => "vm_show_list")
-      h[:title] = "Show VMs in this Cluster, but not in Resource Pools below"
+      h[:title] = "Show VMs in this #{cluster_title}, but not in Resource Pools below"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'vms')
     end
     h
@@ -143,7 +143,7 @@ module EmsClusterHelper::TextualSummary
     num = @record.total_vms
     h = {:label => "All VMs", :image => "vm", :value => num}
     if num > 0 && role_allows(:feature => "vm_show_list")
-      h[:title] = "Show all VMs in this Cluster"
+      h[:title] = "Show all VMs in this #{cluster_title}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'all_vms')
     end
     h
@@ -153,7 +153,7 @@ module EmsClusterHelper::TextualSummary
     num = @record.total_miq_templates
     h = {:label => "All Templates", :image => "vm", :value => num}
     if num > 0 && role_allows(:feature => "miq_template_show_list")
-      h[:title] = "Show all Templates in this Cluster"
+      h[:title] = "Show all Templates in this #{cluster_title}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'miq_templates')
     end
     h
@@ -163,7 +163,7 @@ module EmsClusterHelper::TextualSummary
     num = @record.total_vms
     h = {:label => "All VMs (Tree View)", :image => "vm", :value => num}
     if num > 0 && role_allows(:feature => "vm_show_list")
-      h[:title] = "Show tree of all VMs by Resource Pool in this Cluster"
+      h[:title] = "Show tree of all VMs by Resource Pool in this #{cluster_title}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'descendant_vms')
     end
     h
@@ -184,7 +184,7 @@ module EmsClusterHelper::TextualSummary
     num = @record.number_of(:drift_states)
     h = {:label => "Drift History", :image => "drift", :value => (num == 0 ? "None" : num)}
     if num > 0
-      h[:title] = "Show cluster drift history"
+      h[:title] = "Show #{cluster_title} drift history"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'drift_history', :id => @record)
     end
     h
@@ -275,5 +275,9 @@ module EmsClusterHelper::TextualSummary
     value = @record.drs_migration_threshold
     return nil if value.nil?
     {:label => "DRS Migration Threshold", :value => value}
+  end
+
+  def cluster_title
+    title_for_cluster_record(@record)
   end
 end

--- a/vmdb/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_infra_helper/textual_summary.rb
@@ -44,19 +44,19 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_cpu_resources
-    {:label => "Aggregate Host CPU Resources", :value => mhz_to_human_size(@ems.aggregate_cpu_speed)}
+    {:label => "Aggregate #{title_for_host} CPU Resources", :value => mhz_to_human_size(@ems.aggregate_cpu_speed)}
   end
 
   def textual_memory_resources
-    {:label => "Aggregate Host Memory", :value => number_to_human_size(@ems.aggregate_memory * 1.megabyte,:precision=>0)}
+    {:label => "Aggregate #{title_for_host} Memory", :value => number_to_human_size(@ems.aggregate_memory * 1.megabyte,:precision=>0)}
   end
 
   def textual_cpus
-    {:label => "Aggregate Host CPUs", :value => @ems.aggregate_physical_cpus}
+    {:label => "Aggregate #{title_for_host} CPUs", :value => @ems.aggregate_physical_cpus}
   end
 
   def textual_cpu_cores
-    {:label => "Aggregate Host CPU Cores", :value => @ems.aggregate_logical_cpus}
+    {:label => "Aggregate #{title_for_host} CPU Cores", :value => @ems.aggregate_logical_cpus}
   end
 
   def textual_guid
@@ -64,7 +64,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_infrastructure_folders
-    label     = "Hosts & Clusters"
+    label     = "#{title_for_hosts} & #{title_for_clusters}"
     available = @ems.number_of(:ems_folders) > 0 && @ems.ems_folder_root
     h         = {:label => label, :image => "hosts_and_clusters", :value => available ? "Available" : "N/A"}
     if available
@@ -86,7 +86,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_clusters
-    label = "Clusters"
+    label = title_for_clusters
     num   = @ems.number_of(:ems_clusters)
     h     = {:label => label, :image => "cluster", :value => num}
     if num > 0 && role_allows(:feature => "ems_cluster_show_list")
@@ -97,7 +97,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_hosts
-    label = "Hosts"
+    label = title_for_hosts
     num   = @ems.number_of(:hosts)
     h     = {:label => label, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")
@@ -240,7 +240,7 @@ module EmsInfraHelper::TextualSummary
     value = @ems.host_default_vnc_port_start.blank? ?
         "" :
         "#{@ems.host_default_vnc_port_start} - #{@ems.host_default_vnc_port_end}"
-    {:label => "Host Default VNC Port Range", :value => value}
+    {:label => "#{title_for_host} Default VNC Port Range", :value => value}
   end
 
 end

--- a/vmdb/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_infra_helper/textual_summary.rb
@@ -48,7 +48,8 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_memory_resources
-    {:label => "Aggregate #{title_for_host} Memory", :value => number_to_human_size(@ems.aggregate_memory * 1.megabyte,:precision=>0)}
+    {:label => "Aggregate #{title_for_host} Memory",
+     :value => number_to_human_size(@ems.aggregate_memory * 1.megabyte, :precision => 0)}
   end
 
   def textual_cpus

--- a/vmdb/app/helpers/host_helper/textual_summary.rb
+++ b/vmdb/app/helpers/host_helper/textual_summary.rb
@@ -207,7 +207,7 @@ module HostHelper::TextualSummary
     num = @record.hardware.nil? ? 0 : @record.hardware.number_of(:storage_adapters)
     h = {:label => "Storage Adapters", :image => "sa", :value => num}
     if num > 0
-      h[:title] = "Show Host Storage Adapters"
+      h[:title] = "Show #{host_title} Storage Adapters"
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'storage_adapters')
     end
     h
@@ -217,7 +217,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:switches)
     h = {:label => "Network", :image => "network", :value => (num == 0 ? "N/A" : "Available")}
     if num > 0
-      h[:title] = "Show Host Network"
+      h[:title] = "Show #{host_title} Network"
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'network')
     end
     h
@@ -226,7 +226,7 @@ module HostHelper::TextualSummary
   def textual_devices
     h = {:label => "Devices", :image => "devices", :value => (@devices == nil || @devices.empty? ? "None" : @devices.length)}
     if @devices.length > 0
-      h[:title] = "Show Host devices"
+      h[:title] = "Show #{host_title} devices"
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'devices')
     end
     h
@@ -266,9 +266,9 @@ module HostHelper::TextualSummary
 
   def textual_cluster
     cluster = @record.ems_cluster
-    h = {:label => "Cluster", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
+    h = {:label => title_for_cluster, :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
     if cluster && role_allows(:feature => "ems_cluster_show")
-      h[:title] = "Show this Host's Cluster"
+      h[:title] = "Show this #{host_title}'s #{title_for_cluster}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
@@ -315,7 +315,7 @@ module HostHelper::TextualSummary
     label = ui_lookup(:table => "availability_zone")
     h = {:label => label, :image => "availability_zone", :value => (availability_zone.nil? ? "None" : availability_zone.name)}
     if availability_zone && role_allows(:feature => "availability_zone_show")
-      h[:title] = _("Show this Host's %s") % label
+      h[:title] = _("Show this %s's %s") % [host_title, label]
       h[:link]  = url_for(:controller => 'availability_zone', :action => 'show', :id => availability_zone)
     end
     h
@@ -328,7 +328,7 @@ module HostHelper::TextualSummary
     num   = @record.cloud_tenants.count
     h     = {:label => label, :image => "cloud_tenants", :value => num}
     if num > 0 && role_allows(:feature => "cloud_tenant_show_list")
-      h[:title] = _("Show all used %s on this host") % label
+      h[:title] = _("Show all used %s on this %s") % [host_title, label]
       h[:link]  = url_for(:action => "show", :id => @record, :display => "cloud_tenants")
     end
     h
@@ -435,7 +435,7 @@ module HostHelper::TextualSummary
     else
       h[:image] = "compliance"
       h[:value] = "Available"
-      h[:title] = "Show Compliance History of this Host (Last 10 Checks)"
+      h[:title] = "Show Compliance History of this #{host_title} (Last 10 Checks)"
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => 'compliance_history')
     end
     h
@@ -457,7 +457,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:groups)
     h = {:label => "Groups", :image => "group", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, 'group')} defined on this Host"
+      h[:title] = "Show the #{pluralize(num, 'group')} defined on this #{host_title}"
       h[:link]  = url_for(:action => 'groups', :id => @record, :db => controller.controller_name)
     end
     h
@@ -468,7 +468,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:firewall_rules)
     h = {:label => "Firewall Rules", :image => "firewallrule", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, 'Firewall Rule')} defined on this Host"
+      h[:title] = "Show the #{pluralize(num, 'Firewall Rule')} defined on this #{host_title}"
       h[:link]  = url_for(:action => 'firewall_rules', :id => @record, :db => controller.controller_name)
     end
     h
@@ -484,7 +484,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:patches)
     h = {:label => "Patches", :image => "patch", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, 'Patch')} defined on this Host"
+      h[:title] = "Show the #{pluralize(num, 'Patch')} defined on this #{host_title}"
       h[:link]  = url_for(:action => 'patches', :id => @record, :db => controller.controller_name)
     end
     h
@@ -494,7 +494,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:guest_applications)
     h = {:label => "Packages", :image => "guest_application", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, "Package")} installed on this Host"
+      h[:title] = "Show the #{pluralize(num, "Package")} installed on this #{host_title}"
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'guest_applications', :id => @record, :db => controller.controller_name)
     end
     h
@@ -504,7 +504,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:host_services)
     h = {:label => "Services", :image => "service", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, 'Service')} installed on this Host"
+      h[:title] = "Show the #{pluralize(num, 'Service')} installed on this #{host_title}"
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'host_services', :id => @record, :db => controller.controller_name)
     end
     h
@@ -514,7 +514,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:filesystems)
     h = {:label => "Files", :image => "filesystems", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, 'File')} installed on this Host"
+      h[:title] = "Show the #{pluralize(num, 'File')} installed on this #{host_title}"
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'filesystems', :id => @record, :db => controller.controller_name)
     end
     h
@@ -524,7 +524,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:advanced_settings)
     h = {:label => "Advanced Settings", :image => "advancedsetting", :value => num}
     if num > 0
-      h[:title] = "Show the #{pluralize(num, 'Advanced Setting')} installed on this Host"
+      h[:title] = "Show the #{pluralize(num, 'Advanced Setting')} installed on this #{host_title}"
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'advanced_settings', :id => @record, :db => controller.controller_name)
     end
     h
@@ -534,7 +534,7 @@ module HostHelper::TextualSummary
     num = @record.operating_system.nil? ? 0 : @record.operating_system.number_of(:event_logs)
     h = {:label => "ESX Logs", :image => "logs", :value => (num == 0 ? "Not Available" : "Available")}
     if num > 0
-      h[:title] = "Show Host Network"
+      h[:title] = "Show #{host_title} Network"
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'event_logs')
     end
     h
@@ -569,5 +569,9 @@ module HostHelper::TextualSummary
 
       {:label => "#{label} Credentials", :value => auth.status || "None", :title => auth.status_details}
     end
+  end
+
+  def host_title
+    title_for_host_record(@record)
   end
 end

--- a/vmdb/app/helpers/ontap_file_share_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ontap_file_share_helper/textual_summary.rb
@@ -105,7 +105,7 @@ module OntapFileShareHelper::TextualSummary
   end
 
   def textual_hosts
-    label = "Hosts"
+    label = title_for_hosts
     num   = @record.hosts_size
     h     = {:label => label, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")

--- a/vmdb/app/helpers/ontap_logical_disk_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ontap_logical_disk_helper/textual_summary.rb
@@ -233,7 +233,7 @@ module OntapLogicalDiskHelper::TextualSummary
   end
 
   def textual_hosts
-    label = "Hosts"
+    label = title_for_hosts
     num   = @record.hosts_size
     h     = {:label => label, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")

--- a/vmdb/app/helpers/ontap_storage_system_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ontap_storage_system_helper/textual_summary.rb
@@ -119,7 +119,7 @@ module OntapStorageSystemHelper::TextualSummary
   end
 
   def textual_hosts
-    label = "Hosts"
+    label = title_for_hosts
     num   = @record.hosts_size
     h     = {:label => label, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")

--- a/vmdb/app/helpers/ontap_storage_volume_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ontap_storage_volume_helper/textual_summary.rb
@@ -134,7 +134,7 @@ module OntapStorageVolumeHelper::TextualSummary
   end
 
   def textual_hosts
-    label = "Hosts"
+    label = title_for_hosts
     num   = @record.hosts_size
     h     = {:label => label, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")

--- a/vmdb/app/helpers/provider_foreman_helper.rb
+++ b/vmdb/app/helpers/provider_foreman_helper.rb
@@ -5,7 +5,7 @@ module ProviderForemanHelper
   end
 
   def textual_hostname
-    {:label => "Host Name", :value => @record.hostname}
+    {:label => "#{title_for_host} Name", :value => @record.hostname}
   end
 
   def textual_configuration_profile

--- a/vmdb/app/helpers/resource_pool_helper/textual_summary.rb
+++ b/vmdb/app/helpers/resource_pool_helper/textual_summary.rb
@@ -33,15 +33,18 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_aggregate_cpu_speed
     # TODO: Why aren't we using mhz_to_human_size here?
-    {:label => "Total #{title_for_host} CPU Resources", :value => "#{number_with_delimiter(@record.aggregate_cpu_speed)} MHz"}
+    {:label => "Total #{title_for_host} CPU Resources",
+     :value => "#{number_with_delimiter(@record.aggregate_cpu_speed)} MHz"}
   end
 
   def textual_aggregate_cpu_memory
-    {:label => "Total #{title_for_host} Memory", :value => number_to_human_size(@record.aggregate_memory.megabytes, :precision => 0)}
+    {:label => "Total #{title_for_host} Memory",
+     :value => number_to_human_size(@record.aggregate_memory.megabytes, :precision => 0)}
   end
 
   def textual_aggregate_physical_cpus
-    {:label => "Total #{title_for_host} CPUs", :value => number_with_delimiter(@record.aggregate_physical_cpus)}
+    {:label => "Total #{title_for_host} CPUs",
+     :value => number_with_delimiter(@record.aggregate_physical_cpus)}
   end
 
   def textual_aggregate_logical_cpus
@@ -62,7 +65,9 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_parent_cluster
     cluster = @record.parent_cluster
-    h = {:label => "Parent '#{title_for_cluster}'", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
+    h = {:label => "Parent '#{title_for_cluster}'",
+         :image => "ems_cluster",
+         :value => (cluster.nil? ? "None" : cluster.name)}
     if cluster && role_allows(:feature => "ems_cluster_show")
       h[:title] = "Show Parent #{title_for_cluster} #{cluster.name}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)

--- a/vmdb/app/helpers/resource_pool_helper/textual_summary.rb
+++ b/vmdb/app/helpers/resource_pool_helper/textual_summary.rb
@@ -33,19 +33,19 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_aggregate_cpu_speed
     # TODO: Why aren't we using mhz_to_human_size here?
-    {:label => "Total Host CPU Resources", :value => "#{number_with_delimiter(@record.aggregate_cpu_speed)} MHz"}
+    {:label => "Total #{title_for_host} CPU Resources", :value => "#{number_with_delimiter(@record.aggregate_cpu_speed)} MHz"}
   end
 
   def textual_aggregate_cpu_memory
-    {:label => "Total Host Memory", :value => number_to_human_size(@record.aggregate_memory.megabytes, :precision => 0)}
+    {:label => "Total #{title_for_host} Memory", :value => number_to_human_size(@record.aggregate_memory.megabytes, :precision => 0)}
   end
 
   def textual_aggregate_physical_cpus
-    {:label => "Total Host CPUs", :value => number_with_delimiter(@record.aggregate_physical_cpus)}
+    {:label => "Total #{title_for_host} CPUs", :value => number_with_delimiter(@record.aggregate_physical_cpus)}
   end
 
   def textual_aggregate_logical_cpus
-    {:label => "Total Host CPU Cores", :value => number_with_delimiter(@record.aggregate_logical_cpus)}
+    {:label => "Total #{title_for_host} CPU Cores", :value => number_with_delimiter(@record.aggregate_logical_cpus)}
   end
 
   def textual_aggregate_vm_memory
@@ -62,9 +62,9 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_parent_cluster
     cluster = @record.parent_cluster
-    h = {:label => "Parent Cluster", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
+    h = {:label => "Parent '#{title_for_cluster}'", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
     if cluster && role_allows(:feature => "ems_cluster_show")
-      h[:title] = "Show Parent Cluster '#{cluster.name}'"
+      h[:title] = "Show Parent #{title_for_cluster} #{cluster.name}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
@@ -72,9 +72,9 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_parent_host
     host = @record.parent_host
-    h = {:label => "Parent Host", :image => "host", :value => (host.nil? ? "None" : host.name)}
+    h = {:label => "Parent #{title_for_host}", :image => "host", :value => (host.nil? ? "None" : host.name)}
     if host && role_allows(:feature => "host_show")
-      h[:title] = "Show Parent Host '#{host.name}'"
+      h[:title] = "Show Parent #{title_for_host} '#{host.name}'"
       h[:link]  = url_for(:controller => 'host', :action => 'show', :id => host)
     end
     h

--- a/vmdb/app/helpers/storage_helper/textual_summary.rb
+++ b/vmdb/app/helpers/storage_helper/textual_summary.rb
@@ -71,7 +71,7 @@ module StorageHelper::TextualSummary
   end
 
   def textual_hosts
-    label = "Hosts"
+    label = title_for_hosts
     num   = @record.number_of(:hosts)
     h     = {:label => label, :image => "host", :value => num}
     if num > 0 && role_allows(:feature => "host_show_list")

--- a/vmdb/app/helpers/vm_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_helper/textual_summary.rb
@@ -160,7 +160,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_host_platform
-    {:label => "Parent Host Platform", :value => (@record.host.nil? ? "N/A" : @record.v_host_vmm_product)}
+    {:label => "Parent #{title_for_host} Platform", :value => (@record.host.nil? ? "N/A" : @record.v_host_vmm_product)}
   end
 
   def textual_tools_status
@@ -263,9 +263,9 @@ module VmHelper::TextualSummary
 
   def textual_cluster
     cluster = @record.ems_cluster
-    h = {:label => "Cluster", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
+    h = {:label => title_for_cluster, :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
     if cluster && role_allows(:feature => "ems_cluster_show")
-      h[:title] = "Show this VM's Cluster"
+      h[:title] = "Show this VM's #{title_for_cluster}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
@@ -273,9 +273,9 @@ module VmHelper::TextualSummary
 
   def textual_host
     host = @record.host
-    h = {:label => "Host", :image => "host", :value => (host.nil? ? "None" : host.name)}
+    h = {:label => title_for_host, :image => "host", :value => (host.nil? ? "None" : host.name)}
     if host && role_allows(:feature => "host_show")
-      h[:title] = "Show this VM's Host"
+      h[:title] = "Show this VM's #{title_for_host}"
       h[:link]  = url_for(:controller => 'host', :action => 'show', :id => host)
     end
     h

--- a/vmdb/app/helpers/vm_infra_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_infra_helper/textual_summary.rb
@@ -145,7 +145,7 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_host_platform
-    {:label => "Parent Host Platform", :value => (@record.host.nil? ? "N/A" : @record.v_host_vmm_product)}
+    {:label => "Parent #{title_for_host} Platform", :value => (@record.host.nil? ? "N/A" : @record.v_host_vmm_product)}
   end
 
   def textual_tools_status
@@ -216,9 +216,9 @@ module VmCloudHelper::TextualSummary
 
   def textual_cluster
     cluster = @record.ems_cluster
-    h = {:label => "Cluster", :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
+    h = {:label => title_for_cluster, :image => "ems_cluster", :value => (cluster.nil? ? "None" : cluster.name)}
     if cluster && role_allows(:feature => "ems_cluster_show")
-      h[:title] = "Show this VM's Cluster"
+      h[:title] = "Show this VM's #{title_for_cluster}"
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
     end
     h
@@ -226,9 +226,9 @@ module VmCloudHelper::TextualSummary
 
   def textual_host
     host = @record.host
-    h = {:label => "Host", :image => "host", :value => (host.nil? ? "None" : host.name)}
+    h = {:label => title_for_host, :image => "host", :value => (host.nil? ? "None" : host.name)}
     if host && role_allows(:feature => "host_show")
-      h[:title] = "Show this VM's Host"
+      h[:title] = "Show this VM's #{title_for_host}"
       h[:link]  = url_for(:controller => 'host', :action => 'show', :id => host)
     end
     h

--- a/vmdb/app/presenters/tree_builder_utilization.rb
+++ b/vmdb/app/presenters/tree_builder_utilization.rb
@@ -14,9 +14,9 @@ class TreeBuilderUtilization  < TreeBuilderRegion
       objects = []
       if ems_clusters_count > 0 || non_clustered_hosts_count > 0
         objects.push(:id    => "folder_c_xx-#{to_cid(object.id)}",
-                     :text  => ui_lookup(:tables => "ems_cluster"),
+                     :text  => ui_lookup(:ems_cluster_types => "cluster"),
                      :image => "folder",
-                     :tip   => "#{ui_lookup(:tables => "ems_clusters")} (Click to open)")
+                     :tip   => "#{ui_lookup(:ems_cluster_types => "cluster")} (Click to open)")
       end
       objects
     end

--- a/vmdb/app/views/configuration/_ui_2.html.haml
+++ b/vmdb/app/views/configuration/_ui_2.html.haml
@@ -121,12 +121,12 @@
                     %ul#toolbars= render_view_buttons(:emsinfra, @edit[:new][:views][:emsinfra])
               - if role_allows(:feature => "ems_cluster_show_list")
                 %tr
-                  %td.key= _('Clusters')
+                  %td.key=title_for_clusters
                   %td
                     %ul#toolbars= render_view_buttons(:emscluster, @edit[:new][:views][:emscluster])
               - if role_allows(:feature => "host_show_list")
                 %tr
-                  %td.key= _('Hosts')
+                  %td.key=title_for_hosts
                   %td
                     %ul#toolbars= render_view_buttons(:host, @edit[:new][:views][:host])
               - if role_allows(:feature => "vandt_accord")      ||

--- a/vmdb/app/views/ems_cloud/discover.html.haml
+++ b/vmdb/app/views/ems_cloud/discover.html.haml
@@ -10,7 +10,7 @@
           = button_tag(_("Start"),
                        :name  => "start",
                        :class => "btn btn-primary",
-                       :alt   => t = _("Start the Host Discovery"),
+                       :alt   => t = _("Start the %s Discovery") % title_for_host,
                        :title => t,
                        :type  => "submit")
           = button_tag(_("Cancel"),

--- a/vmdb/app/views/ems_cluster/_main.html.haml
+++ b/vmdb/app/views/ems_cluster/_main.html.haml
@@ -5,7 +5,7 @@
     - if get_vmdb_config[:product][:storage]
       = render :partial => "shared/summary/textual", :locals => {:title => _("Storage Relationships"), :items => textual_group_storage_relationships}
   .col-sm-12.col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for Hosts"), :items => textual_group_host_totals}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for %s") % title_for_hosts, :items => textual_group_host_totals}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for VMs"), :items => textual_group_vm_totals}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Configuration"), :items => textual_group_configuration}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/vmdb/app/views/layouts/_discover.html.haml
+++ b/vmdb/app/views/layouts/_discover.html.haml
@@ -59,7 +59,7 @@
     = button_tag(_("Start"),
                  :class => "btn btn-primary",
                  :name  => "start",
-                 :alt   => t = _("Start the Host Discovery"),
+                 :alt   => t = _("Start the %s Discovery") % title_for_host,
                  :title => t,
                  :type  => "submit")
     = button_tag(_("Cancel"),

--- a/vmdb/app/views/layouts/_form_buttons_verify.html.haml
+++ b/vmdb/app/views/layouts/_form_buttons_verify.html.haml
@@ -10,8 +10,8 @@
   - id = record_id ? record_id : nil
 
 - if session[:host_items].present?
-  - verify_title_off = _("Host to validate against, User ID and matching password fields are needed to perform verification of credentials")
-  - verify_title_on  = _("Validate the credentials by logging into the selected Host")
+  - verify_title_off = _("%s to validate against, User ID and matching password fields are needed to perform verification of credentials") % title_for_host
+  - verify_title_on  = _("Validate the credentials by logging into the selected %s") % title_for_host
 - else
   - verify_title_off ||= _("Server information, User ID and matching password fields are needed to perform verification of credentials")
   - verify_title_on  ||= _("Validate the credentials by logging into the Server")

--- a/vmdb/app/views/layouts/_multi_auth_credentials.html.haml
+++ b/vmdb/app/views/layouts/_multi_auth_credentials.html.haml
@@ -69,7 +69,7 @@
                                 :change_url   => change_url,
                                 :ujs_button   => true,
                                 :record       => record})
-      %span{:style => "color:black"}= _("Used for shh connection to all Hosts in this provider.")
+      %span{:style => "color:black"}= _("Used for shh connection to all %s in this provider.") % title_for_hosts
   - else
     #remote{:name => _("Remote Login")}
       %table.style1
@@ -105,7 +105,7 @@
   %table.admintable
     %tbody
       %tr
-        %td.key= _("Select Host to validate against")
+        %td.key= _("Select %s to validate against") % title_for_host
         %td
           = select_tag('validate_id',
                        options_for_select(@edit[:selected_hosts].invert.sort,

--- a/vmdb/app/views/layouts/_perf_options.html.haml
+++ b/vmdb/app/views/layouts/_perf_options.html.haml
@@ -96,8 +96,8 @@
 
       - if @perf_options[:model] == "VmOrTemplate" && @perf_options[:typ] != "realtime"
         - compare_choices = []
-        - compare_choices.push(["Parent Host", "Host"]) if @perf_record.host
-        - compare_choices.push(["Parent Cluster", "EmsCluster"]) if @perf_record.ems_cluster
+        - compare_choices.push(["Parent '#{title_for_host}'", "Host"]) if @perf_record.host
+        - compare_choices.push(["Parent '#{title_for_cluster}'", "EmsCluster"]) if @perf_record.ems_cluster
 
         - unless compare_choices.empty?
           %dt

--- a/vmdb/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/vmdb/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -1,7 +1,7 @@
 - valtype ||= "default"
 
 - if !session[:host_items].nil?
-  - verify_title_on = "Validate the credentials by logging into the selected Host"
+  - verify_title_on = "Validate the credentials by logging into the selected %s" % title_for_host
 - else
   - verify_title_on = "Validate the credentials by logging into the Server"
 

--- a/vmdb/app/views/layouts/listnav/_cim_base_storage_extent.html.haml
+++ b/vmdb/app/views/layouts/listnav/_cim_base_storage_extent.html.haml
@@ -67,7 +67,7 @@
             :tables                => 'host',
             :display               => 'hosts',
             :action                => 'show',
-            :title                 => _("Show all %s") % ui_lookup(:tables => "host"))
+            :title                 => _("Show all %s") % title_for_hosts)
 
         - if role_allows(:feature => "storage_show_list")
           = li_link_if_nonzero(:count => @record.storages.count,

--- a/vmdb/app/views/layouts/listnav/_cim_storage_extent.html.haml
+++ b/vmdb/app/views/layouts/listnav/_cim_storage_extent.html.haml
@@ -66,7 +66,7 @@
             :tables                => 'host',
             :display               => 'hosts',
             :action                => 'show',
-            :title                 => _("Show all %s") % ui_lookup(:tables => "host"))
+            :title                 => _("Show all %s") % title_for_hosts)
 
         - if role_allows(:feature => "storage_show_list")
           = li_link_if_nonzero(:count => @record.storages.count,

--- a/vmdb/app/views/layouts/listnav/_ems_cluster.html.haml
+++ b/vmdb/app/views/layouts/listnav/_ems_cluster.html.haml
@@ -1,4 +1,5 @@
 - if @record.try(:name)
+  - cluster_title = title_for_cluster_record(@record)
   #accordion.panel-group
     = patternfly_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
       = render :partial => "layouts/quadicon", :locals => {:mode => :icon, :item => @record, :size => 72, :typ => :listnav}
@@ -38,14 +39,15 @@
     = patternfly_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
         - if role_allows(:feature => "host_show_list")
+          - hosts_title = title_for_hosts
           - if @record.total_hosts == 0
             %li.disabled
-              = link_to(_("Hosts (%s)") % @record.total_hosts, "#")
+              = link_to(_("%s (%s)") % [hosts_title, @record.total_hosts], "#")
           - else
             %li
-              = link_to(_("Hosts (%s)") % @record.total_hosts,
+              = link_to(_("%s (%s)") % [hosts_title, @record.total_hosts],
                 {:action => 'show', :id => @record, :display => 'hosts'},
-                :title => _("Show Hosts"))
+                :title => _("Show %s") % hosts_title)
 
         - if role_allows(:feature => "vm_show_list")
           - if @record.total_direct_vms == 0
@@ -55,7 +57,7 @@
             %li
               = link_to(_("Direct VMs: %s") % @record.total_direct_vms,
                 {:action => 'show', :display => "vms", :id => @record.id.to_s},
-                :title => _("Show VMs in this Cluster, but not in Resource Pools below"))
+                :title => _("Show VMs in this #{cluster_title}, but not in Resource Pools below"))
         - if role_allows(:feature => "vm_show_list")
           - if @record.total_vms == 0
             %li.disabled
@@ -64,7 +66,7 @@
             %li
               = link_to(_("All VMs: %s") % @record.total_vms,
                 {:action => 'show', :display => "all_vms", :id => @record.id.to_s},
-                :title => _("Show all VMs in this Cluster"))
+                :title => _("Show all VMs in this #{cluster_title}"))
         - if role_allows(:feature => "miq_template_show_list")
           - if @record.total_miq_templates == 0
             %li.disabled
@@ -73,7 +75,7 @@
             %li
               = link_to(_("All Templates: %s") % @record.total_miq_templates,
                 {:action => 'show', :display => "miq_templates", :id => @record.id.to_s},
-                :title => _("Show all Templates in this Cluster"))
+                :title => _("Show all Templates in this #{cluster_title}"))
         - if role_allows(:feature => "vm_show_list")
           - if @record.total_vms == 0
             %li.disabled
@@ -82,7 +84,7 @@
             %li
               = link_to(_("All VMs (Tree View): %s") % @record.total_vms,
                 {:action => 'show', :display => "descendant_vms", :id => @record.id.to_s},
-                :title => _("Show tree of all VMs by Resource Pool in this Cluster"))
+                :title => _("Show tree of all VMs by Resource Pool in this #{cluster_title}"))
         - if role_allows(:feature => "resource_pool_show_list")
           - if @record.number_of(:resource_pools) == 0
             %li.disabled
@@ -100,7 +102,7 @@
             %li
               = link_to(_("Drift History (%s)") % @record.number_of(:drift_states),
                 {:action => 'drift_history', :id => @record},
-                :title => _("Show cluster drift history"))
+                :title => _("Show #{cluster_title} drift history"))
 
     - if get_vmdb_config[:product][:storage]
       = patternfly_accordion_panel(_("Storage Relationships"), false, "host_inf_rel") do

--- a/vmdb/app/views/layouts/listnav/_ems_infra.html.haml
+++ b/vmdb/app/views/layouts/listnav/_ems_infra.html.haml
@@ -1,4 +1,6 @@
 - if @record.try(:name)
+  - hosts_title    = title_for_hosts
+  - clusters_title = title_for_clusters
   #accordion.panel-group
     = patternfly_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
       = render :partial => "layouts/quadicon", :locals => {:mode => :icon, :item => @record, :size => 72, :typ => :listnav}
@@ -22,12 +24,12 @@
       %ul.nav.nav-pills.nav-stacked
         - if @record.number_of(:ems_folders) == 0 || @record.ems_folder_root.nil?
           %li.disabled
-            = link_to(_('Hosts & Clusters'), "#")
+            = link_to(_("'#{hosts_title}' & '#{clusters_title}'"), "#")
         - else
           %li
-            = link_to(_('Hosts & Clusters'),
+            = link_to(_("'#{hosts_title}' & '#{clusters_title}'"),
               {:action => 'show', :id => @record, :display => 'ems_folders'},
-              :title => _("Show Hosts & Clusters"))
+              :title => _("Show %s & %s") % [hosts_title, clusters_title])
 
         - if @record.number_of(:ems_folders) == 0 || @record.ems_folder_root.nil?
           %li.disabled
@@ -41,22 +43,22 @@
         - if role_allows(:feature => "ems_cluster_show_list")
           - if @record.number_of(:ems_clusters) == 0
             %li.disabled
-              = link_to(_("Clusters (%s)") % @record.number_of(:ems_clusters), "#")
+              = link_to("#{clusters_title} (#{@record.number_of(:ems_clusters)})", "#")
           - else
             %li
-              = link_to_with_icon(_("Clusters (%s)") % @record.number_of(:ems_clusters),
+              = link_to_with_icon("#{clusters_title} (#{@record.number_of(:ems_clusters)})",
                 {:action => 'show', :id => @record, :display => 'ems_clusters'},
-                :title => _("Show all managed Clusters"))
+                :title => _("Show all managed %s") % clusters_title)
 
         - if role_allows(:feature => "host_show_list")
           - if @record.number_of(:hosts) == 0
             %li.disabled
-              = link_to(_("Hosts (%s)") % @record.number_of(:hosts), "#")
+              = link_to("#{hosts_title} (#{@record.number_of(:hosts)}", "#")
           - else
             %li
-              = link_to_with_icon(_("Hosts (%s)") % @record.number_of(:hosts),
+              = link_to_with_icon("#{hosts_title} (#{@record.number_of(:hosts)})",
                 {:action => 'show', :id => @record, :display => 'hosts'},
-                :title => _("Show all managed Hosts"))
+                :title => _("Show all managed %s") % hosts_title)
 
         - if role_allows(:feature => "storage_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:storages),

--- a/vmdb/app/views/layouts/listnav/_host.html.haml
+++ b/vmdb/app/views/layouts/listnav/_host.html.haml
@@ -1,4 +1,5 @@
 - if @record
+  - host_title = title_for_host_record(@record)
   #accordion.panel-group
     = patternfly_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
       - # Calculate the quadicon div height based on # of lines of text
@@ -34,7 +35,7 @@
           %li
             = link_to(_('Devices'),
               {:action  => 'show', :id => @record, :display => 'devices'},
-              :title => _("Show Host devices"))
+              :title => _("Show %s devices") % host_title)
 
         - if @record.number_of(:switches) == 0
           %li.disabled
@@ -43,7 +44,7 @@
           %li
             = link_to(_('Network'),
               {:action  => 'show', :id => @record, :display => 'network'},
-              :title => _("Show Host network"))
+              :title => _("Show %s network") % host_title)
 
         - if @record.hardware.blank? || @record.hardware.number_of(:storage_adapters) == 0
           %li.disabled
@@ -52,7 +53,7 @@
           %li
             = link_to(_('Storage Adapters'),
               {:action  => 'show', :id => @record, :display => 'storage_adapters'},
-              :title => _("Show Host storage adapters"))
+              :title => _("Show %s storage adapters") % host_title)
 
         - if @osinfo.nil? || @osinfo.empty?
           %li.disabled
@@ -61,7 +62,7 @@
           %li
             = link_to(_('OS Information'),
               {:action  => 'show', :id => @record, :display => 'os_info'},
-              :title => _("Show Host OS information"))
+              :title => _("Show %s OS information") % host_title)
 
         - if @vmminfo.nil? || @vmminfo.empty?
           %li.disabled
@@ -106,14 +107,15 @@
           %li
             = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
               {:controller => "ems_infra", :action => 'show', :id => @record.ext_management_system.id.to_s},
-              {:title => _("Show this Host's parent %s") % ui_lookup(:table => "ems_infra")},
+              {:title => _("Show this %s parent %s") % ["#{host_title}'s", ui_lookup(:table => "ems_infra")]},
               '/images/icons/16/link_external.gif')
 
         - if role_allows(:feature => "ems_cluster_show") && !@record.ems_cluster.nil?
+          - cluster_title = title_for_cluster
           %li
-            = link_to("Cluster: #{@record.ems_cluster.name}",
+            = link_to("#{cluster_title}: #{@record.ems_cluster.name}",
               {:controller => "ems_cluster", :action => 'show', :id => @record.ems_cluster.id.to_s},
-              {:title => _("Show this Host's parent Cluster")},
+              {:title => _("Show %s parent %s") % ["#{host_title}'s", cluster_title]},
               '/images/icons/16/link_external.gif')
 
         - if role_allows(:feature => "storage_show_list")
@@ -165,7 +167,7 @@
             %li
               = link_to(_("Drift History (%s)") % states_size,
                 {:action => 'drift_history', :id => @record},
-                :title => _("Show host drift history"))
+                :title => _("Show %s drift history") % host_title)
 
     - if get_vmdb_config[:product][:storage]
       = patternfly_accordion_panel(_("Storage Relationships"), false, "host_inf_rel") do
@@ -205,7 +207,7 @@
           %li
             = link_to(_("Users (%s)") % users_size,
               {:action => 'users', :id => @record, :db => "host"},
-              :title => _("Show the users defined on this Host"))
+              :title => _("Show the users defined on this %s") % host_title)
         - groups_size = @record.number_of(:groups)
         - if groups_size == 0
           %li.disabled
@@ -214,7 +216,7 @@
           %li
             = link_to(_("Groups (%s)") % groups_size,
               {:action => 'groups', :id => @record, :db => "host"},
-              :title => _("Show the groups defined on this Host"))
+              :title => _("Show the groups defined on this %s") % host_title)
 
         - patches_size = @record.number_of(:patches)
         - if patches_size == 0
@@ -224,7 +226,7 @@
           %li
             = link_to(_("Patches (%s)") % patches_size,
               {:action => 'patches', :id => @record, :db => "host"},
-              :title => _("Show the patches installed on this Host"))
+              :title => _("Show the patches installed on this %s") % host_title)
 
         - fws_size = @record.number_of(:firewall_rules)
         - if fws_size == 0
@@ -234,7 +236,7 @@
           %li
             = link_to(_("Firewall Rules (%s)") % fws_size,
               {:action => 'firewall_rules', :id => @record},
-              :title => _("Show the firewall rules on this Host"))
+              :title => _("Show the firewall rules on this %s") % host_title)
 
     = patternfly_accordion_panel(_("Configuration"), false, "host_config") do
       %ul.nav.nav-pills.nav-stacked
@@ -246,7 +248,7 @@
           %li
             = link_to(_("Packages (%s)") % gas_size,
               {:action => 'guest_applications', :id => @record},
-              :title => _("Show the packages installed on this Host"))
+              :title => _("Show the packages installed on this %s") % host_title)
 
         - hs_size = @record.number_of(:host_services)
         - if hs_size == 0
@@ -256,7 +258,7 @@
           %li
             = link_to(_("Services (%s)") % hs_size,
               {:action => 'host_services', :id => @record},
-              :title => _("Show the services installed on this Host"))
+              :title => _("Show the services installed on this %s") % host_title)
 
         - fs_size = @record.number_of(:filesystems)
         - if fs_size == 0
@@ -266,7 +268,7 @@
           %li
             = link_to(_("Files (%s)") % fs_size,
               {:action => 'filesystems', :id => @record},
-              :title => _("Show the files on this Host"))
+              :title => _("Show the files on this %s") % host_title)
 
         - as_size = @record.number_of(:advanced_settings)
         - if as_size == 0
@@ -276,4 +278,4 @@
           %li
             = link_to(("Advanced Settings (%s)") % as_size,
               {:action => 'advanced_settings', :id => @record},
-              :title => _("Show the advanced settings on this Host"))
+              :title => _("Show the advanced settings on this %s") % host_title)

--- a/vmdb/app/views/layouts/listnav/_resource_pool.html.haml
+++ b/vmdb/app/views/layouts/listnav/_resource_pool.html.haml
@@ -1,4 +1,5 @@
 - if @record.try(:name)
+  - host_title = title_for_host
   #accordion.panel-group
     = patternfly_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
       = render :partial => "layouts/quadicon", :locals => {:mode => :icon, :item => @record, :size => 72, :typ => :listnav}
@@ -16,22 +17,22 @@
         - if role_allows(:feature => "ems_cluster_show")
           - if @record.parent_cluster.nil?
             %li.disabled
-              = link_to(_("Parent Cluster: None"), "#")
+              = link_to(_("Parent %s: None") % title_for_cluster, "#")
           - else
             %li
-              = link_to(_("Parent Cluster: %s") % @record.parent_cluster.name,
+              = link_to(_("Parent %s: %s") % [title_for_cluster, @record.parent_cluster.name],
                 {:controller => 'ems_cluster', :action => 'show', :id => @record.parent_cluster.id.to_s},
                 :title => _('Show VMs'))
 
         - if role_allows(:feature => "host_show")
           - if @record.parent_host.nil?
             %li.disabled
-              = link_to(_("Parent Host: None"), "#")
+              = link_to(_("Parent %s: None") % host_title, "#")
           - else
             %li
-              = link_to(_("Parent Host: %s") % @record.parent_host.name,
+              = link_to(_("Parent %s: %s") % [host_title, @record.parent_host.name],
                 {:controller => 'host', :action => 'show', :id => @record.parent_host.id.to_s},
-                :title => _('Show Parent Host'))
+                :title => _('Show Parent %s') % host_title)
 
         - if role_allows(:feature => "vm_show_list")
           - if @record.v_direct_vms == 0

--- a/vmdb/app/views/layouts/listnav/_storage.html.haml
+++ b/vmdb/app/views/layouts/listnav/_storage.html.haml
@@ -1,4 +1,5 @@
 - if @record.try(:name)
+  - hosts_title = title_for_hosts
   #accordion.panel-group
     = patternfly_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
       = render :partial => "layouts/quadicon", :locals => {:mode => :icon, :item => @record, :size => 72, :typ => :listnav}
@@ -23,12 +24,12 @@
         - if role_allows(:feature => "host_show_list")
           - if @record.number_of(:hosts) == 0
             %li.disabled
-              = link_to(_("Hosts (%s)") % @record.number_of(:hosts), "#")
+              = link_to(_("%s (%s)") % [hosts_title, @record.number_of(:hosts)], "#")
           - else
             %li
-              = link_to(_("Hosts (%s)") % @record.number_of(:hosts),
+              = link_to(_("%s (%s)") % [hosts_title, @record.number_of(:hosts)],
                 {:action => 'show', :id => @record, :display => 'hosts'},
-                :title => _("Show all registered Hosts"))
+                :title => _("Show all registered %s") % hosts_title)
 
         - if role_allows(:feature => "vm_show_list")
           - if @record.number_of(:all_vms) == 0

--- a/vmdb/app/views/layouts/listnav/_vm_common.html.haml
+++ b/vmdb/app/views/layouts/listnav/_vm_common.html.haml
@@ -1,4 +1,5 @@
 - if @record && !@in_a_form
+  - host_title = title_for_host
   -  regexosname = Regexp.new(/linux/)
   - linuxos = regexosname.match(@record.os_image_name.downcase)
   #accordion.panel-group
@@ -100,12 +101,12 @@
         - if role_allows(:feature => "host_show")
           - if @record.host.nil?
             %li
-              = link_to_with_icon("Host: #{@record.host.name}",
+              = link_to_with_icon("#{host_title}: #{@record.host.name}",
                 {:controller => "host", :action => 'show', :id => @record.host.id.to_s},
-                :title => _("Show this VM's parent Host"))
+                :title => _("Show this VM's parent %s") % host_title)
           - else
             %li.disabled
-              = link_to(_('Parent Host: None'), "#")
+              = link_to(_('Parent %s: None') % host_title, "#")
 
         - if @record.kind_of?(VmInfra) && role_allows(:feature => "storage_show")
           = li_link_if_condition(:cond => !@record.storage.nil?,

--- a/vmdb/app/views/miq_capacity/_planning_instructions.html.haml
+++ b/vmdb/app/views/miq_capacity/_planning_instructions.html.haml
@@ -1,5 +1,5 @@
 %h3
-  = _('Plan for VM placement on Clusters or Hosts')
+  = _('Plan for VM placement on %s or %s') % [title_for_hosts, title_for_clusters]
 .alert.alert-info
   %span.pficon.pficon-blank
   %strong
@@ -11,7 +11,7 @@
 .alert.alert-info
   %span.pficon.pficon-blank
   %strong
-    = _('3 - Specify Target Options to qualify target Clusters or Hosts.')
+    = _('3 - Specify Target Options to qualify target %s or %s.') % [title_for_hosts, title_for_clusters]
 .alert.alert-info
   %span.pficon.pficon-blank
   %strong

--- a/vmdb/app/views/miq_capacity/_planning_options.html.haml
+++ b/vmdb/app/views/miq_capacity/_planning_options.html.haml
@@ -18,7 +18,7 @@
         "data-miq_observe"     => {:url => url}.to_json)
     - if @sb[:planning][:options][:filter_typ] == "host"
       %br
-      - options = [["<#{_('Choose a Host')}>", "<Choose>"]] + Array(@sb[:planning][:hosts].invert).sort_by { |a| a.first.downcase }
+      - options = [["<#{_('Choose a %s') % title_for_host}>", "<Choose>"]] + Array(@sb[:planning][:hosts].invert).sort_by { |a| a.first.downcase }
       = select_tag("filter_value",
         options_for_select(options, @sb[:planning][:options][:filter_value]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
@@ -27,7 +27,7 @@
         "data-miq_observe"     => {:url => url}.to_json)
     - elsif @sb[:planning][:options][:filter_typ] == "cluster"
       %br
-      - options = [["<#{_('Choose a %s')}>" % ui_lookup(:table => "ems_clusters"), "<Choose>"]] + Array(@sb[:planning][:clusters].invert).sort_by { |a| a.first.downcase }
+      - options = [["<#{_('Choose a %s')}>" % title_for_clusters, "<Choose>"]] + Array(@sb[:planning][:clusters].invert).sort_by { |a| a.first.downcase }
       = select_tag("filter_value",
         options_for_select(options, @sb[:planning][:options][:filter_value]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,

--- a/vmdb/app/views/miq_policy/_action_details.html.haml
+++ b/vmdb/app/views/miq_policy/_action_details.html.haml
@@ -131,7 +131,7 @@
           %h3=_("SNMP Trap")
           %table.style1
             %tr
-              %td.key=_("Host")
+              %td.key=title_for_host
               %td
                 = h(@action.options[:host])
             %tr

--- a/vmdb/app/views/miq_policy/_action_options.html.haml
+++ b/vmdb/app/views/miq_policy/_action_options.html.haml
@@ -165,7 +165,7 @@
     %h3=_("SNMP Trap Settings")
     %table.style1
       %tr
-        %td.key=_("Host")
+        %td.key=title_for_host
         %td
           = text_field_tag("host",
             @edit[:new][:options][:host],

--- a/vmdb/app/views/miq_policy/_alert_details.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_details.html.haml
@@ -178,7 +178,7 @@
           %h3=_('Send SNMP Trap')
           %table.style1
             %tr
-              %td.key=_("Host")
+              %td.key=title_for_host
               %td
                 - @alert.options[:notifications][:snmp][:host].each do |host|
                   = h(host)

--- a/vmdb/app/views/miq_policy/_alert_snmp.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_snmp.html.haml
@@ -13,7 +13,7 @@
             "data-miq_observe_checkbox" => observe)
       - if @edit[:new][:send_snmp]
         %tr
-          %td.key=_('Host')
+          %td.key=title_for_host
           %td
             = text_field_tag("host_1", @edit[:new][:snmp][:host][0],
               :maxlength         => MAX_DESC_LEN,

--- a/vmdb/app/views/miq_policy/_rsop_form.html.haml
+++ b/vmdb/app/views/miq_policy/_rsop_form.html.haml
@@ -26,8 +26,8 @@
             = select_tag('filter_typ',
               options_for_select([["<#{_('Choose')}>"],
                 [_("By %s") % ui_lookup(:table => "ext_management_systems"), "ems"],
-                [_("By %s") % ui_lookup(:table => "ems_clusters"), "cluster"],
-                [_("By Host"), "host"],
+                [_("By %s") % title_for_clusters, "cluster"],
+                [_("By %s") % title_for_host, "host"],
                 [_("Single VM"), "vm"]], @sb[:rsop][:filter]), "data-miq_observe" => observe)
             - if @sb[:rsop][:filter] == "host"
               %br

--- a/vmdb/app/views/miq_request/_prov_host_dialog.html.haml
+++ b/vmdb/app/views/miq_request/_prov_host_dialog.html.haml
@@ -34,7 +34,7 @@
     = render(:partial => "#{pfx}prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
-        :label                      => _("Host"),
+        :label                      => title_for_host,
         :keys                       => keys,
         :extra_table_attributes     => "width=100%"})
     - keys = [:pxe_server_id, :pxe_image_id]
@@ -56,7 +56,7 @@
     = render(:partial => "#{pfx}prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
-        :label                      => _("Cluster"),
+        :label                      => title_for_cluster,
         :prefix                     => pfx,
         :keys                       => keys})
     - keys = [:attached_ds]

--- a/vmdb/app/views/miq_request/_prov_vm_migrate_dialog.html.haml
+++ b/vmdb/app/views/miq_request/_prov_vm_migrate_dialog.html.haml
@@ -32,7 +32,7 @@
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
-        :label                      => _("Cluster"),
+        :label                      => title_for_cluster,
         :keys                       => keys})
 
     - keys = [:rp_filter, :placement_rp_name]
@@ -46,7 +46,7 @@
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
-        :label                      => _("Host"),
+        :label                      => title_for_host,
         :keys                       => keys,
         :extra_table_attributes     => "width=100%"})
 

--- a/vmdb/app/views/miq_request/_request.html.haml
+++ b/vmdb/app/views/miq_request/_request.html.haml
@@ -105,7 +105,7 @@
             - if @miq_request.resource_type == "MiqHostProvisionRequest" &&  @miq_request.resource.miq_host_provisions.length > 0
               %tr
                 %td.key
-                  = _("Provisioned Hosts")
+                  = _("Provisioned %s") % title_for_hosts
                 %td.hover-text{:class => cycle('row0', 'row1'),
                   :onclick            => "DoNav('#{'/miq_request/show/' << @miq_request.id.to_s << '?display=miq_provisions'}');",
                   :onmouseover        => "this.style.cursor='pointer'",

--- a/vmdb/app/views/ontap_file_share/_create_datastore.html.haml
+++ b/vmdb/app/views/ontap_file_share/_create_datastore.html.haml
@@ -13,7 +13,7 @@
           "data-miq_focus"   => true,
           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     %tr
-      %td.key=_('Host')
+      %td.key=title_for_host
       %td
         = select_tag("host_id",
           options_for_select([["<#{_('Choose')}>",nil]] + @edit[:hosts].invert.sort,

--- a/vmdb/app/views/ops/_ldap_server_entry.html.haml
+++ b/vmdb/app/views/ops/_ldap_server_entry.html.haml
@@ -80,7 +80,7 @@
                    :id        => entry_idx,
                    :domain_id => domain_id},
                   :class                 => "btn btn-primary",
-                  :alt                   => t = _("Validate the LDAP Settings by binding with the Host"),
+                  :alt                   => t = _("Validate the LDAP Settings by binding with the %s") % title_for_host,
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true,
                   :remote                => true,

--- a/vmdb/app/views/ops/_ldap_verify_button.html.haml
+++ b/vmdb/app/views/ops/_ldap_verify_button.html.haml
@@ -6,11 +6,11 @@
      :button => "verify",
      :id     => id},
     :class                 => "btn btn-primary btn-xs",
-    :alt                   => _("Validate the LDAP Settings by binding with the Host"),
+    :alt                   => _("Validate the LDAP Settings by binding with the %s") % title_for_host,
     "data-miq_sparkle_on"  => true,
     "data-miq_sparkle_off" => true,
     :remote                => true,
-    :title                 => _("Validate the LDAP Settings by binding with the Host"))
+    :title                 => _("Validate the LDAP Settings by binding with the %s") % title_for_host)
 
 = hidden_div_if(! validate_disabled, :id => "verify_button_off") do
   = button_tag(_("Validate"),

--- a/vmdb/app/views/ops/_rbac_group_details.html.haml
+++ b/vmdb/app/views/ops/_rbac_group_details.html.haml
@@ -113,7 +113,7 @@
                 =_("Tags")
             %li
               %a{:href => "#hosts_clusters"}
-                =_("Hosts & Clusters")
+                =_("%s & %s") % [title_for_hosts, title_for_clusters]
             %li
               %a{:href => "#vms_templates"}
                 =_("VMs & Templates")

--- a/vmdb/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/vmdb/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -1,14 +1,15 @@
 - url = url_for(:action=>'cu_collection_field_changed')
 - if @sb[:active_tab] == "settings_cu_collection"
+  - clusters_title = title_for_clusters
   = form_tag( {:action => 'cu_collection_update'}, {:id => "config_form"}) do
     = render :partial => "layouts/flash_msg"
     .row
       .col-sm-12.col-md-12.col-lg-6
         %fieldset
-          %h3=_("Clusters")
+          %h3=clusters_title
           %table.style1
             %tr
-              %td.key=_("Collect for All Clusters")
+              %td.key=_("Collect for All %s") % clusters_title
               %td
                 = check_box_tag("all_clusters", value="1",
                   checked=@edit[:new][:all_clusters],
@@ -16,13 +17,14 @@
                   "data-miq_observe_checkbox"=>{:url=>url}.to_json)
           .note
             Note:
-            %b=_("Collect for All Clusters must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2")
+            %b=_("Collect for All %s must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2") % clusters_title
           #clusters_div{:style => "display:#{@edit[:new][:all_clusters] ? "none" : ""}"}
+            - cluster_title = title_for_cluster
             - if @edit[:new][:clusters].blank? && @edit[:new][:non_cl_hosts].blank?
-              =_("No Clusters found in the current region.")
+              =_("No %s found in the current region.") % clusters_title
             - else
               %br/
-              %b=_("Enable Collection by Cluster")
+              %b=_("Enable Collection by %s") % cluster_title
               %br/
               %input#cl_toggle{:name => "cl_toggle", :onclick => "miqCheck_CU_All(this,'#{session[:tree_name]}');", :type => "checkbox"}/
               =(_("Check All"))
@@ -37,7 +39,7 @@
                   :exp_tree => true,
                   :checkboxes => true})
               %br/
-              .note=_("VM data will be collected for VMs under selected Hosts only. Data is collected for a Cluster and all of its Hosts when at least one Host is selected.")
+              .note=_("VM data will be collected for VMs under selected %s only. Data is collected for a %s and all of its %s when at least one %s is selected.") % [title_for_hosts, cluster_title, title_for_hosts, title_for_host]
       .col-sm-12.col-md-12.col-lg-6
         %fieldset
           %h3= ui_lookup(:tables=>"storages")

--- a/vmdb/app/views/ops/_settings_import_tab.html.haml
+++ b/vmdb/app/views/ops/_settings_import_tab.html.haml
@@ -10,7 +10,7 @@
         %td.key=_("Type")
         %td
           = select_tag('upload_type',
-            options_for_select([["<Choose>",nil],["Host","host"],["Vm","vm"]],
+            options_for_select([["<Choose>",nil],[title_for_host,"host"],["Vm","vm"]],
             @edit[:new][:upload_type]),
             "data-miq_observe"=>{:url=>url}.to_json)
       - if @edit[:new][:upload_type]

--- a/vmdb/app/views/shared/buttons/_ab_form.html.haml
+++ b/vmdb/app/views/shared/buttons/_ab_form.html.haml
@@ -1,7 +1,8 @@
 - url = url_for(:action => 'automate_button_field_changed')
 #ab_form
   #policy_bar
-    - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten][@resolve[:target_class]] == @edit[:new][:target_class]
+    - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten].invert[@resolve[:new][:target_class]] == @edit[:new][:target_class]
+
       %li
         -t = _("Paste object details for use in a Button.")
         = link_to(image_tag("/images/toolbars/paste.png", :border => "0", :class  => "", :alt => t),

--- a/vmdb/app/views/shared/views/_prov_dialog.html.haml
+++ b/vmdb/app/views/shared/views/_prov_dialog.html.haml
@@ -96,7 +96,7 @@
         = render(:partial => "#{prefix}prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
-            :label                      => _("Cluster"),
+            :label                      => title_for_cluster,
             :prefix                     => prefix,
             :keys                       => keys})
       - if wf.is_a?(MiqProvisionVmwareWorkflow)
@@ -118,7 +118,7 @@
       = render(:partial => "#{prefix}prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
-          :label                      => _("Host"),
+          :label                      => title_for_host,
           :prefix                     => prefix,
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -833,7 +833,7 @@ en:
       CustomButton:             Button
       CustomButtonSet:          Buttons Group
       EmsCloud:                 Cloud Provider
-      EmsCluster:               Clusters / Deployment Roles
+      EmsCluster:               Cluster / Deployment Role
       EmsClusterPerformance:    Performance - Cluster
       EmsContainer:             Container Provider
       EmsEvent:                 Management Event
@@ -846,7 +846,7 @@ en:
       FileDepotSmb:             Samba
       Filesystem:               File
       Flavor:                   Flavor
-      Host:                     Hosts / Nodes
+      Host:                     Host / Node
       HostPerformance:          Performance - Host
       IsoDatastore:             ISO Datastore
       IsoImage:                 ISO Image

--- a/vmdb/config/locales/en.yml
+++ b/vmdb/config/locales/en.yml
@@ -800,9 +800,25 @@ en:
       virtualcenter:   VMware vCenter
       vmwareserver:    VMware Server
 
+    ems_cluster_types:
+      cluster:            Cluster / Deployment Role
+      clusters:           Clusters / Deployment Roles
+      cluster_infra:      Cluster
+      cluster_infras:     Clusters
+      cluster_openstack:  Deployment Role
+      cluster_openstacks: Deployment Roles
+
     host_os_type:
       linux_generic:   Linux
       windows_generic: Windows
+
+    host_types:
+      host:            Host / Node
+      hosts:           Hosts / Nodes
+      host_infra:      Host
+      host_infras:     Hosts
+      host_openstack:  Node
+      host_openstacks: Nodes
 
     model:
       AuditEvent:               EVM Audit Event
@@ -817,7 +833,7 @@ en:
       CustomButton:             Button
       CustomButtonSet:          Buttons Group
       EmsCloud:                 Cloud Provider
-      EmsCluster:               Cluster
+      EmsCluster:               Clusters / Deployment Roles
       EmsClusterPerformance:    Performance - Cluster
       EmsContainer:             Container Provider
       EmsEvent:                 Management Event
@@ -830,6 +846,7 @@ en:
       FileDepotSmb:             Samba
       Filesystem:               File
       Flavor:                   Flavor
+      Host:                     Hosts / Nodes
       HostPerformance:          Performance - Host
       IsoDatastore:             ISO Datastore
       IsoImage:                 ISO Image
@@ -939,8 +956,8 @@ en:
       custom_button_set:           Buttons Group
       ems_cloud:                   Cloud Provider
       ems_clouds:                  Cloud Providers
-      ems_cluster:                 Cluster
-      ems_clusters:                Clusters
+      ems_cluster:                 Cluster / Deployment Role
+      ems_clusters:                Clusters / Deployment Roles
       ems_custom_attribute:        VC Custom Attribute
       ems_custom_attributes:       VC Custom Attributes
       ems_event:                   Management Event
@@ -960,6 +977,8 @@ en:
       flavors:                     Flavors
       floppies:                    Floppy Drives
       guest_devices:               Devices
+      host:                        Host / Node
+      hosts:                       Hosts / Nodes
       host_services:               Services
       iso_datastore:               ISO Datastore
       iso_image:                   ISO Image

--- a/vmdb/db/fixtures/miq_product_features.yml
+++ b/vmdb/db/fixtures/miq_product_features.yml
@@ -1163,186 +1163,186 @@
       :feature_type: view
       :identifier: datacenter_show
 
-# EmsCluster
-- :name: Clusters
-  :description: Everything under Clusters
+# Clusters / Deployment Roles
+- :name: Clusters / Deployment Roles
+  :description: Everything under Clusters / Deployment Roles
   :feature_type: node
   :identifier: ems_cluster
   :children:
   - :name: View
-    :description: View Clusters
+    :description: View Clusters / Deployment Roles
     :feature_type: view
     :identifier: ems_cluster_view
     :children:
     - :name: Compare
-      :description: Compare List of Clusters
+      :description: Compare List of Clusters / Deployment Roles
       :feature_type: view
       :identifier: ems_cluster_compare
     - :name: Drift
-      :description: Display Clusters Drift
+      :description: Display Clusters / Deployment Roles Drift
       :feature_type: view
       :identifier: ems_cluster_drift
     - :name: List
-      :description: Display Lists of Clusters
+      :description: Display Lists of Clusters / Deployment Roles
       :feature_type: view
       :identifier: ems_cluster_show_list
     - :name: Show
-      :description: Display Individual Clusters
+      :description: Display Individual Clusters / Deployment Roles
       :feature_type: view
       :identifier: ems_cluster_show
     - :name: Utilization
-      :description: Show Capacity & Utilization data of Clusters
+      :description: Show Capacity & Utilization data of Clusters / Deployment Roles
       :feature_type: view
       :identifier: ems_cluster_perf
     - :name: Timelines
-      :description: Display Timelines for Clusters
+      :description: Display Timelines for Clusters / Deployment Roles
       :feature_type: view
       :identifier: ems_cluster_timeline
   - :name: Operate
-    :description: Perform Operations on Clusters
+    :description: Perform Operations on Clusters / Deployment Roles
     :feature_type: control
     :identifier: ems_cluster_control
     :children:
     - :name: Analysis
-      :description: Perform SmartState Analysis on Clusters
+      :description: Perform SmartState Analysis on Clusters / Deployment Roles
       :feature_type: control
       :identifier: ems_cluster_scan
     - :name: Manage Policies
-      :description: Manage Policies on Clusters
+      :description: Manage Policies on Clusters / Deployment Roles
       :feature_type: control
       :identifier: ems_cluster_protect
     - :name: Tag
-      :description: Edit Tags for Clusters
+      :description: Edit Tags for Clusters / Deployment Roles
       :feature_type: control
       :identifier: ems_cluster_tag
   - :name: Modify
-    :description: Modify Clusters
+    :description: Modify Clusters / Deployment Roles
     :feature_type: admin
     :identifier: ems_cluster_admin
     :children:
     - :name: Remove
-      :description: Remove Clusters from the VMDB
+      :description: Remove Clusters / Deployment Roles from the VMDB
       :feature_type: admin
       :identifier: ems_cluster_delete
 
-# Hosts
-- :name: Hosts
-  :description: Everything under Hosts
+# Hosts / Nodes
+- :name: Hosts / Nodes
+  :description: Everything under Hosts / Nodes
   :feature_type: node
   :identifier: host
   :children:
   - :name: View
-    :description: View Hosts
+    :description: View Hosts / Nodes
     :feature_type: view
     :identifier: host_view
     :children:
     - :name: Compare
-      :description: Compare List of Hosts
+      :description: Compare List of Hosts / Nodes
       :feature_type: view
       :identifier: host_compare
     - :name: List
-      :description: Display Lists of Hosts
+      :description: Display Lists of Hosts / Nodes
       :feature_type: view
       :identifier: host_show_list
     - :name: Show
-      :description: Display Individual Hosts
+      :description: Display Individual Hosts / Nodes
       :feature_type: view
       :identifier: host_show
     - :name: Drift
-      :description: Display Hosts Drift
+      :description: Display Hosts / Nodes Drift
       :feature_type: view
       :identifier: host_drift
     - :name: Utilization
-      :description: Show Capacity & Utilization data of Hosts
+      :description: Show Capacity & Utilization data of Hosts / Nodes
       :feature_type: view
       :identifier: host_perf
     - :name: Timelines
-      :description: Display Timelines for Hosts
+      :description: Display Timelines for Hosts / Nodes
       :feature_type: view
       :identifier: host_timeline
   - :name: Operate
-    :description: Perform Operations on Hosts
+    :description: Perform Operations on Hosts / Nodes
     :feature_type: control
     :identifier: host_control
     :children:
     - :name: Analysis
-      :description: Perform SmartState Analysis for Hosts
+      :description: Perform SmartState Analysis for Hosts / Nodes
       :feature_type: control
       :identifier: host_scan
     - :name: Analyze then Check Compliance
-      :description: Analyze then Check Compliance for Hosts
+      :description: Analyze then Check Compliance for Hosts / Nodes
       :feature_type: control
       :identifier: host_analyze_check_compliance
     - :name: Check Compliance
-      :description: Check Compliance of Last Known Configuration for Hosts
+      :description: Check Compliance of Last Known Configuration for Hosts / Nodes
       :feature_type: control
       :identifier: host_check_compliance
     - :name: Discover
       :feature_type: control
       :identifier: host_discover
     - :name: Manage Policies
-      :description: Manage Policies for Hosts
+      :description: Manage Policies for Hosts / Nodes
       :feature_type: control
       :identifier: host_protect
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Hosts
+      :description: Refresh relationships and power states for all items related to Hosts / Nodes
       :feature_type: control
       :identifier: host_refresh
     - :name: Edit Tags
-      :description: Edit Host Tags
+      :description: Edit Host / Node Tags
       :feature_type: control
       :identifier: host_tag
     - :name: Power On
-      :description: Power On a Host
+      :description: Power On a Host / Node
       :feature_type: control
       :identifier: host_start
     - :name: Power Off
-      :description: Power Off a Host
+      :description: Power Off a Host / Node
       :feature_type: control
       :identifier: host_stop
     - :name: Reset
-      :description: Reset a Host
+      :description: Reset a Host / Node
       :feature_type: control
       :identifier: host_reset
     - :name: Enter Maintenance Mode
-      :description: Put a Host into Maintenance Mode
+      :description: Put a Host / Node into Maintenance Mode
       :feature_type: control
       :identifier: host_enter_maint_mode
     - :name: Exit Maintenance Mode
-      :description: Take a Host out of Maintenance Mode
+      :description: Take a Host / Node out of Maintenance Mode
       :feature_type: control
       :identifier: host_exit_maint_mode
     - :name: Shutdown Host to Standby
-      :description: Shutdown a Host to Standby Mode
+      :description: Shutdown a Host / Node to Standby Mode
       :feature_type: control
       :identifier: host_standby
     - :name: Shutdown Host
-      :description: Shutdown a Host
+      :description: Shutdown a Host / Node
       :feature_type: control
       :identifier: host_shutdown
     - :name: Restart Host
-      :description: Restart a Host
+      :description: Restart a Host / Node
       :feature_type: control
       :identifier: host_reboot
   - :name: Modify
-    :description: Modify Hosts
+    :description: Modify Hosts / Nodes
     :feature_type: admin
     :identifier: host_admin
     :children:
     - :name: Add
-      :description: Add a Host
+      :description: Add a Host / Node
       :feature_type: admin
       :identifier: host_new
     - :name: Remove
-      :description: Remove Hosts from the VMDB
+      :description: Remove Hosts / Nodes from the VMDB
       :feature_type: admin
       :identifier: host_delete
     - :name: Edit
-      :description: Edit a Host
+      :description: Edit a Host / Node
       :feature_type: admin
       :identifier: host_edit
-    - :name: Provision Hosts
-      :description: Request to Provision Hosts
+    - :name: Provision Hosts / Nodes
+      :description: Request to Provision Hosts / Nodes
       :feature_type: admin
       :identifier: host_miq_request_new
 

--- a/vmdb/lib/vmdb/global_methods.rb
+++ b/vmdb/lib/vmdb/global_methods.rb
@@ -133,6 +133,10 @@ module Vmdb
         ui_lookup_for_model(options[:model]).singularize
       elsif options[:models]
         ui_lookup_for_model(options[:models]).pluralize
+      elsif options[:host_types]
+        ui_lookup_for_host_types(options[:host_types])
+      elsif options[:ems_cluster_types]
+        ui_lookup_for_ems_cluster_types(options[:ems_cluster_types])
       else
         ''
       end
@@ -145,6 +149,14 @@ module Vmdb
 
     def ui_lookup_for_model(text)
       Dictionary.gettext(text, :type => :model, :notfound => :titleize)
+    end
+
+    def ui_lookup_for_host_types(text)
+      Dictionary.gettext(text, :type => :host_types, :notfound => :titleize)
+    end
+
+    def ui_lookup_for_ems_cluster_types(text)
+      Dictionary.gettext(text, :type => :ems_cluster_types, :notfound => :titleize)
     end
 
     # Wrap a report html table body with html table tags and headers for the columns

--- a/vmdb/product/toolbars/ems_cluster_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_cluster_center_tb.yaml
@@ -14,14 +14,14 @@
     - :button: ems_cluster_scan
       :image: scan
       :text: "Perform SmartState Analysis"
-      :title: "Perform SmartState Analysis on this Cluster"
-      :confirm: "Perform SmartState Analysis on this Cluster?"
+      :title: "Perform SmartState Analysis on this item"
+      :confirm: "Perform SmartState Analysis on this item?"
     - :button: ems_cluster_delete
       :image: remove
       :text: "Remove from the VMDB"
-      :title: "Remove this Cluster from the VMDB"
+      :title: "Remove this item from the VMDB"
       :url_parms: '&refresh=y'
-      :confirm: "Warning: This Cluster and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Cluster?"
+      :confirm: "Warning: This item and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this item?"
 - :name: ems_cluster_policy
   :items:
   - :buttonSelect: ems_cluster_policy_choice
@@ -32,11 +32,11 @@
     - :button: ems_cluster_protect
       :image: protect
       :text: "Manage Policies"
-      :title: "Manage Policies for this Cluster"
+      :title: "Manage Policies for this item"
     - :button: ems_cluster_tag
       :image: tag
       :text: "Edit Tags"
-      :title: "Edit Tags for this Cluster"
+      :title: "Edit Tags for this item"
 - :name: ems_cluster_monitoring
   :items:
   - :buttonSelect: ems_cluster_monitoring_choice
@@ -47,12 +47,12 @@
     - :button: ems_cluster_perf
       :image: capacity
       :text: "Utilization"
-      :title: "Show Capacity & Utilization data for this Cluster"
+      :title: "Show Capacity & Utilization data for this item"
       :url: '/show'
       :url_parms: '?display=performance'
     - :button: ems_cluster_timeline
       :image: timeline
       :text: "Timelines"
-      :title: "Show Timelines for this Cluster"
+      :title: "Show Timelines for this item"
       :url: '/show'
       :url_parms: '?display=timeline'

--- a/vmdb/product/toolbars/ems_clusters_center_tb.yaml
+++ b/vmdb/product/toolbars/ems_clusters_center_tb.yaml
@@ -16,25 +16,25 @@
     - :button: ems_cluster_scan
       :image: scan
       :text: "Perform SmartState Analysis"
-      :title: "Perform SmartState Analysis on the selected Clusters"
+      :title: "Perform SmartState Analysis on the selected items"
       :url_parms: 'main_div'
-      :confirm: "Perform SmartState Analysis on the selected Clusters?"
+      :confirm: "Perform SmartState Analysis on the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
     - :button: ems_cluster_compare
       :image: compare
-      :text: "Compare Selected Clusters"
-      :title: "Select two or more Clusters to compare"
+      :text: "Compare Selected items"
+      :title: "Select two or more items to compare"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '2+'
     - :separator:
     - :button: ems_cluster_delete
       :image: remove
-      :text: Remove Clusters from the VMDB
-      :title: "Remove selected Clusters from the VMDB"
+      :text: Remove selected items from the VMDB
+      :title: "Remove selected items from the VMDB"
       :url_parms: 'main_div'
-      :confirm: "Warning: The selected Clusters and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Clusters?"
+      :confirm: "Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
 - :name: ems_cluster_policy
@@ -49,14 +49,14 @@
     - :button: ems_cluster_protect
       :image: protect
       :text: "Manage Policies"
-      :title: "Manage Policies for the selected Clusters"
+      :title: "Manage Policies for the selected items"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: ems_cluster_tag
       :image: tag
       :text: "Edit Tags"
-      :title: "Edit Tags for the selected Clusters"
+      :title: "Edit Tags for the selected items"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/vmdb/product/toolbars/host_center_tb.yaml
+++ b/vmdb/product/toolbars/host_center_tb.yaml
@@ -14,25 +14,25 @@
     - :button: host_refresh
       :image: refresh
       :text: "Refresh Relationships and Power States"
-      :title: "Refresh relationships and power states for all items related to this Host"
-      :confirm: "Refresh relationships and power states for all items related to this Host?"
+      :title: "Refresh relationships and power states for all items related to this item"
+      :confirm: "Refresh relationships and power states for all items related to this item?"
     - :button: host_scan
       :image: scan
       :text: "Perform SmartState Analysis"
-      :title: "Perform SmartState Analysis on this Host"
-      :confirm: "Perform SmartState Analysis on this Host?"
+      :title: "Perform SmartState Analysis on this item"
+      :confirm: "Perform SmartState Analysis on this item?"
     - :separator:
     - :button: host_edit
       :image: edit
-      :text: "Edit this Host"
-      :title: "Edit this Host"
+      :text: "Edit this item"
+      :title: "Edit this item"
       :url: '/edit'
     - :button: host_delete
       :image: remove
       :text: "Remove from the VMDB"
-      :title: "Remove this Host from the VMDB"
+      :title: "Remove this item from the VMDB"
       :url_parms: '&refresh=y'
-      :confirm: "Warning: This Host and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Host?"
+      :confirm: "Warning: This item and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this item?"
 - :name: host_policy
   :items:
   - :buttonSelect: host_policy_choice
@@ -43,21 +43,21 @@
     - :button: host_protect
       :image: protect
       :text: "Manage Policies"
-      :title: "Manage Policies for this Host"
+      :title: "Manage Policies for this item"
     - :button: host_tag
       :image: tag
       :text: "Edit Tags"
-      :title: "Edit Tags for this Host"
+      :title: "Edit Tags for this item"
     - :button: host_check_compliance
       :image: compliance
       :text: "Check Compliance of Last Known Configuration"
-      :title: "Check Compliance of the last known configuration for this Host"
-      :confirm: "Initiate Check Compliance of the last known configuration for this Host?"
+      :title: "Check Compliance of the last known configuration for this item"
+      :confirm: "Initiate Check Compliance of the last known configuration for this item?"
     - :button: host_analyze_check_compliance
       :image: analyze_compliance
       :text: "Analyze then Check Compliance"
-      :title: "Analyze then Check Compliance for this Host"
-      :confirm: "Analyze then Check Compliance for this Host?"
+      :title: "Analyze then Check Compliance for this item"
+      :confirm: "Analyze then Check Compliance for this item?"
 - :name: host_lifecycle
   :items:
   - :buttonSelect: host_lifecycle_choice
@@ -67,8 +67,8 @@
     :items:
     - :button: host_miq_request_new
       :image: provision
-      :text: "Provision this Host"
-      :title: "Provision this Host"
+      :text: "Provision this item"
+      :title: "Provision this item"
 - :name: host_monitoring
   :items:
   - :buttonSelect: host_monitoring_choice
@@ -79,60 +79,60 @@
     - :button: host_perf
       :image: capacity
       :text: "Utilization"
-      :title: "Show Capacity & Utilization data for this Host"
+      :title: "Show Capacity & Utilization data for this item"
       :url: '/show'
       :url_parms: '?display=performance'
     - :button: host_timeline
       :image: timeline
       :text: "Timelines"
-      :title: "Show Timelines for this Host"
+      :title: "Show Timelines for this item"
       :url: '/show'
       :url_parms: '?display=timeline'
 - :name: host_operations
   :items:
   - :buttonSelect: host_power_choice
     :image: power_choice
-    :title: "Host Power Functions"
+    :title: "Power Functions"
     :text: Power
     :items:
     - :button: host_enter_maint_mode
       :image: enter_maint_mode
       :text: "Enter Maintenance Mode"
-      :title: "Put this Host into Maintenance Mode"
-      :confirm: "Put this Host into Maintenance Mode?"
+      :title: "Put this item into Maintenance Mode"
+      :confirm: "Put this item into Maintenance Mode?"
     - :button: host_exit_maint_mode
       :image: exit_maint_mode
       :text: "Exit Maintenance Mode"
-      :title: "Take this Host out of Maintenance Mode"
-      :confirm: "Take this Host out of Maintenance Mode?"
+      :title: "Take this item out of Maintenance Mode"
+      :confirm: "Take this item out of Maintenance Mode?"
     - :button: host_standby
       :image: standby
       :text: "Enter Standby Mode"
-      :title: "Shutdown this Host to Standby Mode"
-      :confirm: "Shutdown this Host to Standby Mode?"
+      :title: "Shutdown this item to Standby Mode"
+      :confirm: "Shutdown this item to Standby Mode?"
     - :button: host_shutdown
       :image: guest_shutdown
       :text: "Shutdown"
-      :title: "Shutdown this Host"
-      :confirm: "Shutdown this Host?"
+      :title: "Shutdown this item"
+      :confirm: "Shutdown this item?"
     - :button: host_reboot
       :image: guest_restart
       :text: "Restart"
-      :title: "Restart this Host"
-      :confirm: "Restart this Host?"
+      :title: "Restart this item"
+      :confirm: "Restart this item?"
     - :separator:
     - :button: host_start
       :image: power_on
       :text: "Power On"
-      :title: "Power On this Host"
-      :confirm: "Power On this Host?"
+      :title: "Power On this item"
+      :confirm: "Power On this item?"
     - :button: host_stop
       :image: power_off
       :text: "Power Off"
-      :title: "Power Off this Host"
-      :confirm: "Power Off this Host?"
+      :title: "Power Off this item"
+      :confirm: "Power Off this item?"
     - :button: host_reset
       :image: power_reset
       :text: "Reset"
-      :title: "Reset this Host"
-      :confirm: "Reset this Host?"
+      :title: "Reset this item"
+      :confirm: "Reset this item?"

--- a/vmdb/product/toolbars/hosts_center_tb.yaml
+++ b/vmdb/product/toolbars/hosts_center_tb.yaml
@@ -14,51 +14,51 @@
     - :button: host_refresh
       :image: refresh
       :text: "Refresh Relationships and Power States"
-      :title: "Refresh relationships and power states for all items related to the selected Hosts"
+      :title: "Refresh relationships and power states for all items related to the selected items"
       :url_parms: 'main_div'
-      :confirm: "Refresh relationships and power states for all items related to the selected Hosts?"
+      :confirm: "Refresh relationships and power states for all items related to the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_scan
       :image: scan
       :text: "Perform SmartState Analysis"
-      :title: "Perform SmartState Analysis on the selected Hosts"
+      :title: "Perform SmartState Analysis on the selected items"
       :url_parms: 'main_div'
-      :confirm: "Perform SmartState Analysis on the selected Hosts?"
+      :confirm: "Perform SmartState Analysis on the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_compare
       :image: compare
-      :text: "Compare Selected Hosts"
-      :title: "Select two or more Hosts to compare"
+      :text: "Compare Selected items"
+      :title: "Select two or more items to compare"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '2+'    
     - :button: host_discover
       :image: discover
-      :text: "Discover Hosts"
-      :title: "Discover Hosts"
+      :text: "Discover items"
+      :title: "Discover items"
       :url: '/discover'
       :url_parms: '?discover_type=hosts'
     - :separator:
     - :button: host_new
       :image: new
       :url: '/new'
-      :text: "Add a New Host"
-      :title: "Add a New Host"
+      :text: "Add a New item"
+      :title: "Add a New item"
     - :button: host_edit
       :image: edit
-      :text: Edit Selected Hosts
-      :title: Edit Selected Hosts
+      :text: Edit Selected items
+      :title: Edit Selected items
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_delete
       :image: remove
-      :text: Remove Hosts from the VMDB
-      :title: Remove Selected Hosts from the VMDB
+      :text: Remove items from the VMDB
+      :title: Remove Selected items from the VMDB
       :url_parms: 'main_div'
-      :confirm: "Warning: The selected Hosts and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Hosts?"
+      :confirm: "Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
 - :name: host_policy
@@ -73,31 +73,31 @@
     - :button: host_protect
       :image: protect
       :text: "Manage Policies"
-      :title: "Manage Policies for the selected Hosts"
+      :title: "Manage Policies for the selected items"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_tag
       :image: tag
       :text: "Edit Tags"
-      :title: "Edit Tags for the selected Hosts"
+      :title: "Edit Tags for the selected items"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_check_compliance
       :image: compliance
       :text: "Check Compliance of Last Known Configuration"
-      :title: "Check Compliance of the last known configuration for the selected Hosts"
+      :title: "Check Compliance of the last known configuration for the selected items"
       :url_parms: 'main_div'
-      :confirm: "Initiate Check Compliance of the last known configuration for the selected Hosts?"
+      :confirm: "Initiate Check Compliance of the last known configuration for the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_analyze_check_compliance
       :image: analyze_compliance
       :text: "Analyze then Check Compliance"
-      :title: "Analyze then Check Compliance for the selected Hosts"
+      :title: "Analyze then Check Compliance for the selected items"
       :url_parms: 'main_div'
-      :confirm: "Analyze then Check Compliance for the selected Hosts?"
+      :confirm: "Analyze then Check Compliance for the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
 - :name: host_lifecycle
@@ -110,8 +110,8 @@
     - :button: host_miq_request_new
       :image: new
       :url_parms: 'main_div'
-      :text: "Provision Hosts"
-      :title: "Request to Provision Hosts"
+      :text: "Provision items"
+      :title: "Request to Provision items"
       :enabled: 'false'
       :onwhen: '1+'
 - :name: host_operations
@@ -126,44 +126,44 @@
     - :button: host_standby
       :image: standby
       :text: "Enter Standby Mode"
-      :title: "Shutdown the selected Hosts to Standby Mode"
-      :confirm: "Shutdown the selected Hosts to Standby Mode?"
+      :title: "Shutdown the selected items to Standby Mode"
+      :confirm: "Shutdown the selected items to Standby Mode?"
       :url_parms: 'main_div'
-      :confirm: "Shutdown the selected Hosts to Standy Mode?"
+      :confirm: "Shutdown the selected items to Standy Mode?"
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_shutdown
       :image: guest_shutdown
       :text: "Shutdown"
-      :title: "Shutdown the selected Hosts"
+      :title: "Shutdown the selected items"
       :url_parms: 'main_div'
-      :confirm: "Shutdown the selected Hosts?"
+      :confirm: "Shutdown the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
     - :button: host_reboot
       :image: guest_restart
       :text: "Restart"
-      :title: "Restart the selected Hosts"
+      :title: "Restart the selected items"
       :url_parms: 'main_div'
-      :confirm: "Restart the selected Hosts?"
+      :confirm: "Restart the selected items?"
       :enabled: 'false'
       :onwhen: '1+'
     - :separator:
     - :button: host_start
       :image: power_on
       :text: "Power On"
-      :title: "Power On the selected Hosts"
+      :title: "Power On the selected items"
       :url_parms: 'main_div'
-      :confirm: "Power On the selected Hosts?"
+      :confirm: "Power On the selected items?"
     - :button: host_stop
       :image: power_off
       :text: "Power Off"
-      :title: "Power Off the selected Hosts"
+      :title: "Power Off the selected items"
       :url_parms: 'main_div'
-      :confirm: "Power Off the selected Hosts?"
+      :confirm: "Power Off the selected items?"
     - :button: host_reset
       :image: power_reset
       :text: "Reset"
-      :title: "Reset the selected Hosts"
+      :title: "Reset the selected items"
       :url_parms: 'main_div'
-      :confirm: "Reset the selected Hosts?"
+      :confirm: "Reset the selected items?"

--- a/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
@@ -35,8 +35,8 @@ describe ApplicationController do
   end
 
   it "should set correct discovery title" do
-    res = controller.send(:set_discover_title,"host", "host")
-    res.should == "Hosts"
+    res = controller.send(:set_discover_title, "hosts", "host")
+    res.should == "Hosts / Nodes"
 
     res = controller.send(:set_discover_title,"ems", "ems_infra")
     res.should == "Infrastructure Providers"

--- a/vmdb/spec/controllers/application_controller/explorer_spec.rb
+++ b/vmdb/spec/controllers/application_controller/explorer_spec.rb
@@ -92,7 +92,7 @@ describe VmInfraController do
         node[:key].should eq("c-#{MiqRegion.compress_id(cluster.id)}")
         node[:title].should eq(cluster.name)
         node[:icon].should eq("cluster.png")
-        node[:tooltip].should eq("Cluster: #{cluster.name}")
+        node[:tooltip].should eq("Cluster / Deployment Role: #{cluster.name}")
       end
 
       it "valid Host node" do
@@ -109,7 +109,7 @@ describe VmInfraController do
         node[:key].should eq("h-#{MiqRegion.compress_id(host.id)}")
         node[:title].should eq(host.name)
         node[:icon].should eq("host.png")
-        node[:tooltip].should eq("Host: #{host.name}")
+        node[:tooltip].should eq("Host / Node: #{host.name}")
       end
     end
 
@@ -128,9 +128,9 @@ describe VmInfraController do
         object = objects.first
 
         object[:id].should    == "folder_c_xx-#{MiqRegion.compress_id(ems.id)}"
-        object[:text].should  == "Clusters"
+        object[:text].should  == "Cluster / Deployment Role"
         object[:image].should == "folder"
-        object[:tip].should   == "Clusters (Click to open)"
+        object[:tip].should   == "Cluster / Deployment Role (Click to open)"
       end
     end
 

--- a/vmdb/spec/controllers/miq_capacity_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_capacity_controller_spec.rb
@@ -11,13 +11,21 @@ describe MiqCapacityController do
         host = FactoryGirl.create(:host, :name => "My Host")
         ds = FactoryGirl.create(:storage_vmware, :name => "My Datastore")
         title_suffix = method == "util_get_node_info" ? "Utilization Trend Summary" : "Bottlenecks Summary"
-        tree_nodes = Hash.new
-        tree_nodes =  {
-                        :region => {:active_node => "mr-#{MiqRegion.compress_id(mr.id)}", :title_prefix => "Region", :title => mr.description},
-                        :e => {:active_node => "e-#{MiqRegion.compress_id(e.id)}", :title_prefix => "Provider", :title => e.name},
-                        :cl => {:active_node => "c-#{MiqRegion.compress_id(cl.id)}", :title_prefix => "Cluster", :title => cl.name},
-                        :host => {:active_node => "h-#{MiqRegion.compress_id(host.id)}", :title_prefix => "Host", :title => host.name},
-                        :ds => {:active_node => "ds-#{MiqRegion.compress_id(ds.id)}", :title_prefix => "Datastore", :title => ds.name}
+        tree_nodes = {:region => {:active_node  => "mr-#{MiqRegion.compress_id(mr.id)}",
+                                  :title_prefix => "Region",
+                                  :title        => mr.description},
+                      :e      => {:active_node  => "e-#{MiqRegion.compress_id(e.id)}",
+                                  :title_prefix => "Provider",
+                                  :title        => e.name},
+                      :cl     => {:active_node  => "c-#{MiqRegion.compress_id(cl.id)}",
+                                  :title_prefix => "Cluster / Deployment Role",
+                                  :title        => cl.name},
+                      :host   => {:active_node  => "h-#{MiqRegion.compress_id(host.id)}",
+                                  :title_prefix => "Host / Node",
+                                  :title        => host.name},
+                      :ds     => {:active_node  => "ds-#{MiqRegion.compress_id(ds.id)}",
+                                  :title_prefix => "Datastore",
+                                  :title        => ds.name}
                       }
         tree_nodes.each do |key,node|
           controller.instance_variable_set(:@temp, {})

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -4025,4 +4025,146 @@ describe ApplicationHelper do
       end
     end
   end
+
+  context "#title_for_clusters" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Clusters / Deployment Roles' when there are both openstack & non-openstack clusters" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = title_for_clusters
+      result.should eq("Clusters / Deployment Roles")
+    end
+
+    it "returns 'Clusters' when there are only non-openstack clusters" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+
+      result = title_for_clusters
+      result.should eq("Clusters")
+    end
+
+    it "returns 'Deployment Roles' when there are only openstack clusters" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = title_for_clusters
+      result.should eq("Deployment Roles")
+    end
+  end
+
+  context "#title_for_cluster" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Cluster' for non-openstack cluster" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+
+      result = title_for_cluster
+      result.should eq("Cluster")
+    end
+
+    it "returns 'Deployment Role' for openstack cluster" do
+      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = title_for_cluster
+      result.should eq("Deployment Role")
+    end
+  end
+
+  context "#title_for_cluster_record" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Cluster' for non-openstack host" do
+      cluster = FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+
+      result = title_for_cluster_record(cluster)
+      result.should eq("Cluster")
+    end
+
+    it "returns 'Deployment Role' for openstack host" do
+      cluster = FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+
+      result = title_for_cluster_record(cluster)
+      result.should eq("Deployment Role")
+    end
+  end
+
+  context "#title_for_hosts" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Hosts / Nodes' when there are both openstack & non-openstack hosts" do
+      FactoryGirl.create(:host_vmware_esx, :ems_id => @ems1.id)
+      FactoryGirl.create(:host_redhat, :ems_id => @ems2.id)
+
+      result = title_for_hosts
+      result.should eq("Hosts / Nodes")
+    end
+
+    it "returns 'Hosts' when there are only non-openstack hosts" do
+      FactoryGirl.create(:host_vmware_esx, :ems_id => @ems1.id)
+
+      result = title_for_hosts
+      result.should eq("Hosts")
+    end
+
+    it "returns 'Nodes' when there are only openstack hosts" do
+      FactoryGirl.create(:host_redhat, :ems_id => @ems2.id)
+
+      result = title_for_hosts
+      result.should eq("Nodes")
+    end
+  end
+
+  context "#title_for_host" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Host' for non-openstack host" do
+      FactoryGirl.create(:host_vmware, :ems_id => @ems1.id)
+
+      result = title_for_host
+      result.should eq("Host")
+    end
+
+    it "returns 'Node' for openstack host" do
+      FactoryGirl.create(:host_redhat, :ems_id => @ems2.id)
+
+      result = title_for_host
+      result.should eq("Node")
+    end
+  end
+
+  context "#title_for_host_record" do
+    before(:each) do
+      @ems1 = FactoryGirl.create(:ems_vmware)
+      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+    end
+
+    it "returns 'Host' for non-openstack host" do
+      host = FactoryGirl.create(:host_vmware, :ems_id => @ems1.id)
+
+      result = title_for_host_record(host)
+      result.should eq("Host")
+    end
+
+    it "returns 'Node' for openstack host" do
+      host = FactoryGirl.create(:host_redhat, :ems_id => @ems2.id)
+
+      result = title_for_host_record(host)
+      result.should eq("Node")
+    end
+  end
 end

--- a/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/vc_refresher_spec.rb
@@ -100,7 +100,7 @@ describe EmsRefresh::Refreshers::VcRefresher do
       :ems_ref               => "resgroup-872",
       :ems_ref_obj           => VimString.new("resgroup-872", :ResourcePool, :ManagedObjectReference),
       :uid_ems               => "resgroup-872",
-      :name                  => "Default for Cluster Testing-Production Cluster",
+      :name                  => "Default for Cluster / Deployment Role Testing-Production Cluster",
       :memory_reserve        => 102298,
       :memory_reserve_expand => true,
       :memory_limit          => 102298,
@@ -441,7 +441,7 @@ describe EmsRefresh::Refreshers::VcRefresher do
         [EmsFolder, "Dev", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {
             [HostVmwareEsx, "vi4esxm3.manageiq.com"] => {
-              [ResourcePool, "Default for Host vi4esxm3.manageiq.com", {:is_default => true}] => {
+              [ResourcePool, "Default for Host / Node vi4esxm3.manageiq.com", {:is_default => true}] => {
                 [VmVmware, "Dev Cucumber Nightly Appl 2011-05-19"] => {},
                 [VmVmware, "DEV-GreggT"] => {},
                 [VmVmware, "DEV-GregM"] => {},
@@ -540,7 +540,8 @@ describe EmsRefresh::Refreshers::VcRefresher do
         [EmsFolder, "Prod", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {
             [EmsCluster, "Testing-Production Cluster"] => {
-              [ResourcePool, "Default for Cluster Testing-Production Cluster", {:is_default => true}] => {
+              [ResourcePool, "Default for Cluster / Deployment Role Testing-Production Cluster",
+               {:is_default => true}] => {
                 [ResourcePool, "Citrix", {:is_default => false}] => {
                   [VmVmware, "Citrix 5"] => {}
                 },
@@ -630,7 +631,7 @@ describe EmsRefresh::Refreshers::VcRefresher do
             },
             [EmsFolder, "Test", {:is_datacenter => false}] => {
               [HostVmwareEsx, "localhost"] => {
-                [ResourcePool, "Default for Host localhost", {:is_default => true}] => {}
+                [ResourcePool, "Default for Host / Node localhost", {:is_default => true}] => {}
               }
             }
           },

--- a/vmdb/spec/models/miq_expression/miq_expression_spec.rb
+++ b/vmdb/spec/models/miq_expression/miq_expression_spec.rb
@@ -471,8 +471,8 @@ describe MiqExpression do
       relats  = MiqExpression.get_relats(Vm)
       details = MiqExpression._model_details(relats, {})
       cluster_sorted = details.select { |d| d.first.starts_with?("Cluster") }.sort
-      cluster_sorted.map(&:first).should include("Cluster : Total Number of Physical CPUs")
-      cluster_sorted.map(&:first).should include("Cluster : Total Number of Logical CPUs")
+      cluster_sorted.map(&:first).should include("Cluster / Deployment Role : Total Number of Physical CPUs")
+      cluster_sorted.map(&:first).should include("Cluster / Deployment Role : Total Number of Logical CPUs")
       hardware_sorted = details.select { |d| d.first.starts_with?("Hardware") }.sort
       hardware_sorted.map(&:first).should_not include("Hardware : Logical Cpus")
     end
@@ -941,7 +941,7 @@ describe MiqExpression do
         FactoryGirl.create(:classification, :parent_id => category.id, :name => 'prod', :description => 'Production')
 
         exp = MiqExpression.new({"CONTAINS" => {"tag" => "Host.managed-environment", "value" => "prod"}})
-        exp.to_human.should == "Host.My Company Tags : Environment CONTAINS 'Production'"
+        exp.to_human.should == "Host / Node.My Company Tags : Environment CONTAINS 'Production'"
 
         exp = MiqExpression.new({"CONTAINS" => {"tag" => "Host.managed-environment", "value" => "prod", "alias" => "Env"}})
         exp.to_human.should == "Env CONTAINS 'Production'"


### PR DESCRIPTION
- Added generic methods to help determine the titles for Host/Cluster screens, along with dictionary entries so ui_lookup calls can be used.
- These changes handle displaying Host/Cluster title as "Hosts / Nodes" & "Clusters / Deployment Roles" on Host & cluster screens if user has both openstack & non-openstack records. Display "Hosts", "Clusters" if user has only non-openstack data and "Nodes", "Deployment Roles" if user only has openstack data in DB.
- Toolbar buttons and product feature titles have been changed to show item/items on Host/Cluster specific buttons & features.

@dclarizio please review/test