### PR TITLE
Explicitly require gssapi library, and add a rescue handler for other er...

### DIFF
--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -42,7 +42,7 @@ class EmsMicrosoft < EmsInfra
   end
 
   def verify_credentials(_auth_type = nil, options = {})
-    silence_warnings{ require 'gssapi' } # Because version 1.0.0 emits warnings
+    silence_warnings { require 'gssapi' } # Because version 1.0.0 emits warnings
 
     raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(options[:auth_type])
 

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -1,5 +1,6 @@
-
 $:.push(File.expand_path(File.join(Rails.root, %w{.. lib Scvmm})))
+
+require 'gssapi'
 
 class EmsMicrosoft < EmsInfra
   include_concern "Powershell"
@@ -52,6 +53,8 @@ class EmsMicrosoft < EmsInfra
       "Remote error message: #{e.message}"
     rescue GSSAPI::GssApiError
       raise MiqException::MiqHostError, "Unable to reach any KDC in realm #{realm}"
+    rescue StandardError => e
+      raise MiqException::MiqHostError, "Unable to connect: #{e.message}"
     end
 
     true

--- a/vmdb/app/models/ems_microsoft.rb
+++ b/vmdb/app/models/ems_microsoft.rb
@@ -1,7 +1,5 @@
 $:.push(File.expand_path(File.join(Rails.root, %w{.. lib Scvmm})))
 
-require 'gssapi'
-
 class EmsMicrosoft < EmsInfra
   include_concern "Powershell"
 
@@ -44,6 +42,8 @@ class EmsMicrosoft < EmsInfra
   end
 
   def verify_credentials(_auth_type = nil, options = {})
+    silence_warnings{ require 'gssapi' } # Because version 1.0.0 emits warnings
+
     raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(options[:auth_type])
 
     begin


### PR DESCRIPTION
This addresses a possible error where GSSAPI is referenced before it is defined. It also deals with the possibility of other types of exceptions not previously handled explicitly.

https://bugzilla.redhat.com/show_bug.cgi?id=1217394