### PR TITLE
remove duplicate constant :service defined

### DIFF
--- a/vmdb/app/helpers/ui_constants.rb
+++ b/vmdb/app/helpers/ui_constants.rb
@@ -215,7 +215,6 @@ module UiConstants
       :ontapstoragevolume    => "list",
       :orchestrationstack    => "list",
       :orchestrationtemplate => "list",
-      :service               => "list",
       :servicetemplate       => "list",
       :storagemanager        => "list",
       :miqtask               => "list",


### PR DESCRIPTION
Ruby is complaining that we have defined `:service` twice in a hash.
Pretty sure the last one in wins.

Not sure which one we want, but the current code is ignoring `:service => "list"` because we also have `:service => "grid"` a few lines down

/cc @dclarizio 