### PR TITLE
[WIP] Session brand

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,6 @@ class ApplicationController < ActionController::Base
   include_concern 'SysprepAnswerFile'
 
   before_action :reset_toolbar
-  before_action :set_session_tenant, :except => [:window_sizes]
   before_action :get_global_session_data, :except => [:resize_layout, :window_sizes, :authenticate]
   before_action :set_user_time_zone, :except => [:window_sizes]
   before_action :set_gettext_locale, :except => [:window_sizes]

--- a/app/controllers/application_controller/tenancy.rb
+++ b/app/controllers/application_controller/tenancy.rb
@@ -14,10 +14,4 @@ module ApplicationController::Tenancy
       #  Tenant.where(:domain => request.domain).first ||
       current_user.try(:current_tenant) || Tenant.default_tenant
   end
-
-  # NOTE: remove when these session vars are removed
-  def set_session_tenant(tenant = current_tenant)
-    session[:customer_name] = tenant.try(:name)
-    tenant
-  end
 end

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -1,9 +1,5 @@
 require 'miq_bulk_import'
 class ConfigurationController < ApplicationController
-  logo_dir = File.expand_path(File.join(Rails.root, "public/upload"))
-  Dir.mkdir logo_dir unless File.exist?(logo_dir)
-  @@logo_file = File.join(logo_dir, "custom_logo.png")
-
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1,11 +1,6 @@
 module OpsController::Settings::Common
   extend ActiveSupport::Concern
 
-  logo_dir = File.expand_path(File.join(Rails.root, "public/upload"))
-  Dir.mkdir logo_dir unless File.exist?(logo_dir)
-  @@logo_file = File.join(logo_dir, "custom_logo.png")
-  @@login_logo_file = File.join(logo_dir, "custom_login_logo.png")
-
   # AJAX driven routine to check for changes in ANY field on the form
   def settings_form_field_changed
     tab = params[:id] ? "settings_#{params[:id]}" : nil # workaround to prevent an error that happens when IE sends a transaction when tab is changed when there is text_area in the form, checking for tab id
@@ -422,8 +417,14 @@ module OpsController::Settings::Common
           add_flash(_("Configuration settings saved"))
         end
         if @sb[:active_tab] == "settings_server" && @sb[:selected_server_id] == MiqServer.my_server.id  # Reset session variables for names fields, if editing current server config
-          session[:customer_name] = @update.config[:server][:company]
-          session[:vmdb_name] = @update.config[:server][:name]
+          current_tenant.update_attributes(
+            :customer_name => @update.config[:server][:company],
+            :vmdb_name     => @update.config[:server][:name]
+          )
+        elsif @sb[:active_tab] == "settings_custom_logos"                           # Reset session variable for logo field
+          current_tenant.update_attributes(
+            :custom_logo => @update.config[:server][:custom_logo]
+          )
         end
         set_user_time_zone if @sb[:active_tab] == "settings_server"
         # settings_set_form_vars
@@ -471,8 +472,10 @@ module OpsController::Settings::Common
         add_flash(_("%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\"") % {:typ => "Configuration", :name => server.name, :server_id => @sb[:selected_server_id], :zone => server.my_zone})
 
         if @sb[:active_tab] == "settings_workers" && @sb[:selected_server_id] == MiqServer.my_server.id  # Reset session variables for names fields, if editing current server config
-          session[:customer_name] = @update.config[:server][:company]
-          session[:vmdb_name] = @update.config[:server][:name]
+          current_tenant.update_attributes(
+            :customer_name => @update.config[:server][:company],
+            :vmdb_name     => @update.config[:server][:name]
+          )
         end
         @changed = false
         get_node_info(x_node)
@@ -1025,8 +1028,6 @@ module OpsController::Settings::Common
       if @edit[:current].config[:server][:custom_logo].nil?
         @edit[:current].config[:server][:custom_logo] = false # Set default custom_logo flag
       end
