### PR TITLE
Create only 1 MiqApproval when testing a single reason.

### DIFF
--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -114,11 +114,9 @@ module MiqAeServiceMiqRequestSpec
       reason = invoke_ae.root(@ae_result_key)
       reason.should be_nil
 
-      wilma          = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'wilma',  :email => 'wilma@bedrock.gov')
       betty          = FactoryGirl.create(:user, :name => 'Betty Rubble',     :userid => 'betty',  :email => 'betty@bedrock.gov')
-      wilma_approval = FactoryGirl.create(:miq_approval, :approver => wilma)
       betty_approval = FactoryGirl.create(:miq_approval, :approver => betty)
-      @miq_request.miq_approvals = [wilma_approval, betty_approval]
+      @miq_request.miq_approvals = [betty_approval]
       @miq_request.save!
 
       MiqApproval.any_instance.stub(:authorized?).and_return(true)
@@ -130,6 +128,9 @@ module MiqAeServiceMiqRequestSpec
       reason = invoke_ae.root(@ae_result_key)
       reason.should == betty_reason
 
+      wilma          = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'wilma',  :email => 'wilma@bedrock.gov')
+      wilma_approval = FactoryGirl.create(:miq_approval, :approver => wilma)
+      @miq_request.miq_approvals << wilma_approval
       wilma_reason = "Where's Fred?"
       wilma_approval.deny(wilma.userid, wilma_reason)
       #wilma_approval.update_attributes(:state => 'denied', :reason => wilma_reason)


### PR DESCRIPTION
We had 2 MiqApprovals attached to the MiqRequest before.
One was "pending" with a nil reason.
One was "deny" with "Where's Barney?" reason.

Sometimes, we got the nil reason, other times we get the "Where's Barney?" reason.

This is because MiqRequest#reason is delegated to MiqRequest#first_approval which does miq_approvals.first.
This is not guaranteed to return the same MiqApproval.
This inconsistent result caused this sporadic test failure:

```
  1) MiqAeMethodService::MiqAeServiceMiqRequest #reason
     Failure/Error: reason.should == betty_reason
       expected: "Where's Barney?"
            got: nil (using ==)
      ./spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb:131:in `block (2 levels) in <module:MiqAeServiceMiqRequestSpec>'
```