### PR TITLE
Fix lib tests from minitest 4 -> 5 upgrade

### DIFF
--- a/lib/test/DiskTestCommon/ext3/tc_ext3_directory.rb
+++ b/lib/test/DiskTestCommon/ext3/tc_ext3_directory.rb
@@ -10,7 +10,7 @@ $:.push("#{File.dirname(__FILE__)}//../../../fs/ext3")
 require 'Ext3Superblock'
 require 'Ext3Directory'
 
-class Ext3TestDirectory < MiniTest::Unit::TestCase
+class Ext3TestDirectory < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ext3']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ext3/tc_ext3_file.rb
+++ b/lib/test/DiskTestCommon/ext3/tc_ext3_file.rb
@@ -9,7 +9,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../../fs/MiqFS")
 require 'MiqFS'
 
-class Ext3TestFile < MiniTest::Unit::TestCase
+class Ext3TestFile < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ext3']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ext3/tc_ext3_superblock.rb
+++ b/lib/test/DiskTestCommon/ext3/tc_ext3_superblock.rb
@@ -9,7 +9,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}//../../../fs/ext3")
 require 'Ext3Superblock'
 
-class Ext3TestSuperblock < MiniTest::Unit::TestCase
+class Ext3TestSuperblock < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ext3']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_boot.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_boot.rb
@@ -10,7 +10,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../../fs/fat32")
 require 'Fat32BootSect'
 
-class Fat32TestBoot < MiniTest::Unit::TestCase
+class Fat32TestBoot < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'fat32']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_boot.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_boot.rb
@@ -55,7 +55,7 @@ class Fat32TestBoot < MiniTest::Unit::TestCase
 	
 	def test_fat32_boot_sect_empty
 		@num_tests += 1
-		assert_raise(RuntimeError) {Fat32::BootSect.new(nil)}
+		assert_raises(RuntimeError) {Fat32::BootSect.new(nil)}
 	end
 	
 	def test_fat32_boot_sect

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_file.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_file.rb
@@ -13,7 +13,7 @@ require 'MiqFS'
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'FSTestUtil'
 
-class Fat32TestFile < MiniTest::Unit::TestCase
+class Fat32TestFile < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'fat32']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_rootdir.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_rootdir.rb
@@ -13,7 +13,7 @@ require 'Fat32DirectoryEntry'
 $:.push("#{File.dirname(__FILE__)}/../../../disk")
 require 'MiqDisk'
 
-class Fat32TestRoot < MiniTest::Unit::TestCase
+class Fat32TestRoot < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'fat32']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_write.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_write.rb
@@ -16,7 +16,7 @@ require 'Fat32BootSect'
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'FSTestUtil'
 
-class Fat32TestWrite < MiniTest::Unit::TestCase
+class Fat32TestWrite < Minitest::Test
 	
 	TEST_SHORT_DIR = "/test"
 	TEST_LONG_DIR  = "/Test Directory"

--- a/lib/test/DiskTestCommon/fat32/tc_fat32_write.rb
+++ b/lib/test/DiskTestCommon/fat32/tc_fat32_write.rb
@@ -77,30 +77,30 @@ class Fat32TestWrite < MiniTest::Unit::TestCase
 				if disk.fs
 					#puts "\nFat32: Testing write directory on #{disk.info.fileName}"
 					# Test short name.
-					assert_raise(RuntimeError) {disk.fs.dirRmdir(TEST_SHORT_DIR)}
+					assert_raises(RuntimeError) {disk.fs.dirRmdir(TEST_SHORT_DIR)}
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirMkdir(TEST_SHORT_DIR)}
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileCtime(TEST_SHORT_DIR)}
 					disk.fs.chdir(TEST_SHORT_DIR)
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirRmdir(TEST_SHORT_DIR)}
-					assert_raise(RuntimeError) {disk.fs.dirEntries("*.*")}
+					assert_raises(RuntimeError) {disk.fs.dirEntries("*.*")}
 					disk.fs.chdir("/")
 					
 					# Test long name.
-					assert_raise(RuntimeError) {disk.fs.dirRmdir(TEST_LONG_DIR)}
+					assert_raises(RuntimeError) {disk.fs.dirRmdir(TEST_LONG_DIR)}
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirMkdir(TEST_LONG_DIR)}
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileCtime(TEST_LONG_DIR)}
 					disk.fs.chdir(TEST_LONG_DIR)
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirRmdir(TEST_LONG_DIR)}
-					assert_raise(RuntimeError) {disk.fs.dirEntries("*.*")}
+					assert_raises(RuntimeError) {disk.fs.dirEntries("*.*")}
 					disk.fs.chdir("/")
 					
 					# Test gray name.
