### PR TITLE
fixed spinner issue in OPS controller

### DIFF
--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -759,7 +759,7 @@ class OpsController < ApplicationController
       end
 
       page << "cfmeDynatree_activateNodeSilently('#{x_active_tree}', '#{x_node}');"
-      page << "miqSparkle(false);"
+      page << "miqSparkleOff();"
       page << javascript_focus_if_exists('server_company')
       page << "if (miqDomElementExists('flash_msg_div')) {"
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")


### PR DESCRIPTION
($.active) is not less than 2 when tree node is clicked on database accordion, replaced miqSparkle(false) call with miqSparkleOff() to directly stop the spinner when right cell is being replaced.

https://bugzilla.redhat.com/show_bug.cgi?id=1217812

@dclarizio please review/test.