### PR TITLE
Smartstate analysis handle missing hostname gracefully

### DIFF
--- a/vmdb/app/models/host.rb
+++ b/vmdb/app/models/host.rb
@@ -1707,6 +1707,12 @@ class Host < ActiveRecord::Base
 
       # Skip SSH for ESXi hosts
       unless self.is_vmware_esxi?
+        if self.hostname.blank?
+          $log.warn "#{log_header} No hostname defined for #{log_target}"
+          task.update_status("Finished", "Warn", "Scanning incomplete due to missing hostname")  if task
+          return
+        end
+
         self.update_ssh_auth_status! if self.respond_to?(:update_ssh_auth_status!)
 
         if self.missing_credentials?


### PR DESCRIPTION
Smartstate handle missing hostname gracefully. Just logging
warning about missing hostname. Right now it throws an exception
when it tries to connect to a blank hostname and the exception
is missleading, cause it references host only by hostname.