### PR TITLE
Fix setting of @display to 'main' when Host/Firewall Rules page

### DIFF
--- a/vmdb/app/controllers/host_controller.rb
+++ b/vmdb/app/controllers/host_controller.rb
@@ -213,6 +213,7 @@ class HostController < ApplicationController
   end
 
   def firewall_rules
+    @display = "main"
     show_association('firewall_rules', 'Firewall Rules', 'firewallrule', :firewall_rules, FirewallRule)
   end
 


### PR DESCRIPTION
When user wants to see Host/Security/Firewall Rules and previously
displayed information changed the value of `@display` then value 'main'
has to be assigned to `@display`

https://bugzilla.redhat.com/show_bug.cgi?id=1213044