### PR TITLE
Session group

### DIFF
--- a/vmdb/app/controllers/application_controller/current_user.rb
+++ b/vmdb/app/controllers/application_controller/current_user.rb
@@ -21,6 +21,8 @@ module ApplicationController::CurrentUser
       session[:userid]    = nil
       session[:username]  = nil
     end
+    self.current_group  = db_user.try(:current_group)
+    self.current_eligible_groups = db_user.try(:miq_groups)
   end
   protected :current_user=
 
@@ -32,7 +34,14 @@ module ApplicationController::CurrentUser
     # Build pre-sprint 69 role name if this is an EvmRole read_only role
     session[:userrole] = role.try(:read_only?) ? role.name.split("-").last : ""
   end
-  protected :current_group=
+  private :current_group=
+
+  def current_eligible_groups=(eligible_groups)
+    # Save an array of groups this user is eligible for, if more than 1
+    eligible_groups = eligible_groups ? eligible_groups.sort_by { |g| g.description.downcase } : []
+    session[:eligible_groups] = eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
+  end
+  private :current_eligible_groups=
 
   def current_user
     User.find_by_userid(session[:userid])

--- a/vmdb/app/controllers/application_controller/current_user.rb
+++ b/vmdb/app/controllers/application_controller/current_user.rb
@@ -30,7 +30,6 @@ module ApplicationController::CurrentUser
 
     role = db_group.try(:miq_user_role)
 
-    session[:role] = role.try(:id)
     # Build pre-sprint 69 role name if this is an EvmRole read_only role
     session[:userrole] = role.try(:read_only?) ? role.name.split("-").last : ""
   end
@@ -64,11 +63,6 @@ module ApplicationController::CurrentUser
     session[:group_description]
   end
   protected :current_group_description
-
-  def current_role
-    session[:role]
-  end
-  protected :current_role
 
   def current_userrole
     session[:userrole]

--- a/vmdb/app/controllers/application_controller/current_user.rb
+++ b/vmdb/app/controllers/application_controller/current_user.rb
@@ -3,7 +3,7 @@ module ApplicationController::CurrentUser
 
   included do
     helper_method :current_user,  :current_userid, :current_username
-    helper_method :current_group, :current_groupid, :current_group_description
+    helper_method :current_group, :current_groupid
   end
 
   def clear_current_user
@@ -26,7 +26,6 @@ module ApplicationController::CurrentUser
 
   def current_group=(db_group)
     session[:group] = db_group.try(:id)
-    session[:group_description] = db_group.try(:description)
 
     role = db_group.try(:miq_user_role)
 
@@ -58,11 +57,6 @@ module ApplicationController::CurrentUser
     session[:group]
   end
   protected :current_groupid
-
-  def current_group_description
-    session[:group_description]
-  end
-  protected :current_group_description
 
   def current_userrole
     session[:userrole]

--- a/vmdb/app/controllers/dashboard_controller.rb
+++ b/vmdb/app/controllers/dashboard_controller.rb
@@ -707,11 +707,6 @@ class DashboardController < ApplicationController
     session['referer'] = referer
 
     self.current_user = db_user
-    self.current_group = db_user.try(:current_group)
-
-    # Save an array of groups this user is eligible for, if more than 1
-    eligible_groups = db_user ? db_user.miq_groups.sort_by { |g| g.description.downcase } : []
-    session[:eligible_groups] = eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
 
     # Clear instance vars that end up in the session
     @sb = @edit = @view = @settings = @lastaction = @perf_options = @assign = nil

--- a/vmdb/app/views/layouts/_user_options.html.haml
+++ b/vmdb/app/views/layouts/_user_options.html.haml
@@ -22,7 +22,7 @@
       - else
         %li.disabled
           %a{:href => "#"}
-            = session[:group_description]
+            = current_group.try(:description)
       %li.divider
       %li
         %a{:href => "/dashboard/logout", :onclick => 'return miqCheckForChanges()', :title => _("Click to Logout")}

--- a/vmdb/spec/controllers/dashboard_controller_spec.rb
+++ b/vmdb/spec/controllers/dashboard_controller_spec.rb
@@ -44,7 +44,6 @@ describe DashboardController do
       UserValidationService.any_instance.stub(:user_is_super_admin?).and_return(true)
       validation = controller.send(:validate_user, user)
       session[:group].should eq(group.id)
-      session[:role].should eq(role.id)
       expect(validation.flash_msg).to be_nil
       expect(validation.url).to eq('some_url')
     end


### PR DESCRIPTION
Three small session changes. #3170

- `session[:role]` is not used, (we use `session[:userrole]` instead)
- offload setting `session[:eligible_groups]` to `current_user` module.
- merge `set_user` and `set_group`
- no need to store `group_description` when we always fetch the group, that holds this description.

/cc @dclarizio @Fryguy 