### PR TITLE
Fix the issue with MiqRequestWorkflow.validate 

### DIFF
--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -167,7 +167,7 @@ class MiqRequestWorkflow
         fld[:error] = nil
 
         # Check the disabled flag here so we reset the "error" value on each field
-        next if dialog_disabled
+        next if dialog_disabled || fld[:display] == :hide
 
         value = get_value(values[f])
 


### PR DESCRIPTION
where hidden fields are still checked.

MiqRequestWorklfow#validate is fixed to skip the field if it is not displayed.
Add test cases. 

https://bugzilla.redhat.com/show_bug.cgi?id=1220815