### PR TITLE
Include jQuery before Angular

### DIFF
--- a/vmdb/app/assets/javascripts/application.js
+++ b/vmdb/app/assets/javascripts/application.js
@@ -1,6 +1,6 @@
-//= require angular
 //= require jquery
 //= require jquery_overrides
+//= require angular
 //= require miq_angular_application
 //= require services/miq_service
 //= require services/miq_db_backup_service


### PR DESCRIPTION
That way, angular.element(...) supports all jQuery selectors, instead of
the jqLite subset.