### PR TITLE
Remove many rubocops from MiqQueue

### DIFF
--- a/vmdb/app/models/compliance.rb
+++ b/vmdb/app/models/compliance.rb
@@ -18,15 +18,13 @@ class Compliance < ActiveRecord::Base
     targets.to_miq_a.each do |target|
       if target.kind_of?(Host)
         # Queue this with the vc-refresher taskid, so that any concurrent ems_refreshes don't clash with this one.
-        zone = target.ext_management_system ? target.ext_management_system.my_zone : nil
-
         MiqQueue.put(
           :class_name  => self.name,
           :method_name => 'scan_and_check_compliance',
           :args        => [[target.class.name, target.id], inputs],
           :task_id     => 'vc-refresher',
           :role        => "ems_inventory",
-          :zone        => zone
+          :zone        => target.ext_management_system.try(:my_zone)
         )
       end
     end

--- a/vmdb/app/models/job.rb
+++ b/vmdb/app/models/job.rb
@@ -85,8 +85,7 @@ class Job < ActiveRecord::Base
     return unless self.is_active?
 
     # Update worker heartbeat
-    worker = MiqQueue.get_worker(self.guid)
-    worker.update_heartbeat unless worker.nil?
+    MiqQueue.get_worker(guid).try(:update_heartbeat)
   end
 
   def self.signal_by_taskid(guid, signal, *args)

--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -36,7 +36,7 @@ class MiqQueue < ActiveRecord::Base
     raise ArgumentError, "which must be an Integer or one of #{PRIORITY_WHICH.join(", ")}" unless which.kind_of?(Integer) || PRIORITY_WHICH.include?(which)
     raise ArgumentError, "dir must be one of #{PRIORITY_DIR.join(", ")}" unless dir.nil? || PRIORITY_DIR.include?(dir)
 
-    which = self.const_get("#{which.to_s.upcase}_PRIORITY") unless which.kind_of?(Integer)
+    which = const_get("#{which.to_s.upcase}_PRIORITY") unless which.kind_of?(Integer)
     priority = which.send(dir == :higher ? "-" : "+", by)
     priority = MIN_PRIORITY if priority > MIN_PRIORITY
     priority = MAX_PRIORITY if priority < MAX_PRIORITY
@@ -131,7 +131,7 @@ class MiqQueue < ActiveRecord::Base
       :handler_type => nil,
       :handler_id   => nil,
     )
-    options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.has_key?(:task_id)
+    options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
     options[:role]         = options[:role].to_s unless options[:role].nil?
 
     msg = MiqQueue.create!(options)
@@ -288,7 +288,7 @@ class MiqQueue < ActiveRecord::Base
       begin
         # Update the queue item based on the returned save options.
         unless save_options.nil?
-          if save_options.has_key?(:msg_timeout) && (msg.msg_timeout > save_options[:msg_timeout])
+          if save_options.key?(:msg_timeout) && (msg.msg_timeout > save_options[:msg_timeout])
             $log.warn("#{log_prefix} #{MiqQueue.format_short_log_msg(msg)} ignoring request to decrease timeout from <#{msg.msg_timeout}> to <#{save_options[:msg_timeout]}>")
             save_options.delete(:msg_timeout)
           end
@@ -315,7 +315,7 @@ class MiqQueue < ActiveRecord::Base
   #   changed, and will be yielded to an optional block, generally for logging
   #   purposes.
   def self.put_unless_exists(find_options)
-    self.put_or_update(find_options) do |msg, item_hash|
+    put_or_update(find_options) do |msg, item_hash|
       ret = yield(msg, item_hash) if block_given?
       # create the record if the original message did not exist, don't change otherwise
       ret if msg.nil?
@@ -329,22 +329,22 @@ class MiqQueue < ActiveRecord::Base
   def deliver(requester = nil)
     log_prefix = LOG_PREFIX[:deliver]
     result = nil
-    self.delivered_on
+    delivered_on
     $log.info("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, Delivering...")
 
     begin
-      raise MiqException::MiqQueueExpired if self.expires_on && (Time.now.utc > self.expires_on)
+      raise MiqException::MiqQueueExpired if expires_on && (Time.now.utc > expires_on)
 
