### PR TITLE
Added API functionality for user role CRUD (with product features)

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -58,10 +58,12 @@ class ApiController < ApplicationController
   include_concern 'PolicyActions'
   include_concern 'Providers'
   include_concern 'Events'
+  include_concern 'Features'
   include_concern 'ProvisionRequests'
   include_concern "Rates"
   include_concern "ReportResults"
   include_concern 'RequestTasks'
+  include_concern 'Roles'
   include_concern 'ServiceCatalogs'
   include_concern 'ServiceRequests'
   include_concern 'Software'

--- a/app/controllers/api_controller/error_handler.rb
+++ b/app/controllers/api_controller/error_handler.rb
@@ -30,8 +30,9 @@ class ApiController
         :message => message,
         :klass   => klass
       }
+      api_log_error("#{klass}: #{message}")
       # We don't want to return the stack trace, but only log it in case of an internal error
-      api_log_error("#{message}\n\n#{backtrace}") if kind == :internal_server_error && !backtrace.empty?
+      api_log_error("\n\n#{backtrace}") if kind == :internal_server_error && !backtrace.empty?
 
       render :json => {:error => err}, :status => status
     end

--- a/app/controllers/api_controller/features.rb
+++ b/app/controllers/api_controller/features.rb
@@ -18,7 +18,6 @@ class ApiController
       elsif data.key?('id') || data.key?('identifier')
         new_features = get_product_features(Array.wrap(data))
       else
-        api_log_info("BadRequestError, Invalid feature assignment format specified.")
         raise BadRequestError, "Invalid feature assignment format specified."
       end
 
@@ -48,7 +47,6 @@ class ApiController
       elsif data.key?('id') || data.key?('identifier')
         removed_features = get_product_features(Array.wrap(data))
       else
-        api_log_info("BadRequestError, Invalid feature un-assignment format specified.")
         raise BadRequestError, "Invalid feature un-assignment format specified."
       end
 

--- a/app/controllers/api_controller/features.rb
+++ b/app/controllers/api_controller/features.rb
@@ -1,0 +1,68 @@
+class ApiController
+  module Features
+    include FeatureHelper
+    #
+    # Features Subcollection Supporting Methods
+    #
+    def features_query_resource(object)
+      object.send("miq_product_features")
+    end
+
+    def features_assign_resource(object, _type, id = nil, data = nil)
+      # If id != 0, an href was submitted instead of id or identifier. Set id key in data hash
+      data['id'] = id unless id == 0
+
+      # Handle a features array if passed in, otherwise look for a single feature id
+      if data.key?('features') && data['features'].kind_of?(Array)
+        new_features = get_product_features(data['features'])
+      elsif data.key?('id') || data.key?('identifier')
+        new_features = get_product_features(Array.wrap(data))
+      else
+        api_log_info("BadRequestError, Invalid feature assignment format specified.")
+        raise BadRequestError, "Invalid feature assignment format specified."
+      end
+
+      existing_features = object.miq_product_features.dup.to_a
+
+      # Find new features that already exist in the role remove from further processing
+      existing_features.each do |existing_feature|
+        new_features.delete_if do |new_feature|
+          existing_feature['id'] == new_feature['id']
+        end
+      end
+
+      existing_features.concat(new_features)
+
+      object.update_attribute(:miq_product_features, existing_features)
+      api_log_info("Modified role #{object.name}: assigned features: #{new_features.collect(&:identifier)}")
+      object
+    end
+
+    def features_unassign_resource(object, _type, id = nil, data = nil)
+      # If id != 0, an href was submitted instead of id or identifier. Set id key in data hash
+      data['id'] = id unless id == 0
+
+      # Handle a features array if passed in, otherwise look for a single feature id
+      if data.key?('features') && data['features'].kind_of?(Array)
+        removed_features = get_product_features(data['features'])
+      elsif data.key?('id') || data.key?('identifier')
+        removed_features = get_product_features(Array.wrap(data))
+      else
+        api_log_info("BadRequestError, Invalid feature un-assignment format specified.")
+        raise BadRequestError, "Invalid feature un-assignment format specified."
+      end
+
+      existing_features = object.miq_product_features.dup.to_a
+
+      removed_features.each do |removed_feature|
+        existing_features.delete_if do |existing_feature|
+          removed_feature['id'] == existing_feature['id']
+        end
+      end
+
+      object.update_attribute(:miq_product_features, existing_features)
+      api_log_info("Modified role #{object.name}: un-assigned features: #{existing_features.collect(&:identifier)}")
+      object
+    end
+  end
+end

