### PR TITLE
Service template specs for Automate Methods

### DIFF
--- a/vmdb/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+include ServiceTemplateHelper
+
+describe "CatalogBundleInitialization Automate Method" do
+  before do
+    @allowed_service_templates = %w(top vm_service1 vm_service2)
+    user_helper
+    build_small_environment
+    build_model
+  end
+
+  def create_request_and_tasks(dialog_options = {})
+    @request = build_service_template_request("top", @user.userid, dialog_options)
+    service_template_stubs
+    request_stubs
+    @request.create_request_tasks
+  end
+
+  def build_model
+    model = {"top"         => {:type          => 'composite',
+                               :children      => %w(vm_service1 vm_service2),
+                               :child_options => {'vm_service1' => {:provision_index => 0},
+                                                  'vm_service2' => {:provision_index => 1}}},
+             "vm_service1" => {:type    => 'atomic',
+                               :request => {:src_vm_id => @src_vm.id,
+                                            :number_of_vms => 1, :userid => @user.userid}
+                              },
+             "vm_service2" => {:type    => 'atomic',
+                               :request => {:src_vm_id => @src_vm.id,
+                                            :number_of_vms => 1, :userid => @user.userid}
+                              }
+            }
+    build_service_template_tree(model)
+  end
+
+  def run_automate_method
+    attrs = []
+    attrs << "ServiceTemplateProvisionTask::service_template_provision_task=#{@stp.id}"
+
+    MiqAeEngine.instantiate("/System/Request/Call_Instance_With_Message?" \
+                            "namespace=Service/Provisioning/StateMachines&class=Methods" \
+                            "&instance=CatalogBundleInitialization&" \
+                            "#{attrs.join('&')}")
+  end
+
+  def root_service_template_task
+    @request.miq_request_tasks.detect { |y| y.miq_request_task_id.nil? }
+  end
+
+  context "override" do
+    before do
+      @service_name = "Fred"
+      @service_description = "My Favorite Service"
+      @dialog_hash = {'dialog_option_1_service_name'        => 'one',
+                      'dialog_option_2_service_name'        => 'two',
+                      'dialog_option_0_service_name'        => @service_name,
+                      'dialog_option_0_service_description' => @service_description,
+                      'dialog_tag_0_tracker'                => 'gps',
+                      'dialog_tag_1_location'               => 'BOM',
+                      'dialog_tag_2_location'               => 'EWR'}
+      @parsed_dialog_options_hash = {1 => {:service_name => "one"},
+                                     2 => {:service_name => "two"},
+                                     0 => {:service_name        => @service_name,
+                                           :service_description => @service_description}}
+      @parsed_dialog_tags_hash = {1 => {:location => "BOM"},
+                                  2 => {:location => "EWR"},
+                                  0 => {:tracker => "gps"}}
+    end
+
+    def check_svc_attrs
+      @stp.reload
+      service = @stp.destination
+      service.description.should eql(@service_description)
+      service.name.should eql(@service_name)
+      service.tags[0].name.should eql('/managed/tracker/gps')
+    end
+
+    def process_stp(options)
+      create_request_and_tasks
+      @stp = root_service_template_task
+      @stp.options = @stp.options.merge(options)
+      @stp.save
+      run_automate_method
+    end
+
+    it "service name and description" do
+      parsed_options = {:parsed_dialog_options => @parsed_dialog_options_hash.to_yaml,
+                        :parsed_dialog_tags    => @parsed_dialog_tags_hash.to_yaml}
+      process_stp(parsed_options)
+      check_svc_attrs
+    end
+
+    it "backward compatibility" do
+      process_stp(:dialog => @dialog_hash)
+      check_svc_attrs
+    end
+  end
+end

