### PR TITLE
Hide Storage* start pages behind product setting.

### DIFF
--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -762,7 +762,7 @@ class ConfigurationController < ApplicationController
 
       # Build the start pages pulldown list
       session[:start_pages] = MiqShortcut.start_pages.each_with_object([]) do |page, pages|
-        pages.push([page[1], page[0]]) if role_allows(:feature => page[2], :any => true)
+        pages.push([page[1], page[0]]) if start_page_allowed?(page[2])
       end
     when 'ui_2'
       @edit = {

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -683,7 +683,7 @@ class DashboardController < ApplicationController
     first_allowed_url = nil
     startpage_already_set = nil
     MiqShortcut.start_pages.each do |url, _description, rbac_feature_name|
-      allowed = role_allows(:feature => rbac_feature_name, :any => true)
+      allowed = start_page_allowed?(rbac_feature_name)
       first_allowed_url ||= url if allowed
       # if default startpage is set, check if it is allowed
       startpage_already_set = true if @settings[:display][:startpage] == url && allowed

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2829,5 +2829,16 @@ module ApplicationHelper
       ui_lookup(:ems_cluster_types => 'cluster_infra')
   end
 
+  def start_page_allowed?(start_page)
+    storage_start_pages = %w(cim_storage_extent_show_list
+                             ontap_file_share_show_list
+                             ontap_logical_disk_show_list
+                             ontap_storage_system_show_list
+                             ontap_storage_volume_show_list
+                             storage_manager_show_list)
+    return false if storage_start_pages.include?(start_page) && !get_vmdb_config[:product][:storage]
+    role_allows(:feature => start_page, :any => true)
+  end
+
   attr_reader :big_iframe
 end

--- a/vmdb/db/fixtures/miq_shortcuts.yml
+++ b/vmdb/db/fixtures/miq_shortcuts.yml
@@ -134,6 +134,36 @@
   :url: /repository/show_list
   :rbac_feature_name: repository_show_list
   :startup: true
+- :name: storage_systems
+  :description: Storage / Storage Systems
+  :url: /ontap_storage_system/show_list
+  :rbac_feature_name: ontap_storage_system_show_list
+  :startup: true
+- :name: file_shares
+  :description: Storage / File Shares
+  :url: /ontap_file_share/show_list
+  :rbac_feature_name: ontap_file_share_show_list
+  :startup: true
+- :name: logical_disks
+  :description: Storage / Logical Disks
+  :url: /ontap_logical_disk/show_list
+  :rbac_feature_name: ontap_logical_disk_show_list
+  :startup: true
+- :name: base_extents
+  :description: Storage / Base Extents
+  :url: /cim_base_storage_extent/show_list
+  :rbac_feature_name: cim_storage_extent_show_list
+  :startup: true
+- :name: storage_volumes
+  :description: Storage / Storage Volumes
+  :url: /ontap_storage_volume/show_list
+  :rbac_feature_name: ontap_storage_volume_show_list
+  :startup: true
+- :name: storage_managers
+  :description: Storage / Storage Managers
+  :url: /storage_manager/show_list
+  :rbac_feature_name: storage_manager_show_list
+  :startup: true
 - :name: control_explorer
   :description: Control / Explorer
   :url: /miq_policy/explorer

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -4166,4 +4166,28 @@ describe ApplicationHelper do
       result.should eq("Node")
     end
   end
+
+  context "#start_page_allowed?" do
+    def role_allows(_)
+      true
+    end
+
+    it "should return true for storage start pages when product flag is set" do
+      cfg = VMDB::Config.new("vmdb")
+      cfg.config.store_path(:product, :storage, true)
+      VMDB::Config.stub(:new).and_return(cfg)
+      result = start_page_allowed?("cim_storage_extent_show_list")
+      result.should be_true
+    end
+
+    it "should return false for storage start pages when product flag is not set" do
+      result = start_page_allowed?("cim_storage_extent_show_list")
+      result.should be_false
+    end
+
+    it "should return true for host start page" do
+      result = start_page_allowed?("host_show_list")
+      result.should be_true
+    end
+  end
 end


### PR DESCRIPTION
- Reverted previous change and added Storage * start pages back in the list and made it visible when product/storage flag is set.
- Added spect test around the new method.

https://bugzilla.redhat.com/show_bug.cgi?id=1153580

@dclarizio please review/test