### PR TITLE
containers: fix KubernetesEventMonitor creation

### DIFF
--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -8,6 +8,14 @@ class EmsKubernetes < EmsContainer
   # decided by the user nor out of control in the defaults of kubeclient gem
   # because it's not guaranteed that the next default version will work with
   # our specific code in ManageIQ.
+  def api_version
+    self.class.api_version
+  end
+
+  def api_version=(_value)
+    raise 'Kubernetes api_version cannot be modified'
+  end
+
   def self.api_version
     kubernetes_version
   end

--- a/vmdb/app/models/ems_openshift.rb
+++ b/vmdb/app/models/ems_openshift.rb
@@ -6,6 +6,19 @@ class EmsOpenshift < EmsContainer
 
   default_value_for :port, 8443
 
+  # This is the API version that we use and support throughout the entire code
+  # (parsers, events, etc.). It should be explicitly selected here and not
+  # decided by the user nor out of control in the defaults of openshift gem
+  # because it's not guaranteed that the next default version will work with
+  # our specific code in ManageIQ.
+  def api_version
+    self.class.api_version
+  end
+
+  def api_version=(_value)
+    raise 'OpenShift api_version cannot be modified'
+  end
+
   def self.api_version
     'v1beta1'
   end


### PR DESCRIPTION
During a recent refactoring (authentication) api_version become a class attribute and in the introduction of ContainerProviderMixin it has been moved to kubernetes_version.

This patch reconciles the two changes in the kubernetes event catcher fixing a problem that prevented the event monitor from starting.

/cc @Fryguy @blomquisg @abonas 