### PR TITLE
Removed load_edit call in db_gc_collection

### DIFF
--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -399,7 +399,6 @@ module OpsController::Diagnostics
   end
 
   def db_gc_collection
-    return unless load_edit("dbbackup_edit__new","replace_cell__explorer")
     begin
       MiqSchedule.run_adhoc_db_gc(:userid => session[:userid])
     rescue StandardError => bang


### PR DESCRIPTION
The db diagnostics form has been converted to angular with all instances of ```@edit``` removed. Therefore ```load_edit``` is not relevant anymore.

https://bugzilla.redhat.com/show_bug.cgi?id=1223114