### PR TITLE
Session login in controllers

### DIFF
--- a/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
@@ -3,6 +3,8 @@ include UiConstants
 
 describe ApplicationController do
   before do
+    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.seed_specific_product_features("everything")
     feature = MiqProductFeature.find_all_by_identifier(["everything"])
     test_user_role  = FactoryGirl.create(:miq_user_role,
                                          :name                 => "test_user_role",

--- a/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/vmdb/spec/controllers/application_controller/ci_processing_spec.rb
@@ -8,8 +8,7 @@ describe ApplicationController do
                                          :name                 => "test_user_role",
                                          :miq_product_features => feature)
     test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-    user = FactoryGirl.create(:user, :userid => 'test_user', :miq_groups => [test_user_group])
-    User.stub(:current_user => user)
+    login_as FactoryGirl.create(:user, :userid => 'test_user', :miq_groups => [test_user_group])
     controller.stub(:role_allows).and_return(true)
   end
 
@@ -60,8 +59,7 @@ describe ApplicationController do
   it "Certain actions should be allowed only for a VM record" do
     admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => MiqProductFeature.find_all_by_identifier(["everything"]))
     admin_group = FactoryGirl.create(:miq_group, :miq_user_role => admin_role)
-    user        = FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [admin_group])
-    User.stub(:current_user => user)
+    login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [admin_group])
     vm = FactoryGirl.create(:vm_vmware)
     controller.instance_variable_set(:@_params, :id => vm.id)
     actions = [:vm_right_size, :vm_reconfigure]

--- a/vmdb/spec/controllers/application_controller/explorer_spec.rb
+++ b/vmdb/spec/controllers/application_controller/explorer_spec.rb
@@ -283,13 +283,12 @@ describe VmInfraController do
     end
 
     context "#x_settings_changed" do
+      let(:user) { FactoryGirl.create(:user, :userid => 'wilma', :settings => {}) }
       before(:each) do
-        set_user_privileges
+        set_user_privileges user
       end
 
       it "sets the width of left pane for session's user" do
-        user = FactoryGirl.create(:user, :userid => 'wilma', :settings => {})
-        session[:userid]   = user.userid
         session[:settings] = {}
         User.stub(:find_by_userid).and_return(user)
 

--- a/vmdb/spec/controllers/application_controller/explorer_spec.rb
+++ b/vmdb/spec/controllers/application_controller/explorer_spec.rb
@@ -178,7 +178,7 @@ describe VmInfraController do
 
         user = FactoryGirl.create(:user_admin)
         user.current_group.set_managed_filters([["/managed/service_level/gold"]])
-        User.stub(:current_user => user)
+        login_as user
 
         Rbac.should_receive(:search).with(:targets => [ems_folder], :results_format=>:objects).and_call_original
 

--- a/vmdb/spec/controllers/application_controller/explorer_spec.rb
+++ b/vmdb/spec/controllers/application_controller/explorer_spec.rb
@@ -173,6 +173,7 @@ describe VmInfraController do
 
     context "#rbac_filtered_objects" do
       it "properly calls RBAC" do
+        EvmSpecHelper.create_guid_miq_server_zone
         ems_folder = FactoryGirl.create(:ems_folder)
         ems = FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder])
 

--- a/vmdb/spec/controllers/application_controller_spec.rb
+++ b/vmdb/spec/controllers/application_controller_spec.rb
@@ -6,10 +6,7 @@ describe ApplicationController do
       EvmSpecHelper.create_guid_miq_server_zone
       controller.instance_variable_set(:@sb, {})
       ur = FactoryGirl.create(:miq_user_role)
-      rptmenu = {:report_menus => [
-                                      ["Configuration Management",["Hosts",["Hosts Summary", "Hosts Summary"]]]
-                                  ]
-                }
+      rptmenu = {:report_menus => [["Configuration Management", ["Hosts", ["Hosts Summary", "Hosts Summary"]]]]}
       group = FactoryGirl.create(:miq_group, :miq_user_role => ur, :settings => rptmenu)
       login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group])
     end

--- a/vmdb/spec/controllers/application_controller_spec.rb
+++ b/vmdb/spec/controllers/application_controller_spec.rb
@@ -1,20 +1,19 @@
 require "spec_helper"
 
 describe ApplicationController do
