### PR TITLE
Foreman configured system view

### DIFF
--- a/vmdb/app/helpers/provider_foreman_helper.rb
+++ b/vmdb/app/helpers/provider_foreman_helper.rb
@@ -29,11 +29,13 @@ module ProviderForemanHelper
   end
 
   def textual_configuration_profile_desc
-    {:label    => _("Configuration Profile Description"),
-     :image    => "configuration_profile",
-     :value    => @record.configuration_profile.try(:description),
-     :explorer => true
+    h = {
+      :label    => _("Configuration Profile Description"),
+      :value    => @record.configuration_profile.try(:description),
+      :explorer => true
     }
+    h[:image] = "configuration_profile" if @record.configuration_profile
+    h
   end
 
   def textual_provider_name
@@ -119,13 +121,13 @@ module ProviderForemanHelper
 
   def textual_configuration_locations_name
     {:label => _("Configuration Location"),
-     :value => @record.configuration_profile.configuration_locations.collect(&:name).join(", ")
+     :value => (@record.configuration_profile.try(:configuration_locations) || []).collect(&:name).join(", ")
     }
   end
 
   def textual_configuration_organizations_name
     {:label => _("Configuration Organization"),
-     :value => @record.configuration_profile.configuration_organizations.collect(&:name).join(", ")
+     :value => (@record.configuration_profile.try(:configuration_organizations) || []).collect(&:name).join(", ")
     }
   end
 end

--- a/vmdb/app/models/configured_system.rb
+++ b/vmdb/app/models/configured_system.rb
@@ -13,6 +13,7 @@ class ConfiguredSystem < ActiveRecord::Base
   belongs_to :operating_system_flavor
   has_and_belongs_to_many :configuration_tags
 
+  delegate :name, :to => :configuration_profile,         :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_compute_profile, :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_domain,          :prefix => true, :allow_nil => true
@@ -31,6 +32,7 @@ class ConfiguredSystem < ActiveRecord::Base
   virtual_column  :configuration_compute_profile_name, :type => :string
   virtual_column  :configuration_domain_name,          :type => :string
   virtual_column  :configuration_environment_name,     :type => :string
+  virtual_column  :configuration_profile_name,         :type => :string
   virtual_column  :configuration_realm_name,           :type => :string
   virtual_column  :operating_system_flavor_name,       :type => :string
   virtual_column  :customization_script_medium_name,   :type => :string

--- a/vmdb/product/views/ConfiguredSystem.yaml
+++ b/vmdb/product/views/ConfiguredSystem.yaml
@@ -25,6 +25,7 @@ cols:
 - build_state
 - my_zone
 - configuration_environment_name
+- configuration_profile_name
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -37,6 +38,7 @@ col_order:
 - build_state
 - my_zone
 - configuration_environment_name
+- configuration_profile_name
 
 # Column titles, in order
 headers:
@@ -46,6 +48,7 @@ headers:
 - Build State
 - Zone
 - Environment
+- Configuration Profile
 
 col_formats:
 -


### PR DESCRIPTION
Update the Forman ConfiguredSystem view to display configuration profiles.

This will allow customers to sort by the profile and display newly provisioned systems that don't have a configuration profile (hostgroup) set.

It also fixes a bug where a host with no profile was not able to display. (method on nil error)

https://bugzilla.redhat.com/show_bug.cgi?id=1219614

/cc @gmcculloug @brandondunne @AparnaKarve 