### PR TITLE
[WIP] Fixed issue in catalog items page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1666,7 +1666,7 @@ class CatalogController < ApplicationController
               add_pictures_to_sync(@record.picture.id) if @record.picture
               if @record.atomic? && need_prov_dialogs?(@record.prov_type)
                 @miq_request = MiqRequest.find_by_id(@record.service_resources[0].resource_id)
-                prov_set_show_vars
+                prov_set_show_vars if @miq_request.present?
               end
               @sb[:dialog_label]       = "No Dialog"
               @sb[:fqname]             = nil


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1251898

While clicking in some items in Catalog Items i'm getting exception:

    [----] F, [2015-05-29T11:08:39.933299 #16503:3fc96ee1be88] FATAL -- : Error caught: [NoMethodError] undefined method `get_options' for nil:NilClass
    /home/rblanco/devel/manageiq/vmdb/app/controllers/application_controller/miq_request_methods.rb:736:in `prov_set_show_vars'
    /home/rblanco/devel/manageiq/vmdb/app/controllers/catalog_controller.rb:1667:in `get_node_info'
    /home/rblanco/devel/manageiq/vmdb/app/controllers/catalog_controller.rb:1755:in `replace_right_cell'
    /home/rblanco/devel/manageiq/vmdb/app/controllers/catalog_controller.rb:313:in `tree_select'
    /home/rblanco/devel/manageiq/vmdb/app/controllers/catalog_controller.rb:304:in `x_show'

![screenshot-localhost 3000 2015-05-29 11-08-21](https://cloud.githubusercontent.com/assets/1187051/7879769/858c212e-05f3-11e5-82fe-fd238ee5e829.png)
![screenshot-localhost 3000 2015-05-29 11-08-44](https://cloud.githubusercontent.com/assets/1187051/7879770/8755ff02-05f3-11e5-93d0-c63bf8f482bc.png)

The fix is just about making sure `prov_set_show_vars` is not called with not properly set `@miq_request` variable.