### PR TITLE
Remove old pending examples

### DIFF
--- a/vmdb/spec/controllers/report_controller_spec.rb
+++ b/vmdb/spec/controllers/report_controller_spec.rb
@@ -742,10 +742,6 @@ describe ReportController do
           assigns(:tl_repaint).should be_true
         end
       end
-      # TODO: Need to add tests for params with starting prefixes like hdr_, calc_, etc...
-      it "Tests for params with prefixed keys, like hdr_ and calc_" do
-        pending "To be written later ..."
-      end
     end
   end
 
@@ -807,27 +803,6 @@ describe ReportController do
         @sch.reload
         @sch.should_not be_enabled
         @sch.updated_at.should be > 10.minutes.ago.utc
-      end
-    end
-  end
-
-  context "ReportController#build_js_options" do
-    context "check replace trees" do
-      before do
-        controller.stub(:get_node_info)
-        controller.stub(:rebuild_trees).and_return(nil)
-      end
-
-      it "rebuild dashboards tree" do
-        pending "placeholder for future tests"
-        controller.instance_variable_set(:@sb,
-                                         {:trees => {
-                                             :db_tree => {:active_node => "root"}
-                                         },
-                                          :active_tree => :db_tree
-                                         })
-        controller.stub(:build_db_tree)
-        js_options = controller.send(:build_js_options, {:replace_trees => [:db]})
       end
     end
   end

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -3060,13 +3060,6 @@ describe ApplicationHelper do
         @tb_buttons["#{parent}__#{@item[:button]}"].should have_key(:title)
       end
 
-      it "when item[:popup] exists" do
-        pending "**** can't mock request"
-        @item[:popup] = true
-        subject.should have_key(:popup)
-        subject.should have_key(:console_url)
-      end
-
       it "when item[:url_parms] exists" do
         subject.should have_key(:url_parms)
       end

--- a/vmdb/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
@@ -47,14 +47,6 @@ module MiqAeMethodSpec
       ws.root("encrypted").should == '********'
     end
 
-    it "executes customer libraries" do
-      pending "has a dependency on the NOW extracted cfme_customer repo: https://github.com/ManageIQ/cfme_customer/blob/master/miq/test_module/test_class.rb#L3"
-      EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_method_spec3"), @domain)
-      ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1")
-      ws.root("error").should be_nil
-      ws.root("param").should == 76
-    end
-
     it "properly processes instance methods via no inheritance" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "method2"), @domain)
       MiqAeDatastore.reset_default_namespace

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb
@@ -102,41 +102,5 @@ module MiqAeServiceHostSpec
       ae_result = invoke_ae.root(@ae_result_key)
       ae_result.should be_nil
     end
-
-    pending "Not yet implemented: 33 specs" do
-      it "#storages"
-      it "#vms"
-      it "#ext_management_system"
-      it "#hardware"
-      it "#switches"
-      it "#lans"
-      it "#operating_system"
-      it "#guest_applications"
-      it "#ems_cluster"
-      it "#ems_events"
-      it "#ems_folder"
-      it "#datacenter"
-      it "#authentication_userid"
-      it "#authentication_password"
-      it "#event_log_threshold?"
-      it "#to_s"
-      it "#domain"
-      it "#files"
-      it "#directories"
-      it "#scan"
-      it "#shutdown"
-      it "#reboot"
-      it "#enter_maintenance_mode"
-      it "#exit_maintenance_mode"
-      it "#in_maintenance_mode?"
-      it "#power_down_to_standby"
-      it "#power_up_from_standby"
-      it "#credentials"
-      it "#ems_custom_set"
-      it "#custom_keys"
-      it "#custom_get"
-      it "#custom_set"
-      it "#ssh_exec"
-    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
@@ -150,27 +150,5 @@ module MiqAeServiceMiqProvisionRequestSpec
       @ae_method.update_attributes(:data => method)
       invoke_ae.root(@ae_result_key).should == 'vm'
     end
