### PR TITLE
miq_cal_skipDays / :skip_days - removal of broken code

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -934,15 +934,15 @@ function miqBuildCalendar() {
       element.datepicker();
     }
 
-    if (typeof ManageIQ.calendar.calDateFrom != "undefined") {
+    if (ManageIQ.calendar.calDateFrom) {
       element.datepicker('setStartDate', ManageIQ.calendar.calDateFrom);
     }
 
-    if (typeof ManageIQ.calendar.calDateTo != "undefined") {
+    if (ManageIQ.calendar.calDateTo) {
       element.datepicker('setEndDate', ManageIQ.calendar.calDateTo);
     }
 
-    if (typeof miq_cal_skipDays != "undefined") {
+    if (typeof miq_cal_skipDays != "undefined" && miq_cal_skipDays) {
       element.datepicker('setDaysOfWeekDisabled', miq_cal_skipDays);
     }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -942,8 +942,8 @@ function miqBuildCalendar() {
       element.datepicker('setEndDate', ManageIQ.calendar.calDateTo);
     }
 
-    if (typeof miq_cal_skipDays != "undefined" && miq_cal_skipDays) {
-      element.datepicker('setDaysOfWeekDisabled', miq_cal_skipDays);
+    if (ManageIQ.calendar.calSkipDays) {
+      element.datepicker('setDaysOfWeekDisabled', ManageIQ.calendar.calSkipDays);
     }
 
     if (observeDateBackup != null) {

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -30,6 +30,7 @@ if (typeof(ManageIQ) === 'undefined') {
     calendar: { // TODO about to be removed
       calDateFrom: null, // to limit calendar starting
       calDateTo: null, // to limit calendar ending
+      calSkipDays: null,  // to disable specific days of week
     },
     charts: {
       chartData: null, // data for charts

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -87,18 +87,10 @@ module ApplicationController::Performance
                                        :locals  => {:chart_data => @chart_data, :chart_set => "candu"})
       unless @no_util_data
         if @perf_options[:typ] == "Hourly"
-          page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate].year},#{@perf_options[:sdate].month - 1},#{@perf_options[:sdate].day});"
-          page << "ManageIQ.calendar.calDateTo   = new Date(#{@perf_options[:edate].year},#{@perf_options[:edate].month - 1},#{@perf_options[:edate].day});"
+          page << js_build_calendar(:date_from => @perf_options[:sdate], :date_to => @perf_options[:edate], :skip_days => @perf_options[:skip_days])
         else
-          page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate_daily].year},#{@perf_options[:sdate_daily].month - 1},#{@perf_options[:sdate_daily].day});"
-          page << "ManageIQ.calendar.calDateTo   = new Date(#{@perf_options[:edate_daily].year},#{@perf_options[:edate_daily].month - 1},#{@perf_options[:edate_daily].day});"
+          page << js_build_calendar(:date_from => @perf_options[:sdate_daily], :date_to => @perf_options[:edate_daily], :skip_days => @perf_options[:skip_days])
         end
-        if @perf_options[:skip_days]
-          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-        else
-          page << "miq_cal_skipDays = null;"
-        end
-        page << 'miqBuildCalendar();'
         page << Charting.js_load_statement
       end
       page << 'miqSparkle(false);'
@@ -222,7 +214,8 @@ module ApplicationController::Performance
     options[:daily_date] ||= [edate_daily.month, edate_daily.day, edate_daily.year].join("/")
 
     if options[:typ] == "Hourly" && options[:time_profile]              # If hourly and profile in effect, set hourly date to a valid day in the profile
-      options[:skip_days] = [0, 1, 2, 3, 4, 5, 6].delete_if { |d| options[:time_profile_days].include?(d) }.join(",")
+      options[:skip_days] = skip_days_from_time_profile(options[:time_profile_days])
+
       hdate = options[:hourly_date].to_date                             # Start at the currently set hourly date
       6.times do                                                        # Go back up to 6 days (try each weekday)
         break if options[:time_profile_days].include?(hdate.wday)       # If weekday is in the profile, use it
@@ -413,14 +406,7 @@ module ApplicationController::Performance
         end
         page.replace("perf_options_div", :partial => "layouts/perf_options")
         page.replace("candu_charts_div", :partial => "layouts/perf_charts", :locals => {:chart_data => @chart_data, :chart_set => "candu"})
-        page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate].year},#{@perf_options[:sdate].month - 1},#{@perf_options[:sdate].day});"
-        page << "ManageIQ.calendar.calDateTo = new Date(#{@perf_options[:edate].year},#{@perf_options[:edate].month - 1},#{@perf_options[:edate].day});"
-        if @perf_options[:skip_days]
-          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-        else
-          page << "miq_cal_skipDays = null;"
-        end
-        page << 'miqBuildCalendar();'
+        page << js_build_calendar(:date_from => @perf_options[:sdate], :date_to => @perf_options[:edate], :skip_days => @perf_options[:skip_days])
         page << Charting.js_load_statement
         page << 'miqSparkle(false);'
       end
