### PR TITLE
Support OSP7 parameter names in OpenStack Infrastructure scaling

### DIFF
--- a/vmdb/app/controllers/ems_infra_controller.rb
+++ b/vmdb/app/controllers/ems_infra_controller.rb
@@ -18,6 +18,14 @@ class EmsInfraController < ApplicationController
     redirect_to :action => 'show_list'
   end
 
+  def osp6?(name)
+    name.include?('::count')
+  end
+
+  def osp7?(name)
+    name.include?('Count')
+  end
+
   def scaling
     assert_privileges("ems_infra_scale")
 
@@ -33,11 +41,11 @@ class EmsInfraController < ApplicationController
       return
     end
 
-    @count_parameters = @stack.parameters.select { |x| x.name.include?('::count') }
+    @count_parameters = @stack.parameters.select { |x| osp6?(x.name) || osp7?(x.name) }
 
     return unless params[:scale]
 
-    scale_parameters = params.select { |k, _v| k.include?('::count') }
+    scale_parameters = params.select { |k, _v| osp6?(k) || osp7?(k) }
     assigned_hosts = scale_parameters.values.sum(&:to_i)
     infra = EmsOpenstackInfra.find(params[:id])
     if assigned_hosts > infra.hosts.count

--- a/vmdb/spec/controllers/ems_infra_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_infra_controller_spec.rb
@@ -124,4 +124,23 @@ describe EmsInfraController do
       flash_messages.first[:message].should include(_("Unable to initiate scaling: my error"))
     end
   end
+
+  describe "#scaling osp7 parameter names" do
+
+    before do
+      set_user_privileges
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_stack_osp7)
+      @orchestration_stack_parameter_compute = FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute_osp7)
+    end
+
+    it "when values are changed, and values do not exceed number of hosts available" do
+      OrchestrationStackOpenstackInfra.any_instance.stub(:raw_update_stack)
+      post :scaling, :id => @ems.id, :scale => "", :orchestration_stack_id => @ems.orchestration_stacks.first.id,
+           @orchestration_stack_parameter_compute.name => 2
+      controller.send(:flash_errors?).should be_false
+      response.body.should include("redirected")
+      response.body.should include("show")
+      response.body.should include("1+to+2")
+    end
+  end
 end

--- a/vmdb/spec/factories/ext_management_system.rb
+++ b/vmdb/spec/factories/ext_management_system.rb
@@ -62,6 +62,13 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_openstack_infra_with_stack_osp7, :parent => :ems_openstack_infra do
+    after :create do |x|
+      x.orchestration_stacks << FactoryGirl.create(:orchestration_stack_openstack_infra_osp7)
+      4.times { x.hosts << FactoryGirl.create(:host_openstack_infra) }
+    end
+  end
+
   factory :ems_openstack_infra_with_authentication, :parent => :ems_openstack_infra do
     after :create do |x|
       x.authentications << FactoryGirl.create(:authentication, :userid => "admin", :password => "123456789")

--- a/vmdb/spec/factories/orchestration_stack.rb
+++ b/vmdb/spec/factories/orchestration_stack.rb
@@ -25,4 +25,26 @@ FactoryGirl.define do
       x.value = "1"
     end
   end
+
+  factory :orchestration_stack_openstack_infra_osp7, :class => "OrchestrationStackOpenstackInfra" do
+    after :create do |x|
+      x.parameters << FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute_osp7)
+      x.parameters << FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_controller_osp7)
+    end
+  end
+
+  factory :orchestration_stack_parameter_openstack_infra_compute_osp7, :parent => :orchestration_stack_parameter_openstack_infra do
+    after :create do |x|
+      x.name = "ComputeCount"
+      x.value = "1"
+    end
+  end
+
+  factory :orchestration_stack_parameter_openstack_infra_controller_osp7, :parent => :orchestration_stack_parameter_openstack_infra do
+    after :create do |x|
+      x.name = "ControllerCount"
+      x.value = "1"
+    end
+  end
+
 end


### PR DESCRIPTION
This change adds support for both OSP6 and OSP7 parameter names.

OSP6 parameter names are in the form: compute-1::count.

In OSP7, the parameter names are in the form: ComputeCount.