-					assert_raise(RuntimeError) {disk.fs.dirRmdir(TEST_GRAY_DIR)}
+					assert_raises(RuntimeError) {disk.fs.dirRmdir(TEST_GRAY_DIR)}
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirMkdir(TEST_GRAY_DIR)}
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileCtime(TEST_GRAY_DIR)}
 					disk.fs.chdir(TEST_GRAY_DIR)
 					assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirRmdir(TEST_GRAY_DIR)}
-					assert_raise(RuntimeError) {disk.fs.dirEntries("*.*")}
+					assert_raises(RuntimeError) {disk.fs.dirEntries("*.*")}
 					disk.fs.chdir("/")
 				else
 					puts "\ntc_fat32_write: FS is nil at line #{__LINE__} on #{disk.info.fileName}"
@@ -122,7 +122,7 @@ class Fat32TestWrite < MiniTest::Unit::TestCase
 				assert_nothing_raised(id(__LINE__, disk)) {f.close}
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileCtime(TEST_SHORT_FILE)}
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileDelete(TEST_SHORT_FILE)}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_FILE, "r")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_FILE, "r")}
 				
 				# Test long name.
 				f = nil
@@ -130,7 +130,7 @@ class Fat32TestWrite < MiniTest::Unit::TestCase
 				assert_nothing_raised(id(__LINE__, disk)) {f.close}
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileCtime(TEST_LONG_FILE)}
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileDelete(TEST_LONG_FILE)}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_LONG_FILE, "r")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_LONG_FILE, "r")}
 				
 				# Test gray name.
 				f = nil
@@ -138,7 +138,7 @@ class Fat32TestWrite < MiniTest::Unit::TestCase
 				assert_nothing_raised(id(__LINE__, disk)) {f.close}
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileCtime(TEST_GRAY_FILE)}
 				assert_nothing_raised {disk.fs.fileDelete(TEST_GRAY_FILE)}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_GRAY_FILE, "r")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_GRAY_FILE, "r")}
 			else
 				puts "\ntc_fat32_write: FS is nil at line #{__LINE__} on #{disk.info.fileName}"
 			end
@@ -153,14 +153,14 @@ class Fat32TestWrite < MiniTest::Unit::TestCase
 				#puts "\nFat32: Testing write file modes on #{disk.info.fileName}"
 				# Open directory should always raise error.
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirMkdir(TEST_SHORT_DIR)}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_DIR, "r")}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_DIR, "w")}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_DIR, "a")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_DIR, "r")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_DIR, "w")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_DIR, "a")}
 
 				disk.fs.chdir(TEST_SHORT_DIR)
 				f = nil; buf = nil
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileDelete(TEST_SHORT_FILE)}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_FILE, "r")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_SHORT_FILE, "r")}
 				assert_nothing_raised(id(__LINE__, disk)) {f = disk.fs.fileOpen(TEST_SHORT_FILE, "w")}
 				assert_nothing_raised(id(__LINE__, disk)) {f.write(TEST_FIRST)}
 				assert_nothing_raised(id(__LINE__, disk)) {f.close}
@@ -191,7 +191,7 @@ class Fat32TestWrite < MiniTest::Unit::TestCase
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.dirRmdir(TEST_SHORT_DIR)}
 				
 				assert_nothing_raised(id(__LINE__, disk)) {disk.fs.fileDelete(TEST_LONG_FILE)}
-				assert_raise(RuntimeError) {f = disk.fs.fileOpen(TEST_LONG_FILE, "r")}
+				assert_raises(RuntimeError) {f = disk.fs.fileOpen(TEST_LONG_FILE, "r")}
 				assert_nothing_raised(id(__LINE__, disk)) {f = disk.fs.fileOpen(TEST_LONG_FILE, "w")}
 				assert_nothing_raised(id(__LINE__, disk)) {f.write(TEST_FIRST)}
 				assert_nothing_raised(id(__LINE__, disk)) {f.close}

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
@@ -10,7 +10,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../../fs/ntfs")
 require 'NtfsBootSect'
 
-class NtfsTestDisk < MiniTest::Unit::TestCase
+class NtfsTestDisk < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
@@ -70,7 +70,7 @@ class NtfsTestDisk < MiniTest::Unit::TestCase
 	
 	def test_ntfs_boot_sect_empty
 		@num_tests += 1
