### PR TITLE
Fix infinite paging in saved report detail

### DIFF
--- a/vmdb/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/vmdb/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -41,7 +41,7 @@
               - else
                 = image_tag('/images/toolbars/first.png', :class => "dimmed small")
                 = image_tag('/images/toolbars/previous.png', :class => "dimmed small")
-              - if pages[:perpage] < pages[:items]
+              - if pages[:current] < pages[:total]
                 = link_to(image_tag('/images/toolbars/next.png', :class => "rollover small"),
                           {:action => action,
                            :page   => pages[:current] + 1},


### PR DESCRIPTION
This reverts commit a3eec76: "Disable next and last pagination buttons when all the report data is on a single page"

The original commit was to fix bz1182360, but this lead to infinite number of pages. The underlying issue (from that bz) has apparently been fixed in the meantime (could not reproduce), so this is no longer necessary.

https://bugzilla.redhat.com/show_bug.cgi?id=1205402