### PR TITLE
Enhance error handling for rollback_complete status

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -4,7 +4,8 @@
 
 $evm.log("info", "Starting Orchestration Provisioning")
 
-service = $evm.root["service_template_provision_task"].destination
+task = $evm.root["service_template_provision_task"]
+service = task.destination
 
 begin
   ems_ref = service.deploy_orchestration_stack
@@ -12,5 +13,6 @@ begin
 rescue => err
   $evm.root['ae_result'] = 'error'
   $evm.root['ae_reason'] = err.message
+  task.miq_request.user_message = err.message
   $evm.log("error", "Stack #{service.stack_name} creation failed. Reason: #{err.message}")
 end


### PR DESCRIPTION
Also make the error visible on UI by setting the user message

https://bugzilla.redhat.com/show_bug.cgi?id=1218436

When the stack has status ROLLBACK_COMPLETE in AWS CloudFormation, no error message is given. We tried to use the non-existing message to update the provision status which caused an error in the log.

The fix is to provide a meaningful error message.

In this work we also pass any error message to user message which is visible on the UI, so the the user no longer sees the general error "Service_Template_Provisioning failed". 