### PR TITLE
Dont allow reserving more memory than allocated

### DIFF
--- a/vmdb/app/models/miq_provision_virt_workflow.rb
+++ b/vmdb/app/models/miq_provision_virt_workflow.rb
@@ -163,6 +163,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     validate_length(field, values, dlg, fld, value)
   end
 
+  def validate_memory_reservation(_field, values, dlg, fld, _value)
+    allocated = get_value(values[:vm_memory]).to_i
+    reserved  = get_value(values[:memory_reserve]).to_i
+    "#{required_description(dlg, fld)} Reservation is larger than VM Memory" if reserved > allocated
+  end
+
   def validate_pxe_image_id(_field, _values, dlg, fld, _value)
     return nil unless supports_pxe?
     return nil unless get_pxe_image.nil?

--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -197,6 +197,11 @@ class MiqRequestWorkflow
           end
         end
 
+        if fld[:validation_method] && respond_to?(fld[:validation_method])
+          valid = !(fld[:error] = send(fld[:validation_method], f, values, dlg, fld, value))
+          next unless valid
+        end
+
         next if value.blank?
 
         msg = "'#{fld[:description]}' in dialog #{dlg[:description]} must be of type #{fld[:data_type]}"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs-user.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs-user.yaml
@@ -695,6 +695,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters: 
           :values: 
             1: "1"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs-user.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs-user.yaml
@@ -1,103 +1,103 @@
---- 
+---
 :name: miq_provision_dialogs-user
 :description: Sample VM Provisioning Dialog for User
 :dialog_type: MiqProvisionWorkflow
-:content: 
-  :buttons: 
+:content:
+  :buttons:
   - :submit
   - :cancel
-  :dialogs: 
-    :requester: 
+  :dialogs:
+    :requester:
       :description: Request
-      :fields: 
-        :owner_phone: 
+      :fields:
+        :owner_phone:
           :description: Phone
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_country: 
+        :owner_country:
           :description: Country/Region
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_phone_mobile: 
+        :owner_phone_mobile:
           :description: Mobile
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_title: 
+        :owner_title:
           :description: Title
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_first_name: 
+        :owner_first_name:
           :description: First Name
           :required: true
           :display: :edit
           :data_type: :string
-        :owner_manager: 
+        :owner_manager:
           :description: Name
           :required: false
           :display: :edit
           :data_type: :string
-        :owner_address: 
+        :owner_address:
           :description: Address
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_company: 
+        :owner_company:
           :description: Company
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_last_name: 
+        :owner_last_name:
           :description: Last Name
           :required: true
           :display: :edit
           :data_type: :string
-        :owner_manager_mail: 
+        :owner_manager_mail:
           :description: E-Mail
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_city: 
+        :owner_city:
           :description: City
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_department: 
+        :owner_department:
           :description: Department
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap: 
-          :pressed: 
+        :owner_load_ldap:
+          :pressed:
             :method: :retrieve_ldap
           :description: Look Up LDAP Email
           :required: false
           :display: :show
           :data_type: :button
-        :owner_manager_phone: 
+        :owner_manager_phone:
           :description: Phone
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_state: 
+        :owner_state:
           :description: State
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_office: 
+        :owner_office:
           :description: Office
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_zip: 
+        :owner_zip:
           :description: Zip code
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_email: 
+        :owner_email:
           :description: E-Mail
           :required: true
           :display: :edit
@@ -108,15 +108,15 @@
           :display: :edit
           :data_type: :string
       :display: :hide
-      :field_order: 
-    :purpose: 
+      :field_order:
+    :purpose:
       :description: Purpose
-      :fields: 
-        :vm_tags: 
+      :fields:
+        :vm_tags:
           :required_method: :validate_tags
           :description: Tags
           :required: false
-          :options: 
+          :options:
             :include: []
 
             :order: []
@@ -130,36 +130,36 @@
 
           :data_type: :integer
       :display: :hide
-      :field_order: 
-    :customize: 
+      :field_order:
+    :customize:
       :description: Customize
-      :fields: 
-        :dns_servers: 
+      :fields:
+        :dns_servers:
           :description: DNS Server list
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_organization: 
+        :sysprep_organization:
           :description: Organization
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_password: 
+        :sysprep_password:
           :description: New Administrator Password
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_custom_spec: 
-          :values_from: 
+        :sysprep_custom_spec:
+          :values_from:
             :method: :allowed_customization_specs
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_server_license_mode: 
-          :values: 
+        :sysprep_server_license_mode:
+          :values:
             perServer: Per server
             perSeat: Per seat
           :description: Identification
@@ -167,35 +167,35 @@
           :display: :edit
           :default: perServer
           :data_type: :string
-        :ldap_ous: 
-          :values_from: 
+        :ldap_ous:
+          :values_from:
             :method: :allowed_ous_tree
           :auto_select_single: false
           :description: LDAP Group
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_timezone: 
-          :values_from: 
+        :sysprep_timezone:
+          :values_from:
             :method: :get_timezones
           :description: Timezone
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :dns_suffixes: 
+        :dns_suffixes:
           :description: DNS Suffix List
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_product_id: 
+        :sysprep_product_id:
           :description: ProductID
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_identification: 
-          :values: 
+        :sysprep_identification:
+          :values:
             domain: Domain
             workgroup: Workgroup
           :description: Identification
@@ -203,25 +203,25 @@
           :display: :edit
           :default: domain
           :data_type: :string
-        :sysprep_per_server_max_connections: 
+        :sysprep_per_server_max_connections:
           :description: Maximum Connections
           :required: false
           :display: :edit
           :default: "5"
           :data_type: :string
-        :sysprep_computer_name: 
+        :sysprep_computer_name:
           :description: Computer Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_workgroup_name: 
+        :sysprep_workgroup_name:
           :description: Workgroup Name
           :required: false
           :display: :edit
           :default: WORKGROUP
           :data_type: :string
-        :sysprep_spec_override: 
-          :values: 
+        :sysprep_spec_override:
+          :values:
             false: 0
             true: 1
           :description: Override Specification Values
@@ -229,8 +229,8 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :addr_mode: 
-          :values: 
+        :addr_mode:
+          :values:
             static: Static
             dhcp: DHCP
           :description: Address Mode
@@ -238,18 +238,18 @@
           :display: :edit
           :default: dhcp
           :data_type: :string
-        :linux_host_name: 
+        :linux_host_name:
           :description: Computer Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_domain_admin: 
+        :sysprep_domain_admin:
           :description: Domain Admin
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_change_sid: 
-          :values: 
+        :sysprep_change_sid:
+          :values:
             false: 0
             true: 1
           :description: Change SID