-
-    pending "Not yet implemented: 19 specs" do
-      it "#set_vm_notes"
-      it "#get_retirement_days"
-      it "#set_network_address_mode"
-      it "#check_quota"
-      it "#eligible_resources"
-      it "#eligible_hosts"
-      it "#eligible_storages"
-      it "#eligible_folders"
-      it "#eligible_clusters"
-      it "#eligible_resource_pools"
-      it "#set_resource"
-      it "#set_host"
-      it "#set_storage"
-      it "#set_cluster"
-      it "#set_resource_pool"
-      it "#set_folder"
-      it "#get_folder_paths"
-      it "#set_nic_settings"
-      it "#set_network_adapter"
-    end
   end
 end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
@@ -174,48 +174,5 @@ module MiqAeServiceVmSpec
       expect(service_vm.retirement_warn).to eq(60)
       expect(vm.retirement_last_warn).to be_nil
     end
-
-    pending "Not yet implemented: 41 specs" do
-      it "#ext_management_system"
-      it "#storage"
-      it "#host"
-      it "#hardware"
-      it "#operating_system"
-      it "#guest_applications"
-      it "#miq_provision"
-      it "#ems_cluster"
-      it "#ems_folder"
-      it "#ems_blue_folder"
-      it "#resource_pool"
-      it "#datacenter"
-      it "#remove_from_disk"
-      it "#registered?"
-      it "#to_s"
-      it "#event_threshold?"
-      it "#event_log_threshold?"
-      it "#performances_maintains_value_for_duration?"
-      it "#reconfigured_hardware_value?"
-      it "#changed_vm_value?"
-      it "#retire_now"
-      it "#files"
-      it "#directories"
-      it "#refresh"
-      it "#start"
-      it "#stop"
-      it "#suspend"
-      it "#unregister"
-      it "#collect_running_processes"
-      it "#shutdown_guest"
-      it "#standby_guest"
-      it "#reboot_guest"
-      it "#migrate"
-      it "#owner"
-      it "#scan"
-      it "#unlink_storage"
-      it "#ems_custom_set"
-      it "#custom_keys"
-      it "#custom_get"
-      it "#custom_set"
-    end
   end
 end

--- a/vmdb/spec/models/log_collection_spec.rb
+++ b/vmdb/spec/models/log_collection_spec.rb
@@ -6,17 +6,6 @@ describe "LogCollection" do
     _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
   end
 
-  it "test ftp functions for FB12142" do
-    pending("Disabled for performance/authentication reasons")
-    MiqServer.any_instance.stub(:get_log_depot_settings).and_return(:username => "manageiq.com\\jrafaniello", :uri => "ftp://miq-websvr1.manageiq.com/scratch/joer", :password => "XXXXXXXXX", :debug => true)
-    log = LogFile.current_logfile
-    @miq_server.log_files << log
-    LogFile.verify_log_depot_settings(@miq_server.get_log_depot_settings)
-    log.add('/etc/hosts')
-    log.delete
-    log.destroy
-  end
-
   context "active log_collection" do
     before do
       @log_file = FactoryGirl.create(:log_file, :state => "collecting")

--- a/vmdb/spec/models/miq_report_spec.rb
+++ b/vmdb/spec/models/miq_report_spec.rb
@@ -57,53 +57,6 @@ describe MiqReport do
 
     end
 
