### PR TITLE
Only use io-extra when supported

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -26,7 +26,6 @@ gem "ffi",                  "~>1.9.3",        :require => false
 gem "ffi-vix_disk_lib",     "~>1.0.1",        :require => false  # used by lib/VixDiskLib
 gem "fog",                  "~>1.29.0",       :require => false
 gem "httpclient",           "~>2.5.3",        :require => false
-gem "io-extra",             "~>1.2.8",        :require => false
 gem "linux_admin",          ">=0.10.1", "<1", :require => false
 gem "log4r",                "=1.1.8",         :require => false
 gem "memoist",              "~>0.11.0",       :require => false

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -1,8 +1,6 @@
 require_relative 'MiqBlockDevOps'
 
-if Platform::OS == :unix
-  require 'io/extra'
-end
+require 'io/extra' if Platform::OS == :unix
 
 class RawBlockIO
 

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -1,4 +1,3 @@
-require 'fcntl'
 require_relative 'MiqBlockDevOps'
 
 class RawBlockIO
@@ -11,8 +10,11 @@ class RawBlockIO
 
     @rawDisk_file = File.open(filename, mode)
 
-    # Enable directio (raw)
-    @rawDisk_file.fcntl(Fcntl::F_SETFL, File::DIRECT)
+    # Enable directio (raw) if supported
+    if defined? File::DIRECT
+      require 'fcntl'
+      @rawDisk_file.fcntl(Fcntl::F_SETFL, File::DIRECT)
+    end
 
     @blockSize      = 512
     @filename       = filename

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -1,12 +1,10 @@
 require_relative 'MiqBlockDevOps'
 
-require 'io/extra' if Platform::OS == :unix
-
 class RawBlockIO
 
   MIN_SECTORS_TO_CACHE = 64
 
-  def initialize(filename, mode="r")
+  def initialize(filename, mode=File::RDONLY|File::DIRECT)
     # We must start with a block special file
     raise "RawBlockIO: #{filename} is not a blockSpecial file" unless File.stat(filename).ftype == 'blockSpecial'
 
@@ -21,10 +19,6 @@ class RawBlockIO
     @endByteAddr    = @size - 1
     @lbaEnd         = @sizeInBlocks - 1
     @seekPos        = 0
-
-    if Platform::OS == :unix
-      @rawDisk_file.directio = IO::DIRECTIO_ON # Enable directio (raw)
-    end
 
     $log.debug "RawBlockIO: opened #{@filename}, size = #{@size} (#{@sizeInBlocks} blocks)"
   end

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -1,14 +1,18 @@
+require 'fcntl'
 require_relative 'MiqBlockDevOps'
 
 class RawBlockIO
 
   MIN_SECTORS_TO_CACHE = 64
 
-  def initialize(filename, mode = File::RDONLY | File::DIRECT)
+  def initialize(filename, mode = "r")
     # We must start with a block special file
     raise "RawBlockIO: #{filename} is not a blockSpecial file" unless File.stat(filename).ftype == 'blockSpecial'
 
     @rawDisk_file = File.open(filename, mode)
+
+    # Enable directio (raw)
+    @rawDisk_file.fcntl(Fcntl::F_SETFL, File::DIRECT)
 
     @blockSize      = 512
     @filename       = filename

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -1,8 +1,8 @@
+require_relative 'MiqBlockDevOps'
 
-$:.push("#{File.dirname(__FILE__)}")
-
-require 'io/extra'
-require 'MiqBlockDevOps'
+if Platform::OS == :unix
+  require 'io/extra'
+end
 
 class RawBlockIO
 
@@ -24,8 +24,9 @@ class RawBlockIO
     @lbaEnd         = @sizeInBlocks - 1
     @seekPos        = 0
 
-    # Enable directio (raw)
-    @rawDisk_file.directio = IO::DIRECTIO_ON
+    if Platform::OS == :unix
+      @rawDisk_file.directio = IO::DIRECTIO_ON # Enable directio (raw)
+    end
 
     $log.debug "RawBlockIO: opened #{@filename}, size = #{@size} (#{@sizeInBlocks} blocks)"
   end
@@ -33,11 +34,11 @@ class RawBlockIO
   def read(len)
     return nil if @seekPos >= @endByteAddr
     len = @endByteAddr - @seekPos if (@seekPos + len) > @endByteAddr
-      
+
     startSector, startOffset = @seekPos.divmod(@blockSize)
     endSector = (@seekPos+len-1)/@blockSize
     numSector = endSector - startSector + 1
-            
+
     rBuf = breadCached(startSector, numSector)
     @seekPos += len
 
@@ -47,7 +48,7 @@ class RawBlockIO
   def write(buf, len)
     return nil if @seekPos >= @endByteAddr
     len = @endByteAddr - @seekPos if (@seekPos + len) > @endByteAddr
-      
+
     startSector, startOffset = @seekPos.divmod(@blockSize)
     endSector = (@seekPos+len-1)/@blockSize
     numSector = endSector - startSector + 1
@@ -86,7 +87,7 @@ class RawBlockIO
     # $log.debug "RawBlockIO.bread: startSector = #{startSector}, numSectors = #{numSectors}, @lbaEnd = #{@lbaEnd}"
     return nil if startSector > @lbaEnd
     numSectors = @sizeInBlocks - startSector if (startSector + numSectors) > @sizeInBlocks
-      
+
     @rawDisk_file.sysseek(startSector * @blockSize, IO::SEEK_SET)
     @rawDisk_file.sysread(numSectors * @blockSize, @cache)
   end
@@ -109,12 +110,12 @@ class RawBlockIO
       endSector     = startSector + sectorsRead - 1
       @cacheRange   = Range.new(startSector, endSector)
     end
-      
+
     sectorOffset = startSector  - @cacheRange.first
     bufferOffset = sectorOffset * @blockSize
     length       = numSectors   * @blockSize
     # $log.debug "RawBlockIO.breadCached: bufferOffset = #{bufferOffset}, length = #{length}"
-      
+
     return @cache[bufferOffset, length]
   end
 

--- a/lib/disk/modules/RawBlockIO.rb
+++ b/lib/disk/modules/RawBlockIO.rb
@@ -4,7 +4,7 @@ class RawBlockIO
 
   MIN_SECTORS_TO_CACHE = 64
 
-  def initialize(filename, mode=File::RDONLY|File::DIRECT)
+  def initialize(filename, mode = File::RDONLY | File::DIRECT)
     # We must start with a block special file
     raise "RawBlockIO: #{filename} is not a blockSpecial file" unless File.stat(filename).ftype == 'blockSpecial'
 


### PR DESCRIPTION
This patch modifies the RawBlockIO.rb file so that it only requires io-extra and uses directio on unix platforms. Also, it uses require_relative instead of mangling $LOAD_PATH.

Basically, this means it won't try to use io-extra if you're using JRuby or on Windows.