### PR TITLE
Session user

### DIFF
--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -324,7 +324,7 @@ class ApplicationController < ActionController::Base
       if params[:col_widths]
         cws = params[:col_widths].split(",")[2..-1]
         if cws.length > 0
-          db_user = User.find_by_userid(session[:userid])
+          db_user = current_user
           if db_user != nil
             db_user.settings[:col_widths] ||= Hash.new                        # Create the col widths hash, if not there
             db_user.settings[:col_widths][cols_key] ||= Hash.new        # Create hash for the view db
@@ -965,7 +965,7 @@ class ApplicationController < ActionController::Base
     reports = Array.new
     folders = Array.new
     rec = MiqGroup.find_by_id(group)
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     @sb[:grp_title] = user.admin_user? ?
       "#{session[:customer_name]} (#{_("All %s") % ui_lookup(:models=>"MiqGroup")})" :
       "#{session[:customer_name]} (#{_("%s") % "#{ui_lookup(:model=>"MiqGroup")}: #{user.current_group.description}"})"
@@ -2605,7 +2605,7 @@ class ApplicationController < ActionController::Base
   end
 
   def find_filtered(db, count, options={})
-    user     = User.find_by_userid(session[:userid])
+    user     = current_user
     mfilters = user ? user.get_managed_filters   : []
     bfilters = user ? user.get_belongsto_filters : []
 
@@ -2621,8 +2621,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ruport_ize_filtered(report, options = {})
-    userid = session[:userid]
-    user = User.find_by_userid(userid)
+    user = current_user
     options[:tag_filters] = user ? user.get_filters   : []
     report.ruport_ize!(options)
   end
@@ -2723,7 +2722,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_gettext_locale
-    user_settings =  User.find_by_userid(session[:userid]).try(:settings)
+    user_settings =  current_user.try(:settings)
     user_locale = user_settings[:display][:locale] if user_settings &&
                                                  user_settings.key?(:display) &&
                                                  user_settings[:display].key?(:locale)

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -39,6 +39,7 @@ class ApplicationController < ActionController::Base
   include_concern 'Timelines'
   include_concern 'TreeSupport'
   include_concern 'SysprepAnswerFile'
+  include_concern 'CurrentUser'
 
   before_filter :get_global_session_data, :except => [:window_sizes, :authenticate]
   before_filter :set_user_time_zone

--- a/vmdb/app/controllers/application_controller.rb
+++ b/vmdb/app/controllers/application_controller.rb
@@ -324,8 +324,7 @@ class ApplicationController < ActionController::Base
       if params[:col_widths]
         cws = params[:col_widths].split(",")[2..-1]
         if cws.length > 0
-          db_user = current_user
-          if db_user != nil
+          if (db_user = current_user)
             db_user.settings[:col_widths] ||= Hash.new                        # Create the col widths hash, if not there
             db_user.settings[:col_widths][cols_key] ||= Hash.new        # Create hash for the view db
             @settings[:col_widths] ||= Hash.new                               # Create the col widths hash, if not there
@@ -334,8 +333,8 @@ class ApplicationController < ActionController::Base
               @settings[:col_widths][cols_key][@view.col_order[i]] = cw.to_i  # Save each cols width
             end
             db_user.settings[:col_widths][cols_key] = @settings[:col_widths][cols_key]
+            db_user.save
           end
-          db_user.save
         end
       end
     end
@@ -2621,8 +2620,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ruport_ize_filtered(report, options = {})
-    user = current_user
-    options[:tag_filters] = user ? user.get_filters   : []
+    options[:tag_filters] = current_user.try(:get_filters) || []
     report.ruport_ize!(options)
   end
 

