### PR TITLE
add silent feature to fix_auth

### DIFF
--- a/vmdb/spec/tools/fix_auth/auth_model_spec.rb
+++ b/vmdb/spec/tools/fix_auth/auth_model_spec.rb
@@ -170,7 +170,7 @@ describe FixAuth::AuthModel do
 
     it "should update with complex contenders" do
       v1 # make sure record exists
-      subject.run
+      subject.run(:silent => true)
       expect(v1.reload.value).to be_encrypted_version(2)
     end
   end

--- a/vmdb/spec/tools/fix_auth/models_spec.rb
+++ b/vmdb/spec/tools/fix_auth/models_spec.rb
@@ -12,7 +12,7 @@ describe FixAuth::FixDatabaseYml do
   it "updates password" do
     with_databaseyml("oldpassword") do |databaseyml|
       FixAuth::FixDatabaseYml.file_name = databaseyml
-      FixAuth::FixDatabaseYml.run(:hardcode => 'newpassword')
+      FixAuth::FixDatabaseYml.run(:hardcode => 'newpassword', :silent => true)
 
       expect(dbpassword(databaseyml)).to be_encrypted("newpassword")
     end
@@ -21,7 +21,7 @@ describe FixAuth::FixDatabaseYml do
   it "does not add a password" do
     with_databaseyml do |databaseyml|
       FixAuth::FixDatabaseYml.file_name = databaseyml
-      FixAuth::FixDatabaseYml.run
+      FixAuth::FixDatabaseYml.run(:silent => true)
       expect(dbpassword(databaseyml)).to be_nil
     end
   end

--- a/vmdb/tools/fix_auth/auth_model.rb
+++ b/vmdb/tools/fix_auth/auth_model.rb
@@ -83,7 +83,7 @@ module FixAuth
 
       def run(options = {})
         return if available_columns.empty?
-        puts "fixing #{table_name}.#{available_columns.join(", ")}"
+        puts "fixing #{table_name}.#{available_columns.join(", ")}" unless options[:silent]
         contenders(options[:v2]).each do |r|
           fix_passwords(r, options)
           if options[:verbose]


### PR DESCRIPTION
Currently, the tests are displaying status information about running fix_auth
We would like that not to display.

This adds a feature to fix_auth to silence this message.

This can be added to the actual command line interface in the future, but the main objective for now is to hide it while running specs.

Fixes #3034

/cc @jrafanie I'd prefer not to rely upon Rspec being defined.
Does this work for you?

```bash
$ ./bin/rspec ./spec/tools/fix_auth/*
...........................................

Finished in 1.29 seconds
43 examples, 0 failures

```