-  before do
-    controller.instance_variable_set(:@sb, {})
-    ur = FactoryGirl.create(:miq_user_role)
-    rptmenu = {:report_menus => [
-                                    ["Configuration Management",["Hosts",["Hosts Summary", "Hosts Summary"]]]
-                                ]
-              }
-    group = FactoryGirl.create(:miq_group, :miq_user_role => ur, :settings => rptmenu)
-    user = FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group])
-    session[:group] = user.current_group.id
-    session[:userid] = user.userid
-  end
-
   context "#find_by_id_filtered" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      controller.instance_variable_set(:@sb, {})
+      ur = FactoryGirl.create(:miq_user_role)
+      rptmenu = {:report_menus => [
+                                      ["Configuration Management",["Hosts",["Hosts Summary", "Hosts Summary"]]]
+                                  ]
+                }
+      group = FactoryGirl.create(:miq_group, :miq_user_role => ur, :settings => rptmenu)
+      login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group])
+    end
+
     it "Verify Invalid input flash error message when invalid id is passed in" do
       lambda { controller.send(:find_by_id_filtered, ExtManagementSystem, "invalid") }.should raise_error(RuntimeError, "Invalid input")
     end
@@ -25,7 +24,6 @@ describe ApplicationController do
 
     it "Verify record gets set when valid id is passed in" do
       ems = FactoryGirl.create(:ext_management_system)
-      session[:userid] = "test"
       record = controller.send(:find_by_id_filtered, ExtManagementSystem, ems.id)
       record.should be_a_kind_of(ExtManagementSystem)
     end

--- a/vmdb/spec/controllers/application_controller_spec.rb
+++ b/vmdb/spec/controllers/application_controller_spec.rb
@@ -39,8 +39,7 @@ describe ApplicationController do
                                            :name                 => "test_user_role",
                                            :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-      User.stub(:current_user => user)
+      login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
     end
 
     it "should not raise an error for feature that user has access to" do
@@ -72,8 +71,7 @@ describe ApplicationController do
                                             :name                 => "test_user_role",
                                             :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => @test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-      User.stub(:current_user => user)
+      login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
     end
 
     it "should return restricted view yaml for restricted user" do

--- a/vmdb/spec/controllers/catalog_controller_spec.rb
+++ b/vmdb/spec/controllers/catalog_controller_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 
 describe CatalogController do
+  let(:user) { FactoryGirl.create(:user) }
   before(:each) do
-    set_user_privileges
+    set_user_privileges user
   end
 
   # some methods should not be accessible through the legacy routes
@@ -331,9 +332,7 @@ describe CatalogController do
   describe "#tags_edit" do
     before(:each) do
       @ot = FactoryGirl.create(:orchestration_template, :name => "foo")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      session[:userid] = user.userid
