### PR TITLE
Fix .sort_by calls on collection proxies

### DIFF
--- a/vmdb/app/controllers/chargeback_controller.rb
+++ b/vmdb/app/controllers/chargeback_controller.rb
@@ -228,7 +228,7 @@ class ChargebackController < ApplicationController
       else
         session[:changed] = false
         @sb[:rate] = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(obj[0])
-        @sb[:rate_details] = @sb[:rate].chargeback_rate_details
+        @sb[:rate_details] = @sb[:rate].chargeback_rate_details.to_a
         if @sb[:rate_details].blank?
           fixture_file = File.join(@@fixture_dir, "chargeback_rates.yml")
           if File.exist?(fixture_file)
@@ -276,7 +276,7 @@ class ChargebackController < ApplicationController
 
   def cb_rate_show
     @display = "main"
-    @sb[:selected_rate_details] = @record.chargeback_rate_details
+    @sb[:selected_rate_details] = @record.chargeback_rate_details.to_a
     @sb[:selected_rate_details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
     if @record == nil
       redirect_to :action=>"cb_rates_list", :flash_msg=>_("Error: Record no longer exists in the database"), :flash_error=>true

--- a/vmdb/app/controllers/report_controller/dashboards.rb
+++ b/vmdb/app/controllers/report_controller/dashboards.rb
@@ -404,10 +404,10 @@ module ReportController::Dashboards
                   @edit[:new][:col3]
     if @sb[:nodes].length == 2 && @sb[:nodes][1] != "g"
       #default dashboard selected
-      @available_widgets = MiqWidget.available_for_all_roles
+      @available_widgets = MiqWidget.available_for_all_roles.to_a
     else
       g = MiqGroup.find(from_cid(@sb[:nodes][2].split('_').first))
-      @available_widgets = MiqWidget.available_for_group(g)
+      @available_widgets = MiqWidget.available_for_group(g).to_a
     end
     @available_widgets.sort_by! { |w| [w.content_type, w.title.downcase] }
 


### PR DESCRIPTION
@matthewd Please review.
@GregP This should fix your problem.

@dclarizio @h-kataria You're going to have to fix one more set [here](https://github.com/ManageIQ/manageiq/blob/d5e05fdb2238c97621ff2a59691956b3cb5f80de/vmdb/app/controllers/miq_ae_class_controller.rb#L835) and [here](https://github.com/ManageIQ/manageiq/blob/d5e05fdb2238c97621ff2a59691956b3cb5f80de/vmdb/app/controllers/miq_ae_class_controller.rb#L842).  That method is pretty nasty anyway cause it could sort the array like 20 times in a row, when once is enough.  Probably better to just set a variable if you should sort it, and then act on that variable elsewhere like in the view.  Or, perhaps you can just always sort by the priority?  I'm not sure why the code selectively sorts.
