### PR TITLE
Accommodate different Qpid Topologies

### DIFF
--- a/lib/openstack/amqp/openstack_qpid_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_qpid_event_monitor.rb
@@ -13,10 +13,27 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
     OpenstackQpidConnection.available? && test_connection(options)
   end
 
+  def self.connection_parameters(options = {})
+    # TODO: get rid of these "optional" connection parameters altogether
+    raise ArgumentError, "hostname and port are required connection parameters" unless options.key?(:hostname) && options.key?(:port)
+    username = options[:username] if options.key? :username
+    password = options[:password] if options.key? :password
+    [
+      options[:hostname],
+      options[:port],
+      username,
+      password
+    ].compact
+  end
+
+  def self.create_connection(options = {})
+    OpenstackQpidConnection.new(*connection_parameters(options))
+  end
+
   def self.test_connection(options = {})
     connection = nil
     begin
-      connection = OpenstackQpidConnection.new(options)
+      connection = create_connection(options)
       connection.open
       connection.open?
     rescue => e
@@ -64,8 +81,8 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
     @connection ||= create_connection(@options)
   end
 
-  def create_connection(options={})
-    OpenstackQpidConnection.new(options)
+  def create_connection(options = {})
+    self.class.create_connection(options)
   end
 
   def receivers

--- a/lib/openstack/amqp/openstack_qpid_receiver.rb
+++ b/lib/openstack/amqp/openstack_qpid_receiver.rb
@@ -5,29 +5,29 @@ require_relative './openstack_qpid_connection'
 # An AMQP Notification Receiver that uses Qpid to listen for messages.
 #
 class OpenstackQpidReceiver
-  # Creates a new OpenstackQpidReceiver using the provided session,
-  # exchange, subject, and options
+  # Creates a new OpenstackQpidReceiver using the provided connection,
+  # service, exchange_name, subject, and options
   # e.g.,
-  #     receiver = OpenstackQpidReceiver.new(session, "nova", "notifications.*")
+  # > receiver = OpenstackQpidReceiver.new(connection, "nova", "amq.topic/topic/nova", "notifications.*")
   #
   # Options:
   # * :capacity: The total number of messages that can be held locally before
-  # fetching more from the broker (default=50)
+  #              fetching more from the broker (default=50)
   # * :duration: The length of time (in seconds) the receiver should wait for a
-  # message from the broker before timing out (default=10 seconds)
-  def initialize(session, exchange, subject, options = {})
+  #              message from the broker before timing out (default=10 seconds)
+  def initialize(connection, service, exchange_name, subject, options = {})
     raise "qpid_messaging is not available" unless OpenstackQpidConnection.available?
 
     @options = {:capacity => 50, :duration => 10}
     @options.merge(options)
 
-    @session          = session
-    @exchange         = exchange
+    @connection       = connection
+    @session          = connection.session
+    @service          = service
+    @exchange_name    = exchange_name
     @subject          = subject
     @capacity         = @options[:capacity]
     @duration_seconds = @options[:duration]
-
-    @address_options = ADDRESS_OPTIONS % subject
   end
 
   # Checks with Openstack's qpid broker for messages and returns as many as
@@ -82,11 +82,15 @@ class OpenstackQpidReceiver
       durable: true
     }
   },
+  link: {
+    name: %{queue_name}
+  }
 }
 EOD
   def address # :nodoc:
     unless @address
-      address_details = "#{@exchange}/#{@subject} ; #{ADDRESS_OPTIONS}"
+      address_options = ADDRESS_OPTIONS % {:queue_name => queue_name}
+      address_details = "#{@exchange_name}/#{@subject} ; #{address_options}"
       @address = Qpid::Messaging::Address.new(address_details)
     end
     @address
@@ -98,5 +102,9 @@ EOD
       @receiver.capacity = @capacity
     end
     @receiver