-      @ot.stub(:tagged_with).with(:cat => "testuser").and_return("my tags")
+      @ot.stub(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag1",
@@ -422,7 +421,6 @@ describe CatalogController do
       EvmSpecHelper.create_guid_miq_server_zone
       expect(MiqServer.my_guid).to be
       expect(MiqServer.my_server).to be
-      session[:userid] = User.current_user.userid
       session[:settings] = {
         :views => {:orchestrationtemplate => "grid"}
       }

--- a/vmdb/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/vmdb/spec/controllers/cloud_tenant_controller_spec.rb
@@ -23,13 +23,12 @@ describe CloudTenantController do
 
   context "#tags_edit" do
     before(:each) do
-      set_user_privileges
       FactoryGirl.create(:vmdb_database)
       EvmSpecHelper.create_guid_miq_server_zone
       @ct = FactoryGirl.create(:cloud_tenant, :name => "cloud-tenant-01")
       user = FactoryGirl.create(:user, :userid => 'testuser')
-      session[:userid] = user.userid
-      @ct.stub(:tagged_with).with(:cat => "testuser").and_return("my tags")
+      set_user_privileges user
+      @ct.stub(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
       @tag1 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag1",

--- a/vmdb/spec/controllers/container_group_controller_spec.rb
+++ b/vmdb/spec/controllers/container_group_controller_spec.rb
@@ -13,7 +13,7 @@ describe ContainerGroupController do
   end
 
   it "renders show screen" do
-    MiqServer.stub(:my_zone).and_return("default")
+    EvmSpecHelper.create_guid_miq_server_zone
     ems = FactoryGirl.create(:ems_kubernetes)
     container_group = ContainerGroup.create(:ext_management_system => ems, :name => "Test Group")
     get :show, :id => container_group.id
@@ -27,8 +27,6 @@ describe ContainerGroupController do
     session[:settings] = {:default_search => 'foo',
                           :views          => {:containergroup => 'list'},
                           :perpage        => {:list => 10}}
-    session[:userid] = User.current_user.userid
-    session[:eligible_groups] = []
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone
 

--- a/vmdb/spec/controllers/container_node_controller_spec.rb
+++ b/vmdb/spec/controllers/container_node_controller_spec.rb
@@ -27,8 +27,6 @@ describe ContainerNodeController do
     session[:settings] = {:default_search => 'foo',
                           :views          => {:containernode => 'list'},
                           :perpage        => {:list => 10}}
-    session[:userid] = User.current_user.userid
-    session[:eligible_groups] = []
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone
 

--- a/vmdb/spec/controllers/container_replicator_controller_spec.rb
+++ b/vmdb/spec/controllers/container_replicator_controller_spec.rb
@@ -27,8 +27,6 @@ describe ContainerReplicatorController do
     session[:settings] = {:default_search => 'foo',
                           :views          => {:containerreplicator => 'list'},
                           :perpage        => {:list => 10}}
-    session[:eligible_groups] = []
-    session[:userid] = User.current_user.userid
 
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/controllers/container_service_controller_spec.rb
+++ b/vmdb/spec/controllers/container_service_controller_spec.rb
@@ -27,8 +27,6 @@ describe ContainerServiceController do
     session[:settings] = {:default_search => 'foo',
                           :views          => {:containerservice => 'list'},
                           :perpage        => {:list => 10}}
-    session[:eligible_groups] = []
-    session[:userid] = User.current_user.userid
 
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/controllers/dashboard_controller_spec.rb
+++ b/vmdb/spec/controllers/dashboard_controller_spec.rb
@@ -65,9 +65,9 @@ describe DashboardController do
       controller.instance_variable_set(:@tabs, [])
       login_as user
       #create a user's dashboard using group dashboard name.
-      user_ws = FactoryGirl.create(:miq_widget_set, :name => "#{user.userid}|#{group.id}|#{ws.name}",
-                                   :set_data => {:last_group_db_updated => Time.now.utc,
-                                                 :col1 => [1], :col2 => [], :col3 =>[]})
+      FactoryGirl.create(:miq_widget_set,
+                         :name     => "#{user.userid}|#{group.id}|#{ws.name}",
+                         :set_data => {:last_group_db_updated => Time.now.utc, :col1 => [1], :col2 => [], :col3 => []})
       controller.show
       controller.send(:flash_errors?).should_not be_true
     end

--- a/vmdb/spec/controllers/dashboard_controller_spec.rb
+++ b/vmdb/spec/controllers/dashboard_controller_spec.rb
@@ -1,29 +1,22 @@
 require "spec_helper"
 
 describe DashboardController do
-  before(:each) do
-    described_class.any_instance.stub(:set_user_time_zone)
-  end
-
   context "POST authenticate" do
     it "validates user" do
+      EvmSpecHelper.create_guid_miq_server_zone
+
       role = FactoryGirl.create(:miq_user_role, :name => 'test_role')
       group = FactoryGirl.create(:miq_group, :description => 'test_group', :miq_user_role => role)
       user = FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group])
-      User.stub(:authenticate).and_return(user)
-      controller.stub(:get_vmdb_config).and_return({:product => {}})
       UserValidationService.any_instance.stub(:user_is_super_admin?).and_return(true)
-      controller.stub(:start_url_for_user).and_return('some_url')
-      post :authenticate, :user_name => user.userid, :user_password => 'secret'
+      post :authenticate, :user_name => user.userid, :user_password => 'dummy'
       session[:userid].should == user.userid
     end
   end
 
   context "#validate_user" do
-    let(:server) { active_record_instance_double("MiqServer", :logon_status => :ready) }
-
     before do