@@ -257,46 +257,46 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :sysprep_domain_name: 
-          :values_from: 
-            :options: 
-              :active_proxy: 
-              :platform: 
+        :sysprep_domain_name:
+          :values_from:
+            :options:
+              :active_proxy:
+              :platform:
             :method: :allowed_domains
           :auto_select_single: false
           :description: Domain Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_upload_file: 
+        :sysprep_upload_file:
           :description: Upload
           :required: false
           :display: :edit
           :data_type: :string
-        :gateway: 
+        :gateway:
           :description: Gateway
           :required: false
           :display: :edit
           :data_type: :string
-        :ip_addr: 
+        :ip_addr:
           :description: IP Address
           :required: false
           :notes: (Enter starting IP address)
           :display: :edit
           :data_type: :string
           :notes_display: :hide
-        :linux_domain_name: 
+        :linux_domain_name:
           :description: Domain Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_domain_password: 
+        :sysprep_domain_password:
           :description: Domain Password
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_auto_logon: 
-          :values: 
+        :sysprep_auto_logon:
+          :values:
             false: 0
             true: 1
           :description: Auto Logon
@@ -304,17 +304,17 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :sysprep_enabled: 
-          :values_from: 
+        :sysprep_enabled:
+          :values_from:
             :method: :allowed_customization
           :description: Customize
           :required: false
           :display: :edit
           :default: disabled
           :data_type: :string
-        :sysprep_delete_accounts: 
+        :sysprep_delete_accounts:
           :display_override: :hide
-          :values: 
+          :values:
             false: 0
             true: 1
           :description: Delete Accounts
@@ -322,30 +322,30 @@
           :display: :hide
           :default: false
           :data_type: :boolean
-        :sysprep_upload_text: 
+        :sysprep_upload_text:
           :description: Sysprep Text
           :required_method: :validate_sysprep_upload
           :required: true
           :display: :edit
           :data_type: :string
-        :wins_servers: 
+        :wins_servers:
           :description: WINS Server list
           :required: false
           :display: :edit
           :data_type: :string
-        :subnet_mask: 
+        :subnet_mask:
           :description: Subnet Mask
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_full_name: 
+        :sysprep_full_name:
           :description: Full Name
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_auto_logon_count: 
-          :values: 
+        :sysprep_auto_logon_count:
+          :values:
             1: "1"
             2: "2"
             3: "3"
@@ -355,20 +355,20 @@
           :default: 1
           :data_type: :integer
       :display: :hide
-    :environment: 
+    :environment:
       :description: Environment
-      :fields: 
-        :placement_cluster_name: 
-          :values_from: 
+      :fields:
+        :placement_cluster_name:
+          :values_from:
             :method: :allowed_clusters
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :integer
-        :cluster_filter: 
-          :values_from: 
-            :options: 
+        :cluster_filter:
+          :values_from:
+            :options:
               :category: :EmsCluster
             :method: :allowed_filters
           :auto_select_single: false
@@ -376,9 +376,9 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :host_filter: 
-          :values_from: 
-            :options: 
+        :host_filter:
+          :values_from:
+            :options:
               :category: :Host
             :method: :allowed_filters
           :auto_select_single: false
@@ -386,9 +386,9 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :ds_filter: 
-          :values_from: 
-            :options: 
+        :ds_filter:
+          :values_from:
+            :options:
               :category: :Storage
             :method: :allowed_filters
           :auto_select_single: false
@@ -396,8 +396,8 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_host_name: 
-          :values_from: 
+        :placement_host_name:
+          :values_from:
             :method: :allowed_hosts
           :auto_select_single: false
           :description: Name
@@ -406,8 +406,8 @@
           :display: :edit
           :data_type: :integer
           :required_description: Host Name
-        :placement_ds_name: 
-          :values_from: 
+        :placement_ds_name:
+          :values_from:
             :method: :allowed_storages
           :auto_select_single: false
           :description: Name
@@ -416,9 +416,9 @@
           :display: :edit
           :data_type: :integer
           :required_description: Datastore Name
-        :rp_filter: 
-          :values_from: 
-            :options: 
+        :rp_filter:
+          :values_from:
+            :options:
               :category: :ResourcePool
             :method: :allowed_filters
           :auto_select_single: false
@@ -426,8 +426,8 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_auto: 
-          :values: 
+        :placement_auto:
+          :values:
             false: 0
             true: 1
           :description: Choose Automatically
@@ -435,16 +435,16 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :placement_folder_name: 
-          :values_from: 
+        :placement_folder_name:
+          :values_from:
             :method: :allowed_folders
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_rp_name: 
-          :values_from: 
+        :placement_rp_name:
+          :values_from:
             :method: :allowed_respools
           :auto_select_single: false
           :description: Name
@@ -460,12 +460,12 @@
           :display: :edit
           :data_type: :integer
       :display: :hide
-    :service: 
+    :service:
       :description: Catalog
-      :fields: 
-        :number_of_vms: 
-          :values_from: 
-            :options: 
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
               :max: 5
             :method: :allowed_number_of_vms
           :description: Count
@@ -473,56 +473,56 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :vm_description: 
+        :vm_description:
           :description: VM Description
           :required: false
           :display: :edit
           :data_type: :string
-          :min_length: 
+          :min_length:
           :max_length: 100
-        :vm_prefix: 
+        :vm_prefix:
           :description: VM Name Prefix/Suffix
           :required_method: :validate_vm_name
           :required: false
           :display: :hide
           :data_type: :string
-        :src_vm_id: 
-          :values_from: 
-            :options: 
+        :src_vm_id:
+          :values_from:
+            :options:
               :tag_filters: []
 
             :method: :allowed_templates
           :description: Name
           :required: true
-          :notes: 
+          :notes:
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :vm_name: 
+        :vm_name:
           :description: VM Name
           :required_method: :validate_vm_name
           :required: true
-          :notes: 
+          :notes:
           :display: :edit
           :data_type: :string
           :notes_display: :show
-          :min_length: 
-          :max_length: 
-        :host_name: 
+          :min_length:
+          :max_length:
+        :host_name:
           :description: Host Name
           :required: false
           :display: :hide
           :data_type: :string
-        :provision_type: 
-          :values_from: 
+        :provision_type:
+          :values_from:
             :method: :allowed_provision_types
           :description: Provision Type
           :required: true
           :display: :hide
           :default: vmware
           :data_type: :string
-        :linked_clone: 
-          :values: 
+        :linked_clone:
+          :values:
             false: 0
             true: 1
           :description: Linked Clone
@@ -532,17 +532,17 @@
           :data_type: :boolean
           :notes: VM requires a snapshot
           :notes_display: :show
-        :snapshot: 
-          :values_from: 
+        :snapshot:
+          :values_from:
             :method: :allowed_snapshots
           :description: Snapshot
           :required: false
           :display: :edit
           :data_type: :string
           :auto_select_single: false
