### PR TITLE
Added recursive flag to remove older upstream dirs

### DIFF
--- a/build/nightly/cleanup.sh
+++ b/build/nightly/cleanup.sh
@@ -8,7 +8,7 @@ upstream=/home/appliances/cfme/upstream
 imgfac_storage=/home/nouser/storage
 tests=/home/appliances/cfme/upstream/test/
 
-find $upstream               -mtime +$days_to_keep_nightlies                              | xargs rm -vf
+find $upstream               -mtime +$days_to_keep_nightlies                              | xargs rm -rvf
 find $tests                  -mtime +$days_to_keep_tests                                  | xargs rm -vf
 find $imgfac_storage -type f -mtime +$days_to_keep_storage   -regex ".*\.\(body\|meta\)$" | xargs rm -vf
 


### PR DESCRIPTION
During the cleanup of older upstream builds, we need the rm -r flag added to remove directories as well as files.

@jvlcek 