### PR TITLE
Update Kubernetes specs tests

### DIFF
--- a/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/vmdb/app/models/ems_refresh/parsers/kubernetes.rb
@@ -98,6 +98,9 @@ module EmsRefresh::Parsers
 
     def parse_service(service)
       new_result = parse_base_item(service)
+      if new_result[:ems_ref].nil? # Typically this happens for kubernetes services
+        new_result[:ems_ref] = "#{new_result[:namespace]}_#{new_result[:name]}"
+      end
       container_groups = []
 
       endpoint_container_groups = @data_index.fetch_path(

--- a/vmdb/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -29,7 +29,7 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
     ContainerNode.count.should         == 1
     Container.count.should             == 3
     ContainerService.count.should      == 6
-    ContainerPortConfig.count.should   == 3
+    ContainerPortConfig.count.should   == 2
     ContainerDefinition.count.should   == 3
   end
 
@@ -46,7 +46,7 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
       # :ems_ref       => "a7566742-e73f-11e4-b613-001a4a5f4a02_heapster_kubernetes/heapster:v0.9",
       :name          => "heapster",
       :restart_count => 0,
-      :image         => "kubernetes/heapster:v0.9",
+      :image         => "kubernetes/heapster:v0.11.0",
       # :backing_ref   => "docker://87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71"
     )
 
@@ -109,7 +109,7 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
     @confs.count.should  == 1
     @confs = @confs.first
     @confs.should have_attributes(
-      :name        => "",
+      :name        => nil,
       :port        => 443,
       :target_port => "443",
       :protocol    => "TCP"

--- a/vmdb/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/vmdb/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -21,6 +21,7 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
       assert_specific_container_group
       assert_specific_container_node
       assert_specific_container_service
+      assert_specific_container_replicator
     end
   end
 
@@ -31,6 +32,7 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
     ContainerService.count.should      == 6
     ContainerPortConfig.count.should   == 2
     ContainerDefinition.count.should   == 3
+    ContainerReplicator.count.should   == 2
   end
 
   def assert_ems
@@ -125,6 +127,16 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
       :restart_policy => "Always",
       :dns_policy     => "ClusterFirst",
       :namespace      => "default"
+    )
+  end
+
+  def assert_specific_container_replicator
+    @replicator = ContainerReplicator.where(:name => "monitoring-influx-grafana-controller").first
+    @replicator.should have_attributes(
+      :name             => "monitoring-influx-grafana-controller",
+      :namespace        => "default",
+      :replicas         => 1,
+      :current_replicas => 1
     )
   end
 end

--- a/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/kubernetes_refresher.yml
+++ b/vmdb/spec/vcr_cassettes/ems_refresh/refreshers/kubernetes_refresher.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:27 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -32,7 +32,7 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/pods",
-            "resourceVersion": "598"
+            "resourceVersion": "123"
           },
           "items": [
             {
@@ -41,38 +41,38 @@ http_interactions:
                 "generateName": "monitoring-heapster-controller-",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/pods/monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "171",
-                "creationTimestamp": "2015-04-20T09:28:50Z",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "89",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
                 "labels": {
-                  "name": "heapster",
-                  "uses": "monitoring-influxdb"
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "heapster"
+                },
+                "annotations": {
+                  "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1beta3\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"default\",\"name\":\"monitoring-heapster-controller\",\"uid\":\"56876271-04df-11e5-ad4b-525400c903c1\",\"apiVersion\":\"v1beta3\",\"resourceVersion\":\"69\"}}"
                 }
               },
               "spec": {
                 "volumes": [
                   {
                     "name": "ssl-certs",
-                    "hostPath": {
-                      "path": "/etc/ssl/certs"
-                    },
-                    "emptyDir": null,
-                    "gcePersistentDisk": null,
-                    "gitRepo": null,
-                    "secret": null,
-                    "nfs": null,
-                    "iscsi": null,
-                    "glusterfs": null
+                    "emptyDir": {}
+                  },
+                  {
+                    "name": "default-token-nsoub",
+                    "secret": {
+                      "secretName": "default-token-nsoub"
+                    }
                   }
                 ],
                 "containers": [
                   {
                     "name": "heapster",
-                    "image": "kubernetes/heapster:v0.9",
+                    "image": "kubernetes/heapster:v0.11.0",
                     "env": [
                       {
                         "name": "INFLUXDB_HOST",
-                        "value": "monitoring-influxdb"
+                        "value": "http://monitoring-influxdb:80"
                       },
                       {
                         "name": "SINK",
@@ -85,16 +85,26 @@ http_interactions:
                         "name": "ssl-certs",
                         "readOnly": true,
                         "mountPath": "/etc/ssl/certs"
+                      },
+                      {
+                        "name": "default-token-nsoub",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
                       }
                     ],
                     "terminationMessagePath": "/dev/termination-log",
                     "imagePullPolicy": "IfNotPresent",
-                    "capabilities": {}
+                    "capabilities": {},
+                    "securityContext": {
+                      "capabilities": {},
+                      "privileged": false
+                    }
                   }
                 ],
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "serviceAccount": "default",
+                "host": "127.0.0.1"
               },
               "status": {
                 "phase": "Running",
@@ -104,69 +114,87 @@ http_interactions:
                     "status": "True"
                   }
                 ],
-                "hostIP": "10.35.0.202",
-                "podIP": "172.17.0.10",
+                "hostIP": "127.0.0.1",
+                "podIP": "172.18.1.5",
+                "startTime": "2015-05-28T02:14:59Z",
                 "containerStatuses": [
                   {
                     "name": "heapster",
                     "state": {
                       "running": {
-                        "startedAt": "2015-04-20T09:29:36Z"
+                        "startedAt": "2015-05-28T02:14:59Z"
                       }
                     },
                     "lastState": {},
                     "ready": true,
                     "restartCount": 0,
-                    "image": "kubernetes/heapster:v0.9",
-                    "imageID": "docker://204dbb8fac26ee36633185b0781f8f10a544ada8fdd7e9832706db67d6249ee6",
-                    "containerID": "docker://6e6119478fe1a60b751f52b39bcaab97015575ac797d7a810bb5804370bd7351"
+                    "image": "kubernetes/heapster:v0.11.0",
+                    "imageID": "docker://6207b36028f56023248abaaa8ed68c964c2364f731c24299cff8a904f1b33cfa",
+                    "containerID": "docker://b1ddf3fb4c7f8df73f8cc1e40b62acbae59ea02ea517e6cbdd14e502edb29040"
                   }
                 ]
               }
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
                 "generateName": "monitoring-influx-grafana-controller-",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/pods/monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "178",