-        :vm_filter: 
-          :values_from: 
-            :options: 
+        :vm_filter:
+          :values_from:
+            :options:
               :category: :Vm
             :method: :allowed_filters
           :description: Filter
@@ -550,11 +550,11 @@
           :display: :edit
           :data_type: :integer
       :display: :show
-    :schedule: 
+    :schedule:
       :description: Schedule
-      :fields: 
-        :schedule_type: 
-          :values: 
+      :fields:
+        :schedule_type:
+          :values:
             schedule: Schedule
             immediately: Immediately on Approval
           :description: When to Provision
@@ -562,8 +562,8 @@
           :display: :edit
           :default: immediately
           :data_type: :string
-        :vm_auto_start: 
-          :values: 
+        :vm_auto_start:
+          :values:
             false: 0
             true: 1
           :description: Power on virtual machines after creation
@@ -571,17 +571,17 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :schedule_time: 
-          :values_from: 
-            :options: 
+        :schedule_time:
+          :values_from:
+            :options:
               :offset: 1.day
             :method: :default_schedule_time
           :description: Provision on
           :required: false
           :display: :edit
           :data_type: :time
-        :retirement: 
-          :values: 
+        :retirement:
+          :values:
             0: Indefinite
             1.month: 1 Month
             3.months: 3 Months
@@ -591,10 +591,10 @@
           :display: :edit
           :default: 0
           :data_type: :integer
-        :retirement_warn: 
-          :values_from: 
-            :options: 
-              :values: 
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
                 1.week: 1 Week
                 2.weeks: 2 Weeks
                 30.days: 30 Days
@@ -607,12 +607,12 @@
           :default: 1.week
           :data_type: :integer
       :display: :show
-    :network: 
+    :network:
       :description: Network
-      :fields: 
-        :vlan: 
-          :values_from: 
-            :options: 
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
@@ -620,17 +620,17 @@
           :required: true
           :display: :edit
           :data_type: :string
-        :mac_address: 
+        :mac_address:
           :description: MAC Address
           :required: false
           :display: :hide
           :data_type: :string
       :display: :hide
-    :hardware: 
+    :hardware:
       :description: Hardware
-      :fields: 
-        :disk_format: 
-          :values: 
+      :fields:
+        :disk_format:
+          :values:
             thick: Thick
             thin: Thin
             unchanged: Default
@@ -639,14 +639,14 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
-        :cpu_limit: 
+        :cpu_limit:
           :description: CPU (MHz)
           :required: false
           :notes: (-1 = Unlimited)
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :memory_limit: 
+        :memory_limit:
           :description: Memory (MB)
           :required: false
           :notes: (-1 = Unlimited)
@@ -675,13 +675,13 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :cpu_reserve: 
+        :cpu_reserve:
           :description: CPU (MHz)
           :required: false
           :display: :edit
           :data_type: :integer
-        :vm_memory: 
-          :values: 
+        :vm_memory:
+          :values:
             "2048": "2048"
             "4096": "4096"
             "1024": "1024"
@@ -690,14 +690,14 @@
           :display: :edit
           :default: "1024"
           :data_type: :string
-        :memory_reserve: 
+        :memory_reserve:
           :description: Memory (MB)
           :required: false
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
-        :network_adapters: 
-          :values: 
+        :network_adapters:
+          :values:
             1: "1"
             2: "2"
             3: "3"
@@ -708,7 +708,7 @@
           :default: 1
           :data_type: :integer
       :display: :hide
-  :dialog_order: 
+  :dialog_order:
   - :requester
   - :purpose
   - :service

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
@@ -1,103 +1,103 @@
---- 
+---
 :name: miq_provision_dialogs
 :description: Sample VM Provisioning Dialog
 :dialog_type: MiqProvisionWorkflow
-:content: 
-  :buttons: 
+:content:
+  :buttons:
   - :submit
   - :cancel
-  :dialogs: 
-    :requester: 
+  :dialogs:
+    :requester:
       :description: Request
-      :fields: 
-        :owner_phone: 
+      :fields:
+        :owner_phone:
           :description: Phone
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_country: 
+        :owner_country:
           :description: Country/Region
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_phone_mobile: 
+        :owner_phone_mobile:
           :description: Mobile
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_title: 
+        :owner_title:
           :description: Title
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_first_name: 
+        :owner_first_name:
           :description: First Name
           :required: true
           :display: :edit
           :data_type: :string
-        :owner_manager: 
+        :owner_manager:
           :description: Name
           :required: false
           :display: :edit
           :data_type: :string
-        :owner_address: 
+        :owner_address:
           :description: Address
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_company: 
+        :owner_company:
           :description: Company
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_last_name: 
+        :owner_last_name:
           :description: Last Name
           :required: true
           :display: :edit
           :data_type: :string
-        :owner_manager_mail: 
+        :owner_manager_mail:
           :description: E-Mail
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_city: 
+        :owner_city:
           :description: City
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_department: 
+        :owner_department:
           :description: Department
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap: 
-          :pressed: 
+        :owner_load_ldap:
+          :pressed:
             :method: :retrieve_ldap
           :description: Look Up LDAP Email
           :required: false
           :display: :show
           :data_type: :button
-        :owner_manager_phone: 
+        :owner_manager_phone:
           :description: Phone
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_state: 
+        :owner_state:
           :description: State
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_office: 
+        :owner_office:
           :description: Office
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_zip: 
+        :owner_zip:
           :description: Zip code
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_email: 
+        :owner_email:
           :description: E-Mail
           :required: true
           :display: :edit
@@ -108,15 +108,15 @@
           :display: :edit
           :data_type: :string
       :display: :show
-      :field_order: 
-    :purpose: 
+      :field_order:
+    :purpose:
       :description: Purpose
-      :fields: 
-        :vm_tags: 
+      :fields:
+        :vm_tags:
           :required_method: :validate_tags
           :description: Tags
           :required: false
-          :options: 
+          :options:
             :include: []
 
             :order: []
@@ -130,36 +130,36 @@
 
           :data_type: :integer
       :display: :show
-      :field_order: 
-    :customize: 
+      :field_order:
+    :customize:
       :description: Customize
-      :fields: 
-        :dns_servers: 
+      :fields:
+        :dns_servers:
           :description: DNS Server list
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_organization: 
+        :sysprep_organization:
           :description: Organization
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_password: 
+        :sysprep_password:
           :description: New Administrator Password
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_custom_spec: 
-          :values_from: 
+        :sysprep_custom_spec:
+          :values_from:
             :method: :allowed_customization_specs
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_server_license_mode: 
-          :values: 
+        :sysprep_server_license_mode:
+          :values:
             perServer: Per server
             perSeat: Per seat
           :description: Identification
@@ -167,35 +167,35 @@
           :display: :edit
           :default: perServer
           :data_type: :string
