### PR TITLE
Changed container service ui to show port configs in a table.

### DIFF
--- a/vmdb/app/helpers/container_service_helper/textual_summary.rb
+++ b/vmdb/app/helpers/container_service_helper/textual_summary.rb
@@ -15,8 +15,17 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_group_port_configs
-    items = ContainerServicePortConfig.where(:container_service_id => @record.id)
-    items.collect { |m| textual_port_config(m) }.flatten.compact
+    labels = [_("Name"), _("Port"), _("Target Port"), _("Protocol")]
+    h = {:labels => labels}
+    h[:values] = @record.container_service_port_configs.collect do |config|
+      [
+        config.name || _("<Unnamed>"),
+        config.port,
+        config.target_port,
+        config.protocol
+      ]
+    end
+    h
   end
 
   def textual_group_relationships

--- a/vmdb/app/views/container_service/_main.html.haml
+++ b/vmdb/app/views/container_service/_main.html.haml
@@ -2,7 +2,7 @@
 .row
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => { :title => _("Properties"), :items => textual_group_properties }
-    = render :partial => "shared/summary/textual", :locals => { :title => _("Port Configurations"), :items => textual_group_port_configs }
+    = render :partial => "shared/summary/textual_multilabel", :locals => { :title => _("Port Configurations"), :items => textual_group_port_configs }
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => { :title => _("Relationships"), :items => textual_group_relationships }
 


### PR DESCRIPTION
Service ports were previously condensed into a single field now they're in a better looking table.
Thanks to @dkorn 
![serviceportconfigs](https://cloud.githubusercontent.com/assets/11256940/8023093/5fe98d32-0d03-11e5-9f3c-e9d8ba7ef602.png)