--- a/vmdb/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+include ServiceTemplateHelper
+
+describe "CatalogItemInitialization Automate Method" do
+  before(:each) do
+    @allowed_service_templates = %w(top vm_service1 vm_service2)
+    user_helper
+    build_small_environment
+    build_model
+  end
+
+  def create_request_and_tasks(dialog_options = {})
+    @request = build_service_template_request("top", @user.userid, dialog_options)
+    service_template_stubs
+    request_stubs
+    @request.create_request_tasks
+  end
+
+  def build_model
+    model = {"top"         => {:type          => 'composite',
+                               :children      => %w(vm_service1 vm_service2),
+                               :child_options => {'vm_service1' => {:provision_index => 0},
+                                                  'vm_service2' => {:provision_index => 1}}},
+             "vm_service1" => {:type    => 'atomic',
+                               :request => {:src_vm_id => @src_vm.id,
+                                           :number_of_vms => 1, :userid => @user.userid}
+                             },
+             "vm_service2" => {:type    => 'atomic',
+                               :request => {:src_vm_id => @src_vm.id,
+                                           :number_of_vms => 1, :userid => @user.userid}
+                             }
+            }
+    build_service_template_tree(model)
+  end
+
+  def run_automate_method(stpt)
+    attrs = []
+    attrs << "ServiceTemplateProvisionTask::service_template_provision_task=#{stpt.id}" if stpt
+
+    MiqAeEngine.instantiate("/System/Request/Call_Instance_With_Message?" \
+                            "namespace=Service/Provisioning/StateMachines&class=Methods" \
+                            "&instance=CatalogItemInitialization&" \
+                            "#{attrs.join('&')}")
+  end
+
+  def root_service_template_task
+    @request.miq_request_tasks.detect { |y| y.miq_request_task_id.nil? }
+  end
+
+  context "options and tags" do
+    it "in provision request" do
+      parsed_dialog_options_hash = {1 => {:vm_target_name => "one"},
+                                    2 => {:vm_target_name => "two"},
+                                    0 => {:root_attr      => "fred"}}
+      parsed_dialog_tags_hash = {1 => {:location => "BOM"},
+                                 2 => {:location => "EWR"},
+                                 0 => {:tracker  => "gps"}}
+
+      create_request_and_tasks
+      stp = root_service_template_task
+      st1 = ServiceTemplate.where(:name => 'vm_service1').try(:first)
+      st2 = ServiceTemplate.where(:name => 'vm_service2').try(:first)
+      stp1 = stp.miq_request_tasks.detect { |x| x.source_id == st1.id }
+      stp2 = stp.miq_request_tasks.detect { |x| x.source_id == st2.id }
+
+      parsed_options = {:parsed_dialog_options => parsed_dialog_options_hash.to_yaml,
+                        :parsed_dialog_tags    => parsed_dialog_tags_hash.to_yaml}
+      required_options = {:vm_target_name => 'one', :root_attr => 'fred'}
+      required_tags    = {:tracker => 'gps', :location => 'bom'}
+      process_stp(stp1, parsed_options, required_options, required_tags)
+      required_options = {:vm_target_name => 'two', :root_attr => 'fred'}
+      required_tags    = {:tracker => 'gps', :location => 'ewr'}
+      process_stp(stp2, parsed_options, required_options, required_tags)
+    end
+
+    def process_stp(stp, parsed_options, required_options, required_tags)
+      stp.options = stp.options.merge(parsed_options)
+      stp.save
+      run_automate_method(stp)
+      stp.reload
+      request_task = stp.miq_request_tasks[0].miq_request_tasks[0]
+      check_vm_task(request_task, required_options, required_tags)
+    end
+
+    def check_vm_task(request_task, required_options, required_tags)
+      check_options(request_task, required_options)
+      check_tags(request_task, required_tags)
+    end
+
+    def check_options(request_task, required_options)
+      options = request_task.options
+      required_options.each { |k, v| options[k].should eql(v) }
+    end
+
+    def check_tags(request_task, required_tags)
+      tags = request_task.get_tags
+      required_tags.each { |k, v| tags[k].should eql(v) }
+    end
+  end
+end

--- a/vmdb/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+include ServiceTemplateHelper
+
+describe "DialogParser Automate Method" do
+  before(:each) do
+    @root_stp = FactoryGirl.create(:miq_request_task, :type => 'ServiceTemplateProvisionTask')
+  end
+
+  def run_automate_method
+    attrs = []
+    attrs << "ServiceTemplateProvisionTask::service_template_provision_task=#{@root_stp.id}"
+
+    MiqAeEngine.instantiate("/System/Request/Call_Instance_With_Message?" \
+                            "namespace=Service/Provisioning/StateMachines&class=Methods" \
+                            "&instance=DialogParser&" \
+                            "#{attrs.join('&')}")
+  end
+
+  def create_tags
+    FactoryGirl.create(:classification_department_with_tags)
+    @array_name  = "Array::dialog_tag_0_department"
+    @dept_ids = Classification.find_by_description('Department').children.collect do |x|
+      "Classification::#{x.id}"
+    end.join(',')
+
+    @dept_array = Classification.find_by_description('Department').children.collect(&:name)
+  end
+
+  context "parser" do
+    it "with options tags and arrays" do
+      create_tags
+      dialog_hash = {'dialog_option_1_numero' => 'one', 'dialog_option_2_numero' => 'two',
+                     'dialog_option_3_numero' => 'three', 'dialog_option_0_numero' => 'zero',
+                     'dialog_tag_0_location' => 'NYC', 'dialog_tag_1_location' => 'BOM',
+                     'dialog_tag_2_location' => 'EWR', @array_name => @dept_ids}
+
+      parsed_dialog_options_hash = {1 => {:numero => "one"},
+                                    2 => {:numero => "two"},
+                                    3 => {:numero => "three"},
+                                    0 => {:numero => "zero"}}
+      parsed_dialog_tags_hash = {0 => {:location => "NYC"},
+                                 1 => {:location => "BOM"},
+                                 2 => {:location => "EWR"}}
+
+      @root_stp.options = @root_stp.options.merge(:dialog => dialog_hash)
+      @root_stp.save
+      run_automate_method
+      @root_stp.reload
+
+      pdo = YAML.load(@root_stp.get_option(:parsed_dialog_options))
+      pdt = YAML.load(@root_stp.get_option(:parsed_dialog_tags))
+      depts = pdt[0].delete(:department)
+      expect(pdo).to eql(parsed_dialog_options_hash)
+      expect(pdt).to eql(parsed_dialog_tags_hash)
+      expect(depts).to match_array(@dept_array)
+    end
+
+    it "with no dialogs set" do
+      @root_stp.options = @root_stp.options.merge(:dialog => {})
+      @root_stp.save
+      expect { run_automate_method }.to raise_exception
+    end
+  end
+end