-        :ldap_ous: 
-          :values_from: 
+        :ldap_ous:
+          :values_from:
             :method: :allowed_ous_tree
           :auto_select_single: false
           :description: LDAP Group
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_timezone: 
-          :values_from: 
+        :sysprep_timezone:
+          :values_from:
             :method: :get_timezones
           :description: Timezone
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :dns_suffixes: 
+        :dns_suffixes:
           :description: DNS Suffix list
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_product_id: 
+        :sysprep_product_id:
           :description: ProductID
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_identification: 
-          :values: 
+        :sysprep_identification:
+          :values:
             domain: Domain
             workgroup: Workgroup
           :description: Identification
@@ -203,25 +203,25 @@
           :display: :edit
           :default: domain
           :data_type: :string
-        :sysprep_per_server_max_connections: 
+        :sysprep_per_server_max_connections:
           :description: Maximum Connections
           :required: false
           :display: :edit
           :default: "5"
           :data_type: :string
-        :sysprep_computer_name: 
+        :sysprep_computer_name:
           :description: Computer Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_workgroup_name: 
+        :sysprep_workgroup_name:
           :description: Workgroup Name
           :required: false
           :display: :edit
           :default: WORKGROUP
           :data_type: :string
-        :sysprep_spec_override: 
-          :values: 
+        :sysprep_spec_override:
+          :values:
             false: 0
             true: 1
           :description: Override Specification Values
@@ -229,8 +229,8 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :addr_mode: 
-          :values: 
+        :addr_mode:
+          :values:
             static: Static
             dhcp: DHCP
           :description: Address Mode
@@ -238,18 +238,18 @@
           :display: :edit
           :default: dhcp
           :data_type: :string
-        :linux_host_name: 
+        :linux_host_name:
           :description: Computer Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_domain_admin: 
+        :sysprep_domain_admin:
           :description: Domain Admin
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_change_sid: 
-          :values: 
+        :sysprep_change_sid:
+          :values:
             false: 0
             true: 1
           :description: Change SID
@@ -257,46 +257,46 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :sysprep_domain_name: 
-          :values_from: 
-            :options: 
-              :active_proxy: 
-              :platform: 
+        :sysprep_domain_name:
+          :values_from:
+            :options:
+              :active_proxy:
+              :platform:
             :method: :allowed_domains
           :auto_select_single: false
           :description: Domain Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_upload_file: 
+        :sysprep_upload_file:
           :description: Upload
           :required: false
           :display: :edit
           :data_type: :string
-        :gateway: 
+        :gateway:
           :description: Gateway
           :required: false
           :display: :edit
           :data_type: :string
-        :ip_addr: 
+        :ip_addr:
           :description: IP Address
           :required: false
           :notes: (Enter starting IP address)
           :display: :edit
           :data_type: :string
           :notes_display: :hide
-        :linux_domain_name: 
+        :linux_domain_name:
           :description: Domain Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_domain_password: 
+        :sysprep_domain_password:
           :description: Domain Password
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_auto_logon: 
-          :values: 
+        :sysprep_auto_logon:
+          :values:
             false: 0
             true: 1
           :description: Auto Logon
@@ -304,17 +304,17 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :sysprep_enabled: 
-          :values_from: 
+        :sysprep_enabled:
+          :values_from:
             :method: :allowed_customization
           :description: Customize
           :required: false
           :display: :edit
           :default: disabled
           :data_type: :string
-        :sysprep_delete_accounts: 
+        :sysprep_delete_accounts:
           :display_override: :hide
-          :values: 
+          :values:
             false: 0
             true: 1
           :description: Delete Accounts
@@ -322,30 +322,30 @@
           :display: :hide
           :default: false
           :data_type: :boolean
-        :sysprep_upload_text: 
+        :sysprep_upload_text:
           :description: Sysprep Text
           :required_method: :validate_sysprep_upload
           :required: true
           :display: :edit
           :data_type: :string
-        :wins_servers: 
+        :wins_servers:
           :description: WINS Server list
           :required: false
           :display: :edit
           :data_type: :string
-        :subnet_mask: 
+        :subnet_mask:
           :description: Subnet Mask
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_full_name: 
+        :sysprep_full_name:
           :description: Full Name
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_auto_logon_count: 
-          :values: 
+        :sysprep_auto_logon_count:
+          :values:
             1: "1"
             2: "2"
             3: "3"
@@ -378,20 +378,20 @@
           :display: :edit
           :data_type: :string
       :display: :show
-    :environment: 
+    :environment:
       :description: Environment
-      :fields: 
-        :placement_cluster_name: 
-          :values_from: 
+      :fields:
+        :placement_cluster_name:
+          :values_from:
             :method: :allowed_clusters
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :integer
-        :cluster_filter: 
-          :values_from: 
-            :options: 
+        :cluster_filter:
+          :values_from:
+            :options:
               :category: :EmsCluster
             :method: :allowed_filters
           :auto_select_single: false
@@ -399,9 +399,9 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :host_filter: 
-          :values_from: 
-            :options: 
+        :host_filter:
+          :values_from:
+            :options:
               :category: :Host
             :method: :allowed_filters
           :auto_select_single: false
@@ -409,9 +409,9 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :ds_filter: 
-          :values_from: 
-            :options: 
+        :ds_filter:
+          :values_from:
+            :options:
               :category: :Storage
             :method: :allowed_filters
           :auto_select_single: false
@@ -419,8 +419,8 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_host_name: 
-          :values_from: 
+        :placement_host_name:
+          :values_from:
             :method: :allowed_hosts
           :auto_select_single: false
           :description: Name
@@ -429,8 +429,8 @@
           :display: :edit
           :data_type: :integer
           :required_description: Host Name
-        :placement_ds_name: 
-          :values_from: 
+        :placement_ds_name:
+          :values_from:
             :method: :allowed_storages
           :auto_select_single: false
           :description: Name
@@ -439,9 +439,9 @@
           :display: :edit
           :data_type: :integer
           :required_description: Datastore Name
-        :rp_filter: 
-          :values_from: 
-            :options: 
+        :rp_filter:
+          :values_from:
+            :options:
               :category: :ResourcePool
             :method: :allowed_filters
           :auto_select_single: false
@@ -449,8 +449,8 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_auto: 
-          :values: 
+        :placement_auto:
+          :values:
             false: 0
             true: 1
           :description: Choose Automatically
@@ -458,16 +458,16 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :placement_folder_name: 
-          :values_from: 
+        :placement_folder_name:
+          :values_from:
             :method: :allowed_folders
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_rp_name: 
-          :values_from: 
+        :placement_rp_name:
+          :values_from:
             :method: :allowed_respools
           :auto_select_single: false
           :description: Name
@@ -483,12 +483,12 @@
           :display: :edit
           :data_type: :integer
       :display: :show
-    :service: 
+    :service:
       :description: Catalog
-      :fields: 
-        :number_of_vms: 
-          :values_from: 
-            :options: 
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
               :max: 50
             :method: :allowed_number_of_vms
           :description: Count
@@ -496,41 +496,41 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :vm_description: 
+        :vm_description:
           :description: VM Description
           :required: false
           :display: :edit
           :data_type: :string
-          :min_length: 
+          :min_length:
           :max_length: 100
-        :vm_prefix: 
+        :vm_prefix:
           :description: VM Name Prefix/Suffix
           :required_method: :validate_vm_name
           :required: false
           :display: :hide
           :data_type: :string
-        :src_vm_id: 
-          :values_from: 
-            :options: 
+        :src_vm_id:
+          :values_from:
+            :options:
               :tag_filters: []
 
             :method: :allowed_templates
           :description: Name
           :required: true
-          :notes: 
+          :notes:
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :vm_name: 
+        :vm_name:
           :description: VM Name
           :required_method: :validate_vm_name
           :required: true
-          :notes: 
+          :notes:
           :display: :edit
           :data_type: :string
           :notes_display: :show
-          :min_length: 
-          :max_length: 
+          :min_length:
+          :max_length:
         :pxe_image_id:
           :values_from:
             :method: :allowed_images
@@ -549,21 +549,21 @@
           :required_method: :validate_pxe_server_id
           :display: :edit
           :data_type: :integer
-        :host_name: 
+        :host_name:
           :description: Host Name
           :required: false
           :display: :hide
           :data_type: :string
-        :provision_type: 
-          :values_from: 
+        :provision_type:
+          :values_from:
             :method: :allowed_provision_types
           :description: Provision Type
           :required: true
           :display: :edit
           :default: vmware
           :data_type: :string
-        :linked_clone: 
-          :values: 
+        :linked_clone:
+          :values:
             false: 0
             true: 1
           :description: Linked Clone
@@ -573,17 +573,17 @@
           :data_type: :boolean
           :notes: VM requires a snapshot
           :notes_display: :show
-        :snapshot: 
-          :values_from: 
+        :snapshot:
+          :values_from:
             :method: :allowed_snapshots
           :description: Snapshot
           :required: false
           :display: :edit
           :data_type: :string
           :auto_select_single: false
-        :vm_filter: 
-          :values_from: 
-            :options: 
+        :vm_filter:
+          :values_from:
+            :options:
               :category: :Vm
             :method: :allowed_filters
           :description: Filter
@@ -591,11 +591,11 @@
           :display: :edit
           :data_type: :integer
       :display: :show
-    :schedule: 
+    :schedule:
       :description: Schedule
-      :fields: 
-        :schedule_type: 
-          :values: 
+      :fields:
+        :schedule_type:
+          :values:
             schedule: Schedule
             immediately: Immediately on Approval
           :description: When to Provision
@@ -603,8 +603,8 @@
           :display: :edit
           :default: immediately
           :data_type: :string
-        :vm_auto_start: 
-          :values: 
+        :vm_auto_start:
+          :values:
             false: 0
             true: 1
           :description: Power on virtual machines after creation
@@ -612,17 +612,17 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :schedule_time: 
-          :values_from: 
-            :options: 
+        :schedule_time:
+          :values_from:
+            :options:
               :offset: 1.day
             :method: :default_schedule_time
           :description: Provision on
           :required: false
           :display: :edit
           :data_type: :time
-        :retirement: 
-          :values: 
+        :retirement:
+          :values:
             0: Indefinite
             1.month: 1 Month
             3.months: 3 Months
@@ -632,10 +632,10 @@
           :display: :edit
           :default: 0
           :data_type: :integer
-        :retirement_warn: 
-          :values_from: 
-            :options: 
-              :values: 
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
                 1.week: 1 Week
                 2.weeks: 2 Weeks
                 30.days: 30 Days
@@ -648,12 +648,12 @@
           :default: 1.week
           :data_type: :integer
       :display: :show
-    :network: 
+    :network:
       :description: Network
-      :fields: 
-        :vlan: 
-          :values_from: 
-            :options: 
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
@@ -661,17 +661,17 @@
           :required: true
           :display: :edit
           :data_type: :string
-        :mac_address: 
+        :mac_address:
           :description: MAC Address
           :required: false
           :display: :hide
           :data_type: :string
       :display: :show
-    :hardware: 
+    :hardware:
       :description: Hardware
-      :fields: 
-        :disk_format: 
-          :values: 
+      :fields:
+        :disk_format:
+          :values:
             thick: Thick
             thin: Thin
             unchanged: Default
@@ -680,14 +680,14 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
-        :cpu_limit: 
+        :cpu_limit:
           :description: CPU (MHz)
           :required: false
           :notes: (-1 = Unlimited)
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :memory_limit: 
+        :memory_limit:
           :description: Memory (MB)
           :required: false
           :notes: (-1 = Unlimited)
@@ -716,13 +716,13 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :cpu_reserve: 
+        :cpu_reserve:
           :description: CPU (MHz)
           :required: false
           :display: :edit
           :data_type: :integer
-        :vm_memory: 
-          :values: 
+        :vm_memory:
+          :values:
             "2048": "2048"
             "4096": "4096"
             "1024": "1024"
@@ -731,14 +731,14 @@
           :display: :edit
           :default: "1024"
           :data_type: :string
-        :memory_reserve: 
+        :memory_reserve:
           :description: Memory (MB)
           :required: false
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
-        :network_adapters: 
-          :values: 
+        :network_adapters:
+          :values:
             1: "1"
             2: "2"
             3: "3"
@@ -749,7 +749,7 @@
           :default: 1
           :data_type: :integer
       :display: :show
-  :dialog_order: 
+  :dialog_order:
   - :requester
   - :purpose
   - :service

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
@@ -736,6 +736,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters: 
           :values: 
             1: "1"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_template.yaml
@@ -695,6 +695,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters: 
           :values: 
             1: "1"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_template.yaml
@@ -1,103 +1,103 @@
---- 
+---
 :name: miq_provision_dialogs_clone_to_template
 :description: Sample VM Clone to Template Dialog
 :dialog_type: MiqProvisionWorkflow
-:content: 
-  :buttons: 
+:content:
+  :buttons:
   - :submit
   - :cancel
-  :dialogs: 
-    :requester: 
+  :dialogs:
+    :requester:
       :description: Request
-      :fields: 
-        :owner_phone: 
+      :fields:
+        :owner_phone:
           :description: Phone
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_country: 
+        :owner_country:
           :description: Country/Region
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_phone_mobile: 
+        :owner_phone_mobile:
           :description: Mobile
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_title: 
+        :owner_title:
           :description: Title
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_first_name: 
+        :owner_first_name:
           :description: First Name
           :required: true
           :display: :edit
           :data_type: :string
