### PR TITLE
Modify Gemfile for MS Windows

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -68,6 +68,11 @@ end
 gem "handsoap",    "~>0.2.5",   :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-2"
 gem "rubywbem",    "=0.1.0",    :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :tag => "v0.1.0-2"
 
+# Windows only. Do not put in Gemfile.lock on other platforms.
+if Gem.win_platform?
+  gem "win32-process", "~>0.8.0", :require => false, :platforms => [:mswin, :mingw]
+end
+
 ### Start of gems excluded from the appliances.
 # The gems listed below do not need to be packaged until we find it necessary or useful.
 # Only add gems here that we do not need on an appliance.

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -11,7 +11,9 @@ gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '=1.2.4'
 gem 'jquery-rails', "=2.1.4"
 
-gem "win32-process", "~>0.8.0", :require => false, :platforms => [:mswin, :mingw]
+if Gem.win_platform?
+  gem "win32-process", "~>0.8.0", :require => false, :platforms => [:mswin, :mingw]
+end
 
 # On MS Windows run "bundle config --local build.libv8 --with-system-v8" first
 

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -11,9 +11,13 @@ gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '=1.2.4'
 gem 'jquery-rails', "=2.1.4"
 
+gem "win32-process", "~>0.8.0", :require => false, :platforms => [:mswin, :mingw]
+
+# On MS Windows run "bundle config --local build.libv8 --with-system-v8" first
+
 gem "sprockets-sass",  "~>1.2.0"
 gem "sprockets-less",  "~>0.6.1"
-gem 'therubyracer', :require => false
+gem 'therubyracer', :require => false, :platform => :ruby
 gem 'less-rails',   :require => false
 
 # Vendored and required

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -11,10 +11,6 @@ gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '=1.2.4'
 gem 'jquery-rails', "=2.1.4"
 
-if Gem.win_platform?
-  gem "win32-process", "~>0.8.0", :require => false, :platforms => [:mswin, :mingw]
-end
-
 # On MS Windows run "bundle config --local build.libv8 --with-system-v8" first
 
 gem "sprockets-sass",  "~>1.2.0"


### PR DESCRIPTION
This change modifies the Gemfile so that it skips therubyracer, and requires win32-process, on MS Windows.

I also put a comment in there for how to get libv8 installed on Windows. Since it's a build option, I cannot put it in the Gemfile directly. Eventually that should be added to the developer's guide. Note that due to a screwball install script, the libv8 gem will spawn some notepad instances that contain ruby code text. These are harmless as far as I can tell, and can be closed.

With this modification I am able to complete a bundle install using Ruby 2.1 on Windows 7. While bundle exec rake evm:db:reset doesn't quite work yet (due to a pg gem issue), adding win32-process to the Gemfile is a necessary first step.