### PR TITLE
Check for FileDepotFtpAnonymousRedhatDropbox prior to building json

### DIFF
--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -356,8 +356,10 @@ module OpsController::Diagnostics
     else
       log_depot_json = build_empty_log_depot_json
     end
-    rh_dropbox_json = build_rh_dropbox_json
-    log_depot_json.merge!(rh_dropbox_json)
+    if defined? FileDepotFtpAnonymousRedhatDropbox
+      rh_dropbox_json = build_rh_dropbox_json
+      log_depot_json.merge!(rh_dropbox_json)
+    end
 
     render :json => log_depot_json
   end


### PR DESCRIPTION
```FileDepotFtpAnonymousRedhatDropbox```  - the model for RH Dropbox exists only after productization has been applied.

We need a check to determine if ```FileDepotFtpAnonymousRedhatDropbox```  exists prior to getting the RH Dropbox specific json.

https://bugzilla.redhat.com/show_bug.cgi?id=1221821