### PR TITLE
Check for non MIME ascii content

### DIFF
--- a/vmdb/app/models/filesystem.rb
+++ b/vmdb/app/models/filesystem.rb
@@ -112,6 +112,8 @@ class Filesystem < ActiveRecord::Base
 
   def contents_displayable?
     return false if name.nil?
+    # We will display max 20k characters in the UI textarea
+    return false if size > 20_000
     mime_type = MIME::Types.of(name).first
     return has_contents? && contents.force_encoding("UTF-8").ascii_only? if mime_type.nil?
     !mime_type.binary?

--- a/vmdb/app/models/filesystem.rb
+++ b/vmdb/app/models/filesystem.rb
@@ -111,10 +111,9 @@ class Filesystem < ActiveRecord::Base
   alias contents_available has_contents?
 
   def contents_displayable?
-    name = base_name
     return false if name.nil?
     mime_type = MIME::Types.of(name).first
-    return false if mime_type.nil?
+    return has_contents? && contents.force_encoding("UTF-8").ascii_only? if mime_type.nil?
     !mime_type.binary?
   end
 

--- a/vmdb/spec/factories/filesystem.rb
+++ b/vmdb/spec/factories/filesystem.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :filesystem do
     sequence(:name)     { |n| "filesystem_#{seq_padded_for_sorting(n)}" }
+    size 200
   end
 
   factory :filesystem_conf_file_ascii, :parent => :filesystem do

--- a/vmdb/spec/factories/filesystem.rb
+++ b/vmdb/spec/factories/filesystem.rb
@@ -2,4 +2,37 @@ FactoryGirl.define do
   factory :filesystem do
     sequence(:name)     { |n| "filesystem_#{seq_padded_for_sorting(n)}" }
   end
+
+  factory :filesystem_conf_file_ascii, :parent => :filesystem do
+    name "/etc/nova/nova.conf"
+    contents <<-EOT
+## NB: Unpolished config file
+## This config file was taken directly from the upstream repo, and tweaked just enough to work.
+## It has not been audited to ensure that everything present is either Heat controlled or a mandatory as-is setting.
+## Please submit patches for any setting that should be deleted or Heat-configurable. '"-"'
+##  https://git.openstack.org/cgit/openstack/tripleo-image-elements
+
+
+[DEFAULT]
+
+
+s3_host=192.0.2.10
+ec2_dmz_host=192.0.2.10
+ec2_url=http://192.0.2.10:8773/services/Cloud
+
+my_ip=192.0.2.13
+    EOT
+  end
+
+  factory :filesystem_conf_file_non_ascii, :parent => :filesystem_conf_file_ascii do
+    contents "abc\u{4242}"
+  end
+
+  factory :filesystem_binary_file, :parent => :filesystem do
+    name "periodical/utilities/blue_screen.exe"
+  end
+
+  factory :filesystem_txt_file, :parent => :filesystem do
+    name "periodical/utilities/blue_screen_description.txt"
+  end
 end

--- a/vmdb/spec/models/filesystem_spec.rb
+++ b/vmdb/spec/models/filesystem_spec.rb
@@ -9,6 +9,13 @@ describe Filesystem do
       expect(filesystem.contents_displayable?).to be_false
     end
 
+    it "filesystem content bigger than 20k characters is not displayable" do
+      filesystem = FactoryGirl.create(:filesystem_conf_file_ascii)
+      filesystem.stub(:size).and_return(40_000)
+
+      expect(filesystem.contents_displayable?).to be_false
+    end
+
     it "non MIME .conf ascii file is displayable" do
       filesystem = FactoryGirl.create(:filesystem_conf_file_ascii)
 

--- a/vmdb/spec/models/filesystem_spec.rb
+++ b/vmdb/spec/models/filesystem_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe Filesystem do
+  context "#contents_displayable?" do
+    it "filesystem with missing name is not displayable" do
+      filesystem = FactoryGirl.create(:filesystem_conf_file_ascii)
+      filesystem.stub(:name).and_return(nil)
+
+      expect(filesystem.contents_displayable?).to be_false
+    end
+
+    it "non MIME .conf ascii file is displayable" do
+      filesystem = FactoryGirl.create(:filesystem_conf_file_ascii)
+
+      expect(filesystem.contents_displayable?).to be_true
+    end
+
+    it "non MIME .conf file, with non ascii characters is not displayable" do
+      filesystem = FactoryGirl.create(:filesystem_conf_file_non_ascii)
+
+      expect(filesystem.contents_displayable?).to be_false
+    end
+
+    it "non MIME .conf file, without content is not displayable" do
+      filesystem = FactoryGirl.create(:filesystem_conf_file_ascii)
+      filesystem.stub(:has_contents?).and_return(false)
+
+      expect(filesystem.contents_displayable?).to be_false
+    end
+
+    it "MIME .exe binary file is not displayable" do
+      filesystem = FactoryGirl.create(:filesystem_binary_file)
+
+      expect(filesystem.contents_displayable?).to be_false
+    end
+
+    it "MIME .txt non binary file is displayable" do
+      filesystem = FactoryGirl.create(:filesystem_txt_file)
+
+      expect(filesystem.contents_displayable?).to be_true
+    end
+  end
+end


### PR DESCRIPTION
Some OpenStack files are not MIME types, but we want to show them.
E.g. .conf or .ini. Adding check for ascii files if they are not
MIME type.

https://bugzilla.redhat.com/show_bug.cgi?id=1222508