### PR TITLE
Change the hover text for compare/drift mode to make it consistent

### DIFF
--- a/vmdb/app/helpers/configuration_helper/configuration_view_helper.rb
+++ b/vmdb/app/helpers/configuration_helper/configuration_view_helper.rb
@@ -52,8 +52,8 @@ module ConfigurationHelper
     end
 
     def compare_or_drift_mode_exists(resource)
-      inactive_icon("view_list.png", _('Details View'), resource, "details") +
-      active_icon("exists.png", _('Exist Mode'))
+      inactive_icon("view_list.png", _('Details Mode'), resource, "details") +
+      active_icon("exists.png", _('Exists Mode'))
     end
 
     def compare_or_drift_mode_details(resource)


### PR DESCRIPTION
Change hover text to 'Details Mode' and 'Exists Mode' when either is selected, in Configure-MySettings->Default Views.

https://bugzilla.redhat.com/show_bug.cgi?id=1227750
https://bugzilla.redhat.com/show_bug.cgi?id=1228130