### PR TITLE
Fix download links for Configuration Profiles and Configured Systems view

### DIFF
--- a/vmdb/app/controllers/provider_foreman_controller.rb
+++ b/vmdb/app/controllers/provider_foreman_controller.rb
@@ -356,6 +356,11 @@ class ProviderForemanController < ApplicationController
     render :layout => "explorer" unless redirected
   end
 
+  def tree_autoload_dynatree
+    @view ||= session[:view]
+    super
+  end
+
   def change_tab
     @sb[:active_tab] = params[:tab_id]
     replace_right_cell


### PR DESCRIPTION
Since ```ApplicationController#download_data``` expects ```@view``` to exist, save ```@view``` from the ```session object``` in ```tree_autoload_dynatree```

https://bugzilla.redhat.com/show_bug.cgi?id=1224947