### PR TITLE
Configured system placement allow nil location and organization

### DIFF
--- a/vmdb/app/models/configured_system_foreman/placement.rb
+++ b/vmdb/app/models/configured_system_foreman/placement.rb
@@ -3,8 +3,10 @@ module ConfiguredSystemForeman::Placement
     cl_history = configuration_location.try(:path) || []
     co_history = configuration_organization.try(:path) || []
     MiqPreloader.preload(cl_history + co_history, :configuration_profiles => :configuration_architecture)
-    cp_by_cl = cl_history.collect(&:configuration_profiles).flatten.uniq
-    cp_by_co = co_history.collect(&:configuration_profiles).flatten.uniq
+    cp_no_cl = ConfigurationProfile.includes(:configuration_locations).find(:all, :conditions => {"configuration_locations_configuration_profiles.configuration_profile_id" => nil})
+    cp_no_co = ConfigurationProfile.includes(:configuration_organizations).find(:all, :conditions => {"configuration_organizations_configuration_profiles.configuration_profile_id" => nil})
+    cp_by_cl = (cl_history.collect(&:configuration_profiles).flatten + cp_no_cl).uniq
+    cp_by_co = (co_history.collect(&:configuration_profiles).flatten + cp_no_co).uniq
     (cp_by_cl & cp_by_co).select { |cp| [configuration_architecture, nil].include?(cp.configuration_architecture) }
   end
 end

--- a/vmdb/spec/models/configured_system_foreman/placement_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman/placement_spec.rb
@@ -6,24 +6,46 @@ describe ConfiguredSystemForeman do
       let(:arch1) { FactoryGirl.create(:configuration_architecture, :name => "i386") }
       let(:arch2) { FactoryGirl.create(:configuration_architecture, :name => "x86_64") }
       let(:cl)    { FactoryGirl.create(:configuration_location) }
+      let(:cl2)   { FactoryGirl.create(:configuration_location) }
       let(:co)    { FactoryGirl.create(:configuration_organization) }
+      let(:co2)   { FactoryGirl.create(:configuration_organization) }
       let(:cp1)   { FactoryGirl.create(:configuration_profile_foreman) }
       let(:cp2)   { FactoryGirl.create(:configuration_profile_foreman, :parent => cp1) }
       let(:cp3)   { FactoryGirl.create(:configuration_profile_foreman, :parent => cp2) }
       let(:cs)    { FactoryGirl.create(:configured_system_foreman, :configuration_organization => co, :configuration_location => cl) }
 
-      it "filters based on locations" do
-        cl.configuration_profiles.push(cp1, cp2)
-        co.configuration_profiles.push(cp1, cp2, cp3)
+      context "filters based on locations" do
+        it "profiles in other locations are not available" do
+          cl.configuration_profiles.push(cp1, cp2)
+          cl2.configuration_profiles.push(cp3)
+          co.configuration_profiles.push(cp1, cp2, cp3)
 
-        expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+          expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+        end
+
+        it "profiles with nil locations are available" do
+          cl.configuration_profiles.push(cp1, cp2)
+          co.configuration_profiles.push(cp1, cp2, cp3)
+
+          expect(cs.available_configuration_profiles).to match_array([cp1, cp2, cp3])
+        end
       end
 
-      it "filters based on organizations" do
-        cl.configuration_profiles.push(cp1, cp2, cp3)
-        co.configuration_profiles.push(cp1, cp2)
+      context "filters based on organizations" do
+        it "profiles in other organizations are not available" do
+          cl.configuration_profiles.push(cp1, cp2, cp3)
+          co.configuration_profiles.push(cp1, cp2)
+          co2.configuration_profiles.push(cp3)
 
-        expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+          expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
+        end
+
+        it "profiles with nil organizations are available" do
+          cl.configuration_profiles.push(cp1, cp2, cp3)
+          co.configuration_profiles.push(cp1, cp2)
+
+          expect(cs.available_configuration_profiles).to match_array([cp1, cp2, cp3])
+        end
       end
 
       it "filters based on architectures" do

--- a/vmdb/spec/models/configured_system_foreman/placement_spec.rb
+++ b/vmdb/spec/models/configured_system_foreman/placement_spec.rb
@@ -14,18 +14,18 @@ describe ConfiguredSystemForeman do
       let(:cp3)   { FactoryGirl.create(:configuration_profile_foreman, :parent => cp2) }
       let(:cs)    { FactoryGirl.create(:configured_system_foreman, :configuration_organization => co, :configuration_location => cl) }
 
+      before { cp1; cp2; cp3 }  # Create ConfigurationProfiles location and/or organization to be assigned by the spec
+
       context "filters based on locations" do
         it "profiles in other locations are not available" do
           cl.configuration_profiles.push(cp1, cp2)
           cl2.configuration_profiles.push(cp3)
-          co.configuration_profiles.push(cp1, cp2, cp3)
 
           expect(cs.available_configuration_profiles).to match_array([cp1, cp2])
         end
 
         it "profiles with nil locations are available" do
           cl.configuration_profiles.push(cp1, cp2)
-          co.configuration_profiles.push(cp1, cp2, cp3)
 
           expect(cs.available_configuration_profiles).to match_array([cp1, cp2, cp3])
         end
@@ -33,7 +33,6 @@ describe ConfiguredSystemForeman do
 
       context "filters based on organizations" do
         it "profiles in other organizations are not available" do
-          cl.configuration_profiles.push(cp1, cp2, cp3)
           co.configuration_profiles.push(cp1, cp2)
           co2.configuration_profiles.push(cp3)
 
@@ -41,7 +40,6 @@ describe ConfiguredSystemForeman do
         end
 
         it "profiles with nil organizations are available" do
-          cl.configuration_profiles.push(cp1, cp2, cp3)
           co.configuration_profiles.push(cp1, cp2)
 
           expect(cs.available_configuration_profiles).to match_array([cp1, cp2, cp3])
@@ -49,8 +47,6 @@ describe ConfiguredSystemForeman do
       end
 
       it "filters based on architectures" do
-        cl.configuration_profiles.push(cp1, cp2, cp3)
-        co.configuration_profiles.push(cp1, cp2, cp3)
         cp3.configuration_tags.push(arch1)
         cs.configuration_tags.push(arch2)
 


### PR DESCRIPTION
Profiles that don't have a location assigned can be assigned to hosts in any location. Same applies to organization.

This fixes our groups search so those groups are returned

https://bugzilla.redhat.com/show_bug.cgi?id=1227418