### PR TITLE
Fix for Double Render error in Foreman Explorer

### DIFF
--- a/vmdb/app/controllers/provider_foreman_controller.rb
+++ b/vmdb/app/controllers/provider_foreman_controller.rb
@@ -242,6 +242,7 @@ class ProviderForemanController < ApplicationController
   def load_or_clear_adv_search
     adv_search_build("ConfiguredSystem")
     session[:edit] = @edit
+    @explorer = true
 
     if x_tree[:type] != :filter || x_node == "root"
       listnav_search_selected(0)

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -260,6 +260,25 @@ describe ProviderForemanController do
     expect(response.status).to eq(200)
   end
 
+  it "renders tree_select as js" do
+    controller.send(:build_foreman_tree, :providers, :foreman_providers_tree)
+
+    controller.stub(:process_show_list)
+    controller.stub(:add_unassigned_configuration_profile_record)
+    controller.stub(:replace_explorer_trees)
+    controller.stub(:build_listnav_search_list)
+    controller.stub(:rebuild_toolbars)
+    controller.stub(:replace_search_box)
+    controller.stub(:update_partials)
+
+    EvmSpecHelper.create_guid_miq_server_zone
+    set_user_privileges
+
+    key = ems_key_for_provider(@provider)
+    post :tree_select, :id => key, :format => :js
+    expect(response.status).to eq(200)
+  end
+
   def find_treenode_for_provider(provider)
     key =  ems_key_for_provider(provider)
     tree =  JSON.parse(controller.instance_variable_get(:@foreman_providers_tree))


### PR DESCRIPTION
In the absence of ```@explorer```, 
https://github.com/ManageIQ/manageiq/blob/master/vmdb/app/controllers/application_controller/filter.rb#L496
causes an extra render to occur during the ```tree_select``` and ```accordion_select``` actions, thereby causing a double render error

(For some reason, this did not seem to be an issue in Rails 3.2.17)