### PR TITLE
Removed unused code from miq_ae_controller

### DIFF
--- a/vmdb/app/controllers/miq_ae_class_controller.rb
+++ b/vmdb/app/controllers/miq_ae_class_controller.rb
@@ -825,24 +825,6 @@ class MiqAeClassController < ApplicationController
     get_instances_form_vars
 
     render :update do |page|                    # Use JS to update the display
-
-      params.each do |var, val|
-        # for instance tab on class screen
-        if var.starts_with?("cls_inst_value") || var.starts_with?("cls_inst_password_value") ||
-            var.starts_with?("cls_inst_collect") || var.starts_with?("cls_inst_on_entry") ||
-            var.starts_with?("cls_inst_on_exit") || var.starts_with?("cls_inst_on_error") ||
-            var.starts_with?("cls_inst_max_retries") || var.starts_with?("cls_inst_max_time")
-          @ae_class.ae_fields.sort_by! { |f| f.priority.to_i } if @ae_class
-        end
-        # for instance node selected in the left tree
-        if var.starts_with?("inst_value") || var.starts_with?("inst_password_value") ||
-            var.starts_with?("inst_collect") || var.starts_with?("inst_on_entry") ||
-            var.starts_with?("inst_on_exit") || var.starts_with?("inst_on_error") ||
-            var.starts_with?("inst_max_retries") || var.starts_with?("inst_max_time")
-          @ae_class.ae_fields.sort_by! { |f| f.priority.to_i } if @ae_class
-        end
-      end
-
       @changed = (@edit[:current] != @edit[:new])
       page << javascript_for_miq_button_visibility(@changed)
     end


### PR DESCRIPTION
User cannot change priority of fields on Instance edit screen, removed leftover code that was doing sort_by on priority field for class ae_fields.

@fryguy @dclarizio please review.

deleted obsolete code that was mentioned in a comment in https://github.com/ManageIQ/manageiq/pull/3175