### PR TITLE
Added VPC and Subnet for T2 and C4 instances

### DIFF
--- a/lib/Amazon/MiqEc2InstanceTypes.rb
+++ b/lib/Amazon/MiqEc2InstanceTypes.rb
@@ -8,6 +8,8 @@ require 'active_support/core_ext/numeric/bytes'
 #   http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/instance-types.html
 #   http://aws.amazon.com/ec2/previous-generation
 #   http://www.ec2instances.info/
+#   http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html
+#   http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/c4-instances.html
 #     NOTE: We may want to consider using the source data directly, however
 #           there aren't the discontinued types.
 #           https://raw.githubusercontent.com/powdahound/ec2instances.info/master/www/instances.json
@@ -36,6 +38,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => true,
     },
 
     "t2.small" => {
@@ -59,6 +62,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => true,
     },
 
     "t2.medium" => {
@@ -82,6 +86,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => true,
     },
 
     "m3.medium" => {
@@ -105,6 +110,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m3.large" => {
@@ -128,6 +134,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m3.xlarge" => {
@@ -151,6 +158,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m3.2xlarge" => {
@@ -174,6 +182,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "c3.large" => {
@@ -197,6 +206,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "c3.xlarge" => {
@@ -220,6 +230,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "c3.2xlarge" => {
@@ -243,6 +254,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "c3.4xlarge" => {
@@ -266,6 +278,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "c3.8xlarge" => {
@@ -289,6 +302,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "c4.large" => {
@@ -312,6 +326,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => true,
     },
 
     "c4.xlarge" => {
@@ -335,6 +350,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => true,
     },
 
     "c4.2xlarge" => {
@@ -358,6 +374,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => true,
     },
 
     "c4.4xlarge" => {
@@ -381,6 +398,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => true,
     },
 
     "c4.8xlarge" => {
@@ -404,6 +422,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => true,
     },
 
     "g2.2xlarge" => {
@@ -427,6 +446,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "g2.8xlarge" => {
@@ -450,6 +470,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "r3.large" => {
@@ -473,6 +494,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => true,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "r3.xlarge" => {
@@ -496,6 +518,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "r3.2xlarge" => {
@@ -519,6 +542,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "r3.4xlarge" => {
@@ -542,6 +566,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "r3.8xlarge" => {
@@ -565,6 +590,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => true,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "i2.xlarge" => {
@@ -588,6 +614,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "i2.2xlarge" => {
@@ -611,6 +638,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "i2.4xlarge" => {
@@ -634,6 +662,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "i2.8xlarge" => {
@@ -657,6 +686,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "d2.xlarge" => {
@@ -680,6 +710,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "d2.2xlarge" => {
@@ -703,6 +734,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "d2.4xlarge" => {
@@ -726,6 +758,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "d2.8xlarge" => {
@@ -749,6 +782,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => true,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
   }
 
@@ -775,6 +809,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m1.small" => {
@@ -798,6 +833,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m1.medium" => {
@@ -821,6 +857,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m1.large" => {
@@ -844,6 +881,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m1.xlarge" => {
@@ -867,6 +905,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "c1.medium" => {
@@ -890,6 +929,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "c1.xlarge" => {
@@ -913,6 +953,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "cc2.8xlarge" => {
@@ -936,6 +977,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "cg1.4xlarge" => {
@@ -959,6 +1001,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m2.xlarge" => {
@@ -982,6 +1025,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m2.2xlarge" => {
@@ -1005,6 +1049,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "m2.4xlarge" => {
@@ -1028,6 +1073,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => true,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "cr1.8xlarge" => {
@@ -1051,6 +1097,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
 
     "hi1.4xlarge" => {
@@ -1074,6 +1121,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     "hs1.8xlarge" => {
@@ -1097,6 +1145,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => true,
+      :vpc_only                => false,
     },
   }
 
@@ -1124,6 +1173,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
 
     # cc1.4xlarge is not available in any of the documentation, but if you
@@ -1149,6 +1199,7 @@ module MiqEc2InstanceTypes
       :ebs_optimized_available => nil,
       :enhanced_networking     => nil,
       :cluster_networking      => nil,
+      :vpc_only                => false,
     },
   }
 

--- a/vmdb/app/helpers/flavor_helper/textual_summary.rb
+++ b/vmdb/app/helpers/flavor_helper/textual_summary.rb
@@ -5,7 +5,16 @@ module FlavorHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w(cpus cpu_cores memory supports_32_bit supports_64_bit supports_hvm supports_paravirtual block_storage_based_only)
+    items = %w(
+      cpus
+      cpu_cores
+      memory
+      supports_32_bit
+      supports_64_bit
+      supports_hvm
+      supports_paravirtual
+      block_storage_based_only
+      cloud_subnet_required)
     items.collect { |m| self.send("textual_#{m}") }.flatten.compact
   end
 
@@ -58,6 +67,11 @@ module FlavorHelper::TextualSummary
   def textual_block_storage_based_only
     return nil if @record.block_storage_based_only.nil?
     {:label => "Block Storage Based", :value => @record.block_storage_based_only?}
+  end
+
+  def textual_cloud_subnet_required
+    return nil if @record.cloud_subnet_required.nil?
+    {:label => "Cloud Subnet Required", :value => @record.cloud_subnet_required?}
   end
 
   def textual_ems_cloud

--- a/vmdb/app/models/ems_refresh/parsers/ec2.rb
+++ b/vmdb/app/models/ems_refresh/parsers/ec2.rb
@@ -181,6 +181,7 @@ module EmsRefresh::Parsers
         :supports_hvm             => flavor[:virtualization_type].include?(:hvm),
         :supports_paravirtual     => flavor[:virtualization_type].include?(:paravirtual),
         :block_storage_based_only => flavor[:ebs_only],
+        :cloud_subnet_required    => flavor[:vpc_only],
 
         # Extra keys
         :disk_size                => flavor[:instance_store_size],

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/Placement.class/__methods__/best_fit_amazon.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/Placement.class/__methods__/best_fit_amazon.rb
@@ -15,3 +15,41 @@
 #  best Availability Zone for you based on system health and available capacity. If you launch additional
 #  instances, only specify an Availability Zone if your new instances must be close to, or separated from,
 #  your running instances."
+#
+#
+# VPC & Subnet
+# For C4 and T2 instances we have to provide VPC and Subnet.
+# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html
+# Read section marked "EC2-VPC-only Support"
+# For other instance types EC2 provides the defaults.
+# This method checks the instance types and sets the VPC and subnet for T2 and C4 instances
+#
+
+def set_property(prov, image, list_method, property)
+  return if prov.get_option(property)
+  result = prov.send(list_method)
+  $evm.log("debug", "#{property} #{result.inspect}")
+  object = result.try(:first)
+  return unless object
+
+  prov.send("set_#{property}", object)
+  $evm.log("info", "Image=[#{image.name}] #{property}=[#{object.name}]")
+end
+
+# Get variables
+prov     = $evm.root["miq_provision"]
+image    = prov.vm_template
+raise "Image not specified" if image.nil?
+
+instance_id    = prov.get_option(:instance_type)
+raise "Instance Type not specified" if instance_id.nil?
+flavor         = $evm.vmdb('flavor').find(instance_id)
+$evm.log("debug", "instance id=#{instance_id} name=#{flavor.try(:name)}")
+
+if flavor.try(:cloud_subnet_required)
+  $evm.log("info", "Setting VPC parameters for instance type=[#{flavor.name}]")
+  set_property(prov, image, :eligible_cloud_networks, :cloud_network)
+  set_property(prov, image, :eligible_cloud_subnets,  :cloud_subnet)
+else
+  $evm.log("info", "Using EC2 for default placement of instance type=[#{flavor.try(:name)}]")
+end

--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Request.class/call_instance_with_message.yaml
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/System/Request.class/call_instance_with_message.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Call_Instance_With_Message
+    inherits: 
+    description: 
+  fields:
+  - rel2:
+      value: "/${/#namespace}/${/#class}/${/#instance}#${/#message}"

--- a/vmdb/db/migrate/20150504111111_add_cloud_subnet_required_to_flavor.rb
+++ b/vmdb/db/migrate/20150504111111_add_cloud_subnet_required_to_flavor.rb
@@ -1,0 +1,5 @@
+class AddCloudSubnetRequiredToFlavor < ActiveRecord::Migration
+  def change
+    add_column :flavors, :cloud_subnet_required, :boolean
+  end
+end

--- a/vmdb/product/views/Flavor.yaml
+++ b/vmdb/product/views/Flavor.yaml
@@ -28,6 +28,7 @@ cols:
 - supports_hvm
 - supports_paravirtual
 - block_storage_based_only
+- cloud_subnet_required
 - total_vms
 
 # Included tables (joined, has_one, has_many) and columns
@@ -52,6 +53,7 @@ col_order:
 - supports_hvm
 - supports_paravirtual
 - block_storage_based_only
+- cloud_subnet_required
 - total_vms
 
 col_formats:
@@ -73,6 +75,7 @@ headers:
 - HVM (Hardware Virtual Machine)
 - Paravirtualization
 - Block Storage Based
+- Subnet Required
 - Instances
 
 # Condition(s) string for the SQL query

--- a/vmdb/spec/automation/unit/method_validation/amazon_auto_placement_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/amazon_auto_placement_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+describe "AMAZON best fit" do
+  let(:ws) do
+    MiqAeEngine.instantiate("/System/Request/Call_Instance_With_Message?" \
+                            "namespace=Cloud/VM/Provisioning&class=Placement" \
+                            "&instance=default&message=amazon&" \
+                            "MiqProvision::miq_provision=#{miq_provision.id}")
+  end
+
+  let(:ems) do
+    FactoryGirl.create(:ems_amazon_with_authentication)
+  end
+
+  let(:vm_template) do
+    FactoryGirl.create(:template_amazon,
+                       :name                  => "template1",
+                       :ext_management_system => ems)
+  end
+  let(:miq_provision) do
+    FactoryGirl.create(:miq_provision_amazon,
+                       :options => {:src_vm_id => vm_template.id},
+                       :state   => 'active',
+                       :status  => 'Ok')
+  end
+
+  let(:t2_small_flavor) do
+    FactoryGirl.create(:flavor_amazon, :ems_id                => ems.id,
+                                       :name                  => 't2.small',
+                                       :cloud_subnet_required => true)
+  end
+
+  let(:m2_small_flavor) do
+    FactoryGirl.create(:flavor_amazon, :ems_id                => ems.id,
+                                       :name                  => 'm2.small',
+                                       :cloud_subnet_required => false)
+  end
+
+  let(:cloud_network1) do
+    FactoryGirl.create(:cloud_network, :ems_id => ems.id, :enabled => true)
+  end
+
+  let(:cloud_subnet1) do
+    FactoryGirl.create(:cloud_subnet, :cloud_network_id => cloud_network1.id)
+  end
+
+  context "provision task object" do
+    it "auto placement of t2 instances" do
+      attrs = {:placement_auto => [true, 1],
+               :instance_type  => [t2_small_flavor.id, "t2.small: T2 Small"]}
+      cloud_subnet1
+      miq_provision.update_attribute(:options, miq_provision.options.merge(attrs))
+      ws.root
+
+      miq_provision.reload
+      expect(miq_provision.options[:cloud_network].first).to eql(cloud_network1.id)
+      expect(miq_provision.options[:cloud_subnet].first).to eql(cloud_subnet1.id)
+    end
+
+    it "auto placement of m2 instances" do
+      attrs = {:placement_auto => [true, 1],
+               :instance_type  => [m2_small_flavor.id, "m2.small: M2 Small"]}
+      cloud_subnet1
+      miq_provision.update_attribute(:options, miq_provision.options.merge(attrs))
+      ws.root
+
+      check_attributes_not_set
+    end
+
+    it "manual placement" do
+      attrs = {:placement_auto => [false, 0]}
+      cloud_subnet1
+      miq_provision.update_attribute(:options, miq_provision.options.merge(attrs))
+      ws.root
+
+      check_attributes_not_set
+    end
+
+    def check_attributes_not_set
+      miq_provision.reload
+      keys = miq_provision.options.keys
+      expect(keys.include?(:cloud_network)).to be_false
+      expect(keys.include?(:cloud_subnet)).to be_false
+    end
+  end
+end

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_other_region_spec.rb
@@ -27,6 +27,7 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
       assert_specific_vm_powered_on
       assert_specific_vm_in_other_region
       assert_relationship_tree
+      assert_subnet_required
     end
   end
 
@@ -261,5 +262,10 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
 
   def assert_relationship_tree
     @ems.descendants_arranged.should match_relationship_tree({})
+  end
+
+  def assert_subnet_required
+    @flavor = FlavorAmazon.where(:name => "t2.small").first
+    @flavor.should have_attributes(:cloud_subnet_required  => true)
   end
 end


### PR DESCRIPTION
Modified best_fit_amazon method to support autoplacement
of C4 abd T2 Amazon instance types

https://bugzilla.redhat.com/show_bug.cgi?id=1211209