### PR TITLE
Reduce meta_fu in Appliance console's ServiceGroup

### DIFF
--- a/lib/appliance_console/service_group.rb
+++ b/lib/appliance_console/service_group.rb
@@ -12,19 +12,6 @@ module ApplianceConsole
       !!@postgresql
     end
 
-    def to_enable
-      postgresql? ? SERVICES + [POSTGRESQL_SERVICE] : SERVICES.dup
-    end
-
-    def to_disable
-      postgresql? ? [] : [POSTGRESQL_SERVICE]
-    end
-    alias :to_stop :to_disable
-
-    def to_start
-      SERVICES.dup
-    end
-
     def restart_services
       enablement
       restart
@@ -42,19 +29,20 @@ module ApplianceConsole
 
     def enable
       enable_miqtop
-      service_command("enable")
+      SERVICES.each { |s| run_service(s, "enable") }
+      run_service(POSTGRESQL_SERVICE, "enable") if postgresql?
     end
 
     def disable
-      service_command("disable")
+      run_service(POSTGRESQL_SERVICE, "disable") unless postgresql?
     end
 
     def start
-      start_command
+      SERVICES.each { |s| run_detached_service(s, "start") }
     end
 
     def stop
-      service_command("stop")
+      run_service(POSTGRESQL_SERVICE, "stop") unless postgresql?
     end
 
     private
@@ -67,18 +55,9 @@ module ApplianceConsole
       LinuxAdmin::Service.new(service).send(action)
     end
 
-    def service_command(action)
-      services = send("to_#{action}")
-      services.each {|s| run_service(s, action) }
-    end
-
     #TODO: Fix LinuxAdmin::Service to detach.
     def run_detached_service(service, action)
       Process.detach(Kernel.spawn("/sbin/service #{service} #{action}", [:out, :err] => ["/dev/null", "w"]))
-    end
-
-    def start_command
-      to_start.each { |s| run_detached_service(s, "start") }
     end
   end
 end

--- a/lib/appliance_console/service_group.rb
+++ b/lib/appliance_console/service_group.rb
@@ -73,8 +73,12 @@ module ApplianceConsole
     end
 
     #TODO: Fix LinuxAdmin::Service to detach.
+    def run_detached_service(service, action)
+      Process.detach(Kernel.spawn("/sbin/service #{service} #{action}", [:out, :err] => ["/dev/null", "w"]))
+    end
+
     def start_command
-      to_start.each {|s| Process.detach(Kernel.spawn("/sbin/service #{s} start", [:out, :err] => ["/dev/null", "w"]))}
+      to_start.each { |s| run_detached_service(s, "start") }
     end
   end
 end

--- a/lib/appliance_console/service_group.rb
+++ b/lib/appliance_console/service_group.rb
@@ -59,9 +59,13 @@ module ApplianceConsole
 
     private
 
+    def run_service(service, action)
+      LinuxAdmin::Service.new(service).send(action)
+    end
+
     def service_command(action)
       services = send("to_#{action}")
-      services.each {|s| LinuxAdmin::Service.new(s).send(action)}
+      services.each {|s| run_service(s, action) }
     end
 
     #TODO: Fix LinuxAdmin::Service to detach.

--- a/lib/appliance_console/service_group.rb
+++ b/lib/appliance_console/service_group.rb
@@ -41,7 +41,7 @@ module ApplianceConsole
     end
 
     def enable
-      LinuxAdmin.run("chkconfig", :params => {"--add" => "miqtop"})  # Is this really needed?
+      enable_miqtop
       service_command("enable")
     end
 
@@ -58,6 +58,10 @@ module ApplianceConsole
     end
 
     private
+
+    def enable_miqtop
+      LinuxAdmin.run("chkconfig", :params => {"--add" => "miqtop"})  # Is this really needed?
+    end
 
     def run_service(service, action)
       LinuxAdmin::Service.new(service).send(action)

--- a/lib/spec/appliance_console/database_configuration_spec.rb
+++ b/lib/spec/appliance_console/database_configuration_spec.rb
@@ -371,6 +371,13 @@ describe ApplianceConsole::DatabaseConfiguration do
         end
       end
     end
+
+    it "#post_activation" do
+      expect(ApplianceConsole::ServiceGroup).to(
+        receive(:new).with(no_args).and_return(double(:restart_services => true))
+      )
+      @config.post_activation
+    end
   end
 
   def stubbed_say(clazz)

--- a/lib/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/lib/spec/appliance_console/internal_database_configuration_spec.rb
@@ -35,10 +35,9 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   end
 
   it "#post_activation" do
-    LinuxAdmin.stub(:run).with("chkconfig", :params => {"--add" => "miqtop"})
-    LinuxAdmin::Service.stub(:new => double.as_null_object)
-    ApplianceConsole::ServiceGroup.any_instance.stub(:start_command)
-    LinuxAdmin::Service.should_receive(:new).with(ApplianceConsole::POSTGRESQL_SERVICE).and_return(double(:enable => true))
+    expect(ApplianceConsole::ServiceGroup).to(
+      receive(:new).with(:internal_postgresql => true).and_return(double(:restart_services => true))
+    )
     @config.post_activation
   end
 

