### PR TITLE
[WIP] Add the git based gems to the load path for the automate ruby method.

### DIFF
--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -140,6 +140,11 @@ begin
   Socket.do_not_reverse_lookup = true  # turn off reverse DNS resolution
 
   require 'drb'
+  # HACK: inject each of the bundler git based gem lib paths from the current
+  # process into the preamble executed in the ruby method subprocess.
+  # Ideally, we should teach rubygems to be able to find the bundler git gems
+  # or have a Gemfile/bundle for automate.
+  #{$LOAD_PATH.grep(/bundler\/gems/).each_with_object("") { |path, string| string << "$LOAD_PATH << '#{path}'\n  " } }
 
   MIQ_OK    = 0
   MIQ_WARN  = 4


### PR DESCRIPTION
Currently, we have several git based gems installed via bundler that automate
ruby methods cannot find because it's run outside of a bundle environment.

Inject each of the bundler git based gem lib paths from the current
process into the preamble executed in the ruby method subprocess.

Ideally, we should teach rubygems to be able to find the bundler git gems
or have a Gemfile/bundle for automate.

https://bugzilla.redhat.com/show_bug.cgi?id=1223042

This produces the an example snippet below in the preamble to be
executed in the ruby method subprocess.

Note, the path below depends where the bundler git gems are located
but the parent process knows this information and can populate the
load path correctly for the child process.

```ruby
  ...
  require 'drb'
  # HACK: inject each of the bundler git based gem lib paths from the current
  # process into the preamble executed in the ruby method subproces.
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/jquery-rjs-33e0fc1c0b25/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/jquery-rjs-33e0fc1c0b25/vendor'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/ziya-597cc777c24f/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/WinRM-f4fa33eba82d/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/soap4r-514bdbe1d0bc/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/ruport-3ba69305f42e/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rubywbem-f2c18cbe14a4/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rubyrep-fd866d906fcb/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/handsoap-daec1277652f/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/railties/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rest-client-08480eb86aef/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/activeresource/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/actionwebservice-fcb04f3fa857/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/activerecord/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/actionmailer/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/actionpack/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/activemodel/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/activesupport/lib'
  $LOAD_PATH << '/opt/rubies/ruby-2.0.0-p643/lib/ruby/gems/2.0.0/bundler/gems/rails-8f014fba21f9/actionpack/lib/action_controller/vendor/html-scanner'
  ...
```