### PR TITLE
Use Rbac.filtered where appropriate

### DIFF
--- a/vmdb/app/helpers/api_helper/renderer.rb
+++ b/vmdb/app/helpers/api_helper/renderer.rb
@@ -167,12 +167,7 @@ module ApiHelper
     private
 
     def resource_search(id, type, klass)
-      options = {
-        :targets        => Array(klass.find(id)),
-        :userid         => @auth_user,
-        :results_format => :objects
-      }
-      res = Rbac.search(options).first.first
+      res = Rbac.filtered([klass.find(id)], :userid => @auth_user).first
       raise ApiController::Forbidden, "Access to the resource #{type}/#{id} is forbidden" unless res
       res
     end
@@ -193,14 +188,12 @@ module ApiHelper
       res = res.reorder(sort_options)             if sort_options.present?
 
       options = {
-        :targets        => res,
         :userid         => @auth_user,
-        :results_format => :objects
       }
       options[:order] = sort_options              if sort_options.present?
       options[:offset], options[:limit] = expand_paginate_params if paginate_params?
 
-      Rbac.search(options).first
+      Rbac.filtered(res, options)
     end
 
     #

--- a/vmdb/app/models/miq_report/generator.rb
+++ b/vmdb/app/models/miq_report/generator.rb
@@ -239,7 +239,10 @@ module MiqReport::Generator
         :limit       => options[:limit],
         :ext_options => ext_options.merge(:reflections => associations, :class => klass)
       )
-      results, attrs = !results.empty? ? Rbac.search(:targets => results, :class => self.db, :filter => self.conditions, :results_format => :objects, :userid => options[:userid], :miq_group_id => options[:miq_group_id]) : [results, {}]
+      results = Rbac.filtered(results, :class        => db,
+                                       :filter       => conditions,
+                                       :userid       => options[:userid],
+                                       :miq_group_id => options[:miq_group_id])
       results = Metric::Helper.remove_duplicate_timestamps(results)
     elsif !self.db_options.blank? && self.db_options.has_key?(:interval)
       # Ad-hoc performance reports
@@ -260,7 +263,10 @@ module MiqReport::Generator
         :limit => options[:limit]
       )
 
-      results, attrs = !results.empty? ? Rbac.search(:targets => results, :class => self.db, :filter => self.conditions, :results_format => :objects, :userid => options[:userid], :miq_group_id => options[:miq_group_id]) : [results, {}]
+      results = Rbac.filtered(results, :class        => db,
+                                       :filter       => conditions,
+                                       :userid       => options[:userid],
+                                       :miq_group_id => options[:miq_group_id])
       results = Metric::Helper.remove_duplicate_timestamps(results)
     else
       # Basic report

--- a/vmdb/app/models/miq_report/search.rb
+++ b/vmdb/app/models/miq_report/search.rb
@@ -103,11 +103,15 @@ module MiqReport::Search
     search_options = options.merge(:class => self.db, :conditions => self.conditions, :results_format => :objects, :include_for_find => includes)
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if apply_sortby_in_search
 
-    unless options[:parent]
-      search_results, attrs = Rbac.search(search_options)
-    else
+    if options[:parent]
       targets = get_parent_targets(options)
-      search_results, attrs = targets.empty? ? [targets, {:auth_count => 0, :total_count => 0}] : Rbac.search(search_options.merge(:targets => targets))
+      if targets.empty?
+        search_results, attrs = [targets, {:auth_count => 0, :total_count => 0}]
+      else
+        search_results, attrs = Rbac.search(search_options.merge(:targets => targets))
+      end
+    else
+      search_results, attrs = Rbac.search(search_options)
     end
 
     search_results ||= []

--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -828,11 +828,11 @@ class MiqRequestWorkflow
   def process_filter_all(filter_prop, ci_klass, targets = [])
     rails_logger("process_filter - [#{ci_klass}]", 0)
     filter_id = get_value(@values[filter_prop]).to_i
-    result =  unless filter_id.zero?
-                MiqSearch.find(filter_id).search(targets, :results_format => :objects, :userid => @requester.userid).first
-              else
-                Rbac.search(:targets => targets, :class => ci_klass, :results_format => :objects, :userid => @requester.userid).first
-              end
+    result = if filter_id.zero?
+               Rbac.filtered(targets, :class => ci_klass, :userid => @requester.userid)
+             else
+               MiqSearch.find(filter_id).filtered(targets, :userid => @requester.userid)
+             end
     rails_logger("process_filter - [#{ci_klass}]", 1)
     result
   end

--- a/vmdb/app/models/miq_search.rb
+++ b/vmdb/app/models/miq_search.rb
@@ -18,7 +18,12 @@ class MiqSearch < ActiveRecord::Base
 
   def search(targets = [], opts = {})
     self.options ||= {}
-    Rbac.search(self.options.merge(:targets => targets, :class => self.db, :filter => self.filter).merge(opts))
+    Rbac.search(options.merge(:targets => targets, :class => db, :filter => filter).merge(opts))
+  end
+
+  def filtered(targets, opts = {})
+    self.options ||= {}
+    Rbac.filtered(targets, options.merge(:class => db, :filter => filter).merge(opts))
   end
 
   def self.get_expressions_by_model(db)

--- a/vmdb/app/models/rbac.rb
+++ b/vmdb/app/models/rbac.rb
@@ -275,8 +275,7 @@ module Rbac
 
   def self.filtered(objects, options = {})
     unless objects.empty?
-      options[:targets] = objects
-      objects, _ = Rbac.search(options)
+      objects, _attrs = Rbac.search(options.merge(:targets => objects, :results_format => :objects))
     end
     objects
   end

--- a/vmdb/app/presenters/tree_builder.rb
+++ b/vmdb/app/presenters/tree_builder.rb
@@ -315,8 +315,7 @@ class TreeBuilder
     check_vm_descendants = false
     check_vm_descendants = options.delete(:match_via_descendants) if options[:match_via_descendants] == "VmOrTemplate"
 
-    options.merge!(:targets => objects, :results_format => :objects)
-    results, _attrs = Rbac.search(options)
+    results = Rbac.filtered(objects, options)
 
     # If we are processing :match_via_descendants and user is filtered (i.e. not like admin/super-admin)
     if check_vm_descendants && User.current_user_has_filters?


### PR DESCRIPTION
Trivial cleanup / refactoring: we already have a method to encapsulate a common pattern, but we're not using it at the moment.