### PR TITLE
Need to redirect /favicon.ico to /assets/favicon.ico

### DIFF
--- a/system/COPY/etc/httpd/conf.d/cfme-https-application.conf
+++ b/system/COPY/etc/httpd/conf.d/cfme-https-application.conf
@@ -32,6 +32,13 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
   ErrorDocument 403 /error/noindex.html
 </Directory>
 
+# Redirect favicon.ico
+RewriteEngine On
+<ifmodule mod_rewrite.c>
+  RewriteCond %{REQUEST_URI} ^/favicon\.ico$ [NC]
+  RewriteRule (.*) /assets/favicon.ico       [L,R=301]
+</ifmodule>
+
 SetEnvIf User-Agent ".*MSIE.*" \
          nokeepalive ssl-unclean-shutdown \
          downgrade-1.0 force-response-1.0


### PR DESCRIPTION
- For non-html API responses, web triggered API requests will still request /favicon.ico, we
need to redirect the browsers's request to /assets/favicon.ico.

https://bugzilla.redhat.com/show_bug.cgi?id=1217336