### PR TITLE
Ensure test always creates a schedule in the future.

### DIFF
--- a/vmdb/spec/controllers/ops_settings_spec.rb
+++ b/vmdb/spec/controllers/ops_settings_spec.rb
@@ -105,7 +105,7 @@ describe OpsController do
           :time_zone          => "UTC",
           :start_hour         => "0",
           :start_min          => "0",
-          :miq_angular_date_1 => (Time.now + 60 * 60 * 24).strftime("%m/%d/%Y")
+          :miq_angular_date_1 => 2.days.from_now.utc.strftime("%m/%d/%Y")
         }
         controller.stub(:assert_privileges)
       end


### PR DESCRIPTION
This test was only creating a schedule in the future sometimes based on your local timezone.
Created in 143639f6569.

Timezones are hard.

Since we would rather not deal with timezones, add 2 days to avoid any possible overlap.
I also threw on utc just to make sure.

Problem:
We were trying to create a schedule to run at 00:00:00 UTC on the next day.
If my timezone is EDT (-4:00) and it's 21:00:00 on May 7th, it's May 7th here but May 8th in UTC.

We construct a UTC schedule time based on only the Year, Month, Day of my local time[1].
So, if it's May 7th, 2015 at 21:00:00, we'd ignore the fact that it's May 7th local time but May 8th UTC.
In this window of 20:00:00-23:59:59 EDT, this schedule created would be in the past.

[1] https://github.com/ManageIQ/manageiq/blob/eec2e177ee8b40d263a30821b9128dde0992fe60/vmdb/app/controllers/ops_controller/settings/schedules.rb#L652-L654

Fixes the following sporadic test failure:

```
  1) OpsController OpsSettings::Schedules schedule additon #does not allow duplicate names when adding
     Failure/Error: assigns(:flash_array).first[:message].should include("Name has already been taken")
       expected "Warning: This 'Run Once' timer is in the past and will never run as currently configured" to include "Name has already been taken"
     # ./spec/controllers/ops_settings_spec.rb:123:in `block (4 levels) in <top (required)>'

  2) OpsController OpsSettings::Schedules schedule additon #does not allow duplicate names when editing
     Failure/Error: assigns(:flash_array).first[:message].should include("Name has already been taken")
       expected "Warning: This 'Run Once' timer is in the past and will never run as currently configured" to include "Name has already been taken"
     # ./spec/controllers/ops_settings_spec.rb:133:in `block (4 levels) in <top (required)>'
```