### PR TITLE
Removed handpointer on unclickable table items

### DIFF
--- a/vmdb/app/views/ops/rhn/_server_table.html.haml
+++ b/vmdb/app/views/ops/rhn/_server_table.html.haml
@@ -42,7 +42,7 @@
                                                   true);")
     %br
     #form_div
-      %table.table.table-striped.table-bordered.table-hover
+      %table.table.table-striped.table-bordered
         %thead
           %th
             = check_box_tag('masterToggle', 1, @check_all,


### PR DESCRIPTION
Configure -> Configuration -> CFME Region (in accordion) settings -> Red Hat Updates tab