### PR TITLE
SCVMM - Handles unset CPU limits and reservations

### DIFF
--- a/vmdb/app/models/miq_provision_microsoft/cloning.rb
+++ b/vmdb/app/models/miq_provision_microsoft/cloning.rb
@@ -88,6 +88,15 @@ module MiqProvisionMicrosoft::Cloning
     end
   end
 
+  def cpu_ps_script
+    cpu_script = ""
+    cpu_script << "-CPUCount #{cpu_count} "
+    cpu_script << "-CPUReserve #{cpu_reserve} " unless cpu_reserve.nil?
+    cpu_script << "-CPUMaximumPercent #{cpu_max} " unless cpu_max.nil?
+
+    cpu_script
+  end
+
   def template_ps_script
     "(Get-SCVMTemplate -Name #{source.name})"
   end
@@ -116,9 +125,7 @@ module MiqProvisionMicrosoft::Cloning
         -Path #{dest_mount_point} \
         -VMTemplate #{template_ps_script}; \
       Set-SCVirtualMachine -VM $vm \
-        -CPUCount #{cpu_count} \
-        -CPUReserve #{cpu_reserve} \
-        -CPUMaximumPercent #{cpu_max} \
+        #{cpu_ps_script} \
         #{memory_ps_script} | Out-Null;  \
       #{network_adapter_ps_script} \
       $vm | Select-Object ID | ConvertTo-Json

--- a/vmdb/app/models/miq_provision_microsoft/cloning.rb
+++ b/vmdb/app/models/miq_provision_microsoft/cloning.rb
@@ -89,8 +89,7 @@ module MiqProvisionMicrosoft::Cloning
   end
 
   def cpu_ps_script
-    cpu_script = ""
-    cpu_script << "-CPUCount #{cpu_count} "
+    cpu_script = "-CPUCount #{cpu_count} "
     cpu_script << "-CPUReserve #{cpu_reserve} " unless cpu_reserve.nil?
     cpu_script << "-CPUMaximumPercent #{cpu_max} " unless cpu_max.nil?
 

--- a/vmdb/spec/models/miq_provision_microsoft_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft_spec.rb
@@ -1,6 +1,19 @@
 require "spec_helper"
 
 describe MiqProvisionMicrosoft do
+  let(:vm_prov) do
+    FactoryGirl.create(
+      :miq_provision_microsoft,
+      :userid       => @user.userid,
+      :miq_request  => @pr,
+      :source       => @vm_template,
+      :request_type => 'template',
+      :state        => 'pending',
+      :status       => 'Ok',
+      :options      => @options
+    )
+  end
+
   context "A new provision request," do
     before(:each) do
       @os = OperatingSystem.new(:product_name => 'Microsoft Windows')
@@ -29,33 +42,23 @@ describe MiqProvisionMicrosoft do
         :provision_type => "microsoft",
         :src_vm_id      => [@vm_template.id, @vm_template.name]
       }
-
-      @vm_prov     = FactoryGirl.create(
-        :miq_provision_microsoft,
-        :userid       => @user.userid,
-        :miq_request  => @pr,
-        :source       => @vm_template,
-        :request_type => 'template',
-        :state        => 'pending',
-        :status       => 'Ok',
-        :options      => @options)
     end
 
     context "SCVMM provisioning" do
       it "#workflow" do
         MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-        @vm_prov.workflow.class.should eq MiqProvisionMicrosoftWorkflow
+        vm_prov.workflow.class.should eq MiqProvisionMicrosoftWorkflow
       end
     end
 
     context "#prepare_for_clone_task" do
       before do
         @host = FactoryGirl.create(:host_microsoft, :ems_ref => "test_ref")
-        @vm_prov.stub(:dest_host).and_return(@host)
+        vm_prov.stub(:dest_host).and_return(@host)
       end
 
       it "with default options" do
-        clone_options = @vm_prov.prepare_for_clone_task
+        clone_options = vm_prov.prepare_for_clone_task
         clone_options[:name].should == @target_vm_name
         clone_options[:host].should == @host
       end