-      MiqServer.stub(:my_server).with(true).and_return(server)
+      EvmSpecHelper.create_guid_miq_server_zone
     end
 
     it "returns flash message when user's group is missing" do
@@ -70,11 +63,9 @@ describe DashboardController do
 
       controller.instance_variable_set(:@sb, {:active_db => ws.name})
       controller.instance_variable_set(:@tabs, [])
-      controller.stub(:role_allows)
-      session[:group] = user.current_group.id
-      session[:userid] = user.userid
+      login_as user
       #create a user's dashboard using group dashboard name.
-      user_ws = FactoryGirl.create(:miq_widget_set, :name => "#{session[:userid]}|#{session[:group]}|#{ws.name}",
+      user_ws = FactoryGirl.create(:miq_widget_set, :name => "#{user.userid}|#{group.id}|#{ws.name}",
                                    :set_data => {:last_group_db_updated => Time.now.utc,
                                                  :col1 => [1], :col2 => [], :col3 =>[]})
       controller.show
@@ -110,7 +101,6 @@ describe DashboardController do
     before do
       MiqRegion.seed
       MiqShortcut.seed
-      described_class.any_instance.stub(:set_user_time_zone)
       controller.stub(:check_privileges).and_return(true)
     end
 

--- a/vmdb/spec/controllers/host_controller_spec.rb
+++ b/vmdb/spec/controllers/host_controller_spec.rb
@@ -72,8 +72,6 @@ describe HostController do
       ra = FactoryGirl.create(:resource_action, :dialog_id => d.id)
       custom_button.resource_action = ra
       custom_button.save
-      user = FactoryGirl.create(:user, :userid => 'wilma')
-      session[:userid] = "wilma"
       post :button, :pressed => "custom_button", :id => host.id, :button_id => custom_button.id
       expect(response.status).to eq(200)
       controller.send(:flash_errors?).should_not be_true

--- a/vmdb/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/vmdb/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -25,7 +25,6 @@ describe MiqPolicyController do
                                                   :current => new,
                                                   :typ => "basic",
                                                   :key => "policy_edit__new"})
