### PR TITLE
Fix JS error when missing toolbar, always provide center toolbar though possibly empty

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1717,13 +1717,19 @@ module ApplicationHelper
 
   # Reload toolbars using new buttons object and xml
   def javascript_for_toolbar_reload(tb, buttons, xml)
-    js = ""
-    js << "#{tb}.unload();"
-    js << "#{tb} = null;"
-    js << "#{tb} = new dhtmlXToolbarObject('#{tb}', 'miq_blue');"
-    js << "miq_toolbars['#{tb}'] = {obj:#{tb}, buttons:#{buttons}, xml:\"#{xml}\"};"
-    js << "miqInitToolbar(miq_toolbars['#{tb}']);"
-    return js
+    %Q{
+      if (miq_toolbars.#{tb} && miq_toolbars.#{tb}.obj)
+        miq_toolbars.#{tb}.obj.unload();
+
+      window.#{tb} = new dhtmlXToolbarObject('#{tb}', 'miq_blue');
+      miq_toolbars['#{tb}'] = {
+        obj: window.#{tb},
+        buttons: #{buttons},
+        xml: "#{xml}"
+      };
+
+      miqInitToolbar(miq_toolbars['#{tb}']);
+    }
   end
 
   def javascript_for_ae_node_selection(id, prev_id, select)

--- a/vmdb/app/views/layouts/_center_buttons.html.haml
+++ b/vmdb/app/views/layouts/_center_buttons.html.haml
@@ -1,3 +1,3 @@
-- if fname = center_toolbar_filename
-  #center_buttons_div
-    = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "center_tb", :tb_yaml => fname}
+- fname = center_toolbar_filename
+#center_buttons_div
+  = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "center_tb", :tb_yaml => fname}

--- a/vmdb/app/views/layouts/_dhtmlxtoolbar.html.haml
+++ b/vmdb/app/views/layouts/_dhtmlxtoolbar.html.haml
@@ -5,7 +5,7 @@
 
 %script{:type => "text/javascript"}
 
-  - unless request.xml_http_request?
+  - if !request.xml_http_request? && !tb_yaml.nil?
     - tb_buttons, tb_xml = build_toolbar_buttons_and_xml(tb_yaml)
 
     window.#{tb} = new dhtmlXToolbarObject("#{tb}", "miq_blue");

--- a/vmdb/app/views/layouts/_dhtmlxtoolbar.html.haml
+++ b/vmdb/app/views/layouts/_dhtmlxtoolbar.html.haml
@@ -8,10 +8,10 @@
   - unless request.xml_http_request?
     - tb_buttons, tb_xml = build_toolbar_buttons_and_xml(tb_yaml)
 
-    var #{tb} = new dhtmlXToolbarObject("#{tb}", "miq_blue");
+    window.#{tb} = new dhtmlXToolbarObject("#{tb}", "miq_blue");
 
     if (typeof miq_toolbars == "undefined") var miq_toolbars = {};
-    miq_toolbars['#{tb}'] = {obj:#{tb}, buttons:#{tb_buttons}, xml:"#{tb_xml}"};
+    miq_toolbars['#{tb}'] = {obj: window.#{tb}, buttons: #{tb_buttons}, xml: "#{tb_xml}"};
 
   - if @record
     var miq_record_id = '#{@record.id}';


### PR DESCRIPTION
When Services/Catalogs > Catalogs is loaded directly, #center_buttons_div exists in the right place and contains #center_tb.

When Services/Catalogs > Service Catalogs is loaded first (that one because it really has no center toolbar), and then Catalogs is loaded, neither exist and the javascript_for_toolbar_reload output fails.


This fixes `_center_buttons` to always render the `#center_buttons_div element`, though possibly empty, and also prevents `_dhtmlxtoolbar` from crashing when it *is* empty, which enables us to create empty toolbars to be initialized later via the `javascript_for_toolbar_reload` helper.
    
Also cleaned up ApplicationHelper::javascript_for_toolbar_reload, explicitly marks #{tb} as global variable (also in _dhtmlxtoolbar partial), looks toolbar up in miq_toolbars for toolbar unload (and checks for its existence). (However, if the corresponding div is missing, dhtmlXToolbarObject constructor will throw anyway.)
    
https://bugzilla.redhat.com/show_bug.cgi?id=1213863