--- a/app/controllers/api_controller/roles.rb
+++ b/app/controllers/api_controller/roles.rb
@@ -1,0 +1,81 @@
+class ApiController
+  module Roles
+    include FeatureHelper
+    def create_resource_roles(type, _id = nil, data = {})
+      if data.key?("id") || data.key?("href")
+        msg = "Resource id or href should not be specified for creating a new #{type}"
+        api_log_info("BadRequestError, #{msg}")
+        raise BadRequestError, msg
+      end
+
+      # Can't create a read-only role (reserved for out-of-box roles)
+      if data ['read_only']
+        msg = "Cannot create a read-only role."
+        api_log_info("BadRequestError, #{msg}")
+        raise BadRequestError, msg
+      end
+
+      role_klass = collection_class(type)
+
+      get_settings_and_features(data)
+
+      role = role_klass.create!(data.except(*ID_ATTRS))
+      api_log_info("Created new role #{role.name}")
+      role
+    rescue => err
+      role.destroy if role
+      raise err
+    end
+
+    def edit_resource_roles(type, id = nil, data = {})
+      unless id
+        msg = "Must specify an id for editing a #{type} resource"
+        api_log_info("BadRequestError, #{msg}")
+        raise BadRequestError, msg
+      end
+
+      # Can't set an existing role to read-only (reserved for out-of-box roles)
+      if data['read_only']
+        msg = "Cannot set a non-system role to read-only."
+        api_log_info("BadRequestError, #{msg}")
+        raise BadRequestError, msg
+      end
+
+      role = resource_search(id, type, collection_class(:roles))
+
+      # Can't edit a read-only role
+      if role.read_only
+        msg = "Cannot edit a role that is read-only."
+        api_log_info("BadRequestError, #{msg}")
+        raise BadRequestError, msg
+      end
+
+      get_settings_and_features(data)
+
+      role.update_attributes!(data.except(*ID_ATTRS))
+      api_log_info("Modified role #{role.name}")
+      role
+    end
+
+    private
+
+    def get_settings_and_features(data)
+      if data['settings']
+        data['settings'][:restrictions] = get_role_settings(data)
+        data.delete('settings') if data['settings'].empty?
+      end
+
+      # Build miq_product_features hash from passed in features, remove features
+      if data['features']
+        data['miq_product_features'] = get_product_features(data['features'])
+        data.delete('features')
+      end
+    end
+
+    def get_role_settings(data)
+      restrictions = {:vms => data['settings']['restrictions']['vms'].to_sym}
+      data['settings'].delete('restrictions')
+      restrictions
+    end
+  end
+end

--- a/app/controllers/api_controller/roles.rb
+++ b/app/controllers/api_controller/roles.rb
@@ -3,16 +3,12 @@ class ApiController
     include FeatureHelper
     def create_resource_roles(type, _id = nil, data = {})
       if data.key?("id") || data.key?("href")
-        msg = "Resource id or href should not be specified for creating a new #{type}"
-        api_log_info("BadRequestError, #{msg}")
-        raise BadRequestError, msg
+        raise BadRequestError, "Resource id or href should not be specified for creating a new #{type}"
       end
 
       # Can't create a read-only role (reserved for out-of-box roles)
       if data ['read_only']
