### PR TITLE
ruby 2.0 and above uses minitest

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -83,6 +83,5 @@ unless ENV['APPLIANCE']
     gem "xml-simple", "=1.0.12",  :require => false  # Used by test/xml/tc_xmlhash_methods.rb
     gem "vcr",        "~>2.6",    :require => false  # Used by manageiq-foreman
     gem "webmock",                :require => false  # Used by vcr / manageiq-foreman
-    gem "minitest",   "< 5",      :require => false
   end
 end

--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -83,5 +83,6 @@ unless ENV['APPLIANCE']
     gem "xml-simple", "=1.0.12",  :require => false  # Used by test/xml/tc_xmlhash_methods.rb
     gem "vcr",        "~>2.6",    :require => false  # Used by manageiq-foreman
     gem "webmock",                :require => false  # Used by vcr / manageiq-foreman
+    gem "minitest",   "< 5",      :require => false
   end
 end

--- a/lib/fs/ext3/test/tc_Ext3BlockPointersPath.rb
+++ b/lib/fs/ext3/test/tc_Ext3BlockPointersPath.rb
@@ -1,11 +1,11 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'enumerator'
 
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'Ext3BlockPointersPath'
 include  Ext3
 
-class TestBlockPointersPath < Test::Unit::TestCase
+class TestBlockPointersPath < MiniTest::Unit::TestCase
 
   NUM_INDIRECTS = 15
   MAX_BLOCK = 3626

--- a/lib/metadata/linux/test/tc_LinuxUtils.rb
+++ b/lib/metadata/linux/test/tc_LinuxUtils.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/unit'
 
 $:.push("#{File.dirname(__FILE__)}/../")
 require 'LinuxUtils'
 
-class TestLinuxUtils < Test::Unit::TestCase
+class TestLinuxUtils < MiniTest::Unit::TestCase
 
 #  puts "  OCTAL_TO_PERMISSIONS = {"
 #  (0..07777).each do |o|

--- a/lib/test/DiskTestCommon/ext3/tc_ext3_directory.rb
+++ b/lib/test/DiskTestCommon/ext3/tc_ext3_directory.rb
@@ -10,7 +10,7 @@ $:.push("#{File.dirname(__FILE__)}//../../../fs/ext3")
 require 'Ext3Superblock'
 require 'Ext3Directory'
 
-class Ext3TestDirectory < Test::Unit::TestCase
+class Ext3TestDirectory < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ext3']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ext3/tc_ext3_file.rb
+++ b/lib/test/DiskTestCommon/ext3/tc_ext3_file.rb
@@ -9,7 +9,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../../fs/MiqFS")
 require 'MiqFS'
 
-class Ext3TestFile < Test::Unit::TestCase
+class Ext3TestFile < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ext3']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ext3/tc_ext3_superblock.rb
+++ b/lib/test/DiskTestCommon/ext3/tc_ext3_superblock.rb
@@ -9,7 +9,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}//../../../fs/ext3")
 require 'Ext3Superblock'
 
-class Ext3TestSuperblock < Test::Unit::TestCase
+class Ext3TestSuperblock < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ext3']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_boot.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_boot.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -10,7 +10,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../../fs/fat32")
 require 'Fat32BootSect'
 
-class Fat32TestBoot < Test::Unit::TestCase
+class Fat32TestBoot < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'fat32']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_file.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_file.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -13,7 +13,7 @@ require 'MiqFS'
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'FSTestUtil'
 
-class Fat32TestFile < Test::Unit::TestCase
+class Fat32TestFile < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'fat32']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_rootdir.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_rootdir.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -13,7 +13,7 @@ require 'Fat32DirectoryEntry'
 $:.push("#{File.dirname(__FILE__)}/../../../disk")
 require 'MiqDisk'
 
-class Fat32TestRoot < Test::Unit::TestCase
+class Fat32TestRoot < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'fat32']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_write.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_write.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -16,7 +16,7 @@ require 'Fat32BootSect'
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'FSTestUtil'
 
-class Fat32TestWrite < Test::Unit::TestCase
+class Fat32TestWrite < MiniTest::Unit::TestCase
 	
 	TEST_SHORT_DIR = "/test"
 	TEST_LONG_DIR  = "/Test Directory"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -10,7 +10,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../../fs/ntfs")
 require 'NtfsBootSect'
 
-class NtfsTestDisk < Test::Unit::TestCase
+class NtfsTestDisk < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_file.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_file.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -13,7 +13,7 @@ require 'MiqFS'
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'FSTestUtil'
 
-class NtfsTestFile < Test::Unit::TestCase
+class NtfsTestFile < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -11,7 +11,7 @@ $:.push("#{File.dirname(__FILE__)}/../../../fs/ntfs")
 require 'NtfsBootSect'
 require 'NtfsMftEntry'
 
