### PR TITLE
Fix Ready column value in container nodes table

### DIFF
--- a/vmdb/app/models/container_node.rb
+++ b/vmdb/app/models/container_node.rb
@@ -11,7 +11,7 @@ class ContainerNode < ActiveRecord::Base
 
   delegate   :hardware, :to => :computer_system
 
-  virtual_column :condition_ready, :type => :string, :uses => :container_node_conditions
+  virtual_column :ready_condition_status, :type => :string, :uses => :container_node_conditions
 
   def ready_condition
     container_node_conditions.find_by_name('Ready')

--- a/vmdb/product/views/ContainerNode.yaml
+++ b/vmdb/product/views/ContainerNode.yaml
@@ -20,7 +20,7 @@ db: ContainerNode
 # Columns to fetch from the main table
 cols:
 - name
-- condition_ready
+- ready_condition_status
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -31,7 +31,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
-- condition_ready
+- ready_condition_status
 
 # Column titles, in order
 headers:
@@ -47,7 +47,7 @@ order: Ascending
 # Columns to sort the report on, in order
 sortby:
 - name
-- condition_ready
+- ready_condition_status
 
 # Group rows (y=yes,n=no,c=count)
 group: n


### PR DESCRIPTION
The Ready column currently doesn't present the status value
as it should have been.
This commit fixes the problem that was introduced in commit:
4d6b5e9c40f9ce47d130a55dbef58266375bba74 (PR #3002)