### PR TITLE
Creation of checksums on upstream nightly build

### DIFF
--- a/build/build.rb
+++ b/build/build.rb
@@ -89,6 +89,9 @@ Dir.chdir("/root/src/imagefactory") do
     file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{git_checkout.commit_sha}.#{FILE_TYPE[imgfac_target]}"
     destination = DESTINATION_DIRECTORY.join(file_name)
     $log.info `mv  #{source} #{destination}`
+    $log.info "Generating image checksums"
+    $log.info `cd #{DESTINATION_DIRECTORY}/; /usr/bin/md5sum * >> md5sum`
+    $log.info `cd #{DESTINATION_DIRECTORY}/; /usr/bin/sha256sum * >> sha256sum`
   end
 end
 


### PR DESCRIPTION
This addition creates the sha25sum and MD5sum files for the upstream nightly builds.
This was tested using temp dirs on build environment.