-      raise "class_name cannot be nil" if self.class_name.nil?
+      raise "class_name cannot be nil" if class_name.nil?
 
-      obj = self.class_name.constantize
+      obj = class_name.constantize
 
-      if self.instance_id
+      if instance_id
         begin
-          if (self.class_name == requester.class.name) && requester.respond_to?(:id) && (self.instance_id == requester.id)
+          if (class_name == requester.class.name) && requester.respond_to?(:id) && (instance_id == requester.id)
             obj = requester
           else
-            obj = obj.find(self.instance_id)
+            obj = obj.find(instance_id)
           end
         rescue ActiveRecord::RecordNotFound => err
           $log.warn  "#{log_prefix} #{MiqQueue.format_short_log_msg(self)} will not be delivered because #{err.message}"
@@ -361,11 +361,11 @@ class MiqQueue < ActiveRecord::Base
       begin
         status = STATUS_OK
         message = "Message delivered successfully"
-        Timeout::timeout(self.msg_timeout) do
-          if obj.is_a?(Class) && !self.target_id.nil?
-            result = obj.send(self.method_name, self.target_id, *args)
+        Timeout::timeout(msg_timeout) do
+          if obj.is_a?(Class) && !target_id.nil?
+            result = obj.send(method_name, target_id, *args)
           else
-            result = obj.send(self.method_name, *args)
+            result = obj.send(method_name, *args)
           end
         end
       rescue MiqException::MiqQueueRetryLater => err
@@ -374,14 +374,14 @@ class MiqQueue < ActiveRecord::Base
         $log.error("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, #{message}")
         status = STATUS_RETRY
       rescue TimeoutError
-        message = "timed out after #{Time.now - self.delivered_on} seconds.  Timeout threshold [#{self.msg_timeout}]"
+        message = "timed out after #{Time.now - self.delivered_on} seconds.  Timeout threshold [#{msg_timeout}]"
         $log.error("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, #{message}")
         status = STATUS_TIMEOUT
       end
     rescue SystemExit
       raise
     rescue MiqException::MiqQueueExpired
-      message = "Expired on [#{self.expires_on}]"
+      message = "Expired on [#{expires_on}]"
       $log.error("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, #{message}")
       status = STATUS_EXPIRED
     rescue Exception => error
@@ -397,7 +397,7 @@ class MiqQueue < ActiveRecord::Base
 
   DELIVER_IN_ERROR_MSG = 'Deliver in error'.freeze
   def delivered_in_error(msg = nil)
-    self.delivered('error', msg || DELIVER_IN_ERROR_MSG, nil)
+    delivered('error', msg || DELIVER_IN_ERROR_MSG, nil)
   end
 
   def delivered(state, msg, result)
@@ -419,28 +419,28 @@ class MiqQueue < ActiveRecord::Base
 
   def m_callback(msg, result)
     log_prefix = LOG_PREFIX[:callback]
-    if self.miq_callback[:class_name] && self.miq_callback[:method_name]
+    if miq_callback[:class_name] && miq_callback[:method_name]
       begin
-        klass = self.miq_callback[:class_name].constantize
-        if self.miq_callback[:instance_id]
-          obj = klass.find(self.miq_callback[:instance_id])
+        klass = miq_callback[:class_name].constantize
+        if miq_callback[:instance_id]
+          obj = klass.find(miq_callback[:instance_id])
         else
           obj = klass
-          $log.debug("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, Could not find callback in Class: [#{self.miq_callback[:class_name]}]") unless obj
+          $log.debug("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, Could not find callback in Class: [#{miq_callback[:class_name]}]") unless obj
         end
-        if obj.respond_to?(self.miq_callback[:method_name])
-          self.miq_callback[:args] ||= []
+        if obj.respond_to?(miq_callback[:method_name])
+          miq_callback[:args] ||= []
 
           log_args = result.inspect
           log_args = "#{log_args[0, 500]}..." if log_args.length > 500  # Trim long results
-          log_args = self.miq_callback[:args] + [self.state, msg, log_args]
+          log_args = miq_callback[:args] + [state, msg, log_args]
           $log.info("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, Invoking Callback with args: #{log_args.inspect}") unless obj.nil?
 