-		assert_raise(RuntimeError) {NTFS::BootSect.new(nil)}
+		assert_raises(RuntimeError) {NTFS::BootSect.new(nil)}
 	end
 	
 	def id(line, disk)

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_file.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_file.rb
@@ -13,7 +13,7 @@ require 'MiqFS'
 $:.push("#{File.dirname(__FILE__)}/..")
 require 'FSTestUtil'
 
-class NtfsTestFile < MiniTest::Unit::TestCase
+class NtfsTestFile < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
@@ -11,7 +11,7 @@ $:.push("#{File.dirname(__FILE__)}/../../../fs/ntfs")
 require 'NtfsBootSect'
 require 'NtfsMftEntry'
 
-class NtfsTestIndex < MiniTest::Unit::TestCase
+class NtfsTestIndex < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
@@ -75,9 +75,9 @@ class NtfsTestIndex < MiniTest::Unit::TestCase
 	
 	def test_ntfs_index_empty_index
 		@num_tests += 1
-		assert_raise(RuntimeError) {NTFS::IndexRoot.new(nil, nil)}
-		assert_raise(RuntimeError) {NTFS::IndexRoot.new(1, nil)}
-		assert_raise(RuntimeError) {NTFS::IndexRoot.new(nil, 1)}
+		assert_raises(RuntimeError) {NTFS::IndexRoot.new(nil, nil)}
+		assert_raises(RuntimeError) {NTFS::IndexRoot.new(1, nil)}
+		assert_raises(RuntimeError) {NTFS::IndexRoot.new(nil, 1)}
 	end
 	
 	def id(line, disk)

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
@@ -61,7 +61,7 @@ class MftEntry
 	end
 end
 
-class NtfsTestMft < MiniTest::Unit::TestCase
+class NtfsTestMft < Minitest::Test
 	
 	CONDITIONS = ['fs_type', 'ntfs']
 	TEST_DB = "#{File.dirname(__FILE__)}/../../vms.yml"

--- a/lib/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
+++ b/lib/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
@@ -132,7 +132,7 @@ class NtfsTestMft < MiniTest::Unit::TestCase
 	
 	def test_emtpy
 		@num_tests += 1
-		assert_raise(RuntimeError) {NTFS::MftEntry.new(nil, nil)}
+		assert_raises(RuntimeError) {NTFS::MftEntry.new(nil, nil)}
 	end
 	
 	def id(line, disk)

--- a/lib/test/DiskTestCommon/tc_MiqDisk.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk.rb
@@ -5,7 +5,7 @@ require 'enumerator'
 require 'minitest/unit'
 
 module DiskTestCommon
