### PR TITLE
Corrects networking tab of SCVMM provisioning workflow

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/vmdb/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -49,7 +49,6 @@ function get_host_inventory {
   $host_hash = @{}
   $host_hash["NetworkAdapters"] = @(Get-VMHostNetworkAdapter -VMHost $_)
   $host_hash["VirtualSwitch"] = @(Get-SCVirtualNetwork -VMHost $_)
-  # $host_hash["VLANs"] = @(Get-SCVirtualNetwork -VMHost $_ | Select-Object -ExpandProperty "VMHostNetworkAdapters" | Select-Object -ExpandProperty "SubnetVLans")
   $host_hash["Properties"] = $_
   $results[$_.ID] = $host_hash
   $_.DiskVolumes | where-object VolumeLabel -ne "System Reserved" | ForEach-Object {

--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -158,6 +158,8 @@ module EmsRefresh::Parsers
       result = []
 
       logical_networks.each do |ln|
+        next if ln.nil?
+
         result << {
           :name    => ln[:Props][:Name],
           :uid_ems => ln[:Props][:ID],

--- a/vmdb/app/models/ems_refresh/parsers/scvmm.rb
+++ b/vmdb/app/models/ems_refresh/parsers/scvmm.rb
@@ -146,10 +146,22 @@ module EmsRefresh::Parsers
         switch = {
           :uid_ems => v_switch[:ID],
           :name    => v_switch[:Name],
-          :lans    => []
+          :lans    => process_logical_networks(v_switch[:LogicalNetworks])
         }
         result << switch
         v_switch[:VMHostNetworkAdapters].collect { |adapter| set_switch_on_pnic(adapter[:Props], switch) }
+      end
+      result
+    end
+
+    def process_logical_networks(logical_networks)
+      result = []
+
+      logical_networks.each do |ln|
+        result << {
+          :name    => ln[:Props][:Name],
+          :uid_ems => ln[:Props][:ID],
+        }
       end
       result
     end

--- a/vmdb/app/models/miq_provision_microsoft_workflow.rb
+++ b/vmdb/app/models/miq_provision_microsoft_workflow.rb
@@ -24,25 +24,6 @@ class MiqProvisionMicrosoftWorkflow < MiqProvisionInfraWorkflow
     show_fields(display_flag, [:vm_minimum_memory, :vm_maximum_memory])
   end
 
-  def allowed_vlans(options = {})
-    if @allowed_vlan_cache.nil?
-      @vlan_options ||= options
-      vlans = {}
-      src = get_source_and_targets
-      return vlans if src.blank?
-
-      unless @vlan_options[:vlans] == false
-        rails_logger('allowed_vlans', 0)
-        hosts = get_selected_hosts(src)
-        hosts.each { |h| h.switches.each { |s| vlans[s.name] = s.name } }
-        rails_logger('allowed_vlans', 1)
-      end
-
-      @allowed_vlan_cache = vlans
-    end
-    filter_by_tags(@allowed_vlan_cache, options)
-  end
-
   def allowed_datacenters(_options = {})
     allowed_ci(:datacenter, [:cluster, :host, :folder])
   end

--- a/vmdb/spec/models/miq_provision_microsoft_workflow_spec.rb
+++ b/vmdb/spec/models/miq_provision_microsoft_workflow_spec.rb
@@ -31,21 +31,5 @@ describe MiqProvisionMicrosoftWorkflow do
 
       MiqProvisionMicrosoftWorkflow.new({}, admin.userid)
     end
-
-    context "#allowed_vlans" do
-      let(:workflow) { MiqProvisionMicrosoftWorkflow.new({:src_vm_id => template.id}, admin.userid) }
-
-      before do
-        @host   = FactoryGirl.create(:host_microsoft, :ext_management_system => provider)
-        @vswitch = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
-
-        workflow.stub(:get_selected_hosts).and_return([@host])
-      end
-
-      it "should return a vlan name" do
-        vlans = workflow.allowed_vlans
-        vlans.keys.should match_array [@vswitch.name]
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR addresses the issue where the networking tab of the SCVMM provisioning workflow displays the virtual switches in the VLAN drop down instead of logical networks. This was not exposed until now because of a networking configuration flaw in the lab used for development.

https://bugzilla.redhat.com/show_bug.cgi?id=1217253