### PR TITLE
Display correct backtraces for invalid automate code

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -103,23 +103,11 @@ module MiqAeEngine
         msg = "Method exited with rc=#{verbose_rc(rc)}"
       rescue => err
         $miq_ae_logger.error("Method exec failed because (#{err.class}:#{err.message})")
-        rc = 16
+        rc = MIQ_ABORT
         msg = "Method execution failed"
       end
 
-      case rc
-      when MIQ_OK
-        $miq_ae_logger.info(msg)
-      when MIQ_WARN
-        $miq_ae_logger.warn(msg)
-      when MIQ_STOP
-        raise MiqAeException::StopInstantiation,  msg
-      when MIQ_ABORT
-        raise MiqAeException::AbortInstantiation, msg
-      else
-        raise MiqAeException::UnknownMethodRc,    msg
-      end
-      return rc
+      process_ruby_method_results(rc, msg)
     end
 
     MIQ_OK    = 0
@@ -226,7 +214,7 @@ RUBY
         msg = "Method exited with rc=#{verbose_rc(rc)}"
       rescue => err
         $miq_ae_logger.error("Method exec failed because (#{err.class}:#{err.message})")
-        rc = 16
+        rc = MIQ_ABORT
         msg = "Method execution failed"
       end
       return rc, msg

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -153,12 +153,12 @@ module MiqAeEngine
       rescue MiqAeException::StopInstantiation => err
         $miq_ae_logger.info("Stopping instantiation because [#{err.message}]")
         delete(obj)
+      rescue MiqAeException::UnknownMethodRc => err
+        $miq_ae_logger.error("Aborting instantiation (unknown method return code) because [#{err.message}]")
+        raise
       rescue MiqAeException::AbortInstantiation => err
         $miq_ae_logger.info("Aborting instantiation because [#{err.message}]")
         raise
-      rescue MiqAeException::UnknownMethodRc => err
-        $miq_ae_logger.error("Aborting instantiation (unknown method return code) because [#{err.message}]")
-        raise MiqAeException::AbortInstantiation, err.message
       ensure
         @current.pop if pushed
       end

--- a/vmdb/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/vmdb/lib/miq_automation_engine/miq_ae_exception.rb
@@ -13,7 +13,7 @@ module MiqAeException
     class ServiceNotFound      < MiqAeEngineError; end
     class StopInstantiation    < MiqAeEngineError; end
     class AbortInstantiation   < MiqAeEngineError; end
-    class UnknownMethodRc      < MiqAeEngineError; end
+    class UnknownMethodRc      < AbortInstantiation; end
     class ObjectNotFound       < MiqAeEngineError; end
     class InvalidPathFormat    < MiqAeEngineError; end
     class InvalidCollection    < MiqAeEngineError; end


### PR DESCRIPTION
When automate has invalid code, it throws an exception. But the exception's text and backtrace do not contain any references to the original code.

For end users, accessing the automate.log can reveal the issue.
For travis failures, it requires much more work to track down the culprit for an error.

You can see the difference by tweaking [MiqAeServiceServiceSpec:85](https://github.com/ManageIQ/manageiq/blob/master/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb#L85-L90):

```ruby
      it "validates the parent service" do
        method = "$evm.root['service'].parent_service = 'validate'"
        @ae_method.update_attributes(:data => method)

        exception_raised = false
        begin
          invoke_ae
        rescue MiqAeException::AbortInstantiation => e
          puts "#{e.class.name}: #{e.message}"
          puts e.backtrace
          exception_raised = true
        end
        expect(exception_raised).to be_true
      end
```

Please look at the first and last lines of the stacktrace.
Both show the same exception, but the after stack trace show the actual error on the first line and the location of the code (in the automate script) in the last line.

Before:
```
./bin/rspec spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb:85

MiqAeException::AbortInstantiation: Method exited with rc=Unknown RC: [1]
/Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb:163:in `rescue in instantiate'
/Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb:166:in `instantiate'
/Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb:73:in `_instantiate'
/Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_workspace.rb:68:in `instantiate'
/Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb:26:in `block in instantiate'
/Users/kbrock/src/manageiq/lib/util/extensions/miq-benchmark.rb:12:in `realtime_store'
/Users/kbrock/src/manageiq/lib/util/extensions/miq-benchmark.rb:31:in `realtime_block'
/Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_engine.rb:26:in `instantiate'
/Users/kbrock/src/manageiq/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb:19:in `invoke_ae'
/Users/kbrock/src/manageiq/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb:91:in `block (3 levels) in <module:MiqAeServiceServiceSpec>'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:114:in `instance_eval'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:114:in `block in run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:111:in `run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:390:in `block in run_examples'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:386:in `map'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:386:in `run_examples'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:371:in `run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `block in run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `map'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `map'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `block in run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/reporter.rb:58:in `report'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:25:in `run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
/Users/kbrock/.gem/ruby/2.1.5/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
```

After
```
./bin/rspec spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb:85

MiqAeException::AbortInstantiation: Method exited with rc=Unknown RC: [1]
(druby://127.0.0.1:61506) /Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service.rb:74:in `block in parent_service=': service must be a MiqAeServiceService (ArgumentError)
from (druby://127.0.0.1:61506) /Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb:259:in `ar_method'
from (druby://127.0.0.1:61506) /Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb:270:in `ar_method'
from (druby://127.0.0.1:61506) /Users/kbrock/src/manageiq/vmdb/lib/miq_automation_engine/service_models/miq_ae_service_service.rb:72:in `parent_service='
from (druby://127.0.0.1:61506) /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/drb/drb.rb:1588:in `perform_without_block'
from (druby://127.0.0.1:61506) /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/drb/drb.rb:1548:in `perform'
from (druby://127.0.0.1:61506) /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/drb/drb.rb:1626:in `block (2 levels) in main_loop'
from (druby://127.0.0.1:61506) /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/drb/drb.rb:1622:in `loop'
from (druby://127.0.0.1:61506) /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/drb/drb.rb:1622:in `block in main_loop'
from (druby://127.0.0.1:61506) /Users/kbrock/src/manageiq/vmdb/lib/extensions/ar_thread.rb:22:in `block in start_with_release'
from <code: $evm.root['service'].parent_service = 'validate'>:1:in `<main>'
```

/cc @gmcculloug @mkanoor can you take a quick look to see if this is worth investigating?
Marked WIP only because I don't want to merge without some larger discussion
