### PR TITLE
Do not get volumes when cinder isn't available

### DIFF
--- a/app/models/ems_refresh/parsers/openstack.rb
+++ b/app/models/ems_refresh/parsers/openstack.rb
@@ -77,6 +77,8 @@ module EmsRefresh::Parsers
     end
 
     def volumes
+      # TODO: support volumes through :nova as well?
+      return [] unless @volume_service_name == :cinder
       @volumes ||= @volume_service.volumes_for_accessible_tenants
     end
 
@@ -145,8 +147,6 @@ module EmsRefresh::Parsers
     end
 
     def get_volumes
-      # TODO: support volumes through :nova as well?
-      return unless @volume_service_name == :cinder
       process_collection(volumes, :cloud_volumes) { |volume| parse_volume(volume) }
     end
 


### PR DESCRIPTION
The openstack inventory parser already has logic in place to avoid getting volumes from Cinder if the cinder service is not running.  However, this check if bypassed when trying to get the list of Availability Zones.

When the openstack inventory parser tries to get the list of Availability Zones, it checks what Availability Zones are assigned to instances as well as which are assigned to volumes.  This check for Availability Zones assigned to volumes does not take into account the fact that cinder might not be running.

https://bugzilla.redhat.com/show_bug.cgi?id=1217916