### PR TITLE
Replace $(..).live with on - removed in new jQuery

### DIFF
--- a/vmdb/app/assets/javascripts/miq_ujs_bindings.js
+++ b/vmdb/app/assets/javascripts/miq_ujs_bindings.js
@@ -104,7 +104,7 @@ $(document).ready(function () {
     miqJqueryRequest(url, options);
   });
 
-  $('[data-miq_observe_date]').live('change', function() {
+  $(document).on('change', '[data-miq_observe_date]', function() {
     miqSendDateRequest($(this));
   });
 


### PR DESCRIPTION
Replace $(..).live with $(..).on - deprecated in new jQuery and removed in newer jQuery