### PR TITLE
scrollbar dipped below visible area  on some screens

### DIFF
--- a/vmdb/app/assets/stylesheets/patternfly_overrides.less
+++ b/vmdb/app/assets/stylesheets/patternfly_overrides.less
@@ -51,7 +51,8 @@ body, html {
   }
   #main_content {
     overflow: auto;
-    height: 100%;
+    height: calc(100% - 30px);
+    padding-bottom: 25px
   }
   #main_footer {
     position: absolute;

--- a/vmdb/app/views/layouts/_page_center.html.haml
+++ b/vmdb/app/views/layouts/_page_center.html.haml
@@ -28,10 +28,7 @@
               // which doesn't honor padding-bottom on a div that is preceded by overflow: auto
               %h1 
                 &nbsp;
-              %h1
-                &nbsp;
-              %h1
-                &nbsp;
+
         .col-sm-3.col-md-2.col-sm-pull-9.col-md-pull-10.sidebar-pf.sidebar-pf-left.scrollable-lg
           = render :partial => "layouts/listnav"
 


### PR DESCRIPTION
Adjusted height calculation and padding of main_content div so that scrollbar ends within visible area

Issue: #2487
https://bugzilla.redhat.com/show_bug.cgi?id=1225026

Old:
![screen shot 2015-05-27 at 9 59 41 am](https://cloud.githubusercontent.com/assets/1287144/7837764/09de1aa2-0457-11e5-8575-adb9a90c5a8e.png)

New:
![screen shot 2015-05-27 at 9 58 55 am](https://cloud.githubusercontent.com/assets/1287144/7837746/eeeae216-0456-11e5-9127-690516079567.png)