### PR TITLE
Refactoring of ssh auth

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -55,8 +55,7 @@ module AuthenticationMixin
   end
 
   def missing_credentials?(type = nil)
-    # TODO(lsmola) re-factor, make keypairs part of best_with, but containing also delegation to parents
-    !has_credentials?(type) && !auth_user_keypair(type)
+    !has_credentials?(type)
   end
 
   def authentication_status

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -10,4 +10,22 @@ FactoryGirl.define do
     authtype    "ipmi"
   end
 
+  factory :authentication_ssh_keypair, :parent => :authentication do
+    authtype    "ssh_keypair"
+    userid      "testuser"
+    password    nil
+    auth_key    'private_key_content'
+  end
+
+  factory :authentication_ssh_keypair_root, :parent => :authentication do
+    authtype    "ssh_keypair"
+    userid      "root"
+    password    nil
+    auth_key    'private_key_content'
+  end
+
+  factory :authentication_ssh_keypair_without_key, :parent => :authentication_ssh_keypair do
+    auth_key    nil
+    status      "Valid"
+  end
 end

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -26,6 +26,6 @@ FactoryGirl.define do
 
   factory :authentication_ssh_keypair_without_key, :parent => :authentication_ssh_keypair do
     auth_key    nil
-    status      "Valid"
+    status      "SomeMockedStatus"
   end
 end

--- a/spec/models/host_openstack_infra_spec.rb
+++ b/spec/models/host_openstack_infra_spec.rb
@@ -213,4 +213,83 @@ openstack-keystone:                     active
       host.filesystems.should include(*(host.host_service_group_openstacks.flat_map(&:filesystems)))
     end
   end
+
+  describe "Overriden auth methods for ssh fleecing" do
+    let(:ext_management_system) do
+      FactoryGirl.create(:ems_openstack_infra).tap do |ems|
+        ems.authentications << FactoryGirl.create(:authentication_ssh_keypair)
+        ems.authentications << FactoryGirl.create(:authentication)
+      end
+    end
+
+    let(:host) do
+      FactoryGirl.create(:host_openstack_infra).tap do |host|
+        host.ext_management_system = ext_management_system
+        host.authentications << FactoryGirl.create(:authentication_ssh_keypair_without_key)
+      end
+    end
+
+    it "#get_parent_keypair returns parent provider auth" do
+      expected_auth = ext_management_system.authentications.where(:authtype => :ssh_keypair).first
+      expect(host.get_parent_keypair(:ssh_keypair)).to eq expected_auth
+    end
+
+    context "#authentication_status" do
+      it "returns host's auth status if auth is there" do
+        expect(host.authentication_status).to eq 'Valid'
+      end
+
+      it "returns 'None' if host's auth is nil" do
+        # Remove the host's auth record
+        host.authentications.where(:authtype => :ssh_keypair).first.destroy
+        host.reload
+        expect(host.authentication_status).to eq 'None'
+      end
+    end
+
+    context "#ssh_users_and_passwords" do
+      it "returns authentication_best_fit" do
+        auth        = ext_management_system.authentications.where(:authtype => :ssh_keypair).first
+        expected_ret = auth.userid, nil, nil, nil, {:key_data => auth.auth_key, :passwordless_sudo => true}
+
+        expect(host.ssh_users_and_passwords).to eq expected_ret
+      end
+
+      it "passes passwordless sudo parameter if user is not 'root'" do
+        # Switch to auth with root user
+        ext_management_system.authentications.where(:authtype => :ssh_keypair).first.destroy
+        ext_management_system.authentications << FactoryGirl.create(:authentication_ssh_keypair_root)
+
+        auth = ext_management_system.authentications.where(:authtype => :ssh_keypair).first
+
+        expected_ret = auth.userid, nil, nil, nil, {:key_data => auth.auth_key, :passwordless_sudo => false}
+
+        expect(host.ssh_users_and_passwords).to eq expected_ret
+      end
+    end
+
+    context "#authentication_best_fit" do
+      it "defaults to parent provider ssh_keypair auth" do
+        ems_auth  = ext_management_system.authentications.where(:authtype => :ssh_keypair).first
+
+        expect(host.authentication_best_fit).to eq ems_auth
+      end
+
+      it "checks that if host's auth_key is nil, parent auth is returned" do
+        ems_auth  = ext_management_system.authentications.where(:authtype => :ssh_keypair).first
+        host_auth = host.authentications.where(:authtype => :ssh_keypair).first
+
+        expect(host_auth.auth_key).to be_nil
+        expect(host.authentication_best_fit(:ssh_keypair)).to eq ems_auth
+      end
+
+      it "checks that if host's auth_key is not nil, host's auth is returned" do
+        host_auth = host.authentications.where(:authtype => :ssh_keypair).first
+        host_auth.auth_key = 'host_private_key_content'
+        host_auth.save
+
+        expect(host.authentication_best_fit(:ssh_keypair)).to eq host_auth
+      end
+    end
+  end
 end


### PR DESCRIPTION
Removing specific check from the general mixin and rather overriding authentication_best_fit method. This method now implements basic inheritance of ssh auth. So we can define credentials on Provider level for all hosts and override individual hosts with another credentials.