+  end
+
+  def queue_name
+    @queue_name ||= "miq-#{@connection.hostname}-#{@exchange_name}".gsub(/\//, "_")
   end
 end

--- a/lib/openstack/amqp/openstack_qpid_receiver.rb
+++ b/lib/openstack/amqp/openstack_qpid_receiver.rb
@@ -15,16 +15,16 @@ class OpenstackQpidReceiver
   # fetching more from the broker (default=50)
   # * :duration: The length of time (in seconds) the receiver should wait for a
   # message from the broker before timing out (default=10 seconds)
-  def initialize(session, exchange, subject, options={})
+  def initialize(session, exchange, subject, options = {})
     raise "qpid_messaging is not available" unless OpenstackQpidConnection.available?
 
     @options = {:capacity => 50, :duration => 10}
     @options.merge(options)
 
-    @session = session
-    @exchange = exchange
-    @subject = subject
-    @capacity = @options[:capacity]
+    @session          = session
+    @exchange         = exchange
+    @subject          = subject
+    @capacity         = @options[:capacity]
     @duration_seconds = @options[:duration]
 
     @address_options = ADDRESS_OPTIONS % subject
@@ -38,7 +38,7 @@ class OpenstackQpidReceiver
   #   receiver = OpenstackQpidReceiver.new(:hostname => "http://host.com")
   #   notifications = receiver.get_notifications
   #   notifications.each {|n| ... }
-  def get_notifications(max=100)
+  def get_notifications(max = 100)
     raise "Max messages must be greater than 0" if max < 1
     messages = []
     while receiver.available > 0 and messages.length < max

--- a/lib/spec/openstack/amqp/openstack_qpid_connection_spec.rb
+++ b/lib/spec/openstack/amqp/openstack_qpid_connection_spec.rb
@@ -12,12 +12,7 @@ describe OpenstackQpidConnection do
 
     OpenstackQpidConnection.stub(:available?).and_return(true)
     OpenstackQpidConnection.any_instance.stub(:create_connection).and_return(@qconnection)
-    @connection = OpenstackQpidConnection.new(:hostname => "hostname", :port => 5672)
-  end
-
-  it "complains that host and port are not provided when they are not included in options" do
-    @bad_connection = OpenstackQpidConnection.new
-    expect { @bad_connection.open }.to raise_error
+    @connection = OpenstackQpidConnection.new("hostname", 5672)
   end
 
   it "opens a connection to qpid" do

--- a/lib/spec/openstack/amqp/openstack_qpid_event_monitor_spec.rb
+++ b/lib/spec/openstack/amqp/openstack_qpid_event_monitor_spec.rb
@@ -11,6 +11,8 @@ describe OpenstackQpidEventMonitor do
     @original_log = $log
     $log = double.as_null_object
 
+    @qpid_session = double("qpid session")
+
     @nova_events = [{:name => "nova 1", :description => "first nova event"},
                {:name => "nova 2", :description => "second nova event"}]
     @glance_events = [{:name => "glance 1", :description => "first glance event"},
@@ -18,8 +20,15 @@ describe OpenstackQpidEventMonitor do
     @all_events = @nova_events + @glance_events
 
     @notification_connection = double("notification_connection", :open => nil, :close => nil)
-    @nova_receiver = double("nova_receiver", :get_notifications => @nova_events)
-    @glance_receiver = double("glance_receiver", :get_notifications => @glance_events)
+    @notification_connection.stub(:session).and_return(@qpid_session)
+    @notification_connection.stub(:hostname).and_return("10.10.10.10")
+
+    @nova_receiver = double("nova_receiver",
+       :get_notifications => @nova_events,
+       :exchange_name     => "nova")
+    @glance_receiver = double("glance_receiver",
+       :get_notifications => @glance_events,
+       :exchange_name     => "glance")
 
     @receivers = {"nova" => @nova_receiver, "glance" => @glance_receiver}
     @topics = {"nova" => "nova_topic", "glance" => "glance_topic"}
@@ -36,8 +45,10 @@ describe OpenstackQpidEventMonitor do
   end
 
   it "initializes receivers based on given topics" do
-    @monitor.should_receive(:create_receiver).with("nova", "nova_topic").and_return(@nova_receiver)
-    @monitor.should_receive(:create_receiver).with("glance", "glance_topic").and_return(@glance_receiver)
+    @monitor.should_receive(:create_v1_receiver).with("nova", "nova_topic").and_return(@nova_receiver)
+    @monitor.should_receive(:create_v2_receiver).with("nova", "nova_topic").and_return(@nova_receiver)
+    @monitor.should_receive(:create_v1_receiver).with("glance", "glance_topic").and_return(@glance_receiver)
+    @monitor.should_receive(:create_v2_receiver).with("glance", "glance_topic").and_return(@glance_receiver)
     @monitor.start
     @monitor.each_batch { @monitor.stop }
   end

--- a/lib/spec/openstack/amqp/openstack_qpid_receiver_spec.rb
+++ b/lib/spec/openstack/amqp/openstack_qpid_receiver_spec.rb
@@ -13,6 +13,10 @@ describe OpenstackQpidReceiver do
     qreceiver = double("qpid receiver")
     qsession = double("qpid session")
 
+    qconnection = double("qpid connection")
+    qconnection.stub(:hostname).and_return("10.10.10.10")
+    qconnection.stub(:session).and_return(qsession)
+
     qsession.should_receive(:create_receiver).and_return(qreceiver)
     qreceiver.should_receive(:capacity=)
 
@@ -29,7 +33,7 @@ describe OpenstackQpidReceiver do
     qreceiver.stub(:available).and_return(3, 2, 1, 0)
     qreceiver.stub(:get).and_return(qpid_messages[0], qpid_messages[1], qpid_messages[2])
 
-    receiver = OpenstackQpidReceiver.new(qsession, "exchange", "topic")
+    receiver = OpenstackQpidReceiver.new(qconnection, "service", "exchange", "topic")
     receiver.stub(:address).and_return("")
     receiver.stub(:duration).and_return(0)
 


### PR DESCRIPTION
Openstack supports two different Qpid Topologies for exchange names.  Originally, exchange names were named the same as the service.  For example, the service `nova` had a Qpid Exchange called `nova` and published messages to a topic called `notifications.info`.  Now, Openstack supports a Qpid V2 Exchange Topology.  So, the service `nova` can have an exchange called `amq.topic/topic/nova`.

Since this is a configurable option in Openstack called `qpid_topology_version`, ManageIQ needs to support both versions of the topology.  Also, it appears that there's no way to query for the currently configured `qpid_topology_version`.  So, the `OpenstackQpidEventMonitor` will create an `OpenstackQpidReceiver` for both topologies per service.  Now, each service will have two receivers:

  * `"nova"`
  * `"amq.topic/topic/nova"`

In addition to adding multiple topology support, this PR also controls the name of the binding queue used to receive messages from the exchange.  When a Qpid Receiver is created without a binding queue name specified, the Qpid library will create a queue with a randomized name (e.g., `"nova_abc123def456"`).  In order to make debugging a little easier, the binding queue is now named following the pattern `"miq-<host|ip>-<exchange_name>"`.  For example: `"miq-10.10.10.10-amq.topic_topic_nova"` (slashes are not allowed in the binding queue name).  This will show that host 10.10.10.10 has a queue listening for messages from nova.  And, users can use the following tools to debug on the OpenStack server:

 * `qpid-config -b queues`: show the list of queues and what exchanges they're bound to
 * `qpid-stat -q`: show the message counts per queue  

https://bugzilla.redhat.com/show_bug.cgi?id=1224389

PS: this will cause #1824 to need rebasing.  I've closed that PR for now until this is merged. 

@Fryguy, @jrafanie: please review