### PR TITLE
BZ110482 Fix backspace on console to clear the backspaced character.

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -171,6 +171,10 @@ loop do
 
     clear_screen
 
+    # Condition the line so Backspace clears the character on screen. Setting provide equivelent line
+    # setting when the console is running via init(1) or invoked from the command line.
+    system("stty -echoprt ixany iexten echoe echok")
+
     say("#{I18n.t("product.name")} Virtual Appliance\n")
     say("To administer this appliance, browse to https://#{ip}\n") if configured
     if $MIQDEBUG

--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -171,8 +171,8 @@ loop do
 
     clear_screen
 
-    # Condition the line so Backspace clears the character on screen. Setting provide equivelent line
-    # setting when the console is running via init(1) or invoked from the command line.
+    # Calling stty to provide the equivalent line settings when the console is run via an ssh session or
+    # over the virtual machine console.
     system("stty -echoprt ixany iexten echoe echok")
 
     say("#{I18n.t("product.name")} Virtual Appliance\n")


### PR DESCRIPTION
Fix backspace on console to clear the backspaced character.

https://bugzilla.redhat.com/show_bug.cgi?id=110482