-                "creationTimestamp": "2015-04-20T09:28:50Z",
+                "selfLink": "/api/v1beta3/namespaces/default/pods/monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "113",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
                 "labels": {
                   "name": "influxGrafana"
+                },
+                "annotations": {
+                  "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1beta3\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"default\",\"name\":\"monitoring-influx-grafana-controller\",\"uid\":\"584c98e3-04df-11e5-ad4b-525400c903c1\",\"apiVersion\":\"v1beta3\",\"resourceVersion\":\"82\"}}"
                 }
               },
               "spec": {
-                "volumes": null,
+                "volumes": [
+                  {
+                    "name": "default-token-nsoub",
+                    "secret": {
+                      "secretName": "default-token-nsoub"
+                    }
+                  }
+                ],
                 "containers": [
                   {
                     "name": "influxdb",
                     "image": "kubernetes/heapster_influxdb:v0.3",
                     "ports": [
                       {
+                        "hostPort": 8083,
                         "containerPort": 8083,
                         "protocol": "TCP"
                       },
                       {
+                        "hostPort": 8086,
                         "containerPort": 8086,
                         "protocol": "TCP"
                       }
                     ],
                     "resources": {},
+                    "volumeMounts": [
+                      {
+                        "name": "default-token-nsoub",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                      }
+                    ],
                     "terminationMessagePath": "/dev/termination-log",
                     "imagePullPolicy": "IfNotPresent",
-                    "capabilities": {}
+                    "capabilities": {},
+                    "securityContext": {
+                      "capabilities": {},
+                      "privileged": false
+                    }
                   },
                   {
                     "name": "grafana",
-                    "image": "kubernetes/heapster_grafana:v0.5",
-                    "ports": [
-                      {
-                        "containerPort": 8080,
-                        "protocol": "TCP"
-                      }
-                    ],
+                    "image": "kubernetes/heapster_grafana:v0.7",
                     "env": [
                       {
                         "name": "INFLUXDB_EXTERNAL_URL",
@@ -174,22 +202,34 @@ http_interactions:
                       },
                       {
                         "name": "INFLUXDB_HOST",
-                        "value": "monitoring-influxdb"
+                        "value": "localhost"
                       },
                       {
                         "name": "INFLUXDB_PORT",
-                        "value": "80"
+                        "value": "8086"
                       }
                     ],
                     "resources": {},
+                    "volumeMounts": [
+                      {
+                        "name": "default-token-nsoub",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                      }
+                    ],
                     "terminationMessagePath": "/dev/termination-log",
                     "imagePullPolicy": "IfNotPresent",
-                    "capabilities": {}
+                    "capabilities": {},
+                    "securityContext": {
+                      "capabilities": {},
+                      "privileged": false
+                    }
                   }
                 ],
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "serviceAccount": "default",
+                "host": "127.0.0.1"
               },
               "status": {
                 "phase": "Running",
@@ -199,28 +239,15 @@ http_interactions:
                     "status": "True"
                   }
                 ],
-                "hostIP": "10.35.0.202",
-                "podIP": "172.17.0.9",
+                "hostIP": "127.0.0.1",
+                "podIP": "172.18.1.6",
+                "startTime": "2015-05-28T02:15:02Z",
                 "containerStatuses": [
-                  {
-                    "name": "grafana",
-                    "state": {
-                      "running": {
-                        "startedAt": "2015-04-20T09:29:39Z"
-                      }
-                    },
-                    "lastState": {},
-                    "ready": true,
-                    "restartCount": 0,
-                    "image": "kubernetes/heapster_grafana:v0.5",
-                    "imageID": "docker://550cea8112c607e1a66ccf021ab75b8fbbb04cf171c8e39ccb7f300995ed60ed",
-                    "containerID": "docker://7996e009081d7fe9a579b973d282d178c009e6f231590f8f08d71c1ee793fe6c"
-                  },
                   {
                     "name": "influxdb",
                     "state": {
                       "running": {
-                        "startedAt": "2015-04-20T09:29:36Z"
+                        "startedAt": "2015-05-28T02:15:02Z"
                       }
                     },
                     "lastState": {},
@@ -228,7 +255,21 @@ http_interactions:
                     "restartCount": 0,
                     "image": "kubernetes/heapster_influxdb:v0.3",
                     "imageID": "docker://514b330600afe3ed9f948f65fab7593b374075d194c65263fe3bafc43820fdad",
-                    "containerID": "docker://997c6a36aec6677fb1d5ae37ed89e483b49798fab4648ccfb21cea3be1cf63d9"
+                    "containerID": "docker://48e813f985e558c27be2efc4ab8a6ee7c2526962bdec0ce04ed282fd6c901abc"
+                  },
+                  {
+                    "name": "grafana",
+                    "state": {
+                      "running": {
+                        "startedAt": "2015-05-28T02:15:02Z"
+                      }
+                    },
+                    "lastState": {},
+                    "ready": true,
+                    "restartCount": 0,
+                    "image": "kubernetes/heapster_grafana:v0.7",
+                    "imageID": "docker://22182f122d461ef2e96af4c2ac1ebfbccf127894da9e9ceb56f7d74496583b30",
+                    "containerID": "docker://bc85701a8a843a8a694ec9c7c5a33251a8a084564151021d8e52e85b90a22d79"
                   }
                 ]
               }
