### PR TITLE
performance: do not load charts on missing metrics

### DIFF
--- a/vmdb/app/controllers/application_controller/performance.rb
+++ b/vmdb/app/controllers/application_controller/performance.rb
@@ -81,14 +81,14 @@ module ApplicationController::Performance
           page << "miq_cal_dateFrom = new Date(#{@perf_options[:sdate_daily].year},#{@perf_options[:sdate_daily].month-1},#{@perf_options[:sdate_daily].day});"
           page << "miq_cal_dateTo   = new Date(#{@perf_options[:edate_daily].year},#{@perf_options[:edate_daily].month-1},#{@perf_options[:edate_daily].day});"
         end
+        if @perf_options[:skip_days]
+          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
+        else
+          page << "miq_cal_skipDays = null;"
+        end
+        page << 'miqBuildCalendar();'
+        page << Charting.js_load_statement
       end
-      if @perf_options[:skip_days]
-        page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-      else
-        page << "miq_cal_skipDays = null;"
-      end
-      page << 'miqBuildCalendar();'
-      page << Charting.js_load_statement
       page << 'miqSparkle(false);'
       if request.parameters["controller"] == "storage" && @perf_options[:cat]
         page << javascript_disable_field('perf_typ')


### PR DESCRIPTION
When metrics are missing we should avoid to run charts-related functions as they most likely fail. E.g.

    miq_chart_data = {"candu":null};

    TypeError: Cannot read property 'length' of null
      at load_jqplot_charts

This patch makes sure that we avoid to add any charts-related ajax (e.g load_jqplot_charts) when data is missing in order to avoid failures and complete the other required operations, e.g. miqSparkle(false)

Fixes #2987
