### PR TITLE
Add status_reason and cloud_tenant to orchestration_stacks

### DIFF
--- a/vmdb/db/migrate/20150505160516_add_status_reason_and_cloud_tenant_to_orchestration_stacks.rb
+++ b/vmdb/db/migrate/20150505160516_add_status_reason_and_cloud_tenant_to_orchestration_stacks.rb
@@ -1,0 +1,6 @@
+class AddStatusReasonAndCloudTenantToOrchestrationStacks < ActiveRecord::Migration
+  def change
+    add_column :orchestration_stacks, :status_reason,   :text
+    add_column :orchestration_stacks, :cloud_tenant_id, :bigint
+  end
+end


### PR DESCRIPTION
Two columns are added to table orchestration_stacks
`status_reason` is a text field collected from provider
`cloud_tenant_id` associates the stack with the provider tenant

Two follow-up PRs will address the use of each individual field.
https://bugzilla.redhat.com/show_bug.cgi?id=1218743
https://bugzilla.redhat.com/show_bug.cgi?id=1218746