### PR TITLE
[WIP] Move validate specs to proper class

### DIFF
--- a/vmdb/spec/factories/miq_dialog.rb
+++ b/vmdb/spec/factories/miq_dialog.rb
@@ -46,6 +46,26 @@ FactoryGirl.define do
         }
       end
     end
+
+    factory :miq_dialog_provision_with_required_method do
+      content do
+        {
+          :dialogs => {
+            :hardware => {
+              :fields      => {
+                :memory_reserve => {
+                  :description       => "Description",
+                  :required_method   => :some_required_method,
+                  :required          => true,
+                  :display           => :edit,
+                  :data_type         => :integer,
+                }
+              }
+            }
+          }
+        }
+      end
+    end
   end
 
   factory :miq_dialog_host_provision, :parent => :miq_dialog do

--- a/vmdb/spec/factories/miq_dialog.rb
+++ b/vmdb/spec/factories/miq_dialog.rb
@@ -26,46 +26,6 @@ FactoryGirl.define do
         }
       }
     end
-
-    factory :miq_dialog_provision_with_validation_method do
-      content do
-        {
-          :dialogs => {
-            :hardware => {
-              :fields      => {
-                :memory_reserve => {
-                  :description       => "Memory (MB)",
-                  :required          => false,
-                  :display           => :edit,
-                  :data_type         => :integer,
-                  :validation_method => :some_validation_method,
-                }
-              }
-            }
-          }
-        }
-      end
-    end
-
-    factory :miq_dialog_provision_with_required_method do
-      content do
-        {
-          :dialogs => {
-            :hardware => {
-              :fields      => {
-                :memory_reserve => {
-                  :description       => "Description",
-                  :required_method   => :some_required_method,
-                  :required          => true,
-                  :display           => :edit,
-                  :data_type         => :integer,
-                }
-              }
-            }
-          }
-        }
-      end
-    end
   end
 
   factory :miq_dialog_host_provision, :parent => :miq_dialog do

--- a/vmdb/spec/factories/miq_request_workflow.rb
+++ b/vmdb/spec/factories/miq_request_workflow.rb
@@ -4,9 +4,8 @@ FactoryGirl.define do
   end
 
   factory :miq_provision_workflow, :class => MiqProvisionWorkflow, :parent => :miq_request_workflow do
-    factory_dialog :miq_dialog_provision
     initialize_with do
-      new({:provision_dialog_name => create(factory_dialog).name}, create(:user_admin).userid)
+      new({:provision_dialog_name => create(:miq_dialog_provision).name}, create(:user_admin).userid)
     end
   end
 

--- a/vmdb/spec/models/miq_provision_vmware_workflow_spec.rb
+++ b/vmdb/spec/models/miq_provision_vmware_workflow_spec.rb
@@ -31,44 +31,5 @@ describe MiqProvisionVmwareWorkflow do
 
       MiqProvisionVmwareWorkflow.new({}, admin.userid)
     end
-
-    context '#validate' do
-      before do
-        template = FactoryGirl.create(:template_vmware,
-                                      :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication)
-        )
-        @dlg = {
-          :description => 'Customize',
-          :fields      => {
-            :sysprep_organization => {
-              :description     => 'Organization',
-              :required_method => :validate_sysprep_field,
-              :required        => true,
-              :display         => :hide,
-              :data_type       => :string,
-              :read_only       => true
-            }
-          },
-          :display     => :show
-        }
-        @values = {
-          :src_vm_id            => [template.id, template.name],
-          :sysprep_organization => nil,
-          :sysprep_enabled      => %w(fields Specification)
-        }
-        @wf = MiqProvisionVmwareWorkflow.new({}, admin.userid, :src_vm_id => [template.id])
-        @wf.instance_variable_set("@dialogs", :dialogs => {:customize => @dlg})
-      end
-
-      it 'when hidden' do
-        expect(@wf.validate(@values)).to be_true
-      end
-
-      it 'when visible' do
-        @dlg[:fields][:sysprep_organization][:display] = :edit
-        expect(@wf.validate(@values)).to be_false
-        expect(@dlg.fetch_path(:fields, :sysprep_organization, :error)).to eq("'Customize/Organization' is required")
-      end
-    end
   end
 end

--- a/vmdb/spec/models/miq_request_workflow_spec.rb
+++ b/vmdb/spec/models/miq_request_workflow_spec.rb
@@ -2,41 +2,48 @@ require "spec_helper"
 
 describe MiqRequestWorkflow do
   context "#validate" do
