### PR TITLE
Fixed code to show correct Provider type image

### DIFF
--- a/vmdb/app/controllers/application_controller/tree_support.rb
+++ b/vmdb/app/controllers/application_controller/tree_support.rb
@@ -500,11 +500,11 @@ module ApplicationController::TreeSupport
     ExtManagementSystem.all.each do |ems| # Go thru all of the providers
       if !@rp_only || (@rp_only && ems.resource_pools.count > 0)
         ems_node = {
-          :key        => "#{ems.class.name}_#{ems.id}",
-          :title      => ems.name,
-          :tooltip    => "#{ui_lookup(:table=>"ems_infras")}: #{ems.name}",
-          :addClass   => "cfme-no-cursor-node",      # No cursor pointer
-          :icon       => "ems.png"
+          :key      => "#{ems.class.name}_#{ems.id}",
+          :title    => ems.name,
+          :tooltip  => "#{ui_lookup(:table => "ems_infras")}: #{ems.name}",
+          :addClass => "cfme-no-cursor-node",      # No cursor pointer
+          :icon     => "vendor-#{ems.image_name}.png"
         }
         if @vat || @rp_only
           ems_node[:hideCheckbox] = true


### PR DESCRIPTION
Fixed code to show correct Provider type image in Hosts & Clusters and VMs & Templates tree on Access Control group view/edit screens.

https://bugzilla.redhat.com/show_bug.cgi?id=1225205

@dclarizio please review

before:
![hosts_clusters_before_fix](https://cloud.githubusercontent.com/assets/3450808/7823890/baddb9ba-03cc-11e5-8abd-e4812a7764f8.png)

after:
![hosts_clusters_tree](https://cloud.githubusercontent.com/assets/3450808/7823892/bdd57108-03cc-11e5-9a2c-0097ea7149b4.png)