### PR TITLE
Allow specification of supported locales

### DIFF
--- a/vmdb/config/initializers/fast_gettext.rb
+++ b/vmdb/config/initializers/fast_gettext.rb
@@ -1,72 +1,10 @@
-def register_human_localenames
-  original_locale = FastGettext.locale
-  FastGettext.class.class_eval { attr_accessor :human_available_locales }
-  FastGettext.human_available_locales = []
-  FastGettext.available_locales.each do |locale|
-    FastGettext.locale = locale
-    # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
-    human_locale = _("locale_name")
-    human_locale = locale if human_locale == "locale_name"
-    FastGettext.human_available_locales << [human_locale, locale]
-  end
-  FastGettext.human_available_locales.sort! { |a, b| a[0] <=> b[0] }
-ensure
-  FastGettext.locale = original_locale
-end
-
-def fix_i18n_available_locales
-  I18n.available_locales += FastGettext.available_locales.grep(/_/).map { |i| i.gsub("_", "-") }
-end
-
-def find_available_locales_via_directories
-  Dir.entries(locale_path)
-    .select { |entry| (File.directory? File.join(locale_path, entry)) && entry != '.' && entry != '..' }
-    .sort
-end
-
-def supported_locales
-  # Format of YAML file is expected to be as follows
-  #  and match the directory names in config/locales
-  #
-  # ---
-  # - en
-  # - it
-  # - nl
-  #
-  YAML.load_file(supported_locales_filename)
-end
-
-def supported_locales_filename
-  File.join(locale_path, "supported.yml")
-end
-
-def find_available_locales
-  available_locales = find_available_locales_via_directories
-  available_locales &= supported_locales if File.exist?(supported_locales_filename)
-  available_locales
-end
-
-def locale_path
-  Rails.root.join("config/locales")
-end
-
 old_debug, $DEBUG = $DEBUG, nil
 begin
   # The `gettext` gem unreasonably assumes that anyone with $DEBUG
   # enabled must want a flood of racc/yydebug output. As we're actually
   # trying to debug something other than their parser, we need to
   # temporarily force it off while we load stuff.
-
-  FastGettext.add_text_domain('manageiq',
-                              :path           => locale_path,
-                              :type           => :po,
-                              :report_warning => false)
-  FastGettext.available_locales = find_available_locales
-
-  # temporary hack to fix a problem with locales including "_"
-  fix_i18n_available_locales
-  FastGettext.default_text_domain = 'manageiq'
-  register_human_localenames
+  Vmdb::FastGettextHelper::register_locales
 ensure
   $DEBUG = old_debug
 end

--- a/vmdb/config/initializers/fast_gettext.rb
+++ b/vmdb/config/initializers/fast_gettext.rb
@@ -4,7 +4,7 @@ begin
   # enabled must want a flood of racc/yydebug output. As we're actually
   # trying to debug something other than their parser, we need to
   # temporarily force it off while we load stuff.
-  Vmdb::FastGettextHelper::register_locales
+  Vmdb::FastGettextHelper.register_locales
 ensure
   $DEBUG = old_debug
 end

--- a/vmdb/config/initializers/fast_gettext.rb
+++ b/vmdb/config/initializers/fast_gettext.rb
@@ -18,6 +18,38 @@ def fix_i18n_available_locales
   I18n.available_locales += FastGettext.available_locales.grep(/_/).map { |i| i.gsub("_", "-") }
 end
 
+def find_available_locales_via_directories
+  Dir.entries(locale_path)
+    .select { |entry| (File.directory? File.join(locale_path, entry)) && entry != '.' && entry != '..' }
+    .sort
+end
+
+def supported_locales
+  # Format of YAML file is expected to be as follows
+  #  and match the directory names in config/locales
+  #
+  # ---
+  # - en
+  # - it
+  # - nl
+  #
+  YAML.load_file(supported_locales_filename)
+end
+
+def supported_locales_filename
+  File.join(locale_path, "supported.yml")
+end
+
+def find_available_locales
+  available_locales = find_available_locales_via_directories
+  available_locales &= supported_locales if File.exist?(supported_locales_filename)
+  available_locales
+end
+
+def locale_path
+  Rails.root.join("config/locales")
+end
+
 old_debug, $DEBUG = $DEBUG, nil
 begin
   # The `gettext` gem unreasonably assumes that anyone with $DEBUG
@@ -25,15 +57,11 @@ begin
   # trying to debug something other than their parser, we need to
   # temporarily force it off while we load stuff.
 
-  locale_path = Rails.root.join("config/locales")
-
   FastGettext.add_text_domain('manageiq',
                               :path           => locale_path,
                               :type           => :po,
                               :report_warning => false)
-  FastGettext.available_locales = Dir.entries(locale_path)
-    .select { |entry| (File.directory? File.join(locale_path, entry)) && entry != '.' && entry != '..' }
-    .sort
+  FastGettext.available_locales = find_available_locales
 
   # temporary hack to fix a problem with locales including "_"
   fix_i18n_available_locales

