### PR TITLE
Fix #2716 created links from container groups(pods) to services in UI

### DIFF
--- a/vmdb/app/controllers/mixins/containers_common_mixin.rb
+++ b/vmdb/app/controllers/mixins/containers_common_mixin.rb
@@ -49,6 +49,17 @@ module ContainersCommonMixin
         pluralize(@view.extras[:total_count] - @view.extras[:auth_count], "other #{title.singularize}")
         + " on this " + ui_lookup(:tables => @table_name)
       end
+    elsif @display == "container_services" || session[:display] == "container_services" && params[:display].nil?
+      title = ui_lookup(:tables => "container_services")
+      drop_breadcrumb(:name => record.name + " (All #{title})",
+                      :url  => "/#{controller_name}/show/#{record.id}?display=#{@display}")
+      @view, @pages = get_view(ContainerService, :parent => record)  # Get the records (into a view) and the paginator
+      @showtype = @display
+      if @view.extras[:total_count] > @view.extras[:auth_count] && @view.extras[:total_count] &&
+         @view.extras[:auth_count]
+        count_text = pluralize(@view.extras[:total_count] - @view.extras[:auth_count], "other #{title.singularize}")
+        @bottom_msg = "* You are not authorized to view #{count_text} on this #{ui_lookup(:tables => @table_name)}"
+      end
     end
     # Came in from outside show_list partial
     if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]

--- a/vmdb/app/helpers/container_group_helper/textual_summary.rb
+++ b/vmdb/app/helpers/container_group_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module ContainerGroupHelper::TextualSummary
   end
 
   def textual_group_relationships
-    items = %w(ems containers container_node)
+    items = %w(ems containers container_node services)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
@@ -76,6 +76,16 @@ module ContainerGroupHelper::TextualSummary
     if role_allows(:feature => "container_node_show")
       h[:link]  = url_for(:action => 'show', :id => node, :controller => 'container_node')
       h[:title] = "View #{label} #{(@record.container_node.name)}"
+    end
+    h
+  end
+
+  def textual_services
+    num_of_services = @record.number_of(:container_services)
+    label = ui_lookup(:tables => "container_service")
+    h = {:label => label, :image => "container_service", :value => num_of_services}
+    if num_of_services > 0 && role_allows(:feature => "container_service_show")
+      h[:link] = url_for(:action => 'show', :controller => 'container_group', :display => 'container_services')
     end
     h
   end

--- a/vmdb/app/views/container_group/show.html.haml
+++ b/vmdb/app/views/container_group/show.html.haml
@@ -1,4 +1,7 @@
 - if @display == 'containers'
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+- elsif @display == 'container_services' && @showtype != "compare"
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
     = render :partial => @showtype
+

--- a/vmdb/app/views/layouts/listnav/_container_group.html.haml
+++ b/vmdb/app/views/layouts/listnav/_container_group.html.haml
@@ -36,3 +36,13 @@
             = link_to("#{ui_lookup(:table => "container_node")}: #{@record.container_node.name}",
                 {:controller => 'container_node', :action => 'show', :id => @record.container_node},
                 :title => _("View %s %s") % [ui_lookup(:table => "container_node"), @record.container_node.name])
+        - if role_allows(:feature => "container_service_show_list")
+          - num_services = @record.number_of(:container_services)
+          - if num_services == 0
+            %li.disabled
+              = link_to(_("%s (0)") % ui_lookup(:table => "container_service"), "#")
+          - else
+            %li
+              = link_to(_("%s (%s)") % [ui_lookup(:table => "container_service"), num_services],
+                {:action => 'show', :id => @record, :display => 'container_services'},
+                  :title => _("Show Container Services"))


### PR DESCRIPTION
Black dots for emphasis. 
@abonas
![podstoserviceui](https://cloud.githubusercontent.com/assets/11256940/7517460/d4beea6e-f4dd-11e4-9ef4-afafe842f679.png)

