### PR TITLE
Increased field size of Realm text field.

### DIFF
--- a/vmdb/app/views/ems_infra/_form_fields.html.haml
+++ b/vmdb/app/views/ems_infra/_form_fields.html.haml
@@ -20,5 +20,5 @@
         %td.wide
           = text_field_tag("realm",
                            @edit[:new][:realm],
-                           :maxlength => 15,
+                           :maxlength => MAX_NAME_LEN,
                            "data-miq_observe" => {:interval => ".5", :url => url}.to_json)


### PR DESCRIPTION
This was missed during cherry-picking Kerberos support for SCVMM changes from 5.3.z to upstream due to erb/haml conversions.

https://bugzilla.redhat.com/show_bug.cgi?id=1158646

@dclarizio please review/test. This BZ is marked as a blocker with unspecified pri. & medium sev.