### PR TITLE
Retiring a deleted stack from provider

### DIFF
--- a/vmdb/app/models/orchestration_stack.rb
+++ b/vmdb/app/models/orchestration_stack.rb
@@ -59,4 +59,12 @@ class OrchestrationStack < ActiveRecord::Base
   def raw_status
     ext_management_system.stack_status(name, ems_ref)
   end
+
+  def raw_exists?
+    status, _reason = raw_status
+    status.nil? || status.downcase == 'delete_complete' ? false : true
+  rescue => err
+    return false if err.to_s =~ /[S|s]tack.+does not exist/
+    raise
+  end
 end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -18,7 +18,7 @@ object:
       datatype: string
       priority: 1
       owner: 
-      default_value: /Cloud/Orchestration/Provisioning/StateMachines/Methods/Preprovision
+      default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/Preprovision"
       substitute: true
       message: create
       visibility: 
@@ -118,7 +118,7 @@ object:
       datatype: string
       priority: 6
       owner: 
-      default_value: /Cloud/Orchestration/Provisioning/StateMachines/Methods/Provision
+      default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/Provision"
       substitute: true
       message: create
       visibility: 
@@ -138,7 +138,7 @@ object:
       datatype: string
       priority: 7
       owner: 
-      default_value: /Cloud/Orchestration/Provisioning/StateMachines/Methods/CheckProvisioned
+      default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/CheckProvisioned"
       substitute: true
       message: create
       visibility: 
@@ -158,7 +158,7 @@ object:
       datatype: string
       priority: 8
       owner: 
-      default_value: /Cloud/Orchestration/Provisioning/StateMachines/Methods/PostProvision
+      default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/PostProvision"
       substitute: true
       message: create
       visibility: 
@@ -258,7 +258,7 @@ object:
       datatype: string
       priority: 13
       owner: 
-      default_value: /Cloud/Orchestration/Provisioning/Email/ServiceProvision_complete?event=service_provisioned
+      default_value: "/Cloud/Orchestration/Provisioning/Email/ServiceProvision_complete?event=service_provisioned"
       substitute: true
       message: create
       visibility: 
@@ -278,7 +278,7 @@ object:
       datatype: string
       priority: 14
       owner: 
-      default_value: /System/CommonMethods/StateMachineMethods/service_provision_finished
+      default_value: "/System/CommonMethods/StateMachineMethods/service_provision_finished"
       substitute: true
       message: create
       visibility: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
@@ -3,15 +3,15 @@
 #
 $evm.root['ae_result'] = 'ok'
 stack = $evm.root['orchestration_stack']
-$evm.log("info", "Check stack #{stack.name} removed from provider")
+$evm.log("info", "Checking stack #{stack.try(:name)} removed from provider")
 
-if stack && !$evm.get_state_var('stack_removed_from_provider')
+if stack && $evm.get_state_var('stack_exists_in_provider')
   status, _reason = stack.raw_status
   if status.nil?
     $evm.root['ae_result'] = 'error'
     $evm.root['ae_reason'] = 'Cannot find status of stack #{stack.name}. It may no longer exist in the provider'
   elsif status.downcase == 'delete_complete'
-    $evm.set_state_var('stack_removed_from_provider', true)
+    $evm.set_state_var('stack_exists_in_provider', false)
   else
     $evm.root['ae_result']	   = 'retry'
     $evm.root['ae_retry_interval'] = '1.minute'

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
@@ -5,11 +5,11 @@ $evm.root['ae_result'] = 'ok'
 stack = $evm.root['orchestration_stack']
 $evm.log("info", "Check stack #{stack.name} removed from provider")
 
-if stack
+if stack && !$evm.get_state_var('stack_removed_from_provider')
   status, _reason = stack.raw_status
   if status.nil?
     $evm.root['ae_result'] = 'error'