--- a/lib/spec/appliance_console/service_group_spec.rb
+++ b/lib/spec/appliance_console/service_group_spec.rb
@@ -5,11 +5,9 @@ require "appliance_console/service_group"
 require "linux_admin"
 
 describe ApplianceConsole::ServiceGroup do
-  before do
-    @group = described_class.new
-    @common_services  = %w{evminit memcached miqtop evmserverd}
-    @postgres_service = %w{postgresql92-postgresql}
-  end
+  let(:group)             { described_class.new }
+  let(:common_services)   { %w(evminit memcached miqtop evmserverd) }
+  let(:postgres_service)  { %w(postgresql92-postgresql) }
 
   it "#postgresql?" do
     expect(described_class.new(:internal_postgresql => true).postgresql?).to be_true
@@ -18,60 +16,58 @@ describe ApplianceConsole::ServiceGroup do
   end
 
   context "postgresql" do
-    before do
-      @group.stub(:postgresql? => true)
-    end
+    let(:group) { described_class.new(:internal_postgresql => true) }
 
     it "#to_enable" do
-      expect(@group.to_enable).to eq(@common_services | @postgres_service)
+      expect(group.to_enable).to eq(common_services | postgres_service)
     end
 
     it "#to_start" do
-      expect(@group.to_start).to eq(@common_services)
+      expect(group.to_start).to eq(common_services)
     end
 
     it "#to_disable" do
-      expect(@group.to_disable).to eq([])
+      expect(group.to_disable).to eq([])
     end
 
     it "#to_stop" do
-      expect(@group.to_stop).to eq([])
+      expect(group.to_stop).to eq([])
     end
   end
 
   context "without postgresql" do
     it "#to_enable" do
-      expect(@group.to_enable).to eq(@common_services)
+      expect(group.to_enable).to eq(common_services)
     end
 
     it "#to_start" do
-      expect(@group.to_start).to eq(@common_services)
+      expect(group.to_start).to eq(common_services)
     end
 
     it "#to_disable" do
-      expect(@group.to_disable).to eq(@postgres_service)
+      expect(group.to_disable).to eq(postgres_service)
     end
 
     it "#to_stop" do
-      expect(@group.to_stop).to eq(@postgres_service)
+      expect(group.to_stop).to eq(postgres_service)
     end
   end
 
   shared_examples_for "service management" do |command|
     it "##{command}" do
       LinuxAdmin.should_receive(:run).with("chkconfig", :params => {"--add" => "miqtop"}) if command == "enable"
-      expected_calls = @group.send("to_#{command}")
+      expected_calls = group.send("to_#{command}")
 
       # Hack until LinuxAdmin::Service start handles detaching.
       if command == "start"
-        @group.should_receive(:start_command)
+        group.should_receive(:start_command)
       else
         expected_calls.each do |service|
           LinuxAdmin::Service.should_receive(:new).with(service).and_return(double(command => true))
         end
       end
 
-      @group.send(command)
+      group.send(command)
     end
   end
 

--- a/lib/spec/appliance_console/service_group_spec.rb
+++ b/lib/spec/appliance_console/service_group_spec.rb
@@ -53,6 +53,16 @@ describe ApplianceConsole::ServiceGroup do
     end
   end
 
+  # this is private, but since we are stubbing it, make sure it works
+  context "#run_service" do
+    it "invokes LinuxAdmin service call" do
+      stub = double
+      expect(stub).to receive('start').and_return(true)
+      expect(LinuxAdmin::Service).to receive(:new).with('service').and_return(stub)
+      group.send(:run_service, 'service', 'start')
+    end
+  end
+
   shared_examples_for "service management" do |command|
     it "##{command}" do
       LinuxAdmin.should_receive(:run).with("chkconfig", :params => {"--add" => "miqtop"}) if command == "enable"
@@ -63,7 +73,7 @@ describe ApplianceConsole::ServiceGroup do
         group.should_receive(:start_command)
       else
         expected_calls.each do |service|
-          LinuxAdmin::Service.should_receive(:new).with(service).and_return(double(command => true))
+          expect(group).to receive(:run_service).with(service, command).and_return(true)
         end
       end
 

--- a/lib/spec/appliance_console/service_group_spec.rb
+++ b/lib/spec/appliance_console/service_group_spec.rb
@@ -71,6 +71,19 @@ describe ApplianceConsole::ServiceGroup do
     end
   end
 
+  # this is private, but since we are stubbing it, make sure it works
+  context "#detached_service" do
+    it "invokes Spawn" do
+      spwn = double
+      expect(Kernel).to receive(:spawn).with(
+        "/sbin/service service start", [:out, :err] => ["/dev/null", "w"]
+      ).and_return(spwn)
+      expect(Process).to receive(:detach).with(spwn)
+
+      group.send(:run_detached_service, "service", "start")
+    end
+  end
+
   shared_examples_for "service management" do |command|
     it "##{command}" do
       expect(group).to receive(:enable_miqtop) if command == "enable"

