### PR TITLE
Fix appliance_console unable to join external db

### DIFF
--- a/lib/appliance_console/database_configuration.rb
+++ b/lib/appliance_console/database_configuration.rb
@@ -83,7 +83,7 @@ module ApplianceConsole
 
     def join_region
       require 'tempfile'
-      temp = Tempfile.new(RAILS_ROOT.join("tmp").to_s)
+      temp = Tempfile.new(["joinregion", ".rb"], RAILS_ROOT.join("tmp").to_s)
       params = { nil => ['runner', temp.path]}
 
       output = nil


### PR DESCRIPTION
Apparently `Temp.new(path)` no longer works.

This fix passes in the expected filename first, including the
extension for good measure:

```ruby
Temp.new([prefix, postfix], path)
```

https://bugzilla.redhat.com/show_bug.cgi?id=1217818

/cc @jrafanie 