### PR TITLE
Setting User.current_user

### DIFF
--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -515,6 +515,7 @@ class DashboardController < ApplicationController
       end
     when :fail
       session[:userid], session[:username], session[:user_tags] = nil
+      User.current_user = nil
       add_flash(validation.flash_msg || "Error: Authentication failed", :error)
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
@@ -637,6 +638,7 @@ class DashboardController < ApplicationController
     user.logoff if user
 
     session.clear
+    User.current_user = nil
     session[:auto_login] = false
     redirect_to :action => 'login'
   end
@@ -713,8 +715,6 @@ class DashboardController < ApplicationController
 
     return nil if db_user.nil? || !db_user.userid
     session[:userid] = db_user.userid
-
-
     session[:username] = db_user.name
 
     # set group and role ids

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -708,11 +708,12 @@ class DashboardController < ApplicationController
     session[:winW]     = winw
     session['referer'] = referer
 
+    # Set the current user/userid in this thread for models to use
+    User.current_user = db_user
+
     return nil if db_user.nil? || !db_user.userid
     session[:userid] = db_user.userid
 
-    # Set the current userid in the User class for this thread for models to use
-    User.current_userid = session[:userid]
 
     session[:username] = db_user.name
 

--- a/vmdb/app/models/user.rb
+++ b/vmdb/app/models/user.rb
@@ -910,6 +910,11 @@ class User < ActiveRecord::Base
     Thread.current[:userid] = saved_userid
   end
 
+  def self.current_user=(user)
+    Thread.current[:user]   = user
+    Thread.current[:userid] = user.try(:userid)
+  end
+
   def self.current_userid=(userid)
     Thread.current[:user]   = nil
     Thread.current[:userid] = userid


### PR DESCRIPTION
Just nailing down. It has the potential to sneak by somewhere.

1. Instead of setting User.current_userid and then looking up the object again, just set the actual user value
2. make sure when we are clearing session[:userid] we are also clearing User.current_user

/cc @Fryguy @jrafanie 