### PR TITLE
Filter the available ConfigurationProfiles for provisioning dialogs

### DIFF
--- a/vmdb/app/models/configuration_location.rb
+++ b/vmdb/app/models/configuration_location.rb
@@ -1,6 +1,11 @@
 class ConfigurationLocation < ActiveRecord::Base
   belongs_to :provisioning_manager
   belongs_to :parent, :class_name => 'ConfigurationLocation'
+  has_and_belongs_to_many :configuration_profiles
 
   alias_attribute :display_name, :title
+
+  def path
+    (parent.try(:path) || []).push(self)
+  end
 end

--- a/vmdb/app/models/configuration_organization.rb
+++ b/vmdb/app/models/configuration_organization.rb
@@ -1,6 +1,11 @@
 class ConfigurationOrganization < ActiveRecord::Base
   belongs_to :provisioning_manager
   belongs_to :parent, :class_name => 'ConfigurationOrganization'
+  has_and_belongs_to_many :configuration_profiles
 
   alias_attribute :display_name, :title
+
+  def path
+    (parent.try(:path) || []).push(self)
+  end
 end

--- a/vmdb/app/models/configuration_profile.rb
+++ b/vmdb/app/models/configuration_profile.rb
@@ -15,6 +15,8 @@ class ConfigurationProfile < ActiveRecord::Base
   has_and_belongs_to_many :configuration_organizations, :join_table => :configuration_organizations_configuration_profiles
   has_and_belongs_to_many :configuration_tags
 
+  virtual_has_one :configuration_architecture, :class_name => 'ConfigurationArchitecture', :uses => :configuration_tags
+
   def configuration_architecture
     tag_hash[ConfigurationArchitecture]
   end

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -53,7 +53,12 @@ class ConfiguredSystem < ActiveRecord::Base
   alias_method :manager, :configuration_manager
 
   def self.common_configuration_profiles_for_selected_hosts(ids)
-    where(:id => ids).collect(&:available_configuration_profiles).inject(:&).presence
+    hosts = where(:id => ids)
+    MiqPreloader.preload(hosts, [
+      :configuration_location     => { :configuration_profiles => :configuration_architecture},
+      :configuration_organization => { :configuration_profiles => :configuration_architecture},
+    ])
+    hosts.collect(&:available_configuration_profiles).inject(:&).presence
   end
 
   def name

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -52,12 +52,8 @@ class ConfiguredSystem < ActiveRecord::Base
 
   alias_method :manager, :configuration_manager
 
-  def self.common_configuration_profiles_for_selected_hosts(ids)
-    hosts = where(:id => ids)
-    MiqPreloader.preload(hosts, [
-      :configuration_location     => { :configuration_profiles => :configuration_architecture},
-      :configuration_organization => { :configuration_profiles => :configuration_architecture},
-    ])
+  def self.common_configuration_profiles_for_selected_configured_systems(ids)
+    hosts = includes(:configuration_location, :configuration_organization).where(:id => ids)
     hosts.collect(&:available_configuration_profiles).inject(:&).presence
   end
 

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -52,6 +52,10 @@ class ConfiguredSystem < ActiveRecord::Base
 
   alias_method :manager, :configuration_manager
 
+  def self.common_configuration_profiles_for_selected_hosts(ids)
+    where(:id => ids).collect(&:available_configuration_profiles).inject(:&).presence
+  end
+
   def name
     hostname
   end

--- a/vmdb/app/models/configured_system_foreman.rb
+++ b/vmdb/app/models/configured_system_foreman.rb
@@ -1,5 +1,6 @@
 class ConfiguredSystemForeman < ConfiguredSystem
   include ProviderObjectMixin
+  include_concern 'Placement'
 
   belongs_to :configuration_profile, :class_name => 'ConfigurationProfileForeman'
   belongs_to :direct_operating_system_flavor,

--- a/vmdb/app/models/configured_system_foreman/placement.rb
+++ b/vmdb/app/models/configured_system_foreman/placement.rb
@@ -1,0 +1,7 @@
+module ConfiguredSystemForeman::Placement
+  def available_configuration_profiles
+    cp_by_cl = configuration_location.path.collect(&:configuration_profiles).flatten!.uniq
+    cp_by_co = configuration_organization.path.collect(&:configuration_profiles).flatten!.uniq
+    (cp_by_cl & cp_by_co).select { |cp| [configuration_architecture, nil].include?(cp.configuration_architecture) }
+  end
+end

--- a/vmdb/app/models/configured_system_foreman/placement.rb
+++ b/vmdb/app/models/configured_system_foreman/placement.rb
@@ -1,7 +1,10 @@
 module ConfiguredSystemForeman::Placement
   def available_configuration_profiles
