### PR TITLE
Fix deprecation use where().first not find(:first)

### DIFF
--- a/vmdb/app/apis/miqservices_ops.rb
+++ b/vmdb/app/apis/miqservices_ops.rb
@@ -11,7 +11,7 @@ module MiqservicesOps
 
         # If we get a job id use that to lookup the vm
         unless jobid.blank?
-          job = Job.find(:first, :conditions => ["guid = ?", jobid], :select => "target_id")
+          job = Job.where(:guid => jobid).select("target_id").first
           vm = VmOrTemplate.find_by_id(job.target_id) if job
         end
 

--- a/vmdb/app/models/miq_cim_association.rb
+++ b/vmdb/app/models/miq_cim_association.rb
@@ -68,25 +68,25 @@ class MiqCimAssociation < ActiveRecord::Base
   end
 
   def self.get_association_id(assoc, from_inst, to_inst)
-    self.select(:id).find(:first, :conditions => {
+    select(:id).where(
       :obj_name     => from_inst.obj_name_str,
       :result_obj_name  => to_inst.obj_name_str,
       :assoc_class    => assoc[:AssocClass],
       # :result_class   => to_inst.class_name,  # use the specific class instead of the one in assoc
       :role       => assoc[:Role],
       # :result_role    => assoc[:ResultRole]
-    })
+    ).first
   end
 
   def self.get_rev_association_id(assoc, from_inst, to_inst)
-    self.select(:id).find(:first, :conditions => {
+    select(:id).where(
       :obj_name     => to_inst.obj_name_str,
       :result_obj_name  => from_inst.obj_name_str,
       :assoc_class    => assoc[:AssocClass],
       # :result_class   => from_inst.class_name,  # use the specific class instead of the one in assoc
       :role       => assoc[:ResultRole],
       # :result_role    => assoc[:Role]
-    })
+    ).first
   end
 
   def self.where_association(assoc)

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb
@@ -5,7 +5,7 @@ module MiqAeServiceHostSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
       @host = FactoryGirl.create(:host)
     end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_methods_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_methods_spec.rb
@@ -5,7 +5,7 @@ module MiqAeServiceMethodsSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
     end
 

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
@@ -11,7 +11,7 @@ module MiqAeServiceMiqHostProvisionRequestSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @user                       = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_spec.rb
@@ -5,7 +5,7 @@ module MiqAeServiceMiqHostProvisionSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @miq_host_provision = FactoryGirl.create(:miq_host_provision, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok')

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
@@ -11,7 +11,7 @@ module MiqAeServiceMiqProvisionRequestSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @ems                   = FactoryGirl.create(:ems_vmware_with_authentication)

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
@@ -5,7 +5,7 @@ module MiqAeServiceMiqProvisionSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
 

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_vmware_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_vmware_spec.rb
@@ -5,7 +5,7 @@ module MiqAeServiceMiqProvisionVmwareSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @ems           = FactoryGirl.create(:ems_vmware_with_authentication)

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -10,7 +10,7 @@ module MiqAeServiceMiqRequestSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @fred          = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
@@ -5,7 +5,7 @@ module MiqAeServiceMiqRequestTaskSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @miq_request_task = FactoryGirl.create(:miq_request_task, :status => 'Ok')

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
@@ -26,7 +26,7 @@ module MiqAeServiceServiceReconfigureRequestSpec
       FactoryGirl.create(:ui_task_set_approver)
     end
 
-    let(:ae_method)     { ::MiqAeMethod.find(:first) }
+    let(:ae_method)     { ::MiqAeMethod.first }
     let(:user)          { FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred') }
     let(:request)       { FactoryGirl.create(:service_reconfigure_request, :requester => user, :userid => user.userid) }
 

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
@@ -26,7 +26,7 @@ module MiqAeServiceServiceReconfigureTaskSpec
       FactoryGirl.create(:ui_task_set_approver)
     end
 
-    let(:ae_method) { ::MiqAeMethod.find(:first) }
+    let(:ae_method) { ::MiqAeMethod.first }
     let(:user)      { FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred') }
     let(:options)   { {} }
     let(:task)      do

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
@@ -9,7 +9,7 @@ module MiqAeServiceServiceSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @service   = FactoryGirl.create(:service, :name => "test_service", :description => "test_description")

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
@@ -9,7 +9,7 @@ module MiqAeServiceServiceTemplateProvisionRequestSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
       @user          = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
       @approver_role = FactoryGirl.create(:ui_task_set_approver)

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
@@ -9,7 +9,7 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
       @options       = {}
       @service_template_provision_task = FactoryGirl.create(:service_template_provision_task,  :state => 'pending', :status => 'Ok', :request_type => "clone_to_service", :options => @options)

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_spec.rb
@@ -6,7 +6,7 @@ module MiqAeServiceServiceTemplateSpec
       before(:each) do
         MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                       'AUTOMATE', 'test1', 'test')
-        @ae_method     = ::MiqAeMethod.find(:first)
+        @ae_method     = ::MiqAeMethod.first
         @ae_result_key = 'foo'
         @service_template   = FactoryGirl.create(:service_template)
       end

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
@@ -14,7 +14,7 @@ module MiqAeServiceSpec
                                :priority => 3}
                     ]
       MiqAutomateHelper.create_dummy_method(identifiers, fields)
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
     end
 

