### PR TITLE
Remove first duplicated :service key since last one in wins.

### DIFF
--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -215,7 +215,6 @@ module UiConstants
       :ontapstoragevolume    => "list",
       :orchestrationstack    => "list",
       :orchestrationtemplate => "list",
-      :service               => "list",
       :servicetemplate       => "list",
       :storagemanager        => "list",
       :miqtask               => "list",


### PR DESCRIPTION
{:a => 2, :a => 1} => {:a => 1}

Fixes ruby 2.2 warning: app/helpers/ui_constants.rb:218: warning: duplicated key at line 226 ignored: :service

Note, expand the diff to see line 226 where service is "grid".  Since last one wins, I removed the first.