### PR TITLE
Explicitly tell Active Record when referencing a table from a string with Rails 4.

### DIFF
--- a/vmdb/app/models/vm.rb
+++ b/vmdb/app/models/vm.rb
@@ -43,7 +43,8 @@ class Vm < VmOrTemplate
     end
     conds[0] = "(#{conds[0].join(" AND ")})"
 
-    Hardware.includes(include.uniq).where(conds).collect { |h|  h.vm_or_template.kind_of?(Vm) ? h.vm_or_template : nil}.compact
+    include.uniq!
+    Hardware.includes(include).where(conds).references(include).collect { |h|  h.vm_or_template.kind_of?(Vm) ? h.vm_or_template : nil}.compact
   end
 
   def running_processes


### PR DESCRIPTION
Fix the issue of PG::Error: ERROR:  missing FROM-clause entry for table "guest_devices" (ActiveRecord::StatementInvalid) when starting MIQ server.