### PR TITLE
Fix auth now works with evm 4.0 upgrades

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -11,10 +11,10 @@ gem "iniparse"
 #       this file, the directories resolve correctly.
 
 # Locally modified and required
-gem "activesupport", "=3.2.17", :git => "git://github.com/ManageIQ/rails.git", :tag => "vendored-3.2.17-13"
+gem "activesupport", "=3.2.17", :git => "git://github.com/ManageIQ/rails.git", :tag => "vendored-3.2.17-14"
 
 # ActiveRecord is used by appliance_console
-gem "activerecord",  "=3.2.17", :git => "git://github.com/ManageIQ/rails.git", :tag => "vendored-3.2.17-13"
+gem "activerecord",  "=3.2.17", :git => "git://github.com/ManageIQ/rails.git", :tag => "vendored-3.2.17-14"
 
 # Not locally modified and not required
 gem "awesome_spawn",        "~> 1.3",        :require => false

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -18,7 +18,7 @@ gem 'less-rails',   :require => false
 
 # Vendored and required
 # TODO: Fix AWS tests now that our api specs and the soap4r 1.6.0 specs pass on 1.8.7/1.9.3
-gem "rails",                          "=3.2.17",                         :git => "git://github.com/ManageIQ/rails.git", :tag => "vendored-3.2.17-13"
+gem "rails",                          "=3.2.17",                         :git => "git://github.com/ManageIQ/rails.git", :tag => "vendored-3.2.17-14"
 gem "ruport",                         "=1.7.0",                          :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-2"
 
 # Vendored but not required


### PR DESCRIPTION
active record no longer accesses Rails module in 2 places
without checks.

https://bugzilla.redhat.com/show_bug.cgi?id=1217532

/cc @jrafanie 