### PR TITLE
[WIP] MiqCalendar (miq-calendar) angular directive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "rails",                           RAILS_VERSION
 gem "activerecord-deprecated_finders", "~>1.0.4",     :require => "active_record/deprecated_finders"
 
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
-gem 'angularjs-rails', '=1.2.4'
-gem 'jquery-rails', "=2.2.2"
+gem 'angularjs-rails', '~>1.3.15'
+gem 'jquery-rails', "~>2.2.2"
 gem 'jquery-hotkeys-rails'
 gem 'codemirror-rails', "=4.2"
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require directives/checkchange
 //= require directives/verifypasswd
 //= require directives/repository/valid_unc_path
+//= require directives/miq_calendar
 //= require services/miq_service
 //= require services/timer_option_service
 //= require controllers/provider_foreman/provider_foreman_form_controller

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -14,7 +14,7 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
       name: '',
       timer_typ: '',
       timer_value: '',
-      miq_angular_date_1: '',
+      start_date: '',
       start_hour: '',
       start_min: '',
       time_zone: '',
@@ -26,6 +26,7 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
     $scope.formId = scheduleFormId;
     $scope.afterGet = false;
     $scope.modelCopy = angular.copy( $scope.scheduleModel );
+    $scope.oneMonthAgo = oneMonthAgo;
 
     miqAngularApplication.$scope = $scope;
 
@@ -35,15 +36,15 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
       $scope.scheduleModel.filter_typ          = 'all';
       $scope.scheduleModel.enabled             = '1';
       $scope.scheduleModel.filterValuesEmpty   = true;
-      var today                                 = new Date();
-      var tomorrowsDate                         = parseInt(today.getDate()) + 1;
-      $scope.scheduleModel.miq_angular_date_1  = today.getMonth() + 1 + "/" + tomorrowsDate + "/" + today.getFullYear();
+      var today                                = new Date();
+      var tomorrowsDate                        = parseInt(today.getDate()) + 1;
+      $scope.scheduleModel.start_date          = today.getMonth() + 1 + "/" + tomorrowsDate + "/" + today.getFullYear();
       $scope.scheduleModel.timer_typ           = 'Once';
       $scope.scheduleModel.time_zone           = 'UTC';
       $scope.scheduleModel.start_hour          = '0';
       $scope.scheduleModel.start_min           = '0';
-      $scope.afterGet                           = true;
-      $scope.modelCopy                          = angular.copy( $scope.scheduleModel );
+      $scope.afterGet                          = true;
+      $scope.modelCopy                         = angular.copy( $scope.scheduleModel );
     } else {
       $scope.newRecord = false;
 
@@ -62,7 +63,7 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
         $scope.scheduleModel.name               = data.schedule_name;
         $scope.scheduleModel.timer_typ          = data.schedule_timer_type;
         $scope.scheduleModel.timer_value        = data.schedule_timer_value;
-        $scope.scheduleModel.miq_angular_date_1 = data.schedule_start_date;
+        $scope.scheduleModel.start_date         = data.schedule_start_date;
         $scope.scheduleModel.start_hour         = data.schedule_start_hour;
         $scope.scheduleModel.start_min          = data.schedule_start_min;
         $scope.scheduleModel.time_zone          = data.schedule_time_zone;
@@ -90,8 +91,6 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
         miqService.sparkleOff();
       });
     }
