### PR TITLE
Host.all isn't guaranteed to return an array in the same order.

### DIFF
--- a/vmdb/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/vmdb/spec/models/miq_provision_virt_workflow_spec.rb
@@ -98,8 +98,7 @@ describe MiqProvisionVirtWorkflow do
 
       context "#allowed_dvs" do
         before do
-          FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
-          @host2  = Host.all[1]
+          @host2 = FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
           @host2_dvs = {'pg1' => ['switch21'], 'pg2' => ['switch2'], 'pg3' => ['switch23']}
           workflow.stub(:get_host_dvs).with(@host2, nil).and_return(@host2_dvs)
           workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => @src_vm.id,


### PR DESCRIPTION
Set the instance variable on Factory creation instead of doing a post-create query.

Introduced here: dd1fe8b1f147c7

Fixes sporadic test failure where the database returns a different host first:

```
  1) MiqProvisionVirtWorkflow network selection dvs #allowed_dvs multiple hosts auto placement
     Failure/Error: dvs = workflow.allowed_dvs({}, nil)
       <MiqProvisionVirtWorkflow:0x00000020675f50> received :get_host_dvs with unexpected arguments
         expected: (#<HostVmware id: 1000000001270, name: "host_0000000000880", ...)
              got: (#<HostVmware id: 1000000001271, name: "host_0000000000881", ...)
        Please stub a default value first if message might be received with other args as well.
```

cc @mkanoor 

Thanks @matthewd for the near instant problem determination.