-    it "reports on EVM table indexes and metrics with an error" do
-
-      pending "to be imlemented once has_one bug is fixed" do
-        # report_args = {
-        #   "title"       => "VmdbIndex",
-        #   "name"        => "VmdbIndex",
-        #   "db"          => "VmdbIndex",
-        #   "cols"        => ["name"],
-        #   "include"     => {"vmdb_table" => {"columns" => ["type"]}, "latest_hourly_metric" => {"columns"=>["rows", "size", "wasted_bytes", "percent_bloat"]}},
-        #   "col_order"   => ["name", "latest_hourly_metric.rows", "latest_hourly_metric.size", "latest_hourly_metric.wasted_bytes", "latest_hourly_metric.percent_bloat"],
-        #   "col_formats" => [nil, nil, :bytes_human, :bytes_human, nil],
-        #   "headers"     => ["Name", "Rows", "Size", "Wasted", "Percent Bloat"],
-        #   "order"       => "Ascending",
-        #   "sortby"      => ["name"],
-        #   "group"       => "n",
-        # }
-
-        report = MiqReport.new(@report_args)
-
-  # Rails.logger.level = 0
-
-  #       results = VmdbIndex.all(:conditions=>"((vmdb_tables.type = 'VmdbTableEvm'))",
-  #                             :include => {
-  #                               :vmdb_table=>{},
-  #                              :latest_hourly_metric=>{}
-  #                             },
-  #                             :order=>"LOWER(vmdb_indexes.name) asc",
-  #                             :limit=>8,
-  #                             :offset=>0
-  #                 )
-  #       puts "Test results: #{results.length}"
-
-  # Rails.logger.level = 1
-
-        search_expression  = MiqExpression.new({"and" => [{"=" => {"value" => "VmdbTableEvm", "field" => "VmdbIndex.vmdb_table-type"}}]})
-
-        options = { :targets_hash   => true,
-                    :filter         => search_expression,
-                    :page           => 1,
-                    :per_page       => 8
-        }
-
-        results, attrs = report.paged_view_search(options)
-        results.count.should be 4
-      end
-    end
-
     describe 'self.get_expressions_by_model' do
       it 'it returns only reports with non-nil conditions' do
 

--- a/vmdb/spec/models/miq_widget_spec.rb
+++ b/vmdb/spec/models/miq_widget_spec.rb
@@ -205,17 +205,6 @@ describe MiqWidget do
     end
   end
 
-  it "should not delete schedule when zone is gone" do
-    pending "issue reported in FB#15499"
-    @zone = FactoryGirl.create(:zone, :name => "testing")
-    @schedule = FactoryGirl.create(:miq_schedule, :zone_id => @zone.id)
-    @schedule_id = @schedule.id
-    @widget = FactoryGirl.create(:miq_widget, :miq_schedule_id => @schedule_id)
-
-    @zone.destroy
-    MiqSchedule.exists?(@schedule_id).should be_true
-  end
-
   context "#queue_generate_content" do
     before(:each) do
       MiqReport.seed_report("Top CPU Consumers weekly")

--- a/vmdb/spec/models/mixins/reserved_mixin_spec.rb
+++ b/vmdb/spec/models/mixins/reserved_mixin_spec.rb
@@ -314,13 +314,6 @@ describe ReservedMixin do
           @t.update_attribute(:some_field, "test2")
           @t.updated_on.should_not == @last_update
         end
-
-        it "and data not changing" do
-          pending("implementation") do
-            @t.update_attribute(:some_field, "test")
-            @t.updated_on.should == @last_update
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
Let's delete stuff we don't need.  :fire: :scissors: 

* Most of these pending examples are from 2013 or earlier
* Most are either placeholders for work we never did or are no longer relevant
* I've cc'd who I think can :+1: :-1: each commit

Please :+1: if your commit is ok to remove.

Note, this doesn't remove all pending examples, only the really old ones that I thought were very easy deletes.