@@ -448,14 +434,7 @@ module ApplicationController::Performance
         end
         page.replace("perf_options_div", :partial => "layouts/perf_options")
         page.replace("candu_charts_div", :partial => "layouts/perf_charts", :locals => {:chart_data => @chart_data, :chart_set => "candu"})
-        page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate_daily].year},#{@perf_options[:sdate_daily].month - 1},#{@perf_options[:sdate_daily].day});"
-        page << "ManageIQ.calendar.calDateTo = new Date(#{@perf_options[:edate_daily].year},#{@perf_options[:edate_daily].month - 1},#{@perf_options[:edate_daily].day});"
-        if @perf_options[:skip_days]
-          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-        else
-          page << "miq_cal_skipDays = null;"
-        end
-        page << 'miqBuildCalendar();'
+        page << js_build_calendar(:date_from => @perf_options[:sdate_daily], :date_to => @perf_options[:edate_daily], :skip_days => @perf_options[:skip_days])
         page << Charting.js_load_statement
         page << 'miqSparkle(false);'
       end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1914,8 +1914,8 @@ class CatalogController < ApplicationController
         presenter[:set_visible_elements][:pc_div_1] = false
         @record.dialog_fields.each do |field|
           if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
-            presenter[:build_calendar]  = {
-              :date_from => field.show_past_dates ? nil : Time.zone.now.to_i * 1000
+            presenter[:build_calendar] = {
+              :date_from => field.show_past_dates ? nil : Time.zone.now,
             }
           end
         end

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -446,7 +446,8 @@ class MiqCapacityController < ApplicationController
     @sb[:util][:options][:chart_date] ||= [edate.month, edate.day, edate.year].join("/")
 
     if @sb[:util][:options][:time_profile]                              # If profile in effect, set date to a valid day in the profile
-      @sb[:util][:options][:skip_days] = [0, 1, 2, 3, 4, 5, 6].delete_if { |d| @sb[:util][:options][:time_profile_days].include?(d) }.join(",")
+      @sb[:util][:options][:skip_days] = skip_days_from_time_profile(@sb[:util][:options][:time_profile_days])
+
       cdate = @sb[:util][:options][:chart_date].to_date                 # Start at the currently set date
       6.times do                                                        # Go back up to 6 days (try each weekday)
         break if @sb[:util][:options][:time_profile_days].include?(cdate.wday)  # If weekday is in the profile, use it
@@ -494,10 +495,10 @@ class MiqCapacityController < ApplicationController
     presenter[:set_visible_elements][:toolbar] = true
     presenter[:update_partials][:main_div] = r[:partial => 'utilization_tabs']
     presenter[:right_cell_text] = @right_cell_text
-    presenter[:build_calendar]  = {
-      :skip_days => @sb[:util][:options][:skip_days],
+    presenter[:build_calendar] = {
       :date_from => @sb[:util][:options][:sdate],
       :date_to   => @sb[:util][:options][:edate],
+      :skip_days => @sb[:util][:options][:skip_days],
     }
 
     # FIXME: where is curTab declared?

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -441,8 +441,8 @@ class MiqCapacityController < ApplicationController
     end
     @sb[:util][:options][:trend_start] = sdate
     @sb[:util][:options][:trend_end] = edate
-    @sb[:util][:options][:sdate] = [sdate.year.to_s, (sdate.month - 1).to_s, sdate.day.to_s].join(", ") # Start and end dates for calendar control
-    @sb[:util][:options][:edate] = [edate.year.to_s, (edate.month - 1).to_s, edate.day.to_s].join(", ")
+    @sb[:util][:options][:sdate] = sdate  # Start and end dates for calendar control
+    @sb[:util][:options][:edate] = edate
     @sb[:util][:options][:chart_date] ||= [edate.month, edate.day, edate.year].join("/")
 
     if @sb[:util][:options][:time_profile]                              # If profile in effect, set date to a valid day in the profile

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -572,8 +572,8 @@ class OpsController < ApplicationController
     when "se"         # schedule edit
       # when editing/adding schedule in settings tree
       presenter[:update_partials][:settings_list] = r[:partial => "schedule_form"]
-      presenter[:build_calendar]  = {
-        :date_from => (Time.zone.now - 1.month).in_time_zone(@edit[:tz]).to_i * 1000
+      presenter[:build_calendar] = {
+        :date_from => (Time.zone.now - 1.month).in_time_zone(@edit[:tz]),
       }
       if !@schedule.id
         @right_cell_text = _("Adding a new %s") % ui_lookup(:model => "MiqSchedule")

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -782,7 +782,7 @@ class ReportController < ApplicationController
         presenter[:open_accord] = 'widgets'
         if @in_a_form
           presenter[:build_calendar] = {
-            :date_from => Time.now.in_time_zone(@edit[:tz]).to_i * 1000,
+            :date_from => Time.now.in_time_zone(@edit[:tz]),
             :date_to   => nil,
           }
           # URL to be used in miqDropComplete method

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -419,8 +419,8 @@ class ServiceController < ApplicationController
     if @record.kind_of?(Dialog)
       @record.dialog_fields.each do |field|
         if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-          presenter[:build_calendar]  = {
-            :date_from => field.show_past_dates ? nil : Time.zone.now.to_i * 1000
+          presenter[:build_calendar] = {
+            :date_from => field.show_past_dates ? nil : Time.zone.now,
           }
         end
       end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1515,8 +1515,8 @@ module VmCommon
       if @record.kind_of?(Dialog)
         @record.dialog_fields.each do |field|
           if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-            presenter[:build_calendar]  = {
-              :date_from => field.show_past_dates ? nil : Time.zone.now.to_i * 1000
+            presenter[:build_calendar] = {
+              :date_from => field.show_past_dates ? nil : Time.zone.now,
             }
           end
         end
@@ -1527,7 +1527,7 @@ module VmCommon
         locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids][0] if @sb[:action] == "tag"
         unless %w(ownership retire).include?(@sb[:action])
           presenter[:build_calendar] = {
-            :date_from => Time.zone.now.to_i * 1000,
+            :date_from => Time.zone.now,
             :date_to   => nil,
           }
         end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1192,6 +1192,13 @@ module ApplicationHelper
     end
   end
 
+  def skip_days_from_time_profile(time_profile_days)
+    (1..7).to_a.delete_if do |d|
+      # time_profile_days has 0 for sunday, skip_days needs 7 for sunday
+      time_profile_days.include?(d % 7)
+    end
+  end
+
   def breadcrumb_prohibited_for_action?
     !%w(accordion_select explorer tree_select).include?(action_name)
   end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -121,7 +121,7 @@ module JsHelper
     <<EOD
 ManageIQ.calendar.calDateFrom = #{js_format_date(options[:date_from])};
 ManageIQ.calendar.calDateTo = #{js_format_date(options[:date_to])};
-miq_cal_skipDays = #{skip_days};
+ManageIQ.calendar.calSkipDays = #{skip_days};
 miqBuildCalendar();
 EOD
   end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -114,4 +114,19 @@ module JsHelper
   def javascript_update_element(element, content)
     "$('##{element}').html('#{escape_javascript(content)}');"
   end
+
+  def js_build_calendar(options = {})
+    skip_days = options[:skip_days].nil? ? 'undefined' : options[:skip_days].to_a.to_json
+
+    <<EOD
+ManageIQ.calendar.calDateFrom = #{js_format_date(options[:date_from])};
+ManageIQ.calendar.calDateTo = #{js_format_date(options[:date_to])};
+miq_cal_skipDays = #{skip_days};
+miqBuildCalendar();
+EOD
+  end
+
+  def js_format_date(value)
+    value.nil? ? 'undefined' : "new Date('#{value.iso8601}')"
+  end
 end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -17,10 +17,7 @@ class ExplorerPresenter
   #
   #   add_nodes                        -- JSON string of nodes to add to the active tree
   #   delete_node                      -- key of node to be deleted from the active tree
-  #   cal_date_from
-  #   cal_date_to
-  #   build_calendar                   -- call miqBuildCalendar, true/false or Hash with
-  #                                       compulsory key :skip_days
+  #   build_calendar                   -- call miqBuildCalendar, true/false or Hash (:date_from, :date_to, :skip_days)
   #   init_dashboard
   #   ajax_action                      -- Hash of options for AJAX action to fire
   #   clear_gtl_list_grid
@@ -177,21 +174,13 @@ class ExplorerPresenter
   end
 
   def build_calendar
-    out = []
-    if Hash === @options[:build_calendar]
+    if @options[:build_calendar].kind_of? Hash
       calendar_options = @options[:build_calendar]
-      out << "ManageIQ.calendar.calDateFrom = #{format_cal_date(calendar_options[:date_from])};" if calendar_options.key?(:date_from)
-      out << "ManageIQ.calendar.calDateTo   = #{format_cal_date(calendar_options[:date_to])};"   if calendar_options.key?(:date_to)
-
-      if calendar_options.key?(:skip_days)
-        skip_days = calendar_options[:skip_days].nil? ?
-          'null' : ("'" + calendar_options[:skip_days] + "'")
-        out << "miq_cal_skipDays = #{skip_days};"
-      end
+    else
+      calendar_options = {}
     end
 
-    out << 'miqBuildCalendar();'
-    out.join("\n")
+    js_build_calendar(calendar_options)
   end
 
   # Fire an AJAX action
@@ -220,11 +209,5 @@ class ExplorerPresenter
   def update_partial(element, content)
     # FIXME: replace with javascript_update_element
     "$('##{element}').html('#{escape_javascript(content)}');"
-  end
-
-  private
-
-  def format_cal_date(value)
-    value.nil? ? 'undefined' : "new Date(#{value})"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1526,6 +1526,20 @@ describe ApplicationHelper do
     end
   end
 
+  context '#skip_days_from_time_profile' do
+    it 'should return empty array for whole week' do
+      skip_days_from_time_profile((0..6).to_a).should eq([])
+    end
+
+    it 'should return whole week for empty array' do
+      skip_days_from_time_profile([]).should eq((1..7).to_a)
+    end
+
+    it 'should handle Sundays' do
+      skip_days_from_time_profile((1..6).to_a).should eq([7])
+    end
+  end
+
   it 'output of remote_function should not be html_safe' do
     remote_function(:url => {:controller => 'vm_infra', :action => 'explorer'}).html_safe?.should be_false
   end

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -128,7 +128,7 @@ describe JsHelper do
       expected = <<EOD
 ManageIQ.calendar.calDateFrom = undefined;
 ManageIQ.calendar.calDateTo = undefined;
-miq_cal_skipDays = undefined;
+ManageIQ.calendar.calSkipDays = undefined;
 miqBuildCalendar();
 EOD
 
@@ -143,7 +143,7 @@ EOD
       expected = <<EOD
 ManageIQ.calendar.calDateFrom = new Date('1970-01-01T00:00:00Z');
 ManageIQ.calendar.calDateTo = new Date('2000-01-01T00:00:00Z');
-miq_cal_skipDays = [1,2,3];
+ManageIQ.calendar.calSkipDays = [1,2,3];
 miqBuildCalendar();
 EOD
 

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -33,9 +33,6 @@ describe JsHelper do
     end
   end
 
-  context '#update_element' do
-  end
-
   context '#javascript_focus' do
     it 'returns js to focus on an element' do
       javascript_focus('foo').should eq("$('#foo').focus();")
@@ -123,6 +120,44 @@ describe JsHelper do
       javascript_unchecked(
         'foo'
       ).should eq("if ($('#foo').prop('type') == 'checkbox') {$('#foo').prop('checked', false);}")
+    end
+  end
+
+  context '#js_build_calendar' do
+    it 'returns JS to build calendar with no options' do
+      expected = <<EOD
+ManageIQ.calendar.calDateFrom = undefined;
+ManageIQ.calendar.calDateTo = undefined;
+miq_cal_skipDays = undefined;
+miqBuildCalendar();
+EOD
+
+      js_build_calendar.should eq(expected)
+    end
+
+    it 'returns JS to build calendar with options' do
+      opt = {:date_from => Time.at(0).utc,
+             :date_to   => Time.at(946684800).utc,
+             :skip_days => [ 1, 2, 3 ]}
+
+      expected = <<EOD
+ManageIQ.calendar.calDateFrom = new Date('1970-01-01T00:00:00Z');
+ManageIQ.calendar.calDateTo = new Date('2000-01-01T00:00:00Z');
+miq_cal_skipDays = [1,2,3];
+miqBuildCalendar();
+EOD
+
+      js_build_calendar(opt).should eq(expected)
+    end
+  end
+
+  context '#js_format_date' do
+    it 'returns undefined for nil' do
+      js_format_date(nil).should eq('undefined')
+    end
+
+    it 'returns new Date with iso string as param' do
+      js_format_date(Time.at(946684800).utc).should eq("new Date('2000-01-01T00:00:00Z')")
     end
   end
 end

--- a/spec/presenters/explorer_presenter_spec.rb
+++ b/spec/presenters/explorer_presenter_spec.rb
@@ -48,43 +48,22 @@ describe ExplorerPresenter do
     end
 
     context "#build_calendar" do
-      it 'returns JS to build calendar with no options' do
+      it 'calls js_build_calendar' do
         @presenter[:build_calendar] = true
-        @presenter.build_calendar.should == 'miqBuildCalendar();'
+        expect(@presenter).to receive(:js_build_calendar)
+        @presenter.build_calendar
       end
 
-      it 'returns JS to build calendar with options' do
-        @presenter[:build_calendar] = {
-          :date_from => 'Fantomas',
-          :date_to   => 'was',
-          :skip_days => 'here!',
-        }
-
-        js_str = @presenter.build_calendar
-
-        expected = <<EOD
-ManageIQ.calendar.calDateFrom = new Date(Fantomas);
-ManageIQ.calendar.calDateTo   = new Date(was);
-miq_cal_skipDays = 'here!';
-miqBuildCalendar();
-EOD
-        (js_str + "\n").should == expected
-      end
-
-      it 'returns JS to undefine a date' do
-        @presenter[:build_calendar] = {
-          :date_from => 'Fantomas is gone!',
-          :date_to   => nil,
-        }
-
-        js_str = @presenter.build_calendar
-
-        expected = <<EOD
-ManageIQ.calendar.calDateFrom = new Date(Fantomas is gone!);
-ManageIQ.calendar.calDateTo   = undefined;
-miqBuildCalendar();
-EOD
-        (js_str + "\n").should == expected
+      it 'calls js_build_calendar with params' do
+        # with_indifferent_access because ExplorerPresenter#options is, and it's recursively infectious - ie. won't compare otherwise
+        obj = {
+          :date_from => Time.at(0).utc,
+          :date_to   => Time.at(946684800).utc,
+          :skip_days => [ 1, 2, 3 ],
+        }.with_indifferent_access
+        @presenter[:build_calendar] = obj
+        expect(@presenter).to receive(:js_build_calendar).with(obj)
+        @presenter.build_calendar
       end
     end
   end


### PR DESCRIPTION
According to http://docs.dhtmlx.com/api__dhtmlxcalendar_setinsensitivedays.html ,
setInsensitiveDays expects dates, not days of week.

Thus, that functionality as it is always triggers a JS error.

So I'm assuming that we can safely remove it? Or at the very least this shows what needs to get rewritten.