### PR TITLE
Remove log file binary blobs

### DIFF
--- a/vmdb/app/models/miq_task.rb
+++ b/vmdb/app/models/miq_task.rb
@@ -175,10 +175,6 @@ class MiqTask < ActiveRecord::Base
     self.binary_blob.binary = YAML.dump(value)
   end
 
-  def cleanup_log
-    self.log_file.destroy unless self.log_file.nil?
-  end
-
   def self.generic_action_with_callback(options, queue_options)
     # Pre-reqs:
     # options hash contains the following required keys:

--- a/vmdb/app/models/miq_task.rb
+++ b/vmdb/app/models/miq_task.rb
@@ -175,10 +175,6 @@ class MiqTask < ActiveRecord::Base
     self.binary_blob.binary = YAML.dump(value)
   end
 
-  def log_data
-    self.log_file.nil? ? nil : self.log_file.file_from_db
-  end
-
   def cleanup_log
     self.log_file.destroy unless self.log_file.nil?
   end

--- a/vmdb/spec/models/miq_task_spec.rb
+++ b/vmdb/spec/models/miq_task_spec.rb
@@ -163,16 +163,6 @@ describe MiqTask do
       LogFile.count.should == 0
     end
 
-    it "should get log_data properly" do
-      log_data = "test log data" * 100000
-      l = FactoryGirl.create(:log_file, :miq_task_id => @miq_task.id)
-      l.binary_blob = FactoryGirl.create(:binary_blob, :name => "logs", :data_type => "zip")
-      l.binary_blob.binary = log_data.dup # BinaryBlob#binary= method destroys the input data
-
-      @miq_task.reload
-      @miq_task.log_data.should == log_data
-    end
-
     it "should queue callback properly" do
       state   = MiqTask::STATE_QUEUED
       message = 'Message for testing: queue_callback'

--- a/vmdb/spec/models/miq_task_spec.rb
+++ b/vmdb/spec/models/miq_task_spec.rb
@@ -152,17 +152,6 @@ describe MiqTask do
       @miq_task.task_results.should == results
     end
 
-    it "should cleanup_log properly" do
-      l = FactoryGirl.create(:log_file, :miq_task_id => @miq_task.id)
-      @miq_task.reload
-      @miq_task.log_file.should == l
-
-      @miq_task.cleanup_log
-      @miq_task.reload
-      @miq_task.log_file.should be_nil
-      LogFile.count.should == 0
-    end
-
     it "should queue callback properly" do
       state   = MiqTask::STATE_QUEUED
       message = 'Message for testing: queue_callback'


### PR DESCRIPTION
Binary blobs have not been used in log collection for a long time.  It's time for this code to go :scissors: 