### PR TITLE
Added changes to reset provider region after user changes provider type

### DIFF
--- a/vmdb/app/controllers/ems_common.rb
+++ b/vmdb/app/controllers/ems_common.rb
@@ -736,6 +736,7 @@ module EmsCommon
     @edit[:new][:provider_region] = params[:provider_region] if params[:provider_region]
     @edit[:new][:hostname] = params[:hostname] if params[:hostname]
     if params[:server_emstype]
+      @edit[:new][:provider_region] = @ems.provider_region
       @edit[:new][:emstype] = params[:server_emstype]
       if ["openstack", "openstack_infra"].include?(params[:server_emstype])
         @edit[:new][:port] = @ems.port ? @ems.port : 5000

--- a/vmdb/app/models/mixins/ems_openstack_mixin.rb
+++ b/vmdb/app/models/mixins/ems_openstack_mixin.rb
@@ -156,4 +156,8 @@ module EmsOpenstackMixin
     $log.error "MIQ(#{self.class.name}##{__method__}) template=[#{template.name}], error: #{err}"
     raise MiqException::MiqOrchestrationValidationError, err.to_s, err.backtrace
   end
+
+  def description
+    self.class.description
+  end
 end

--- a/vmdb/spec/controllers/ems_common_controller_spec.rb
+++ b/vmdb/spec/controllers/ems_common_controller_spec.rb
@@ -19,6 +19,21 @@ describe EmsCloudController do
       end
     end
 
+    context "#get_form_vars" do
+      it "check if provider_region gets reset when provider type is changed on add screen" do
+        controller.instance_variable_set(:@edit, :new => {})
+        controller.instance_variable_set(:@_params, :server_emstype => "ec2")
+        controller.instance_variable_set(:@_params, :provider_region => "some_region")
+
+        controller.send(:get_form_vars)
+        assigns(:edit)[:new][:provider_region].should == "some_region"
+
+        controller.instance_variable_set(:@_params, :server_emstype => "openstack")
+        controller.send(:get_form_vars)
+        assigns(:edit)[:new][:provider_region].should be_nil
+      end
+    end
+
     context "#form_field_changed" do
       before :each do
         set_user_privileges


### PR DESCRIPTION
- Added changes to reset provider region value in case user changed provider type after selecting provider region for a different type and then changed type to "Openstack". Added spec test to verify.
- Added a description method to EmsOpenstack, to prevent from blowing up in UI incase somehow user's db has provider_region column populated for Openstack Provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1229104
https://bugzilla.redhat.com/show_bug.cgi?id=1229781

@Fryguy @dclarizio please review.

Steps to recreate:
Try to Add a new cloud provider, select provider type as "Amazon EC2", select a value in region pull down, then change provider type to "Openstack" fill in appropriate data and add provider, when trying to go to summary screen of newly added provider it blows up.