--- a/vmdb/app/controllers/application_controller/current_user.rb
+++ b/vmdb/app/controllers/application_controller/current_user.rb
@@ -1,0 +1,77 @@
+module ApplicationController::CurrentUser
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_user,  :current_userid, :current_username
+    helper_method :current_group, :current_groupid, :current_group_description
+  end
+
+  def clear_current_user
+    self.current_user = nil
+  end
+  protected :clear_current_user
+
+  def current_user=(db_user)
+    if db_user
+      User.current_userid = db_user.userid
+      session[:userid]    = db_user.userid
+      session[:username]  = db_user.name
+    else
+      User.current_userid = nil
+      session[:userid]    = nil
+      session[:username]  = nil
+    end
+  end
+  protected :current_user=
+
+  def current_group=(db_group)
+    session[:group] = db_group.try(:id)
+    session[:group_description] = db_group.try(:description)
+
+    role = db_group.try(:miq_user_role)
+
+    session[:role] = role.try(:id)
+    # Build pre-sprint 69 role name if this is an EvmRole read_only role
+    session[:userrole] = role.try(:read_only?) ? role.name.split("-").last : ""
+  end
+  protected :current_group=
+
+  def current_user
+    User.find_by_userid(session[:userid])
+  end
+  protected :current_user
+
+  def current_userid
+    session[:userid]
+  end
+  protected :current_userid
+
+  def current_username
+    session[:username]
+  end
+  protected :current_username
+
+  def current_group
+    MiqGroup.find_by_id(session[:group])
+  end
+
+  def current_groupid
+    session[:group]
+  end
+  protected :current_groupid
+
+  def current_group_description
+    session[:group_description]
+  end
+  protected :current_group_description
+
+  def current_role
+    session[:role]
+  end
+  protected :current_role
+
+  def current_userrole
+    session[:userrole]
+  end
+  protected :current_userrole
+end

--- a/vmdb/app/controllers/application_controller/explorer.rb
+++ b/vmdb/app/controllers/application_controller/explorer.rb
@@ -37,7 +37,7 @@ module ApplicationController::Explorer
 
     if params.key?(:width)
       # Store the new settings in the user record and in @settings (session)
-      db_user = User.find_by_userid(session[:userid])
+      db_user = current_user
       unless db_user.nil?
         db_user.settings[:explorer] ||= {}
         db_user.settings[:explorer][params[:controller]] ||= {}
@@ -449,7 +449,7 @@ module ApplicationController::Explorer
       end
       return objects
     when :roles
-      user = User.find_by_userid(session[:userid])
+      user = current_user
       if user.super_admin_user?
         roles = MiqGroup.all
       else
@@ -512,7 +512,7 @@ module ApplicationController::Explorer
     when :savedreports
       # Saving the unique folder id's that hold reports under them, to use them in view to generate link
       @sb[:folder_ids] = Hash.new
-      u = User.find_by_userid(session[:userid])
+      u = current_user
       g = u.admin_user? ? nil : session[:group]
       MiqReport.having_report_results(:miq_group => g, :select => [:id, :name]).each do |r|
         @sb[:folder_ids][r.name] = to_cid(r.id.to_i)

--- a/vmdb/app/controllers/application_controller/explorer.rb
+++ b/vmdb/app/controllers/application_controller/explorer.rb
@@ -512,8 +512,7 @@ module ApplicationController::Explorer
     when :savedreports
       # Saving the unique folder id's that hold reports under them, to use them in view to generate link
       @sb[:folder_ids] = Hash.new
-      u = current_user
-      g = u.admin_user? ? nil : session[:group]
+      g = current_user.admin_user? ? nil : session[:group]
       MiqReport.having_report_results(:miq_group => g, :select => [:id, :name]).each do |r|
         @sb[:folder_ids][r.name] = to_cid(r.id.to_i)
       end

--- a/vmdb/app/controllers/application_controller/filter.rb
+++ b/vmdb/app/controllers/application_controller/filter.rb
@@ -704,7 +704,7 @@ module ApplicationController::Filter
         if @settings[:default_search] && @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym] # See if a default search exists
           def_search = @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym]
           if id.to_i == def_search.to_i
-            db_user = User.find_by_userid(session[:userid])
+            db_user = current_user
             db_user.settings[:default_search].delete(@edit[@expkey][:exp_model].to_s.to_sym)
             db_user.save
             @edit[:adv_search_applied] = nil          # clearing up applied search results
@@ -909,7 +909,7 @@ module ApplicationController::Filter
         end
       end
       if @flash_array.blank?
