### PR TITLE
Uses FactoryGirl in HostOpenstackInfra spec

### DIFF
--- a/vmdb/spec/models/host_openstack_infra_spec.rb
+++ b/vmdb/spec/models/host_openstack_infra_spec.rb
@@ -66,7 +66,7 @@ openstack-keystone:                     active
     end
 
     before do
-      HostServiceGroupOpenstack.create(:host => host, :name => 'Keystone service')
+      FactoryGirl.create(:host_service_group_openstack, :host => host, :name =>  'Keystone service')
     end
 
     context "with stubbed MiqLinux::Utils" do


### PR DESCRIPTION
This changes usage of HostServiceGroupOpenstack.create to
FactoryGirl.create in spec for HostOpenstackInfra.