-        msg = "Cannot create a read-only role."
-        api_log_info("BadRequestError, #{msg}")
-        raise BadRequestError, msg
+        raise BadRequestError, "Cannot create a read-only role."
       end
 
       role_klass = collection_class(type)
@@ -29,25 +25,19 @@ class ApiController
 
     def edit_resource_roles(type, id = nil, data = {})
       unless id
-        msg = "Must specify an id for editing a #{type} resource"
-        api_log_info("BadRequestError, #{msg}")
-        raise BadRequestError, msg
+        raise BadRequestError, "Must specify an id for editing a #{type} resource"
       end
 
       # Can't set an existing role to read-only (reserved for out-of-box roles)
       if data['read_only']
-        msg = "Cannot set a non-system role to read-only."
-        api_log_info("BadRequestError, #{msg}")
-        raise BadRequestError, msg
+        raise BadRequestError, "Cannot set a non-system role to read-only."
       end
 
       role = resource_search(id, type, collection_class(:roles))
 
       # Can't edit a read-only role
       if role.read_only
-        msg = "Cannot edit a role that is read-only."
-        api_log_info("BadRequestError, #{msg}")
-        raise BadRequestError, msg
+        raise BadRequestError, "Cannot edit a role that is read-only."
       end
 
       get_settings_and_features(data)

--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -1,0 +1,26 @@
+module FeatureHelper
+  def get_product_features(features_hash)
+    feature_klass = collection_class(:features)
+
+    new_features = []
+    features_hash.each do |feature|
+      # Look for the feature identifier field first as this will remain constant
+      if feature.key?('identifier') && !feature['identifier'].nil?
+        new_features.push(resource_search_by_criteria('identifier', feature['identifier'], feature_klass))
+      else # Fallback to a feature id or href field.
+        new_features.push(resource_search(parse_id(feature, 'features'), 'features', feature_klass))
+      end
+    end
+    new_features.compact
+  end
+
+  def resource_search_by_criteria(criteria, search_val, klass)
+    search_method = "find_by_#{criteria}"
+    options = {
+      :targets        => Array(klass.send(search_method, search_val)),
+      :userid         => @auth_user,
+      :results_format => :objects
+    }
+    Rbac.search(options).first.first
+  end
+end

--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -1,9 +1,9 @@
 module FeatureHelper
-  def get_product_features(features_hash)
+  def get_product_features(features_ids)
     feature_klass = collection_class(:features)
 
     new_features = []
-    features_hash.each do |feature|
+    features_ids.each do |feature|
       # Look for the feature identifier field first as this will remain constant
       if feature.key?('identifier') && !feature['identifier'].nil?
         new_features.push(resource_search_by_criteria('identifier', feature['identifier'], feature_klass))

--- a/config/api.yml
+++ b/config/api.yml
@@ -144,6 +144,17 @@
     - :subcollection
     :methods: *70174834086080
     :klass: MiqEventDefinition
+  :features:
+    :description: Product Features
+    :options:
+    - :subcollection
+    - :show
+    :methods: *70174834085860
+    :klass: MiqProductFeature
+    :subcollection_actions:
+      :post:
+      - :name: assign
+      - :name: unassign
   :flavors:
     :description: Flavors
     :options:
@@ -492,10 +503,14 @@
     :description: Roles
     :options:
     - :collection
-    :methods: *70174834086080
+    :methods: *70174834085620
     :klass: MiqUserRole
+    :subcollections:
+    - :features
     :collection_actions:
       :post:
+      - :name: create
+        :identifier: rbac_role_add
       - :name: add
         :identifier: rbac_role_add
       - :name: edit
@@ -506,6 +521,8 @@
       :post:
       - :name: edit
         :identifier: rbac_role_edit