-        db_user = User.find_by_userid(session[:userid])
+        db_user = current_user
         if db_user != nil
           db_user.settings[:default_search] ||= Hash.new                        # Create the col widths hash, if not there
           db_user.settings[:default_search][cols_key] ||= Hash.new        # Create hash for the view db
@@ -1734,7 +1734,7 @@ module ApplicationController::Filter
   end
 
   def build_listnav_search_list(db)
-    @settings[:default_search] = User.find_by_userid(session[:userid]).settings[:default_search]  # Get the user's default search settings again, incase default search was deleted
+    @settings[:default_search] = current_user.settings[:default_search]  # Get the user's default search settings again, incase default search was deleted
     @default_search = MiqSearch.find(@settings[:default_search][db.to_sym].to_s) if @settings[:default_search] && @settings[:default_search][db.to_sym] && @settings[:default_search][db.to_sym] != 0 && MiqSearch.exists?(@settings[:default_search][db.to_sym])
     temp = MiqSearch.new
     temp.description = "ALL"

--- a/vmdb/app/controllers/application_controller/policy_support.rb
+++ b/vmdb/app/controllers/application_controller/policy_support.rb
@@ -226,8 +226,7 @@ module ApplicationController::PolicySupport
   def assigned_filters
     assigned_filters = Array.new
     #adding assigned filters for a user into hash to display categories bold and gray out subcategory if checked
-    @get_filters = [current_user.get_managed_filters]
-    @get_filters = @get_filters.flatten
+    @get_filters = [current_user.get_managed_filters].flatten
     h = Hash[*@get_filters.collect { |v| [@get_filters.index(v), v] }.flatten]
     @get_filters = h.invert
     h.invert.each do | val, key |

--- a/vmdb/app/controllers/application_controller/policy_support.rb
+++ b/vmdb/app/controllers/application_controller/policy_support.rb
@@ -226,7 +226,7 @@ module ApplicationController::PolicySupport
   def assigned_filters
     assigned_filters = Array.new
     #adding assigned filters for a user into hash to display categories bold and gray out subcategory if checked
-    @get_filters = [User.find_by_userid(session[:userid]).get_managed_filters]
+    @get_filters = [current_user.get_managed_filters]
     @get_filters = @get_filters.flatten
     h = Hash[*@get_filters.collect { |v| [@get_filters.index(v), v] }.flatten]
     @get_filters = h.invert

--- a/vmdb/app/controllers/configuration_controller.rb
+++ b/vmdb/app/controllers/configuration_controller.rb
@@ -242,7 +242,7 @@ class ConfigurationController < ApplicationController
         # Remove any old settings hashes *****************************
         @settings[:display].delete(:pres_mode)                    # :pres_mode replaced by :theme
 
-        db_user = User.find_by_userid(session[:userid])
+        db_user = current_user
         unless db_user.nil?                                       # Only if userid is in the DB
           db_user.settings = db_user.settings == nil ? @settings : db_user.settings.merge(@settings)  # Create or merge the settings into the db
           # Remove any old settings hashes *****************************
@@ -277,7 +277,7 @@ class ConfigurationController < ApplicationController
         @settings[:views].delete(:vm_summary_cool)                # :views/:vm_summary_cool changed to :dashboards
         @settings[:views].delete(:dashboards)                    # :dashboards is obsolete now
 
-        db_user = User.find_by_userid(session[:userid])
+        db_user = current_user
         unless db_user.nil?                                       # Only if userid is in the DB
           db_user.settings = db_user.settings == nil ? @settings : db_user.settings.merge(@settings)  # Create or merge the settings into the db
           # Remove any old settings hashes *****************************
@@ -729,7 +729,7 @@ class ConfigurationController < ApplicationController
                   }
 
   def merge_in_user_settings(settings)
-    db_user = User.find_by_userid(session[:userid])
+    db_user = current_user
     if db_user.try(:settings)
       settings.each do |key, value|
         value.merge!(db_user.settings[key]) unless db_user.settings[key].nil?

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -514,7 +514,8 @@ class DashboardController < ApplicationController
         page.redirect_to(validation.url)
       end
     when :fail