--- a/vmdb/lib/vmdb/fast_gettext_helper.rb
+++ b/vmdb/lib/vmdb/fast_gettext_helper.rb
@@ -1,15 +1,19 @@
 module Vmdb
   module FastGettextHelper
-  	def self.register_human_localenames
+    def self.human_locale(locale)
+      # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
+      human_locale = _("locale_name")
+      human_locale = locale if human_locale == "locale_name"
+      human_locale
+    end
+
+    def self.register_human_localenames
       original_locale = FastGettext.locale
       FastGettext.class.class_eval { attr_accessor :human_available_locales }
       FastGettext.human_available_locales = []
       FastGettext.available_locales.each do |locale|
         FastGettext.locale = locale
-        # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
-        human_locale = _("locale_name")
-        human_locale = locale if human_locale == "locale_name"
-        FastGettext.human_available_locales << [human_locale, locale]
+        FastGettext.human_available_locales << [human_locale(locale), locale]
       end
       FastGettext.human_available_locales.sort! { |a, b| a[0] <=> b[0] }
     ensure

--- a/vmdb/lib/vmdb/fast_gettext_helper.rb
+++ b/vmdb/lib/vmdb/fast_gettext_helper.rb
@@ -42,9 +42,13 @@ module Vmdb
       @supported_locales_filename ||= File.join(locale_path, "supported.yml")
     end
 
+    def self.supported_locales_specified?
+      File.exist?(supported_locales_filename)
+    end
+
     def self.find_available_locales
       available_locales = find_available_locales_via_directories
-      available_locales &= supported_locales if File.exist?(supported_locales_filename)
+      available_locales &= supported_locales if supported_locales_specified?
       available_locales
     end
 

--- a/vmdb/lib/vmdb/fast_gettext_helper.rb
+++ b/vmdb/lib/vmdb/fast_gettext_helper.rb
@@ -39,7 +39,7 @@ module Vmdb
     end
 
     def self.supported_locales_filename
-      File.join(locale_path, "supported.yml")
+      @supported_locales_filename ||= File.join(locale_path, "supported.yml")
     end
 
     def self.find_available_locales
@@ -49,7 +49,7 @@ module Vmdb
     end
 
     def self.locale_path
-      Rails.root.join("config/locales")
+      @locale_path ||= Rails.root.join("config/locales")
     end
 
     def self.register_locales

--- a/vmdb/lib/vmdb/fast_gettext_helper.rb
+++ b/vmdb/lib/vmdb/fast_gettext_helper.rb
@@ -1,0 +1,68 @@
+module Vmdb
+  module FastGettextHelper
+  	def self.register_human_localenames
+      original_locale = FastGettext.locale
+      FastGettext.class.class_eval { attr_accessor :human_available_locales }
+      FastGettext.human_available_locales = []
+      FastGettext.available_locales.each do |locale|
+        FastGettext.locale = locale
+        # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
+        human_locale = _("locale_name")
+        human_locale = locale if human_locale == "locale_name"
+        FastGettext.human_available_locales << [human_locale, locale]
+      end
+      FastGettext.human_available_locales.sort! { |a, b| a[0] <=> b[0] }
+    ensure
+      FastGettext.locale = original_locale
+    end
+
+    def self.fix_i18n_available_locales
+      I18n.available_locales += FastGettext.available_locales.grep(/_/).map { |i| i.gsub("_", "-") }
+    end
+
+    def self.find_available_locales_via_directories
+      Dir.entries(locale_path)
+        .select { |entry| (File.directory? File.join(locale_path, entry)) && entry != '.' && entry != '..' }
+        .sort
+    end
+
+    def self.supported_locales
+      # Format of YAML file is expected to be as follows
+      #  and match the directory names in config/locales
+      #
+      # ---
+      # - en
+      # - it
+      # - nl
+      #
+      YAML.load_file(supported_locales_filename)
+    end
+
+    def self.supported_locales_filename
+      File.join(locale_path, "supported.yml")
+    end
+
+    def self.find_available_locales
+      available_locales = find_available_locales_via_directories
+      available_locales &= supported_locales if File.exist?(supported_locales_filename)
+      available_locales
+    end
+
+    def self.locale_path
+      Rails.root.join("config/locales")
+    end
+
+    def self.register_locales
+      FastGettext.add_text_domain('manageiq',
+                                  :path           => locale_path,
+                                  :type           => :po,
+                                  :report_warning => false)
+      FastGettext.available_locales = find_available_locales
+
+      # temporary hack to fix a problem with locales including "_"
+      fix_i18n_available_locales
+      FastGettext.default_text_domain = 'manageiq'
+      register_human_localenames
+    end
+  end
+end


### PR DESCRIPTION
The specification occurs IF the file RAILS_ROOT/config/locales/supported.yml exists.
The contents of the YAML file are expected to be as follows and match the directory names in config/locales

```yaml
---
- en
- it
- nl
```