### PR TITLE
Adds auth_key to list of auth attrs for OSInfra

### DIFF
--- a/vmdb/app/models/ems_openstack_infra.rb
+++ b/vmdb/app/models/ems_openstack_infra.rb
@@ -49,6 +49,10 @@ class EmsOpenstackInfra < EmsInfra
     %w(default amqp ssh_keypair)
   end
 
+  def supported_auth_attributes
+    %w(userid password auth_key)
+  end
+
   def supports_authentication?(authtype)
     supported_auth_types.include?(authtype.to_s)
   end


### PR DESCRIPTION
auth_key attribute needs to be allowed to enable creating OpenStack
Infra Providers with ssh_keypair credentials.