-      session[:userid], session[:username], session[:user_tags] = nil
+      self.current_user = nil
+      session[:user_tags] = nil
       add_flash(validation.flash_msg || "Error: Authentication failed", :error)
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -633,7 +633,7 @@ class DashboardController < ApplicationController
   end
 
   def logout
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     user.logoff if user
 
     session.clear
@@ -644,7 +644,7 @@ class DashboardController < ApplicationController
   # User request to change to a different eligible group
   def change_group
     # Get the user and new group and set current_group in the user record
-    db_user = User.find_by_userid(session[:userid])
+    db_user = current_user
     to_group = MiqGroup.find_by_id(params[:to_group])
     db_user.current_group = to_group
     db_user.save

--- a/vmdb/app/controllers/miq_request_controller.rb
+++ b/vmdb/app/controllers/miq_request_controller.rb
@@ -141,8 +141,9 @@ class MiqRequestController < ApplicationController
       gv_options = {:filter=>prov_condition(@sb[:def_prov_options][resource_type.to_sym])}
       @view, @pages = get_view(kls, gv_options) # Get view and paginator, based on the selected options
     else
-      requester = current_user
-      gv_options = {:filter=>prov_condition({:resource_type=>resource_type, :time_period=>time_period, :requester_id=>requester ? requester.id : nil})}
+      gv_options = {:filter => prov_condition(:resource_type => resource_type,
+                                              :time_period   => time_period,
+                                              :requester_id  => current_user.try(:id))}
       @view, @pages = get_view(kls, gv_options)     # Get requests for this user
     end
     @sb[:prov_options] ||= Hash.new
@@ -418,8 +419,7 @@ class MiqRequestController < ApplicationController
     cond = [{"AFTER" => {"value" => "#{opts[:time_period].to_i} Days Ago", "field" => "MiqRequest-created_on"}}]  # Start with setting time
 
     if !is_approver
-      requester = current_user
-      cond.push("=" => {"value" => requester.try(:id), "field" => "MiqRequest-requester_id"})
+      cond.push("=" => {"value" => current_user.try(:id), "field" => "MiqRequest-requester_id"})
     end
 
     if opts[:user_choice] && opts[:user_choice] != "all"
@@ -498,6 +498,7 @@ class MiqRequestController < ApplicationController
   end
 
   def is_approver
+    # TODO: this should be current_user
     User.current_user.role_allows?(:identifier => 'miq_request_approval')
   end
 

--- a/vmdb/app/controllers/miq_request_controller.rb
+++ b/vmdb/app/controllers/miq_request_controller.rb
@@ -141,7 +141,7 @@ class MiqRequestController < ApplicationController
       gv_options = {:filter=>prov_condition(@sb[:def_prov_options][resource_type.to_sym])}
       @view, @pages = get_view(kls, gv_options) # Get view and paginator, based on the selected options
     else
-      requester = User.find_by_userid(session[:userid])
+      requester = current_user
       gv_options = {:filter=>prov_condition({:resource_type=>resource_type, :time_period=>time_period, :requester_id=>requester ? requester.id : nil})}
       @view, @pages = get_view(kls, gv_options)     # Get requests for this user
     end
@@ -418,7 +418,7 @@ class MiqRequestController < ApplicationController
     cond = [{"AFTER" => {"value" => "#{opts[:time_period].to_i} Days Ago", "field" => "MiqRequest-created_on"}}]  # Start with setting time
 
     if !is_approver
-      requester = User.find_by_userid(session[:userid])
+      requester = current_user
       cond.push("=" => {"value" => requester.try(:id), "field" => "MiqRequest-requester_id"})
     end
 

--- a/vmdb/app/controllers/report_controller.rb
+++ b/vmdb/app/controllers/report_controller.rb
@@ -564,7 +564,7 @@ class ReportController < ApplicationController
     @changed = session[:changed] = true
     @in_a_form = true
     @export_reports = Hash.new
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     MiqReport.all.each do |rep|
       if rep.rpt_type == "Custom" && (user.admin_user? || (rep.miq_group && rep.miq_group.id == user.current_group.id))
         @export_reports[rep.name] = rep.id

