### PR TITLE
remove MiqQueue.merge

### DIFF
--- a/vmdb/app/models/miq_queue.rb
+++ b/vmdb/app/models/miq_queue.rb
@@ -73,7 +73,6 @@ class MiqQueue < ActiveRecord::Base
     :unget     => "MIQ(MiqQueue.unget)     ",
     :deliver   => "MIQ(MiqQueue.deliver)   ",
     :delivered => "MIQ(MiqQueue.delivered) ",
-    :merge     => "MIQ(MiqQueue.merge)     ",
     :callback  => "MIQ(MiqQueue.m_callback)",
     :atStartup => "MIQ(MiqQueue.atStartup) ",
     :dev_null  => "MIQ(MiqQueue.dev_null)  ",
@@ -292,9 +291,6 @@ class MiqQueue < ActiveRecord::Base
       end
     end
     return msg
-  end
-  class << self
-    alias_method :merge, :put_or_update
   end
 
   # Find the MiqQueue item with the specified find options, and if not found


### PR DESCRIPTION
MiqQueue.merge was removed
- merged: 0d226f644f3c1a32e7e5ea1f25d63b412c173cf2 Dec 2013
- commit: 0d6170ea23affdfde4904a5bb3e1fa264e16ac21 Nov 2013

At the time, there were a bunch of branches rolling around, so we
opted to push off the actual removal of MiqQueue.merge in a later
commit.

Here we are. it is time to remove