-        :owner_manager: 
+        :owner_manager:
           :description: Name
           :required: false
           :display: :edit
           :data_type: :string
-        :owner_address: 
+        :owner_address:
           :description: Address
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_company: 
+        :owner_company:
           :description: Company
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_last_name: 
+        :owner_last_name:
           :description: Last Name
           :required: true
           :display: :edit
           :data_type: :string
-        :owner_manager_mail: 
+        :owner_manager_mail:
           :description: E-Mail
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_city: 
+        :owner_city:
           :description: City
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_department: 
+        :owner_department:
           :description: Department
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap: 
-          :pressed: 
+        :owner_load_ldap:
+          :pressed:
             :method: :retrieve_ldap
           :description: Look Up LDAP Email
           :required: false
           :display: :show
           :data_type: :button
-        :owner_manager_phone: 
+        :owner_manager_phone:
           :description: Phone
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_state: 
+        :owner_state:
           :description: State
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_office: 
+        :owner_office:
           :description: Office
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_zip: 
+        :owner_zip:
           :description: Zip code
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_email: 
+        :owner_email:
           :description: E-Mail
           :required: true
           :display: :edit
@@ -108,15 +108,15 @@
           :display: :edit
           :data_type: :string
       :display: :show
-      :field_order: 
-    :purpose: 
+      :field_order:
+    :purpose:
       :description: Purpose
-      :fields: 
-        :vm_tags: 
+      :fields:
+        :vm_tags:
           :required_method: :validate_tags
           :description: Tags
           :required: false
-          :options: 
+          :options:
             :include: []
 
             :order: []
@@ -130,36 +130,36 @@
 
           :data_type: :integer
       :display: :show
-      :field_order: 
-    :customize: 
+      :field_order:
+    :customize:
       :description: Customize
-      :fields: 
-        :dns_servers: 
+      :fields:
+        :dns_servers:
           :description: DNS Server list
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_organization: 
+        :sysprep_organization:
           :description: Organization
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_password: 
+        :sysprep_password:
           :description: New Administrator Password
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_custom_spec: 
-          :values_from: 
+        :sysprep_custom_spec:
+          :values_from:
             :method: :allowed_customization_specs
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_server_license_mode: 
-          :values: 
+        :sysprep_server_license_mode:
+          :values:
             perServer: Per server
             perSeat: Per seat
           :description: Identification
@@ -167,35 +167,35 @@
           :display: :edit
           :default: perServer
           :data_type: :string
-        :ldap_ous: 
-          :values_from: 
+        :ldap_ous:
+          :values_from:
             :method: :allowed_ous_tree
           :auto_select_single: false
           :description: LDAP Group
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_timezone: 
-          :values_from: 
+        :sysprep_timezone:
+          :values_from:
             :method: :get_timezones
           :description: Timezone
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :dns_suffixes: 
+        :dns_suffixes:
           :description: DNS Suffix List
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_product_id: 
+        :sysprep_product_id:
           :description: ProductID
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_identification: 
-          :values: 
+        :sysprep_identification:
+          :values:
             domain: Domain
             workgroup: Workgroup
           :description: Identification
@@ -203,25 +203,25 @@
           :display: :edit
           :default: domain
           :data_type: :string
-        :sysprep_per_server_max_connections: 
+        :sysprep_per_server_max_connections:
           :description: Maximum Connections
           :required: false
           :display: :edit
           :default: "5"
           :data_type: :string
-        :sysprep_computer_name: 
+        :sysprep_computer_name:
           :description: Computer Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_workgroup_name: 
+        :sysprep_workgroup_name:
           :description: Workgroup Name
           :required: false
           :display: :edit
           :default: WORKGROUP
           :data_type: :string
-        :sysprep_spec_override: 
-          :values: 
+        :sysprep_spec_override:
+          :values:
             false: 0
             true: 1
           :description: Override Specification Values
@@ -229,8 +229,8 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :addr_mode: 
-          :values: 
+        :addr_mode:
+          :values:
             static: Static
             dhcp: DHCP
           :description: Address Mode
@@ -238,18 +238,18 @@
           :display: :edit
           :default: dhcp
           :data_type: :string
-        :linux_host_name: 
+        :linux_host_name:
           :description: Computer Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_domain_admin: 
+        :sysprep_domain_admin:
           :description: Domain Admin
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_change_sid: 
-          :values: 
+        :sysprep_change_sid:
+          :values:
             false: 0
             true: 1
           :description: Change SID
@@ -257,46 +257,46 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :sysprep_domain_name: 
-          :values_from: 
-            :options: 
-              :active_proxy: 
-              :platform: 
+        :sysprep_domain_name:
+          :values_from:
+            :options:
+              :active_proxy:
+              :platform:
             :method: :allowed_domains
           :auto_select_single: false
           :description: Domain Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_upload_file: 
+        :sysprep_upload_file:
           :description: Upload
           :required: false
           :display: :edit
           :data_type: :string
-        :gateway: 
+        :gateway:
           :description: Gateway
           :required: false
           :display: :edit
           :data_type: :string
-        :ip_addr: 
+        :ip_addr:
           :description: IP Address
           :required: false
           :notes: (Enter starting IP address)
           :display: :edit
           :data_type: :string
           :notes_display: :hide
-        :linux_domain_name: 
+        :linux_domain_name:
           :description: Domain Name
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_domain_password: 
+        :sysprep_domain_password:
           :description: Domain Password
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_auto_logon: 
-          :values: 
+        :sysprep_auto_logon:
+          :values:
             false: 0
             true: 1
           :description: Auto Logon
@@ -304,17 +304,17 @@
           :display: :edit
           :default: true
           :data_type: :boolean
-        :sysprep_enabled: 
-          :values_from: 
+        :sysprep_enabled:
+          :values_from:
             :method: :allowed_customization
           :description: Customize
           :required: false
           :display: :edit
           :default: disabled
           :data_type: :string
-        :sysprep_delete_accounts: 
+        :sysprep_delete_accounts:
           :display_override: :hide
-          :values: 
+          :values:
             false: 0
             true: 1
           :description: Delete Accounts
@@ -322,30 +322,30 @@
           :display: :hide
           :default: false
           :data_type: :boolean
-        :sysprep_upload_text: 
+        :sysprep_upload_text:
           :description: Sysprep Text
           :required_method: :validate_sysprep_upload
           :required: true
           :display: :edit
           :data_type: :string
-        :wins_servers: 
+        :wins_servers:
           :description: WINS Server list
           :required: false
           :display: :edit
           :data_type: :string
-        :subnet_mask: 
+        :subnet_mask:
           :description: Subnet Mask
           :required: false
           :display: :edit
           :data_type: :string
