### PR TITLE
Let MiqWidget.get_group check for nil group.

### DIFF
--- a/vmdb/app/models/miq_widget.rb
+++ b/vmdb/app/models/miq_widget.rb
@@ -494,6 +494,8 @@ class MiqWidget < ActiveRecord::Base
   end
 
   def self.get_group(group)
+    return nil if group.nil?
+
     original = group
 
     case group


### PR DESCRIPTION
When a user's dashboard got created the first time, method create_initial_content_for_user is called without a group specified. So when it calls MiqWidget.get_group, the default value for group 'nil' is passed to the method.
https://bugzilla.redhat.com/show_bug.cgi?id=1226366