### PR TITLE
Properly pass verify_ssl into foreman api

### DIFF
--- a/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
+++ b/lib/manageiq_foreman/lib/manageiq_foreman/connection.rb
@@ -10,7 +10,8 @@ module ManageiqForeman
       connection_attrs[:uri] = connection_attrs.delete(:base_url)
       connection_attrs[:api_version] ||= 2
       connection_attrs[:apidoc_cache_dir] ||= tmpdir
-      @api = ApipieBindings::API.new(connection_attrs)
+      options = {:verify_ssl => connection_attrs.delete(:verify_ssl)}
+      @api = ApipieBindings::API.new(connection_attrs, options)
     end
 
     def verify?


### PR DESCRIPTION
apipie-bindings expects :verify_ssl to be in a
second hash passed to the initializer.

This means we were not able to communicate with a foreman server
with self signed certificates. (common)

https://bugzilla.redhat.com/show_bug.cgi?id=1212423

/cc @jrafanie @brandondunne @gmcculloug @Fryguy 