### PR TITLE
Fix integer data type for dialog fields

### DIFF
--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -224,32 +224,25 @@ module ApplicationController::DialogRunner
   def dialog_get_form_vars
     @record = Dialog.find_by_id(@edit[:rec_id])
 
-    params.each do |p|
-      #if p[0] contains name w/ __protected(password field), so remove it
-      p[0] = p[0].split("__protected").first if p[0].ends_with?("__protected")
+    params.each do |parameter_key, parameter_value|
+      parameter_key = parameter_key.split("__protected").first if parameter_key.ends_with?("__protected")
 
-      #if date/datetime field came in
-      if p[0].starts_with?("miq_date__")
+      if parameter_key.starts_with?("miq_date__") && @record.field_name_exist?(parameter_key.split("miq_date__").last)
+        @edit[:wf].set_value(parameter_key.split("miq_date__").last, parameter_value)
 
-        @edit[:wf].set_value(p[0].split("miq_date__").last,p[1]) if @record.field_name_exist?(p[0].split("miq_date__").last)
-
-      #if start hour/min came in for date/datetime field
-      elsif ["start_hour", "start_min"].include?(p[0])
+      elsif %w(start_hour start_min).include?(parameter_key)
         field_name = ""
 
-        @edit[:wf].dialog.dialog_tabs.each do |tab|
-          tab.dialog_groups.each do |group|
-            group.dialog_fields.each_with_index do |field,i|
-              field_name = field.name if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
-            end
-          end
+        @edit[:wf].dialog.dialog_fields.each_with_index do |field, _|
+          field_name = field.name if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
         end
 
-        #if user didnt choose the date and goes with default shown in the textbox, need to set that value in wf before adding hour/min
+        # if user didnt choose the date and goes with default shown in the textbox,
+        # need to set that value in wf before adding hour/min
         if @edit[:wf].value(field_name).nil?
           t = Time.now.in_time_zone(session[:user_tz]) + 1.day
           date_val = ["#{t.month}/#{t.day}/#{t.year}"]
-          @edit[:wf].set_value(field_name,date_val)
+          @edit[:wf].set_value(field_name, date_val)
         else
           date_val = @edit[:wf].value(field_name).split(" ")
         end
@@ -257,20 +250,22 @@ module ApplicationController::DialogRunner
         start_hour = date_val.length >= 2 ? date_val[1].split(":").first : 0
         start_min = date_val.length >= 3 ? date_val[1].split(":").last : 0
 
-        if p[0] == "start_hour"
-          @edit[:wf].set_value(field_name,"#{date_val[0]} #{p[1]}:#{start_min}")
+        if parameter_key == "start_hour"
+          time_value = "#{parameter_value}:#{start_min}"
         else
-          @edit[:wf].set_value(field_name,"#{date_val[0]} #{start_hour}:#{p[1]}")
+          time_value = "#{start_hour}:#{parameter_value}"
         end
 
-      elsif @edit[:wf].dialog.field(p[0]).try(:type) == "DialogFieldCheckBox"
-        checkbox_value = p[1] == "1" ? "t" : "f"
-        @edit[:wf].set_value(p[0], checkbox_value) if @record.field_name_exist?(p[0])
+        @edit[:wf].set_value(field_name, "#{date_val[0]} #{time_value}")
+
+      elsif @edit[:wf].dialog.field(parameter_key).try(:type) == "DialogFieldCheckBox"
+        checkbox_value = parameter_value == "1" ? "t" : "f"
+        @edit[:wf].set_value(parameter_key, checkbox_value) if @record.field_name_exist?(parameter_key)
 
       else
-        if @record.field_name_exist?(p[0])
-          p[1] = p[1].to_i if @edit[:wf].dialog_field(p[0]).data_type == "integer"
-          @edit[:wf].set_value(p[0], p[1])
+        if @record.field_name_exist?(parameter_key)
+          parameter_value = parameter_value.to_i if @edit[:wf].dialog_field(parameter_key).data_type == "integer"
+          @edit[:wf].set_value(parameter_key, parameter_value)
         end
       end
     end