--- a/vmdb/spec/support/service_template_helper.rb
+++ b/vmdb/spec/support/service_template_helper.rb
@@ -35,7 +35,7 @@ module ServiceTemplateHelper
   end
 
   def link_all_children(item, properties, hash)
-    children = properties[:children] 
+    children = properties[:children]
     child_options = properties.key?(:child_options) ? properties[:child_options] : {}
     children.each do |name|
       child_item = ServiceTemplate.find_by_name(name) || build_a_composite(name, hash)

--- a/vmdb/spec/support/service_template_helper.rb
+++ b/vmdb/spec/support/service_template_helper.rb
@@ -1,0 +1,96 @@
+module ServiceTemplateHelper
+  def build_service_template_tree(hash)
+    build_all_atomics(hash)
+    build_all_composites(hash)
+  end
+
+  def build_all_atomics(hash)
+    hash.each do |name, value|
+      next unless value[:type] == "atomic"
+      item  = FactoryGirl.create(:service_template, :name         => name,
+                                                    :service_type => 'atomic')
+      options = value[:request]
+      mprt = FactoryGirl.create(:miq_provision_request_template,
+                                :userid    => options[:userid],
+                                :src_vm_id => options[:src_vm_id],
+                                :options   => options)
+      add_st_resource(item, mprt)
+    end
+  end
+
+  def build_all_composites(hash)
+    hash.each do |name, value|
+      next unless value[:type] == "composite"
+      next if ServiceTemplate.find_by_name(name)
+      build_a_composite(name, hash)
+    end
+  end
+
+  def build_a_composite(name, hash)
+    item  = FactoryGirl.create(:service_template, :name         => name,
+                                                  :service_type => 'composite')
+    properties = hash[name]
+    link_all_children(item, properties, hash) unless properties[:children].empty?
+    item
+  end
+
+  def link_all_children(item, properties, hash)
+    children = properties[:children] 
+    child_options = properties.key?(:child_options) ? properties[:child_options] : {}
+    children.each do |name|
+      child_item = ServiceTemplate.find_by_name(name) || build_a_composite(name, hash)
+      add_st_resource(item, child_item, child_options.fetch(name, {}))
+    end
+  end
+
+  def add_st_resource(svc, resource, options = {})
+    svc.add_resource(resource, options)
+    svc.service_resources.each(&:save)
+  end
+
+  def build_service_template_request(root_st_name, userid, dialog_options = {})
+    root = ServiceTemplate.find_by_name(root_st_name)
+    return nil unless root
+    options = {:src_id => root.id, :target_name => "barney"}.merge(dialog_options)
+    FactoryGirl.create(:service_template_provision_request,
+                       :description    => 'Service Request',
+                       :source_type    => 'ServiceTemplate',
+                       :type           => 'ServiceTemplateProvisionRequest',
+                       :request_type   => 'clone_to_service',
+                       :approval_state => 'approved',
+                       :source_id      => root.id,
+                       :userid         => userid,
+                       :options        => options)
+  end
+
+  def request_stubs
+    @request.stub(:approved?).and_return(true)
+    MiqRequestTask.any_instance.stub(:approved?).and_return(true)
+    MiqProvision.any_instance.stub(:get_next_vm_name).and_return("fred")
+    @request.stub(:automate_event_failed?).and_return(false)
+  end
+
+  def build_small_environment
+    @guid = MiqUUID.new_guid
+    MiqServer.stub(:my_guid).and_return(@guid)
+    @zone       = FactoryGirl.create(:zone)
+    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
+    MiqServer.stub(:my_server).and_return(@miq_server)
+    @ems = FactoryGirl.create(:ems_vmware_with_authentication)
+    @host1 =  FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
+    @src_vm = FactoryGirl.create(:vm_vmware, :host   => @host1,
+                                             :ems_id => @ems.id,
+                                             :name   => "barney")
+  end
+
+  def service_template_stubs
+    ServiceTemplate.stub(:automate_result) do |_uri, name|
+      @allowed_service_templates.include?(name)
+    end
+  end
+
+  def user_helper
+    User.any_instance.stub(:role).and_return("admin")
+    @user        = FactoryGirl.create(:user, :name => 'Wilma',  :userid => 'wilma')
+  end
+end


### PR DESCRIPTION
Added specs to test the following Automate Methods used during Service Provisioning

1. Catalog_bundle_initialization
2. Catalog_item_initialization
3. dialog_parser
