### PR TITLE
Swap the Time-like object order with the String to avoid a warning.

### DIFF
--- a/vmdb/app/models/metric/ci_mixin/capture/openstack_base.rb
+++ b/vmdb/app/models/metric/ci_mixin/capture/openstack_base.rb
@@ -227,7 +227,7 @@ module Metric::CiMixin::Capture::OpenstackBase
       multi_counter_aligned_start        ||= last_period
       multi_counter_aligned_end          ||= period
       multi_counter_aligned_start_guard  ||= last_period
-      multi_counter_aligned_start_guard    = period if multi_counter_aligned_start_guard == 'initialize_with_period'
+      multi_counter_aligned_start_guard    = period if 'initialize_with_period' == multi_counter_aligned_start_guard
 
       multi_counter_metrics              ||= {}
       last_multi_counter_metrics         ||= {}


### PR DESCRIPTION
Note:
It looks like this is fixed in Rails in this PR:
https://github.com/rails/rails/pull/18365

Fixes the following warnings on ruby 2.2:

```
app/models/metric/ci_mixin/capture/openstack_base.rb:230: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
app/models/metric/ci_mixin/capture/openstack_base.rb:230: warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.
```