### PR TITLE
Enhancement to support optional --ipadomain

### DIFF
--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -96,6 +96,7 @@ module ApplianceConsole
         opt :ipaserver,  "IPA Server FQDN",  :type => :string
         opt :ipaprincipal,  "IPA Server principal", :type => :string,          :default => "admin"
         opt :ipapassword,   "IPA Server password",  :type => :string
+        opt :ipadomain,     "IPA Server domain (optional)", :type => :string
         opt :iparealm,      "IPA Server realm (optional)", :type => :string
         opt :ca,                   "CA name used for certmonger",       :type => :string,  :default => "ipa"
         opt :postgres_client_cert, "install certs for postgres client", :type => :boolean
@@ -210,6 +211,7 @@ module ApplianceConsole
       config = ExternalHttpdAuthentication.new(
         host,
         :ipaserver => options[:ipaserver],
+        :domain    => options[:ipadomain],
         :realm     => options[:iparealm],
         :principal => options[:ipaprincipal],
         :password  => options[:ipapassword],

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -103,9 +103,10 @@ describe ApplianceConsole::Cli do
           .with('client.domain.com',
                 :ipaserver => 'ipa.domain.com',
                 :principal => 'admin',
-                :realm     => 'domain.com',
+                :domain    => 'domain.com',
+                :realm     => 'DOMAIN.COM',
                 :password  => 'pass').and_return(double(:activate => true, :post_activation => nil))
-      subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass --iparealm domain.com)).run
+      subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass --iparealm DOMAIN.COM --ipadomain domain.com)).run
     end
 
     it "should not post_activate install ipa (aside: testing passing in host" do
@@ -116,6 +117,7 @@ describe ApplianceConsole::Cli do
           .with('client.domain.com',
                 :ipaserver => 'ipa.domain.com',
                 :principal => 'admin',
+                :domain    => nil,
                 :realm     => nil,
                 :password  => 'pass').and_return(double(:activate => false))
       subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass --host client.domain.com)).run


### PR DESCRIPTION
In environments where the IPA Domain cannot be derived from the client's
FQDN, we need to provide the --ipadomain option to the
appliance console CLI. This capability was provided in the appliance
console UI but not from the CLI.

https://bugzilla.redhat.com/show_bug.cgi?id=1213378