### PR TITLE
Remove association to stack for disconnected VMs

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -629,6 +629,19 @@ class VmOrTemplate < ActiveRecord::Base
     end
 
     self.disconnect_host
+
+    disconnect_stack if respond_to?(:orchestration_stack)
+  end
+
+  def disconnect_stack(stack = nil)
+    return unless orchestration_stack
+    return if stack && stack != orchestration_stack
+
+    log_text = " from stack [#{orchestration_stack.name}] id [#{orchestration_stack.id}]"
+    _log.info "Disconnecting Vm [#{name}] id [#{id}]#{log_text}"
+
+    self.orchestration_stack = nil
+    save
   end
 
   def connect_ems(e)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1228367

When a VM is disconnected in VMDB, currently only relations with ems and host are disconnected. This fix is to clear the relationship to stack so that when browsing the stack the achieved VMs will not be included in the stack's instances association.

Looking at the schema for vms table, we see the VM has belong_to relations to other types such as cloud_network, cloud_subnet, cloud_tenant, flavor, availability_zone, that are still not disconnected. Should we fix all these relations at one shot?