### PR TITLE
Create sha256sum checksum for upstream request

### DIFF
--- a/build/build.rb
+++ b/build/build.rb
@@ -89,6 +89,12 @@ Dir.chdir("/root/src/imagefactory") do
     file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{git_checkout.commit_sha}.#{FILE_TYPE[imgfac_target]}"
     destination = DESTINATION_DIRECTORY.join(file_name)
     $log.info `mv  #{source} #{destination}`
+    $log.info "Generating image checksums"
+    Dir.chdir(DESTINATION_DIRECTORY) do
+      $log.info `/usr/bin/sha256sum * >> SHA256SUM`
+      $log.info `/usr/bin/gpg --batch --no-tty --passphrase-file /root/.gnupg/pass -b SHA256SUM`
+      FileUtils.cp("/root/.gnupg/cfme_public.key", DESTINATION_DIRECTORY)
+    end
   end
 end
 


### PR DESCRIPTION
A request came in to verify the integrity of the upstream downloads:
http://talk.manageiq.org/t/verifying-integrity-of-downloads/699

Added:
1. sha256sum creation for upstream appliances
1. the creation of a gpg signature file
1. the copying of a signed public key for validation

Removed:
1. removed existing md5sum creation as redundant

Note:
1. solution was tested 
1. this change folows the existing script format used in the build.rb file
1. will plan on future updates to this script for refinements
1. will add a readme on gpg verification that will be copied to the same dir as gpg signature

@jvlcek 