### PR TITLE
Added missing Tenants default view setting

### DIFF
--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -189,6 +189,7 @@ module UiConstants
       :containerproject      => "list",
       :cimbasestorageextent  => "list",
       :cimstorageextent      => "list",
+      :cloudtenant           => "list",
       :drift                 => "expanded",
       :drift_mode            => "details",
       :emscloud              => "grid",

--- a/vmdb/app/views/configuration/_ui_2.html.haml
+++ b/vmdb/app/views/configuration/_ui_2.html.haml
@@ -66,6 +66,7 @@
       .col-sm-12.col-md-12.col-lg-6
         - if role_allows(:feature => "ems_cloud_show_list")           ||
         -    role_allows(:feature => "availability_zone_show_list")   ||
+        -    role_allows(:feature => "cloud_tenant_show_list")        ||
         -    role_allows(:feature => "flavor_show_list")              ||
         -    role_allows(:feature => "instances_accord")              ||
         -    role_allows(:feature => "instances_filter_accord")       ||
@@ -84,6 +85,11 @@
                   %td.key= _('Availability Zones')
                   %td
                     %ul#toolbars= render_view_buttons(:availabilityzone, @edit[:new][:views][:availabilityzone])
+              - if role_allows(:feature => "cloud_tenant_show_list")
+                %tr
+                  %td.key= _('Tenants')
+                  %td
+                    %ul#toolbars= render_view_buttons(:cloudtenant, @edit[:new][:views][:cloudtenant])
               - if role_allows(:feature => "flavor_show_list")
                 %tr
                   %td.key= _('Flavors')


### PR DESCRIPTION
Added missing "Tenants" setting in the clouds section on Configure/My Settings/Default Views screen

https://bugzilla.redhat.com/show_bug.cgi?id=1224207

@dclarizio @mpovolny please review.

![tenants_settings](https://cloud.githubusercontent.com/assets/3450808/7778038/ac9d8e78-0095-11e5-96f0-8aa8ba3ab3b9.png)