--- a/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
+++ b/vmdb/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
@@ -9,7 +9,7 @@ module MiqAeServiceVmSpec
     before(:each) do
       MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
                                                     'AUTOMATE', 'test1', 'test')
-      @ae_method     = ::MiqAeMethod.find(:first)
+      @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
       @vm   = FactoryGirl.create(:vm_vmware, :name => "template1", :location => "abc/abc.vmx")

--- a/vmdb/spec/models/miq_host_provision_request_spec.rb
+++ b/vmdb/spec/models/miq_host_provision_request_spec.rb
@@ -92,7 +92,7 @@ describe MiqHostProvisionRequest do
         it "should add and delete tags from a request" do
           @pr.get_tags.length.should == 0
 
-          t = Classification.find(:first, :conditions => {:description => 'Department', :parent_id => 0}, :include => :tag)
+          t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
           @pr.add_tag(t.name, t.children.first.name)
           @pr.get_tags[t.name.to_sym].should be_kind_of(String) # Single tag returns as a String
           @pr.get_tags[t.name.to_sym].should == t.children.first.name
@@ -139,7 +139,7 @@ describe MiqHostProvisionRequest do
         it "should return classifications for tags" do
           @pr.get_tags.length.should == 0
 
-          t = Classification.find(:first, :conditions => {:description => 'Department', :parent_id => 0}, :include => :tag)
+          t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
           @pr.add_tag(t.name, t.children.first.name)
           @pr.get_tags[t.name.to_sym].should be_kind_of(String)
 

--- a/vmdb/spec/models/miq_provision_request_spec.rb
+++ b/vmdb/spec/models/miq_provision_request_spec.rb
@@ -135,7 +135,7 @@ describe MiqProvisionRequest do
         it "should add and delete tags from a request" do
           @pr.get_tags.length.should == 0
 
-          t = Classification.find(:first, :conditions => {:description => 'Department', :parent_id => 0}, :include => :tag)
+          t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
           @pr.add_tag(t.name, t.children.first.name)
           @pr.get_tags[t.name.to_sym].should be_kind_of(String) # Single tag returns as a String
           @pr.get_tags[t.name.to_sym].should == t.children.first.name
@@ -182,7 +182,7 @@ describe MiqProvisionRequest do
         it "should return classifications for tags" do
           @pr.get_tags.length.should == 0
 
-          t = Classification.find(:first, :conditions => {:description => 'Department', :parent_id => 0}, :include => :tag)
+          t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
           @pr.add_tag(t.name, t.children.first.name)
           @pr.get_tags[t.name.to_sym].should be_kind_of(String)
 

--- a/vmdb/spec/models/miq_task_spec.rb
+++ b/vmdb/spec/models/miq_task_spec.rb
@@ -215,7 +215,7 @@ describe MiqTask do
       task.message.should == "Queued the action: [#{task.name}] being run for user: [#{task.userid}]"
 
       MiqQueue.count.should == 1
-      message = MiqQueue.find(:first)
+      message = MiqQueue.first
       message.class_name.should  == "MyClass"
       message.method_name.should == "my_method"
       message.args.should        == [1, 2, 3]
