### PR TITLE
Fix MiqWidget#grouped_subscribers

### DIFF
--- a/vmdb/app/models/miq_widget.rb
+++ b/vmdb/app/models/miq_widget.rb
@@ -315,12 +315,10 @@ class MiqWidget < ActiveRecord::Base
     $log.info("#{log_prefix} for group: [#{group.name}] users: [#{userid}]...")
 
     user = userid
-    if userid.kind_of?(String)
-      user = User.in_my_region.where(:userid => userid).first
-      if user.nil?
-        $log.error("#{log_prefix} User #{userid} was not found")
-        return
-      end
+    user = User.in_my_region.where(:userid => userid).first if userid.kind_of?(String)
+    if user.nil?
+      $log.error("#{log_prefix} User #{userid} was not found")
+      return
     end
 
     timezone = user.get_timezone
@@ -443,7 +441,8 @@ class MiqWidget < ActiveRecord::Base
     groups_by_id    = MiqGroup.where(:id => grouped_users.keys).index_by(&:id)
     users_by_userid = User.in_my_region.where(:userid => grouped_users.values.flatten.uniq).index_by(&:userid)
     grouped_users.each_with_object({}) do |(k, v), h|
-      h[groups_by_id[k]] = users_by_userid.values_at(*v)
+      user_objs = users_by_userid.values_at(*v).reject(&:blank?)
+      h[groups_by_id[k]] = user_objs unless user_objs.blank?
     end
   end
 


### PR DESCRIPTION
to skip the user that does not exist any more.

Normally when a user is removed, say from UI, the associated dashboards are cleared as well.
But during this customer's migration from 3.0 to 3.1, looks like some users got deleted and left behind the dashboards in DB.

https://bugzilla.redhat.com/show_bug.cgi?id=1227426