### PR TITLE
Rename RabbitMQ binding queues

### DIFF
--- a/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -95,7 +95,8 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
     if @options[:topics]
       @options[:topics].each do |exchange, topic|
         amqp_exchange = channel.topic(exchange)
-        @queues[exchange] = channel.queue(topic).bind(amqp_exchange, :routing_key => topic)
+        queue_name = "miq-#{@options[:hostname]}-#{exchange}"
+        @queues[exchange] = channel.queue(queue_name).bind(amqp_exchange, :routing_key => topic)
       end
     end
   end


### PR DESCRIPTION
When CFME connects to RabbitMQ to collect OpenStack events, it creates queues to bind to the OpenStack services' exchanges.  The queues were named after the services to which they were bound.  For example, binding to the "nova" service would result in a binding queue called "nova".
    
If more than one appliance attempted to connect to RabbitMQ to collect OpenStack events, only the first appliance to create the binding queue would receive any events.
    
Now, the binding queue is named after the appliance connecting to the RabbitMQ service.  The new binding queue name will look like `"miq-<host|ip>-<exchange>"`

  * e.g.: `"miq-10.10.10.10-nova"`
    
This allows for two things:  individual appliances will get their own binding queue per service, and administrators will be able to tell which binding queues belong to which appliances.
    
https://bugzilla.redhat.com/show_bug.cgi?id=1223976