### PR TITLE
Bump to ruby 2.0.0-p645.

### DIFF
--- a/build/kickstarts/base.ks.erb
+++ b/build/kickstarts/base.ks.erb
@@ -237,7 +237,7 @@ make install
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-/usr/local/bin/ruby-install ruby 2.0.0-p643 -- --disable-install-doc --enable-shared
+/usr/local/bin/ruby-install ruby 2.0.0-p645 -- --disable-install-doc --enable-shared
 
 # Add the ruby binaries path to the PATH so we can find bundle and friends:
 ruby_bin_path=(/opt/rubies/ruby-2.0.0*/bin)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2015/04/13/ruby-2-0-0-p645-released/
CVE-2015-1855: Ruby OpenSSL Hostname Verification