### PR TITLE
add children relation to foreman configuration profile parents

### DIFF
--- a/vmdb/app/models/configuration_profile_foreman.rb
+++ b/vmdb/app/models/configuration_profile_foreman.rb
@@ -7,6 +7,10 @@ class ConfigurationProfileForeman < ConfigurationProfile
   belongs_to :direct_customization_script_medium,
              :class_name  => 'CustomizationScriptMedium'
 
+  has_many :children,
+           :class_name  => 'ConfigurationProfileForeman',
+           :foreign_key => :parent_id
+
   has_and_belongs_to_many :direct_configuration_tags,
                           :join_table  => 'direct_configuration_profiles_configuration_tags',
                           :class_name  => 'ConfigurationTag',

--- a/vmdb/spec/models/configuration_profile_foreman_spec.rb
+++ b/vmdb/spec/models/configuration_profile_foreman_spec.rb
@@ -3,6 +3,23 @@ require "spec_helper"
 describe ConfigurationProfileForeman do
   subject { described_class.new }
 
+  let(:cp1)   { FactoryGirl.create(:configuration_profile_foreman) }
+  let(:cp2)   { FactoryGirl.create(:configuration_profile_foreman, :parent => cp1) }
+
+  describe "#parent" do
+    it "has a parent" do
+      cp2 # make sure it is created
+      expect(cp2.parent).to eq(cp1)
+    end
+  end
+
+  describe "#children" do
+    it "has children" do
+      cp2 # make sure it is created
+      expect(cp1.children).to eq([cp2])
+    end
+  end
+
   describe "#configuration_tags" do
     let(:cd) { ConfigurationDomain.new(:name => "cd") }
     let(:cr) { ConfigurationRealm.new(:name => "cr") }


### PR DESCRIPTION
Foreman's configuration profile has parent, but never declared the inverse children relationship.

~~@AparnaKarve I think we manually do this in the UI. If you know where it is off hand, could you point me to the spot? If not, we can worry about it later.~~

/cc @brandondunne 