### PR TITLE
Changed name of container_replication_controller to container_replicator

### DIFF
--- a/vmdb/app/models/container_replicator.rb
+++ b/vmdb/app/models/container_replicator.rb
@@ -1,4 +1,4 @@
-class ContainerReplicationController < ActiveRecord::Base
+class ContainerReplicator < ActiveRecord::Base
   include CustomAttributeMixin
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -51,7 +51,7 @@ module EmsRefresh::Parsers
     end
 
     def get_replication_controllers(inventory)
-      process_collection(inventory["replication_controller"], :container_replication_controllers)\
+      process_collection(inventory["replication_controller"], :container_replicators)\
                                                                                 { |n| parse_replication_controllers(n) }
     end
 
@@ -172,15 +172,15 @@ module EmsRefresh::Parsers
       new_result
     end
 
-    def parse_replication_controllers(container_replication_controller)
-      new_result = parse_base_item(container_replication_controller)
+    def parse_replication_controllers(container_replicator)
+      new_result = parse_base_item(container_replicator)
 
       # TODO: parse template
       new_result.merge!(
-        :replicas         => container_replication_controller.spec.replicas,
-        :current_replicas => container_replication_controller.status.replicas,
-        :labels           => parse_labels(container_replication_controller),
-        :selector_parts   => parse_selector_parts(container_replication_controller)
+        :replicas         => container_replicator.spec.replicas,
+        :current_replicas => container_replicator.status.replicas,
+        :labels           => parse_labels(container_replicator),
+        :selector_parts   => parse_selector_parts(container_replicator)
       )
 
       new_result

--- a/vmdb/app/models/ems_refresh/save_inventory_container.rb
+++ b/vmdb/app/models/ems_refresh/save_inventory_container.rb
@@ -2,7 +2,7 @@ module EmsRefresh::SaveInventoryContainer
   def save_ems_container_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
     child_keys = [:container_nodes, :container_groups, :container_services,
-                  :container_replication_controllers, :container_routes, :container_projects]
+                  :container_routes, :container_projects, :container_replicators]
 
     # Save and link other subsections
     child_keys.each do |k|
@@ -64,19 +64,19 @@ module EmsRefresh::SaveInventoryContainer
     save_inventory_single(:computer_system, container_node, hash, [:hardware])
   end
 
-  def save_container_replication_controllers_inventory(ems, hashes, target = nil)
+  def save_container_replicators_inventory(ems, hashes, target = nil)
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_replication_controllers(true)
+    ems.container_replicators(true)
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_replication_controllers.dup
+                ems.container_replicators.dup
               else
                 []
               end
-    save_inventory_multi(:container_replication_controllers, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(:container_replicators, ems, hashes, deletes, [:ems_ref],
                          [:labels, :selector_parts])
-    store_ids_for_new_records(ems.container_replication_controllers, hashes, :ems_ref)
+    store_ids_for_new_records(ems.container_replicators, hashes, :ems_ref)
   end
 
   def save_container_services_inventory(ems, hashes, target = nil)

--- a/vmdb/app/models/mixins/container_provider_mixin.rb
+++ b/vmdb/app/models/mixins/container_provider_mixin.rb
@@ -5,7 +5,7 @@ module ContainerProviderMixin
     has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_groups, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_replication_controllers, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
 
     # TODO: support real authentication using certificates
     before_validation :ensure_authentications_record

--- a/vmdb/db/migrate/20150514124529_rename_replication_controllers_to_container_replicators.rb
+++ b/vmdb/db/migrate/20150514124529_rename_replication_controllers_to_container_replicators.rb
@@ -1,0 +1,9 @@
+class RenameReplicationControllersToContainerReplicators < ActiveRecord::Migration
+  def self.up
+    rename_table :container_replication_controllers, :container_replicators
+  end
+
+  def self.down
+    rename_table :container_replicators, :container_replication_controllers
+  end
+end


### PR DESCRIPTION
@abonas @simon3z Please review

I kept the name replication controller wherever k8s objects(like pod) are referenced such as [here](https://github.com/ManageIQ/manageiq/blob/13af4bc4b723e8dedc0f06055678dc56f91766ab/vmdb/app/models/ems_refresh/parsers/kubernetes.rb#L17)