### PR TITLE
Fixed this error "undefined method: verify_credentials" during FileDepot validation

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -535,7 +535,8 @@ class ApplicationController < ActionController::Base
       settings[:uri] = @edit[:new][:uri_prefix] + "://" + @edit[:new][:uri]
     else
       settings = {:username => params[:log_userid], :password => params[:log_password]}
-      settings[:uri] = params[:uri_prefix] + "://" + params[:uri]
+      settings[:uri] = "#{params[:uri_prefix]}://#{params[:uri]}"
+      settings[:uri_prefix] = params[:uri_prefix]
     end
 
     begin


### PR DESCRIPTION
```verify_file_depot``` needs ```:uri_prefix``` to perform the FileDepot validation, which was supplied.

https://bugzilla.redhat.com/show_bug.cgi?id=1219642