### PR TITLE
Report editor - handle tags on entitites

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1652,29 +1652,32 @@ module ReportController::Reports::Editor
     pivot_cols = {}
     rpt.col_formats ||= Array.new(rpt.col_order.length)   # Create array of nils if col_formats not present (backward compat)
     rpt.col_order.each_with_index do |col, idx|
-      unless col.include?(".")  # Main table field
+      if !col.include?(".")  # Main table field
         field_key = rpt.db + "-" + col
         field_value = friendly_model_name(rpt.db) +
                       Dictionary.gettext(rpt.db + "." + col.split("__").first, :type => :column, :notfound => :titleize)
       else                      # Included table field
         inc_string = find_includes(col.split("__").first, rpt.include)  # Get the full include string
-        field_key = rpt.db + "." + inc_string.to_s + "-" + col.split(".")[1]
-        if inc_string.to_s == "managed" # don't titleize tag name, need it to lookup later to get description by tag name
-          field_value = friendly_model_name(rpt.db + "." + inc_string.to_s) + col.split(".")[1]
+        field_key = rpt.db + "." + inc_string.to_s + "-" + col.split(".").last
+        if inc_string.to_s.ends_with?(".managed") || inc_string.to_s == "managed"
+          # don't titleize tag name, need it to lookup later to get description by tag name
+          field_value = friendly_model_name(rpt.db + "." + inc_string.to_s) + col.split(".").last
         else
           field_value = friendly_model_name(rpt.db + "." + inc_string.to_s) +
-                        Dictionary.gettext(col.split(".")[1].split("__").first, :type => :column, :notfound => :titleize)
+                        Dictionary.gettext(col.split(".").last.split("__").first, :type => :column, :notfound => :titleize)
         end
       end
+
       if field_key.include?("__")                           # Check for calculated pivot column
         field_key1, calc_typ = field_key.split("__")
         pivot_cols[field_key1] ||= []
         pivot_cols[field_key1] << calc_typ.to_sym
         pivot_cols[field_key1].sort!                          # Sort the array
-        fields.push([field_value, field_key1])  unless fields.include?([field_value, field_key1]) # Add original col to fields array
+        fields.push([field_value, field_key1]) unless fields.include?([field_value, field_key1]) # Add original col to fields array
       else
         fields.push([field_value, field_key])               # Add to fields array
       end
+
       # Create the groupby keys if groupby array is present
       if rpt.rpt_options &&
          rpt.rpt_options[:pivot] &&
@@ -1690,6 +1693,7 @@ module ReportController::Reports::Editor
           @edit[:new][:pivotby3] = field_key if col == rpt.rpt_options[:pivot][:group_cols][2]
         end
       end
+
       # Create the sortby keys if sortby array is present
       if rpt.sortby.kind_of?(Array)
         if rpt.sortby.length > 0
@@ -1754,24 +1758,34 @@ module ReportController::Reports::Editor
 
   # Build the full includes string by finding the column in the includes hash
   def find_includes(col, includes)
-    table = col.split(".")[0]
-    field = col.split(".")[1]
-    if includes[table]                              # Does this level include have the table name?
-      if includes[table]["columns"].include?(field) # If so, does the columns have the field name?
-        return table                                # Yes, return the table name
-      end
-    else                                            # Need to go to the next level
-      includes.each_pair do |key, inc|              # Check each included table
-        if inc["include"]                           # Does the included table have an include?
-          inc_table = find_includes(col, inc["include"])  # Yes, recursively search it for the table.col
-          if inc_table.nil?                         # If it comes back nil, we never found it
-            return nil
-          else
-            return key + "." + inc_table          # Otherwise, return the table name + the included string
-          end
-        end
+    tables = col.split(".")[0..-2]
+    field = col.split(".").last
+
+    table = tables.first
+
+    # Does this level include have the table name and does columns have the field name?
+    if includes[table] && includes[table]["columns"] && includes[table]["columns"].include?(field)
+      return table                                # Yes, return the table name
+    end
+
+    if includes[table] && includes[table]["include"]
+      new_col = [ tables[1..-1], field ].flatten.join('.')
+      # recursively search it for the table.col
+      inc_table = find_includes(new_col, includes[table]["include"])
+      return table + '.' + inc_table if inc_table
+    end
+
+    # Need to go to the next level
+    includes.each_pair do |key, inc|              # Check each included table
+      if inc["include"]                           # Does the included table have an include?
+        inc_table = find_includes(col, inc["include"])  # Yes, recursively search it for the table.col
+        return nil if inc_table.nil?                         # If it comes back nil, we never found it
+
+        # Otherwise, return the table name + the included string
+        return key + "." + inc_table
       end
     end
