### PR TITLE
Add public/pictures/ to .gitignore

### DIFF
--- a/vmdb/.gitignore
+++ b/vmdb/.gitignore
@@ -56,6 +56,7 @@ public/dhtmlx_test_cal.html
 public/test_grid.xml
 public/test_grid-0.xml
 public/upload
+public/pictures/
 
 # public/dhtmlx/
 public/dhtmlx/dhtmlxtoolbar.js.orig


### PR DESCRIPTION
The directory gets created and filled with images on *some* ocassions, that leads me to believe it should be gitignored as well.