### PR TITLE
Add 'Ready' column to container nodes table

### DIFF
--- a/vmdb/app/models/container_node.rb
+++ b/vmdb/app/models/container_node.rb
@@ -10,4 +10,14 @@ class ContainerNode < ActiveRecord::Base
   belongs_to :lives_on, :polymorphic => true
 
   delegate   :hardware, :to => :computer_system
+
+  virtual_column :condition_ready, :type => :string, :uses => :container_node_conditions
+
+  def ready_condition
+    container_node_conditions.find_by_name('Ready')
+  end
+
+  def ready_condition_status
+    ready_condition.try(:status) || 'None'
+  end
 end

--- a/vmdb/app/models/container_node_condition.rb
+++ b/vmdb/app/models/container_node_condition.rb
@@ -1,3 +1,4 @@
 class ContainerNodeCondition < ActiveRecord::Base
+  include ReportableMixin
   belongs_to :container_node
 end

--- a/vmdb/product/views/ContainerNode.yaml
+++ b/vmdb/product/views/ContainerNode.yaml
@@ -20,24 +20,26 @@ db: ContainerNode
 # Columns to fetch from the main table
 cols:
 - name
+- condition_ready
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-
 
 # Included tables and columns for query performance
 include_for_find:
 
 # Order of columns (from all tables)
-col_order: 
+col_order:
 - name
+- condition_ready
 
 # Column titles, in order
 headers:
 - Name
+- Ready
 
 # Condition(s) string for the SQL query
-conditions: 
+conditions:
 
 # Order string for the SQL query
 order: Ascending
@@ -45,6 +47,7 @@ order: Ascending
 # Columns to sort the report on, in order
 sortby:
 - name
+- condition_ready
 
 # Group rows (y=yes,n=no,c=count)
 group: n


### PR DESCRIPTION
The only current valid condition is Ready.
The new column present the status of NodeReady condition, that is:
'True', 'False' or 'Unknown'.