### PR TITLE
Stack summary page: add link to orchestration template

### DIFF
--- a/vmdb/app/controllers/catalog_controller.rb
+++ b/vmdb/app/controllers/catalog_controller.rb
@@ -263,7 +263,7 @@ class CatalogController < ApplicationController
       set_form_locals_for_sysprep
     end
 
-    render :layout => "explorer"
+    render :layout => "explorer", :action => "explorer"
   end
 
   def set_form_locals_for_sysprep
@@ -820,6 +820,20 @@ class CatalogController < ApplicationController
     when "save"
       service_dialog_from_ot_submit_save
     end
+  end
+
+  def ot_show
+    assert_privileges("orchestration_templates_view")
+    id = params.delete(:id)
+    ot = OrchestrationTemplate.find_by_id(id)
+    self.x_active_tree = :ot_tree
+    self.x_active_accord = 'ot'
+    x_tree_init(:ot_tree, :ot, "OrchestrationTemplate") unless x_tree
+    ot_type = ot.type == "OrchestrationTemplateHot" ? "othot" : "otcfn"
+    x_tree[:open_nodes].push("xx-#{ot_type}") unless x_tree[:open_nodes].include?("xx-#{ot_type}")
+    self.x_node = "ot-#{to_cid(ot.id)}"
+    x_tree[:open_nodes].push(self.x_node)
+    explorer
   end
 
   private

--- a/vmdb/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/vmdb/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -58,7 +58,12 @@ module OrchestrationStackHelper::TextualSummary
     template = @record.orchestration_template
     return nil if template.nil?
     label = ui_lookup(:table => "orchestration_template")
-    {:label => label, :image => "orchestration_template", :value => template.name}
+    h = {:label => label, :image => "orchestration_template", :value => template.name}
+    if role_allows(:feature => "orchestration_templates_view")
+      h[:title] = "Show this Orchestration Template"
+      h[:link] = url_for(:controller => 'catalog', :action => 'ot_show', :id => template.id)
+    end
+    h
   end
 
   def textual_instances

--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -165,6 +165,7 @@ Vmdb::Application.routes.draw do
         download_data
         explorer
         ot_edit
+        ot_show
         show
       ),
       :post => %w(


### PR DESCRIPTION
The orchestration stack view showing the new link to orchestration template:
![os](https://cloud.githubusercontent.com/assets/6648365/8203890/40bc4bae-14e5-11e5-8ca2-79f699a71303.jpg)

The orchestration template shown:
![ot](https://cloud.githubusercontent.com/assets/6648365/8203898/4ed2e522-14e5-11e5-8a9f-66ea2f8baa15.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1221754