--- a/vmdb/app/controllers/report_controller/menus.rb
+++ b/vmdb/app/controllers/report_controller/menus.rb
@@ -260,7 +260,7 @@ module ReportController::Menus
   def edit_reports
     @edit[:selected_reports] = Array.new
     @edit[:available_reports] = Array.new
-    user = current_user
+    current_group_id = current_user.current_group.try(:id).to_i
     id = session[:node_selected].split('__')
     @selected = id[1].split(':')
     all = MiqReport.all.sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
@@ -286,7 +286,7 @@ module ReportController::Menus
                   if rep.class == Array
                     rep.each do |r|
                       report = MiqReport.find_by_name(r.strip)
-                      r_name = (@edit[:user_typ] || report.miq_group_id.to_i == user.current_group.id.to_i) ? r : "* #{r}"
+                      r_name = (@edit[:user_typ] || report.miq_group_id.to_i == current_group_id) ? r : "* #{r}"
                       @selected_reports.push(r_name)
                     end
                   end
@@ -321,7 +321,7 @@ module ReportController::Menus
     @all_reports.each do |rep|
       if !@assigned_reports.include?(rep)
         r = MiqReport.find_by_name(rep.strip)
-        @available_reports.push(rep) if @edit[:user_typ] || r.miq_group_id.to_i == user.current_group.id.to_i
+        @available_reports.push(rep) if @edit[:user_typ] || r.miq_group_id.to_i == current_group_id
       end
     end
 
@@ -764,8 +764,7 @@ module ReportController::Menus
     x_tree_init(name, type, "MiqUserRole", :open_all => true)
     tree_nodes = x_build_dynatree(x_tree(name))
 
-    user = current_user
-    if user.super_admin_user?
+    if current_user.super_admin_user?
       title  = "All #{ui_lookup(:models=>"MiqGroup")}"
     else
       title  = "My #{ui_lookup(:model=>"MiqGroup")}"
@@ -786,7 +785,7 @@ module ReportController::Menus
       title  = "All #{ui_lookup(:models=>"MiqGroup")}"
     else
       title  = "My #{ui_lookup(:model=>"MiqGroup")}"
-      roles = [MiqGroup.find_by_id(user.current_group_id)]
+      roles = [user.current_group]
     end
     return roles,title
   end

--- a/vmdb/app/controllers/report_controller/menus.rb
+++ b/vmdb/app/controllers/report_controller/menus.rb
@@ -260,7 +260,7 @@ module ReportController::Menus
   def edit_reports
     @edit[:selected_reports] = Array.new
     @edit[:available_reports] = Array.new
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     id = session[:node_selected].split('__')
     @selected = id[1].split(':')
     all = MiqReport.all.sort_by { |r| [r.rpt_type, r.filename.to_s, r.name] }
@@ -454,7 +454,7 @@ module ReportController::Menus
       add_flash(_("No %s were selected to move right") % "fields", :error)
       return
     else
-      user = User.find_by_userid(session[:userid])
+      user = current_user
       flg = 0
       @edit[:selected_reports].each do |nf|               # Go thru all new fields
         if params[:selected_reports].include?(nf)         # See if this col was selected to move
@@ -616,7 +616,7 @@ module ReportController::Menus
     @edit[:form_vars] = Hash.new
     @edit[:current] = Array.new
     @edit[:new] = @rpt_menu if !@rpt_menu.nil?
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     @edit[:user_typ] = user.admin_user?
     @edit[:user_group] = user.current_group.id
     @edit[:group_reports] = Array.new
@@ -764,7 +764,7 @@ module ReportController::Menus
     x_tree_init(name, type, "MiqUserRole", :open_all => true)
     tree_nodes = x_build_dynatree(x_tree(name))
 
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     if user.super_admin_user?
       title  = "All #{ui_lookup(:models=>"MiqGroup")}"
     else
@@ -780,7 +780,7 @@ module ReportController::Menus
   end
 
   def get_group_roles
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     if user.super_admin_user?
       roles = MiqGroup.all
       title  = "All #{ui_lookup(:models=>"MiqGroup")}"

--- a/vmdb/app/controllers/report_controller/reports/editor.rb
+++ b/vmdb/app/controllers/report_controller/reports/editor.rb
@@ -1357,7 +1357,7 @@ module ReportController::Reports::Editor
       rpt.rpt_options[:summary][:hide_detail_rows] = @edit[:new][:hide_details]
     end
 
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     rpt.user = user
     rpt.miq_group = user.current_group
   end
