### PR TITLE
fix appliance console cli messaging around adding tmp disk

### DIFF
--- a/lib/appliance_console/cli.rb
+++ b/lib/appliance_console/cli.rb
@@ -227,13 +227,18 @@ module ApplianceConsole
     end
 
     def config_tmp_disk
-      say "creating temp disk"
       if (tmp_disk = disk_from_string(options[:tmpdisk]))
+        say "creating temp disk"
         config = ApplianceConsole::TempStorageConfiguration.new(:disk => tmp_disk)
         config.activate
       else
-        say "could not find disk #{options[:tmpdisk]}"
-        say "if you pass auto, it will choose: #{disk.try(:path) || "no disks with a free partition"}"
+        choose_disk = disk.try(:path)
+        if choose_disk
+          say "could not find disk #{options[:tmpdisk]}"
+          say "if you pass auto, it will choose: #{choose_disk}"
+        else
+          say "no disks with a free partition"
+        end
       end
     end
 

--- a/lib/spec/appliance_console/cli_spec.rb
+++ b/lib/spec/appliance_console/cli_spec.rb
@@ -181,6 +181,35 @@ describe ApplianceConsole::Cli do
 
       subject.parse(%w(--tmpdisk x)).run
     end
+
+    it "configures disk with auto" do
+      subject.should_receive(:disk_from_string).with('auto').and_return('/dev/x')
+      subject.should_receive(:say)
+      ApplianceConsole::TempStorageConfiguration.should_receive(:new)
+        .with(:disk      => '/dev/x')
+      .and_return(double(:activate => true))
+
+      subject.parse(%w(--tmpdisk auto)).run
+    end
+
+    it "suggests disk with unknown disk" do
+      subject.should_receive(:disk_from_string).with('abc').and_return(nil)
+      subject.should_receive(:disk).and_return(double(:path => 'dev-good'))
+      subject.should_receive(:say).with(/abc/)
+      subject.should_receive(:say).with(/dev-good/)
+      expect(ApplianceConsole::TempStorageConfiguration).not_to receive(:new)
+
+      subject.parse(%w(--tmpdisk abc)).run
+    end
+
+    it "complains when no disks available" do
+      subject.should_receive(:disk_from_string).with('abc').and_return(nil)
+      subject.should_receive(:disk).and_return(nil)
+      subject.should_receive(:say).with(/no disk/)
+      expect(ApplianceConsole::TempStorageConfiguration).not_to receive(:new)
+
+      subject.parse(%w(--tmpdisk abc)).run
+    end
   end
 
   # private methods


### PR DESCRIPTION
Had a question from customer service around adding a partition to a VM when there is no partition available.

The messaging for choosing a disk, and the default for auto are the same. It is only the case when there is no hard disk partition available that the text changes. I had 2 hard drives to try more use cases.

TL;DR: look at the last line of the output.

/cc @roliveri @abellotti 

before:
```bash
[root@localhost ~]# appliance_console_cli --tmpdisk auto
creating temp disk
Configuring /dev/sdc as temp storage...
Add temp disk starting
Add temp disk complete
[root@localhost ~]# appliance_console_cli --tmpdisk xxx
creating temp disk
could not find disk xxx
if you pass auto, it will choose: /dev/sdb
[root@localhost ~]# appliance_console_cli --tmpdisk auto
creating temp disk
Configuring /dev/sdb as temp storage...
Add temp disk starting
Add temp disk complete
[root@localhost ~]# appliance_console_cli --tmpdisk auto
creating temp disk
could not find disk auto
if you pass auto, it will choose: no disks with a free partition
```
after:
```bash
[root@cfme-client ~]# appliance_console_cli --tmpdisk auto
creating temp disk
Configuring /dev/sdc as temp storage...
Add temp disk starting
Add temp disk complete
[root@cfme-client ~]# appliance_console_cli --tmpdisk xxx
could not find disk xxx
if you pass auto, it will choose: /dev/sdb
[root@cfme-client ~]# appliance_console_cli --tmpdisk /dev/sdb
creating temp disk
Configuring /dev/sdb as temp storage...
Add temp disk starting
Add temp disk complete
[root@cfme-client ~]# appliance_console_cli --tmpdisk auto
no disks with a free partition
```