### PR TITLE
Menu items changing names on show time for infra.

### DIFF
--- a/vmdb/app/presenters/menu/default_menu.rb
+++ b/vmdb/app/presenters/menu/default_menu.rb
@@ -34,27 +34,37 @@ module Menu
       end
 
       def infrastructure_menu_section
+        hosts_name    = hybrid_name(EmsCluster, N_("Hosts"),    N_("Nodes"),            N_("Hosts / Nodes"))
+        clusters_name = hybrid_name(Host,       N_("Clusters"), N_("Deployment Roles"), N_("Clusters / Deployment Roles"))
+
         Menu::Section.new(:inf, "Infrastructure", [
           Menu::Item.new('ems_infra',        N_('Providers'),        'ems_infra',     {:feature => 'ems_infra_show_list'},     '/ems_infra'),
-          Menu::Item.new('ems_cluster',      N_('Clusters'),         'ems_cluster',   {:feature => 'ems_cluster_show_list'},   '/ems_cluster'),
-          Menu::Item.new('host',             N_('Hosts'),            'host',          {:feature => 'host_show_list'},          '/host'),
+          Menu::Item.new('ems_cluster',      clusters_name,          'ems_cluster',   {:feature => 'ems_cluster_show_list'},   '/ems_cluster'),
+          Menu::Item.new('host',             hosts_name,             'host',          {:feature => 'host_show_list'},          '/host'),
           Menu::Item.new('vm_infra',         N_('Virtual Machines'), 'vm_infra_explorer_accords',
-                                                                                     {:feature => 'vm_infra_explorer_accords', :any => true},
-                                                                                                                              '/vm_infra/explorer'),
+                                                                                      {:feature => 'vm_infra_explorer_accords', :any => true},
+                                                                                                                               '/vm_infra/explorer'),
           Menu::Item.new('resource_pool',    N_('Resource Pools'),   'resource_pool', {:feature => 'resource_pool_show_list'}, '/resource_pool'),
           Menu::Item.new('storage',          ui_lookup(:tables => 'storages'),
-                                                                    'storage',       {:feature => 'storage_show_list'},       '/storage'),
+                                                                     'storage',       {:feature => 'storage_show_list'},       '/storage'),
           Menu::Item.new('repository',       N_('Repositories'),     'repository',    {:feature => 'repository_show_list'},    '/repository'),
           Menu::Item.new('pxe',              N_('PXE'),              'pxe',           {:feature => 'pxe', :any => true},       '/pxe/explorer'),
           Menu::Item.new('miq_request_host', N_('Requests'),         nil,             {:feature => 'miq_request_show_list'},   '/miq_request?typ=host'),
-          Menu::Item.new('provider_foreman',
-                         N_('Configuration Management'),
-                         'provider_foreman_explorer_accords',
-                         {:feature => 'provider_foreman_explorer_accords',
-                          :any     => true},
-                         '/provider_foreman/explorer')
+          Menu::Item.new('provider_foreman', N_('Configuration Management'), 'provider_foreman_explorer_accords',
+                         {:feature => 'provider_foreman_explorer_accords', :any => true}, '/provider_foreman/explorer')
         ])
       end
+
+      def hybrid_name(klass, name1, name2, name3)
+        lambda do
+          case klass.node_types
+          when :non_openstack then name1
+          when :openstack     then name2
+          else                     name3
+          end
+        end
+      end
+      private :hybrid_name
 
       def container_menu_section
         Menu::Section.new(:cnt, "Containers", [
@@ -72,7 +82,7 @@ module Menu
           Menu::Item.new('ontap_logical_disk',   ui_lookup(:tables => 'ontap_logical_disk'),   'ontap_logical_disk',   {:feature => 'ontap_logical_disk_show_list'},   '/ontap_logical_disk'),
           Menu::Item.new('ontap_storage_volume', ui_lookup(:tables => 'ontap_storage_volume'), 'ontap_storage_volume', {:feature => 'ontap_storage_volume_show_list'}, '/ontap_storage_volume'),
           Menu::Item.new('ontap_file_share',     ui_lookup(:tables => 'ontap_file_share'),     'ontap_file_share',     {:feature => 'ontap_file_share_show_list'},     '/ontap_file_share'),
-          Menu::Item.new('storage_manager',      N_('Storage Managers'),                        'storage_manager',      {:feature => 'storage_manager_show_list'}, '/storage_manager')
+          Menu::Item.new('storage_manager',      N_('Storage Managers'),                       'storage_manager',      {:feature => 'storage_manager_show_list'}, '/storage_manager')
         ])
       end
 

--- a/vmdb/app/presenters/menu/item.rb
+++ b/vmdb/app/presenters/menu/item.rb
@@ -1,7 +1,11 @@
 module Menu
-  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type) do
-    def initialize(an_id, name, features, rbac_feature, href, type = :default)
+  Item = Struct.new(:id, :_name, :feature, :rbac_feature, :href, :type) do
+    def initialize(an_id, _name, features, rbac_feature, href, type = :default)
       super
+    end
+
+    def name
+      _name.kind_of?(Proc) ? _name.call : _name
     end
 
     def visible?

--- a/vmdb/app/presenters/menu/item.rb
+++ b/vmdb/app/presenters/menu/item.rb
@@ -1,11 +1,12 @@
 module Menu
-  Item = Struct.new(:id, :_name, :feature, :rbac_feature, :href, :type) do
-    def initialize(an_id, _name, features, rbac_feature, href, type = :default)
+  Item = Struct.new(:id, :name, :feature, :rbac_feature, :href, :type) do
+    def initialize(an_id, a_name, features, rbac_feature, href, type = :default)
       super
+      @name = a_name.kind_of?(Proc) ? a_name : lambda { a_name }
     end
 
     def name
-      _name.kind_of?(Proc) ? _name.call : _name
+      @name.call
     end
 
     def visible?


### PR DESCRIPTION
Alternative to #2715

 * removed the def inside def which was a mistake
 * merged the 2 classes to have less code

Is it better this way? Ping @Fryguy 

Or should I create a class for each new menu item with the case copied into each of them? My guess is that we will have more menu items that will change names sooner or later and I would prefer a more generic way to do that (as I have in this PR) to having to write a class or a if-else statement for each such changing menu item.

Also more generic approach can better be used from plugins that would define menu items.