### PR TITLE
Collect stack status_reason at refresh and report

### DIFF
--- a/vmdb/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/vmdb/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module OrchestrationStackHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w(name description type status)
+    items = %w(name description type status status_reason)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
@@ -36,6 +36,10 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_status
     {:label => "Status", :value => @record.status}
+  end
+
+  def textual_status_reason
+    {:label => "Status Reason", :value => @record.status_reason}
   end
 
   def textual_ems_cloud

--- a/vmdb/app/models/ems_refresh/parsers/ec2.rb
+++ b/vmdb/app/models/ems_refresh/parsers/ec2.rb
@@ -426,15 +426,16 @@ module EmsRefresh::Parsers
       uid = stack.stack_id.to_s
       child_stacks, resources = find_stack_resources(stack)
       new_result = {
-        :type        => "OrchestrationStackAmazon",
-        :ems_ref     => uid,
-        :name        => stack.name,
-        :description => stack.description,
-        :status      => stack.status,
-        :children    => child_stacks,
-        :resources   => resources,
-        :outputs     => find_stack_outputs(stack),
-        :parameters  => find_stack_parameters(stack),
+        :type          => "OrchestrationStackAmazon",
+        :ems_ref       => uid,
+        :name          => stack.name,
+        :description   => stack.description,
+        :status        => stack.status,
+        :status_reason => stack.status_reason,
+        :children      => child_stacks,
+        :resources     => resources,
+        :outputs       => find_stack_outputs(stack),
+        :parameters    => find_stack_parameters(stack),
 
         :orchestration_template => find_stack_template(stack)
       }

--- a/vmdb/app/models/ems_refresh/parsers/openstack_common/orchestration_stacks.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack_common/orchestration_stacks.rb
@@ -53,6 +53,7 @@ module EmsRefresh
             :name                   => stack.stack_name,
             :description            => stack.description,
             :status                 => stack.stack_status,
+            :status_reason          => stack.stack_status_reason,
             :children               => child_stacks,
             :resources              => resources,
             :outputs                => find_stack_outputs(stack),

--- a/vmdb/product/views/OrchestrationStack.yaml
+++ b/vmdb/product/views/OrchestrationStack.yaml
@@ -22,6 +22,7 @@ cols:
 - name
 - type
 - status
+- status_reason
 - total_vms
 - total_security_groups
 - total_cloud_networks
@@ -42,6 +43,7 @@ col_order:
 - ext_management_system.name
 - type
 - status
+- status_reason
 - total_vms
 - total_security_groups
 - total_cloud_networks
@@ -52,6 +54,7 @@ headers:
 - Provider
 - Type
 - Status
+- Status Reason
 - Instances
 - Security Groups
 - Cloud Networks

--- a/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -443,6 +443,9 @@ describe EmsRefresh::Refreshers::Ec2Refresher do
   end
 
   def assert_specific_orchestration_stack
+    OrchestrationStackAmazon.where(:name => "cloudformation-spec").first.status_reason.should ==
+      "The following resource(s) failed to create: [IPAddress, WebServerWaitCondition]. "
+
     @orch_stack = OrchestrationStackAmazon.where(:name => "cloudformation-spec-WebServerInstance-QS899ZNAHZU6").first
     @orch_stack.should have_attributes(
       :status  => "CREATE_COMPLETE",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1218743

A new column `stack_reason` has been added to `orchestration_stacks`. This work is to collect `stack_reason` at refresh and show it in the stack summary page as well as in the report.