### PR TITLE
Add vm_infra post route for sort_template_grid

### DIFF
--- a/vmdb/config/routes.rb
+++ b/vmdb/config/routes.rb
@@ -1808,6 +1808,7 @@ Vmdb::Application.routes.draw do
         sort_host_grid
         sort_iso_img_grid
         sort_vc_grid
+        sort_template_grid
         sort_vm_grid
         squash_toggle
         tagging_edit


### PR DESCRIPTION
Pretty much the same thing that sort_vc_grid does, sort_template_grid is
called from _prov_template_grid but the link_to call failed because the
controller is vm_infra, not miq_request there.

https://bugzilla.redhat.com/show_bug.cgi?id=1223348