@@ -236,7 +277,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:28 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/services
@@ -249,7 +290,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -258,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:29 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -269,7 +310,7 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/services",
-            "resourceVersion": "603"
+            "resourceVersion": "123"
           },
           "items": [
             {
@@ -277,9 +318,8 @@ http_interactions:
                 "name": "kubernetes",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/services/kubernetes",
-                "uid": "a36a2858-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "5",
-                "creationTimestamp": "2015-04-20T09:28:43Z",
+                "resourceVersion": "6",
+                "creationTimestamp": null,
                 "labels": {
                   "component": "apiserver",
                   "provider": "kubernetes"
@@ -288,13 +328,11 @@ http_interactions:
               "spec": {
                 "ports": [
                   {
-                    "name": "",
                     "protocol": "TCP",
                     "port": 443,
                     "targetPort": 443
                   }
                 ],
-                "selector": null,
                 "portalIP": "10.0.0.2",
                 "sessionAffinity": "None"
               },
@@ -305,9 +343,8 @@ http_interactions:
                 "name": "kubernetes-ro",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/services/kubernetes-ro",
-                "uid": "a36e0599-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "6",
-                "creationTimestamp": "2015-04-20T09:28:43Z",
+                "resourceVersion": "8",
+                "creationTimestamp": null,
                 "labels": {
                   "component": "apiserver",
                   "provider": "kubernetes"
@@ -316,13 +353,11 @@ http_interactions:
               "spec": {
                 "ports": [
                   {
-                    "name": "",
                     "protocol": "TCP",
                     "port": 80,
                     "targetPort": 80
                   }
                 ],
-                "selector": null,
                 "portalIP": "10.0.0.1",
                 "sessionAffinity": "None"
               },
@@ -333,14 +368,17 @@ http_interactions:
                 "name": "monitoring-grafana",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-grafana",
-                "uid": "a7494354-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "22",
-                "creationTimestamp": "2015-04-20T09:28:50Z"
+                "uid": "4ee66cb2-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "57",
+                "creationTimestamp": "2015-05-28T02:14:45Z",
+                "labels": {
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "monitoring-grafana"
+                }
               },
               "spec": {
                 "ports": [
                   {
-                    "name": "",
                     "protocol": "TCP",
                     "port": 80,
                     "targetPort": 8080
@@ -349,7 +387,7 @@ http_interactions:
                 "selector": {
                   "name": "influxGrafana"
                 },
-                "portalIP": "10.0.0.59",
+                "portalIP": "10.0.0.123",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -359,23 +397,27 @@ http_interactions:
                 "name": "monitoring-heapster",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-heapster",
-                "uid": "a75625b8-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "24",
-                "creationTimestamp": "2015-04-20T09:28:50Z"
+                "uid": "50aae876-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "60",
+                "creationTimestamp": "2015-05-28T02:14:48Z",
+                "labels": {
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "heapster"
+                }
               },
               "spec": {
                 "ports": [
                   {
-                    "name": "",
                     "protocol": "TCP",
                     "port": 80,
                     "targetPort": 8082
                   }
                 ],
                 "selector": {
+                  "kubernetes.io/cluster-service": "true",
                   "name": "heapster"
                 },
-                "portalIP": "10.0.0.227",
+                "portalIP": "10.0.0.164",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -385,14 +427,17 @@ http_interactions:
                 "name": "monitoring-influxdb",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-influxdb",
-                "uid": "a7641ae9-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "28",
-                "creationTimestamp": "2015-04-20T09:28:50Z"
+                "uid": "5231c711-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "63",
+                "creationTimestamp": "2015-05-28T02:14:50Z",
+                "labels": {
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "monitoring-influxdb"
+                }
               },
               "spec": {
                 "ports": [
                   {
-                    "name": "",
                     "protocol": "TCP",
                     "port": 80,
                     "targetPort": 8086
@@ -401,7 +446,7 @@ http_interactions:
                 "selector": {
                   "name": "influxGrafana"
                 },
-                "portalIP": "10.0.0.43",
+                "portalIP": "10.0.0.13",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -411,23 +456,29 @@ http_interactions:
                 "name": "monitoring-influxdb-ui",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/services/monitoring-influxdb-ui",
-                "uid": "a76e689d-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "30",
-                "creationTimestamp": "2015-04-20T09:28:50Z"
+                "uid": "53d78b27-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "66",
+                "creationTimestamp": "2015-05-28T02:14:53Z"
               },
               "spec": {
                 "ports": [
                   {
-                    "name": "",
+                    "name": "http",
                     "protocol": "TCP",
-                    "port": 80,
+                    "port": 8083,
                     "targetPort": 8083
+                  },
+                  {
+                    "name": "api",
+                    "protocol": "TCP",
+                    "port": 8086,
+                    "targetPort": 8086
                   }
                 ],
                 "selector": {
                   "name": "influxGrafana"
                 },
-                "portalIP": "10.0.0.104",
+                "portalIP": "10.0.0.210",
                 "sessionAffinity": "None"
               },
               "status": {}
@@ -435,7 +486,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:29 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/replicationcontrollers
@@ -448,7 +499,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -457,7 +508,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:31 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -468,7 +519,7 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/replicationcontrollers",
-            "resourceVersion": "607"
+            "resourceVersion": "123"
           },
           "items": [
             {
@@ -476,10 +527,11 @@ http_interactions:
                 "name": "monitoring-heapster-controller",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/replicationcontrollers/monitoring-heapster-controller",
-                "uid": "a7519595-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "46",
-                "creationTimestamp": "2015-04-20T09:28:50Z",
+                "uid": "56876271-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "75",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
                 "labels": {
+                  "kubernetes.io/cluster-service": "true",
                   "name": "heapster"
                 }
               },
@@ -492,34 +544,25 @@ http_interactions:
                   "metadata": {
                     "creationTimestamp": null,
                     "labels": {
-                      "name": "heapster",
-                      "uses": "monitoring-influxdb"
+                      "kubernetes.io/cluster-service": "true",
+                      "name": "heapster"
                     }
                   },
                   "spec": {
                     "volumes": [
                       {
                         "name": "ssl-certs",
-                        "hostPath": {
-                          "path": "/etc/ssl/certs"
-                        },
-                        "emptyDir": null,
-                        "gcePersistentDisk": null,
-                        "gitRepo": null,
-                        "secret": null,
-                        "nfs": null,
-                        "iscsi": null,
-                        "glusterfs": null
+                        "emptyDir": {}
                       }
                     ],
                     "containers": [
                       {
                         "name": "heapster",
-                        "image": "kubernetes/heapster:v0.9",
+                        "image": "kubernetes/heapster:v0.11.0",
                         "env": [
                           {
                             "name": "INFLUXDB_HOST",
-                            "value": "monitoring-influxdb"
+                            "value": "http://monitoring-influxdb:80"
                           },
                           {
                             "name": "SINK",
@@ -536,11 +579,16 @@ http_interactions:
                         ],
                         "terminationMessagePath": "/dev/termination-log",
                         "imagePullPolicy": "IfNotPresent",
-                        "capabilities": {}
+                        "capabilities": {},
+                        "securityContext": {
+                          "capabilities": {},
+                          "privileged": false
+                        }
                       }
                     ],
                     "restartPolicy": "Always",
-                    "dnsPolicy": "ClusterFirst"
+                    "dnsPolicy": "ClusterFirst",
+                    "serviceAccount": ""
                   }
                 }
               },
@@ -553,9 +601,9 @@ http_interactions:
                 "name": "monitoring-influx-grafana-controller",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/replicationcontrollers/monitoring-influx-grafana-controller",
-                "uid": "a75b3f84-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "47",
-                "creationTimestamp": "2015-04-20T09:28:50Z",
+                "uid": "584c98e3-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "88",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
                 "labels": {
                   "name": "influxGrafana"
                 }
@@ -573,17 +621,18 @@ http_interactions:
                     }
                   },
                   "spec": {
-                    "volumes": null,
                     "containers": [
                       {
                         "name": "influxdb",
                         "image": "kubernetes/heapster_influxdb:v0.3",
                         "ports": [
                           {
+                            "hostPort": 8083,
                             "containerPort": 8083,
                             "protocol": "TCP"
                           },
                           {
+                            "hostPort": 8086,
                             "containerPort": 8086,
                             "protocol": "TCP"
                           }
@@ -591,17 +640,15 @@ http_interactions:
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
                         "imagePullPolicy": "IfNotPresent",
-                        "capabilities": {}
+                        "capabilities": {},
+                        "securityContext": {
+                          "capabilities": {},
+                          "privileged": false
+                        }
                       },
                       {
                         "name": "grafana",
-                        "image": "kubernetes/heapster_grafana:v0.5",
-                        "ports": [
-                          {
-                            "containerPort": 8080,
-                            "protocol": "TCP"
-                          }
-                        ],
+                        "image": "kubernetes/heapster_grafana:v0.7",
                         "env": [
                           {
                             "name": "INFLUXDB_EXTERNAL_URL",
@@ -609,21 +656,26 @@ http_interactions:
                           },
                           {
                             "name": "INFLUXDB_HOST",
-                            "value": "monitoring-influxdb"
+                            "value": "localhost"
                           },
                           {
                             "name": "INFLUXDB_PORT",
-                            "value": "80"
+                            "value": "8086"
                           }
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
                         "imagePullPolicy": "IfNotPresent",
-                        "capabilities": {}
+                        "capabilities": {},
+                        "securityContext": {
+                          "capabilities": {},
+                          "privileged": false
+                        }
                       }
                     ],
                     "restartPolicy": "Always",
-                    "dnsPolicy": "ClusterFirst"
+                    "dnsPolicy": "ClusterFirst",
+                    "serviceAccount": ""
                   }
                 }
               },
@@ -634,7 +686,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:31 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/nodes
@@ -647,7 +699,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -656,9 +708,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:33 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Content-Length:
-      - '1555'
+      - '1533'
     body:
       encoding: UTF-8
       string: |-
@@ -667,56 +719,57 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/nodes",
-            "resourceVersion": "613"
+            "resourceVersion": "123"
           },
           "items": [
             {
               "metadata": {
-                "name": "dhcp-0-202.tlv.redhat.com",
-                "selfLink": "/api/v1beta3/nodes/dhcp-0-202.tlv.redhat.com",
-                "uid": "a3d2a008-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "613",
-                "creationTimestamp": "2015-04-20T09:28:44Z"
+                "name": "127.0.0.1",
+                "selfLink": "/api/v1beta3/nodes/127.0.0.1",
+                "uid": "a7b87121-04de-11e5-ad4b-525400c903c1",
+                "resourceVersion": "123",
+                "creationTimestamp": "2015-05-28T02:10:04Z"
               },
               "spec": {
-                "externalID": "dhcp-0-202.tlv.redhat.com"
+                "externalID": "127.0.0.1"
               },
               "status": {
                 "capacity": {
                   "cpu": "2",
-                  "memory": "2937564Ki"
+                  "maxpods": "100",
+                  "memory": "1630360Ki"
                 },
                 "conditions": [
                   {
                     "type": "Ready",
                     "status": "True",
-                    "lastHeartbeatTime": "2015-04-20T09:32:33Z",
-                    "lastTransitionTime": "2015-04-20T09:28:46Z",
+                    "lastHeartbeatTime": "2015-05-28T02:16:54Z",
+                    "lastTransitionTime": "2015-05-28T02:10:06Z",
                     "reason": "kubelet is posting ready status"
                   }
                 ],
                 "addresses": [
                   {
                     "type": "LegacyHostIP",
-                    "address": "10.35.0.202"
+                    "address": "127.0.0.1"
                   }
                 ],
                 "nodeInfo": {
-                  "machineID": "8b4806e4334f470aa612265388e4121e",
-                  "systemUUID": "8B4806E4-334F-470A-A612-265388E4121E",
-                  "bootID": "8bf324a5-8d03-49ce-8324-14617e6ddec2",
+                  "machineID": "7781b4bef7b9439f92affb710a6311e0",
+                  "systemUUID": "7781B4BE-F7B9-439F-92AF-FB710A6311E0",
+                  "bootID": "f01a3567-174d-4e18-af11-791055db63eb",
                   "kernelVersion": "3.10.0-229.1.2.el7.x86_64",
                   "osImage": "CentOS Linux 7 (Core)",
                   "containerRuntimeVersion": "docker://1.5.0-dev",
-                  "kubeletVersion": "v0.14.1-583-g4f0822d5fb10d5",
-                  "KubeProxyVersion": "v0.14.1-583-g4f0822d5fb10d5"
+                  "kubeletVersion": "v0.17.0-441-g6b6b47a777b480",
+                  "kubeProxyVersion": "v0.17.0-441-g6b6b47a777b480"
                 }
               }
             }
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:33 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/events
@@ -729,7 +782,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -738,7 +791,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:35 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -749,469 +802,519 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/events",
-            "resourceVersion": "618"
+            "resourceVersion": "123"
           },
           "items": [
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aecdc352df13",
+                "name": "127.0.0.1.13e240ea155adf29",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aecdc352df13",
-                "uid": "a92b352b-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "41",
-                "creationTimestamp": "2015-04-20T09:28:53Z",
-                "deletionTimestamp": "2015-04-20T10:28:53Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/127.0.0.1.13e240ea155adf29",
+                "uid": "a8337ecb-04de-11e5-ad4b-525400c903c1",
+                "resourceVersion": "15",
+                "creationTimestamp": "2015-05-28T02:10:05Z",
+                "deletionTimestamp": "2015-05-28T03:10:05Z"
               },
               "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
-                "apiVersion": "v1beta3",
-                "resourceVersion": "25"
+                "kind": "Node",
+                "name": "127.0.0.1",
+                "uid": "127.0.0.1"
               },
-              "reason": "failedScheduling",
-              "message": "Error scheduling: no minions available to schedule pods",
+              "reason": "starting",
+              "message": "Starting kubelet.",
               "source": {
-                "component": "scheduler"
+                "component": "kubelet",
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:28:50Z",
-              "lastTimestamp": "2015-04-20T09:28:53Z",
-              "count": 3
-            },
-            {
-              "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aecf66cd9593",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aecf66cd9593",
-                "uid": "ab92d0b7-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "60",
-                "creationTimestamp": "2015-04-20T09:28:57Z",
-                "deletionTimestamp": "2015-04-20T10:28:57Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
-                "apiVersion": "v1beta3",
-                "resourceVersion": "25"
-              },
-              "reason": "scheduled",
-              "message": "Successfully assigned monitoring-heapster-controller-39o8t to dhcp-0-202.tlv.redhat.com",
-              "source": {
-                "component": "scheduler"
-              },
-              "firstTimestamp": "2015-04-20T09:28:57Z",
-              "lastTimestamp": "2015-04-20T09:28:57Z",
+              "firstTimestamp": "2015-05-28T02:10:05Z",
+              "lastTimestamp": "2015-05-28T02:10:05Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aed6b128034c",
+                "name": "127.0.0.1.13e240ea46645573",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed6b128034c",
-                "uid": "be6849c6-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "142",
-                "creationTimestamp": "2015-04-20T09:29:29Z",
-                "deletionTimestamp": "2015-04-20T10:29:29Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/127.0.0.1.13e240ea46645573",
+                "uid": "a8b0860d-04de-11e5-ad4b-525400c903c1",
+                "resourceVersion": "16",
+                "creationTimestamp": "2015-05-28T02:10:06Z",
+                "deletionTimestamp": "2015-05-28T03:10:06Z"
+              },
+              "involvedObject": {
+                "kind": "Node",
+                "name": "127.0.0.1",
+                "uid": "127.0.0.1"
+              },
+              "reason": "online",
+              "message": "Node 127.0.0.1 is now online",
+              "source": {
+                "component": "kubelet",
+                "host": "127.0.0.1"
+              },
+              "firstTimestamp": "2015-05-28T02:10:06Z",
+              "lastTimestamp": "2015-05-28T02:10:06Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-heapster-controller-39o8t.13e2412e30b41e08",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13e2412e30b41e08",
+                "uid": "568d9d92-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "74",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
+                "deletionTimestamp": "2015-05-28T03:14:58Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
                 "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "59",
+                "resourceVersion": "70"
+              },
+              "reason": "scheduled",
+              "message": "Successfully assigned monitoring-heapster-controller-39o8t to 127.0.0.1",
+              "source": {
+                "component": "scheduler"
+              },
+              "firstTimestamp": "2015-05-28T02:14:58Z",
+              "lastTimestamp": "2015-05-28T02:14:58Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-heapster-controller-39o8t.13e2412e372f3ab3",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13e2412e372f3ab3",
+                "uid": "569e158b-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "76",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
+                "deletionTimestamp": "2015-05-28T03:14:58Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-heapster-controller-39o8t",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "73",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "pulled",
               "message": "Successfully pulled image \"gcr.io/google_containers/pause:0.8.0\"",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:28Z",