-
-    miqService.buildCalendar(oneMonthAgo.year, parseInt(oneMonthAgo.month) + 1, oneMonthAgo.date);
 
     $scope.$watch("scheduleModel.name", function() {
       $scope.form = $scope.angularForm;
@@ -253,13 +252,6 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
 
   $scope.addClicked = function() {
     $scope.saveClicked();
-  };
-
-  $scope.triggerCheckChange = function(date) {
-    $scope.miq_angular_date_1 = date;
-    $scope.$apply(function() {
-      $scope.angularForm.miq_angular_date_1.$setViewValue($scope.miq_angular_date_1);
-    });
   };
 
   $scope.filterValueRequired = function(value) {

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -246,7 +246,7 @@ miqAngularApplication.controller('scheduleFormController', ['$http', '$scope', '
   };
 
   $scope.saveClicked = function() {
-    scheduleEditButtonClicked('save', true);
+    scheduleEditButtonClicked('save', $scope.scheduleModel);
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -33,6 +33,9 @@ miqAngularApplication.directive('checkchange', function() {
           if(scope.form[ctrl.$name].$pristine) {
             scope.form.$pristine = true;
             for (var name in scope.form) {
+              if (name.match(/^\$/)) {
+                continue;
+              }
               if (ctrl.$name != name && scope.modelCopy[name] != scope.form[name].$modelValue) {
                 if (scope.skipCheck[ctrl.$name] == undefined || scope.skipCheck[ctrl.$name].indexOf(name) == -1) {
                   scope.form.$pristine = false;

--- a/app/assets/javascripts/directives/miqrequired.js
+++ b/app/assets/javascripts/directives/miqrequired.js
@@ -7,8 +7,9 @@ miqAngularApplication.directive('miqrequired', function() {
             setValidity(scope, ctrl, ctrl.$modelValue);
           }
         });
-        ctrl.$parsers.unshift(function() {
+        ctrl.$parsers.unshift(function(val) {
           setValidity(scope, ctrl, ctrl.$viewValue);
+          return val;
         });
 
         var setValidity = function(scope, ctrl, value) {

--- a/app/assets/javascripts/directives/repository/valid_unc_path.js
+++ b/app/assets/javascripts/directives/repository/valid_unc_path.js
@@ -1,15 +1,16 @@
-miqAngularApplication.directive('checkpath', function (){
+miqAngularApplication.directive('checkpath', function() {
   return {
     require: 'ngModel',
-       link: function (scope, elem, attrs, ctrl) {
-         scope.$watch("repoModel.repo_path", function() {
-           if(ctrl.$modelValue != undefined && scope.afterGet) {
-             setValidity(scope, ctrl, ctrl.$modelValue, false);
-           }
-         });
-         ctrl.$parsers.unshift(function() {
-           setValidity(scope, ctrl, ctrl.$viewValue, true);
-          });
+    link: function (scope, elem, attrs, ctrl) {
+      scope.$watch("repoModel.repo_path", function() {
+        if(ctrl.$modelValue != undefined && scope.afterGet) {
+          setValidity(scope, ctrl, ctrl.$modelValue, false);
+        }
+      });
+      ctrl.$parsers.unshift(function(val) {
+        setValidity(scope, ctrl, ctrl.$viewValue, true);
+        return val;
+      });
 
       validPath = function(scope, path, bClearMsg) {
         modified_path = path.replace(/\\/g, "/");
@@ -41,5 +42,5 @@ miqAngularApplication.directive('checkpath', function (){
         }
       };
     }
-  }
+  };
 });

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1072,16 +1072,9 @@ function miqDropComplete(event, ui) {
 }
 
 // Attach a calendar control to all text boxes that start with miq_date_
-function miqBuildCalendar(bAngular) {
-  var all;
-
-  if (bAngular === undefined) {
-    // Get all of the input boxes with ids starting with "miq_date_"
-    all = $('input[id^=miq_date_]');
-  } else {
-    all = $('input[id^=miq_angular_date_]');
-  }
-  all.each(function () {
+function miqBuildCalendar() {
+  // Get all of the input boxes with ids starting with "miq_date_"
+  $('input[id^=miq_date_]').each(function () {
     // Attach dhtmlxcalendars to each one
     var el = $(this);
     var cal = new dhtmlxCalendarObject(el.attr('id'));
@@ -1113,22 +1106,13 @@ function miqBuildCalendar(bAngular) {
     }
 
     // Create an observer for the date field if the html5 attr is specified
-    if (el.attr('data-miq_observe_date') == "execAngular") {
+    if (this.getAttribute('data-miq_observe_date')) {
       el.change(function () {
-        miqSetAngularDate(el);
+        miqSendDateRequest(el);
       });
       cal.attachEvent("onClick", function () {
-        miqSetAngularDate(el);
+        miqSendDateRequest(el);
       });
-    } else {
-      if (this.getAttribute('data-miq_observe_date')) {
-        el.change(function () {
-          miqSendDateRequest(el);
-        });
-        cal.attachEvent("onClick", function () {
-          miqSendDateRequest(el);
-        });
-      }
     }
   });
 }
@@ -1148,10 +1132,6 @@ function miqSendDateRequest(el) {
   } else {
     miqJqueryRequest(urlstring);
   }
-}
-
-function miqSetAngularDate(el) {
-  miqAngularApplication.$scope.triggerCheckChange($('#' + el.attr('id')).val());
 }
 
 // Build an explorer view using a YUI layout and a jQuery accordion

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -863,11 +863,15 @@ function miqAjaxButtonSend(url, serialize_fields) {
 
 // Function to generate an Ajax request
 function miqAjax(url, serialize_fields) {
-  if (serialize_fields) {
-    miqJqueryRequest(url, {beforeSend: true, complete: true, data: miqSerializeForm('form_div')});
-  } else {
-    miqJqueryRequest(url, {beforeSend: true, complete: true});
+  var data = undefined;
+
+  if (serialize_fields === true) {
+    data = miqSerializeForm('form_div');
+  } else if (serialize_fields) {  // object or possibly FormData
+    data = serialize_fields;
   }
+
+  miqJqueryRequest(url, {beforeSend: true, complete: true, data: data});
 }
 
 // Function to generate an Ajax request for EVM async processing

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -853,7 +853,7 @@ function miqAjaxButtonSend(url, serialize_fields) {
   if ($.active) {
     miqAjaxTimers++;
     setTimeout(function () {
-      miqAjaxButtonSend(url);
+      miqAjaxButtonSend(url, serialize_fields);
     }, 700);
   } else {
     miqAjax(url, serialize_fields);

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -7,6 +7,7 @@ miqAngularApplication.service('miqService', function() {
     miqButtons('hide');
   };
 
+  // serializeFields may be either bool (true means use form_div, false no data) or an object (will be passed on as data)
   this.miqAjaxButton = function(url, serializeFields) {
     miqAjaxButton(url, serializeFields);
   };

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -7,11 +7,6 @@ miqAngularApplication.service('miqService', function() {
     miqButtons('hide');
   };
 
-  this.buildCalendar = function(year, month, date) {
-    miq_cal_dateFrom = new Date(year, month, date);
-    miqBuildCalendar(true);
-  };
-
   this.miqAjaxButton = function(url, serializeFields) {
     miqAjaxButton(url, serializeFields);
   };

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -149,7 +149,7 @@ module OpsController::Settings::Schedules
       :schedule_description => schedule.description,
       :schedule_enabled     => schedule.enabled ? "1" : "0",
       :schedule_name        => schedule.name,
-      :schedule_start_date  => schedule.run_at[:start_time].strftime("%m/%d/%Y"),
+      :schedule_start_date  => schedule.run_at[:start_time].strftime("%Y-%m-%d"),
       :schedule_start_hour  => schedule.run_at[:start_time].strftime("%H").to_i,
       :schedule_start_min   => schedule.run_at[:start_time].strftime("%M").to_i,
       :schedule_time_zone   => schedule.run_at[:tz],
@@ -391,12 +391,7 @@ module OpsController::Settings::Schedules
 
     build_schedule_options_for_select
 
-    one_month_ago = (Time.now - 1.month).in_time_zone(session[:user_tz])
-    @one_month_ago = {
-      :year  => one_month_ago.year,
-      :month => one_month_ago.month - 1, # Javascript counts months 0-11
-      :date  => one_month_ago.day
-    }
+    @one_month_ago = (Time.now - 1.month).in_time_zone(session[:user_tz])
   end
 
   def build_global_and_my_filters(type)
@@ -640,7 +635,7 @@ module OpsController::Settings::Schedules
   end
 
   def schedule_set_start_time_record_vars(schedule)
-    run_at = create_time_in_utc("#{params[:miq_angular_date_1]} #{params[:start_hour]}:#{params[:start_min]}:00",
+    run_at = create_time_in_utc("#{params[:start_date]} #{params[:start_hour]}:#{params[:start_min]}:00",
                                 params[:time_zone])
     schedule.run_at[:start_time] = "#{run_at} Z"
   end

--- a/app/views/ops/_schedule_form.html.haml
+++ b/app/views/ops/_schedule_form.html.haml
@@ -35,5 +35,5 @@
 
 :javascript
   miqAngularApplication.value('scheduleFormId', '#{@schedule.id || "new"}');
-  miqAngularApplication.value('oneMonthAgo', {year: '#{@one_month_ago[:year]}', month: '#{@one_month_ago[:month]}', date: '#{@one_month_ago[:date]}'});
+  miqAngularApplication.value('oneMonthAgo', '#{@one_month_ago.strftime("%Y-%m-%d")}');
   angular.bootstrap(jQuery('#form_div'), ['miqAngularApplication']);

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -28,7 +28,7 @@
       %tr
         %td.key=_("Starting Date")
         %td#start_date
-          %input#miq_angular_date_1.css1(readonly="true" ng-model="scheduleModel.miq_angular_date_1" name="miq_angular_date_1" data-miq_observe_date="execAngular" checkchange)
+          %input.css1(readonly="true" ng-model="scheduleModel.start_date" name="start_date" miq-calendar checkchange date-from="{{oneMonthAgo}}")
 
       %tr
         %td.key

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -104,7 +104,7 @@ describe OpsController do
           :time_zone          => "UTC",
           :start_hour         => "0",
           :start_min          => "0",
-          :miq_angular_date_1 => 2.days.from_now.utc.strftime("%m/%d/%Y")
+          :start_date         => 2.days.from_now.utc.strftime("%Y-%m-%d"),
         }
         controller.stub(:assert_privileges)
       end

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -8,18 +8,13 @@ describe('scheduleFormController', function() {
     timerOptionService = _timerOptionService_;
     spyOn(miqService, 'showButtons');
     spyOn(miqService, 'hideButtons');
-    spyOn(miqService, 'buildCalendar');
     spyOn(miqService, 'miqAjaxButton');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
     spyOn(timerOptionService, 'getOptions').and.returnValue(['some', 'options']);
     $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
-    oneMonthAgo = {
-      year: 2014,
-      month: 5,
-      date: 7
-    };
+    oneMonthAgo = "2014-05-07";
 
     // For the initialization scheduleDate test. This freezes time to 1/2/2014.
     var fakeToday = new Date(2014, 0, 2);
@@ -86,7 +81,7 @@ describe('scheduleFormController', function() {
     });
 
     it('sets the scheduleDate', function() {
-      expect($scope.scheduleModel.miq_angular_date_1).toEqual('now');
+      expect($scope.scheduleModel.start_date).toEqual('now');
     });
 
     it('sets the scheduleStartHour', function() {
@@ -145,7 +140,7 @@ describe('scheduleFormController', function() {
       });
 
       it('sets the scheduleDate to today', function() {
-        expect($scope.scheduleModel.miq_angular_date_1).toEqual("1/3/2014");
+        expect($scope.scheduleModel.start_date).toEqual("2014-01-03");
       });
 
       it('sets the scheduleTimerType to once', function() {
@@ -271,10 +266,6 @@ describe('scheduleFormController', function() {
           expect($scope.scheduleModel.filterValuesEmpty).toBe(false);
         });
       });
-    });
-
-    it('builds a calendar', function() {
-      expect(miqService.buildCalendar).toHaveBeenCalledWith(2014, 6, 7);
     });
   });
 

--- a/spec/javascripts/directives/miqrequired_spec.js
+++ b/spec/javascripts/directives/miqrequired_spec.js
@@ -26,4 +26,3 @@ describe('miqrequired initialization', function() {
     });
   });
 });
-

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -6,7 +6,6 @@ describe('miqService', function() {
   beforeEach(inject(function(miqService) {
     testService = miqService;
     spyOn(window, 'miqButtons');
-    spyOn(window, 'miqBuildCalendar');
     spyOn(window, 'miqAjaxButton');
     spyOn(window, 'miqSparkleOn');
     spyOn(window, 'miqSparkleOff');
@@ -23,18 +22,6 @@ describe('miqService', function() {
     it('calls the global buttons function with hide', function() {
       testService.hideButtons();
       expect(window.miqButtons).toHaveBeenCalledWith('hide');
-    });
-  });
-
-  describe('#buildCalendar', function() {
-    it('sets up the date from', function() {
-      testService.buildCalendar(2014, 2, 3);
-      expect(window.miq_cal_dateFrom).toEqual(new Date(2014, 2, 3));
-    });
-
-    it('calls the global build calendar function', function() {
-      testService.buildCalendar();
-      expect(window.miqBuildCalendar).toHaveBeenCalled();
     });
   });
 

--- a/vmdb/app/assets/javascripts/directives/miq_calendar.js
+++ b/vmdb/app/assets/javascripts/directives/miq_calendar.js
@@ -1,0 +1,71 @@
+/** miq-calendar directive
+ * should be on input[type=text]
+ * original value (if any) will be parsed as an ISO date
+ * output value will be in ISO format as well
+ * optionally accepts date-from=(iso), date-to=(iso)
+ * + date-format in $filter('date') format (MM/dd/yyyy is the default)
+ */
+miqAngularApplication.directive('miqCalendar', ['$timeout', '$parse', '$filter', function($timeout, $parse, $filter) {
+  return {
+    require: 'ngModel',
+    link: function(scope, elem, attr, ctrl) {
+      var elem_id = elem.attr('id');
+
+      // prevents clash with old calendar code
+      if (elem_id && elem_id.match(/^miq_angular_date|^miq_date/)) {
+        console.error("Can't use miqCalendar together with miqBuildCalendar magic, sorry", elem);
+        return;
+      }
+
+      // temporary - dhtmlx needs id
+      if (! elem_id) {
+        // needs jQuery UI
+        elem.uniqueId()
+        elem_id = elem.attr('id');
+      }
+
+      var cal = new dhtmlxCalendarObject(elem_id);
+      cal.setDateFormat("%Y-%m-%d");
+      cal.setSkin("dhx_skyblue");
+      cal.hideTime();
+      cal.setPosition('right');
+      // start week from sunday, default is (1) monday
+      cal.setWeekStartDay(7);
+
+      // replaces miq_cal_dateFrom & miq_cal_dateTo
+      if (attr.dateFrom && attr.dateTo) {
+        cal.setSensitiveRange(new Date(attr.dateFrom), new Date(attr.dateTo));
+      } else if (attr.dateFrom && ! attr.dateTo) {
+        cal.setSensitiveRange(new Date(attr.dateFrom));
+      }
+
+      var modelSetter = $parse(attr.ngModel).assign;
+
+      var refreshModel = function() {
+        // trigger a digest cycle - not $apply because that one triggers an error when called when already in a digest cycle
+        $timeout(function() {
+          var val = elem.val();
+          modelSetter(scope, val);
+        });
+      };
+
+      var refreshCal = function(val) {
+        // dhtmlxCalendar handles both the set input format (m/d/Y), the default one, or a Date object
+        cal.setDate(val);
+        if (ctrl.$setDirty) // angular 1.2 compatibility
+          ctrl.$setDirty();
+      }
+
+      ctrl.$formatters.unshift(function(val) {
+        if (!val)
+          return "";
+
+        return $filter('date')(new Date(val), attr.dateFormat || 'MM/dd/yyyy');
+      });
+
+      elem.on('change', refreshModel);
+      cal.attachEvent('onClick', refreshModel);
+      scope.$watch(attr.ngModel, refreshCal);
+    },
+  };
+}]);

--- a/vmdb/app/assets/javascripts/directives/miq_calendar.js
+++ b/vmdb/app/assets/javascripts/directives/miq_calendar.js
@@ -52,8 +52,6 @@ miqAngularApplication.directive('miqCalendar', ['$timeout', '$parse', '$filter',
       var refreshCal = function(val) {
         // dhtmlxCalendar handles both the set input format (m/d/Y), the default one, or a Date object
         cal.setDate(val);
-        if (ctrl.$setDirty) // angular 1.2 compatibility
-          ctrl.$setDirty();
       }
 
       ctrl.$formatters.unshift(function(val) {

--- a/vmdb/app/assets/javascripts/directives/miq_calendar.js
+++ b/vmdb/app/assets/javascripts/directives/miq_calendar.js
@@ -12,7 +12,7 @@ miqAngularApplication.directive('miqCalendar', ['$timeout', '$parse', '$filter',
       var elem_id = elem.attr('id');
 
       // prevents clash with old calendar code
-      if (elem_id && elem_id.match(/^miq_angular_date|^miq_date/)) {
+      if (elem_id && elem_id.match(/^miq_date/)) {
         console.error("Can't use miqCalendar together with miqBuildCalendar magic, sorry", elem);
         return;
       }


### PR DESCRIPTION
implements subset of the miqBuildCalendar functionality, but cleanly, as
an angular directive

sample usage:

	%input{ :type => 'text', 'miq-calendar' => true, 'ng-model' => "something" }

(No magic ids, no miqService.buildCalendar(), no $scope.triggerCheckChange)

Optional attributes:

   * date-from=iso string
   * date-to=iso string
   * date-format=format string for angular's `$filter('date')` (used for displaying, not storing)

Unlike miqBuildCalendar, it uses ISO date string for the model value, not %m/%d/%Y.

@mzazrivec you might find this useful ;)

Upgrade to angular 1.3 and related test fixes are here as well.