--- a/lib/spec/appliance_console/service_group_spec.rb
+++ b/lib/spec/appliance_console/service_group_spec.rb
@@ -54,6 +54,14 @@ describe ApplianceConsole::ServiceGroup do
   end
 
   # this is private, but since we are stubbing it, make sure it works
+  context "#enable_miqtop" do
+    it "calls chkconfig" do
+      expect(LinuxAdmin).to receive(:run).with("chkconfig", :params => {"--add" => "miqtop"})
+      group.send(:enable_miqtop)
+    end
+  end
+
+  # this is private, but since we are stubbing it, make sure it works
   context "#run_service" do
     it "invokes LinuxAdmin service call" do
       stub = double
@@ -65,7 +73,8 @@ describe ApplianceConsole::ServiceGroup do
 
   shared_examples_for "service management" do |command|
     it "##{command}" do
-      LinuxAdmin.should_receive(:run).with("chkconfig", :params => {"--add" => "miqtop"}) if command == "enable"
+      expect(group).to receive(:enable_miqtop) if command == "enable"
+
       expected_calls = group.send("to_#{command}")
 
       # Hack until LinuxAdmin::Service start handles detaching.

--- a/lib/spec/appliance_console/service_group_spec.rb
+++ b/lib/spec/appliance_console/service_group_spec.rb
@@ -23,41 +23,66 @@ describe ApplianceConsole::ServiceGroup do
     end
   end
 
-  context "postgresql" do
-    let(:group) { described_class.new(:internal_postgresql => true) }
+  describe "#enable" do
+    let(:group) { described_class.new(:internal_postgresql => false) }
 
-    it "#to_enable" do
-      expect(group.to_enable).to eq(common_services | postgres_service)
-    end
-
-    it "#to_start" do
-      expect(group.to_start).to eq(common_services)
-    end
-
-    it "#to_disable" do
-      expect(group.to_disable).to eq([])
-    end
-
-    it "#to_stop" do
-      expect(group.to_stop).to eq([])
-    end
-  end
-
-  context "without postgresql" do
     it "#to_enable" do
       expect(group.to_enable).to eq(common_services)
     end
 
+    context "with postgres" do
+      let(:group) { described_class.new(:internal_postgresql => true) }
+      it "#to_enable" do
+        expect(group.to_enable).to eq(common_services | postgres_service)
+      end
+    end
+  end
+
+  describe "#start" do
+    let(:group) { described_class.new(:internal_postgresql => false) }
+
     it "#to_start" do
       expect(group.to_start).to eq(common_services)
     end
+
+    context "with postgres" do
+      let(:group) { described_class.new(:internal_postgresql => true) }
+
+      it "#to_start" do
+        expect(group.to_start).to eq(common_services)
+      end
+    end
+  end
+
+  describe "#disable" do
+    let(:group) { described_class.new(:internal_postgresql => false) }
 
     it "#to_disable" do
       expect(group.to_disable).to eq(postgres_service)
     end
 
+    context "with postgres" do
+      let(:group) { described_class.new(:internal_postgresql => true) }
+
+      it "#to_disable" do
+        expect(group.to_disable).to eq([])
+      end
+    end
+  end
+
+  describe "#stop" do
+    let(:group) { described_class.new(:internal_postgresql => false) }
+
     it "#to_stop" do
       expect(group.to_stop).to eq(postgres_service)
+    end
+
+    context "with postgres" do
+      let(:group) { described_class.new(:internal_postgresql => true) }
+
+      it "#to_stop" do
+        expect(group.to_stop).to eq([])
+      end
     end
   end
 

--- a/lib/spec/appliance_console/service_group_spec.rb
+++ b/lib/spec/appliance_console/service_group_spec.rb
@@ -9,10 +9,18 @@ describe ApplianceConsole::ServiceGroup do
   let(:common_services)   { %w(evminit memcached miqtop evmserverd) }
   let(:postgres_service)  { %w(postgresql92-postgresql) }
 
-  it "#postgresql?" do
-    expect(described_class.new(:internal_postgresql => true).postgresql?).to be_true
-    expect(described_class.new(:internal_postgresql => false).postgresql?).to be_false
-    expect(described_class.new.postgresql?).to be_false
+  describe "#postgresql?" do
+    it { expect(group).not_to be_postgresql }
+
+    context "when internal postgres" do
+      let(:group) { described_class.new(:internal_postgresql => true) }
+      it { expect(group).to be_postgresql }
+    end
+
+    context "when not internal postgres" do
+      let(:group) { described_class.new(:internal_postgresql => false) }
+      it { expect(group).not_to be_postgresql }
+    end
   end
 
   context "postgresql" do


### PR DESCRIPTION
I had trouble finding a bug that was in a path passed into `ServiceGroup#run_detached` from the appliance console.

For some reason, the indirection of calling to_* obscured the error.
The conditional logic in the shared example did not provide much help.

The goal of extracting `detach` will have to wait until it gets into `AwesomeSpawn` and then `LinuxAdmin`.

Goals of this PR:

1. Remove all the conditional logic from shared_examples code in specs. (ended up deleting it)
2. Change tests to explicitly state which services are expected to start and stop.
3. Change `ServiceGroup` to just state which services to start and stop.
