### PR TITLE
Prefer .is_or_subclass_of? over <=

### DIFF
--- a/vmdb/app/models/mixins/new_with_type_sti_mixin.rb
+++ b/vmdb/app/models/mixins/new_with_type_sti_mixin.rb
@@ -7,7 +7,7 @@ module NewWithTypeStiMixin
     def new(*args, &block)
       if (h = args.first).is_a?(Hash) && (type = h[inheritance_column.to_sym] || h[inheritance_column.to_s])
         klass = type.constantize
-        raise "#{klass.name} is not a subclass of #{self.name}" unless klass <= self
+        raise "#{klass.name} is not a subclass of #{self.name}" unless klass.is_or_subclass_of?(self)
         args.unshift(args.shift.except(inheritance_column.to_sym, inheritance_column.to_s))
         klass.new(*args, &block)
       else


### PR DESCRIPTION
<= doesn't handle all cases

In rails console with ```<=```:
```ruby
irb(main):006:0> MiqSchedule.new.verify_file_depot(:uri_prefix => "nfs", :uri => "nfs://example.com")
  MiqSchedule Load (0.7ms)  SELECT "miq_schedules".* FROM "miq_schedules" WHERE "miq_schedules"."id" = $1 LIMIT 1  [["id", 1]]
  MiqSchedule Inst Including Associations (0.3ms - 1rows)
RuntimeError: FileDepotNfs is not a subclass of FileDepot
	from /home/bdunne/projects/redhat/manageiq/vmdb/app/models/mixins/new_with_type_sti_mixin.rb:10:in `new'
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/activerecord/lib/active_record/reflection.rb:183:in `build_association'
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/activerecord/lib/active_record/associations/association.rb:239:in `build_record'
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/activerecord/lib/active_record/associations/singular_association.rb:29:in `build'
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/activerecord/lib/active_record/associations/builder/singular_association.rb:20:in `block in define_constructors'
	from /home/bdunne/projects/redhat/manageiq/vmdb/app/models/miq_schedule.rb:315:in `verify_file_depot'
	from (irb):6
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib/rails/commands/console.rb:47:in `start'
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib/rails/commands/console.rb:8:in `start'
	from /home/bdunne/.gem/ruby/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib/rails/commands.rb:41:in `<top (required)>'
	from script/rails:6:in `require'
	from script/rails:6:in `<main>'
```



In rails console with ```.is_or_subclass_of?```:
```ruby
irb(main):001:0> MiqSchedule.first.verify_file_depot(:uri_prefix => "nfs", :uri => "nfs://example.com")
  MiqSchedule Load (0.7ms)  SELECT "miq_schedules".* FROM "miq_schedules" LIMIT 1
  MiqSchedule Inst Including Associations (76.8ms - 1rows)
DEPOT #<FileDepotNfs id: nil, name: nil, uri: "nfs://example.com", created_at: nil, updated_at: nil, type: "FileDepotNfs", support_case: nil>
=> nil
```