### PR TITLE
Allow dynamic drop down list to be submitted on first entry

### DIFF
--- a/vmdb/app/models/dialog_field_drop_down_list.rb
+++ b/vmdb/app/models/dialog_field_drop_down_list.rb
@@ -39,7 +39,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
 
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : super
-    @default_value ||= @raw_values.first.first
+    @default_value ||= sort_data(@raw_values).first.first
     self.value = @default_value
 
     @raw_values

--- a/vmdb/app/models/dialog_field_drop_down_list.rb
+++ b/vmdb/app/models/dialog_field_drop_down_list.rb
@@ -39,6 +39,10 @@ class DialogFieldDropDownList < DialogFieldSortedItem
 
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : super
+    @default_value ||= @raw_values.first.first
+    self.value = @default_value
+
+    @raw_values
   end
 
   def values_from_automate

--- a/vmdb/app/models/dialog_field_drop_down_list.rb
+++ b/vmdb/app/models/dialog_field_drop_down_list.rb
@@ -13,7 +13,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   end
 
   def initial_values
-    [["", "<None>"]]
+    [[nil, "<None>"]]
   end
 
   def refresh_json_value(checked_value)
@@ -24,7 +24,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
       @value = checked_value
     else
-      @value = default_value
+      @value = @default_value
     end
 
     {:refreshed_values => refreshed_values, :checked_value => @value}
@@ -40,7 +40,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : super
     @default_value ||= sort_data(@raw_values).first.first
-    self.value = @default_value
+    self.value ||= @default_value
 
     @raw_values
   end

--- a/vmdb/app/models/dialog_field_sorted_item.rb
+++ b/vmdb/app/models/dialog_field_sorted_item.rb
@@ -23,16 +23,8 @@ class DialogFieldSortedItem < DialogField
 
   # Sort values before sending back
   def values
-    sort_field = self.sort_by
     values_data = raw_values
-    return values_data if sort_field == :none
-
-    value_position = sort_field     == :value    ? :first : :last
-    value_modifier = self.data_type == "integer" ? :to_i  : :to_s
-
-    values_data = values_data.sort_by {|d| d.send(value_position).send(value_modifier)}
-    return values_data.reverse! if sort_order == :descending
-    values_data
+    sort_data(values_data)
   end
 
   def get_default_value
@@ -55,5 +47,18 @@ class DialogFieldSortedItem < DialogField
 
     result = automate_hash["values"].to_a
     result.blank? ? initial_values : result
+  end
+
+  private
+
+  def sort_data(data_to_sort)
+    return data_to_sort if sort_by == :none
+
+    value_position = sort_by   == :value    ? :first : :last
+    value_modifier = data_type == "integer" ? :to_i  : :to_s
+
+    data_to_sort = data_to_sort.sort_by { |d| d.send(value_position).send(value_modifier) }
+    return data_to_sort.reverse! if sort_order == :descending
+    data_to_sort
   end
 end

--- a/vmdb/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/vmdb/spec/models/dialog_field_drop_down_list_spec.rb
@@ -90,22 +90,50 @@ describe DialogFieldDropDownList do
     end
   end
 
-  describe "#raw_values" do
+  describe "#refresh_json_value" do
     let(:dialog_field) { described_class.new(:dynamic => dynamic) }
 
     context "when the dialog_field is dynamic" do
       let(:dynamic) { true }
 
-      it "returns the values from automate" do
+      before do
+        DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return(
+          [["123", 456], ["789", 101]]
+        )
+        dialog_field.value = "123"
+      end
 
+      it "sets the value" do
+        dialog_field.refresh_json_value("789")
+        expect(dialog_field.value).to eq("789")
+      end
+
+      it "returns the values from automate" do
+        expect(dialog_field.refresh_json_value("789")).to eq(
+          :refreshed_values => [["789", 101], ["123", 456]],
+          :checked_value    => "789"
+        )
       end
     end
 
     context "when the dialog_field is not dynamic" do
       let(:dynamic) { false }
 
-      it "returns the values" do
+      before do
+        dialog_field.values = [["123", 456], ["789", 101]]
+        dialog_field.value = "123"
+      end
 
+      it "sets the value" do
+        dialog_field.refresh_json_value("789")
+        expect(dialog_field.value).to eq("789")
+      end
+
+      it "returns the values" do
+        expect(dialog_field.refresh_json_value("789")).to eq(
+          :refreshed_values => [["789", 101], ["123", 456]],
+          :checked_value    => "789"
+        )
       end
     end
   end


### PR DESCRIPTION
Without a default value set, the value for the dynamic drop down list wasn't being set when the values were being calculated, so when trying to submit with the first item selected, it was returning an error. This fixes that issue and allows the list to be submitted immediately since the first item will actually be set to the value of the dialog field.

https://bugzilla.redhat.com/show_bug.cgi?id=1219950

Also I apparently had a test skeleton outlined in the spec, but never actually gave it tests whenever it got merged before.

@dclarizio Please Review