### PR TITLE
default foreman verify_ssl to true

### DIFF
--- a/vmdb/app/controllers/provider_foreman_controller.rb
+++ b/vmdb/app/controllers/provider_foreman_controller.rb
@@ -93,13 +93,13 @@ class ProviderForemanController < ApplicationController
       @provider_foreman = ProviderForeman.new(:name       => params[:name],
                                               :url        => params[:url],
                                               :zone_id    => Zone.find_by_name(MiqServer.my_zone).id,
-                                              :verify_ssl => params[:verify_ssl].eql?("on") ? true : nil)
+                                              :verify_ssl => params[:verify_ssl].eql?("on"))
     else
       config_mgr = ConfigurationManagerForeman.find(params[:id])
       @provider_foreman = ProviderForeman.find(config_mgr.provider_id)
       @provider_foreman.update_attributes(:name       => params[:name],
                                           :url        => params[:url],
-                                          :verify_ssl => params[:verify_ssl].eql?("on") ? true : nil)
+                                          :verify_ssl => params[:verify_ssl].eql?("on"))
 
     end
     update_authentication_provider_foreman
@@ -165,7 +165,7 @@ class ProviderForemanController < ApplicationController
     @provider_foreman = ProviderForeman.new(:name       => params[:name],
                                             :url        => params[:url],
                                             :zone_id    => Zone.find_by_name(MiqServer.my_zone).id,
-                                            :verify_ssl => params[:verify_ssl].eql?("on") ? true : nil)
+                                            :verify_ssl => params[:verify_ssl].eql?("on"))
     update_authentication_provider_foreman
 
     begin

--- a/vmdb/app/models/provider.rb
+++ b/vmdb/app/models/provider.rb
@@ -8,6 +8,9 @@ class Provider < ActiveRecord::Base
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
 
+  default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
+  validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
+
   def self.leaf_subclasses
     descendants.select { |d| d.subclasses.empty? }
   end

--- a/vmdb/db/migrate/20150501193927_default_provider_verify_ssl.rb
+++ b/vmdb/db/migrate/20150501193927_default_provider_verify_ssl.rb
@@ -1,0 +1,11 @@
+class DefaultProviderVerifySsl < ActiveRecord::Migration
+  def up
+    say_with_time "Setting Provider verify_ssl values for nils" do
+      Provider.where(:verify_ssl => nil).update_all(:verify_ssl => OpenSSL::SSL::VERIFY_PEER)
+    end
+  end
+
+  def down
+    # it was ambigious before, no need to set back to nil
+  end
+end

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -5,7 +5,7 @@ describe ProviderForemanController do
   before(:each) do
     set_user_privileges
     @zone = FactoryGirl.create(:zone, :name => 'zone1')
-    @provider = ProviderForeman.create(:name => "test", :url => "10.8.96.102", :verify_ssl => nil, :zone => @zone)
+    @provider = ProviderForeman.create(:name => "test", :url => "10.8.96.102", :zone => @zone)
     @config_mgr = ConfigurationManagerForeman.find_all_by_provider_id(@provider.id).first
     @config_profile = ConfigurationProfileForeman.create(:name                     => "testprofile",
                                                          :configuration_manager_id => @config_mgr.id)

--- a/vmdb/spec/models/provider_foreman_spec.rb
+++ b/vmdb/spec/models/provider_foreman_spec.rb
@@ -4,7 +4,9 @@ require "manageiq_foreman"
 
 describe ProviderForeman do
   let(:provider) { FactoryGirl.build(:provider_foreman) }
-  let(:attrs)    { {:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => nil} }
+  let(:attrs)    do
+    {:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER}
+  end
 
   describe "#connect" do
     it "with no port" do

--- a/vmdb/spec/models/provider_spec.rb
+++ b/vmdb/spec/models/provider_spec.rb
@@ -6,7 +6,7 @@ describe Provider do
   describe "#verify_ssl" do
     context "when non set" do
       it "is default to verify ssl" do
-        expect(provider.verify_ssl).to be_nil
+        expect(provider.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
         expect(provider).to be_verify_ssl
       end
     end


### PR DESCRIPTION
The current behavior is to leave ssl_verify field null. (verify = true)

But unfortunately, with ssl connectivity, that is different from ruby's default boolean behavior:

|value|verify|boolean
|---|---|---|
|nil|**true**|false
|false|false|false|
|true|true|true

This is causing issues with the ui.
Solution, only support true/false for verify.
Caveat, we actually store `0` and `1` (i.e.: `SSL::VERIFY_NONE`, `SSL::VERIFY_PEER`)

/cc @brandondunne @AparnaKarve @gmcculloug 