-          cb_args = self.miq_callback[:args] + [self.state, msg, result]
-          cb_args << self if cb_args.length == (obj.method(self.miq_callback[:method_name]).arity - 1)
-          obj.send(self.miq_callback[:method_name], *cb_args)
+          cb_args = miq_callback[:args] + [state, msg, result]
+          cb_args << self if cb_args.length == (obj.method(miq_callback[:method_name]).arity - 1)
+          obj.send(miq_callback[:method_name], *cb_args)
         else
-          $log.warn("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, Instance: [#{obj}], does not respond to Method: [#{self.miq_callback[:method_name]}], skipping")
+          $log.warn("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, Instance: [#{obj}], does not respond to Method: [#{miq_callback[:method_name]}], skipping")
         end
       rescue => err
         $log.error("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}: #{err}")
@@ -457,16 +457,16 @@ class MiqQueue < ActiveRecord::Base
     MiqQueue.put(options)
   end
 
-  def check_for_timeout(log_prefix = "MIQ(MiqQueue.check_for_timeout)", grace = 10.seconds, timeout = self.msg_timeout.seconds)
-    if self.state == 'dequeue' && Time.now.utc > (self.updated_on + timeout.seconds + grace.seconds).utc
-      msg = " processed by #{self.handler.format_full_log_msg}" unless self.handler.nil?
-      $log.warn("#{log_prefix} Timed Out Active #{MiqQueue.format_short_log_msg(self)}#{msg} after #{Time.now.utc - self.updated_on} seconds")
-      self.destroy rescue nil
+  def check_for_timeout(log_prefix = "MIQ(MiqQueue.check_for_timeout)", grace = 10.seconds, timeout = msg_timeout.seconds)
+    if self.state == 'dequeue' && Time.now.utc > (updated_on + timeout.seconds + grace.seconds).utc
+      msg = " processed by #{handler.format_full_log_msg}" unless handler.nil?
+      $log.warn("#{log_prefix} Timed Out Active #{MiqQueue.format_short_log_msg(self)}#{msg} after #{Time.now.utc - updated_on} seconds")
+      destroy rescue nil
     end
   end
 
   def finished?
-    FINISHED_STATES.include?(self.state)
+    FINISHED_STATES.include?(state)
   end
 
   def unfinished?
@@ -485,7 +485,7 @@ class MiqQueue < ActiveRecord::Base
       options = YAML::load(ERB.new(File.read(@@delete_command_file)).result)
       if options[:required_role].nil? || MiqServer.my_server(true).has_active_role?(options[:required_role])
         $log.info("#{log_prefix} Executing: [#{@@delete_command_file}], Options: [#{options.inspect}]")
-        deleted = self.delete_all(options[:conditions])
+        deleted = delete_all(options[:conditions])
         $log.info("#{log_prefix} Executing: [#{@@delete_command_file}] complete, #{deleted} rows deleted")
       end
       File.delete(@@delete_command_file)
@@ -494,13 +494,13 @@ class MiqQueue < ActiveRecord::Base
     $log.info("#{log_prefix} Cleaning up queue messages...")
     MiqQueue.where(:state => STATE_DEQUEUE).each do |message|
       if message.handler.nil?
-        $log.warn("#{log_prefix} Cleaning message in dequeue state without worker: #{self.format_full_log_msg(message)}")
+        $log.warn("#{log_prefix} Cleaning message in dequeue state without worker: #{format_full_log_msg(message)}")
       else
         handler_server = message.handler            if message.handler.kind_of?(MiqServer)
         handler_server = message.handler.miq_server if message.handler.kind_of?(MiqWorker)
         next unless handler_server == MiqServer.my_server
 
-        $log.warn("#{log_prefix} Cleaning message: #{self.format_full_log_msg(message)}")
+        $log.warn("#{log_prefix} Cleaning message: #{format_full_log_msg(message)}")
       end
       message.update_attributes(:state => STATE_ERROR) rescue nil
     end

--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -401,16 +401,14 @@ class MiqQueue < ActiveRecord::Base
   end
 
   def delivered(state, msg, result)
