### PR TITLE
Renamed spinner class for better PatternFly compatibility

### DIFF
--- a/vmdb/app/assets/javascripts/miq_application.js
+++ b/vmdb/app/assets/javascripts/miq_application.js
@@ -1478,7 +1478,7 @@ function miqSpinner(status) {
         trail: 60, // Afterglow percentage
         shadow: false, // Whether to render a shadow
         hwaccel: false, // Whether to use hardware acceleration
-        className: 'spinner', // The CSS class to assign to the spinner
+        className: 'miq-spinner', // The CSS class to assign to the spinner
         zIndex: 2e9, // The z-index (defaults to 2000000000)
         top: 'auto', // Top position relative to parent in px
         left: 'auto' // Left position relative to parent in px
@@ -1514,7 +1514,7 @@ function miqSearchSpinner(status) {
         trail: 60, // Afterglow percentage
         shadow: false, // Whether to render a shadow
         hwaccel: false, // Whether to use hardware acceleration
-        className: 'spinner', // The CSS class to assign to the spinner
+        className: 'miq-spinner', // The CSS class to assign to the spinner
         zIndex: 2e9, // The z-index (defaults to 2000000000)
         top: 'auto', // Top position relative to parent in px
         left:'auto' // Left position relative to parent in px


### PR DESCRIPTION
PatternFly already has a `.spinner` class which is currently commented out, but we can't comment it out when using a gem.