### PR TITLE
Fix AWS event mappings

### DIFF
--- a/vmdb/config/event_handling.tmpl.yml
+++ b/vmdb/config/event_handling.tmpl.yml
@@ -1370,12 +1370,12 @@ event_handling:
   - refresh:
     - ems
   AWS_EC2_Instance_CREATE:
-  - policy:
-    - src_vm
-    - vm_create
   - refresh:
     - ems
   AWS_EC2_Instance_UPDATE:
+  - refresh:
+    - ems
+  AWS_EC2_Instance_DELETE:
   - refresh:
     - ems
   AWS_EC2_Instance_running:
@@ -1387,13 +1387,13 @@ event_handling:
   AWS_EC2_Instance_stopped:
   - policy:
     - src_vm
-    - vm_power_off
+    - vm_poweroff
   - refresh:
     - ems
   AWS_EC2_Instance_shutting-down:
   - policy:
     - src_vm
-    - vm_power_off
+    - vm_poweroff
   - refresh:
     - ems
 


### PR DESCRIPTION
Add handling for AWS_EC2_Instance_DELETE event
Correct policy calls to vm_poweroff for AWS_EC2_Instance_stopped and AWS_EC2_Instance_shutting-down events.
Remove vm_create policy call for AWS_EC2_Instance_CREATE event since this event is raise from the code automatically when the VM instance is added to the database.

https://bugzilla.redhat.com/show_bug.cgi?id=1207865
https://bugzilla.redhat.com/show_bug.cgi?id=1217597
https://bugzilla.redhat.com/show_bug.cgi?id=1217601