### PR TITLE
Convert nil automate values to empty string for XML

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -191,7 +191,7 @@ module MiqAeEngine
       when 'Fixnum'                   then xml.Fixnum   value
       when 'Symbol'                   then xml.Symbol   value.to_s
       when 'TrueClass', 'FalseClass'  then xml.Boolean  value.to_s
-      when /MiqAeMethodService::(.*)/ then xml.send($1, :object_id => value.object_id, :id => value.id)
+      when /MiqAeMethodService::(.*)/ then xml.tag!($1, :object_id => value.object_id, :id => value.id)
       when 'Array'                    then xml.Array  {
         value.each_index { |i|
           xml.Element(:index => i+1) { attribute_value_to_xml(value[i], xml) }
@@ -206,7 +206,7 @@ module MiqAeEngine
         $miq_ae_logger.error "Found DRbUnknown for value: #{value.inspect} in XML: #{xml.inspect}"
         xml.String value
       else
-        xml.send(value.class.to_s) { xml.cdata! value.inspect }
+        xml.tag!(value.class.to_s) { xml.cdata! value.inspect }
       end
     end
 


### PR DESCRIPTION
The user chooses an incorrect Automation request causing
nil attributes to be stored in the workspace. These nil values
fail during xml conversion, causing a stack trace.

https://bugzilla.redhat.com/show_bug.cgi?id=1216005