### PR TITLE
Fixed unique names for provisioned VMs when ordered through a service

### DIFF
--- a/vmdb/app/models/miq_provision_request_template.rb
+++ b/vmdb/app/models/miq_provision_request_template.rb
@@ -1,32 +1,15 @@
 class MiqProvisionRequestTemplate < MiqProvisionRequest
-
   def create_tasks_for_service(service_task, parent_svc)
-
     template_service_resource = ServiceResource.find_by_id(service_task.options[:service_resource_id])
     scaling_min = template_service_resource.nil? ? 1 : template_service_resource.scaling_min
 
-    tasks = []
-    0.upto(scaling_min - 1).each do |idx|
-
-      task = self.create_request_task(idx)
-      task.options[:miq_force_unique_name] = [true, 1]
-      task.options[:service_guid] = parent_svc.guid
-      task.options[:service_resource_id] = template_service_resource.id
-      task.options[:service_template_request] = false
-      task.userid = service_task.userid
-      user = User.find_by_userid(task.userid)
-      unless user.nil?
-        task.options[:owner_email]      = user.email
-        task.options[:owner_first_name] = user.first_name
-        task.options[:owner_last_name]  = user.last_name
-      end
-      task.save!
-      service_task.miq_request.miq_request_tasks << task
-
-      tasks << task
+    0.upto(scaling_min - 1).collect do |idx|
+      task = create_request_task(idx)
+      update_service_options(task, parent_svc, template_service_resource)
+      update_owner(task, service_task)
+      req_task.miq_request_id = service_task.miq_request.id
+      task
     end
-
-    return tasks
   end
 
   def request_task_class
@@ -36,5 +19,28 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
   def execute
     # Should not be called.
     raise "Provision Request Templates do not support the execute method."
+  end
+
+  private
+
+  def update_service_options(task, parent_svc, template_service_resource)
+    task.options = task.options.merge(
+      :miq_force_unique_name    => [true, 1],
+      :service_guid             => parent_svc.guid,
+      :service_resource_id      => template_service_resource.id,
+      :service_template_request => false
+    )
+  end
+
+  def update_owner(task, service_task)
+    task.userid = service_task.userid
+    user = User.find_by_userid(task.userid)
+    return if user.nil?
+
+    task.options = task.options.merge(
+      :owner_email      => user.email,
+      :owner_first_name => user.first_name,
+      :owner_last_name  => user.last_name
+    )
   end
 end

--- a/vmdb/app/models/miq_provision_request_template.rb
+++ b/vmdb/app/models/miq_provision_request_template.rb
@@ -1,14 +1,17 @@
 class MiqProvisionRequestTemplate < MiqProvisionRequest
   def create_tasks_for_service(service_task, parent_svc)
     template_service_resource = ServiceResource.find_by_id(service_task.options[:service_resource_id])
-    scaling_min = template_service_resource.nil? ? 1 : template_service_resource.scaling_min
+    scaling_min = template_service_resource.try(:scaling_min) || 1
 
-    0.upto(scaling_min - 1).collect do |idx|
-      task = create_request_task(idx)
-      update_service_options(task, parent_svc, template_service_resource)
-      update_owner(task, service_task)
-      req_task.miq_request_id = service_task.miq_request.id
-      task
+    scaling_min.times.collect do |idx|
+      create_request_task(idx) do |req_task|
+        req_task.miq_request_id = service_task.miq_request.id
+        req_task.userid         = service_task.userid
+
+        task_options     = req_task.options.merge(service_options(parent_svc, template_service_resource))
+        task_options     = task_options.merge(owner_options(req_task))
+        req_task.options = task_options
+      end
     end
   end
 
@@ -23,24 +26,23 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
 
   private
 
-  def update_service_options(task, parent_svc, template_service_resource)
-    task.options = task.options.merge(
+  def service_options(parent_svc, template_service_resource)
+    {
       :miq_force_unique_name    => [true, 1],
       :service_guid             => parent_svc.guid,
       :service_resource_id      => template_service_resource.id,
       :service_template_request => false
-    )
+    }
   end
 
-  def update_owner(task, service_task)
-    task.userid = service_task.userid
+  def owner_options(task)
     user = User.find_by_userid(task.userid)
-    return if user.nil?
+    return {} if user.nil?
 
