### PR TITLE
Remove Rack hack to show ip addresses

### DIFF
--- a/vmdb/config/initializers/ad_show_ips.rb
+++ b/vmdb/config/initializers/ad_show_ips.rb
@@ -1,7 +1,0 @@
-module ActionDispatch
-  class RemoteIp
-    def proxies
-      /^127\.0\.0\.1$/
-    end
-  end
-end


### PR DESCRIPTION
This is no longer working locally.
Not sure what happened

Best to just remove this for now and bring in a new one or wait for
fixes from rails 5.x. Maybe backpatch fix into our rails 4.x branch