@@ -235,7 +235,7 @@ describe MiqTask do
     it "should queue up deletes when calling MiqTask.delete_by_id" do
       MiqTask.delete_by_id([@miq_task1.id, @miq_task3.id])
       MiqQueue.count.should == 1
-      message = MiqQueue.find(:first)
+      message = MiqQueue.first
 
       message.class_name.should  == "MiqTask"
       message.method_name.should == "destroy_all"
@@ -255,7 +255,7 @@ describe MiqTask do
       MiqTask.delete_older(5.minutes.ago.utc, nil)
 
       MiqQueue.count.should == 1
-      message = MiqQueue.find(:first)
+      message = MiqQueue.first
 
       message.class_name.should  == "MiqTask"
       message.method_name.should == "destroy_all"
@@ -273,7 +273,7 @@ describe MiqTask do
       MiqTask.delete_older(11.minutes.ago.utc, nil)
 
       MiqQueue.count.should == 1
-      message = MiqQueue.find(:first)
+      message = MiqQueue.first
 
       message.class_name.should  == "MiqTask"
       message.method_name.should == "destroy_all"

--- a/vmdb/spec/models/miq_widget_spec.rb
+++ b/vmdb/spec/models/miq_widget_spec.rb
@@ -276,7 +276,7 @@ describe MiqWidget do
     it "creates a new task when previous task is finished" do
       @widget.queue_generate_content
       MiqTask.first.state_finished
-      message = MiqQueue.find(:first, :conditions => @q_options)
+      message = MiqQueue.where(@q_options).first
       message.update_attribute(:state, MiqQueue::STATE_ERROR)
 
       @widget.queue_generate_content
@@ -299,7 +299,7 @@ describe MiqWidget do
       task = MiqTask.first
       task.state_active
 
-      message = MiqQueue.find(:first, :conditions => @q_options)
+      message = MiqQueue.where(@q_options).first
       message.destroy
       MiqQueue.count.should == 0
 
@@ -317,7 +317,7 @@ describe MiqWidget do
       task = MiqTask.first
       task.state_active
 
-      message = MiqQueue.find(:first, :conditions => @q_options)
+      message = MiqQueue.where(@q_options).first
       message.update_attribute(:state, MiqQueue::STATE_ERROR)
       MiqQueue.count.should == 1
 

--- a/vmdb/spec/models/storage_spec.rb
+++ b/vmdb/spec/models/storage_spec.rb
@@ -214,11 +214,11 @@ describe Storage do
         MiqEvent.should_receive(:raise_evm_job_event).once
         @storage1.scan
 
-        task = MiqTask.find(:first)
+        task = MiqTask.first
         task.userid.should == "system"
         task.name.should == "SmartState Analysis for [#{@storage1.name}]"
 
-        message = MiqQueue.find(:first, :conditions => { :method_name => "smartstate_analysis"})
+        message = MiqQueue.where(:method_name => "smartstate_analysis").first
         message.instance_id.should == @storage1.id
         message.args.should == [task.id]
         message.zone.should == @zone.name

--- a/vmdb/spec/models/vmdb_table_spec.rb
+++ b/vmdb/spec/models/vmdb_table_spec.rb
@@ -309,14 +309,12 @@ EOF
       context "first" do
         it "without conditions" do
           t = VmdbTable.vmdb_table_names.first
-          VmdbTable.find(:first).name.should == t
-          VmdbTable.first.name.should        == t
+          expect(VmdbTable.first.name).to eq(t)
         end
 
         it "with conditions" do
           t = VmdbTable.vmdb_table_names.second
-          VmdbTable.find(:first, :conditions => {:id => [2, 3]}).name.should == t
-          VmdbTable.first(:conditions => {:id => [2, 3]}).name.should        == t
+          expect(VmdbTable.where(:id => [2, 3]).first.name).to eq(t)
         end
       end
 


### PR DESCRIPTION
fixes deprecation warning:
```
DEPRECATION WARNING: Calling #find(:first) is deprecated. Please call #first directly instead. You have also used finder options. These are also deprecated. Please build a scope instead of using finder options. (called from block (3 levels) in <top (required)> at /Users/kbrock/src/manageiq/vmdb/spec/models/miq_widget_spec.rb:279)
```