--- a/vmdb/app/controllers/application_controller/dialog_runner.rb
+++ b/vmdb/app/controllers/application_controller/dialog_runner.rb
@@ -268,7 +268,10 @@ module ApplicationController::DialogRunner
         @edit[:wf].set_value(p[0], checkbox_value) if @record.field_name_exist?(p[0])
 
       else
-        @edit[:wf].set_value(p[0],p[1]) if @record.field_name_exist?(p[0])
+        if @record.field_name_exist?(p[0])
+          p[1] = p[1].to_i if @edit[:wf].dialog_field(p[0]).data_type == "integer"
+          @edit[:wf].set_value(p[0], p[1])
+        end
       end
     end
   end

--- a/vmdb/app/models/dialog_field.rb
+++ b/vmdb/app/models/dialog_field.rb
@@ -89,7 +89,7 @@ class DialogField < ActiveRecord::Base
   end
 
   def automate_output_value
-    @value
+    data_type == "integer" ? @value.to_i : @value
   end
 
   def automate_key_name

--- a/vmdb/spec/models/dialog_field_spec.rb
+++ b/vmdb/spec/models/dialog_field_spec.rb
@@ -1,113 +1,135 @@
 require "spec_helper"
 
 describe DialogField do
-  before(:each) do
-    @df = FactoryGirl.create(:dialog_field, :label => 'dialog_field', :name => 'dialog_field')
-  end
-
-  it "sets default value for required attribute" do
-    @df.required.should == false
-  end
-
-  it "fields named 'action' or 'controller' are invalid" do
-    action_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'action')
-    action_field.should_not be_valid
-    controller_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'controller')
-    controller_field.should_not be_valid
-    foo_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'foo')
-    foo_field.should be_valid
-  end
-
-  it "supports more than 255 characters within default_value" do
-    str = "0" * 10000
-    @df.default_value = str
-    expect { @df.save }.to_not raise_error
-    @df.reload
-    @df.default_value.should == str
-  end
-
-  describe "#validate" do
-    let(:dialog_field) do
-      described_class.new(:label    => 'dialog_field',
-                          :name     => 'dialog_field',
-                          :required => required,
-                          :value    => value)
+  context "legacy tests" do
+    before(:each) do
+      @df = FactoryGirl.create(:dialog_field, :label => 'dialog_field', :name => 'dialog_field')
     end
-    let(:dialog_tab)   { active_record_instance_double('DialogTab',   :label => 'tab') }
-    let(:dialog_group) { active_record_instance_double('DialogGroup', :label => 'group') }
 
-    shared_examples_for "DialogField#validate that returns nil" do
-      it "returns nil" do
-        dialog_field.validate(dialog_tab, dialog_group).should be_nil
+    it "sets default value for required attribute" do
+      @df.required.should == false
+    end
+
+    it "fields named 'action' or 'controller' are invalid" do
+      action_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'action')
+      action_field.should_not be_valid
+      controller_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'controller')
+      controller_field.should_not be_valid
+      foo_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'foo')
+      foo_field.should be_valid
+    end
+
+    it "supports more than 255 characters within default_value" do
+      str = "0" * 10000
+      @df.default_value = str
+      expect { @df.save }.to_not raise_error
+      @df.reload
+      @df.default_value.should == str
+    end
+
+    describe "#validate" do
+      let(:dialog_field) do
+        described_class.new(:label    => 'dialog_field',
+                            :name     => 'dialog_field',
+                            :required => required,
+                            :value    => value)
       end
-    end
+      let(:dialog_tab)   { active_record_instance_double('DialogTab',   :label => 'tab') }
+      let(:dialog_group) { active_record_instance_double('DialogGroup', :label => 'group') }
 
-    context "when required is true" do
-      let(:required) { true }
-
-      context "with a blank value" do
-        let(:value) { "" }
-
-        it "returns error message" do
-          dialog_field.validate(dialog_tab, dialog_group).should eq("tab/group/dialog_field is required")
+      shared_examples_for "DialogField#validate that returns nil" do
+        it "returns nil" do
+          dialog_field.validate(dialog_tab, dialog_group).should be_nil
         end
       end
 
-      context "with a non-blank value" do
-        let(:value) { "test value" }
+      context "when required is true" do
+        let(:required) { true }
 
