### PR TITLE
Avoid hardcoding the foreman image name to allow for subclassing.

### DIFF
--- a/vmdb/app/helpers/provider_foreman_helper.rb
+++ b/vmdb/app/helpers/provider_foreman_helper.rb
@@ -38,7 +38,7 @@ module ProviderForemanHelper
 
   def textual_provider_name
     {:label    => _("Provider"),
-     :image    => "vendor-foreman",
+     :image    => "vendor-#{@record.configuration_manager.image_name}",
      :value    => @record.configuration_manager.try(:name),
      :explorer => true
     }

--- a/vmdb/app/models/provider.rb
+++ b/vmdb/app/models/provider.rb
@@ -21,6 +21,10 @@ class Provider < ActiveRecord::Base
     end
   end
 
+  def image_name
+    self.class.name[/^Provider(.+)/, 1].to_s.underscore
+  end
+
   def verify_ssl=(val)
     val = resolve_verify_ssl_value(val)
     super

--- a/vmdb/app/presenters/tree_node_builder.rb
+++ b/vmdb/app/presenters/tree_node_builder.rb
@@ -48,8 +48,16 @@ class TreeNodeBuilder
   def build
     case object
     when AvailabilityZone     then generic_node(object.name, "availability_zone.png", "Availability Zone: #{object.name}")
-    when ExtManagementSystem  then generic_node(object.name, "vendor-#{object.image_name}.png",
-      "#{ui_lookup(:table=>object.kind_of?(EmsInfra) ? "ems_infra" : "ems_cloud")}: #{object.name}")
+    when ExtManagementSystem  then
+      # TODO: This should really leverage .base_model on an EMS
+      prefix_model =
+        case object
+        when EmsCloud then "EmsCloud"
+        when EmsInfra then "EmsInfra"
+        else               "ExtManagementSystem"
+        end
+
+      generic_node(object.name, "vendor-#{object.image_name}.png", "#{ui_lookup(:model => prefix_model)}: #{object.name}")
     when ChargebackRate       then generic_node(object.description, "chargeback_rates.png")
     when Condition            then generic_node(object.description, "miq_condition.png")
     when ConfigurationProfile then generic_node(object.name, "configuration_profile.png", "Configuration Profile: #{object.name}")
@@ -93,7 +101,6 @@ class TreeNodeBuilder
     when MiqUserRole          then generic_node(object.name, "miq_user_role.png")
     when OrchestrationTemplateCfn then generic_node(object.name, "orchestration_template_cfn.png")
     when OrchestrationTemplateHot then generic_node(object.name, "orchestration_template_hot.png")
-    when ConfigurationManagerForeman             then generic_node(object.name, "vendor-foreman.png", "Provider: #{object.name}")
     when PxeImage             then generic_node(object.name, object.default_for_windows ? "win32service.png" : "pxeimage.png")
     when WindowsImage         then generic_node(object.name, "os-windows_generic.png")
     when PxeImageType         then generic_node(object.name, "pxeimagetype.png")

--- a/vmdb/app/views/layouts/quadicon/_single_quad.html.haml
+++ b/vmdb/app/views/layouts/quadicon/_single_quad.html.haml
@@ -5,7 +5,7 @@
     - else
       - img = item.class.to_s.underscore
   - elsif item.kind_of?(ConfigurationManagerForeman)
-    - img = "vendor-foreman_configuration"
+    - img = "vendor-#{item.image_name}"
   - else
     - img = item.class.base_class.to_s.underscore
   .flobj


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1218944

This allows overriding the image_name method to replace it with a different icon.  This is how it works for every other EMS, so this really makes it match the existing EMS stuff.

@dclarizio @h-kataria Please review
cc @epwinchell @kbrock @gmcculloug @chessbyte 