### PR TITLE
remove session[:user_tags]

### DIFF
--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -515,7 +515,6 @@ class DashboardController < ApplicationController
       end
     when :fail
       self.current_user = nil
-      session[:user_tags] = nil
       add_flash(validation.flash_msg || "Error: Authentication failed", :error)
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
@@ -725,8 +724,6 @@ class DashboardController < ApplicationController
 
   # Initialize session hash variables for the logged in user
   def session_init(db_user)
-    session[:user_tags] = db_user.tag_list unless db_user == nil      # Get user's tags
-
     # Load settings for this user, if they exist
     @settings = copy_hash(DEFAULT_SETTINGS)             # Start with defaults
     unless db_user == nil || db_user.settings == nil    # If the user has saved settings

--- a/vmdb/app/services/user_validation_service.rb
+++ b/vmdb/app/services/user_validation_service.rb
@@ -22,7 +22,6 @@ class UserValidationService
 
     unless user[:name]
       self.current_userid = nil
-      session[:user_tags] = nil
       return ValidateResult.new(:fail, @flash_msg ||= "Error: Authentication failed")
     end
 


### PR DESCRIPTION
For some reason we set `session[:user_tags]` but do not access.

Can someone verify that we need it?

/cc @dclarizio 