### PR TITLE
Remove a use of actionwebservice struct

### DIFF
--- a/vmdb/app/models/miq_host_provision_workflow.rb
+++ b/vmdb/app/models/miq_host_provision_workflow.rb
@@ -216,9 +216,9 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   def self.from_ws(*args)
     version = args.first.to_f
 
-    # Move optional arguments into the VmdbwsSupport::ProvisionOptions object
+    # Move optional arguments into the MiqHashStruct object
     prov_args = args[0,6]
-    prov_options = VmdbwsSupport::ProvisionOptions.new(:values => args[6], :ems_custom_attributes => args[7], :miq_custom_attributes => args[8])
+    prov_options = MiqHashStruct.new(:values => args[6], :ems_custom_attributes => args[7], :miq_custom_attributes => args[8])
     prov_args << prov_options
     MiqHostProvisionWorkflow.from_ws_ver_1_x(*prov_args)
   end
@@ -230,7 +230,7 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   def self.from_ws_ver_1_x(version, userid, template_fields, vm_fields, requester, tags, options)
     log_header = "#{self.class.name}.from_ws"
     begin
-      options = VmdbwsSupport::ProvisionOptions.new if options.nil?
+      options = MiqHashStruct.new if options.nil?
       $log.warn "#{log_header} Web-service host provisioning starting with interface version <#{version}> by requester <#{userid}>"
 
       init_options = {:use_pre_dialog => false, :request_type => self.request_type(parse_ws_string(template_fields)[:request_type])}

--- a/vmdb/app/models/miq_provision_virt_workflow.rb
+++ b/vmdb/app/models/miq_provision_virt_workflow.rb
@@ -1007,8 +1007,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     version = args.first.to_f
     return from_ws_ver_1_0(*args) if version == 1.0
 
-    # Move optional arguments into the VmdbwsSupport::ProvisionOptions object
-    prov_options = VmdbwsSupport::ProvisionOptions.new(
+    # Move optional arguments into the MiqHashStruct object
+    prov_options = MiqHashStruct.new(
       :values                => args[6],
       :ems_custom_attributes => args[7],
       :miq_custom_attributes => args[8],
@@ -1231,7 +1231,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def self.from_ws_ver_1_x(version, userid, template_fields, vm_fields, requester, tags, options)
-    options = VmdbwsSupport::ProvisionOptions.new if options.nil?
+    options = MiqHashStruct.new if options.nil?
     log_header = "#{name}.from_ws_ver_1_x"
     $log.warn "#{log_header} Web-service provisioning starting with interface version <#{version}> by requester <#{userid}>"
 

--- a/vmdb/spec/apis/vmdbws_provisioning_spec.rb
+++ b/vmdb/spec/apis/vmdbws_provisioning_spec.rb
@@ -79,7 +79,7 @@ describe VmdbwsController, :apis => true do
 
     it "should create an MiqProvisionRequest when calling WS version 2.0 with a ProvisionOptions object" do
       params = @params[0,5]
-      params << VmdbwsSupport::ProvisionOptions.new(:values => @params[5], :ems_custom_attributes => @params[6], :miq_custom_attributes => @params[7])
+      params << MiqHashStruct.new(:values => @params[5], :ems_custom_attributes => @params[6], :miq_custom_attributes => @params[7])
       req = invoke(:VmProvisionRequest, *params)
       req.should be_an_instance_of(VmdbwsSupport::ProxyMiqProvisionRequest)
       req.approval_state.should == 'pending_approval'
@@ -104,7 +104,7 @@ describe VmdbwsController, :apis => true do
         )
 
         params = @params[0,5]
-        params << VmdbwsSupport::ProvisionOptions.new(:values => @params[5], :ems_custom_attributes => @params[6], :miq_custom_attributes => @params[7])
+        params << MiqHashStruct.new(:values => @params[5], :ems_custom_attributes => @params[6], :miq_custom_attributes => @params[7])
         @proxy_request = invoke(:VmProvisionRequest, *params)
         @miq_request = MiqRequest.find_by_id(@proxy_request.id)
 

--- a/vmdb/spec/models/miq_host_provision_workflow_spec.rb
+++ b/vmdb/spec/models/miq_host_provision_workflow_spec.rb
@@ -36,7 +36,6 @@ describe MiqHostProvisionWorkflow do
 
       context "Without a Valid IPMI Host," do
         it "should not create an MiqRequest when calling from_ws" do
-          pending "requires actionwebservice"
           lambda { MiqHostProvisionWorkflow.from_ws("1.1", "admin", @templateFields, @hostFields, @requester, false, nil, nil)}.should raise_error(RuntimeError)
         end
       end
@@ -50,7 +49,6 @@ describe MiqHostProvisionWorkflow do
         end
 
         it "should create an MiqRequest when calling from_ws" do
-          pending "requires actionwebservice"
           request = MiqHostProvisionWorkflow.from_ws("1.1", "admin", @templateFields, @hostFields, @requester, false, nil, nil)
           request.should be_a_kind_of(MiqRequest)
           opt = request.options

--- a/vmdb/spec/models/miq_provision_workflow_spec.rb
+++ b/vmdb/spec/models/miq_provision_workflow_spec.rb
@@ -48,7 +48,6 @@ describe MiqProvisionWorkflow do
 
         it "should encrypt fields" do
           password_input = "secret"
-          pending "requires actionwebservice"
           request = MiqProvisionVmwareWorkflow.from_ws("1.1", "admin", "name=template", "vm_name=spec_test|root_password=#{password_input}",
                                                        "owner_email=admin|owner_first_name=test|owner_last_name=test", nil, nil, nil, nil)
 

--- a/vmdb/spec/requests/api/providers_spec.rb
+++ b/vmdb/spec/requests/api/providers_spec.rb
@@ -94,8 +94,6 @@ describe ApiController do
     end
 
     it "supports single provider creation" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:providers, :create)
 
       run_post(providers_url, sample_rhevm)
