### PR TITLE
Renamed a JS function that can be called/used from multiple screens.

### DIFF
--- a/vmdb/app/assets/javascripts/miq_dynatree.js
+++ b/vmdb/app/assets/javascripts/miq_dynatree.js
@@ -1,12 +1,8 @@
 // Functions used by CFME for the dynatree control
 
-// OnCheck handler for the Role features tree
-function cfmeOnClick_RoleFeatureCheck(node) {
-  if (node.isSelected())
-    var checked = '0';  // If node was selected, now unchecking
-  else
-    var checked = '1';
-  var url = check_url + node.data.key + '?check=' + checked
+// OnCheck handler for the checkboxes in tree
+function miqOnCheck_handler(node) {
+  var url = check_url + node.data.key + '?check=' + (node.isSelected() ? '0' : '1')
   miqJqueryRequest(url);
 }
 

--- a/vmdb/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -34,7 +34,7 @@
         :locals         => {:tree_id    => "obj_treebox",
           :tree_name                    => "obj_tree",
           :json_tree                    => @assign[:obj_tree],
-          :oncheck                      => "cfmeOnClick_SmartProxyAffinityCheck",
+          :oncheck                      => "miqOnCheck_handler",
           :check_url                    => "alert_profile_assign_changed/",
           :exp_tree                     => false,
           :checkboxes                   => true})

--- a/vmdb/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_profile_details.html.haml
@@ -133,7 +133,7 @@
                           - objs.push(o.absolute_path(:exclude_hidden => true))
                         - else
                           - objs.push(o.name)
-                      - objs.sort(&:downcase).each do |obj|
+                      - objs.sort_by(&:downcase).each do |obj|
                         %tr
                           %td
                             = h(obj)

--- a/vmdb/app/views/ops/_rbac_role_details.html.haml
+++ b/vmdb/app/views/ops/_rbac_role_details.html.haml
@@ -58,7 +58,7 @@
                               :three_checks   => true,
                               :check_url      => "/ops/rbac_role_field_changed/",
                               :disable_checks => @edit.nil?,
-                              :oncheck        => @edit.nil? ? nil : "cfmeOnClick_RoleFeatureCheck",
+                              :oncheck        => @edit.nil? ? nil : "miqOnCheck_handler",
                               :open_close_all_on_dbl_click => true})
       &nbsp;&nbsp;*
       =_("Double click a feature to open/close all children.")


### PR DESCRIPTION
- Renamed existing method 'cfmeOnClick_RoleFeatureCheck' method to 'miqOnCheck_handler' so it can be called/used from other places as well. This issue was caused by removal of 'cfmeOnClick_SmartProxyAffinityCheck' JS function in https://github.com/ManageIQ/manageiq/pull/1531 that was identical to 'cfmeOnClick_RoleFeatureCheck' function.
- Fixed an issue with sort that was causing the screen to blow up after Alert Profile assignment was saved

https://bugzilla.redhat.com/show_bug.cgi?id=1219171

before
![before](https://cloud.githubusercontent.com/assets/3450808/7503161/0fec845e-f40f-11e4-8410-10127806b302.png)

after
![after](https://cloud.githubusercontent.com/assets/3450808/7503162/11e90052-f40f-11e4-8c20-47e022c9893c.png)

@dclarizio please review/test