-        session[:userid] = User.current_user.userid
         session[:edit] = assigns(:edit)
         active_node = "xx-compliance_xx-compliance-host"
         controller.instance_variable_set(:@sb, {:trees => {:policy_tree => {:active_node => active_node}},

--- a/vmdb/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/vmdb/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -6,7 +6,7 @@ describe ReportController do
     context "#set_form_vars" do
       it "check existence of cb_owner_id key" do
         user = FactoryGirl.create(:user)
-        session[:userid] = user.userid
+        login_as user
         rep = FactoryGirl.create(
                                   :miq_report,
                                   :db => "Chargeback",

--- a/vmdb/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/vmdb/spec/controllers/miq_report_controller/reports_spec.rb
@@ -17,8 +17,7 @@ describe ReportController do
       tabs.each_pair do |tab_title, tab_number|
         title = tab_title.to_s.titleize
         it "check existence of flash message when tab is changed to #{title} without selecting fields" do
-          user = FactoryGirl.create(:user)
-          session[:userid] = user.userid
+          login_as FactoryGirl.create(:user)
           controller.instance_variable_set(:@sb, {})
           controller.instance_variable_set(:@edit, :new => {:fields => []})
           controller.instance_variable_set(:@_params, :tab => "new_#{tab_number}")
@@ -30,8 +29,7 @@ describe ReportController do
         end
 
         it "flash messages should be nil when tab is changed to #{title} after selecting fields" do
-          user = FactoryGirl.create(:user)
-          session[:userid] = user.userid
+          login_as FactoryGirl.create(:user)
           controller.instance_variable_set(:@sb, {})
           controller.instance_variable_set(:@edit, :new => {
                                                       :fields  => [["Date Created", "Vm-ems_created_on"]],

--- a/vmdb/spec/controllers/miq_request_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_request_controller_spec.rb
@@ -20,7 +20,7 @@ describe MiqRequestController do
   end
 
   context "#prov_condition builds correct MiqExpression hash" do
-    before { User.current_userid = FactoryGirl.create(:user_admin).userid }
+    before { login_as FactoryGirl.create(:user_admin) }
 
     it "MiqRequest-created_on" do
       content = {"value" => "9 Days Ago", "field" => "MiqRequest-created_on"}

--- a/vmdb/spec/controllers/miq_request_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_request_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqRequestController do
   context "#post_install_callback should render nothing" do
     before do
-      described_class.any_instance.stub(:set_user_time_zone)
+      EvmSpecHelper.create_guid_miq_server_zone
     end
 
     it "when called with a task id" do
@@ -20,7 +20,8 @@ describe MiqRequestController do
   end
 
   context "#prov_condition builds correct MiqExpression hash" do
-    before { login_as FactoryGirl.create(:user_admin) }
+    let(:user) { FactoryGirl.create(:user_admin) }
+    before { login_as user }
 
     it "MiqRequest-created_on" do
       content = {"value" => "9 Days Ago", "field" => "MiqRequest-created_on"}
@@ -30,7 +31,7 @@ describe MiqRequestController do
 
     context "MiqRequest-requester_id set based on user_id" do
       it "user with approver priveleges" do
-        content = {"value" => nil, "field" => "MiqRequest-requester_id"}
+        content = {"value" => user.id, "field" => "MiqRequest-requester_id"}
         MiqExpression.should_receive(:new).with { |h| expect(h.fetch_path("and", 1, "=")).to eq(content) }
         controller.send(:prov_condition, {})
       end

--- a/vmdb/spec/controllers/miq_request_controller_spec.rb
+++ b/vmdb/spec/controllers/miq_request_controller_spec.rb
@@ -38,7 +38,7 @@ describe MiqRequestController do
 
       it "user without approver priveleges" do
         user             = FactoryGirl.create(:user)
-        session[:userid] = user.userid
+        login_as user
         content          = {"value" => user.id, "field" => "MiqRequest-requester_id"}
         MiqExpression.should_receive(:new).with { |h| expect(h.fetch_path("and", 1, "=")).to eq(content) }
         controller.send(:prov_condition, {})

--- a/vmdb/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/vmdb/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -35,7 +35,7 @@ shared_examples "logs_collect" do |type|
   context "nothing preventing collection" do
     it "succeeds" do
       klass.any_instance.should_receive(:log_collection_active_recently?).and_return(false)
-      klass.any_instance.should_receive(:synchronize_logs).with(nil, {})
+      klass.any_instance.should_receive(:synchronize_logs).with(user.userid, {})
       controller.should_receive(:replace_right_cell).with(active_node)
 
       controller.send(:logs_collect)
@@ -63,10 +63,6 @@ describe OpsController do
       FactoryGirl.create(:vmdb_database)
       EvmSpecHelper.create_guid_miq_server_zone
 
-      expect(MiqServer.my_guid).to be
-      expect(MiqServer.my_server).to be
-
-      session[:userid] = User.current_user.userid
       session[:sandboxes] = { "ops" => { :active_tree => :diagnostics_tree } }
       post :tree_select, :id => 'root', :format => :js
 
@@ -76,8 +72,9 @@ describe OpsController do
   end
 
   context "::Diagnostics" do
+    let(:user) { FactoryGirl.create(:user) }
     before do
-      set_user_privileges
+      set_user_privileges user
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
     end
 

--- a/vmdb/spec/controllers/ops_controller_spec.rb
+++ b/vmdb/spec/controllers/ops_controller_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe OpsController do
   before(:each) do
+    EvmSpecHelper.create_guid_miq_server_zone
     set_user_privileges
   end
 
@@ -22,7 +23,6 @@ describe OpsController do
   end
 
   it 'can view the db_settings tab' do
-    EvmSpecHelper.create_guid_miq_server_zone
     session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
                                      :active_tab  => 'db_settings',
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
@@ -32,7 +32,6 @@ describe OpsController do
 
   it 'can view the db_connections tab' do
     FactoryGirl.create(:vmdb_database)
-    EvmSpecHelper.create_guid_miq_server_zone
     session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
                                      :active_tab  => 'db_connections',
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
@@ -114,9 +113,6 @@ describe OpsController do
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}
-      session[:userid] = User.current_user.userid
-      session[:eligible_groups] = []
-      EvmSpecHelper.create_guid_miq_server_zone
 
       miq_schedule = FactoryGirl.create(:miq_schedule,
                                         :name        => "test_db_schedule",

--- a/vmdb/spec/controllers/ops_controller_spec.rb
+++ b/vmdb/spec/controllers/ops_controller_spec.rb
@@ -193,8 +193,7 @@ describe OpsController do
                                           :name                 => "test_user_role",
                                           :miq_product_features => feature)
     test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => @test_user_role)
-    user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-    User.stub(:current_user => user)
+    login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
     MiqServer.stub(:my_server).with(true).and_return(server)
     controller.stub(:get_vmdb_config).and_return(:product => {})
   end

--- a/vmdb/spec/controllers/ops_settings_spec.rb
+++ b/vmdb/spec/controllers/ops_settings_spec.rb
@@ -92,7 +92,6 @@ describe OpsController do
     context "schedule additon" do
       before(:each) do
         EvmSpecHelper.create_guid_miq_server_zone
-        session[:userid] = User.current_user.userid
         controller.should_receive(:render)
         @schedule = FactoryGirl.create(:miq_schedule, :userid => "test", :towhat => "Vm")
         @params = {

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -44,7 +44,7 @@ describe ProviderForemanController do
                                          :miq_product_features => feature)
     test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
     user = FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
-    User.stub(:current_user => user)
+    login_as user
     session[:settings] = {:default_search => '',
                           :views          => {},
                           :perpage        => {:list => 10}}
@@ -72,7 +72,7 @@ describe ProviderForemanController do
                                            :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
       user = FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
-      User.stub(:current_user => user)
+      login_as user
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}
@@ -94,7 +94,7 @@ describe ProviderForemanController do
                                            :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
       user = FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
-      User.stub(:current_user => user)
+      login_as user
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}
@@ -116,8 +116,7 @@ describe ProviderForemanController do
                                            :name                 => "test_user_role",
                                            :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-      User.stub(:current_user => user)
+      login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
     end
 
     it "should not raise an error for feature that user has access to" do

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -73,7 +73,6 @@ describe ProviderForemanController do
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}
-      session[:userid] = user.userid
       get :explorer
       accords = controller.instance_variable_get(:@accords)
       expect(accords.size).to eq(1)
