### PR TITLE
By redirecting STDERR to STDOUT, we missed out on logging the error.

### DIFF
--- a/vmdb/lib/db_administration/miq_postgres_admin.rb
+++ b/vmdb/lib/db_administration/miq_postgres_admin.rb
@@ -210,7 +210,7 @@ class MiqPostgresAdmin
   def self.runcmd_with_logging(cmd_str, opts, params = {})
     $log.info("MIQ(MiqPostgresAdmin.run_cmd) Running command... #{AwesomeSpawn.build_command_line(cmd_str, params)}")
     with_pgpass_file(opts) do
-      AwesomeSpawn.run!("#{cmd_str} 2>&1", :params => params).output
+      AwesomeSpawn.run!(cmd_str, :params => params).output
     end
   end
 


### PR DESCRIPTION
AwesomeSpawn already logs the command, the exit code, and STDERR.
See https://github.com/ManageIQ/awesome_spawn/blob/f7b6de278d578348551756f0f43ada49a0c1865f/lib/awesome_spawn.rb#L100-101

As an example, if I try to restore a DB with a missing smb/nfs file:

Before:
```
 INFO -- : MIQ(MiqPostgresAdmin.run_cmd) Running command... pg_restore --no-password --dbname vmdb_production --verbose --exit-on-error /mnt/miq_f9d23bb2-f36b-11e4-a8c4-fa163e238bee/jrafanie-backup
ERROR -- : AwesomeSpawn: pg_restore 2>&1 exit code: 1
ERROR -- : AwesomeSpawn:
```

After:
```
 INFO -- : MIQ(MiqPostgresAdmin.run_cmd) Running command... pg_restore --no-password --dbname vmdb_production --verbose --exit-on-error /mnt/miq_4916c9d4-f373-11e4-b965-fa163e238bee/jrafanie-backup
ERROR -- : AwesomeSpawn: pg_restore exit code: 1
ERROR -- : AwesomeSpawn: pg_restore: [archiver] could not open input file "/mnt/miq_4916c9d4-f373-11e4-b965-fa163e238bee/jrafanie-backup": No such file or directory
```

https://bugzilla.redhat.com/show_bug.cgi?id=1217641