### PR TITLE
Lock kubeclient and openshift_client gem versions

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -34,8 +34,8 @@ gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>1.2.0",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "ovirt",                   "~>0.4.2",           :require => false
-gem "kubeclient",              ">=0.1.16",          :require => false
-gem "openshift_client",        ">=0.0.5",           :require => false
+gem "kubeclient",              "=0.1.16",           :require => false
+gem "openshift_client",        "=0.0.5",            :require => false
 gem "rest-client",                                  :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",                "~>0.5.21",          :require => false
 gem "Platform",                "=0.4.0",            :require => false


### PR DESCRIPTION
kubeclient and openshift_client are rapidly changing, so the best
practice for now should be to lock them to a specific working version we
know is working.