### PR TITLE
implement MiqProductFeature#find_all_by_identifier

### DIFF
--- a/vmdb/app/models/miq_product_feature.rb
+++ b/vmdb/app/models/miq_product_feature.rb
@@ -25,8 +25,7 @@ class MiqProductFeature < ActiveRecord::Base
   end
 
   def self.feature_parent(identifier)
-    feat = self.features[identifier.to_s]
-    feat[:parent] if feat
+    features[identifier.to_s].try(:[], :parent)
   end
 
   def self.parent_for_feature(identifier)
@@ -130,5 +129,9 @@ class MiqProductFeature < ActiveRecord::Base
       role.miq_product_features << self
       role.save!
     end
+  end
+
+  def self.find_all_by_identifier(features)
+    where(:identifier => features)
   end
 end

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -66,7 +66,7 @@ describe ProviderForemanController do
     it "renders explorer based on RBAC access to feature 'configured_system_tag'" do
       set_user_privileges
       EvmSpecHelper.seed_specific_product_features("configured_system_tag")
-      feature = MiqProductFeature.find_all_by_identifier(["configured_system_tag"])
+      feature = MiqProductFeature.find_all_by_identifier("configured_system_tag")
       test_user_role  = FactoryGirl.create(:miq_user_role,
                                            :name                 => "test_user_role",
                                            :miq_product_features => feature)
@@ -88,7 +88,7 @@ describe ProviderForemanController do
     it "renders explorer based on RBAC access to feature 'provider_foreman_add_provider'" do
       set_user_privileges
       EvmSpecHelper.seed_specific_product_features("provider_foreman_add_provider")
-      feature = MiqProductFeature.find_all_by_identifier(["provider_foreman_add_provider"])
+      feature = MiqProductFeature.find_all_by_identifier("provider_foreman_add_provider")
       test_user_role  = FactoryGirl.create(:miq_user_role,
                                            :name                 => "test_user_role",
                                            :miq_product_features => feature)
@@ -111,7 +111,7 @@ describe ProviderForemanController do
   context "asserts correct privileges" do
     before do
       EvmSpecHelper.seed_specific_product_features("configured_system_provision")
-      feature = MiqProductFeature.find_all_by_identifier(["configured_system_provision"])
+      feature = MiqProductFeature.find_all_by_identifier("configured_system_provision")
       test_user_role  = FactoryGirl.create(:miq_user_role,
                                            :name                 => "test_user_role",
                                            :miq_product_features => feature)

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -53,11 +53,12 @@ describe ApplicationHelper do
   end
 
   describe "#role_allows" do
+    let(:features) { MiqProductFeature.find_all_by_identifier("everything") }
     before(:each) do
       MiqRegion.seed
       EvmSpecHelper.seed_specific_product_features("miq_report", "service")
 
-      @admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => MiqProductFeature.find_all_by_identifier(["everything"]))
+      @admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => features)
       @admin_group = FactoryGirl.create(:miq_group, :miq_user_role => @admin_role)
       @user        = FactoryGirl.create(:user, :name => 'wilma', :miq_groups => [@admin_group])
       User.stub(:current_user => @user)

--- a/vmdb/spec/models/miq_user_role_spec.rb
+++ b/vmdb/spec/models/miq_user_role_spec.rb
@@ -44,18 +44,18 @@ describe MiqUserRole do
         vm
       ))
 
-      @idents1 = ["dashboard_admin"]
-      @role1   = FactoryGirl.create(:miq_user_role, :name => "Role1", :miq_product_features => MiqProductFeature.find_all_by_identifier(@idents1))
+      feature1 = MiqProductFeature.find_all_by_identifier("dashboard_admin")
+      @role1   = FactoryGirl.create(:miq_user_role, :name => "Role1", :miq_product_features => feature1)
       @group1  = FactoryGirl.create(:miq_group, :description => "Group1", :miq_user_role => @role1)
       @user1   = FactoryGirl.create(:user, :userid => "user1", :miq_groups => [@group1])
 
-      @idents2 = ["everything"]
-      @role2   = FactoryGirl.create(:miq_user_role, :name => "Role2", :miq_product_features => MiqProductFeature.find_all_by_identifier(@idents2))
+      feature2 = MiqProductFeature.find_all_by_identifier("everything")
+      @role2   = FactoryGirl.create(:miq_user_role, :name => "Role2", :miq_product_features => feature2)
       @group2  = FactoryGirl.create(:miq_group, :description => "Group2", :miq_user_role => @role2)
       @user2   = FactoryGirl.create(:user, :userid => "user2", :miq_groups => [@group2])
 
-      @idents3 = ["host_show_list", "host_scan", "host_edit"]
-      @role3   = FactoryGirl.create(:miq_user_role, :name => "Role3", :miq_product_features => MiqProductFeature.find_all_by_identifier(@idents3))
+      feature3 = MiqProductFeature.find_all_by_identifier(%w(host_show_list host_scan host_edit))
+      @role3   = FactoryGirl.create(:miq_user_role, :name => "Role3", :miq_product_features => feature3)
       @group3  = FactoryGirl.create(:miq_group, :description => "Group3", :miq_user_role => @role3)
       @user3   = FactoryGirl.create(:user, :userid => "user3", :miq_groups => [@group3])
     end

--- a/vmdb/spec/models/miq_widget_spec.rb
+++ b/vmdb/spec/models/miq_widget_spec.rb
@@ -14,13 +14,13 @@ describe MiqWidget do
     before(:each) do
       MiqReport.seed_report("Vendor and Guest OS")
 
-      @idents1 = ["dashboard_admin"]
-      @role1   = FactoryGirl.create(:miq_user_role, :name => "Role1", :miq_product_features => MiqProductFeature.find_all_by_identifier(@idents1))
+      feature1 = MiqProductFeature.find_all_by_identifier("dashboard_admin")
+      @role1   = FactoryGirl.create(:miq_user_role, :name => "Role1", :miq_product_features => feature1)
       @group1  = FactoryGirl.create(:miq_group, :miq_user_role => @role1)
       @user1   = FactoryGirl.create(:user, :miq_groups => [@group1], :name => "Administrator", :userid => "admin")
 
-      @idents2 = ["everything"]
-      @role2   = FactoryGirl.create(:miq_user_role, :name => "Role2", :miq_product_features => MiqProductFeature.find_all_by_identifier(@idents2))
+      feature2 = MiqProductFeature.find_all_by_identifier("everything")
+      @role2   = FactoryGirl.create(:miq_user_role, :name => "Role2", :miq_product_features => feature2)
       @group2  = FactoryGirl.create(:miq_group, :description => "Group2", :miq_user_role => @role2)
       @user2   = FactoryGirl.create(:user, :userid => "user2", :miq_groups => [@group2])
 


### PR DESCRIPTION
Fixes MiqProductFeature#find_all_by_identifier
```
DEPRECATION WARNING: This dynamic method is deprecated. Please use e.g. Post.where(...).all instead. (called from block (3 levels) in <top (required)> at /Users/kbrock/src/manageiq/vmdb/spec/models/miq_widget_spec.rb:18)
```