### PR TITLE
Correct tasks description.

### DIFF
--- a/vmdb/config/api.yml
+++ b/vmdb/config/api.yml
@@ -655,7 +655,7 @@
       - :name: assign
       - :name: unassign
   :tasks:
-    :description: Request Tasks
+    :description: Tasks
     :options:
     - :collection
     - :subcollection


### PR DESCRIPTION
Both 'tasks' and 'request tasks' had the same description of 'Request
Tasks'. This change gives tasks a distinct description of simply
'Tasks'.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1232924