### PR TITLE
Use new activerecord 4 'references' feature

### DIFF
--- a/vmdb/app/models/vm.rb
+++ b/vmdb/app/models/vm.rb
@@ -37,11 +37,13 @@ class Vm < VmOrTemplate
       conds[0] << "networks.hostname = ?"
       conds    << hostname
       include  << :networks
+      references << :networks
     end
     if ipaddress
       conds[0] << "networks.ipaddress = ?"
       conds    << ipaddress
       include  << :networks
+      references << :networks
     end
     conds[0] = "(#{conds[0].join(" AND ")})"
 

--- a/vmdb/app/models/vm.rb
+++ b/vmdb/app/models/vm.rb
@@ -25,11 +25,13 @@ class Vm < VmOrTemplate
     return [] if mac_address.nil? && hostname.nil? && ipaddress.nil?
 
     include = [:vm_or_template]
+    references = []
     conds = [["hardwares.vm_or_template_id IS NOT NULL"]]
     if mac_address
       conds[0] << "guest_devices.address = ?"
       conds    << mac_address
       include  << :nics
+      references << :guest_devices
     end
     if hostname
       conds[0] << "networks.hostname = ?"
@@ -43,7 +45,10 @@ class Vm < VmOrTemplate
     end
     conds[0] = "(#{conds[0].join(" AND ")})"
 
-    Hardware.includes(include.uniq).where(conds).collect { |h|  h.vm_or_template.kind_of?(Vm) ? h.vm_or_template : nil}.compact
+    Hardware.includes(include.uniq)
+            .references(references.uniq)
+            .where(conds)
+            .collect { |h|  h.vm_or_template.kind_of?(Vm) ? h.vm_or_template : nil}.compact
   end
 
   def running_processes

--- a/vmdb/spec/models/vm_spec.rb
+++ b/vmdb/spec/models/vm_spec.rb
@@ -57,6 +57,24 @@ describe Vm do
       expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(address, nil, nil))
         .to eql([@vm1])
     end
+
+    it "hostname" do
+      hostname = "ABCDEFG"
+      network = FactoryGirl.create(:network, :hostname => hostname)
+      @hardware1.networks << network
+
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, hostname, nil))
+        .to eql([@vm1])
+    end
+
+    it "ipaddress" do
+      ipaddress = "127.0.0.1"
+      network = FactoryGirl.create(:network, :ipaddress => ipaddress)
+      @hardware1.networks << network
+
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, nil, ipaddress))
+        .to eql([@vm1])
+    end
   end
 
   context "with relationships of multiple types" do

--- a/vmdb/spec/models/vm_spec.rb
+++ b/vmdb/spec/models/vm_spec.rb
@@ -40,6 +40,25 @@ describe Vm do
     lambda { vm.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
   end
 
+  context ".find_all_by_mac_address_and_hostname_and_ipaddress" do
+    before do
+      @hardware1 = FactoryGirl.create(:hardware)
+      @vm1 = FactoryGirl.create(:vm_vmware, :hardware => @hardware1)
+
+      @hardware2 = FactoryGirl.create(:hardware)
+      @vm2 = FactoryGirl.create(:vm_vmware, :hardware => @hardware2)
+    end
+
+    it "mac_address" do
+      address = "ABCDEFG"
+      guest_device = FactoryGirl.create(:guest_device, :address => address, :device_type => "ethernet")
+      @hardware1.guest_devices << guest_device
+
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(address, nil, nil))
+        .to eql([@vm1])
+    end
+  end
+
   context "with relationships of multiple types" do
     before(:each) do
       @rp        = FactoryGirl.create(:resource_pool, :name => "RP")


### PR DESCRIPTION
Fixes error occurring during startup sequence

```
/opt/rubies/ruby-2.0.0-p645/lib/ruby/gems/2.0.0/bundler/gems/rails-07c6433ba9e2/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:596:in `exec': PG::Error: ERROR:  missing FROM-clause entry for table "guest_devices" (ActiveRecord::StatementInvalid)
LINE 1: ...ERE ((hardwares.vm_or_template_id IS NOT NULL AND guest_devi...
                                                             ^
: SELECT "hardwares".* FROM "hardwares" WHERE ((hardwares.vm_or_template_id IS NOT NULL AND guest_devices.address = '52:54:00:45:FD:A4' AND networks.hostname = 'localhost.localdomain.localdomain' AND networks.ipaddress = '192.168.122.140'))

	from /var/www/miq/vmdb/app/models/vm.rb:47:in `find_all_by_mac_address_and_hostname_and_ipaddress'
	from /var/www/miq/vmdb/app/models/miq_server.rb:237:in `start'
	from /var/www/miq/vmdb/lib/workers/evm_server.rb:68:in `start'
```