### PR TITLE
CiProcessing#reconfigurevms - vm_reconfigure should call find_checked_items even when :id param present

### DIFF
--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -994,7 +994,7 @@ module ApplicationController::CiProcessing
     if !session[:checked_items].nil? && (@lastaction == "set_checked_items" || params[:pressed] == "miq_request_edit")
       @edit[:req_id] = params[:id]
       recs = session[:checked_items]
-    elsif !params[:id]
+    elsif !params[:id] || params[:pressed] == 'vm_reconfigure'
       recs = find_checked_items
     end
     if recs.blank?


### PR DESCRIPTION
Selecting multiple vms under provider summary and pressing reconfigure would not call find_checked_items to find the selected VMs but would use params[:id] instead, but that's the provider id, not vm

Assuming the `!params[:id]` check is still useful somewhere, so special-casing it.

https://bugzilla.redhat.com/show_bug.cgi?id=1214204