### PR TITLE
Add suport for HTTP Basic authentication for containers

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -33,7 +33,7 @@ gem "memoist",              "~>0.11.0",       :require => false
 gem "more_core_extensions", "~>1.2.0",        :require => false
 gem "nokogiri",             "~>1.5.0",        :require => false
 gem "ovirt",                "~>0.4.2",        :require => false
-gem "kubeclient",           ">=0.1.14",       :require => false
+gem "kubeclient",           ">=0.1.16",       :require => false
 gem "openshift_client",     ">=0.0.5",        :require => false
 gem "rest-client",                            :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",             "~>0.5.21",       :require => false

--- a/vmdb/app/models/ems_kubernetes.rb
+++ b/vmdb/app/models/ems_kubernetes.rb
@@ -20,8 +20,16 @@ class EmsKubernetes < EmsContainer
     @description ||= "Kubernetes".freeze
   end
 
-  def self.raw_connect(hostname, port, _service = nil)
-    kubernetes_connect(hostname, port)
+  def supported_auth_types
+    %w(basic)
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
+  def self.raw_connect(hostname, port, username = nil, password = nil, _service = nil)
+    kubernetes_connect(hostname, port, username, password)
   end
 
   def self.event_monitor_class

--- a/vmdb/app/models/ems_openshift.rb
+++ b/vmdb/app/models/ems_openshift.rb
@@ -18,12 +18,12 @@ class EmsOpenshift < EmsContainer
     @description ||= "OpenShift".freeze
   end
 
-  def self.raw_connect(hostname, port, service = nil)
+  def self.raw_connect(hostname, port, username = nil, password = nil, service = nil)
     service   ||= "openshift"
-    send("#{service}_connect", hostname, port)
+    send("#{service}_connect", hostname, port, username, password)
   end
 
-  def self.openshift_connect(hostname, port)
+  def self.openshift_connect(hostname, port, _username = nil, _password = nil)
     require 'openshift_client'
     api_endpoint = raw_api_endpoint(hostname, port)
     osclient = OpenshiftClient::Client.new(api_endpoint, api_version)


### PR DESCRIPTION
As of kubeclient 0.1.16, basic HTTP auth is supported.
This patch adds the option to specify a username and password for  a
container provider (cmd only).

Signed-off-by: Ofer Schreiber <oschreib@redhat.com>