### PR TITLE
Added containerservice, containergroup keys to NAV_TAB_PATH

### DIFF
--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -715,15 +715,17 @@ class ConfigurationController < ApplicationController
   end
 
   NAV_TAB_PATH =  {
-                    :container     => %w(Containers Containers),
-                    :host          => %w(Infrastructure Hosts),
-                    :miqtemplate   => %w(Services Workloads Templates\ &\ Images),
-                    :storage       => %w(Infrastructure Datastores),
-                    :templatecloud => %w(Cloud Instances Images),
-                    :templateinfra => %w(Infrastructure Virtual\ Machines Templates),
-                    :vm            => %w(Services Workloads VMs\ &\ Instances),
-                    :vmcloud       => %w(Cloud Instances Instances),
-                    :vminfra       => %w(Infrastructure Virtual\ Machines VMs)
+                    :container        => %w(Containers Containers),
+                    :containergroup   => %w(Containers Containers\ Groups),
+                    :containerservice => %w(Containers Services),
+                    :host             => %w(Infrastructure Hosts),
+                    :miqtemplate      => %w(Services Workloads Templates\ &\ Images),
+                    :storage          => %w(Infrastructure Datastores),
+                    :templatecloud    => %w(Cloud Instances Images),
+                    :templateinfra    => %w(Infrastructure Virtual\ Machines Templates),
+                    :vm               => %w(Services Workloads VMs\ &\ Instances),
+                    :vmcloud          => %w(Cloud Instances Instances),
+                    :vminfra          => %w(Infrastructure Virtual\ Machines VMs)
                   }
 
   def merge_in_user_settings(settings)

--- a/vmdb/spec/controllers/configuration_controller_spec.rb
+++ b/vmdb/spec/controllers/configuration_controller_spec.rb
@@ -14,4 +14,18 @@ describe ConfigurationController do
       end
     end
   end
+
+  context "#set_form_vars" do
+    before do
+      MiqRegion.seed
+      MiqSearch.seed
+    end
+
+    it "#successfully sets all_view_tree for default filters tree" do
+      controller.instance_variable_set(:@temp, {})
+      controller.instance_variable_set(:@tabform, "ui_3")
+      controller.send(:set_form_vars)
+      assigns(:temp)[:all_views_tree].should_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
- After new search default filters were added for Containers Service and Groups, needed to add those 2 keys to NAV_TAB_PATH constant that's used to build the default filters tree.
- Added spec test to verify the issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1220901

@dclarizio please review/test