### PR TITLE
Towards JRuby support

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -42,7 +42,12 @@ gem "rufus-lru",            "~>1.0.3",        :require => false
 gem "uuidtools",            "~>2.1.3",        :require => false
 gem "sass",                 "3.1.20",         :require => false
 gem "trollop",              "~>2.0",          :require => false
-gem "psych",                "~>2.0.12"
+
+# JRuby has its own version of psych
+if RUBY_PLATFORM != 'java'
+  gem "psych",              "~>2.0.12"
+end
+
 gem "apipie-bindings",      "~>0.0.12",       :require => false
 
 # qpid group is needed to gate the inclusion of qpid_messaging gem on platforms

--- a/lib/util/win32/miq-wmi.rb
+++ b/lib/util/win32/miq-wmi.rb
@@ -1,17 +1,17 @@
 $:.push("#{File.dirname(__FILE__)}")
 require 'rubygems'
-require 'platform'
 
 class WMIHelper
   WMI_ROOT_NAMESPACE = "root\\cimv2" unless defined?(WMI_ROOT_NAMESPACE)
 
-  platform = Platform::IMPL
-  unless platform == :macosx
+  platform = RbConfig::CONFIG['host_os'].to_sym
+
+  unless platform == :darwin
     platform = :mswin if platform == :mingw
     require "miq-wmi-#{platform}"
     include Kernel.const_get("Wmi#{platform.to_s.capitalize}")
   end
-  
+
 	def initialize(server=nil, username=nil, password=nil, namespace=WMI_ROOT_NAMESPACE)
     @server = server
     @username = username

--- a/lib/util/win32/miq-wmi.rb
+++ b/lib/util/win32/miq-wmi.rb
@@ -1,15 +1,14 @@
-$:.push("#{File.dirname(__FILE__)}")
-require 'rubygems'
+require 'ffi'
 
 class WMIHelper
   WMI_ROOT_NAMESPACE = "root\\cimv2" unless defined?(WMI_ROOT_NAMESPACE)
 
-  platform = RbConfig::CONFIG['host_os'].to_sym
+  platform = FFI::Platform::OS
 
-  unless platform == :darwin
-    platform = :mswin if platform == :mingw
-    require "miq-wmi-#{platform}"
-    include Kernel.const_get("Wmi#{platform.to_s.capitalize}")
+  unless FFI::Platform.mac?
+    platform = 'mswin' if FFI::Platform.windows?
+    require_relative "miq-wmi-#{platform}"
+    include Kernel.const_get("Wmi#{platform.capitalize}")
   end
 
 	def initialize(server=nil, username=nil, password=nil, namespace=WMI_ROOT_NAMESPACE)

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -42,7 +42,13 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "default_value_for",              "~>2.0.3"
-gem "thin",                           "~>1.3.1"  # Used by rails server through rack
+
+if RUBY_PLATFORM == 'java'
+  gem "puma"
+else
+  gem "thin",                           "~>1.3.1"  # Used by rails server through rack
+end
+
 gem "bcrypt-ruby",                    "~> 3.0.1"
 gem 'outfielding-jqplot-rails',       "= 1.0.8"
 gem 'secure_headers'
@@ -66,7 +72,13 @@ gem "net-sftp",                       "~>2.0.5",      :require => false
 gem "net-ssh",                        "~>2.9.1",      :require => false
 gem "open4",                          "~>1.3.0",      :require => false
 gem "ovirt_metrics",                  "~>1.0.1",      :require => false
-gem "pg",                             "~>0.12.2",     :require => false
+
+if RUBY_PLATFORM == 'java'
+  gem "sequel", :require => false
+else
+  gem "pg", "~>0.12.2", :require => false
+end
+
 gem "rack",                           "~>1.4.1",      :require => false
 
 gem "ruby-progressbar",               "~>0.0.10",     :require => false
@@ -83,7 +95,11 @@ gem 'spice-html5-rails'
 #
 unless ENV['APPLIANCE']
   group :development do
-    gem "ruby-prof",                    :require => false
+    if RUBY_PLATFORM == 'java'
+      gem "jruby-prof",                   :require => false
+    else
+      gem "ruby-prof",                    :require => false
+    end
 
     gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
     # used for finding translations

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -74,7 +74,7 @@ gem "open4",                          "~>1.3.0",      :require => false
 gem "ovirt_metrics",                  "~>1.0.1",      :require => false
 
 if RUBY_PLATFORM == 'java'
-  gem "sequel", :require => false
+  gem "activerecord-jdbcpostgresql-adapter", "~>1.3.16", :require => false
 else
   gem "pg", "~>0.12.2", :require => false
 end


### PR DESCRIPTION
This patch is a step towards JRuby support. Mostly this means the following Gemfile modifications:

* Don't bundle psych (JRuby has it's own version)
* Use puma instead of thin
* Use jruby-prof instead of ruby-prof (dev)
* Use activerecord-jdbcpostgresql-adapter instead of pg

There's also a problem with using the Platform gem because it uses RUBY_PLATFORM under the hood instead of RbConfig. JRuby treats the platform as "java", not the operating system, so it doesn't work. For now I'm leveraging FFI::Platform instead since that's already in the Gemfile as a dependency, but I could easily replace it with RbConfig instead if necessary.

Does the app work then? Eh, I can't get past "bundle exec rake evm:db:reset" at the moment because it runs out of heap space, but I thought this would be a worthwhile first step.