### PR TITLE
Server Settings - SMTP disable password field if Authentication is none

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -61,8 +61,10 @@ module OpsController::Settings::Common
 
         if @smtp_auth_none
           page << javascript_disable_field('smtp_user_name')
+          page << javascript_disable_field('smtp_password')
         else
           page << javascript_enable_field('smtp_user_name')
+          page << javascript_enable_field('smtp_password')
         end
 
         if @changed || @login_text_changed


### PR DESCRIPTION
Previously, only the username field got disabled, this disables the
password fields as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1227645