-class NtfsTestIndex < Test::Unit::TestCase
+class NtfsTestIndex < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
@@ -1,6 +1,6 @@
 # encoding: US-ASCII
 
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/../..")
@@ -61,7 +61,7 @@ class MftEntry
 	end
 end
 
-class NtfsTestMft < Test::Unit::TestCase
+class NtfsTestMft < MiniTest::Unit::TestCase
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/tc_MiqDisk.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk.rb
@@ -2,10 +2,10 @@ $:.push("#{File.dirname(__FILE__)}/../../disk/")
 require 'MiqDisk'
 require 'ostruct'
 require 'enumerator'
-require 'test/unit'
+require 'minitest/unit'
 
 module DiskTestCommon
-  class TestMiqDisk < Test::Unit::TestCase
+  class TestMiqDisk < MiniTest::Unit::TestCase
     FILE_PATH = (Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
 
     FILE_DESC_4GB    = FILE_PATH + "disks/DiskTestCommon_MiqDisk_Flat4GB.vmdk"

--- a/lib/test/DiskTestCommon/tc_MiqDisk_read_length.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk_read_length.rb
@@ -6,7 +6,7 @@ require 'VmsFromYaml'
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
 
-class TestMiqDiskReadLen < Test::Unit::TestCase
+class TestMiqDiskReadLen < MiniTest::Unit::TestCase
 	
 	TEST_DB = "#{File.dirname(__FILE__)}/../vms.yml"	
 	

--- a/lib/test/DiskTestCommon/tc_MiqDisk_write.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk_write.rb
@@ -6,7 +6,7 @@ require 'VmsFromYaml'
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
 
-class TestMiqDiskWrite < Test::Unit::TestCase
+class TestMiqDiskWrite < MiniTest::Unit::TestCase
 	
 	TEST_DB = "#{File.dirname(__FILE__)}/../vms.yml"
 	

--- a/lib/test/DiskTestCommon/tc_MiqLargeFile.rb
+++ b/lib/test/DiskTestCommon/tc_MiqLargeFile.rb
@@ -3,11 +3,11 @@ $:.push("#{File.dirname(__FILE__)}/../../metadata/util/")
 require 'MiqLargeFile'
 require 'md5deep'
 require 'enumerator'
-require 'test/unit'
+require 'minitest/unit'
 require 'tmpdir'
 
 module DiskTestCommon
-  class TestMiqLargeFile < Test::Unit::TestCase
+  class TestMiqLargeFile < MiniTest::Unit::TestCase
     FILE_PATH = (Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
 
     FILE_1MB = FILE_PATH + "containers/raw/DiskTestCommon_MiqLargeFile_1MB"

--- a/lib/test/DiskTestCommon/tc_seek.rb
+++ b/lib/test/DiskTestCommon/tc_seek.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 $:.push("#{File.dirname(__FILE__)}/..")
@@ -10,7 +10,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../fs/MiqFS")
 require 'MiqFS'
 
-class TestSeek < Test::Unit::TestCase
+class TestSeek < MiniTest::Unit::TestCase
 	
 	TEST_DB = "#{File.dirname(__FILE__)}/../vms.yml"
 	TEST_FILE = '/SeekTest.dat'

--- a/lib/test/DiskTestCommon/tc_vfyreg.rb
+++ b/lib/test/DiskTestCommon/tc_vfyreg.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/unit'
 require 'ostruct'
 
 require 'FSTestUtil'
@@ -13,7 +13,7 @@ $:.push("#{File.dirname(__FILE__)}/../../fs/MiqFS")
 require 'MiqFS'
 
 # WINDOWS SPECIFIC.
-class TestReg < Test::Unit::TestCase
+class TestReg < MiniTest::Unit::TestCase
 	
 	#define registry structures
 	REGISTRY_HEADER_REGF = BinaryStruct.new([

--- a/lib/test/Iso9660/tc_iso9660BootSector.rb
+++ b/lib/test/Iso9660/tc_iso9660BootSector.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'test/unit'
+require 'minitest/unit'
 
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
@@ -8,7 +8,7 @@ $:.push("#{File.dirname(__FILE__)}/../../fs/iso9660")
 require 'Iso9660BootSector'
 include Iso9660
 
-class TestIso9660BootSector < Test::Unit::TestCase
+class TestIso9660BootSector < MiniTest::Unit::TestCase
 	
 	def test_boot_sector
 		puts "Testing boot sector"

--- a/lib/test/Iso9660/tc_iso9660Directory.rb
+++ b/lib/test/Iso9660/tc_iso9660Directory.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'test/unit'
+require 'minitest/unit'
 
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
@@ -10,7 +10,7 @@ require 'Iso9660DirectoryEntry'
 require 'Iso9660Directory'
 include Iso9660
 
-class TestIso9660Directory < Test::Unit::TestCase
+class TestIso9660Directory < MiniTest::Unit::TestCase
 	
 	def test_root_dir
 		puts "Testing root dir."

--- a/lib/test/Iso9660/tc_iso9660FileSystem.rb
+++ b/lib/test/Iso9660/tc_iso9660FileSystem.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'test/unit'
+require 'minitest/unit'
 
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
@@ -49,7 +49,7 @@ def Dir(fs)
 	end
 end
 
-class TestIso9660FileSystem < Test::Unit::TestCase
+class TestIso9660FileSystem < MiniTest::Unit::TestCase
 	
 	def test_miq_fs
 		puts "Testing file system"

--- a/lib/test/discovery/tc_DiscoveryModules.rb
+++ b/lib/test/discovery/tc_DiscoveryModules.rb
@@ -9,11 +9,11 @@ require 'WindowsProbe'
 
 require 'enumerator'
 require 'ostruct'
-require 'test/unit'
+require 'minitest/unit'
 
 module MiqDiscovery
 	
-	class TestDiscoveryModules < Test::Unit::TestCase
+	class TestDiscoveryModules < MiniTest::Unit::TestCase
 		def setup
 #			unless $log
 #				$:.push("#{File.dirname(__FILE__)}/../../util")

--- a/lib/test/extract/tc_md5deep.rb
+++ b/lib/test/extract/tc_md5deep.rb
@@ -1,10 +1,10 @@
 $:.push("#{File.dirname(__FILE__)}/../../metadata/util/")
 require 'md5deep'
-require 'test/unit'
+require 'minitest/unit'
 
 module Extract
 	
-class TestVersionInfo < Test::Unit::TestCase
+class TestVersionInfo < MiniTest::Unit::TestCase
 
   def test_md5deep
     md5 = MD5deep.new

--- a/lib/test/extract/tc_registry.rb
+++ b/lib/test/extract/tc_registry.rb
@@ -6,12 +6,12 @@ require 'MiqVm'
 require 'MIQExtract'
 require 'miq-xml'
 require 'digest/md5'
-require 'test/unit'
+require 'minitest/unit'
 
 $qaShare = File.join((Platform::IMPL == :macosx ? "/Volumes" : "/mnt"), "manageiq", "fleecing_test", "images", "virtual_machines")
 
 module Extract
-  class TestRegistry < Test::Unit::TestCase
+  class TestRegistry < MiniTest::Unit::TestCase
     @@vmList = [
       {:vmName => File.join($qaShare, "vmware", "Windows Server 2003 Enterprise Edition/Windows Server 2003 Enterprise Edition.vmx"), :guestOS => "Windows"},
       {:vmName => File.join($qaShare, "vmware", "Debian 40 Server/debian40server.vmx"), :guestOS => "Linux"},

--- a/lib/test/extract/tc_versioninfo.rb
+++ b/lib/test/extract/tc_versioninfo.rb
@@ -1,10 +1,10 @@
 $:.push("#{File.dirname(__FILE__)}/../../metadata/util/win32")
 require 'versioninfo'
-require 'test/unit'
+require 'minitest/unit'
 
 module Extract
 	
-class TestVersionInfo < Test::Unit::TestCase
+class TestVersionInfo < MiniTest::Unit::TestCase
   def setup
     @dataPath = File.join(File.dirname(File.expand_path(__FILE__)), "data")
     @noFile   = File.expand_path(File.join(@dataPath, "nofile.txt"))

--- a/lib/test/test_helper.rb
+++ b/lib/test/test_helper.rb
@@ -1,5 +1,5 @@
 require_relative "../bundler_setup"
-require 'test/unit'
+require 'minitest/unit'
 
 # Push the lib directory onto the load path
 $:.push(File.expand_path(File.join(File.dirname(__FILE__), '..')))

--- a/lib/test/xml/tc_encoding.rb
+++ b/lib/test/xml/tc_encoding.rb
@@ -1,10 +1,10 @@
 $:.push("#{File.dirname(__FILE__)}")
 $:.push("#{File.dirname(__FILE__)}/../../util/")
 require 'rubygems'
-require 'test/unit'
+require 'minitest/unit'
 require 'miq-xml'
 
-class XmlEncoding < Test::Unit::TestCase
+class XmlEncoding < MiniTest::Unit::TestCase
 
   def test_attribute_encoding
     xml = REXML::Document.new("<test/>")

--- a/lib/test/xml/tc_nokogiri.rb
+++ b/lib/test/xml/tc_nokogiri.rb
@@ -1,11 +1,11 @@
 $:.push("#{File.dirname(__FILE__)}")
 $:.push("#{File.dirname(__FILE__)}/../../util/")
 require 'rubygems'
-require 'test/unit'
+require 'minitest/unit'
 require 'miq-xml'
 require 'nokogiri'
 
-class NokogiriXmlMethods < Test::Unit::TestCase
+class NokogiriXmlMethods < MiniTest::Unit::TestCase
 #  require 'xml_base_parser_tests'
 #  include XmlBaseParserTests
 

--- a/lib/test/xml/tc_rexml.rb
+++ b/lib/test/xml/tc_rexml.rb
@@ -1,11 +1,11 @@
 $:.push("#{File.dirname(__FILE__)}")
 $:.push("#{File.dirname(__FILE__)}/../../util/")
 require 'rubygems'
-require 'test/unit'
+require 'minitest/unit'
 require 'miq-xml'
 
 
-class TestBaseXmlMethods < Test::Unit::TestCase
+class TestBaseXmlMethods < MiniTest::Unit::TestCase
   require 'xml_base_parser_tests'
   include XmlBaseParserTests
 

--- a/lib/test/xml/tc_xml.rb
+++ b/lib/test/xml/tc_xml.rb
@@ -1,8 +1,8 @@
 $:.push("#{File.dirname(__FILE__)}/../../util/")
 require 'miq-xml'
-require 'test/unit'
+require 'minitest/unit'
 
-class TestBaseXmlMethods < Test::Unit::TestCase
+class TestBaseXmlMethods < MiniTest::Unit::TestCase
 	def setup
 	end
 	

--- a/lib/test/xml/tc_xmlhash_methods.rb
+++ b/lib/test/xml/tc_xmlhash_methods.rb
@@ -1,11 +1,11 @@
 $:.push("#{File.dirname(__FILE__)}")
 $:.push("#{File.dirname(__FILE__)}/../../util/")
 require 'rubygems'
-require 'test/unit'
+require 'minitest/unit'
 require 'miq-xml'
 require 'xmlsimple'
 
-class TestXmlHashMethods < Test::Unit::TestCase
+class TestXmlHashMethods < MiniTest::Unit::TestCase
   require 'xml_base_parser_tests'
   include XmlBaseParserTests
 

--- a/vmdb/lib/prototype_legacy_helper/test/test_prototype_helper.rb
+++ b/vmdb/lib/prototype_legacy_helper/test/test_prototype_helper.rb
@@ -5,7 +5,7 @@ end
 
 $:.unshift File.expand_path('../../lib', __FILE__)
 
-require 'test/unit'
+require 'minitest/unit'
 require 'action_view'
 require 'action_controller'
 require 'active_model'

--- a/vmdb/lib/resource_feeder/test/atom_feed_test.rb
+++ b/vmdb/lib/resource_feeder/test/atom_feed_test.rb
@@ -1,5 +1,5 @@
 require File.dirname(__FILE__) + '/test_helper'
-class AtomFeedTest < Test::Unit::TestCase
+class AtomFeedTest < MiniTest::Unit::TestCase
   attr_reader :request
 
   def setup

--- a/vmdb/lib/resource_feeder/test/rss_feed_test.rb
+++ b/vmdb/lib/resource_feeder/test/rss_feed_test.rb
@@ -1,5 +1,5 @@
 require File.dirname(__FILE__) + '/test_helper'
-class RssFeedTest < Test::Unit::TestCase
+class RssFeedTest < MiniTest::Unit::TestCase
   def setup
     @records = Array.new(5).fill(Post.new)
     @records.each &:save

--- a/vmdb/lib/resource_feeder/test/test_helper.rb
+++ b/vmdb/lib/resource_feeder/test/test_helper.rb
@@ -30,7 +30,7 @@ class Post
   end
 end
 
-class Test::Unit::TestCase
+class MiniTest::Unit::TestCase
   include ResourceFeeder::Rss, ResourceFeeder::Atom
 
   def render_feed(xml)

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -181,7 +181,7 @@ end
 #  end
 #
 #  # Add another test to the EmsEvent test
-#  class MiqAeServiceEmsEventTest < Test::Unit::TestCase
+#  class MiqAeServiceEmsEventTest < MiniTest::Unit::TestCase
 #
 #    def test_wrap_object_call
 #      e = @klass.new(@o1)


### PR DESCRIPTION
On ruby 2.2, tests were failing.

2.0 uses minitest, but has a backwards compatible test/unit module.
2.2 no longer has this.

Changed over the minitest references to make the tests pass in ruby 2.2 (and 2.0)

/cc @tenderlove @Fryguy @jrafanie 