+
     nil
   end
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1769,7 +1769,7 @@ module ReportController::Reports::Editor
     end
 
     if includes[table] && includes[table]["include"]
-      new_col = [ tables[1..-1], field ].flatten.join('.')
+      new_col = [tables[1..-1], field].flatten.join('.')
       # recursively search it for the table.col
       inc_table = find_includes(new_col, includes[table]["include"])
       return table + '.' + inc_table if inc_table
@@ -1777,13 +1777,13 @@ module ReportController::Reports::Editor
 
     # Need to go to the next level
     includes.each_pair do |key, inc|              # Check each included table
-      if inc["include"]                           # Does the included table have an include?
-        inc_table = find_includes(col, inc["include"])  # Yes, recursively search it for the table.col
-        return nil if inc_table.nil?                         # If it comes back nil, we never found it
+      next unless inc["include"]                           # Does the included table have an include?
 
-        # Otherwise, return the table name + the included string
-        return key + "." + inc_table
-      end
+      inc_table = find_includes(col, inc["include"])  # Yes, recursively search it for the table.col
+      return nil if inc_table.nil?                         # If it comes back nil, we never found it
+
+      # Otherwise, return the table name + the included string
+      return key + "." + inc_table
     end
 
     nil

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1336,18 +1336,22 @@ module ReportController::Reports::Editor
           inc_hash[table]["columns"] ||= []    # Create the columns array for this table
           f = field.split("-")[1].split("__").first   # Grab the field name after the hyphen, before the "__"
           inc_hash[table]["columns"].push(f) unless inc_hash[table]["columns"].include?(f) # Add the field to the columns, if not there
-          rpt.col_order.push(table + "." + field.split("-")[1]) # Add the table.field to the col_order array
+
+          table_field = tables.join('.') + "." + field.split("-")[1]
+          rpt.col_order.push(table_field)             # Add the table.field to the col_order array
+
           if field == sortby1                         # Is this the first sort field?
-            rpt.sortby = [table + "." + field.split("-")[1]] + rpt.sortby # Put the field first in the sortby array
+            rpt.sortby = [table_field] + rpt.sortby   # Put the field first in the sortby array
           elsif field == @edit[:new][:sortby2]        # Is this the second sort field?
-            rpt.sortby.push(table + "." + field.split("-")[1])  # Add the field to the sortby array
+            rpt.sortby.push(table_field)              # Add the field to the sortby array
           end
+
           if field == @edit[:new][:pivotby1]          # Save the group fields
-            @pg1 = table + "." + field.split("-")[1]
+            @pg1 = table_field
           elsif field == @edit[:new][:pivotby2]
-            @pg2 = table + "." + field.split("-")[1]
+            @pg2 = table_field
           elsif field == @edit[:new][:pivotby3]
-            @pg3 = table + "." + field.split("-")[1]
+            @pg3 = table_field
           end
         else                                          # Set up for the next embedded include hash
           inc_hash[table]["include"] ||= {}     # Create include hash for next level


### PR DESCRIPTION
Right now, creating a new report (based on EVM Groups, among others), each tag is available in multiple variants .. say "My Company Tags : Demo" (`managed-demo`), "VMs.My Company Tags : Demo" (`vms.managed-demo`) and "Miq Templates.My Company Tags : Demo" (`miq_templates.managed-demo`). But upon saving, all these variants are changed to the basic variety (`managed-demo`), losing the entity info.

This PR aims to fix that.

https://bugzilla.redhat.com/show_bug.cgi?id=1193652