### PR TITLE
Flash message fixed for Service Dialogs Edit

### DIFF
--- a/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -192,13 +192,14 @@ module MiqAeCustomizationController::Dialogs
     assert_privileges("dialog_edit")
     case params[:button]
     when 'cancel'
+      if params[:id]
+        dialog_label = session[:edit][:current][:label]
+        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "Dialog"), :name => dialog_label})
+      else
+        add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "Dialog"))
+      end
       @edit = session[:edit] = nil # clean out the saved info
       self.x_active_tree = :dialogs_tree
-      if !@record || @record.id.blank?
-        add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model=>"Dialog"))
-      else
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model=>ui_lookup(:model=>"Dialog"), :name=>@record.label})
-      end
       get_node_info
       replace_right_cell(x_node)
 


### PR DESCRIPTION
Corrected flash message text to Edit... when cancelling out of Service Dialog Edit mode.

https://bugzilla.redhat.com/show_bug.cgi?id=1178213