### PR TITLE
Fix Automate ManageIQ service dialog parsing issue.

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -20,7 +20,7 @@ def process_comma_separated_object_array(sequence_id, option_key, value, hash)
   value.split(",").each do |entry|
     vmdb_obj = vmdb_object_from_array_entry(entry)
     next if vmdb_obj.nil?
-    options_value_array << vmdb_obj.respond_to?(:name) ? vmdb_obj.name : "#{vmdb_obj.class.name}::#{vmdb_obj.id}"
+    options_value_array << (vmdb_obj.respond_to?(:name) ? vmdb_obj.name : "#{vmdb_obj.class.name}::#{vmdb_obj.id}")
   end
   hash[sequence_id][option_key] = options_value_array
 end


### PR DESCRIPTION
Fixed problem where parsed dialog options contained true instead of dialog value.

before:
parsed_dialog_tags: "---\n0:\n  :tagcontrol:\n  - true\n  :test:\n  - true\n  - true\n2:\n  :stuff: tag 2\n3:\n  :stuff: tag_3_stuff\n"

after:
parsed_dialog_tags: "---\n0:\n  :tagcontrol:\n  - qa\n  :test:\n  - accounting\n  - automotive\n  - communication\n2:\n  :stuff: tag 2\n3:\n  :stuff: tag_3_stuff\n"

https://bugzilla.redhat.com/show_bug.cgi?id=1227937