@@ -109,8 +107,6 @@ describe ApiController do
     end
 
     it "supports single provider creation via action" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:providers, :create)
 
       run_post(providers_url, gen_request(:create, sample_rhevm))
@@ -140,8 +136,6 @@ describe ApiController do
     end
 
     it "supports single provider creation with compound credentials" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:providers, :create)
 
       run_post(providers_url, sample_rhevm.merge("credentials" => compound_credentials))
@@ -160,8 +154,6 @@ describe ApiController do
     end
 
     it "supports multiple provider creation" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:providers, :create)
 
       run_post(providers_url, gen_request(:create, [sample_vmware, sample_rhevm]))

--- a/vmdb/spec/requests/api/providers_spec.rb
+++ b/vmdb/spec/requests/api/providers_spec.rb
@@ -33,7 +33,7 @@ describe ApiController do
     {
       "type"      => "EmsRedhat",
       "name"      => "sample rhevm",
-      "port"      => 5000,
+      "port"      => "5000",
       "hostname"  => "sample_rhevm.provider.com",
       "ipaddress" => "100.200.300.2"
     }

--- a/vmdb/spec/requests/api/provision_requests_spec.rb
+++ b/vmdb/spec/requests/api/provision_requests_spec.rb
@@ -64,8 +64,6 @@ describe ApiController do
     end
 
     it "supports single request with normal post" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
       dialog  # Create the Provisioning dialog
@@ -80,8 +78,6 @@ describe ApiController do
     end
 
     it "supports single request with create action" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
       dialog  # Create the Provisioning dialog
@@ -96,8 +92,6 @@ describe ApiController do
     end
 
     it "supports multiple requests" do
-      pending "requires actionwebservice"
-
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
       dialog  # Create the Provisioning dialog

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -55,7 +55,6 @@ RSpec.configure do |config|
   config.include MigrationSpecHelper, :migrations => :up
   config.include MigrationSpecHelper, :migrations => :down
 
-  config.include ActionWebServiceInvokeHelper, :apis => true
   config.include ApiSpecHelper,                :type => :request, :rest_api => true, :example_group => {
     :file_path => config.escaped_path(%w(spec requests api))
   }


### PR DESCRIPTION
Some tests were marked as pending because we couldn't remove the AWS dependency.

This PR re-enables most of those tests by dropping the dependency:

* Remove use of VmdbwsSupport::ProvisionOptions (needs actionwebservice) in favor of MiqHashStruct.
* ext_management_systems port column is a string. :cry:
* Remove pending tests now that they can run without aws :tada:

Thanks @gmcculloug for the suggestion to use MiqHashStruct.
cc @matthewd 

@abellotti see the change from 5000 to "5000" in the test below.  I believe that's a rails 4.2 fix as the same change wasn't required against pre-rails 4.2.
