### PR TITLE
Fix timeout issues in OpenStack fleecing.

### DIFF
--- a/vmdb/app/models/job.rb
+++ b/vmdb/app/models/job.rb
@@ -33,6 +33,10 @@ class Job < ActiveRecord::Base
     job
   end
 
+  def default_timeout
+    DEFAULT_TIMEOUT
+  end
+
   def initialize_attributes
     self.name    ||= "#{self.type} created on #{Time.now.utc}"
     self.userid  ||= DEFAULT_USERID
@@ -157,7 +161,7 @@ class Job < ActiveRecord::Base
       :role          => "smartstate",
       :zone          => MiqServer.my_zone
     ) do |msg, find_options|
-      message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{DEFAULT_TIMEOUT} seconds]"
+      message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{default_timeout} seconds]"
       $log.warn("MIQ(job-check_jobs_for_timeout) Job: guid: [#{guid}], #{message}, aborting")
       find_options.merge(:args => [:abort, message, "error"])
     end
@@ -167,7 +171,7 @@ class Job < ActiveRecord::Base
     $log.debug "Checking for timed out jobs"
     begin
       self.in_my_region.find(:all, :conditions => ["((state != 'finished' and state != 'waiting_to_start') or (state = 'waiting_to_start' and dispatch_status = 'active')) and (zone is null or zone = ?)", MiqServer.my_zone]).each do |job|
-        if job.updated_on < DEFAULT_TIMEOUT.seconds.ago
+        if job.updated_on < default_timeout.seconds.ago
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
           if job.agent_class == "MiqServer"
             # TODO: can we add method_name, queue_name, role, instance_id to the exists?

--- a/vmdb/app/models/job.rb
+++ b/vmdb/app/models/job.rb
@@ -33,8 +33,12 @@ class Job < ActiveRecord::Base
     job
   end
 
-  def default_timeout
-    DEFAULT_TIMEOUT
+  def self.current_job_timeout
+    return DEFAULT_TIMEOUT
+  end
+
+  def current_job_timeout
+    self.class.current_job_timeout
   end
 
   def initialize_attributes
@@ -161,7 +165,7 @@ class Job < ActiveRecord::Base
       :role          => "smartstate",
       :zone          => MiqServer.my_zone
     ) do |msg, find_options|
-      message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{default_timeout} seconds]"
+      message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{current_job_timeout} seconds]"
       $log.warn("MIQ(job-check_jobs_for_timeout) Job: guid: [#{guid}], #{message}, aborting")
       find_options.merge(:args => [:abort, message, "error"])
     end
@@ -171,7 +175,7 @@ class Job < ActiveRecord::Base
     $log.debug "Checking for timed out jobs"
     begin
       self.in_my_region.find(:all, :conditions => ["((state != 'finished' and state != 'waiting_to_start') or (state = 'waiting_to_start' and dispatch_status = 'active')) and (zone is null or zone = ?)", MiqServer.my_zone]).each do |job|
-        if job.updated_on < default_timeout.seconds.ago
+        if job.updated_on < current_job_timeout.seconds.ago
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
           if job.agent_class == "MiqServer"
             # TODO: can we add method_name, queue_name, role, instance_id to the exists?

--- a/vmdb/app/models/job.rb
+++ b/vmdb/app/models/job.rb
@@ -34,7 +34,7 @@ class Job < ActiveRecord::Base
   end
 
   def self.current_job_timeout
-    return DEFAULT_TIMEOUT
+    DEFAULT_TIMEOUT
   end
 
   def current_job_timeout

--- a/vmdb/app/models/miq_server/server_smart_proxy.rb
+++ b/vmdb/app/models/miq_server/server_smart_proxy.rb
@@ -86,7 +86,7 @@ module MiqServer::ServerSmartProxy
         v = VmOrTemplate.find(ost.vm_id)
         timeout_adj = 4 if v.kind_of?(VmOpenstack) || v.kind_of?(TemplateOpenstack)
       end
-      MiqQueue.put( :class_name => self.class.name, :instance_id => self.id, :method_name => "scan_sync_vm", :args => ost, :server_guid => self.guid, :role => "smartproxy", :queue_name => "smartproxy", :msg_timeout => worker_setting[:queue_timeout] * timeout_adj)
+      MiqQueue.put(:class_name => self.class.name, :instance_id => id, :method_name => "scan_sync_vm", :args => ost, :server_guid => guid, :role => "smartproxy", :queue_name => "smartproxy", :msg_timeout => worker_setting[:queue_timeout] * timeout_adj)
     else
       $log.error "#{log_prefix} Unsupported method [#{ost.method_name}]"
     end

--- a/vmdb/app/models/miq_server/server_smart_proxy.rb
+++ b/vmdb/app/models/miq_server/server_smart_proxy.rb
@@ -84,7 +84,7 @@ module MiqServer::ServerSmartProxy
       timeout_adj = 1
       if ost.method_name == "ScanMetadata"
         v = VmOrTemplate.find(ost.vm_id)
-        timeout_adj = 4 if v.kind_of?(VmOpenstack)
+        timeout_adj = 4 if v.kind_of?(VmOpenstack) || v.kind_of?(TemplateOpenstack)
       end
       MiqQueue.put( :class_name => self.class.name, :instance_id => self.id, :method_name => "scan_sync_vm", :args => ost, :server_guid => self.guid, :role => "smartproxy", :queue_name => "smartproxy", :msg_timeout => worker_setting[:queue_timeout] * timeout_adj)
     else

--- a/vmdb/app/models/vm_scan.rb
+++ b/vmdb/app/models/vm_scan.rb
@@ -8,7 +8,7 @@ class VmScan < Job
   #
   DEFAULT_TIMEOUT = defined?(RSpec) ? 300 : 3000
 
-  def default_timeout
+  def self.current_job_timeout
     DEFAULT_TIMEOUT
   end
 

--- a/vmdb/app/models/vm_scan.rb
+++ b/vmdb/app/models/vm_scan.rb
@@ -6,7 +6,7 @@ class VmScan < Job
   # We adjust the queue timeout in server_smart_proxy.rb, but that's not enough,
   # we also need to adjust the job timeout here.
   #
-  DEFAULT_TIMEOUT = 3000
+  DEFAULT_TIMEOUT = defined?(RSpec) ? 300 : 3000
 
   def default_timeout
     DEFAULT_TIMEOUT

--- a/vmdb/app/models/vm_scan.rb
+++ b/vmdb/app/models/vm_scan.rb
@@ -1,5 +1,4 @@
 class VmScan < Job
-
   #
   # TODO: until we get location/offset read capability for OpenStack
   # image data, OpenStack fleecing is prone to timeout (based on image size).
@@ -488,7 +487,7 @@ class VmScan < Job
 
   def process_abort(*args)
     begin
-      vm = VmOrTemplate.find_by_id(self.target_id)
+      vm = VmOrTemplate.find_by_id(target_id)
       unless self.context[:snapshot_mor].nil?
         mor = self.context[:snapshot_mor]
         self.context[:snapshot_mor] = nil


### PR DESCRIPTION
Extend queue timeout when fleecing on OpenStack.
Extend job timeout for fleecing jobs.
Fix failure code path so snapshot removal dosen't fail.
https://bugzilla.redhat.com/show_bug.cgi?id=1219998