### PR TITLE
Fixed flash message titles when Refresh task is performed

### DIFF
--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -1211,11 +1211,12 @@ module ApplicationController::CiProcessing
     else
       items = find_checked_items
       if items.empty?
-        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => controller_name),
+        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:ui_title => 'foreman'),
                                                                 :task  => display_name}, :error)
+      else
+        process_foreman(items, method) unless items.empty? && !flash_errors?
       end
     end
-    process_foreman(items, method) unless items.empty? && !flash_errors?
   end
 
   def process_foreman(providers, task)
@@ -1228,8 +1229,10 @@ module ApplicationController::CiProcessing
     rescue StandardError => bang                            # Catch any errors
       add_flash(_("Error during '%s': ") % task << bang.message, :error)
   else
-    add_flash(_("%{task} initiated for %{count_model} (Foreman) from the CFME Database") %
-      {:task        => Dictionary.gettext(task, :type => :task).titleize,
+    add_flash(_("%{task} initiated for %{count_model} (%{controller}) from the CFME Database") %
+      {:task        => Dictionary.gettext(task, :type => :task).titleize.gsub("Ems",
+                                                                              "#{ui_lookup(:ui_title => 'foreman')}"),
+       :controller  => ui_lookup(:ui_title => 'foreman'),
        :count_model => pluralize(providers.length, ui_lookup(:model => kls.to_s))})
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1224959

@dclarizio please review.

before:
![no_items_selected_before](https://cloud.githubusercontent.com/assets/3450808/7823305/9b9b9fda-03c8-11e5-98eb-d57286a8128e.png)
![foreman_refresh_before](https://cloud.githubusercontent.com/assets/3450808/7823308/9db94ff6-03c8-11e5-8574-7c03080330d6.png)

after:
![flash_message_fix1](https://cloud.githubusercontent.com/assets/3450808/7823311/a042630c-03c8-11e5-8f8e-a85e62d50d83.png)
![flash_message_fix2](https://cloud.githubusercontent.com/assets/3450808/7823314/a3491334-03c8-11e5-9604-9ceb78c83e23.png)