-  class TestMiqDisk < MiniTest::Unit::TestCase
+  class TestMiqDisk < Minitest::Test
     FILE_PATH = (Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
 
     FILE_DESC_4GB    = FILE_PATH + "disks/DiskTestCommon_MiqDisk_Flat4GB.vmdk"

--- a/lib/test/DiskTestCommon/tc_MiqDisk.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk.rb
@@ -57,7 +57,7 @@ module DiskTestCommon
         diskInfo.fileName = filename
 
         d = MiqDisk.getDisk(diskInfo)
-        assert_not_nil(MiqDisk, d)
+        refute_nil(MiqDisk, d)
         d.close
       end
     end

--- a/lib/test/DiskTestCommon/tc_MiqDisk_read_length.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk_read_length.rb
@@ -6,7 +6,7 @@ require 'VmsFromYaml'
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
 
-class TestMiqDiskReadLen < MiniTest::Unit::TestCase
+class TestMiqDiskReadLen < Minitest::Test
 	
 	TEST_DB = "#{File.dirname(__FILE__)}/../vms.yml"	
 	

--- a/lib/test/DiskTestCommon/tc_MiqDisk_read_length.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk_read_length.rb
@@ -42,7 +42,7 @@ class TestMiqDiskReadLen < MiniTest::Unit::TestCase
 					end
 				end
 				res, h = dk.close
-				assert_not_equal(h, -1) if h
+				refute_equal(h, -1) if h
 			else
 				puts "\ntc_MiqDisk_read_length: no disk for #{di.fileName}"
 				puts "Spec is:\n#{spec.inspect}"

--- a/lib/test/DiskTestCommon/tc_MiqDisk_write.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk_write.rb
@@ -6,7 +6,7 @@ require 'VmsFromYaml'
 $:.push("#{File.dirname(__FILE__)}/../../disk")
 require 'MiqDisk'
 
-class TestMiqDiskWrite < MiniTest::Unit::TestCase
+class TestMiqDiskWrite < Minitest::Test
 	
 	TEST_DB = "#{File.dirname(__FILE__)}/../vms.yml"
 	

--- a/lib/test/DiskTestCommon/tc_MiqDisk_write.rb
+++ b/lib/test/DiskTestCommon/tc_MiqDisk_write.rb
@@ -51,7 +51,7 @@ class TestMiqDiskWrite < MiniTest::Unit::TestCase
 						end
 					end
 					res, h = dk.close
-					assert_not_equal(h, -1) if h
+					refute_equal(h, -1) if h
 				else
 					puts "\ntc_MiqDisk_write: no disk for #{di.fileName}"
 					puts "Spec is:\n#{spec.inspect}"

--- a/lib/test/DiskTestCommon/tc_MiqLargeFile.rb
+++ b/lib/test/DiskTestCommon/tc_MiqLargeFile.rb
@@ -40,7 +40,7 @@ module DiskTestCommon
         next unless File.exist?(filename)
 
         f = MiqLargeFile.open(filename, "r")
-        assert_not_nil(MiqLargeFile, f)
+        refute_nil(MiqLargeFile, f)
         f.close
       end
     end

--- a/lib/test/DiskTestCommon/tc_MiqLargeFile.rb
+++ b/lib/test/DiskTestCommon/tc_MiqLargeFile.rb
@@ -7,7 +7,7 @@ require 'minitest/unit'
 require 'tmpdir'
 
 module DiskTestCommon
-  class TestMiqLargeFile < MiniTest::Unit::TestCase
+  class TestMiqLargeFile < Minitest::Test
     FILE_PATH = (Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
 
     FILE_1MB = FILE_PATH + "containers/raw/DiskTestCommon_MiqLargeFile_1MB"

--- a/lib/test/DiskTestCommon/tc_seek.rb
+++ b/lib/test/DiskTestCommon/tc_seek.rb
@@ -10,7 +10,7 @@ require 'MiqDisk'
 $:.push("#{File.dirname(__FILE__)}/../../fs/MiqFS")
 require 'MiqFS'
 
-class TestSeek < MiniTest::Unit::TestCase
+class TestSeek < Minitest::Test
 	
 	TEST_DB = "#{File.dirname(__FILE__)}/../vms.yml"
 	TEST_FILE = '/SeekTest.dat'

--- a/lib/test/DiskTestCommon/tc_seek.rb
+++ b/lib/test/DiskTestCommon/tc_seek.rb
@@ -49,7 +49,7 @@ class TestSeek < MiniTest::Unit::TestCase
 		@disks.each do |disk|
 			next if disk.nil?
 			res, h = disk.dk.close if disk.dk
-			assert_not_equal(h, -1) if h
+			refute_equal(h, -1) if h
 		end
 	end
 	

--- a/lib/test/DiskTestCommon/tc_vfyreg.rb
+++ b/lib/test/DiskTestCommon/tc_vfyreg.rb
@@ -82,7 +82,7 @@ class TestReg < MiniTest::Unit::TestCase
 		@disks.each do |disk|
 			next if disk.nil?
 			res, h = disk.dk.close if disk.dk
-			assert_not_equal(h, -1) if h
+			refute_equal(h, -1) if h
 		end
 	end
 	

--- a/lib/test/DiskTestCommon/tc_vfyreg.rb
+++ b/lib/test/DiskTestCommon/tc_vfyreg.rb
@@ -13,7 +13,7 @@ $:.push("#{File.dirname(__FILE__)}/../../fs/MiqFS")
 require 'MiqFS'
 
 # WINDOWS SPECIFIC.
-class TestReg < MiniTest::Unit::TestCase
+class TestReg < Minitest::Test
 	
 	#define registry structures
 	REGISTRY_HEADER_REGF = BinaryStruct.new([

--- a/lib/test/Iso9660/tc_iso9660BootSector.rb
+++ b/lib/test/Iso9660/tc_iso9660BootSector.rb
@@ -8,7 +8,7 @@ $:.push("#{File.dirname(__FILE__)}/../../fs/iso9660")
 require 'Iso9660BootSector'
 include Iso9660
 
-class TestIso9660BootSector < MiniTest::Unit::TestCase
+class TestIso9660BootSector < Minitest::Test
 	
 	def test_boot_sector
 		puts "Testing boot sector"

--- a/lib/test/Iso9660/tc_iso9660Directory.rb
+++ b/lib/test/Iso9660/tc_iso9660Directory.rb
@@ -10,7 +10,7 @@ require 'Iso9660DirectoryEntry'
 require 'Iso9660Directory'
 include Iso9660
 
-class TestIso9660Directory < MiniTest::Unit::TestCase
+class TestIso9660Directory < Minitest::Test
 	
 	def test_root_dir
 		puts "Testing root dir."

--- a/lib/test/Iso9660/tc_iso9660FileSystem.rb
+++ b/lib/test/Iso9660/tc_iso9660FileSystem.rb
@@ -49,7 +49,7 @@ def Dir(fs)
 	end
 end
 
-class TestIso9660FileSystem < MiniTest::Unit::TestCase
+class TestIso9660FileSystem < Minitest::Test
 	
 	def test_miq_fs
 		puts "Testing file system"

--- a/lib/test/discovery/tc_DiscoveryModules.rb
+++ b/lib/test/discovery/tc_DiscoveryModules.rb
@@ -13,7 +13,7 @@ require 'minitest/unit'
 
 module MiqDiscovery
 	
-	class TestDiscoveryModules < MiniTest::Unit::TestCase
+	class TestDiscoveryModules < Minitest::Test
 		def setup
 #			unless $log
 #				$:.push("#{File.dirname(__FILE__)}/../../util")

--- a/lib/test/extract/tc_md5deep.rb
+++ b/lib/test/extract/tc_md5deep.rb
@@ -4,7 +4,7 @@ require 'minitest/unit'
 
 module Extract
 	
-class TestVersionInfo < MiniTest::Unit::TestCase
+class TestVersionInfo < Minitest::Test
 
   def test_md5deep
     md5 = MD5deep.new

--- a/lib/test/extract/tc_md5deep.rb
+++ b/lib/test/extract/tc_md5deep.rb
@@ -20,7 +20,7 @@ class TestVersionInfo < MiniTest::Unit::TestCase
     assert_equal(:dir, xml.root.elements[1].name)
     
     # Base element should have a valid MD5 sig.
-    assert_not_nil(xml.root.elements[1].attributes['md5'])
+    refute_nil(xml.root.elements[1].attributes['md5'])
 
     # MD5 sig should be 32 bits in length
     assert_in_delta(32, xml.root.elements[1].attributes['md5'].strip.length, 0)

--- a/lib/test/extract/tc_registry.rb
+++ b/lib/test/extract/tc_registry.rb
@@ -75,7 +75,7 @@ module Extract
       # "ntevents"
       %w{vmconfig accounts software services system}.each do |c|
         xml = vm.extract(c)
-        assert_not_nil(xml, "Category [#{c}] returned a nil instead of XML data.")
+        refute_nil(xml, "Category [#{c}] returned a nil instead of XML data.")
 
         xml = xml.to_xml
         validateVmXml(xml, c)
@@ -83,9 +83,9 @@ module Extract
     end
 
     def validateVmXml(xml, category)
-      assert_not_nil(xml.root.attributes['version'])
-      assert_not_nil(xml.root.attributes['created_on'])
-      assert_not_nil(xml.root.attributes['display_time'])
+      refute_nil(xml.root.attributes['version'])
+      refute_nil(xml.root.attributes['created_on'])
+      refute_nil(xml.root.attributes['display_time'])
       assert_instance_of(String, xml.root.attributes['display_time'])
       assert_instance_of(Fixnum, eval(xml.root.attributes['created_on']))
 
@@ -172,7 +172,7 @@ module Extract
         assert(filesFound.include?(hive))
 
         # Check that all the registy hives are non zero byte files
-        assert_not_equal(0, fs.fileSize(File.join(currPath, hive)))
+        refute_equal(0, fs.fileSize(File.join(currPath, hive)))
       end
     end
   end

--- a/lib/test/extract/tc_registry.rb
+++ b/lib/test/extract/tc_registry.rb
@@ -11,7 +11,7 @@ require 'minitest/unit'
 $qaShare = File.join((Platform::IMPL == :macosx ? "/Volumes" : "/mnt"), "manageiq", "fleecing_test", "images", "virtual_machines")
 
 module Extract
-  class TestRegistry < MiniTest::Unit::TestCase
+  class TestRegistry < Minitest::Test
     @@vmList = [
       {:vmName => File.join($qaShare, "vmware", "Windows Server 2003 Enterprise Edition/Windows Server 2003 Enterprise Edition.vmx"), :guestOS => "Windows"},
       {:vmName => File.join($qaShare, "vmware", "Debian 40 Server/debian40server.vmx"), :guestOS => "Linux"},

--- a/lib/test/extract/tc_versioninfo.rb
+++ b/lib/test/extract/tc_versioninfo.rb
@@ -4,7 +4,7 @@ require 'minitest/unit'
 
 module Extract
 	
-class TestVersionInfo < MiniTest::Unit::TestCase
+class TestVersionInfo < Minitest::Test
   def setup
     @dataPath = File.join(File.dirname(File.expand_path(__FILE__)), "data")
     @noFile   = File.expand_path(File.join(@dataPath, "nofile.txt"))

--- a/lib/test/extract/tc_versioninfo.rb
+++ b/lib/test/extract/tc_versioninfo.rb
@@ -33,7 +33,7 @@ class TestVersionInfo < MiniTest::Unit::TestCase
   end
   
   def test_textFile
-    assert_raise(RuntimeError) {File.getVersionInfo(__FILE__)}  # Test this ruby source file, which does not have version info
+    assert_raises(RuntimeError) {File.getVersionInfo(__FILE__)}  # Test this ruby source file, which does not have version info
   end
   
   def test_no_file
@@ -41,10 +41,10 @@ class TestVersionInfo < MiniTest::Unit::TestCase
       File.delete(@noFile)
     rescue Errno::ENOENT
     end
-    assert_raise(Errno::ENOENT) {File.getVersionInfo(@noFile)}  # This file should not exist
+    assert_raises(Errno::ENOENT) {File.getVersionInfo(@noFile)}  # This file should not exist
 
     f = File.new(@noFile,"w+")
-    assert_raise(RuntimeError) {File.getVersionInfo(@noFile)}  # This file should now exist, but be zero bytes
+    assert_raises(RuntimeError) {File.getVersionInfo(@noFile)}  # This file should now exist, but be zero bytes
     f.close
     File.delete(@noFile)
   end

--- a/lib/test/test_helper.rb
+++ b/lib/test/test_helper.rb
@@ -1,5 +1,5 @@
 require_relative "../bundler_setup"
-require 'minitest/unit'
+require 'minitest/autorun'
 
 # Push the lib directory onto the load path
 $:.push(File.expand_path(File.join(File.dirname(__FILE__), '..')))

--- a/lib/test/xml/tc_encoding.rb
+++ b/lib/test/xml/tc_encoding.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'minitest/unit'
 require 'miq-xml'
 
-class XmlEncoding < MiniTest::Unit::TestCase
+class XmlEncoding < Minitest::Test
 
   def test_attribute_encoding
     xml = REXML::Document.new("<test/>")

--- a/lib/test/xml/tc_nokogiri.rb
+++ b/lib/test/xml/tc_nokogiri.rb
@@ -114,7 +114,7 @@ class NokogiriXmlMethods < MiniTest::Unit::TestCase
     xml_new = MiqXml.newDoc(@xml_klass)
     assert_nil(xml_new.root)
     xml_new.add_element('root')
-    assert_not_nil(xml_new.root)
+    refute_nil(xml_new.root)
     assert_equal("root", xml_new.root.name.to_s)
 
     new_node = xml_new.root.add_element("node1", "enabled"=>true, "disabled"=>false, "nothing"=>nil)
@@ -131,11 +131,11 @@ class NokogiriXmlMethods < MiniTest::Unit::TestCase
 
     assert_kind_of(@xml_klass::Document, xml_new.document)
     assert_kind_of(@xml_klass::Document, xml_new.doc)
-    assert_not_equal(@xml_klass::Document, xml_new.root.class)
+    refute_equal(@xml_klass::Document, xml_new.root.class)
     assert_kind_of(@xml_klass::Document, xml_new.root.doc)
     assert_equal(xml_new.document, xml_new.doc)
     assert_kind_of(@xml_klass::Document, xml_new.root.doc)
-    assert_not_equal(@xml_klass::Document, xml_new.root.root.class)
+    refute_equal(@xml_klass::Document, xml_new.root.root.class)
 
     # Create an empty document with the utf-8 encoding
     # During assert allow for single quotes and new line char.
@@ -163,14 +163,14 @@ class NokogiriXmlMethods < MiniTest::Unit::TestCase
   def test_find_first()
     xml = @xml
     x = xml.find_first("//row")
-    assert_not_nil(x)
+    refute_nil(x)
     assert_equal("8", x.attributes["id"].to_s)
   end
 
   def test_find_match()
     xml = @xml
     x = xml.find_match("//row")
-    assert_not_nil(x)
+    refute_nil(x)
     assert_equal(5, x.length)
     assert_equal("8", x[0].attributes["id"].to_s)
     assert_equal("4", x[3].attributes["id"].to_s)

--- a/lib/test/xml/tc_nokogiri.rb
+++ b/lib/test/xml/tc_nokogiri.rb
@@ -5,7 +5,7 @@ require 'minitest/unit'
 require 'miq-xml'
 require 'nokogiri'
 
-class NokogiriXmlMethods < MiniTest::Unit::TestCase
+class NokogiriXmlMethods < Minitest::Test
 #  require 'xml_base_parser_tests'
 #  include XmlBaseParserTests
 

--- a/lib/test/xml/tc_rexml.rb
+++ b/lib/test/xml/tc_rexml.rb
@@ -5,7 +5,7 @@ require 'minitest/unit'
 require 'miq-xml'
 
 
-class TestBaseXmlMethods < MiniTest::Unit::TestCase
+class TestBaseXmlMethods < Minitest::Test
   require 'xml_base_parser_tests'
   include XmlBaseParserTests
 

--- a/lib/test/xml/tc_xml.rb
+++ b/lib/test/xml/tc_xml.rb
@@ -2,7 +2,7 @@ $:.push("#{File.dirname(__FILE__)}/../../util/")
 require 'miq-xml'
 require 'minitest/unit'
 
-class TestBaseXmlMethods < MiniTest::Unit::TestCase
+class TestBaseXmlMethods < Minitest::Test
 	def setup
 	end
 	

--- a/lib/test/xml/tc_xmlhash_methods.rb
+++ b/lib/test/xml/tc_xmlhash_methods.rb
@@ -5,7 +5,7 @@ require 'minitest/unit'
 require 'miq-xml'
 require 'xmlsimple'
 
-class TestXmlHashMethods < MiniTest::Unit::TestCase
+class TestXmlHashMethods < Minitest::Test
   require 'xml_base_parser_tests'
   include XmlBaseParserTests
 

--- a/lib/test/xml/tc_xmlhash_methods.rb
+++ b/lib/test/xml/tc_xmlhash_methods.rb
@@ -43,9 +43,9 @@ class TestXmlHashMethods < MiniTest::Unit::TestCase
 
     count = 0
     node.attributes.each_pair do |k,v|
-      assert_not_nil(k)
+      refute_nil(k)
       assert_instance_of(Symbol, k)
-      assert_not_nil(v)
+      refute_nil(v)
       assert_instance_of(String, v)
       count += 1
     end
@@ -53,9 +53,9 @@ class TestXmlHashMethods < MiniTest::Unit::TestCase
     
     count = 0
     node.attributes.to_h.each do|k,v|
-      assert_not_nil(k)
+      refute_nil(k)
       assert_instance_of(Symbol, k)
-      assert_not_nil(v)
+      refute_nil(v)
       count += 1
     end
     assert_equal(3, count)
@@ -86,7 +86,7 @@ class TestXmlHashMethods < MiniTest::Unit::TestCase
     xml_new = MiqXml.newDoc(@xml_klass)
     assert_nil(xml_new.root)
     xml_new.add_element('root')
-    assert_not_nil(xml_new.root)
+    refute_nil(xml_new.root)
     assert_equal("root", xml_new.root.name.to_s)
 
     new_node = xml_new.root.add_element("node1", "enabled"=>true, "disabled"=>false, "nothing"=>nil)
@@ -103,11 +103,11 @@ class TestXmlHashMethods < MiniTest::Unit::TestCase
 
     assert_kind_of(@xml_klass::Document, xml_new.document)
     assert_kind_of(@xml_klass::Document, xml_new.doc)
-    assert_not_equal(@xml_klass::Document, xml_new.root.class)
+    refute_equal(@xml_klass::Document, xml_new.root.class)
     assert_kind_of(@xml_klass::Document, xml_new.root.doc)
     assert_equal(xml_new.document, xml_new.doc)
     assert_kind_of(@xml_klass::Document, xml_new.root.doc)
-    assert_not_equal(@xml_klass::Document, xml_new.root.root.class)
+    refute_equal(@xml_klass::Document, xml_new.root.root.class)
 
     # Create an empty document with the utf-8 encoding
     # During assert allow for single quotes and new line char.

--- a/lib/test/xml/xml_base_parser_tests.rb
+++ b/lib/test/xml/xml_base_parser_tests.rb
@@ -367,9 +367,9 @@ module XmlBaseParserTests
 
     count = 0
     node.attributes.each_attrib do |k,v|
-      assert_not_nil(k)
+      refute_nil(k)
       assert_instance_of(String, k)
-      assert_not_nil(v)
+      refute_nil(v)
       assert_instance_of(String, v)
       count += 1
     end
@@ -377,9 +377,9 @@ module XmlBaseParserTests
 
     count = 0
     node.attributes.to_h.each do|k,v|
-      assert_not_nil(k)
+      refute_nil(k)
       assert_instance_of(Symbol, k)
-      assert_not_nil(v)
+      refute_nil(v)
       count += 1
     end
     assert_equal(3, count)
@@ -438,7 +438,7 @@ module XmlBaseParserTests
     node = xml.root.elements[6]
     assert_equal("5", node.attributes["id"].to_s)
 
-    assert_raise(RuntimeError) {xml.root.elements[0]}
+    assert_raises(RuntimeError) {xml.root.elements[0]}
 
     assert_nil(xml.root.elements[7])
 
@@ -469,7 +469,7 @@ module XmlBaseParserTests
     xml_new = MiqXml.newDoc(@xml_klass)
     assert_nil(xml_new.root)
     xml_new.add_element('root')
-    assert_not_nil(xml_new.root)
+    refute_nil(xml_new.root)
     assert_equal("root", xml_new.root.name.to_s)
 
     new_node = xml_new.root.add_element("node1", "enabled"=>true, "disabled"=>false, "nothing"=>nil)
@@ -486,11 +486,11 @@ module XmlBaseParserTests
 
     assert_kind_of(@xml_klass::Document, xml_new.document)
     assert_kind_of(@xml_klass::Document, xml_new.doc)
-    assert_not_equal(@xml_klass::Document, xml_new.root.class)
+    refute_equal(@xml_klass::Document, xml_new.root.class)
     assert_kind_of(@xml_klass::Document, xml_new.root.doc)
     assert_equal(xml_new.document, xml_new.doc)
     assert_kind_of(@xml_klass::Document, xml_new.root.doc)
-    assert_not_equal(@xml_klass::Document, xml_new.root.root.class)
+    refute_equal(@xml_klass::Document, xml_new.root.root.class)
 
     # Create an empty document with the utf-8 encoding
     # During assert allow for single quotes and new line char.
@@ -531,24 +531,24 @@ module XmlBaseParserTests
   def test_find_first()
     xml = @xml
     x = REXML::XPath.first(xml, "//row")
-    assert_not_nil(x)
+    refute_nil(x)
     assert_equal("8", x.attributes["id"])
 
     x = xml.find_first("//row")
-    assert_not_nil(x)
+    refute_nil(x)
     assert_equal("8", x.attributes["id"])
   end
 
   def test_find_match()
     xml = @xml
     x = REXML::XPath.match(xml, "//row")
-    assert_not_nil(x)
+    refute_nil(x)
     assert_equal(5, x.length)
     assert_equal("8", x[0].attributes["id"])
     assert_equal("4", x[3].attributes["id"])
 
     x = xml.find_match("//row")
-    assert_not_nil(x)
+    refute_nil(x)
     assert_equal(5, x.length)
     assert_equal("8", x[0].attributes["id"])
     assert_equal("4", x[3].attributes["id"])
@@ -557,7 +557,7 @@ module XmlBaseParserTests
   def test_deep_clone()
     xml = @xml
     xml2 = xml.deep_clone()
-    assert_not_equal(xml.object_id, xml2.object_id)
+    refute_equal(xml.object_id, xml2.object_id)
     xml.write(xml_str1='')
     xml2.write(xml_str2='')
     assert_equal(xml_str1, xml_str2)
@@ -628,22 +628,22 @@ module XmlBaseParserTests
     assert_kind_of(@xml_klass::Document, xml)
 
     frozen_text = "A&P".freeze
-    assert_nothing_raised {xml.root.text = frozen_text}
+    xml.root.text = frozen_text
     assert_equal("A&P", xml.root.text)
   end
 
   def test_write_method()
     # Test writing from the document
     @xml.write(test_string = "")
-    assert_not_equal("", test_string)
+    refute_equal("", test_string)
     test_string = @xml.to_s
-    assert_not_equal("", test_string)
+    refute_equal("", test_string)
 
 
     # Test writing from an element
     @xml.root.write(test_string = "")
-    assert_not_equal("", test_string)
+    refute_equal("", test_string)
     test_string = @xml.root.to_s
-    assert_not_equal("", test_string)
+    refute_equal("", test_string)
   end
 end


### PR DESCRIPTION
cc @matthewd @tenderlove 

#### Fix 'Warning: you should require 'minitest/autorun' instead.' …
This caused lib test/unit / minitest tests to not run.

#### Fix some minitest 4 -> 5 removals. …
assert_raise(RuntimeError) becomes assert_raises(RuntimeError)
assert_not_nil             becomes refute_nil
assert_not_equal           becomes refute_equal

assert_nothing_raised (removed, doesn't test anything so just remove the assertion)

#### Fixed warning: MiniTest::Unit::TestCase is now Minitest::Test