-              "lastTimestamp": "2015-04-20T09:29:28Z",
+              "firstTimestamp": "2015-05-28T02:14:58Z",
+              "lastTimestamp": "2015-05-28T02:14:58Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aed769a3903e",
+                "name": "monitoring-heapster-controller-39o8t.13e2412e51c8a99e",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed769a3903e",
-                "uid": "c0509481-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "152",
-                "creationTimestamp": "2015-04-20T09:29:32Z",
-                "deletionTimestamp": "2015-04-20T10:29:32Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13e2412e51c8a99e",
+                "uid": "56e2253a-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "77",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
+                "deletionTimestamp": "2015-05-28T03:14:58Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
                 "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "59",
+                "resourceVersion": "73",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "created",
-              "message": "Created with docker id be2610ef34e18c8468381b4ecac0ef9b3b4eb0b657bba5b15de8d667db959a26",
+              "message": "Created with docker id 81990a43a70c08d3c4ed919fdcb0f79226076d6d9578fab78b29589f111e5ecc",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:31Z",
-              "lastTimestamp": "2015-04-20T09:29:31Z",
+              "firstTimestamp": "2015-05-28T02:14:58Z",
+              "lastTimestamp": "2015-05-28T02:14:58Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aed776282ead",
+                "name": "monitoring-heapster-controller-39o8t.13e2412e5917eb65",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed776282ead",
-                "uid": "c0ac1bac-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "154",
-                "creationTimestamp": "2015-04-20T09:29:32Z",
-                "deletionTimestamp": "2015-04-20T10:29:32Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13e2412e5917eb65",
+                "uid": "56f5134d-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "78",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
+                "deletionTimestamp": "2015-05-28T03:14:58Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
                 "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "59",