@@ -94,7 +93,6 @@ describe ProviderForemanController do
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}
-      session[:userid] = user.userid
       get :explorer
       accords = controller.instance_variable_get(:@accords)
       expect(accords.size).to eq(1)

--- a/vmdb/spec/controllers/provider_foreman_controller_spec.rb
+++ b/vmdb/spec/controllers/provider_foreman_controller_spec.rb
@@ -36,7 +36,8 @@ describe ProviderForemanController do
   end
 
   it "renders explorer" do
-    set_user_privileges
+    EvmSpecHelper.create_guid_miq_server_zone
+
     EvmSpecHelper.seed_specific_product_features("providers_accord", "configured_systems_filter_accord")
     feature = MiqProductFeature.find_all_by_identifier(%w(providers_accord configured_systems_filter_accord))
     test_user_role  = FactoryGirl.create(:miq_user_role,
@@ -44,13 +45,10 @@ describe ProviderForemanController do
                                          :miq_product_features => feature)
     test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
     user = FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
-    login_as user
+    set_user_privileges user
     session[:settings] = {:default_search => '',
                           :views          => {},
                           :perpage        => {:list => 10}}
-    session[:userid] = user.userid
-    session[:eligible_groups] = []
-    EvmSpecHelper.create_guid_miq_server_zone
     get :explorer
     accords = controller.instance_variable_get(:@accords)
     expect(accords.size).to eq(2)
@@ -60,11 +58,10 @@ describe ProviderForemanController do
 
   context "renders explorer based on RBAC" do
     before do
-      session[:eligible_groups] = []
       EvmSpecHelper.create_guid_miq_server_zone
     end
+
     it "renders explorer based on RBAC access to feature 'configured_system_tag'" do
-      set_user_privileges
       EvmSpecHelper.seed_specific_product_features("configured_system_tag")
       feature = MiqProductFeature.find_all_by_identifier("configured_system_tag")
       test_user_role  = FactoryGirl.create(:miq_user_role,
@@ -72,7 +69,7 @@ describe ProviderForemanController do
                                            :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
       user = FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
-      login_as user
+      set_user_privileges user
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}
@@ -86,7 +83,6 @@ describe ProviderForemanController do
     end
 
     it "renders explorer based on RBAC access to feature 'provider_foreman_add_provider'" do
