### PR TITLE
OpenstackInfra fix event connection to Host

### DIFF
--- a/vmdb/app/models/ems_event/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_event/parsers/openstack_infra.rb
@@ -17,9 +17,9 @@ module EmsEvent::Parsers::OpenstackInfra
     }
 
     payload = event[:content]["payload"]
-    event_hash[:host_ems_ref]              = payload["node"]              if payload.has_key? "node"
-    event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.has_key? "availability_zone"
-    event_hash[:chain_id]                  = payload["reservation_id"]    if payload.has_key? "reservation_id"
+    event_hash[:host_ems_ref]              = payload["node"]              if payload.key? "node"
+    event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
+    event_hash[:chain_id]                  = payload["reservation_id"]    if payload.key? "reservation_id"
     event_hash
   end
 end

--- a/vmdb/app/models/ems_event/parsers/openstack_infra.rb
+++ b/vmdb/app/models/ems_event/parsers/openstack_infra.rb
@@ -17,9 +17,9 @@ module EmsEvent::Parsers::OpenstackInfra
     }
 
     payload = event[:content]["payload"]
-    event_hash[:host_ems_ref] = Host.where('ems_ref_obj LIKE ?', "%#{payload['instance_id']}%").first.try(:ems_ref) if payload.has_key? "instance_id"
+    event_hash[:host_ems_ref]              = payload["node"]              if payload.has_key? "node"
     event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.has_key? "availability_zone"
-    event_hash[:chain_id] = payload["reservation_id"]                     if payload.has_key? "reservation_id"
+    event_hash[:chain_id]                  = payload["reservation_id"]    if payload.has_key? "reservation_id"
     event_hash
   end
 end


### PR DESCRIPTION
Event payload actually contains reference to host in 'node' index.
So we don't have to obtain that reference in the complex way that
is there now, which was dependent of refresh and error prone.