-    context "validation_method" do
-      let(:wf_without_validation) { FactoryGirl.build(:miq_provision_workflow) }
-      let(:wf_with_validation)    { FactoryGirl.build(:miq_provision_workflow, :factory_dialog => :miq_dialog_provision_with_validation_method) }
+    let(:dialog)   { workflow.instance_variable_get(:@dialogs) }
+    let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
 
+    context "validation_method" do
       it "skips validation if no validation_method is defined" do
-        expect(wf_without_validation.get_all_dialogs[:customize][:fields][:root_password][:validation_method]).to eq(nil)
-        expect(wf_without_validation.validate({})).to be_true
+        expect(workflow.get_all_dialogs[:customize][:fields][:root_password][:validation_method]).to eq(nil)
+        expect(workflow.validate({})).to be_true
       end
 
       it "calls the validation_method if defined" do
-        expect(wf_with_validation).to receive(:respond_to?).with(:some_validation_method).and_return(true)
-        expect(wf_with_validation).to receive(:some_validation_method).once
-        expect(wf_with_validation.validate({})).to be_true
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :validation_method, :some_validation_method)
+
+        expect(workflow).to receive(:respond_to?).with(:some_validation_method).and_return(true)
+        expect(workflow).to receive(:some_validation_method).once
+        expect(workflow.validate({})).to be_true
       end
 
       it "returns false when validation fails" do
-        expect(wf_with_validation).to receive(:respond_to?).with(:some_validation_method).and_return(true)
-        expect(wf_with_validation).to receive(:some_validation_method).and_return("Some Error")
-        expect(wf_with_validation.validate({})).to be_false
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :validation_method, :some_validation_method)
+
+        expect(workflow).to receive(:respond_to?).with(:some_validation_method).and_return(true)
+        expect(workflow).to receive(:some_validation_method).and_return("Some Error")
+        expect(workflow.validate({})).to be_false
       end
     end
 
     context 'required_method is only run on visible fields' do
-      let(:wf_with_required_method) { FactoryGirl.build(:miq_provision_workflow, :factory_dialog => :miq_dialog_provision_with_required_method) }
-
       it "field hidden" do
-        wf_with_required_method.instance_variable_get(:@dialogs).store_path(:dialogs, :hardware, :fields, :memory_reserve, :display, :hide)
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :required_method, :some_required_method)
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :required, true)
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :display, :hide)
 
-        expect(wf_with_required_method).to_not receive(:some_required_method)
-        expect(wf_with_required_method.validate({})).to be_true
+        expect(workflow).to_not receive(:some_required_method)
+        expect(workflow.validate({})).to be_true
       end
 
       it "field visible" do
-        expect(wf_with_required_method).to receive(:some_required_method).and_return("Some Error")
-        expect(wf_with_required_method.validate({})).to be_false
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :required_method, :some_required_method)
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :required, true)
+
+        expect(workflow).to receive(:some_required_method).and_return("Some Error")
+        expect(workflow.validate({})).to be_false
       end
     end
   end

--- a/vmdb/spec/models/miq_request_workflow_spec.rb
+++ b/vmdb/spec/models/miq_request_workflow_spec.rb
@@ -12,14 +12,14 @@ describe MiqRequestWorkflow do
       end
 
       it "calls the validation_method if defined" do
-        wf_with_validation.should_receive(:respond_to?).with(:some_validation_method).and_return(true)
-        wf_with_validation.should_receive(:some_validation_method).once
+        expect(wf_with_validation).to receive(:respond_to?).with(:some_validation_method).and_return(true)
+        expect(wf_with_validation).to receive(:some_validation_method).once
         expect(wf_with_validation.validate({})).to be_true
       end
 
       it "returns false when validation fails" do
-        wf_with_validation.should_receive(:respond_to?).with(:some_validation_method).and_return(true)
-        wf_with_validation.should_receive(:some_validation_method).and_return("Some Error")
+        expect(wf_with_validation).to receive(:respond_to?).with(:some_validation_method).and_return(true)
+        expect(wf_with_validation).to receive(:some_validation_method).and_return("Some Error")
         expect(wf_with_validation.validate({})).to be_false
       end
     end


### PR DESCRIPTION
```#validate``` is defined on MiqRequestWorkflow and should be moved to reflect that.

cc @lfu 

Depends on #2920