### PR TITLE
Change the version of gettext_i18n_rails in Gemfile

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -46,7 +46,7 @@ gem 'secure_headers'
 gem 'mime-types'
 # Needed by the REST API
 gem "jbuilder",                       "~>2.0.7"
-gem "gettext_i18n_rails",             "~>1.2.0"
+gem "gettext_i18n_rails",             "~>1.2.3"
 gem "rails-i18n",                     "~> 3.0.0"
 
 # Not vendored and not required


### PR DESCRIPTION
Update version of gettext_i18n_rails to the latest. A Path to generated model attributes file has been changed between the versions (1.2.2 vs. 1.2.3).
https://github.com/grosser/gettext_i18n_rails/commit/daef9d9c19a2c017babcd8cc734592023e42f679