### PR TITLE
Make show_association optionally take @record, overriden in VmCommon to use VmOrTemplate to load it

### DIFF
--- a/vmdb/app/controllers/application_controller/ci_processing.rb
+++ b/vmdb/app/controllers/application_controller/ci_processing.rb
@@ -1897,14 +1897,14 @@ module ApplicationController::CiProcessing
     @edit[:new][owner] != @edit[:current][owner]
   end
 
-  def show_association(action, display_name, listicon, method, klass, association = nil, conditions =nil)
+  def show_association(action, display_name, listicon, method, klass, association = nil, conditions = nil)
     # Ajax request means in explorer, or if current explorer is one of the explorer controllers
     @explorer = true if request.xml_http_request? && explorer_controller?
     if @explorer  # Save vars for tree history array
       @x_show = params[:x_show]
       @sb[:action] = @lastaction = action
     end
-    @record = identify_record(params[:id])
+    @record = identify_record(params[:id], controller_to_model)
     @view = session[:view]                  # Restore the view from the session to get column names for the display
     return if record_no_longer_exists?(@record, klass.to_s)
     @lastaction = action


### PR DESCRIPTION
This makes linux_initprocesses (and others) load from VmOrTemplate,
not VmCloud - without it, /vm_cloud/linux_initprocesses/119 tries to
load VmCloud(id=119) and not VmOrTemplate(id=119) in CiProcessing#show_association.

This has been broken since ec1389e which unified all the
show_association methods, without the special @record load handling
that was present in VmCommon. Without it, a load from VmCloud is
attempted instead of VmOrTemplate, and fails.

This likely affects *all* show_association calls made from vm_common -
Running Processes, Registry Entries, Advanced Settings, Init Processes,
Win32 Services, Kernel Drivers, File System Drivers, Files and Security Groups.

https://bugzilla.redhat.com/show_bug.cgi?id=1211665