### PR TITLE
don't store vmdb info in session

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -2348,13 +2348,6 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    # Set version info, if it doesn't exist
-    if session[:vmdb] == nil
-      session[:vmdb] = Hash.new
-      session[:vmdb][:version] = Vmdb::Appliance.VERSION
-      session[:vmdb][:build]   = Vmdb::Appliance.BUILD_NUMBER
-    end
-
     # Get customer name
     session[:customer_name] = get_vmdb_config[:server][:company] if session[:customer_name] == nil
     session[:vmdb_name] = get_vmdb_config[:server][:name] if session[:vmdb_name] == nil

--- a/vmdb/app/controllers/support_controller.rb
+++ b/vmdb/app/controllers/support_controller.rb
@@ -20,9 +20,7 @@ class SupportController < ApplicationController
   def about
 #   @tabs ||= [ ["1", ""] ]
 #   @tabs.push( ["1", "Help"] )
-    session[:vmdb] ||= Hash.new
-    session[:vmdb][:version] ||= Vmdb::Appliance.VERSION
-    session[:vmdb][:build]   ||= Vmdb::Appliance.BUILD
+    @vmdb = {:version => Vmdb::Appliance.VERSION, :build => Vmdb::Appliance.BUILD}
     @user_role = User.current_user.miq_user_role_name
     @layout = "about"
   end

--- a/vmdb/app/views/support/show.html.haml
+++ b/vmdb/app/views/support/show.html.haml
@@ -7,7 +7,7 @@
           %h3=_('Session Information')
           %table.style1
             - [[_("Server Name"),     h(session[:vmdb_name])],
-               [_("Version"),         h(session[:vmdb][:version] + "." + session[:vmdb][:build])],
+               [_("Version"),         h(@vmdb[:version] + "." + @vmdb[:build])],
                [_("User Name"),       h(session[:username])],
                [_("User Role"),       h(@user_role)],
                [_("Browser"),         h(browser_info("name"))],


### PR DESCRIPTION
Looks like we are storing the `VERSION` and `BUILD_NUMBER` in the session.

It was only referenced in `/support/show.html.haml` -- I was only able to access this from `/support/about`.

Any reason to store this data in the session?
Thanks

/cc @dclarizio @Fryguy 