+      - :name: delete
+        :identifier: rbac_role_delete
       :delete:
       - :name: delete
         :identifier: rbac_role_delete

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -27,9 +27,9 @@ describe ApiController do
   let(:expected_attributes) { %w(id name read_only settings) }
   let(:sample_role1) do
     {
-      "name"      => "sample_role_1",
-      "settings"  => {"restrictions"  => {"vms" => "user"}},
-      "features"  => [
+      "name"     => "sample_role_1",
+      "settings" => {"restrictions" => {"vms" => "user"}},
+      "features" => [
         {:identifier => "vm_explorer"},
         {:identifier => "ems_infra_tag"},
         {:identifier => "my_settings_time_profiles"}
@@ -38,9 +38,9 @@ describe ApiController do
   end
   let(:sample_role2) do
     {
-      "name"      => "sample_role_2",
-      "settings"  => {"restrictions"  => {"vms" => "user_or_group"}},
-      "features"  => [
+      "name"     => "sample_role_2",
+      "settings" => {"restrictions" => {"vms" => "user_or_group"}},
+      "features" => [
         {:identifier => "miq_request_view"},
         {:identifier => "miq_report_run"},
         {:identifier => "storage_manager_show_list"}
@@ -85,7 +85,8 @@ describe ApiController do
 
   describe "Features" do
     it "query available features" do
-      role = FactoryGirl.create(:miq_user_role, :name => "Test Role",
+      role = FactoryGirl.create(:miq_user_role,
+                                :name                 => "Test Role",
                                 :miq_product_features => @product_features)
       url = roles_url + "/#{role.id}/"
       test_features_query(role, url, MiqProductFeature, :identifier)
@@ -154,7 +155,8 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = @result["results"]
-      r1_id, r2_id = results.first["id"], results.second["id"]
+      r1_id = results.first["id"]
+      r2_id = results.second["id"]
       expect(MiqUserRole.exists?(r1_id)).to be_true
       expect(MiqUserRole.exists?(r2_id)).to be_true
 
@@ -192,12 +194,12 @@ describe ApiController do
 
       role = FactoryGirl.create(:miq_user_role)
 
-      run_post(roles_url(role.id), gen_request(:edit, "name"      => "updated role",
-                                                      "settings"  => {"restrictions"  => {"vms" => "user_or_group"}}))
+      run_post(roles_url(role.id), gen_request(:edit, "name"     => "updated role",
+                                                      "settings" => {"restrictions"  => {"vms" => "user_or_group"}}))
 
       expect_single_resource_query("id"       => role.id,
                                    "name"     => "updated role",
-                                   "settings" => {"restrictions"  => {"vms" => "user_or_group"}})
+                                   "settings" => {"restrictions" => {"vms" => "user_or_group"}})
       expect(role.reload.name).to eq("updated role")
       expect(role.settings[:restrictions][:vms]).to eq(:user_or_group)
     end
@@ -274,6 +276,7 @@ describe ApiController do
       run_post(url, gen_request(:unassign, removed_feature))
 
       expect_request_success
+      # Confirm that we've only removed ems_infra_tag
       expect_result_resources_to_include_keys("results", %w(id name read_only))
 
       # Refresh the role object

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -1,0 +1,375 @@
+#
+# Rest API Request Tests - Roles specs
+#
+# - Query all available features          /api/roles/:id/?expand=features       GET
+# - Creating a role                       /api/roles                            POST
+# - Creating a role via action            /api/roles                            action "create"
+# - Creating multiple roles               /api/roles                            action "create"
+# - Edit a role                           /api/roles/:id                        action "edit"
+# - Edit multiple roles                   /api/roles                            action "edit"
+# - Assign a single feature               /api/roles/:id/features               POST, action "assign"
+# - Assign multiple features              /api/roles/:id/features               POST, action "assign"
+# - Un-assign a single feature            /api/roles/:id/features               POST, action "unassign"
+# - Un-assign multiple features           /api/roles/:id/features               POST, action "unassign"
+# - Delete a role                         /api/roles/:id                        DELETE
+# - Delete a role by action               /api/roles/:id                        action "delete"
+# - Delete multiple roles                 /api/roles                            action "delete"
+#
+require 'spec_helper'
+
+describe ApiController do
+  include Rack::Test::Methods
+
+  let(:feature_identifiers) do
+    %w(vm_explorer ems_infra_tag my_settings_time_profiles
+       miq_request_view miq_report_run storage_manager_show_list)
+  end
+  let(:expected_attributes) { %w(id name read_only settings) }
+  let(:sample_role1) do
+    {
+      "name"      => "sample_role_1",
+      "settings"  => {"restrictions"  => {"vms" => "user"}},
+      "features"  => [
+        {:identifier => "vm_explorer"},
+        {:identifier => "ems_infra_tag"},
+        {:identifier => "my_settings_time_profiles"}
+      ]
+    }
+  end
+  let(:sample_role2) do
+    {
+      "name"      => "sample_role_2",
+      "settings"  => {"restrictions"  => {"vms" => "user_or_group"}},
+      "features"  => [
+        {:identifier => "miq_request_view"},
+        {:identifier => "miq_report_run"},
+        {:identifier => "storage_manager_show_list"}
+      ]
+    }
+  end
+  let(:features_list) do
+    {
+      "features"  => [
+        {:identifier => "miq_request_view"},
+        {:identifier => "miq_report_run"},
+        {:identifier => "storage_manager_show_list"}
+      ]
+    }
+  end
+
+  before(:each) do
+    init_api_spec_env
+
+    @product_features = feature_identifiers.collect do |identifier|
+      FactoryGirl.create(:miq_product_feature, :identifier => identifier)
+    end
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  def test_features_query(role, role_url, klass, attr = :id)
+    api_basic_authorize
+
+    run_get role_url, :expand => "features"
+    expect_request_success
+
+    expect(@result).to have_key("name")
+    expect(@result["name"]).to eq(role.name)
+    expect(@result).to have_key("features")
+    expect(@result["features"].size).to eq(fetch_value(role.miq_product_features.count))
+
+    expect_result_resources_to_include_data("features", attr.to_s => klass.pluck(attr))
+  end
+
+  describe "Features" do
+    it "query available features" do
+      role = FactoryGirl.create(:miq_user_role, :name => "Test Role",
+                                :miq_product_features => @product_features)
+      url = roles_url + "/#{role.id}/"
+      test_features_query(role, url, MiqProductFeature, :identifier)
+    end
+  end
+
+  describe "Roles create" do
+    it "rejects creation without appropriate role" do
+      api_basic_authorize
+
+      run_post(roles_url, sample_role1)
+
+      expect_request_forbidden
+    end
+
+    it "rejects role creation with id specified" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      run_post(roles_url, "name" => "sample role", "id" => 100)
+
+      expect_bad_request(/id or href should not be specified/i)
+    end
+
+    it "supports single role creation" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      run_post(roles_url, sample_role1)
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", expected_attributes)
+
+      role_id = @result["results"].first["id"]
+
+      run_get "#{roles_url}/#{role_id}/", :expand => "features"
+
+      expect(MiqUserRole.exists?(role_id)).to be_true
+      role = MiqUserRole.find(role_id)
+
+      sample_role1['features'].each do |feature|
+        expect(role.allows?(feature)).to be_true
+      end
+    end
+
+    it "supports single role creation via action" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      run_post(roles_url, gen_request(:create, sample_role1))
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", expected_attributes)
+
+      role_id = @result["results"].first["id"]
+      expect(MiqUserRole.exists?(role_id)).to be_true
+      role = MiqUserRole.find(role_id)
+      sample_role1['features'].each do |feature|
+        expect(role.allows?(feature)).to be_true
+      end
+    end
+
+    it "supports multiple role creation" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      run_post(roles_url, gen_request(:create, [sample_role1, sample_role2]))
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", expected_attributes)
+
+      results = @result["results"]
+      r1_id, r2_id = results.first["id"], results.second["id"]
+      expect(MiqUserRole.exists?(r1_id)).to be_true
+      expect(MiqUserRole.exists?(r2_id)).to be_true
+
+      role1 = MiqUserRole.find(r1_id)
+      role2 = MiqUserRole.find(r2_id)
+
+      sample_role1['features'].each do |feature|
+        expect(role1.allows?(feature)).to be_true
+      end
+      sample_role2['features'].each do |feature|
+        expect(role2.allows?(feature)).to be_true
+      end
+    end
+  end
+
+  describe "Roles edit" do
+    it "rejects role edits without appropriate role" do
+      role = FactoryGirl.create(:miq_user_role)
+      api_basic_authorize
+      run_post(roles_url, gen_request(:edit, "name" => "role name", "href" => roles_url(role.id)))
+
+      expect_request_forbidden
+    end
+
+    it "rejects role edits for invalid resources" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+
+      run_post(roles_url(999_999), gen_request(:edit, "name" => "updated role name"))
+
+      expect_resource_not_found
+    end
+
+    it "supports single role edit" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+
+      role = FactoryGirl.create(:miq_user_role)
+
+      run_post(roles_url(role.id), gen_request(:edit, "name"      => "updated role",
+                                                      "settings"  => {"restrictions"  => {"vms" => "user_or_group"}}))
+
+      expect_single_resource_query("id"       => role.id,
+                                   "name"     => "updated role",
+                                   "settings" => {"restrictions"  => {"vms" => "user_or_group"}})
+      expect(role.reload.name).to eq("updated role")
+      expect(role.settings[:restrictions][:vms]).to eq(:user_or_group)
+    end
+
+    it "supports multiple role edits" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+
+      r1 = FactoryGirl.create(:miq_user_role, :name => "role1")
+      r2 = FactoryGirl.create(:miq_user_role, :name => "role2")
+
+      run_post(roles_url, gen_request(:edit,
+                                      [{"href" => roles_url(r1.id), "name" => "updated role1"},
+                                       {"href" => roles_url(r2.id), "name" => "updated role2"}]))
+
+      expect_results_to_match_hash("results",
+                                   [{"id" => r1.id, "name" => "updated role1"},
+                                    {"id" => r2.id, "name" => "updated role2"}])
+
+      expect(r1.reload.name).to eq("updated role1")
+      expect(r2.reload.name).to eq("updated role2")
+    end
+  end
+
+  describe "Role Feature Assignments" do
+    it "supports assigning just a single product feature" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+      role = FactoryGirl.create(:miq_user_role_miq_request_approver)
+
+      new_feature = {:identifier => "miq_request_view"}
+      url = "#{roles_url}/#{role.id}/features"
+      run_post(url, gen_request(:assign, new_feature))
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", %w(id name read_only))
+
+      # Refresh the role object
+      role = MiqUserRole.find(role.id)
+
+      # Confirm original feature
+      expect(role.allows?(:identifier => 'miq_request_approval')).to be_true
+
+      # Confirm new feature
+      expect(role.allows?(new_feature)).to be_true
+    end
+
+    it "supports assigning multiple product features" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+      role = FactoryGirl.create(:miq_user_role_miq_request_approver)
+
+      url = "#{roles_url}/#{role.id}/features"
+      run_post(url, gen_request(:assign, features_list))
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", %w(id name read_only))
+
+      # Refresh the role object
+      role = MiqUserRole.find(role.id)
+
+      # Confirm original feature
+      expect(role.allows?(:identifier => 'miq_request_approval')).to be_true
+
+      # Confirm new features
+      features_list['features'].each do |feature|
+        expect(role.allows?(feature)).to be_true
+      end
+    end
+
+    it "supports un-assigning just a single product feature" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+      role = FactoryGirl.create(:miq_user_role, :miq_product_features => @product_features)
+
+      removed_feature = {:identifier => "ems_infra_tag"}
+      url = "#{roles_url}/#{role.id}/features"
+      run_post(url, gen_request(:unassign, removed_feature))
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", %w(id name read_only))
+
+      # Refresh the role object
+      role = MiqUserRole.find(role.id)
+
+      @product_features.each do |feature|
+        expect(role.allows?(feature)).to be_true unless feature[:identifier].eql?('ems_infra_tag')
+        expect(role.allows?(feature)).to be_false if feature[:identifier].eql?('ems_infra_tag')
+      end
+    end
+
+    it "supports un-assigning multiple product features" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+      role = FactoryGirl.create(:miq_user_role, :miq_product_features => @product_features)
+
+      url = "#{roles_url}/#{role.id}/features"
+      run_post(url, gen_request(:unassign, features_list))
+
+      expect_request_success
+      expect_result_resources_to_include_keys("results", %w(id name read_only))
+
+      # Refresh the role object
+      role = MiqUserRole.find(role.id)
+
+      # Confirm requested features removed first, and others remain
+      @product_features.each do |feature|
+        expect(role.allows?(feature)).to be_true unless features_list['features'].find do |removed_feature|
+          removed_feature[:identifier] == feature[:identifier]
+        end
+        expect(role.allows?(feature)).to be_false if features_list['features'].find do |removed_feature|
+          removed_feature[:identifier] == feature[:identifier]
+        end
+      end
+    end
+  end
+
+  describe "Roles delete" do
+    it "rejects role deletion, by post action, without appropriate role" do
+      api_basic_authorize
+
+      run_post(roles_url, gen_request(:delete, "name" => "role name", "href" => roles_url(100)))
+
+      expect_request_forbidden
+    end
+
+    it "rejects role deletion without appropriate role" do
+      api_basic_authorize
+
+      run_delete(roles_url(100))
+
+      expect_request_forbidden
+    end
+
+    it "rejects role deletes for invalid roles" do
+      api_basic_authorize collection_action_identifier(:roles, :delete)
+
+      run_delete(roles_url(999_999))
+
+      expect_resource_not_found
+    end
+
+    it "supports single role delete" do
+      api_basic_authorize collection_action_identifier(:roles, :delete)
+
+      role = FactoryGirl.create(:miq_user_role, :name => "role1")
+
+      run_delete(roles_url(role.id))
+
+      expect_request_success_with_no_content
+      expect(MiqUserRole.exists?(role.id)).to be_false
+    end
+
+    it "supports single role delete action" do
+      api_basic_authorize collection_action_identifier(:roles, :delete)
+
+      role = FactoryGirl.create(:miq_user_role, :name => "role1")
+
+      run_post(roles_url(role.id), gen_request(:delete))
+
+      expect_request_success
+      expect(MiqUserRole.exists?(role.id)).to be_false
+    end
+
+    it "supports multiple role deletes" do
+      api_basic_authorize collection_action_identifier(:roles, :delete)
+
+      r1 = FactoryGirl.create(:miq_user_role, :name => "role name 1")
+      r2 = FactoryGirl.create(:miq_user_role, :name => "role name 2")
+
+      run_post(roles_url, gen_request(:delete,
+                                      [{"href" => roles_url(r1.id)},
+                                       {"href" => roles_url(r2.id)}]))
+
+      expect_request_success
+      expect(MiqUserRole.exists?(r1.id)).to be_false
+      expect(MiqUserRole.exists?(r2.id)).to be_false
+    end
+  end
+end

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -88,8 +88,7 @@ describe ApiController do
       role = FactoryGirl.create(:miq_user_role,
                                 :name                 => "Test Role",
                                 :miq_product_features => @product_features)
-      url = roles_url + "/#{role.id}/"
-      test_features_query(role, url, MiqProductFeature, :identifier)
+      test_features_query(role, roles_url(role.id), MiqProductFeature, :identifier)
     end
   end
 


### PR DESCRIPTION
This PR adds the CRUD abilities for user roles, with product
features, through the API. This will allow for quickly
importing/exporting roles and product features settings
programmatically.