### PR TITLE
[RFE] Automate Services backwards compatibility change for dialog options.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
@@ -73,13 +73,18 @@ def dialog_parser_error
   exit MIQ_ABORT
 end
 
+def yaml_data(option)
+  @task.get_option(option).nil? ? nil : YAML.load(@task.get_option(option))
+end
+
 def parsed_dialog_information
-  dialog_options_hash = @task.get_option(:parsed_dialog_options).nil? ? nil : YAML.load(@task.get_option(:parsed_dialog_options))
-  dialog_tags_hash = @task.get_option(:parsed_dialog_tags).nil? ? nil : YAML.load(@task.get_option(:parsed_dialog_tags))
+  dialog_options_hash = yaml_data(:parsed_dialog_options)
+  dialog_tags_hash = yaml_data(:parsed_dialog_tags)
   if dialog_options_hash.blank? && dialog_tags_hash.blank?
     log_and_update_message(:info, "Instantiating dialog_parser to populate dialog options")
     $evm.instantiate('/Service/Provisioning/StateMachines/Methods/DialogParser')
-    dialog_options_hash, dialog_tags_hash = parsed_dialog_information
+    dialog_options_hash = yaml_data(:parsed_dialog_options)
+    dialog_tags_hash = yaml_data(:parsed_dialog_tags)
     dialog_parser_error if dialog_options_hash.blank? && dialog_tags_hash.blank?
   end
 

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
@@ -68,14 +68,19 @@ def tag_service(dialogs_tags_hash)
   log_and_update_message(:info, "Processing tag_service...Complete", true)
 end
 
-def parsed_dialog_information
-  # get parsed dialog options and tags from the task
-  dialog_options_hash = YAML.load(@task.get_option(:parsed_dialog_options))
-  dialog_tags_hash = YAML.load(@task.get_option(:parsed_dialog_tags))
+def dialog_parser_error
+  log_and_update_message(:error, "Error loading dialog options")
+  exit MIQ_ABORT
+end
 
+def parsed_dialog_information
+  dialog_options_hash = @task.get_option(:parsed_dialog_options).nil? ? nil : YAML.load(@task.get_option(:parsed_dialog_options))
+  dialog_tags_hash = @task.get_option(:parsed_dialog_tags).nil? ? nil : YAML.load(@task.get_option(:parsed_dialog_tags))
   if dialog_options_hash.blank? && dialog_tags_hash.blank?
-    log(:error, "Error loading dialog options")
-    exit MIQ_ABORT
+    log_and_update_message(:info, "Instantiating dialog_parser to populate dialog options")
+    $evm.instantiate('/Service/Provisioning/StateMachines/Methods/DialogParser')
+    dialog_options_hash, dialog_tags_hash = parsed_dialog_information
+    dialog_parser_error if dialog_options_hash.blank? && dialog_tags_hash.blank?
   end
 
   log_and_update_message(:info, "dialog_options: #{dialog_options_hash.inspect}")

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -198,13 +198,18 @@ def dialog_parser_error
   exit MIQ_ABORT
 end
 
+def yaml_data(option)
+  @task.get_option(option).nil? ? nil : YAML.load(@task.get_option(option))
+end
+
 def parsed_dialog_information
-  dialog_options_hash = @task.get_option(:parsed_dialog_options).nil? ? nil : YAML.load(@task.get_option(:parsed_dialog_options))
-  dialog_tags_hash = @task.get_option(:parsed_dialog_tags).nil? ? nil : YAML.load(@task.get_option(:parsed_dialog_tags))
+  dialog_options_hash = yaml_data(:parsed_dialog_options)
+  dialog_tags_hash = yaml_data(:parsed_dialog_tags)
   if dialog_options_hash.blank? && dialog_tags_hash.blank?
     log_and_update_message(:info, "Instantiating dialog_parser to populate dialog options")
     $evm.instantiate('/Service/Provisioning/StateMachines/Methods/DialogParser')
-    dialog_options_hash, dialog_tags_hash = parsed_dialog_information
+    dialog_options_hash = yaml_data(:parsed_dialog_options)
+    dialog_tags_hash = yaml_data(:parsed_dialog_tags)
     dialog_parser_error if dialog_options_hash.blank? && dialog_tags_hash.blank?
   end
 


### PR DESCRIPTION
Add call to instantiate dialog options if parsed dialog options are not found.

https://bugzilla.redhat.com/show_bug.cgi?id=1216210