### PR TITLE
Enable automate role on new servers by default

### DIFF
--- a/vmdb/config/vmdb.tmpl.yml
+++ b/vmdb/config/vmdb.tmpl.yml
@@ -194,7 +194,7 @@ server:
   monitor_poll: 5.seconds
   name: EVM
   remote_console_type: VMRC
-  role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,web_services
+  role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,web_services,automate
   server_dequeue_frequency: 5.seconds
   session_store: cache
   startup_timeout: 300


### PR DESCRIPTION
Automate is required for many areas of the product (VM/Service/Orchestration provisioning, custom buttons, retirement, etc) it makes sense to have the role enabled by default on new appliances.  Users can still disable the role on appliances as needed.