### PR TITLE
Fixed compressed icons within Bootstrap tables

### DIFF
--- a/vmdb/app/assets/stylesheets/patternfly_overrides.less
+++ b/vmdb/app/assets/stylesheets/patternfly_overrides.less
@@ -189,6 +189,7 @@ li.brand-white-label.whitelabeled {
 
 table.table tbody td img {
   height: 20px;
+  width: 20px;
 }
 
 .table > thead > tr > th {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1201140