### PR TITLE
Remove unused product_update factory

### DIFF
--- a/vmdb/spec/factories/product_update.rb
+++ b/vmdb/spec/factories/product_update.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :product_update do
-  end
-end


### PR DESCRIPTION
The class was removed in commit [681518f6](https://github.com/ManageIQ/manageiq/commit/681518f6#diff-a34aaa981054d20b30876a378558277bL6)