### PR TITLE
Fixed to not allow deletion of default dialog from summary screen.

### DIFF
--- a/vmdb/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/vmdb/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -86,12 +86,14 @@ module MiqAeCustomizationController::OldDialogs
       else
         dialogs.push(params[:id])
         dialog = MiqDialog.find_by_id(from_cid(params[:id]))  if method == 'destroy'        #need to set this for destroy method so active node can be set to image_type folder node after record is deleted
-        process_old_dialogs(dialogs, method)  unless dialogs.empty?
-        # TODO: tells callers to go back to show_list because this SMIS Agent may be gone
-        # Should be refactored into calling show_list right here
-        if method == 'destroy'
-          self.x_node = "xx-MiqDialog_#{dialog.dialog_type}"
+        if dialog.default
+          add_flash(_("Default %{model} \"%{name}\" cannot be deleted") % {:model => ui_lookup(:model => "MiqDialog"),
+                                                                           :name  => dialog.name}, :error)
+        else
+          process_old_dialogs(dialogs, method)  unless dialogs.empty?
         end
+
+        self.x_node = "xx-MiqDialog_#{dialog.dialog_type}" if method == 'destroy' && !flash_errors?
         get_node_info
         replace_right_cell(x_node,[:old_dialogs])
       end

--- a/vmdb/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/vmdb/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+include UiConstants
+
+describe MiqAeCustomizationController do
+  context "::OldDialogs" do
+    context "#old_dialogs_button_operation" do
+      it "Only non-default dialogs should get deleted" do
+        dialog1 = FactoryGirl.create(:miq_dialog, :name        => "Test_Dialog1",
+                                                  :description => "Test Description 1",
+                                                  :default     => true
+                                   )
+        dialog2 = FactoryGirl.create(:miq_dialog, :name        => "Test_Dialog2",
+                                                  :description => "Test Description 2",
+                                                  :default     => false
+        )
+        controller.instance_variable_set(:@sb,
+                                         :active_tree => :old_dialogs_tree,
+                                         :trees       => {
+                                           :old_dialogs_tree => {
+                                             :active_node => "xx-MiqDialog_MiqProvisionWorkflow"}
+                                         }
+        )
+        controller.stub(:get_node_info)
+        controller.stub(:replace_right_cell)
+
+        # Now delete the Dialog
+        controller.instance_variable_set(:@_params, "check_#{dialog1.id}" => "1", "check_#{dialog2.id}" => "1")
+        controller.send(:old_dialogs_button_operation, 'destroy', 'Test Dialog')
+
+        # Check for Dialog Label to be part of flash message displayed
+        flash_messages = assigns(:flash_array)
+        flash_messages.first[:message].should include("Default Dialog \"Test_Dialog1\" cannot be deleted")
+        controller.send(:flash_errors?).should be_true
+        flash_messages.last[:message].should include("Dialog \"Test Description 2\": Delete successful")
+      end
+
+      it "Default Dialog should not be deleted" do
+        dialog = FactoryGirl.create(:miq_dialog, :name        => "Test_Dialog",
+                                                 :description => "Test Description",
+                                                 :default     => true
+        )
+        controller.instance_variable_set(:@sb,
+                                         :trees       => {:old_dialogs_tree => {:active_node => "odg-#{dialog.id}"}},
+                                         :active_tree => :old_dialogs_tree)
+        controller.stub(:replace_right_cell)
+
+        # Now delete the Dialog
+        controller.instance_variable_set(:@_params, :id => dialog.id)
+        controller.send(:old_dialogs_button_operation, 'destroy', 'Test Dialog')
+
+        # Check for Dialog Label to be part of flash message displayed
+        flash_messages = assigns(:flash_array)
+        flash_messages.first[:message].should include("Default Dialog \"Test_Dialog\" cannot be deleted")
+
+        controller.send(:flash_errors?).should be_true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed to not allow deletion of default dialog from summary screen. Added spec tests to verify that default dialogs do not get deleted from summary screen or list view.

https://bugzilla.redhat.com/show_bug.cgi?id=1229677

@fryguy @dclarizio please review