### PR TITLE
Added missing "Smart Management" box on Container Provider summary.

### DIFF
--- a/vmdb/app/helpers/ems_container_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_container_helper/textual_summary.rb
@@ -22,6 +22,11 @@ module EmsContainerHelper::TextualSummary
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
+  def textual_group_smart_management
+    items = %w{zone}
+    items.collect { |m| self.send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #


### PR DESCRIPTION
- Added missing textual_group_smart_management box on Container Provider summary. Tags can be added to this box once Container Providers have tagging support.

Fixed an error caused by https://github.com/ManageIQ/manageiq/pull/2929 to add Smart Management box to provider summary screens:
[----] F, [2015-05-19T12:37:18.073725 #9856:725e98] FATAL -- : Error caught: [NameError] undefined local variable or method `textual_group_smart_management' for #<#<Class:0x0000000c396d20>:0x0000000f4a2e00>
/home/hkataria/dev/manageiq/vmdb/app/views/shared/views/ems_common/_main.html.haml:8:in `_app_views_shared_views_ems_common__main_html_haml___2349708870252420787_9439700'

after fix:
![screenshot from 2015-05-19 12 43 07](https://cloud.githubusercontent.com/assets/3450808/7708678/4cbd3ae8-fe25-11e4-9df9-0c68d5c4a19b.png)
