### PR TITLE
Fix table cell ordering in template selection table

### DIFF
--- a/vmdb/app/views/miq_request/_pre_prov.html.haml
+++ b/vmdb/app/views/miq_request/_pre_prov.html.haml
@@ -26,10 +26,6 @@
             = h(row.name)
           %td
             = h(row.operating_system.try(:product_name))
-          - if @edit[:vm_headers].include?("cloud_tenant")
-            %td
-              - if row.respond_to?(:cloud_tenant)
-                = h(row.cloud_tenant.try(:name))
           %td
             = h(row.platform)
           %td
@@ -43,3 +39,7 @@
               = h(row.ext_management_system.name)
           %td
             = h(row.v_total_snapshots)
+          - if @edit[:vm_headers].include?("cloud_tenant")
+            %td
+              - if row.respond_to?(:cloud_tenant)
+                = h(row.cloud_tenant.try(:name))


### PR DESCRIPTION
Seems there was some modification and the body does not reflect the header order any more.

I did this modification to a live appliance and the columns corresponded. The problem was with Instances but I also checked VMs and seems it is correct now in both occassions.