### PR TITLE
Upgrade jQuery to 1.9.1

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -9,7 +9,7 @@ MiqBundler.include_gemfile("../lib/Gemfile", binding)
 
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '=1.2.4'
-gem 'jquery-rails', "=2.1.4"
+gem 'jquery-rails', "~>2.2.2"
 gem 'jquery-hotkeys-rails'
 gem 'codemirror-rails', "=4.2"
 


### PR DESCRIPTION
Because we don't support IE8 anymore and Bootstrap requires > 1.9