@@ -1527,7 +1527,7 @@ module ReportController::Reports::Editor
     else
       @edit[:new][:cb_show_typ] = "owner"
       @edit[:new][:cb_owner_id] = session[:userid]
-      @edit[:cb_owner_name] = User.find_by_userid(session[:userid]).name
+      @edit[:cb_owner_name] = current_user.name
     end
 
     # Get chargeback tags

--- a/vmdb/app/controllers/report_controller/saved_reports.rb
+++ b/vmdb/app/controllers/report_controller/saved_reports.rb
@@ -24,7 +24,7 @@ module ReportController::SavedReports
       return
     end
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name=>"#{rr.name} - #{format_timezone(rr.created_on,Time.zone,"gt")}", :model=>"Saved Report"}
-    user = User.find_by_userid(session[:userid])
+    user = current_user
     if user.admin_user? || rr.miq_group_id == session[:group]
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime] = rr.last_run_on
@@ -158,7 +158,7 @@ module ReportController::SavedReports
   end
 
   def set_saved_reports_condition(rep_id=nil)
-    u = User.find_by_userid(session[:userid])
+    u = current_user
     cond = Array.new
 
     # Replaced this code as all saved, requested, scheduled reports have miq_report_id set, others don't

--- a/vmdb/app/controllers/report_controller/saved_reports.rb
+++ b/vmdb/app/controllers/report_controller/saved_reports.rb
@@ -24,8 +24,7 @@ module ReportController::SavedReports
       return
     end
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name=>"#{rr.name} - #{format_timezone(rr.created_on,Time.zone,"gt")}", :model=>"Saved Report"}
-    user = current_user
-    if user.admin_user? || rr.miq_group_id == session[:group]
+    if current_user.admin_user? || rr.miq_group_id == session[:group]
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime] = rr.last_run_on
       task = MiqTask.find_by_id(rr.miq_task_id)
@@ -158,7 +157,6 @@ module ReportController::SavedReports
   end
 
   def set_saved_reports_condition(rep_id=nil)
-    u = current_user
     cond = Array.new
 
     # Replaced this code as all saved, requested, scheduled reports have miq_report_id set, others don't
@@ -175,7 +173,7 @@ module ReportController::SavedReports
     end
 
     # Admin users can see all saved reports
-    unless u.admin_user?
+    unless current_user.admin_user?
       cond[0] << " AND miq_group_id=?"
       cond.push(session[:group])
     end

--- a/vmdb/app/services/user_validation_service.rb
+++ b/vmdb/app/services/user_validation_service.rb
@@ -4,7 +4,7 @@ class UserValidationService
   end
 
   extend Forwardable
-  delegate [:session, :url_for, :initiate_wait_for_task, :session_init,
+  delegate [:session, :url_for, :initiate_wait_for_task, :session_init, :current_userid=,
             :session_reset, :get_vmdb_config, :start_url_for_user] => :@controller
 
   ValidateResult = Struct.new(:result, :flash_msg, :url)
@@ -21,8 +21,8 @@ class UserValidationService
     end
 
     unless user[:name]
-      session[:userid], session[:username], session[:user_tags] = nil
-      User.current_userid = nil
+      self.current_userid = nil
+      session[:user_tags] = nil
       return ValidateResult.new(:fail, @flash_msg ||= "Error: Authentication failed")
     end
 


### PR DESCRIPTION
A number of places know the intimate details of `session[:userid]` and `session[:username]` and
`User.current_user` (a thread local variable accessible to models).

This PR tries to move us towards a single way of accessing the currently logged in user, namely `current_user`. This will be accessible from controllers and views.

This change will allow us to change our tests to use a common test helper `login_as`, and setup the 'currently logged in user' consistently. (some tests set `User.current_user` while others set various `session` variables)

Even while introducing this PR, I was surprised that a number of places were not setting up the `session`. The goal is to make this consistent so we can build upon the current user and current tenant in multi-tenancy.

---

part of #3170