@@ -64,37 +67,27 @@ describe MiqProvisionMicrosoft do
     context "#parse mount point" do
       before do
         @datastore = FactoryGirl.create(:storage, :name => "C:\\directoryname\\test_datastore")
-        @vm_prov.stub(:dest_datastore).and_return(@datastore)
+        vm_prov.stub(:dest_datastore).and_return(@datastore)
       end
 
       it "valid drive" do
-        @vm_prov.dest_mount_point.should == "C:"
+        vm_prov.dest_mount_point.should == "C:"
       end
     end
 
     context "#no network adapter available" do
       it "set adapter" do
-        expect(@vm_prov.network_adapter_ps_script).to be_nil
+        expect(vm_prov.network_adapter_ps_script).to be_nil
       end
     end
 
     context "#network adapter available" do
       before do
         @options[:vlan] = "virtualnetwork1"
-
-        @vm_prov     = FactoryGirl.create(
-          :miq_provision_microsoft,
-          :userid       => @user.userid,
-          :miq_request  => @pr,
-          :source       => @vm_template,
-          :request_type => 'template',
-          :state        => 'pending',
-          :status       => 'Ok',
-          :options      => @options)
       end
 
       it "set adapter" do
-        expect(@vm_prov.network_adapter_ps_script).to_not be_nil
+        expect(vm_prov.network_adapter_ps_script).to_not be_nil
       end
     end
 
@@ -103,20 +96,10 @@ describe MiqProvisionMicrosoft do
         @options[:number_of_cpus] = 2
         @options[:cpu_limit]      = nil
         @options[:cpu_reserve]    = nil
-
-        @vm_prov     = FactoryGirl.create(
-          :miq_provision_microsoft,
-          :userid       => @user.userid,
-          :miq_request  => @pr,
-          :source       => @vm_template,
-          :request_type => 'template',
-          :state        => 'pending',
-          :status       => 'Ok',
-          :options      => @options)
       end
 
       it "set vm" do
-        @vm_prov.cpu_ps_script.should == "-CPUCount 2 "
+        vm_prov.cpu_ps_script.should == "-CPUCount 2 "
       end
     end
 
@@ -125,20 +108,10 @@ describe MiqProvisionMicrosoft do
         @options[:cpu_limit]      = 40
         @options[:cpu_reserve]    = nil
         @options[:number_of_cpus] = 2
-
-        @vm_prov     = FactoryGirl.create(
-          :miq_provision_microsoft,
-          :userid       => @user.userid,
-          :miq_request  => @pr,
-          :source       => @vm_template,
-          :request_type => 'template',
-          :state        => 'pending',
-          :status       => 'Ok',
-          :options      => @options)
       end
 
       it "set vm" do
-        @vm_prov.cpu_ps_script.should == "-CPUCount 2 -CPUMaximumPercent 40 "
+        vm_prov.cpu_ps_script.should == "-CPUCount 2 -CPUMaximumPercent 40 "
       end
     end
 
@@ -147,20 +120,10 @@ describe MiqProvisionMicrosoft do
         @options[:cpu_reserve]    = 15
         @options[:cpu_limit]      = nil
         @options[:number_of_cpus] = 2
-
-        @vm_prov     = FactoryGirl.create(
-          :miq_provision_microsoft,
-          :userid       => @user.userid,
-          :miq_request  => @pr,
-          :source       => @vm_template,
-          :request_type => 'template',
-          :state        => 'pending',
-          :status       => 'Ok',
-          :options      => @options)
       end
 
       it "set vm" do
-        @vm_prov.cpu_ps_script.should == "-CPUCount 2 -CPUReserve 15 "
+        vm_prov.cpu_ps_script.should == "-CPUCount 2 -CPUReserve 15 "
       end
     end
   end


### PR DESCRIPTION
When provisioning a new virtual machine for the SCVMM provider type an exception is thrown by SCVMM if the CPU limits and reservations have not been set.
This PR addresses this by checking if these values are nil before setting them in the powershell command.

https://bugzilla.redhat.com/show_bug.cgi?id=1216157