### PR TITLE
Clarify summary screen CPU details

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1521,21 +1521,29 @@ class ApplicationController < ActionController::Base
     @devices = Array.new    # This will be an array of hashes to allow the rhtml to pull out each device field by name
     unless db_record.hardware.nil?
       db_notes = db_record.hardware.annotation.nil? ? "<No notes have been entered for this VM>" : db_record.hardware.annotation
-      # add processor entry to the device array
-      @devices.push({ :device=>"Processors",
-                                      :description=>db_record.hardware.numvcpus,
-                                      :icon=>"processor" }) unless db_record.hardware.numvcpus.nil?
-      # add cpu entries to the device array
-      @devices.push({ :device => "CPU Type",
-                              :description => db_record.hardware.cpu_type.to_s,
-                              :icon => "processor" }) unless db_record.hardware.cpu_type.nil?
-      @devices.push({ :device => "CPU Speed",
-                              :description => db_record.hardware.cpu_speed.to_s << " MHz",
-                              :icon => "processor" }) unless db_record.hardware.cpu_speed.nil?
-      # add memory entry to the device array
-      @devices.push({ :device => "Memory",
-                                      :description => db_record.hardware.memory_cpu.to_s << " MB",
-                                      :icon => "memory" }) unless db_record.hardware.memory_cpu.nil?
+
+      if db_record.hardware.logical_cpus
+        cpu_details =
+          if db_record.num_cpu && db_record.cores_per_socket
+            " (#{pluralize(@record.num_cpu, 'socket')} x #{pluralize(@record.cores_per_socket, 'core')})"
+          else
+            ""
+          end
+
+        @devices.push(:device      => "Processors",
+                      :description => "#{db_record.hardware.logical_cpus}#{cpu_details}",
+                      :icon        => "processor")
+      end
+
+      @devices.push(:device      => "CPU Type",
+                    :description => db_record.hardware.cpu_type,
+                    :icon        => "processor") if db_record.hardware.cpu_type
+      @devices.push(:device      => "CPU Speed",
+                    :description => "#{db_record.hardware.cpu_speed} MHz",
+                    :icon        => "processor") if db_record.hardware.cpu_speed
+      @devices.push(:device      => "Memory",
+                    :description => "#{db_record.hardware.memory_cpu} MB",
+                    :icon        => "memory") if db_record.hardware.memory_cpu
 
       # Add disks to the device array
       if !db_record.hardware.disks.nil?

--- a/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -110,21 +110,6 @@ module VmCloudHelper::TextualSummary
     {:label => "Custom Identifier", :value => @record.custom_1}
   end
 
-  def textual_container
-    h = {:label => "Container"}
-    vendor = @record.vendor
-    if vendor.blank?
-      h[:value] = "None"
-    else
-      h[:image] = "vendor-#{vendor.downcase}"
-      h[:value] = "#{vendor} (#{pluralize(@record.num_cpu, 'CPU')}, #{@record.mem_cpu} MB)"
-      h[:title] = "Show VMM container information"
-      h[:explorer] = true
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')
-    end
-    h
-  end
-
   def textual_tools_status
     {:label => "Platform Tools", :value => (@record.tools_status.nil? ? "N/A" : @record.tools_status)}
   end

--- a/vmdb/app/helpers/vm_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_helper/textual_summary.rb
@@ -151,10 +151,17 @@ module VmHelper::TextualSummary
       h[:value] = "None"
     else
       h[:image] = "vendor-#{vendor.downcase}"
-      h[:value] = "#{vendor} (#{pluralize(@record.num_cpu, 'CPU')}, #{@record.mem_cpu} MB)"
       h[:title] = "Show VMM container information"
       h[:explorer] = true
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')
+
+      cpu_details =
+        if @record.num_cpu && @record.cores_per_socket
+          " (#{pluralize(@record.num_cpu, 'socket')} x #{pluralize(@record.cores_per_socket, 'core')})"
+        else
+          ""
+        end
+      h[:value] = "#{vendor}: #{pluralize(@record.logical_cpus, 'CPU')}#{cpu_details}, #{@record.mem_cpu} MB"
     end
     h
   end

--- a/vmdb/app/helpers/vm_infra_helper/textual_summary.rb
+++ b/vmdb/app/helpers/vm_infra_helper/textual_summary.rb
@@ -129,21 +129,6 @@ module VmCloudHelper::TextualSummary
     {:label => "Custom Identifier", :value => @record.custom_1}
   end
 
-  def textual_container
-    h = {:label => "Container"}
-    vendor = @record.vendor
-    if vendor.blank?
-      h[:value] = "None"
-    else
-      h[:image] = "vendor-#{vendor.downcase}"
-      h[:value] = "#{vendor} (#{pluralize(@record.num_cpu, 'CPU')}, #{@record.mem_cpu} MB)"
-      h[:title] = "Show VMM container information"
-      h[:explorer] = true
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')
-    end
-    h
-  end
-
   def textual_host_platform
     {:label => "Parent Host Platform", :value => (@record.host.nil? ? "N/A" : @record.v_host_vmm_product)}
   end

