### PR TITLE
Removed Back to summary screen button from drift screen.

### DIFF
--- a/vmdb/product/toolbars/drift_center_tb.yaml
+++ b/vmdb/product/toolbars/drift_center_tb.yaml
@@ -3,14 +3,7 @@
 #
 ---
 :button_groups:
-- :name: record_summary
-  :items:
-  - :button: show_summary
-    :image: summary-blue
-    :title: 'Show #{@record.name} Summary'
-    :url: '/show'
-    :url_parms: '?id=#{@record.id}'
-- :name: comapre_tasks
+- :name: drift_tasks
   :items:
   - :buttonTwoState: drift_all
     :image: compare_all


### PR DESCRIPTION
This was causing 2 Back to summary screen buttons to be present on Drift screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1221479

@dclarizio please review/test

before:
![screenshot from 2015-05-15 11 14 41](https://cloud.githubusercontent.com/assets/3450808/7655852/89bc7bd6-faf4-11e4-8534-7f215b4ed42d.png)

after:
![screenshot from 2015-05-15 11 22 18](https://cloud.githubusercontent.com/assets/3450808/7655873/aa780fe8-faf4-11e4-9d86-f5c0b8de06cc.png)