The problem with marking them pending is that it floods the test output with this:
```
Pending:
  MiqAeMethodService::MiqAeServiceMiqProvisionRequest Not yet implemented: 19 specs
    # No reason given
    # ./spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb:154
  ReservedMixin#save will touch the parent record's updated_on with existing reserved data and data not changing
    # implementation
    # ./spec/models/mixins/reserved_mixin_spec.rb:318
  MiqWidget should not delete schedule when zone is gone
    # issue reported in FB#15499
    # ./spec/models/miq_widget_spec.rb:208
  MiqReport#paged_view_search_gp reports on EVM table indexes and metrics with an error
    # to be imlemented once has_one bug is fixed
    # ./spec/models/miq_report_spec.rb:60
  TreeNodeBuilder.build MiqDialog node
    # No reason given
    # ./spec/presenters/tree_node_builder_spec.rb:266
  VmdbTable New model-based-rewrite
    # No reason given
    # ./spec/models/vmdb_table_spec.rb:78
  MiqDatabase New model-based-rewrite
    # No reason given
    # ./spec/models/miq_database_spec.rb:80
  ApplicationHelper#build_toolbar_save_button saves the item info by the same key when item[:popup] exists
    # **** can't mock request
    # ./spec/helpers/application_helper_spec.rb:3063
  Metric as vmware with a vm and a fake vim handle capturing vm realtime data should normalize percent values > 100 to 100
    # Need to be updated due to source data change
    # ./spec/models/metric_spec.rb:387
  Metric as vmware with a vm and a fake vim handle capturing vm realtime data maintains_value_for_duration? will return correct values
    # Need to be updated due to source data change
    # ./spec/models/metric_spec.rb:409
  Metric as vmware with a vm and a fake vim handle capturing vm realtime data maintains_value_for_duration? with overlap and slope will return correct values
    # Need to be updated due to source data change
    # ./spec/models/metric_spec.rb:434
  MiqAeMethodService::MiqAeServiceHost Not yet implemented: 33 specs
    # No reason given
    # ./spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb:106
  LogCollection test ftp functions for FB12142
    # Disabled for performance/authentication reasons
    # ./spec/models/log_collection_spec.rb:9
  VmInfraController ApplicationController::Explorer #valid_active_node invalid node
    # handling invalid nodes
    # ./spec/controllers/application_controller/explorer_spec.rb:27
  MiqAeCustomizationController#group_form_field_changed assign buttons all buttons selected for when we redesign rotate functionality
    # No reason given
    # ./spec/controllers/miq_ae_customization_controller_spec.rb:128
  MiqAeCustomizationController group_reorder_field_changed all buttons selected for when we redesign rotate functionality
    # No reason given
    # ./spec/controllers/miq_ae_customization_controller_spec.rb:60
  MiqExpression should test error handling
    # This test occasionally fails for no apparent reason
    # ./spec/models/miq_expression/miq_expression_spec.rb:320
  ReportController ReportController#build_js_options check replace trees rebuild dashboards tree
    # placeholder for future tests
    # ./spec/controllers/report_controller_spec.rb:821
  ReportController Get form variables handle input fields Tests for params with prefixed keys, like hdr_ and calc_
    # To be written later ...
    # ./spec/controllers/report_controller_spec.rb:746
  MiqAeEngine::MiqAeMethod executes customer libraries
    # has a dependency on the NOW extracted cfme_customer repo: https://github.com/ManageIQ/cfme_customer/blob/master/miq/test_module/test_class.rb#L3
    # ./spec/lib/miq_automation_engine/miq_ae_method_spec.rb:50
  MiqAeMethodService::MiqAeServiceVm Not yet implemented: 41 specs
    # No reason given
    # ./spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb:178
  Login process w/o a valid session these tests are failing on CC monitor
    # No reason given
    # ./spec/requests/auth_spec.rb:13
  OpsController#schedule_form_fields
    # No reason given
    # ./spec/controllers/ops_controller/settings/schedules_spec.rb:10
  OpsController#schedule_form_filter_type_field_changed when the filter_type is 'my' responds with a filtered my_filter list
    # No reason given
    # ./spec/controllers/ops_controller/settings/schedules_spec.rb:106
  OpsController#schedule_form_filter_type_field_changed when the filter_type is 'global' responds with a filtered global filter list
    # No reason given
    # ./spec/controllers/ops_controller/settings/schedules_spec.rb:94
  expression to sql should test_full_sql
    # should be removed or not skipped
    # ./spec/models/miq_expression/miq_expression_to_sql_spec.rb:81
  expression to sql should test_basic_sql
    # should be removed or not skipped
    # ./spec/models/miq_expression/miq_expression_to_sql_spec.rb:63
  expression to sql should test_full
    # should be removed or not skipped
    # ./spec/models/miq_expression/miq_expression_to_sql_spec.rb:50
  expression to sql should test_basic
    # should be removed or not skipped
    # ./spec/models/miq_expression/miq_expression_to_sql_spec.rb:33
```