-        :sysprep_full_name: 
+        :sysprep_full_name:
           :description: Full Name
           :required_method: :validate_sysprep_field
           :required: true
           :display: :edit
           :data_type: :string
-        :sysprep_auto_logon_count: 
-          :values: 
+        :sysprep_auto_logon_count:
+          :values:
             1: "1"
             2: "2"
             3: "3"
@@ -355,20 +355,20 @@
           :default: 1
           :data_type: :integer
       :display: :show
-    :environment: 
+    :environment:
       :description: Environment
-      :fields: 
-        :placement_cluster_name: 
-          :values_from: 
+      :fields:
+        :placement_cluster_name:
+          :values_from:
             :method: :allowed_clusters
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :integer
-        :cluster_filter: 
-          :values_from: 
-            :options: 
+        :cluster_filter:
+          :values_from:
+            :options:
               :category: :EmsCluster
             :method: :allowed_filters
           :auto_select_single: false
@@ -376,9 +376,9 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :host_filter: 
-          :values_from: 
-            :options: 
+        :host_filter:
+          :values_from:
+            :options:
               :category: :Host
             :method: :allowed_filters
           :auto_select_single: false
@@ -386,9 +386,9 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :ds_filter: 
-          :values_from: 
-            :options: 
+        :ds_filter:
+          :values_from:
+            :options:
               :category: :Storage
             :method: :allowed_filters
           :auto_select_single: false
@@ -396,8 +396,8 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_host_name: 
-          :values_from: 
+        :placement_host_name:
+          :values_from:
             :method: :allowed_hosts
           :auto_select_single: false
           :description: Name
@@ -406,8 +406,8 @@
           :display: :edit
           :data_type: :integer
           :required_description: Host Name
-        :placement_ds_name: 
-          :values_from: 
+        :placement_ds_name:
+          :values_from:
             :method: :allowed_storages
           :auto_select_single: false
           :description: Name
@@ -416,9 +416,9 @@
           :display: :edit
           :data_type: :integer
           :required_description: Datastore Name
-        :rp_filter: 
-          :values_from: 
-            :options: 
+        :rp_filter:
+          :values_from:
+            :options:
               :category: :ResourcePool
             :method: :allowed_filters
           :auto_select_single: false
@@ -426,8 +426,8 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_auto: 
-          :values: 
+        :placement_auto:
+          :values:
             false: 0
             true: 1
           :description: Choose Automatically
@@ -435,16 +435,16 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :placement_folder_name: 
-          :values_from: 
+        :placement_folder_name:
+          :values_from:
             :method: :allowed_folders
           :auto_select_single: false
           :description: Name
           :required: false
           :display: :edit
           :data_type: :integer
-        :placement_rp_name: 
-          :values_from: 
+        :placement_rp_name:
+          :values_from:
             :method: :allowed_respools
           :auto_select_single: false
           :description: Name
@@ -460,12 +460,12 @@
           :display: :edit
           :data_type: :integer
       :display: :show
-    :service: 
+    :service:
       :description: Catalog
-      :fields: 
-        :number_of_vms: 
-          :values_from: 
-            :options: 
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
               :max: 1
             :method: :allowed_number_of_vms
           :description: Count
@@ -473,56 +473,56 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :vm_description: 
+        :vm_description:
           :description: VM Description
           :required: false
           :display: :edit
           :data_type: :string
-          :min_length: 
+          :min_length:
           :max_length: 100
-        :vm_prefix: 
+        :vm_prefix:
           :description: VM Name Prefix/Suffix
           :required_method: :validate_vm_name
           :required: false
           :display: :hide
           :data_type: :string
-        :src_vm_id: 
-          :values_from: 
-            :options: 
+        :src_vm_id:
+          :values_from:
+            :options:
               :tag_filters: []
 
             :method: :allowed_templates
           :description: Name
           :required: true
-          :notes: 
+          :notes:
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :vm_name: 
+        :vm_name:
           :description: VM Name
           :required_method: :validate_vm_name
           :required: true
-          :notes: 
+          :notes:
           :display: :edit
           :data_type: :string
           :notes_display: :show
-          :min_length: 
-          :max_length: 
-        :host_name: 
+          :min_length:
+          :max_length:
+        :host_name:
           :description: Host Name
           :required: false
           :display: :hide
           :data_type: :string
-        :provision_type: 
-          :values_from: 
+        :provision_type:
+          :values_from:
             :method: :allowed_provision_types
           :description: Provision Type
           :required: true
           :display: :edit
           :default: vmware
           :data_type: :string
-        :linked_clone: 
-          :values: 
+        :linked_clone:
+          :values:
             false: 0
             true: 1
           :description: Linked Clone
@@ -532,17 +532,17 @@
           :data_type: :boolean
           :notes: VM requires a snapshot
           :notes_display: :show
-        :snapshot: 
-          :values_from: 
+        :snapshot:
+          :values_from:
             :method: :allowed_snapshots
           :description: Snapshot
           :required: false
           :display: :edit
           :data_type: :string
           :auto_select_single: false
-        :vm_filter: 
-          :values_from: 
-            :options: 
+        :vm_filter:
+          :values_from:
+            :options:
               :category: :Vm
             :method: :allowed_filters
           :description: Filter
@@ -550,11 +550,11 @@
           :display: :edit
           :data_type: :integer
       :display: :show
-    :schedule: 
+    :schedule:
       :description: Schedule
-      :fields: 
-        :schedule_type: 
-          :values: 
+      :fields:
+        :schedule_type:
+          :values:
             schedule: Schedule
             immediately: Immediately on Approval
           :description: When to Provision
@@ -562,8 +562,8 @@
           :display: :edit
           :default: immediately
           :data_type: :string
-        :vm_auto_start: 
-          :values: 
+        :vm_auto_start:
+          :values:
             false: 0
             true: 1
           :description: Power on virtual machines after creation
@@ -571,17 +571,17 @@
           :display: :edit
           :default: false
           :data_type: :boolean
-        :schedule_time: 
-          :values_from: 
-            :options: 
+        :schedule_time:
+          :values_from:
+            :options:
               :offset: 1.day
             :method: :default_schedule_time
           :description: Provision on
           :required: false
           :display: :edit
           :data_type: :time
-        :retirement: 
-          :values: 
+        :retirement:
+          :values:
             0: Indefinite
             1.month: 1 Month
             3.months: 3 Months
@@ -591,10 +591,10 @@
           :display: :edit
           :default: 0
           :data_type: :integer
-        :retirement_warn: 
-          :values_from: 
-            :options: 
-              :values: 
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
                 1.week: 1 Week
                 2.weeks: 2 Weeks
                 30.days: 30 Days
