### PR TITLE
[HOLD] work around activerecord requiring "Rails"

### DIFF
--- a/vmdb/tools/fix_auth.rb
+++ b/vmdb/tools/fix_auth.rb
@@ -19,5 +19,6 @@ require 'fix_auth/auth_config_model'
 require 'fix_auth/models'
 require 'fix_auth/cli'
 require 'fix_auth/fix_auth'
+require 'fix_auth/rails_mock' if __FILE__ == $PROGRAM_NAME
 
 FixAuth::Cli.run(ARGV, ENV) if __FILE__ == $PROGRAM_NAME

--- a/vmdb/tools/fix_auth/cli.rb
+++ b/vmdb/tools/fix_auth/cli.rb
@@ -33,6 +33,7 @@ module FixAuth
     end
 
     def run
+      ENV['RAILS_ROOT'] = options[:root] if options[:root]
       ::FixAuth::FixAuth.new(options).run
     end
 

--- a/vmdb/tools/fix_auth/rails_mock.rb
+++ b/vmdb/tools/fix_auth/rails_mock.rb
@@ -1,0 +1,11 @@
+unless defined?(Rails)
+  module Rails
+    def self.rails_root
+      @rails_root ||= ENV["RAILS_ROOT"]
+    end
+
+    def self.env
+      @env ||= ActiveSupport::StringInquirer.new("production")
+    end
+  end
+end


### PR DESCRIPTION
active record currently accesses `Rails` module in 2 places without checks.
This is causing `fix_auth` to blowup.

https://bugzilla.redhat.com/show_bug.cgi?id=1217532

/cc @Fryguy @matthewd @tenderlove @jrafanie 

---

DO NOT MERGE WITHOUT READING:

I either want to this pr (hack fix_auth) OR manageiq/rails#16 - but not both.
