### PR TITLE
Clear out all user thread local vars

### DIFF
--- a/vmdb/app/models/user.rb
+++ b/vmdb/app/models/user.rb
@@ -903,15 +903,18 @@ class User < ActiveRecord::Base
   def self.with_userid(userid)
     saved_user   = Thread.current[:user]
     saved_userid = Thread.current[:userid]
+    saved_filters = Thread.current[:user_has_filters]
     self.current_userid = userid
     yield
   ensure
     Thread.current[:user]   = saved_user
     Thread.current[:userid] = saved_userid
+    Thread.current[:user_has_filters] = saved_filters
   end
 
   def self.current_userid=(userid)
     Thread.current[:user]   = nil
+    Thread.current[:user_has_filters] = nil
     Thread.current[:userid] = userid
   end
 


### PR DESCRIPTION
Thread local variables stay around for the duration of a server, including requests by other users.
Currently we are setting `:user_has_filter` but not clearing it. So future requests from other users end up getting a stale value.

When a user is set or temporarily changed, it now properly clears the value for thread local `:user_has_filters`.

@dclarizio I found this while looking into the `current_group` issue.

1. This is a bug, but probably wouldn't have caused the issue you were seeing.
2. This is only referenced by [tree_builder.rb:322], can we just remove it all together?
3. ~~Or, can we move into the session and out of thread local? Thread local seems like overkill.~~ EDIT: too many changes

thnx

/cc @Fryguy 

[tree_builder.rb:322]: https://github.com/ManageIQ/manageiq/blob/master/vmdb/app/presenters/tree_builder.rb#L322