-      set_user_privileges
       EvmSpecHelper.seed_specific_product_features("provider_foreman_add_provider")
       feature = MiqProductFeature.find_all_by_identifier("provider_foreman_add_provider")
       test_user_role  = FactoryGirl.create(:miq_user_role,
@@ -94,7 +90,7 @@ describe ProviderForemanController do
                                            :miq_product_features => feature)
       test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
       user = FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
-      login_as user
+      set_user_privileges user
       session[:settings] = {:default_search => '',
                             :views          => {},
                             :perpage        => {:list => 10}}

--- a/vmdb/spec/controllers/vm_cloud_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_cloud_controller_spec.rb
@@ -43,8 +43,6 @@ describe VmCloudController do
 
   it 'can render the explorer' do
     session[:settings] = {:views => {}, :perpage => {:list => 10}}
-    session[:userid] = User.current_user.userid
-    session[:eligible_groups] = []
 
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -6,10 +6,6 @@ describe VmInfraController do
     set_user_privileges
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone
-    expect(MiqServer.my_guid).to be
-    expect(MiqServer.my_server).to be
-
-    session[:userid] = User.current_user.userid
   end
 
   context "VMs & Templates #tree_select" do

--- a/vmdb/spec/controllers/vm_infra_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller_spec.rb
@@ -9,8 +9,6 @@ describe VmInfraController do
 
   it 'can render the explorer' do
     session[:settings] = {:views => {}, :perpage => {:list => 10}}
-    session[:userid] = User.current_user.userid
-    session[:eligible_groups] = []
 
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/controllers/vm_or_template_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_or_template_controller_spec.rb
@@ -61,8 +61,6 @@ describe VmOrTemplateController do
 
   it 'can render the explorer' do
     session[:settings] = {:views => {}, :perpage => {:list => 10}}
-    session[:userid] = User.current_user.userid
-    session[:eligible_groups] = []
 
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone

--- a/vmdb/spec/helpers/application_helper_spec.rb
+++ b/vmdb/spec/helpers/application_helper_spec.rb
@@ -61,7 +61,7 @@ describe ApplicationHelper do
       @admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => features)
       @admin_group = FactoryGirl.create(:miq_group, :miq_user_role => @admin_role)
       @user        = FactoryGirl.create(:user, :name => 'wilma', :miq_groups => [@admin_group])
-      User.stub(:current_user => @user)
+      login_as  @user
     end
 
     context "when with :feature" do
@@ -785,7 +785,7 @@ describe ApplicationHelper do
     before do
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred')
       @record = double("record")
