### PR TITLE
Fixed translation missing errors on I18N calls.

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -240,7 +240,7 @@ module EmsCommon
       end
 
       if @edit[:new][:emstype] == "scvmm" && @edit[:new][:security_protocol] == "kerberos" && @edit[:new][:realm].blank?
-        add_flash(I18n.t("flash.edit.field_required", :field=>"Realm"), :error)
+        add_flash(_("%s is required") % "Realm", :error)
       end
 
       if !@flash_array
@@ -617,7 +617,7 @@ module EmsCommon
   def valid_record?(ems)
     @edit[:errors] = Array.new
     if ems.emstype == "scvmm" && ems.security_protocol == "kerberos" && ems.realm.blank?
-      add_flash(I18n.t("flash.edit.field_required", :field=>"Realm"), :error)
+      add_flash(_("%s is required") % "Realm", :error)
     end
     if !ems.authentication_password.blank? && ems.authentication_userid.blank?
       @edit[:errors].push(_("Username must be entered if Password is entered"))

--- a/vmdb/app/controllers/miq_policy_controller.rb
+++ b/vmdb/app/controllers/miq_policy_controller.rb
@@ -384,12 +384,12 @@ class MiqPolicyController < ApplicationController
 
   def iterate_status(items = nil, result = [], parent_id = nil, indent = nil)
     items.each do |item|
-      entry = { "id"     => result.count.to_s,
-                "title"  => "<b>#{I18n.t("model_name.#{item[:class].underscore}")}:</b>" +
-                             " #{item[:description]}",
-                "parent" => parent_id,
-                "status_icon" => get_status_icon(item[:status]),
-                "indent" => (indent.nil? ? 0 : indent + 1)}
+      entry = {"id"          => result.count.to_s,
+               "title"       => "<b>#{Dictionary.gettext(item[:class].underscore, :type => :model_name, :notfound => :titleize)}:</b>" +
+                              " #{item[:description]}",
+               "parent"      => parent_id,
+               "status_icon" => get_status_icon(item[:status]),
+               "indent"      => (indent.nil? ? 0 : indent + 1)}
 
       entry["_collapsed"] = false if item[:children]
 

--- a/vmdb/app/controllers/ops_controller/settings/schedules.rb
+++ b/vmdb/app/controllers/ops_controller/settings/schedules.rb
@@ -73,7 +73,8 @@ module OpsController::Settings::Schedules
         end
       else
         AuditEvent.success(build_saved_audit_hash(old_schedule_attributes, schedule, params[:button] == "add"))
-        add_flash(I18n.t("flash.edit.saved", :model => ui_lookup(:model => "MiqSchedule"), :name => schedule.name))
+        add_flash(_("%{model} \"%{name}\" was saved") %
+                      {:model => ui_lookup(:model => "MiqSchedule"), :name => schedule.name})
         if params[:button] == "add"
           self.x_node  = "xx-msc"
           schedules_list

--- a/vmdb/config/locales/ja.yml
+++ b/vmdb/config/locales/ja.yml
@@ -1,0 +1,7 @@
+# Sample localization file for Japanese. Add more files in this directory for other locales.
+# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+ja:
+  product:
+    name: ManageIQ
+

--- a/vmdb/config/locales/nl.yml
+++ b/vmdb/config/locales/nl.yml
@@ -1,0 +1,6 @@
+# Sample localization file for Nederlands. Add more files in this directory for other locales.
+# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+nl:
+  product:
+    name: ManageIQ


### PR DESCRIPTION
Added ja & nl translation files to fix translation missing message on I18N.t calls. Converted calls that should have been gettext calls instead of I18N calls.

https://bugzilla.redhat.com/show_bug.cgi?id=1225377

@dclarizio please review/test

before:
![attachment](https://cloud.githubusercontent.com/assets/3450808/7919514/cf7c84d4-0866-11e5-9b98-a6690910ee00.png)

![policy_import_before](https://cloud.githubusercontent.com/assets/3450808/7919428/3b96ad3a-0866-11e5-91de-e5052fea8b9d.png)

after:
![ja_title_fixed](https://cloud.githubusercontent.com/assets/3450808/7919427/3b9349b0-0866-11e5-81e7-b480e44e1b39.png)

![ja_policy_import](https://cloud.githubusercontent.com/assets/3450808/7919456/6f82ae82-0866-11e5-8733-539df7c8a1f8.png)

