### PR TITLE
containers: add specific kubernetes entities

### DIFF
--- a/vmdb/app/models/container.rb
+++ b/vmdb/app/models/container.rb
@@ -1,4 +1,6 @@
 class Container < ActiveRecord::Base
   include ReportableMixin
+  include NewWithTypeStiMixin
+
   belongs_to :container_group
 end

--- a/vmdb/app/models/container_group.rb
+++ b/vmdb/app/models/container_group.rb
@@ -1,6 +1,8 @@
 class ContainerGroup < ActiveRecord::Base
   include CustomAttributeMixin
   include ReportableMixin
+  include NewWithTypeStiMixin
+
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :restart_policy, :dns_policy
 

--- a/vmdb/app/models/container_group_kubernetes.rb
+++ b/vmdb/app/models/container_group_kubernetes.rb
@@ -1,0 +1,3 @@
+class ContainerGroupKubernetes < ContainerGroup
+  alias_attribute :pod_uid, :ems_ref
+end

--- a/vmdb/app/models/container_kubernetes.rb
+++ b/vmdb/app/models/container_kubernetes.rb
@@ -1,0 +1,3 @@
+class ContainerKubernetes < Container
+  delegate :pod_uid, :to => :container_group
+end

--- a/vmdb/app/models/container_node.rb
+++ b/vmdb/app/models/container_node.rb
@@ -1,5 +1,7 @@
 class ContainerNode < ActiveRecord::Base
   include ReportableMixin
+  include NewWithTypeStiMixin
+
   # :name, :uid, :creation_timestamp, :resource_version
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many   :container_groups

--- a/vmdb/app/models/container_node_kubernetes.rb
+++ b/vmdb/app/models/container_node_kubernetes.rb
@@ -1,0 +1,2 @@
+class ContainerNodeKubernetes < ContainerNode
+end

--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -79,6 +79,7 @@ module EmsRefresh::Parsers
       new_result = parse_base_item(node)
 
       new_result.merge!(
+        :type             => 'ContainerNodeKubernetes',
         :identity_infra   => node.spec.externalID,
         :identity_machine => node.status.nodeInfo.machineID,
         :identity_system  => node.status.nodeInfo.systemUUID
@@ -143,6 +144,7 @@ module EmsRefresh::Parsers
       new_result = parse_base_item(pod)
 
       new_result.merge!(
+        :type                 => 'ContainerGroupKubernetes',
         :restart_policy       => pod.spec.restartPolicy,
         :dns_policy           => pod.spec.dnsPolicy,
         :ipaddress            => pod.status.podIP,
@@ -273,6 +275,7 @@ module EmsRefresh::Parsers
 
     def parse_container(container, pod_id)
       {
+        :type          => 'ContainerKubernetes',
         :ems_ref       => "#{pod_id}_#{container.name}_#{container.image}",
         :name          => container.name,
         :image         => container.image,

--- a/vmdb/db/migrate/20150326015341_add_container_group_node_relationship.rb
+++ b/vmdb/db/migrate/20150326015341_add_container_group_node_relationship.rb
@@ -1,4 +1,4 @@
-class ContainerGroup < ActiveRecord::Migration
+class AddContainerGroupNodeRelationship < ActiveRecord::Migration
   def change
     add_column :container_groups, :container_node_id, :bigint
   end

--- a/vmdb/db/migrate/20150522161336_add_container_entities_type.rb
+++ b/vmdb/db/migrate/20150522161336_add_container_entities_type.rb
@@ -1,0 +1,34 @@
+class AddContainerEntitiesType < ActiveRecord::Migration
+  class ContainerNode < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Container < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ContainerGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    add_column :container_nodes, :type, :string
+    say_with_time("Update ContainerNodes type to ContainerNodeKubernetes") do
+      ContainerNode.update_all(:type => "ContainerNodeKubernetes")
+    end
+    add_column :containers, :type, :string
+    say_with_time("Update Containers type to ContainerKubernetes") do
+      Container.update_all(:type => "ContainerKubernetes")
+    end
+    add_column :container_groups, :type, :string
+    say_with_time("Update ContainerGroups type to ContainerGroupKubernetes") do
+      ContainerGroup.update_all(:type => "ContainerGroupKubernetes")
+    end
+  end
+
+  def down
+    remove_column :container_nodes, :type
+    remove_column :containers, :type
+    remove_column :container_groups, :type
+  end
+end

--- a/vmdb/spec/migrations/20150522161336_add_container_entities_type_spec.rb
+++ b/vmdb/spec/migrations/20150522161336_add_container_entities_type_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150522161336_add_container_entities_type")
+
+describe AddContainerEntitiesType do
+  let(:container_node_stub)  { migration_stub(:ContainerNode) }
+  let(:container_stub)       { migration_stub(:Container) }
+  let(:container_group_stub) { migration_stub(:ContainerGroup) }
+
+  migration_context :up do
+    it "up" do
+      container_node = container_node_stub.create!
+      container = container_stub.create!
+      container_group = container_group_stub.create!
+
+      migrate
+
+      expect(container_node.reload).to have_attributes(:type => "ContainerNodeKubernetes")
+      expect(container.reload).to have_attributes(:type => "ContainerKubernetes")
+      expect(container_group.reload).to have_attributes(:type => "ContainerGroupKubernetes")
+    end
+  end
+
+  migration_context :down do
+    it "down" do
+      container_node = container_node_stub.create!(:type => "ContainerNodeKubernetes")
+      container = container_stub.create!(:type => "ContainerKubernetes")
+      container_group = container_group_stub.create!(:type => "ContainerGroupKubernetes")
+
+      migrate
+
+      ContainerNode.find(container_node.id).should_not respond_to(:type)
+      Container.find(container.id).should_not respond_to(:type)
+      ContainerGroup.find(container_group.id).should_not respond_to(:type)
+    end
+  end
+end


### PR DESCRIPTION
In the long term we want to support more than just kubernetes/openshift containers (e.g. amazon).

More specifically, for example, metric collection (C&U) is per type of node/container/etc. (kubernetes vs amazon), so in order to select the proper metric collection strategy we have to identify the entities and collect the data accordingly. 

/cc @Fryguy @blomquisg @abonas 