### PR TITLE
Don't send credentials over the wire with SSL on (try SSL first)

### DIFF
--- a/lib/openstack/openstack_handle/handle.rb
+++ b/lib/openstack/openstack_handle/handle.rb
@@ -28,12 +28,16 @@ module OpenstackHandle
 
     # Tries both non-SSL and SSL connections to Openstack
     def self.try_connection
-      # attempt to connect without SSL
-      yield "http", {}
-    rescue Excon::Errors::SocketError => err
-      raise unless err.message.include?("end of file reached (EOFError)")
-      # attempt the same connection with SSL
+      # attempt to connect with SSL
       yield "https", {:ssl_verify_peer => false}
+    rescue Excon::Errors::SocketError => err
+      # TODO recognizing something in exception message is not very reliable. But somebody would need to go to excon gem
+      # and do proper exceptions like Excon::Errors::SocketError::UnknownProtocolSSL,
+      # Excon::Errors::SocketError::BadCertificate, etc. all of them inheriting from Excon::Errors::SocketError
+      raise unless (err.message.include?("end of file reached (EOFError)") ||
+                    err.message.include?("unknown protocol (OpenSSL::SSL::SSLError)"))
+      # attempt the same connection without SSL
+      yield "http", {}
     end
 
     def self.raw_connect_try_ssl(username, password, address, port, service = "Compute", opts = nil)


### PR DESCRIPTION
Don't send credentials over the wire with SSL on. Try ssl
connection first. This way we will avoid sending credentials
unencrypted over the wire, when we want SSL connection.