### PR TITLE
Added curly braces in the if block.

### DIFF
--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -1721,17 +1721,18 @@ module ApplicationHelper
   # Reload toolbars using new buttons object and xml
   def javascript_for_toolbar_reload(tb, buttons, xml)
     %Q{
-      if (miq_toolbars.#{tb} && miq_toolbars.#{tb}.obj)
+      if (miq_toolbars.#{tb} && miq_toolbars.#{tb}.obj){
         miq_toolbars.#{tb}.obj.unload();
 
-      window.#{tb} = new dhtmlXToolbarObject('#{tb}', 'miq_blue');
-      miq_toolbars['#{tb}'] = {
-        obj: window.#{tb},
-        buttons: #{buttons},
-        xml: "#{xml}"
-      };
+        window.#{tb} = new dhtmlXToolbarObject('#{tb}', 'miq_blue');
+        miq_toolbars['#{tb}'] = {
+          obj: window.#{tb},
+          buttons: #{buttons},
+          xml: "#{xml}"
+        };
 
-      miqInitToolbar(miq_toolbars['#{tb}']);
+        miqInitToolbar(miq_toolbars['#{tb}']);
+      }
     }
   end
 


### PR DESCRIPTION
Only unload/initialize toolbar when tb is present in miq_toolbars, need to add braces around statements if block.

https://bugzilla.redhat.com/show_bug.cgi?id=1218786

@himdel please review, Looks like fix in https://github.com/ManageIQ/manageiq/pull/2796 has caused this issue. This code in explorer presenter seems to be the culprit https://github.com/ManageIQ/manageiq/blob/master/vmdb/app/presenters/explorer_presenter.rb#L163

@dclarizio please review/test.