### PR TITLE
VmdbDatabaseConnection - wait_resource is :integer, not :string

### DIFF
--- a/vmdb/app/models/miq_report/generator/sorting.rb
+++ b/vmdb/app/models/miq_report/generator/sorting.rb
@@ -18,7 +18,7 @@ module MiqReport::Generator::Sorting
       base_col_name = sb.split(SORT_COL_SUFFIX).first
       ctype = self.class.get_col_type(self.col_to_expression_col(base_col_name)) || :string
       sb_nil_sub[idx] = case ctype
-      when :string, :text, :boolean             then "00ff".hex.chr
+      when :string, :text, :boolean             then "00ff".hex.chr   # "\xFF"
       when :integer, :fixnum, :decimal, :float  then @table.data.collect { |d| d.data[sb] }.compact.max.to_i + 1
       when :datetime                            then Time.at(@table.data.collect { |d| d.data[sb] }.compact.max.to_i + 1).utc
       when :date                                then max = @table.data.collect { |d| d.data[sb] }.compact.max; max.nil? ? nil : max + 1

--- a/vmdb/app/models/vmdb_database_connection.rb
+++ b/vmdb/app/models/vmdb_database_connection.rb
@@ -19,7 +19,7 @@ class VmdbDatabaseConnection < ActiveRecord::Base
   virtual_column :command,           :type => :string
   virtual_column :spid,              :type => :integer
   virtual_column :task_state,        :type => :string
-  virtual_column :wait_resource,     :type => :string
+  virtual_column :wait_resource,     :type => :integer  # oid
   virtual_column :wait_time,         :type => :integer
   virtual_column :vmdb_database_id,  :type => :integer
 


### PR DESCRIPTION
Because pg_locks.relation is of type oid, at least since 7.4 and up to
9.5 including. And oid is an integer.

This fixes an "comparison of Array with Array failed" that would happen
when trying to sort the client connections table by wait_resource, and
one client had a lock (thus, integer value), and other didn't (nil -
converted to "\xFF" in MiqReport::Generator::Sorting#build_sort_table,
because of the false type).

https://bugzilla.redhat.com/show_bug.cgi?id=1229308