--- a/vmdb/app/models/metric/processing.rb
+++ b/vmdb/app/models/metric/processing.rb
@@ -10,7 +10,8 @@ module Metric::Processing
     :derived_vm_allocated_disk_storage,
     :derived_vm_count_off,
     :derived_vm_count_on,
-    :derived_vm_numvcpus,
+    :derived_vm_numvcpus, # This is actually logical cpus, but needs to be renamed.
+                          # See VimPerformanceState#capture_numvcpus
     :derived_vm_used_disk_storage,
   ]
 
@@ -48,7 +49,7 @@ module Metric::Processing
       when "count"
         method = [group, typ, mode].join("_")
         result[col] = state.send(method)
-      when "numvcpus"
+      when "numvcpus" # This is actually logical cpus.  See note above.
         result[col] = state.send(typ) if obj.kind_of?(VmOrTemplate)
       end
     end

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -157,6 +157,8 @@ class VmOrTemplate < ActiveRecord::Base
   virtual_column :num_hard_disks,                       :type => :integer,    :uses => {:hardware => :hard_disks}
   virtual_column :num_disks,                            :type => :integer,    :uses => {:hardware => :disks}
   virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
+  virtual_column :logical_cpus,                         :type => :integer,    :uses => :hardware
+  virtual_column :cores_per_socket,                     :type => :integer,    :uses => :hardware
   virtual_column :v_annotation,                         :type => :string,     :uses => :hardware
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
@@ -1654,6 +1656,14 @@ class VmOrTemplate < ActiveRecord::Base
 
   def num_cpu
     return self.hardware.nil? ? 0 : self.hardware.numvcpus
+  end
+
+  def logical_cpus
+    return self.hardware.nil? ? 0 : self.hardware.logical_cpus
+  end
+
+  def cores_per_socket
+    return self.hardware.nil? ? 0 : self.hardware.cores_per_socket
   end
 
   def num_disks

--- a/vmdb/spec/models/mixins/aggregation_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/aggregation_mixin_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe AggregationMixin do
+  it "#aggregate_cpu_speed" do
+    cluster = FactoryGirl.create(:ems_cluster, :hosts =>
+      2.times.collect do
+        FactoryGirl.create(:host,
+          :hardware => FactoryGirl.create(:hardware,
+            :numvcpus => 2, :cores_per_socket => 4, :logical_cpus => 8, :cpu_speed => 2_999
+          )
+        )
+      end
+    )
+
+    expect(cluster.aggregate_cpu_speed).to eq(47_984) # 2999 cpu_speed * 8 logical_cpus * 2 hardwares
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1038869

@dclarizio @h-kataria Please review.  Note that the RHEV screenshot below is the one that is the real confusion because the UI showed number of sockets, but most people are expecting total logical CPUs.  By showing all information, there is no confusion.

- First commit clears up the confusion in the UI (screenshots below)
- Second commit clears up some confusion in the backend with some comments, and a spec that proves the values are correct.

---

RHEV VM Summary before
![screen shot 2015-04-29 at 4 38 39 pm](https://cloud.githubusercontent.com/assets/52120/7400922/52305e8e-ee8e-11e4-97b4-8b4eb6aee55a.png)
RHEV VM Summary after
![screen shot 2015-04-29 at 4 31 54 pm](https://cloud.githubusercontent.com/assets/52120/7400926/5794a65a-ee8e-11e4-999c-b3bfd88320a8.png)

---

Clicking on container before
![screen shot 2015-04-29 at 4 40 00 pm](https://cloud.githubusercontent.com/assets/52120/7400948/7609b3f0-ee8e-11e4-85e2-e98600ba09b8.png)
Clicking on container after
![screen shot 2015-04-29 at 4 32 08 pm](https://cloud.githubusercontent.com/assets/52120/7400980/a5a70126-ee8e-11e4-8464-c03530362863.png)

---

VMware VM Summary before
![screen shot 2015-04-29 at 4 37 27 pm](https://cloud.githubusercontent.com/assets/52120/7400983/aa965718-ee8e-11e4-9550-140c21bb9af7.png)
VMware VM Summary after
![screen shot 2015-04-29 at 4 32 50 pm](https://cloud.githubusercontent.com/assets/52120/7401011/bbc1408e-ee8e-11e4-8b16-63c2a0b93f32.png)

---

Amazon VM Summary before
![screen shot 2015-04-29 at 4 35 54 pm](https://cloud.githubusercontent.com/assets/52120/7401017/c3772456-ee8e-11e4-93c3-4ad7733574a5.png)
Amazon VM Summary after
![screen shot 2015-04-29 at 4 34 54 pm](https://cloud.githubusercontent.com/assets/52120/7401022/c982a014-ee8e-11e4-9116-7f8340f7d641.png)
