### PR TITLE
Host detail broken dues to missing num_cpu method

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1524,7 +1524,7 @@ class ApplicationController < ActionController::Base
 
       if db_record.hardware.logical_cpus
         cpu_details =
-          if db_record.num_cpu && db_record.cores_per_socket
+          if db_record.respond_to?(:num_cpu) && db_record.num_cpu && db_record.respond_to?(:cores_per_socket) && db_record.cores_per_socket
             " (#{pluralize(@record.num_cpu, 'socket')} x #{pluralize(@record.cores_per_socket, 'core')})"
           else
             ""


### PR DESCRIPTION
Host detail broken due to missing num_cpu method, adding check
for existence of the method.