-    cp_by_cl = configuration_location.path.collect(&:configuration_profiles).flatten!.uniq
-    cp_by_co = configuration_organization.path.collect(&:configuration_profiles).flatten!.uniq
+    cl_history = configuration_location.try(:path) || []
+    co_history = configuration_organization.try(:path) || []
+    MiqPreloader.preload(cl_history + co_history, :configuration_profiles => :configuration_architecture)
+    cp_by_cl = cl_history.collect(&:configuration_profiles).flatten.uniq
+    cp_by_co = co_history.collect(&:configuration_profiles).flatten.uniq
     (cp_by_cl & cp_by_co).select { |cp| [configuration_architecture, nil].include?(cp.configuration_architecture) }
   end
 end

--- a/vmdb/app/models/configured_system_foreman/placement.rb
+++ b/vmdb/app/models/configured_system_foreman/placement.rb
@@ -1,10 +1,14 @@
 module ConfiguredSystemForeman::Placement
   def available_configuration_profiles
-    cl_history = configuration_location.try(:path) || []
-    co_history = configuration_organization.try(:path) || []
-    MiqPreloader.preload(cl_history + co_history, :configuration_profiles => :configuration_architecture)
-    cp_by_cl = cl_history.collect(&:configuration_profiles).flatten.uniq
-    cp_by_co = co_history.collect(&:configuration_profiles).flatten.uniq
-    (cp_by_cl & cp_by_co).select { |cp| [configuration_architecture, nil].include?(cp.configuration_architecture) }
+    return [] if configuration_location.nil? || configuration_organization.nil?
+    cl_path_ids = configuration_location.path.collect(&:id)
+    co_path_ids = configuration_organization.path.collect(&:id)
+    ConfigurationProfile.joins(:configuration_locations, :configuration_organizations)
+      .includes(:configuration_architecture)
+      .where(
+        :configuration_locations_configuration_profiles     => {:configuration_location_id     => cl_path_ids},
+        :configuration_organizations_configuration_profiles => {:configuration_organization_id => co_path_ids},
+      )
+      .select { |cp| [configuration_architecture, nil].include?(cp.configuration_architecture) }
   end
 end

--- a/vmdb/app/models/miq_provision_configured_system_foreman_workflow.rb
+++ b/vmdb/app/models/miq_provision_configured_system_foreman_workflow.rb
@@ -31,9 +31,8 @@ class MiqProvisionConfiguredSystemForemanWorkflow < MiqProvisionConfiguredSystem
 
   def allowed_configuration_profiles(_options = {})
     @allowed_configuration_profiles ||= begin
-      configured_system_ids  = get_value(@values[:src_configured_system_ids])
-      configuration_managers = ConfiguredSystem.where(:id => configured_system_ids).collect(&:configuration_manager)
-      configuration_managers.collect(&:configuration_profiles).flatten.each_with_object({}) do |cp, hash|
+      profiles = ConfiguredSystem.common_configuration_profiles_for_selected_hosts(@values[:src_configured_system_ids])
+      profiles.each_with_object({}) do |cp, hash|
         hash[cp.id] = cp.name
       end
     end

--- a/vmdb/spec/factories/configuration_architecture.rb
+++ b/vmdb/spec/factories/configuration_architecture.rb
@@ -1,0 +1,1 @@
+FactoryGirl.define { factory :configuration_architecture }