+                "resourceVersion": "73",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "started",
-              "message": "Started with docker id be2610ef34e18c8468381b4ecac0ef9b3b4eb0b657bba5b15de8d667db959a26",
+              "message": "Started with docker id 81990a43a70c08d3c4ed919fdcb0f79226076d6d9578fab78b29589f111e5ecc",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:32Z",
-              "lastTimestamp": "2015-04-20T09:29:32Z",
+              "firstTimestamp": "2015-05-28T02:14:58Z",
+              "lastTimestamp": "2015-05-28T02:14:58Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aed853d62f2a",
+                "name": "monitoring-heapster-controller-39o8t.13e2412e70315d08",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed853d62f2a",
-                "uid": "c2d17324-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "164",
-                "creationTimestamp": "2015-04-20T09:29:36Z",
-                "deletionTimestamp": "2015-04-20T10:29:36Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13e2412e70315d08",
+                "uid": "5730115b-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "79",
+                "creationTimestamp": "2015-05-28T02:14:59Z",
+                "deletionTimestamp": "2015-05-28T03:14:59Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
                 "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "59",
+                "resourceVersion": "73",
                 "fieldPath": "spec.containers{heapster}"
               },
               "reason": "created",
-              "message": "Created with docker id 6e6119478fe1a60b751f52b39bcaab97015575ac797d7a810bb5804370bd7351",
+              "message": "Created with docker id b1ddf3fb4c7f8df73f8cc1e40b62acbae59ea02ea517e6cbdd14e502edb29040",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:35Z",
-              "lastTimestamp": "2015-04-20T09:29:35Z",
+              "firstTimestamp": "2015-05-28T02:14:59Z",
+              "lastTimestamp": "2015-05-28T02:14:59Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-heapster-controller-39o8t.13d6aed888a58a6f",
+                "name": "monitoring-heapster-controller-39o8t.13e2412e76831fcb",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13d6aed888a58a6f",
-                "uid": "c36a093b-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "167",
-                "creationTimestamp": "2015-04-20T09:29:37Z",
-                "deletionTimestamp": "2015-04-20T10:29:37Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller-39o8t.13e2412e76831fcb",
+                "uid": "57402809-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "80",
+                "creationTimestamp": "2015-05-28T02:14:59Z",
+                "deletionTimestamp": "2015-05-28T03:14:59Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
                 "name": "monitoring-heapster-controller-39o8t",
-                "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
+                "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "59",
+                "resourceVersion": "73",
                 "fieldPath": "spec.containers{heapster}"
               },
               "reason": "started",