@@ -607,12 +607,12 @@
           :default: 1.week
           :data_type: :integer
       :display: :show
-    :network: 
+    :network:
       :description: Network
-      :fields: 
-        :vlan: 
-          :values_from: 
-            :options: 
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
@@ -620,17 +620,17 @@
           :required: true
           :display: :edit
           :data_type: :string
-        :mac_address: 
+        :mac_address:
           :description: MAC Address
           :required: false
           :display: :hide
           :data_type: :string
       :display: :show
-    :hardware: 
+    :hardware:
       :description: Hardware
-      :fields: 
-        :disk_format: 
-          :values: 
+      :fields:
+        :disk_format:
+          :values:
             thick: Thick
             thin: Thin
             unchanged: Default
@@ -639,14 +639,14 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
-        :cpu_limit: 
+        :cpu_limit:
           :description: CPU (MHz)
           :required: false
           :notes: (-1 = Unlimited)
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :memory_limit: 
+        :memory_limit:
           :description: Memory (MB)
           :required: false
           :notes: (-1 = Unlimited)
@@ -675,13 +675,13 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :cpu_reserve: 
+        :cpu_reserve:
           :description: CPU (MHz)
           :required: false
           :display: :edit
           :data_type: :integer
-        :vm_memory: 
-          :values: 
+        :vm_memory:
+          :values:
             "2048": "2048"
             "4096": "4096"
             "1024": "1024"
@@ -690,14 +690,14 @@
           :display: :edit
           :default: "1024"
           :data_type: :string
-        :memory_reserve: 
+        :memory_reserve:
           :description: Memory (MB)
           :required: false
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
-        :network_adapters: 
-          :values: 
+        :network_adapters:
+          :values:
             1: "1"
             2: "2"
             3: "3"
@@ -708,7 +708,7 @@
           :default: 1
           :data_type: :integer
       :display: :show
-  :dialog_order: 
+  :dialog_order:
   - :requester
   - :purpose
   - :service

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_vm.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_vm.yaml
@@ -704,6 +704,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters:
           :values:
             1: "1"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_dialogs_template.yaml
@@ -736,6 +736,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters:
           :values:
             1: "1"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -476,6 +476,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters:
           :values:
             1: "1"

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -476,6 +476,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :validation_method: :validate_memory_reservation
         :network_adapters:
           :values:
             1: "1"

--- a/vmdb/spec/factories/miq_dialog.rb
+++ b/vmdb/spec/factories/miq_dialog.rb
@@ -26,6 +26,26 @@ FactoryGirl.define do
         }
       }
     end
+
+    factory :miq_dialog_provision_with_validation_method do
+      content do
+        {
+          :dialogs => {
+            :hardware => {
+              :fields      => {
+                :memory_reserve => {
+                  :description       => "Memory (MB)",
+                  :required          => false,
+                  :display           => :edit,
+                  :data_type         => :integer,
+                  :validation_method => :some_validation_method,
+                }
+              }
+            }
+          }
+        }
+      end
+    end
   end
 
   factory :miq_dialog_host_provision, :parent => :miq_dialog do

--- a/vmdb/spec/factories/miq_provision_virt_workflow.rb
+++ b/vmdb/spec/factories/miq_provision_virt_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_provision_virt_workflow, :parent => :miq_provision_workflow, :class => "MiqProvisionVirtWorkflow"
-end

--- a/vmdb/spec/factories/miq_provision_workflow.rb
+++ b/vmdb/spec/factories/miq_provision_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_provision_workflow, :parent => :miq_request_workflow
-end

--- a/vmdb/spec/factories/miq_request_workflow.rb
+++ b/vmdb/spec/factories/miq_request_workflow.rb
@@ -1,12 +1,18 @@
 FactoryGirl.define do
   factory :miq_request_workflow do
     skip_create
-    initialize_with { new({:provision_dialog_name => "miq_provision_dialogs"}, "admin") }
+  end
+
+  factory :miq_provision_workflow, :class => MiqProvisionWorkflow, :parent => :miq_request_workflow do
+    factory_dialog :miq_dialog_provision
+    initialize_with do
+      new({:provision_dialog_name => create(factory_dialog).name}, create(:user_admin).userid)
+    end
   end
 
   factory :miq_provision_configured_system_foreman_workflow, :parent => :miq_request_workflow, :class => MiqProvisionConfiguredSystemForemanWorkflow do
     initialize_with do
-      new({:provision_dialog_name => FactoryGirl.create(:miq_provision_configured_system_foreman_dialog).name}, FactoryGirl.create(:user_admin).userid)
+      new({:provision_dialog_name => create(:miq_provision_configured_system_foreman_dialog).name}, create(:user_admin).userid)
     end
   end
 end

--- a/vmdb/spec/factories/miq_request_workflow.rb
+++ b/vmdb/spec/factories/miq_request_workflow.rb
@@ -15,4 +15,6 @@ FactoryGirl.define do
       new({:provision_dialog_name => create(:miq_provision_configured_system_foreman_dialog).name}, create(:user_admin).userid)
     end
   end
+
+  factory :miq_provision_virt_workflow, :class => MiqProvisionVirtWorkflow, :parent => :miq_provision_workflow
 end

--- a/vmdb/spec/models/miq_request_workflow_spec.rb
+++ b/vmdb/spec/models/miq_request_workflow_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe MiqRequestWorkflow do
+  context "#validate" do
+    context "validation_method" do
+      let(:wf_without_validation) { FactoryGirl.build(:miq_provision_workflow) }
+      let(:wf_with_validation)    { FactoryGirl.build(:miq_provision_workflow, :factory_dialog => :miq_dialog_provision_with_validation_method) }
+
+      it "skips validation if no validation_method is defined" do
+        expect(wf_without_validation.get_all_dialogs[:customize][:fields][:root_password][:validation_method]).to eq(nil)
+        expect(wf_without_validation.validate({})).to be_true
+      end
+
+      it "calls the validation_method if defined" do
+        wf_with_validation.should_receive(:respond_to?).with(:some_validation_method).and_return(true)
+        wf_with_validation.should_receive(:some_validation_method).once
+        expect(wf_with_validation.validate({})).to be_true
+      end
+
+      it "returns false when validation fails" do
+        wf_with_validation.should_receive(:respond_to?).with(:some_validation_method).and_return(true)
+        wf_with_validation.should_receive(:some_validation_method).and_return("Some Error")
+        expect(wf_with_validation.validate({})).to be_false
+      end
+    end
+  end
+end


### PR DESCRIPTION
When provisioning a VM, users are allowed to set a memory reservation.  Reserving more memory than the total memory associated with the VM doesn't make sense.  Some providers return an error when you try to do this, we should not allow the request to be created in such a way.

https://bugzilla.redhat.com/show_bug.cgi?id=1216889