### PR TITLE
Support networks in different tenants

### DIFF
--- a/lib/openstack/openstack_handle/network_delegate.rb
+++ b/lib/openstack/openstack_handle/network_delegate.rb
@@ -22,5 +22,9 @@ module OpenstackHandle
     def quotas_for_accessible_tenants
       @os_handle.accessor_for_accessible_tenants(SERVICE_NAME, :quotas_for_current_tenant, 'id', false)
     end
+
+    def networks_for_accessible_tenants
+      @os_handle.accessor_for_accessible_tenants(SERVICE_NAME, :networks, :id)
+    end
   end
 end

--- a/vmdb/app/models/ems_refresh/parsers/openstack.rb
+++ b/vmdb/app/models/ems_refresh/parsers/openstack.rb
@@ -73,7 +73,7 @@ module EmsRefresh::Parsers
     end
 
     def networks
-      @networks ||= @network_service.networks
+      @networks ||= @network_service.networks_for_accessible_tenants
     end
 
     def volumes


### PR DESCRIPTION
If the user belongs to a various tenants, the network information is only gathered for the main tenant.