-              "message": "Started with docker id 6e6119478fe1a60b751f52b39bcaab97015575ac797d7a810bb5804370bd7351",
+              "message": "Started with docker id b1ddf3fb4c7f8df73f8cc1e40b62acbae59ea02ea517e6cbdd14e502edb29040",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:36Z",
-              "lastTimestamp": "2015-04-20T09:29:36Z",
+              "firstTimestamp": "2015-05-28T02:14:59Z",
+              "lastTimestamp": "2015-05-28T02:14:59Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aecdc88a2b10",
+                "name": "monitoring-heapster-controller.13e2412e2f82a53f",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aecdc88a2b10",
-                "uid": "a93896eb-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "43",
-                "creationTimestamp": "2015-04-20T09:28:53Z",
-                "deletionTimestamp": "2015-04-20T10:28:53Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-heapster-controller.13e2412e2f82a53f",
+                "uid": "568a85a1-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "71",
+                "creationTimestamp": "2015-05-28T02:14:58Z",
+                "deletionTimestamp": "2015-05-28T03:14:58Z"
               },
               "involvedObject": {
-                "kind": "Pod",
+                "kind": "ReplicationController",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-heapster-controller",
+                "uid": "56876271-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "29"
+                "resourceVersion": "69"
               },
-              "reason": "failedScheduling",
-              "message": "Error scheduling: no minions available to schedule pods",
+              "reason": "successfulCreate",
+              "message": "Created pod: monitoring-heapster-controller-39o8t",
               "source": {
-                "component": "scheduler"
+                "component": "replication-controller"
               },
-              "firstTimestamp": "2015-04-20T09:28:50Z",
-              "lastTimestamp": "2015-04-20T09:28:53Z",
-              "count": 3
+              "firstTimestamp": "2015-05-28T02:14:58Z",
+              "lastTimestamp": "2015-05-28T02:14:58Z",
+              "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aecf6d323264",
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412ee2c24d02",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aecf6d323264",
-                "uid": "aba38226-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "63",
-                "creationTimestamp": "2015-04-20T09:28:57Z",
-                "deletionTimestamp": "2015-04-20T10:28:57Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412ee2c24d02",
+                "uid": "5855ae44-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "87",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
+                "deletionTimestamp": "2015-05-28T03:15:01Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "29"
+                "resourceVersion": "83"
               },
               "reason": "scheduled",
-              "message": "Successfully assigned monitoring-influx-grafana-controller-rnzju to dhcp-0-202.tlv.redhat.com",
+              "message": "Successfully assigned monitoring-influx-grafana-controller-mdyqf to 127.0.0.1",
               "source": {
                 "component": "scheduler"
               },
-              "firstTimestamp": "2015-04-20T09:28:57Z",
-              "lastTimestamp": "2015-04-20T09:28:57Z",
+              "firstTimestamp": "2015-05-28T02:15:01Z",
+              "lastTimestamp": "2015-05-28T02:15:01Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed6b18e9b97",
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412ee4a9cb78",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed6b18e9b97",
-                "uid": "bea55362-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "144",
-                "creationTimestamp": "2015-04-20T09:29:29Z",
-                "deletionTimestamp": "2015-04-20T10:29:29Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412ee4a9cb78",
+                "uid": "585a5e9f-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "90",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
+                "deletionTimestamp": "2015-05-28T03:15:01Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "62",
+                "resourceVersion": "86",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "pulled",
               "message": "Successfully pulled image \"gcr.io/google_containers/pause:0.8.0\"",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:28Z",
-              "lastTimestamp": "2015-04-20T09:29:28Z",
+              "firstTimestamp": "2015-05-28T02:15:01Z",
+              "lastTimestamp": "2015-05-28T02:15:01Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed754c7e6b6",
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412efd9ff899",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed754c7e6b6",
-                "uid": "bff50754-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "150",
-                "creationTimestamp": "2015-04-20T09:29:31Z",
-                "deletionTimestamp": "2015-04-20T10:29:31Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412efd9ff899",
+                "uid": "589a21b2-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "92",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
+                "deletionTimestamp": "2015-05-28T03:15:01Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "62",
+                "resourceVersion": "86",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "created",
-              "message": "Created with docker id 26c7485bab3c13eaf87d70a36416c6df8211ce0f71f1039b265841e0e857fb69",
+              "message": "Created with docker id 18b14193133cb102823accca283cad93312ff88dda1c12996e70704554eba816",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:31Z",
-              "lastTimestamp": "2015-04-20T09:29:31Z",
+              "firstTimestamp": "2015-05-28T02:15:01Z",
+              "lastTimestamp": "2015-05-28T02:15:01Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed77213f01e",
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412f0544e812",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed77213f01e",
-                "uid": "c06f170a-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "153",
-                "creationTimestamp": "2015-04-20T09:29:32Z",
-                "deletionTimestamp": "2015-04-20T10:29:32Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412f0544e812",
+                "uid": "58addac5-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "93",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
+                "deletionTimestamp": "2015-05-28T03:15:01Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "62",
+                "resourceVersion": "86",
                 "fieldPath": "implicitly required container POD"
               },
               "reason": "started",
-              "message": "Started with docker id 26c7485bab3c13eaf87d70a36416c6df8211ce0f71f1039b265841e0e857fb69",
+              "message": "Started with docker id 18b14193133cb102823accca283cad93312ff88dda1c12996e70704554eba816",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:32Z",
-              "lastTimestamp": "2015-04-20T09:29:32Z",
+              "firstTimestamp": "2015-05-28T02:15:01Z",
+              "lastTimestamp": "2015-05-28T02:15:01Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed84ed2381b",
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412f1b30d33d",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed84ed2381b",
-                "uid": "c294676b-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "163",
-                "creationTimestamp": "2015-04-20T09:29:36Z",
-                "deletionTimestamp": "2015-04-20T10:29:36Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412f1b30d33d",
+                "uid": "58e5beb6-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "94",
+                "creationTimestamp": "2015-05-28T02:15:02Z",
+                "deletionTimestamp": "2015-05-28T03:15:02Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "62",
-                "fieldPath": "spec.containers{influxdb}"
-              },
-              "reason": "created",
-              "message": "Created with docker id 997c6a36aec6677fb1d5ae37ed89e483b49798fab4648ccfb21cea3be1cf63d9",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-20T09:29:35Z",
-              "lastTimestamp": "2015-04-20T09:29:35Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed865e5b53e",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed865e5b53e",
-                "uid": "c30e765f-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "166",
-                "creationTimestamp": "2015-04-20T09:29:36Z",
-                "deletionTimestamp": "2015-04-20T10:29:36Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
-                "apiVersion": "v1beta3",
-                "resourceVersion": "62",
-                "fieldPath": "spec.containers{influxdb}"
-              },
-              "reason": "started",
-              "message": "Started with docker id 997c6a36aec6677fb1d5ae37ed89e483b49798fab4648ccfb21cea3be1cf63d9",
-              "source": {
-                "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
-              },
-              "firstTimestamp": "2015-04-20T09:29:36Z",
-              "lastTimestamp": "2015-04-20T09:29:36Z",
-              "count": 1
-            },
-            {
-              "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed912cd7a49",
-                "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed912cd7a49",
-                "uid": "c47cff06-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "173",
-                "creationTimestamp": "2015-04-20T09:29:39Z",
-                "deletionTimestamp": "2015-04-20T10:29:39Z"
-              },
-              "involvedObject": {
-                "kind": "Pod",
-                "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
-                "apiVersion": "v1beta3",
-                "resourceVersion": "62",
+                "resourceVersion": "86",
                 "fieldPath": "spec.containers{grafana}"
               },
               "reason": "created",