-      User.stub(:current_user).and_return(@user)
+      login_as @user
       @settings = {
         :views => {
           :compare      => 'compressed',

--- a/vmdb/spec/spec_helper.rb
+++ b/vmdb/spec/spec_helper.rb
@@ -64,6 +64,8 @@ RSpec.configure do |config|
   config.include ViewSpecHelper, :type => :view
   config.include UiConstants, :type => :controller
   config.include AuthHelper,  :type => :controller
+  config.include AuthHelper,  :type => :view
+  config.include AuthHelper,  :type => :helper
   config.include AuthRequestHelper, :type => :request
   config.include UiConstants, :type => :view
 

--- a/vmdb/spec/support/auth_helper.rb
+++ b/vmdb/spec/support/auth_helper.rb
@@ -5,6 +5,11 @@ module AuthHelper
 
   def login_as(user)
     User.stub(:current_user => user)
+    User.stub(:current_userid => user.userid)
+    session[:userid]   = user.userid
+    session[:username] = user.name
+    session[:group]    = user.current_group.id if user.current_group
+    session[:eligible_groups] = []
   end
 end
 

--- a/vmdb/spec/support/auth_helper.rb
+++ b/vmdb/spec/support/auth_helper.rb
@@ -8,7 +8,7 @@ module AuthHelper
     User.stub(:current_userid => user.userid)
     session[:userid]   = user.userid
     session[:username] = user.name
-    session[:group]    = user.current_group.id if user.current_group
+    session[:group]    = user.current_group.try(:id)
     session[:eligible_groups] = []
   end
 end

--- a/vmdb/spec/support/auth_helper.rb
+++ b/vmdb/spec/support/auth_helper.rb
@@ -2,6 +2,10 @@ module AuthHelper
   def http_login(username = 'username', password = 'password')
     request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
   end
+
+  def login_as(user)
+    User.stub(:current_user => user)
+  end
 end
 
 module AuthRequestHelper

--- a/vmdb/spec/support/controller_spec_helper.rb
+++ b/vmdb/spec/support/controller_spec_helper.rb
@@ -7,10 +7,13 @@ module ControllerSpecHelper
     end
   end
 
-  def set_user_privileges
+  def set_user_privileges(user = FactoryGirl.create(:user))
+    allow(User).to receive(:server_timezone).and_return("UTC")
     described_class.any_instance.stub(:set_user_time_zone)
+
+    # TODO: remove these stubs
     controller.stub(:check_privileges).and_return(true)
-    login_as FactoryGirl.create(:user)
+    login_as user
     User.any_instance.stub(:role_allows?).and_return(true)
   end
 

--- a/vmdb/spec/support/controller_spec_helper.rb
+++ b/vmdb/spec/support/controller_spec_helper.rb
@@ -10,8 +10,7 @@ module ControllerSpecHelper
   def set_user_privileges
     described_class.any_instance.stub(:set_user_time_zone)
     controller.stub(:check_privileges).and_return(true)
-    user = FactoryGirl.create(:user)
-    User.stub(:current_user => user)
+    login_as FactoryGirl.create(:user)
     User.any_instance.stub(:role_allows?).and_return(true)
   end
 
@@ -41,7 +40,7 @@ module ControllerSpecHelper
     @test_user = FactoryGirl.create(:user,
                                     :name       => 'test_user',
                                     :miq_groups => [test_group])
-    User.stub(:current_user => @test_user)
+    login_as @test_user
   end
 
   shared_context "valid session" do

--- a/vmdb/spec/views/miq_request/_prov_options.html.erb_spec.rb
+++ b/vmdb/spec/views/miq_request/_prov_options.html.erb_spec.rb
@@ -52,7 +52,7 @@ describe 'miq_request/_prov_options.html.haml' do
     end
 
     it 'for admin' do
-      User.stub(:current_user => @admin)
+      login_as @admin
       render
       @users.each do |u|
         rendered.should have_selector('select#user_choice option', :text => u.name)
@@ -60,7 +60,7 @@ describe 'miq_request/_prov_options.html.haml' do
     end
 
     it 'for approver' do
-      User.stub(:current_user => @approver)
+      login_as @approver
       render
       @users.each do |u|
         rendered.should have_selector('select#user_choice option', :text => u.name)
@@ -96,7 +96,7 @@ describe 'miq_request/_prov_options.html.haml' do
       sb[:def_prov_options][:MiqProvisionRequest][:applied_states] = %w(pending_approval)
       view.instance_variable_set(:@sb, sb)
 
-      User.stub(:current_user => desktop)
+      login_as desktop
       render
       rendered.should have_selector('td', :text => desktop.name)
       rendered.should_not have_selector('select#user_choice option')
@@ -123,7 +123,7 @@ describe 'miq_request/_prov_options.html.haml' do
       sb[:def_prov_options][:MiqProvisionRequest][:applied_states] = %w(pending_approval)
       view.instance_variable_set(:@sb, sb)
 
-      User.stub(:current_user => vm_user)
+      login_as vm_user
       render
       rendered.should have_selector('td', :text => vm_user.name)
       rendered.should_not have_selector('select#user_choice option')


### PR DESCRIPTION
I am trying to move current_user into helpers #3170 

Currently, many of the controller specs are written in a way that will fail if we properly set the `session[:user*]` and `User.current_user`.

This is attempting to start standardizing the way we set the `current_user`. (Looks like we now have 3 different methods to do this.)

I did need to introduce `EvmSpecHelper.create_guid_miq_server_zone` in a few spots and changed the specs to properly accept these concepts set correctly.
Did not attempt to track down all the places we stub `MyServer.my_zone` nor 

This did not attempt to remove the stubbing of our RBAC / 
/cc @dclarizio @Fryguy @eclarizio 