-      @logo_file = @@logo_file
-      @login_logo_file = @@login_logo_file
       @in_a_form = true
     when "settings_advanced"                                  # Advanced yaml editor
       session[:config_file_name] ||= AVAILABLE_CONFIG_NAMES_FOR_SELECT.first.last # Start with first config file name

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -418,8 +418,7 @@ module OpsController::Settings::Common
         end
         if @sb[:active_tab] == "settings_server" && @sb[:selected_server_id] == MiqServer.my_server.id  # Reset session variables for names fields, if editing current server config
           current_tenant.update_attributes(
-            :customer_name => @update.config[:server][:company],
-            :vmdb_name     => @update.config[:server][:name]
+            :name => @update.config[:server][:company],
           )
         elsif @sb[:active_tab] == "settings_custom_logos"                           # Reset session variable for logo field
           current_tenant.update_attributes(
@@ -473,8 +472,7 @@ module OpsController::Settings::Common
 
         if @sb[:active_tab] == "settings_workers" && @sb[:selected_server_id] == MiqServer.my_server.id  # Reset session variables for names fields, if editing current server config
           current_tenant.update_attributes(
-            :customer_name => @update.config[:server][:company],
-            :vmdb_name     => @update.config[:server][:name]
+            :name => @update.config[:server][:company],
           )
         end
         @changed = false

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -40,7 +40,7 @@ module TextualSummaryHelper
   end
 
   def textual_tags
-    label = "#{session[:customer_name]} Tags"
+    label = "#{current_tenant.name} Tags"
     h = {:label => label}
     tags = session[:assigned_filters]
     if tags.blank?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1085,7 +1085,6 @@ class MiqExpression
       :include_model => true,
       :include_table => true
     }.merge(options)
-    @company ||= VMDB::Config.new("vmdb").config[:server][:company]
     tables, col = val.split("-")
     first = true
     val_is_a_tag = false
@@ -1094,7 +1093,7 @@ class MiqExpression
       friendly = tables.split(".").collect do|t|
         if t.downcase == "managed"
           val_is_a_tag = true
-          @company + " Tags"
+          "#{User.current_tenant.name} Tags"
         elsif t.downcase == "user_tag"
           "My Tags"
         else

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -197,6 +197,10 @@ class Tenant < ActiveRecord::Base
     !!logo_file_name
   end
 
+  # for now, we are ignoring the custom_logo and custom_login_logo checkboxes
+  def custom_logo=(_ignore)
+  end
+
   def login_logo?
     !!login_logo_file_name
   end

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -1,6 +1,6 @@
 - auth_mode   = get_vmdb_config[:authentication][:mode]
 %span#badge
-  %img{:src => "#{current_tenant.logo? ? '/upload/custom_logo.png' : image_path("login-screen-logo.png")}"}
+  %img{:src => current_tenant.login_logo.url}
 .container
   .row
     .col-md-12

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -13,7 +13,7 @@
 
     = csrf_meta_tag
 
-  %body{:onload => "miqOnLoad();", :class => get_vmdb_config[:server][:custom_login_logo] ? 'whitelabel' : ''}
+  %body{:onload => "miqOnLoad();", :class => ("whitelabel" if current_tenant.login_logo?)}
     - if MiqServer.my_server(true).logon_status == :starting
       :javascript
         self.setTimeout("miqAjax('/dashboard/login_retry')",10000);

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -2,8 +2,8 @@
   - url = url_for(:action => 'settings_form_field_changed', :id => "#{@sb[:active_tab].split('_')[1]}_#{@sb[:active_tab].split('_').last}")
   = render :partial => "layouts/flash_msg"
   %h3= _("Custom Logo Image (Shown on top right of all screens)")
-  - if File.exist?(@logo_file)
-    = image_tag("/upload/custom_logo.png?#{rand(99_999_999)}")
+  - if current_tenant.logo?
+    = image_tag("#{current_tenant.logo.url}?#{rand(99_999_999).to_s}")
   - else
     = render :partial => 'layouts/info_msg', :locals => {:message => "No custom logo image has been uploaded yet."}
   = form_tag({:action => "upload_logo"}, :class => "form-horizontal", :multipart => true) do
@@ -21,7 +21,7 @@
                     :id    => "upload",
                     :class => "btn btn-default")
         = _("* Requirements: File-type - PNG; Dimensions - 350x70.")
-  - if File.exist?(@logo_file)
+  - if current_tenant.logo?
     %br/
     %form.form-horizontal
       .form-group
@@ -32,8 +32,8 @@
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
   %hr/
   %h3= _("Custom Login Background Image")
-  - if File.exist?(@login_logo_file)
-    = image_tag("/upload/custom_login_logo.png?#{rand(99_999_999)}",
+  - if current_tenant.login_logo?
+    = image_tag("#{current_tenant.login_logo.url}?#{rand(99_999_999)}",
                 :height => 400,
                 :width  => 675)
     %br/
@@ -60,7 +60,7 @@
                     :class => "btn btn-default")
         = _("* Requirements: File-type - PNG; Dimensions - 1280x1000.")
 
