### PR TITLE
Add rack-cache dependency to Gemfile

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -78,6 +78,7 @@ gem "snmp",                           "~>1.1.0",      :require => false
 gem "uglifier",                       "~>2.4.0",      :require => false
 gem "novnc-rails",                    "~>0.2"
 gem 'spice-html5-rails'
+gem 'rack-cache'
 
 ### Start of gems excluded from the appliances.
 # The gems listed below do not need to be packaged until we find it necessary or useful.


### PR DESCRIPTION
ActionPack 4+ does not depend on rack-cache but it is included
in vmdb/config/environments/production.rb resulting in the following error:

```
/opt/rubies/ruby-2.0.0-p645/lib/ruby/gems/2.0.0/bundler/gems/rails-07c6433ba9e2/activesupport/lib/active_support/dependencies.rb:274:in `require': cannot load such file -- rack/cache (LoadError)
	from /opt/rubies/ruby-2.0.0-p645/lib/ruby/gems/2.0.0/bundler/gems/rails-07c6433ba9e2/activesupport/lib/active_support/dependencies.rb:274:in `block in require'
	from /opt/rubies/ruby-2.0.0-p645/lib/ruby/gems/2.0.0/bundler/gems/rails-07c6433ba9e2/activesupport/lib/active_support/dependencies.rb:240:in `load_dependency'
	from /opt/rubies/ruby-2.0.0-p645/lib/ruby/gems/2.0.0/bundler/gems/rails-07c6433ba9e2/activesupport/lib/active_support/dependencies.rb:274:in `require'
	from /var/www/miq/vmdb/config/environments/production.rb:78:in `block in <top (required)>'
```