### PR TITLE
Handle Fog network service not available error.

### DIFF
--- a/lib/openstack/openstack_handle/handle.rb
+++ b/lib/openstack/openstack_handle/handle.rb
@@ -66,8 +66,9 @@ module OpenstackHandle
       else
         Fog.const_get(service).new(opts)
       end
-    rescue Fog::Errors::NotFound => err
+    rescue ArgumentError, Fog::Errors::NotFound => err
       raise MiqException::ServiceNotAvailable if err.message.include?("Could not find service")
+      raise MiqException::ServiceNotAvailable if err.message =~ /\w+ has no \w+ service/
       raise
     end
 


### PR DESCRIPTION
Fog-core v1.31.1 changed the error class and message returned when a service is not available.
It returns an ArgumentError object with a message like "openstack has no network service"