-        it_behaves_like "DialogField#validate that returns nil"
+        context "with a blank value" do
+          let(:value) { "" }
+
+          it "returns error message" do
+            dialog_field.validate(dialog_tab, dialog_group).should eq("tab/group/dialog_field is required")
+          end
+        end
+
+        context "with a non-blank value" do
+          let(:value) { "test value" }
+
+          it_behaves_like "DialogField#validate that returns nil"
+        end
+      end
+
+      context "when required is false" do
+        let(:required) { false }
+
+        context "with a blank value" do
+          let(:value) { "" }
+
+          it_behaves_like "DialogField#validate that returns nil"
+        end
+
+        context "with a non-blank value" do
+          let(:value) { "test value" }
+
+          it_behaves_like "DialogField#validate that returns nil"
+        end
       end
     end
 
-    context "when required is false" do
-      let(:required) { false }
-
-      context "with a blank value" do
-        let(:value) { "" }
-
-        it_behaves_like "DialogField#validate that returns nil"
+    describe "#initialize_with_values" do
+      it "uses #automate_key_name for extracting initial dialog values" do
+        dialog_value = "dummy dialog value"
+        @df.initialize_with_values(@df.automate_key_name => dialog_value)
+        @df.value.should == dialog_value
       end
 
-      context "with a non-blank value" do
-        let(:value) { "test value" }
+      it "initializes to nil with no initial value and no default value" do
+        initial_dialog_values = {}
+        @df.initialize_with_values(initial_dialog_values)
+        @df.value.should be_nil
+      end
 
-        it_behaves_like "DialogField#validate that returns nil"
+      it "initializes to the default value with no initial value and a default value" do
+        initial_dialog_values = {}
+        @df.default_value = "default_test"
+        @df.initialize_with_values(initial_dialog_values)
+        @df.value.should == "default_test"
+      end
+
+      it "initializes to the dialog value with a dialog value and no default value" do
+        initial_dialog_values = {@df.automate_key_name => "test"}
+        @df.initialize_with_values(initial_dialog_values)
+        @df.value.should == "test"
+      end
+
+      it "initializes to the dialog value with a dialog value and a default value" do
+        initial_dialog_values = {@df.automate_key_name => "test"}
+        @df.default_value = "default_test"
+        @df.initialize_with_values(initial_dialog_values)
+        @df.value.should == "test"
       end
     end
   end
 
-  describe "#initialize_with_values" do
-    it "uses #automate_key_name for extracting initial dialog values" do
-      dialog_value = "dummy dialog value"
-      @df.initialize_with_values(@df.automate_key_name => dialog_value)
-      @df.value.should == dialog_value
+  describe "#automate_output_values" do
+    let(:dialog_field) { described_class.new(:data_type => data_type, :value => "123") }
+
+    context "when the data type is integer" do
+      let(:data_type) { "integer" }
+
+      it "returns the value as an integer" do
+        expect(dialog_field.automate_output_value).to eq(123)
+      end
     end
 
-    it "initializes to nil with no initial value and no default value" do
-      initial_dialog_values = {}
-      @df.initialize_with_values(initial_dialog_values)
-      @df.value.should be_nil
-    end
+    context "when the data type is not an integer" do
+      let(:data_type) { "potato" }
 
-    it "initializes to the default value with no initial value and a default value" do
-      initial_dialog_values = {}
-      @df.default_value = "default_test"
-      @df.initialize_with_values(initial_dialog_values)
-      @df.value.should == "default_test"
-    end
-
-    it "initializes to the dialog value with a dialog value and no default value" do
-      initial_dialog_values = {@df.automate_key_name => "test"}
-      @df.initialize_with_values(initial_dialog_values)
-      @df.value.should == "test"
-    end
-
-    it "initializes to the dialog value with a dialog value and a default value" do
-      initial_dialog_values = {@df.automate_key_name => "test"}
-      @df.default_value = "default_test"
-      @df.initialize_with_values(initial_dialog_values)
-      @df.value.should == "test"
+      it "returns the value" do
+        expect(dialog_field.automate_output_value).to eq("123")
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, when selected an item from a drop down, the value would be passed into the controller and simply saved (all parameters that get passed in are strings), and it would ignore the data type that was set.

This fix honors the integer data type when selecting a value so that integers end up getting passed to automate.