### PR TITLE
Fixed method 'list_row_image' to pass the correct param

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -1210,7 +1210,7 @@ class ApplicationController < ActionController::Base
                 "../../../pictures/#{item.picture.basename}"
               end
             end
-    list_row_image(pn, image, (@listicon || view.db).underscore, item.name)
+    list_row_image(pn, image, (@listicon || view.db).underscore, item)
   end
 
   def get_host_for_vm(vm)
@@ -2713,8 +2713,8 @@ class ApplicationController < ActionController::Base
     to_cid(row['id'])
   end
 
-  def list_row_image(image_path, image, model_image, _itemname)
-    image ? image : "#{image_path}#{model_image}.png"
+  def list_row_image(image_path, image, model_image, _item)
+    image || "#{image_path}#{model_image}.png"
   end
 
   def render_flash_not_applicable_to_model(type)

--- a/vmdb/app/controllers/provider_foreman_controller.rb
+++ b/vmdb/app/controllers/provider_foreman_controller.rb
@@ -851,8 +851,8 @@ class ProviderForemanController < ApplicationController
     end
   end
 
-  def list_row_image(image_path, image, model_image, itemname)
-    if itemname == _("Unassigned Profiles Group")
+  def list_row_image(image_path, image, model_image, item)
+    if item.name == _("Unassigned Profiles Group")
       image_path ? "#{image_path}folder.png" : "folder"
     else
       super


### PR DESCRIPTION
The controller that overrides ```list_row_image``` will retrieve the appropriate attribute from ```item``` and use it as necessary.

https://bugzilla.redhat.com/show_bug.cgi?id=1229431