-              "message": "Created with docker id 7996e009081d7fe9a579b973d282d178c009e6f231590f8f08d71c1ee793fe6c",
+              "message": "Created with docker id bc85701a8a843a8a694ec9c7c5a33251a8a084564151021d8e52e85b90a22d79",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:39Z",
-              "lastTimestamp": "2015-04-20T09:29:39Z",
+              "firstTimestamp": "2015-05-28T02:15:02Z",
+              "lastTimestamp": "2015-05-28T02:15:02Z",
               "count": 1
             },
             {
               "metadata": {
-                "name": "monitoring-influx-grafana-controller-rnzju.13d6aed92033e11b",
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412f23b23e85",
                 "namespace": "default",
-                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-rnzju.13d6aed92033e11b",
-                "uid": "c4d843ae-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "174",
-                "creationTimestamp": "2015-04-20T09:29:39Z",
-                "deletionTimestamp": "2015-04-20T10:29:39Z"
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412f23b23e85",
+                "uid": "58fbd9ba-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "95",
+                "creationTimestamp": "2015-05-28T02:15:02Z",
+                "deletionTimestamp": "2015-05-28T03:15:02Z"
               },
               "involvedObject": {
                 "kind": "Pod",
                 "namespace": "default",
-                "name": "monitoring-influx-grafana-controller-rnzju",
-                "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
                 "apiVersion": "v1beta3",
-                "resourceVersion": "62",
+                "resourceVersion": "86",
                 "fieldPath": "spec.containers{grafana}"
               },
               "reason": "started",
-              "message": "Started with docker id 7996e009081d7fe9a579b973d282d178c009e6f231590f8f08d71c1ee793fe6c",
+              "message": "Started with docker id bc85701a8a843a8a694ec9c7c5a33251a8a084564151021d8e52e85b90a22d79",
               "source": {
                 "component": "kubelet",
-                "host": "dhcp-0-202.tlv.redhat.com"
+                "host": "127.0.0.1"
               },
-              "firstTimestamp": "2015-04-20T09:29:39Z",
-              "lastTimestamp": "2015-04-20T09:29:39Z",
+              "firstTimestamp": "2015-05-28T02:15:02Z",
+              "lastTimestamp": "2015-05-28T02:15:02Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412f44bb9c69",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412f44bb9c69",
+                "uid": "59501124-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "96",
+                "creationTimestamp": "2015-05-28T02:15:02Z",
+                "deletionTimestamp": "2015-05-28T03:15:02Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "86",
+                "fieldPath": "spec.containers{influxdb}"
+              },
+              "reason": "created",
+              "message": "Created with docker id 48e813f985e558c27be2efc4ab8a6ee7c2526962bdec0ce04ed282fd6c901abc",
+              "source": {
+                "component": "kubelet",
+                "host": "127.0.0.1"
+              },
+              "firstTimestamp": "2015-05-28T02:15:02Z",
+              "lastTimestamp": "2015-05-28T02:15:02Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller-mdyqf.13e2412f4a05ce3a",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller-mdyqf.13e2412f4a05ce3a",
+                "uid": "595db4bd-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "97",
+                "creationTimestamp": "2015-05-28T02:15:02Z",
+                "deletionTimestamp": "2015-05-28T03:15:02Z"
+              },
+              "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller-mdyqf",
+                "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "86",
+                "fieldPath": "spec.containers{influxdb}"
+              },
+              "reason": "started",
+              "message": "Started with docker id 48e813f985e558c27be2efc4ab8a6ee7c2526962bdec0ce04ed282fd6c901abc",
+              "source": {
+                "component": "kubelet",
+                "host": "127.0.0.1"
+              },
+              "firstTimestamp": "2015-05-28T02:15:02Z",
+              "lastTimestamp": "2015-05-28T02:15:02Z",
+              "count": 1
+            },
+            {
+              "metadata": {
+                "name": "monitoring-influx-grafana-controller.13e2412ee13ed635",
+                "namespace": "default",
+                "selfLink": "/api/v1beta3/namespaces/default/events/monitoring-influx-grafana-controller.13e2412ee13ed635",
+                "uid": "5851731a-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "84",
+                "creationTimestamp": "2015-05-28T02:15:01Z",
+                "deletionTimestamp": "2015-05-28T03:15:01Z"
+              },
+              "involvedObject": {
+                "kind": "ReplicationController",
+                "namespace": "default",
+                "name": "monitoring-influx-grafana-controller",
+                "uid": "584c98e3-04df-11e5-ad4b-525400c903c1",
+                "apiVersion": "v1beta3",
+                "resourceVersion": "82"
+              },
+              "reason": "successfulCreate",
+              "message": "Created pod: monitoring-influx-grafana-controller-mdyqf",
+              "source": {
+                "component": "replication-controller"
+              },
+              "firstTimestamp": "2015-05-28T02:15:01Z",
+              "lastTimestamp": "2015-05-28T02:15:01Z",
               "count": 1
             }
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:36 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/endpoints
@@ -1224,7 +1327,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -1233,7 +1336,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:38 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -1244,7 +1347,7 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/endpoints",
-            "resourceVersion": "625"
+            "resourceVersion": "123"
           },
           "items": [
             {
@@ -1252,9 +1355,9 @@ http_interactions:
                 "name": "kubernetes",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/endpoints/kubernetes",
-                "uid": "a37316f5-e73f-11e4-b613-001a4a5f4a02",
+                "uid": "a72b5116-04de-11e5-ad4b-525400c903c1",
                 "resourceVersion": "7",
-                "creationTimestamp": "2015-04-20T09:28:43Z"
+                "creationTimestamp": "2015-05-28T02:10:03Z"
               },
               "subsets": [
                 {
@@ -1277,9 +1380,9 @@ http_interactions:
                 "name": "kubernetes-ro",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/endpoints/kubernetes-ro",
-                "uid": "a376f279-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "8",
-                "creationTimestamp": "2015-04-20T09:28:43Z"
+                "uid": "a72d5893-04de-11e5-ad4b-525400c903c1",
+                "resourceVersion": "9",
+                "creationTimestamp": "2015-05-28T02:10:03Z"
               },
               "subsets": [
                 {
@@ -1302,21 +1405,25 @@ http_interactions:
                 "name": "monitoring-grafana",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-grafana",
-                "uid": "a9c9c6d0-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "193",
-                "creationTimestamp": "2015-04-20T09:28:54Z"
+                "uid": "4eea00af-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "115",
+                "creationTimestamp": "2015-05-28T02:14:45Z",
+                "labels": {
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "monitoring-grafana"
+                }
               },
               "subsets": [
                 {
                   "addresses": [
                     {
-                      "IP": "172.17.0.9",
+                      "IP": "172.18.1.6",
                       "targetRef": {
                         "kind": "Pod",
                         "namespace": "default",
-                        "name": "monitoring-influx-grafana-controller-rnzju",
-                        "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
-                        "resourceVersion": "178"
+                        "name": "monitoring-influx-grafana-controller-mdyqf",
+                        "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
+                        "resourceVersion": "113"
                       }
                     }
                   ],
@@ -1334,21 +1441,25 @@ http_interactions:
                 "name": "monitoring-heapster",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-heapster",
-                "uid": "aa7edaf0-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "194",
-                "creationTimestamp": "2015-04-20T09:28:55Z"
+                "uid": "50ad853e-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "91",
+                "creationTimestamp": "2015-05-28T02:14:48Z",
+                "labels": {
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "heapster"
+                }
               },
               "subsets": [
                 {
                   "addresses": [
                     {
-                      "IP": "172.17.0.10",
+                      "IP": "172.18.1.5",
                       "targetRef": {
                         "kind": "Pod",
                         "namespace": "default",
                         "name": "monitoring-heapster-controller-39o8t",
-                        "uid": "a7566742-e73f-11e4-b613-001a4a5f4a02",
-                        "resourceVersion": "171"
+                        "uid": "5688e48b-04df-11e5-ad4b-525400c903c1",
+                        "resourceVersion": "89"
                       }
                     }
                   ],
@@ -1366,21 +1477,25 @@ http_interactions:
                 "name": "monitoring-influxdb",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-influxdb",
-                "uid": "aada66e1-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "196",
-                "creationTimestamp": "2015-04-20T09:28:56Z"
+                "uid": "5234368a-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "116",
+                "creationTimestamp": "2015-05-28T02:14:50Z",
+                "labels": {
+                  "kubernetes.io/cluster-service": "true",
+                  "name": "monitoring-influxdb"
+                }
               },
               "subsets": [
                 {
                   "addresses": [
                     {
-                      "IP": "172.17.0.9",
+                      "IP": "172.18.1.6",
                       "targetRef": {
                         "kind": "Pod",
                         "namespace": "default",
-                        "name": "monitoring-influx-grafana-controller-rnzju",
-                        "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
-                        "resourceVersion": "178"
+                        "name": "monitoring-influx-grafana-controller-mdyqf",
+                        "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
+                        "resourceVersion": "113"
                       }
                     }
                   ],
@@ -1398,27 +1513,33 @@ http_interactions:
                 "name": "monitoring-influxdb-ui",
                 "namespace": "default",
                 "selfLink": "/api/v1beta3/namespaces/default/endpoints/monitoring-influxdb-ui",
-                "uid": "ab35f567-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "197",
-                "creationTimestamp": "2015-04-20T09:28:56Z"
+                "uid": "53da6471-04df-11e5-ad4b-525400c903c1",
+                "resourceVersion": "114",
+                "creationTimestamp": "2015-05-28T02:14:53Z"
               },
               "subsets": [
                 {
                   "addresses": [
                     {
-                      "IP": "172.17.0.9",
+                      "IP": "172.18.1.6",
                       "targetRef": {
                         "kind": "Pod",
                         "namespace": "default",
-                        "name": "monitoring-influx-grafana-controller-rnzju",
-                        "uid": "a7649eaa-e73f-11e4-b613-001a4a5f4a02",
-                        "resourceVersion": "178"
+                        "name": "monitoring-influx-grafana-controller-mdyqf",
+                        "uid": "584ed5e7-04df-11e5-ad4b-525400c903c1",
+                        "resourceVersion": "113"
                       }
                     }
                   ],
                   "ports": [
                     {
+                      "name": "http",
                       "port": 8083,
+                      "protocol": "TCP"
+                    },
+                    {
+                      "name": "api",
+                      "port": 8086,
                       "protocol": "TCP"
                     }
                   ]
@@ -1428,7 +1549,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:38 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 - request:
     method: get
     uri: https://10.35.0.202:6443/api/v1beta3/namespaces
@@ -1441,7 +1562,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p598
+      - rest-client/2.0.0.alpha (linux-gnu x86_64) ruby/2.0.0p353
   response:
     status:
       code: 200
@@ -1450,7 +1571,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2015 09:32:40 GMT
+      - Thu, 28 May 2015 02:17:02 GMT
       Content-Length:
       - '563'
     body:
@@ -1461,16 +1582,16 @@ http_interactions:
           "apiVersion": "v1beta3",
           "metadata": {
             "selfLink": "/api/v1beta3/namespaces",
-            "resourceVersion": "630"
+            "resourceVersion": "123"
           },
           "items": [
             {
               "metadata": {
                 "name": "default",
                 "selfLink": "/api/v1beta3/namespaces/default",
-                "uid": "a3653796-e73f-11e4-b613-001a4a5f4a02",
-                "resourceVersion": "4",
-                "creationTimestamp": "2015-04-20T09:28:43Z"
+                "uid": "a727455b-04de-11e5-ad4b-525400c903c1",
+                "resourceVersion": "5",
+                "creationTimestamp": "2015-05-28T02:10:03Z"
               },
               "spec": {
                 "finalizers": [
@@ -1484,5 +1605,5 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 20 Apr 2015 09:32:40 GMT
+  recorded_at: Thu, 28 May 2015 02:17:01 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This PR updates the kubernetes VCR to v0.17.0-441-g6b6b47a (openshift v0.5.2) fixing also the new nits related to the latest API changes. It also adds a container_replicator test that was currently missing.