### PR TITLE
Use renamed option: `config.serve_static_files`

### DIFF
--- a/vmdb/config/environments/metric_fu.rb
+++ b/vmdb/config/environments/metric_fu.rb
@@ -8,7 +8,7 @@ Vmdb::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Log error messages when you accidentally call methods on nil

--- a/vmdb/config/environments/production.rb
+++ b/vmdb/config/environments/production.rb
@@ -10,7 +10,7 @@ Vmdb::Application.configure do
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
   # TODO: enable static asset server for now so rails serves the images/css, etc.
-  config.serve_static_assets = true
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/vmdb/config/environments/test.rb
+++ b/vmdb/config/environments/test.rb
@@ -8,7 +8,7 @@ Vmdb::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Log error messages when you accidentally call methods on nil


### PR DESCRIPTION
Fixes: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly.