### PR TITLE
Fixed typo causing exception on alert details page

### DIFF
--- a/vmdb/app/views/miq_policy/_alert_details.html.haml
+++ b/vmdb/app/views/miq_policy/_alert_details.html.haml
@@ -242,8 +242,8 @@
                   %tbody
                     - @alert_profiles.each do |ap|
                       - id = "xx-#{@alert.db}_ap-#{to_cid(ap.id)}"
-                      %tr{:title => _("View this Alert Profile")),
-                        :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=alert_profile"}
+                      %tr{:title => _("View this Alert Profile"),
+                          :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=alert_profile")}
                         %td
                           %img{:src => "/images/icons/new/miq_alert_profile.png"}
                         %td


### PR DESCRIPTION
Control → Explorer → Alerts →[specific one alert]