-    begin
-      log_prefix = LOG_PREFIX[:delivered]
-      self.state = state
-      $log.info("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, State: [#{state}], Delivered in [#{Time.now - self.delivered_on}] seconds")
-      m_callback(msg, result) unless self.miq_callback.blank?
-    rescue => err
-      $log.error("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, #{err.message}")
-    ensure
-      self.destroy
-    end
+    log_prefix = LOG_PREFIX[:delivered]
+    self.state = state
+    $log.info("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, State: [#{state}], Delivered in [#{Time.now - delivered_on}] seconds")
+    m_callback(msg, result) unless miq_callback.blank?
+  rescue => err
+    $log.error("#{log_prefix} #{MiqQueue.format_short_log_msg(self)}, #{err.message}")
+  ensure
+    destroy
   end
 
   def delivered_on

--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -110,11 +110,12 @@ class MiqQueue < ActiveRecord::Base
       :server_guid  => nil,
       :msg_timeout  => TIMEOUT,
       :deliver_on   => nil
+    ).merge(
+      :zone         => Zone.determine_queue_zone(options),
+      :state        => STATE_READY,
+      :handler_type => nil,
+      :handler_id   => nil,
     )
-    options[:zone]         = Zone.determine_queue_zone(options)
-    options[:state]        = STATE_READY
-    options[:handler_type] = nil
-    options[:handler_id]   = nil
     options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.has_key?(:task_id)
     options[:role]         = options[:role].to_s unless options[:role].nil?
 

--- a/vmdb/spec/models/compliance_spec.rb
+++ b/vmdb/spec/models/compliance_spec.rb
@@ -3,11 +3,7 @@ require "spec_helper"
 describe Compliance do
   context "A small virtual infrastructure" do
     before(:each) do
-      @zone  = FactoryGirl.create(:zone)
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid)
-      MiqServer.my_server_clear_cache
+      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems   = FactoryGirl.create(:ems_vmware,    :name => "Test EMS", :zone => @zone)
       @host1 = FactoryGirl.create(:host,      :name => "Host1", :ext_management_system => @ems)
       @host2 = FactoryGirl.create(:host,      :name => "Host2")

--- a/vmdb/spec/models/miq_queue_spec.rb
+++ b/vmdb/spec/models/miq_queue_spec.rb
@@ -4,7 +4,7 @@ describe MiqQueue do
   specify { FactoryGirl.build(:miq_queue).should be_valid }
 
   context "#deliver" do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     end
 
@@ -53,7 +53,7 @@ describe MiqQueue do
   end
 
   context "With messages left in dequeue at startup," do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @other_miq_server = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone)
@@ -63,7 +63,7 @@ describe MiqQueue do
     end
 
     context "where worker has a message in dequeue" do
-      before(:each) do
+      before do
         @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @worker)
       end
 
@@ -88,7 +88,7 @@ describe MiqQueue do
     end
 
     context "where worker on other server has a message in dequeue" do
-      before(:each) do
+      before do
         @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @other_worker)
       end
 
@@ -101,7 +101,7 @@ describe MiqQueue do
     end
 
     context "message in dequeue without a worker" do
-      before(:each) do
+      before do
         @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE)
       end
 
@@ -218,7 +218,7 @@ describe MiqQueue do
   end
 
   context "miq_queue with messages" do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @t1 = Time.parse("Wed Apr 20 00:15:00 UTC 2011")
@@ -256,7 +256,7 @@ describe MiqQueue do
   end
 
   context "deliver to queue" do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @t1 = Time.parse("Wed Apr 20 00:15:00 UTC 2011")
@@ -307,7 +307,7 @@ describe MiqQueue do
   end
 
   context "worker" do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @worker       = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
@@ -324,7 +324,7 @@ describe MiqQueue do
   end
 
   context "#put" do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     end
 
@@ -363,7 +363,7 @@ describe MiqQueue do
         :args        => [1,2]
       )
 
-      expect(MiqQueue.first.state).to eq("ready")
+      expect(MiqQueue.first.state).to eq(MiqQueue::STATE_READY)
     end
 
     it "should respect hash updates in put_unless_exists" do


### PR DESCRIPTION
Had a number of rubocop cleanup idems from March 2014 when working through `MiqQueue`.

This does not change any code, just removes `self`, `return`, `if` blocks, and `has_key?`.

Should be able to scan it in changes view (vs each commit)
If anything looks even remotely like a change, please say so.

/cc @jrafanie 

---
UPDATE:

There is one change: it removes the deprecated `MiqQueue.merge`.