--- a/vmdb/spec/factories/configuration_location.rb
+++ b/vmdb/spec/factories/configuration_location.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :configuration_location do
+    sequence(:name) { |n| "configuration_location#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/vmdb/spec/factories/configuration_organization.rb
+++ b/vmdb/spec/factories/configuration_organization.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :configuration_organization do
+    sequence(:name) { |n| "configuration_organization#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/vmdb/spec/factories/configuration_profile.rb
+++ b/vmdb/spec/factories/configuration_profile.rb
@@ -1,4 +1,1 @@
-FactoryGirl.define do
-  factory :configuration_profile do
-  end
-end
+FactoryGirl.define { factory :configuration_profile }

--- a/vmdb/spec/factories/configuration_profile_foreman.rb
+++ b/vmdb/spec/factories/configuration_profile_foreman.rb
@@ -1,0 +1,1 @@
+FactoryGirl.define { factory :configuration_profile_foreman, :class => "ConfigurationProfileForeman", :parent => :configuration_profile }

--- a/vmdb/spec/factories/configured_system.rb
+++ b/vmdb/spec/factories/configured_system.rb
@@ -1,4 +1,1 @@
-FactoryGirl.define do
-  factory :configured_system do
-  end
-end
+FactoryGirl.define { factory :configured_system }

--- a/vmdb/spec/factories/configured_system_foreman.rb
+++ b/vmdb/spec/factories/configured_system_foreman.rb
@@ -1,0 +1,1 @@
+FactoryGirl.define { factory :configured_system_foreman, :class => "ConfiguredSystemForeman", :parent => :configured_system }

--- a/vmdb/spec/models/configured_system_foreman/placement_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman/placement_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe ConfiguredSystemForeman do
+  context "::Placement" do
+    context "#available_configuration_profiles" do
+      let(:cl)  { FactoryGirl.build(:configuration_location) }
+      let(:co)  { FactoryGirl.build(:configuration_organization) }
+      let(:cp1) { FactoryGirl.build(:configuration_profile_foreman) }
+      let(:cp2) { FactoryGirl.build(:configuration_profile_foreman, :parent => cp1) }
+      let(:cp3) { FactoryGirl.build(:configuration_profile_foreman, :parent => cp2) }
+      let(:cs)  { FactoryGirl.build(:configured_system_foreman, :configuration_organization => co, :configuration_location => cl) }
+
+      it "filters based on locations" do
+        cl.configuration_profiles.push(cp1, cp2)
+        co.configuration_profiles.push(cp1, cp2, cp3)
+
+        expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+      end
+
+      it "filters based on organizations" do
+        cl.configuration_profiles.push(cp1, cp2, cp3)
+        co.configuration_profiles.push(cp1, cp2)
+
+        expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+      end
+
+      it "filters based on architectures" do
+        cl.configuration_profiles.push(cp1, cp2, cp3)
+        co.configuration_profiles.push(cp1, cp2, cp3)
+        cp3.stub(:configuration_architecture => active_record_instance_double("ConfigurationArchitecture", :name => "i386"))
+        cs.stub(:configuration_architecture => active_record_instance_double("ConfigurationArchitecture", :name => "x86_64"))
+
+        expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+      end
+    end
+  end
+end

--- a/vmdb/spec/models/configured_system_foreman/placement_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman/placement_spec.rb
@@ -3,12 +3,14 @@ require "spec_helper"
 describe ConfiguredSystemForeman do
   context "::Placement" do
     context "#available_configuration_profiles" do
-      let(:cl)  { FactoryGirl.build(:configuration_location) }
-      let(:co)  { FactoryGirl.build(:configuration_organization) }
-      let(:cp1) { FactoryGirl.build(:configuration_profile_foreman) }
-      let(:cp2) { FactoryGirl.build(:configuration_profile_foreman, :parent => cp1) }
-      let(:cp3) { FactoryGirl.build(:configuration_profile_foreman, :parent => cp2) }
-      let(:cs)  { FactoryGirl.build(:configured_system_foreman, :configuration_organization => co, :configuration_location => cl) }
+      let(:arch1) { FactoryGirl.create(:configuration_architecture, :name => "i386") }
+      let(:arch2) { FactoryGirl.create(:configuration_architecture, :name => "x86_64") }
+      let(:cl)    { FactoryGirl.create(:configuration_location) }
+      let(:co)    { FactoryGirl.create(:configuration_organization) }
+      let(:cp1)   { FactoryGirl.create(:configuration_profile_foreman) }
+      let(:cp2)   { FactoryGirl.create(:configuration_profile_foreman, :parent => cp1) }
+      let(:cp3)   { FactoryGirl.create(:configuration_profile_foreman, :parent => cp2) }
+      let(:cs)    { FactoryGirl.create(:configured_system_foreman, :configuration_organization => co, :configuration_location => cl) }
 
       it "filters based on locations" do
         cl.configuration_profiles.push(cp1, cp2)
@@ -27,8 +29,8 @@ describe ConfiguredSystemForeman do
       it "filters based on architectures" do
         cl.configuration_profiles.push(cp1, cp2, cp3)
         co.configuration_profiles.push(cp1, cp2, cp3)
-        cp3.stub(:configuration_architecture => active_record_instance_double("ConfigurationArchitecture", :name => "i386"))
-        cs.stub(:configuration_architecture => active_record_instance_double("ConfigurationArchitecture", :name => "x86_64"))
+        cp3.configuration_tags.push(arch1)
+        cs.configuration_tags.push(arch2)
 
         expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
       end


### PR DESCRIPTION
For each ConfiguredSystem, find its available ConfigurationProfiles taking
into account its ConfigurationLocation, ConfigurationOrganization and
ConfigurationArchitecture. Take a union of all arrays from all selected
ConfiguredSystems resulting in an array of ConfigurationProfiles that can
be applied to all selected ConfiguredSystems.

This is needed, but I think we need to request that the foreman team maintain their filtering logic.  Ideally I would prefer to ask their API what Hostgroups are available for a given Host.