### PR TITLE
set appropriate active accordion based upon role_allows call.

### DIFF
--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -105,38 +105,41 @@ class OpsController < ApplicationController
     @timeline = @timeline_filter = true # Load timeline JS modules
     return unless load_edit(params[:edit_key], "explorer") if params[:edit_key]
     @breadcrumbs = []
-
-    @sb[:active_accord] ||= 'settings'
     @trees   = []
     @accords = []
     if role_allows(:feature => "ops_settings")
       @accords.push(:name => "settings", :title => "Settings", :container => "settings_tree_div")
-      self.x_active_tree ||= 'settings_tree'
-      @sb[:active_tab]   ||= "settings_server"
+      self.x_active_accord ||= 'settings'
+      self.x_active_tree  ||= 'settings_tree'
+      @sb[:active_tab]    ||= "settings_server"
       @built_trees << settings_build_tree
     end
     if role_allows(:feature => "ops_rbac")
       @accords.push(:name => "rbac", :title => "Access Control", :container => "rbac_tree_div")
-      self.x_active_tree ||= 'rbac_tree'
+      self.x_active_accord ||= 'rbac'
+      self.x_active_tree   ||= 'rbac_tree'
       @built_trees << rbac_build_tree
       x_node_set("root", :rbac_tree) unless x_node(:rbac_tree)
       @sb[:active_tab] ||= "rbac_details"
     end
     if role_allows(:feature => "ops_diagnostics")
       @accords.push(:name => "diagnostics", :title => "Diagnostics", :container => "diagnostics_tree_div")
-      self.x_active_tree ||= 'diagnostics_tree'
+      self.x_active_accord ||= 'diagnostics'
+      self.x_active_tree   ||= 'diagnostics_tree'
       @built_trees << diagnostics_build_tree
       x_node_set("svr-#{to_cid(@sb[:my_server_id])}", :diagnostics_tree) unless x_node(:diagnostics_tree)
       @sb[:active_tab] ||= "diagnostics_summary"
     end
     if get_vmdb_config[:product][:analytics]
       @accords.push(:name => "analytics", :title => "Analytics", :container => "analytics_tree_div")
+      self.x_active_accord ||= 'analytics'
       @built_trees << analytics_build_tree
       x_node_set("svr-#{to_cid(@sb[:my_server_id])}", :analytics_tree) unless x_node(:analytics_tree)
     end
     if role_allows(:feature => "ops_db")
       @accords.push(:name => "vmdb", :title => "Database", :container => "vmdb_tree_div")
-      self.x_active_tree ||= 'vmdb_tree'
+      self.x_active_accord ||= 'vmdb'
+      self.x_active_tree   ||= 'vmdb_tree'
       @built_trees << db_build_tree
       x_node_set("root", :vmdb_tree) unless x_node(:vmdb_tree)
       @sb[:active_tab] ||= "db_summary"


### PR DESCRIPTION
Set active_accord value inside if role_allows block for each type of accordion to match the active_tree, so correct right cell headers are displayed. Added spec test to verify the fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1224959

@dclarizio please review

before:
![1222479_before](https://cloud.githubusercontent.com/assets/3450808/7994662/17a3d3f2-0add-11e5-88bf-c3c3d4f464fa.png)

after:
![1222479_after](https://cloud.githubusercontent.com/assets/3450808/7994665/1e492c48-0add-11e5-8db7-0ba3655e7ce0.png)
