### PR TITLE
Remove the Rack::Cache logging verbosity hack to see if it's needed.

### DIFF
--- a/vmdb/config/environments/production.rb
+++ b/vmdb/config/environments/production.rb
@@ -72,10 +72,4 @@ Vmdb::Application.configure do
   config.action_controller.include_all_helpers = false
 
   config.action_controller.allow_forgery_protection = true
-
-  # Disable Rack::Cache verbose miss/hit logging
-  # TODO: Use dalli to store cached pages
-  require 'rack/cache'
-  config.middleware.delete ::Rack::Cache
-  config.middleware.use ::Rack::Cache, :metastore => "rails:/", :entitystore => "rails:/", :verbose => false
 end


### PR DESCRIPTION
This was originally added in 25c12a411ac46e91e1a144e2e112f0c71be29759
to fix: 943007 (MANAGEIQ-13554)

When we migrated to Rails 3 back in late 2011, we were getting these log lines:

cache: [HTTP_METHOD URL] invalidate, pass

The suggestion at that time was to modify the rack-cache to change the verbosity (http://rtomayko.github.io/rack-cache/configuration)

After removing this locally, I don't see these messages in my production.log.
Let's see if this is still a problem and try to fix it differently if so.

Related to #3171