-    task.options = task.options.merge(
+    {
       :owner_email      => user.email,
       :owner_first_name => user.first_name,
       :owner_last_name  => user.last_name
-    )
+    }
   end
 end

--- a/vmdb/app/models/miq_request.rb
+++ b/vmdb/app/models/miq_request.rb
@@ -435,6 +435,9 @@ class MiqRequest < ActiveRecord::Base
     customize_request_task_attributes(req_task_attribs, idx)
     req_task = self.class.new_request_task(req_task_attribs)
     req_task.miq_request = self
+
+    yield req_task if block_given?
+
     req_task.save!
     req_task.after_request_task_create
 

--- a/vmdb/spec/models/miq_provision_request_template_spec.rb
+++ b/vmdb/spec/models/miq_provision_request_template_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+describe MiqProvisionRequestTemplate do
+  let(:user)             { FactoryGirl.create(:user) }
+  let(:template)         do
+    FactoryGirl.create(:template_vmware,
+                       :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication))
+  end
+  let(:parent_svc)       { FactoryGirl.create(:service, :guid => MiqUUID.new_guid) }
+  let(:service_resource) { FactoryGirl.create(:service_resource) }
+  let(:service_template_request) { FactoryGirl.create(:service_template_provision_request, :userid => user.userid) }
+  let(:service_task) do
+    FactoryGirl.create(:service_template_provision_task,
+                       :status       => 'Ok',
+                       :state        => 'pending',
+                       :request_type => 'clone_to_service',
+                       :miq_request  => service_template_request,
+                       :options      => {:service_resource_id => service_resource.id})
+  end
+  let(:provision_request_template) do
+    FactoryGirl.create(:miq_provision_request_template,
+                       :userid    => user.userid,
+                       :src_vm_id => template.id,
+                       :options   => {
+                         :src_vm_id           => template.id,
+                         :service_resource_id => service_resource.id
+                       })
+  end
+
+  describe '#create_tasks_for_service' do
+    before do
+      MiqProvisionVmware.any_instance.stub(:get_hostname).and_return('hostname')
+      MiqAeEngine.stub(:resolve_automation_object).and_return(double(:root => 'miq'))
+    end
+
+    it 'should only call get_next_vm_name once' do
+      expect_any_instance_of(MiqProvisionVmware).to receive(:get_next_vm_name).once.and_call_original
+
+      provision_request_template.create_tasks_for_service(service_task, parent_svc)
+    end
+
+    it 'should create sequenced VM names' do
+      task1 = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
+      expect(task1.options[:vm_target_name]).to eq('miq_0001')
+
+      task2 = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
+      expect(task2.options[:vm_target_name]).to eq('miq_0002')
+    end
+
+    it 'assign task to a request' do
+      task = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
+      expect(task.miq_request).to eq(service_template_request)
+    end
+
+    describe "scaling_min" do
+      it "runs once with scaling min nil" do
+        service_resource.update_attributes(:scaling_min => nil)
+        expect(provision_request_template.create_tasks_for_service(service_task, parent_svc).count).to eq(1)
+      end
+
+      it "runs never with scaling min 0" do
+        service_resource.update_attributes(:scaling_min => 0)
+        expect(provision_request_template.create_tasks_for_service(service_task, parent_svc).count).to eq(0)
+      end
+
+      it "runs twice with scaling min 2" do
+        service_resource.update_attributes(:scaling_min => 2)
+        expect(provision_request_template.create_tasks_for_service(service_task, parent_svc).count).to eq(2)
+      end
+    end
+
+    it "does not modify owner in options" do
+      task = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
+
+      expect(task.options[:owner_email]).to be_nil
+    end
+
+    context "with service_task user" do
+      let(:user) { FactoryGirl.create(:user_with_email) }
+
+      it "sets owner in options" do
+        service_task.update_attributes(:userid => user.userid)
+        task = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
+
+        expect(task.options[:owner_email]).to eq(user.email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Service ordering is a repeatable task that requires the creation of unique names for provisioned VMs that are part of the service template.  To ensure that a unique name is applied to the provisioned VMs a flag is set on the provision task to instruct the naming code to append an enumeration sequence to the VM name if one is not already supplied.  PR #2023 fixed an issue with the naming code being run twice for a service provision but exposed the current bug because the naming code was running before the unique_name flag was set.

This change allows the caller to provide a block and update the new task object before the naming code is run.

https://bugzilla.redhat.com/show_bug.cgi?id=1219098