-  - if File.exist?(@login_logo_file)
+  - if current_tenant.login_logo?
     %br/
     %form.form-horizontal
       .form-group

--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -171,7 +171,7 @@ module ReportFormatter
         unless mri.user_categories.blank?
           user_filters = mri.user_categories.flatten
           unless user_filters.blank?
-            customer_name = VMDB::Config.new("vmdb").config[:server][:company]
+            customer_name = User.current_tenant.name
             user_filter = "User assigned " + customer_name + " Tag filters:"
             t = user_filter + " " * (@line_len - 2 - user_filter.length)
             output << fit_to_width("|#{t}|" + CRLF)
@@ -186,7 +186,7 @@ module ReportFormatter
         unless mri.categories.blank?
           categories = mri.categories.flatten
           unless categories.blank?
-            customer_name = VMDB::Config.new("vmdb").config[:server][:company]
+            customer_name = User.current_tenant.name
             customer_name_title = "Report based " + customer_name + " Tag filters:"
             t = customer_name_title + " " * (@line_len - customer_name_title.length - 2)
             output << fit_to_width("|#{t}|" + CRLF)

--- a/product/toolbars/miq_group_center_tb.yaml
+++ b/product/toolbars/miq_group_center_tb.yaml
@@ -30,5 +30,5 @@
     :items:
     - :button: rbac_group_tags_edit
       :image: tag
-      :text: "Edit '#{session[:customer_name]}' Tags for this Group"
-      :title: "Edit '#{session[:customer_name]}' Tags for this Group"
+      :text: "Edit '#{current_tenant.name}' Tags for this Group"
+      :title: "Edit '#{current_tenant.name}' Tags for this Group"

--- a/product/toolbars/miq_groups_center_tb.yaml
+++ b/product/toolbars/miq_groups_center_tb.yaml
@@ -44,8 +44,8 @@
     :items:
     - :button: rbac_group_tags_edit
       :image: tag
-      :text: "Edit '#{session[:customer_name]}' Tags for the selected Groups"
-      :title: "Edit '#{session[:customer_name]}' Tags for the selected Groups"
+      :text: "Edit '#{current_tenant.name}' Tags for the selected Groups"
+      :title: "Edit '#{current_tenant.name}' Tags for the selected Groups"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/product/toolbars/user_center_tb.yaml
+++ b/product/toolbars/user_center_tb.yaml
@@ -34,5 +34,5 @@
     :items:
     - :button: rbac_user_tags_edit
       :image: tag
-      :text: "Edit '#{session[:customer_name]}' Tags for this User"
-      :title: "Edit '#{session[:customer_name]}' Tags for this User"
+      :text: "Edit '#{current_tenant.name}' Tags for this User"
+      :title: "Edit '#{current_tenant.name}' Tags for this User"

--- a/product/toolbars/users_center_tb.yaml
+++ b/product/toolbars/users_center_tb.yaml
@@ -46,8 +46,8 @@
     :items:
     - :button: rbac_user_tags_edit
       :image: tag
-      :text: "Edit '#{session[:customer_name]}' Tags for the selected Users"
-      :title: "Edit '#{session[:customer_name]}' Tags for the selected Users"
+      :text: "Edit '#{current_tenant.name}' Tags for the selected Users"
+      :title: "Edit '#{current_tenant.name}' Tags for the selected Users"
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'

--- a/spec/views/dashboard/login.html.haml_spec.rb
+++ b/spec/views/dashboard/login.html.haml_spec.rb
@@ -6,6 +6,7 @@ describe "dashboard/login.html.haml" do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       stub_server_configuration(:server => {}, :session => {}, :authentication => {})
+      view.stub(:current_tenant).and_return(Tenant.seed)
     end
 
     it "when authentication is 'database'" do


### PR DESCRIPTION
**blocked:** tenant object is pulled out in #3336

Introduce a brand object that holds branding information for a server.
In multi-tenancy, each tenant will have a different brand.

This holds a few basics:

- `session[:customer_name]`
- `session[:vmdb_name]`
- `session[:custom_logo]`
- paths to images (and file references)
- helpers for css classes

Improvements saved for the future (and possibly someone else):

- logos are still hardcoded in the less file.
- brand information still comes from `vmdb.yml`.
- only 1 brand per server.
- more branding and customization fields.

/cc @Fryguy @dclarizio @epwinchell 
/bcc @gmcculloug 