### PR TITLE
Fix custom naming for AMQP binding queues

### DIFF
--- a/lib/openstack/amqp/openstack_qpid_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_qpid_event_monitor.rb
@@ -47,9 +47,11 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
   end
 
   def initialize(options = {})
-    @options = options
+    @options          = options
     @options[:port] ||= DEFAULT_AMQP_PORT
-    @receiver_options = options.slice(:duration, :capacity)
+    @receiver_options = @options.slice(:duration, :capacity)
+    @client_ip        = @options[:client_ip]
+
     @collecting_events = false
   end
 
@@ -109,11 +111,11 @@ class OpenstackQpidEventMonitor < OpenstackEventMonitor
   end
 
   def create_v1_receiver(service, topic)
-    OpenstackQpidReceiver.new(connection, service, service, topic, @receiver_options)
+    OpenstackQpidReceiver.new(connection, service, service, topic, @client_ip, @receiver_options)
   end
 
   def create_v2_receiver(service, topic)
     exchange = "amq.topic/topic/#{service}"
-    OpenstackQpidReceiver.new(connection, service, exchange, topic, @receiver_options)
+    OpenstackQpidReceiver.new(connection, service, exchange, topic, @client_ip, @receiver_options)
   end
 end

--- a/lib/openstack/amqp/openstack_qpid_receiver.rb
+++ b/lib/openstack/amqp/openstack_qpid_receiver.rb
@@ -15,7 +15,7 @@ class OpenstackQpidReceiver
   #              fetching more from the broker (default=50)
   # * :duration: The length of time (in seconds) the receiver should wait for a
   #              message from the broker before timing out (default=10 seconds)
-  def initialize(connection, service, exchange_name, subject, options = {})
+  def initialize(connection, service, exchange_name, subject, client_ip, options = {})
     raise "qpid_messaging is not available" unless OpenstackQpidConnection.available?
 
     @options = {:capacity => 50, :duration => 10}
@@ -26,6 +26,7 @@ class OpenstackQpidReceiver
     @service          = service
     @exchange_name    = exchange_name
     @subject          = subject
+    @client_ip        = client_ip
     @capacity         = @options[:capacity]
     @duration_seconds = @options[:duration]
   end
@@ -105,6 +106,6 @@ EOD
   end
 
   def queue_name
-    @queue_name ||= "miq-#{@connection.hostname}-#{@exchange_name}".gsub(/\//, "_")
+    @queue_name ||= "miq-#{@client_ip}-#{@exchange_name}".gsub(/\//, "_")
   end
 end

--- a/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/lib/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -44,8 +44,10 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
   end
 
   def initialize(options = {})
-    @options = options
+    @options          = options
     @options[:port] ||= DEFAULT_AMQP_PORT
+    @client_ip        = @options[:client_ip]
+
     @collecting_events = false
     @events = []
     #protect threaded access to the events array
@@ -95,7 +97,7 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
     if @options[:topics]
       @options[:topics].each do |exchange, topic|
         amqp_exchange = channel.topic(exchange)
-        queue_name = "miq-#{@options[:hostname]}-#{exchange}"
+        queue_name = "miq-#{@client_ip}-#{exchange}"
         @queues[exchange] = channel.queue(queue_name).bind(amqp_exchange, :routing_key => topic)
       end
     end

--- a/lib/spec/openstack/amqp/openstack_qpid_event_monitor_spec.rb
+++ b/lib/spec/openstack/amqp/openstack_qpid_event_monitor_spec.rb
@@ -33,7 +33,7 @@ describe OpenstackQpidEventMonitor do
     @receivers = {"nova" => @nova_receiver, "glance" => @glance_receiver}
     @topics = {"nova" => "nova_topic", "glance" => "glance_topic"}
     @receiver_options = {:capacity => 1, :duration => 1}
-    @options = @receiver_options.merge({:topics => @topics})
+    @options = @receiver_options.merge({:topics => @topics, :client_ip => "10.11.12.13"})
 
     @monitor = OpenstackQpidEventMonitor.new(@options)
     @monitor.stub(:create_connection).and_return(@notification_connection)

--- a/lib/spec/openstack/amqp/openstack_qpid_receiver_spec.rb
+++ b/lib/spec/openstack/amqp/openstack_qpid_receiver_spec.rb
@@ -33,7 +33,7 @@ describe OpenstackQpidReceiver do
     qreceiver.stub(:available).and_return(3, 2, 1, 0)
     qreceiver.stub(:get).and_return(qpid_messages[0], qpid_messages[1], qpid_messages[2])
 
-    receiver = OpenstackQpidReceiver.new(qconnection, "service", "exchange", "topic")
+    receiver = OpenstackQpidReceiver.new(qconnection, "service", "exchange", "topic", "10.11.12.13")
     receiver.stub(:address).and_return("")
     receiver.stub(:duration).and_return(0)
 

--- a/lib/spec/openstack/amqp/openstack_rabbit_event_monitor_spec.rb
+++ b/lib/spec/openstack/amqp/openstack_rabbit_event_monitor_spec.rb
@@ -17,7 +17,7 @@ describe OpenstackRabbitEventMonitor do
 
     @topics = {"nova" => "nova_topic", "glance" => "glance_topic"}
     @receiver_options = {:capacity => 1, :duration => 1}
-    @options = @receiver_options.merge({:topics => @topics})
+    @options = @receiver_options.merge({:topics => @topics, :client_ip => "10.11.12.13"})
   end
 
   after do

--- a/vmdb/lib/workers/mixins/event_catcher_openstack_mixin.rb
+++ b/vmdb/lib/workers/mixins/event_catcher_openstack_mixin.rb
@@ -10,9 +10,11 @@ module EventCatcherOpenstackMixin
         options[:username] = @ems.authentication_userid(:amqp)
         options[:password] = @ems.authentication_password(:amqp)
       end
-      options[:topics] = self.worker_settings[:topics]
+      options[:topics]   = self.worker_settings[:topics]
       options[:duration] = self.worker_settings[:duration]
       options[:capacity] = self.worker_settings[:capacity]
+
+      options[:client_ip] = MiqServer.my_server.ipaddress
       @event_monitor_handle = OpenstackEventMonitor.new(options)
     end
     @event_monitor_handle


### PR DESCRIPTION
The original fixes for the bugs linked below used the OpenStack server's IP address as the hostname information in the binding queue name.  This meant that any two appliances that attempted to connect to a single OpenStack env would create the same named binding queues.

This fix uses the appliance's ip address in the binding queue name, making the name of the binding queue unique per appliance.

https://bugzilla.redhat.com/show_bug.cgi?id=1224389
https://bugzilla.redhat.com/show_bug.cgi?id=1223976