### PR TITLE
[RFE]Automate Allow miq_request description to be set by user.

### DIFF
--- a/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -25,8 +25,11 @@ module MiqAeMethodService
     association :approvers
 
     def set_message(value)
-      object_send(:update_attribute, :message, value)
+      object_send(:update_attributes, :message => value)
     end
 
+    def description=(new_description)
+      object_send(:update_attributes, :description => new_description)
+    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -238,5 +238,13 @@ module MiqAeServiceMiqRequestSpec
       invoke_ae
       @miq_request.reload.message.should == message
     end
+
+    it "#description=" do
+      description = 'test description'
+      method  = "$evm.root['miq_request'].description=('#{description}')"
+      @ae_method.update_attributes(:data => method)
+      invoke_ae
+      @miq_request.reload.description.should == description
+    end
   end
 end


### PR DESCRIPTION
New service model method description= allows users to set the request description.

https://bugzilla.redhat.com/show_bug.cgi?id=1152687

automate method code example:
......
  task = $evm.root["service_template_provision_task"]
  request = task.miq_request
  request.description="DESCRIPTION UPDATED HERE"
