### PR TITLE
Removed codemirror's javascript include tag from the global header

### DIFF
--- a/vmdb/app/views/layouts/_global_header.html.haml
+++ b/vmdb/app/views/layouts/_global_header.html.haml
@@ -13,7 +13,6 @@
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag 'template'
     = stylesheet_link_tag 'jquery/miq/jquery-ui-1.9.2.custom'
-    = stylesheet_link_tag 'codemirror-4.2/lib/codemirror'
     = render :partial => "stylesheets/template50"
     = javascript_include_tag 'application'
     - if Rails.env.development?


### PR DESCRIPTION
Codemirror is included through application.js, so this line generated an error.
Resolves #3110 