-    $evm.root['ae_reason'] = 'Cannot find status of stack #{stack.name}. It may not exist in the provider'
+    $evm.root['ae_reason'] = 'Cannot find status of stack #{stack.name}. It may no longer exist in the provider'
   elsif status.downcase == 'delete_complete'
     $evm.set_state_var('stack_removed_from_provider', true)
   else

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
@@ -4,7 +4,7 @@
 
 stack = $evm.root['orchestration_stack']
 
-if stack && $evm.get_state_var('stack_removed_from_provider')
+if stack && !$evm.get_state_var('stack_exists_in_provider')
   $evm.log('info', "Removing stack <#{stack.name}> from VMDB")
   stack.remove_from_vmdb
   $evm.root['orchestration_stack'] = nil

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -5,10 +5,14 @@
 # Get stack from root object
 stack = $evm.root['orchestration_stack']
 
-$evm.set_state_var('stack_removed_from_provider', false)
-
 if stack
   ems = stack.ext_management_system
-  $evm.log('info', "Removing stack:<#{stack.name}> from provider:<#{ems.try(:name)}>")
-  stack.raw_delete_stack
+  if stack.raw_exists?
+    $evm.log('info', "Removing stack:<#{stack.name}> from provider:<#{ems.try(:name)}>")
+    stack.raw_delete_stack
+    $evm.set_state_var('stack_removed_from_provider', false)
+  else
+    $evm.log('info', "Stack <#{stack.name}> no longer exists in provider:<#{ems.try(:name)}>")
+    $evm.set_state_var('stack_removed_from_provider', true)
+  end
 end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -10,9 +10,9 @@ if stack
   if stack.raw_exists?
     $evm.log('info', "Removing stack:<#{stack.name}> from provider:<#{ems.try(:name)}>")
     stack.raw_delete_stack
-    $evm.set_state_var('stack_removed_from_provider', false)
+    $evm.set_state_var('stack_exists_in_provider', true)
   else
     $evm.log('info', "Stack <#{stack.name}> no longer exists in provider:<#{ems.try(:name)}>")
-    $evm.set_state_var('stack_removed_from_provider', true)
+    $evm.set_state_var('stack_existes_in_provider', false)
   end
 end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/__class__.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/__class__.yaml
@@ -178,7 +178,7 @@ object:
       datatype: string
       priority: 13
       owner: 
-      default_value: "#/Cloud/Orchestration/Retirement/Email/stack_retirement_emails?event=stack_retired"
+      default_value: "/Cloud/Orchestration/Retirement/Email/stack_retirement_emails?event=stack_retired"
       substitute: true
       message: create
       visibility: 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/default.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/default.yaml
@@ -7,4 +7,4 @@ object:
     name: Default
     inherits: 
     description: 
-  fields:
+  fields: []

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
@@ -28,5 +28,13 @@ module MiqAeMethodService
       @object = nil
       true
     end
+
+    def raw_exists?
+      status, reason = raw_status
+      status.nil? || status.downcase == 'delete_complete' ? false : true
+    rescue => err
+      return false if err.to_s =~ /[S|s]tack.+does not exist/
+      raise
+    end
   end
 end

--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
@@ -14,6 +14,7 @@ module MiqAeMethodService
     expose :raw_delete_stack
     expose :raw_update_stack
     expose :raw_status
+    expose :raw_exists?
 
     def add_to_service(service)
       error_msg = "service must be a MiqAeServiceService"
@@ -27,14 +28,6 @@ module MiqAeMethodService
       object_send(:destroy)
       @object = nil
       true
-    end
-
-    def raw_exists?
-      status, reason = raw_status
-      status.nil? || status.downcase == 'delete_complete' ? false : true
-    rescue => err
-      return false if err.to_s =~ /[S|s]tack.+does not exist/
-      raise
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1215216

This fix is to address the retirement failure of a deleted stack from provider.
When we detect the stack is no longer in the provider, we will skip the step to delete it from the provide and move on to remove it from VMDB.

There are two other minor fixes: 
1. Enable sending email when a stack is retired
2. YAML formatting