### PR TITLE
fix_auth works again for database yml

### DIFF
--- a/vmdb/spec/tools/fix_auth/models_spec.rb
+++ b/vmdb/spec/tools/fix_auth/models_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+$LOAD_PATH << Rails.root.join("tools")
+
+require "fix_auth"
+require "tempfile"
+require "yaml"
+
+describe FixAuth::FixDatabaseYml do
+  # TODO: add legacy password tests
+
+  it "updates password" do
+    with_databaseyml("oldpassword") do |databaseyml|
+      FixAuth::FixDatabaseYml.file_name = databaseyml
+      FixAuth::FixDatabaseYml.run(:hardcode => 'newpassword')
+
+      expect(dbpassword(databaseyml)).to be_encrypted("newpassword")
+    end
+  end
+
+  it "does not add a password" do
+    with_databaseyml do |databaseyml|
+      FixAuth::FixDatabaseYml.file_name = databaseyml
+      FixAuth::FixDatabaseYml.run
+      expect(dbpassword(databaseyml)).to be_nil
+    end
+  end
+
+  private
+
+  # create a temporary databaseyml file to test
+  def with_databaseyml(password = nil)
+    temp = Tempfile.new(["database", ".yml"], Rails.root.join("tmp").to_s)
+    temp.write(YAML.dump(settings(password)))
+    temp.close
+
+    yield temp.path
+  ensure
+    temp.delete
+  end
+
+  def dbpassword(filename)
+    YAML.load_file(filename)["production"]["password"]
+  end
+
+  def settings(password)
+    settings = {
+      "username" => "root",
+      "host"     => "server.example.com"
+    }
+    settings["password"] = password if password
+    {"production" => settings}
+  end
+end

--- a/vmdb/tools/fix_auth/models.rb
+++ b/vmdb/tools/fix_auth/models.rb
@@ -102,6 +102,7 @@ module FixAuth
     class << self
       attr_accessor :available_columns
       attr_accessor :file_name
+      alias_method  :table_name, :file_name
     end
 
     def initialize(options = {})


### PR DESCRIPTION
Broke `fix_auth --databaseyml` in #2684 

#2684 moved the displaying of status information into the common `run` method. This status had the table name and the columns being updated.
While this works for all models, it had a problem with `FixDatabaseYml`. This is not an ActiveRecord model, so it did not have `table_name` defined. This resulted in a "table_name method not found"

This pr defines `FixDatabaseYml.table_name` so the status can be printed. And the code can run

Added specs to protect regressions.

https://bugzilla.redhat.com/show_bug.cgi?id=1217532