### PR TITLE
Block duplicated events

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -20,13 +20,9 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered?(event)
-      _log.info "#{log_prefix} Skipping filtered Azure event #{parse_event_type(event)} for #{event["resourceId"]}"
-    else
-      _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}"
-      EmsEvent.add_queue('add_azure', @cfg[:ems_id], event)
-    end
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}"
+    EmsEvent.add_queue('add_azure', @cfg[:ems_id], event)
   end
 
   private
@@ -49,6 +45,8 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
 
   def filtered?(event)
     event_type = parse_event_type(event)
-    filtered_events.include?(event_type)
+    filtered_events.include?(event_type).tap do |result|
+      _log.info "#{log_prefix} Skipping filtered Azure event #{event_type} for #{event["resourceId"]}" if result
+    end
   end
 end

--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -84,8 +84,8 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     raise NotImplementedError, _("must be implemented in subclass")
   end
 
-  def process_event(_event)
-    raise NotImplementedError, _("must be implemented in subclass")
+  def process_event(event)
+    queue_event(event) unless filtered?(event)
   end
 
   def event_monitor_running

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
@@ -23,15 +23,9 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered?(event)
-      _log.info(
-        "#{log_prefix} Skipping filtered Google event #{parse_event_type(event)} for #{parse_resource_id(event)}"
-      )
-    else
-      _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
-      EmsEvent.add_queue('add_google', @cfg[:ems_id], event)
-    end
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
+    EmsEvent.add_queue('add_google', @cfg[:ems_id], event)
   end
 
   private
@@ -46,6 +40,10 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
 
   def filtered?(event)
     event_type = parse_event_type(event)
-    filtered_events.include?(event_type)
+    filtered_events.include?(event_type).tap do |result|
+      _log.info(
+        "#{log_prefix} Skipping filtered Google event #{event_type} for #{parse_resource_id(event)}"
+      ) if result
+    end
   end
 end

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -48,28 +48,30 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered_events.include?(event.payload[:event_type])
-      _log.info "#{log_prefix} Skipping caught event [#{event.payload["event_type"]}]"
-    else
-      _log.info "#{log_prefix} Caught event [#{event.payload["event_type"]}]"
-
-      event_hash = {}
-      # copy content
-      content = event.payload
-      event_hash[:content] = content.reject { |k, _v| k.start_with? "_context_" }
-
-      # copy context
-      event_hash[:context] = {}
-      content.select { |k, _v| k.start_with? "_context_" }.each_pair do |k, v|
-        event_hash[:context][k] = v
-      end
-
-      # copy attributes
-      event_hash[:user_id]      = event.metadata[:user_id]
-      event_hash[:priority]     = event.metadata[:priority]
-      event_hash[:content_type] = event.metadata[:content_type]
-      add_openstack_queue(event_hash)
+  def filtered?(event)
+    filtered_events.include?(event.payload[:event_type]).tap do |result|
+      _log.info "#{log_prefix} Skipping caught event [#{event.payload["event_type"]}]" if result
     end
+  end
+
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event [#{event.payload["event_type"]}]"
+
+    event_hash = {}
+    # copy content
+    content = event.payload
+    event_hash[:content] = content.reject { |k, _v| k.start_with? "_context_" }
+
+    # copy context
+    event_hash[:context] = {}
+    content.select { |k, _v| k.start_with? "_context_" }.each_pair do |k, v|
+      event_hash[:context][k] = v
+    end
+
+    # copy attributes
+    event_hash[:user_id]      = event.metadata[:user_id]
+    event_hash[:priority]     = event.metadata[:priority]
+    event_hash[:content_type] = event.metadata[:content_type]
+    add_openstack_queue(event_hash)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -39,12 +39,14 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered_events.include?(event[:name])
-      _log.info "#{log_prefix} Skipping caught event [#{event[:name]}]"
-    else
-      _log.info "#{log_prefix} Caught event [#{event[:name]}]"
-      EmsEvent.add_queue('add_rhevm', @cfg[:ems_id], event.to_hash)
+  def filtered?(event)
+    filtered_events.include?(event[:name]).tap do |result|
+      _log.info "#{log_prefix} Skipping caught event [#{event[:name]}]" if result
     end
+  end
+
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event [#{event[:name]}]"
+    EmsEvent.add_queue('add_rhevm', @cfg[:ems_id], event.to_hash)
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -43,6 +43,18 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
     reset_event_monitor_handle
   end
 
+  def event_dedup_key(event)
+    # duplicate the event but remove ids and timestamps that change with every event
+    # the remaining attributes are used to determine whether an event is a duplicate of another
+    event.except("key", "chainId", "createdTime").tap do |hash|
+      hash["info"] &&= hash["info"].except("key", "task", "queueTime", "eventChainId")
+    end
+  end
+
+  def event_dedup_descriptor(event)
+    event_dedup_key(event)
+  end
+
   def filtered?(event)
     event_type = event['eventType']
     return true if event_type.nil?

--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -43,27 +43,35 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
     reset_event_monitor_handle
   end
 
-  def process_event(event)
+  def filtered?(event)
     event_type = event['eventType']
-    return if event_type.nil?
+    return true if event_type.nil?
+
+    sub_event_type, display_name = sub_type_and_name(event)
+
+    return false unless filtered_events.include?(event_type) || filtered_events.include?(sub_event_type)
+
+    _log.info("#{log_prefix} Skipping caught event [#{display_name}] chainId [#{event['chainId']}]")
+    true
+  end
+
+  def queue_event(event)
+    _sub_event_type, display_name = sub_type_and_name(event)
+    _log.info("#{log_prefix} Queueing event [#{display_name}] chainId [#{event['chainId']}]")
+    EmsEvent.add_queue('add_vc', @cfg[:ems_id], event)
+  end
+
+  def sub_type_and_name(event)
+    event_type = event['eventType']
 
     case event_type
     when "TaskEvent"
-      sub_event_type = event.fetch_path('info', 'name')
-      display_name   = "#{event_type}]-[#{sub_event_type}"
+      [event.fetch_path('info', 'name'), "#{event_type}]-[#{sub_event_type}"]
     when "EventEx"
-      sub_event_type = event['eventTypeId']
-      display_name   = "#{event_type}]-[#{sub_event_type}"
+      [event['eventTypeId'], "#{event_type}]-[#{sub_event_type}"]
     else
-      sub_event_type = nil
-      display_name   = event_type
-    end
-
-    if filtered_events.include?(event_type) || filtered_events.include?(sub_event_type)
-      _log.info "#{log_prefix} Skipping caught event [#{display_name}] chainId [#{event['chainId']}]"
-    else
-      _log.info "#{log_prefix} Queueing event [#{display_name}] chainId [#{event['chainId']}]"
-      EmsEvent.add_queue('add_vc', @cfg[:ems_id], event)
+      [nil, event_type]
     end
   end
+  private :sub_type_and_name
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1109,6 +1109,11 @@
       :thread_shutdown_timeout: 10.seconds
     :event_catcher:
       :defaults:
+        :flooding_monitor_enabled: false
+        :flooding_monitor_window: 5.minutes
+        :flooding_monitor_slot_size: 5.seconds
+        :flooding_monitor_threshold: 20
+        :flooded_log_count: 20
         :ems_event_page_size: 100
         :ems_event_thread_shutdown_timeout: 10.seconds
         :memory_threshold: 2.gigabytes

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
@@ -6,6 +6,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner do
     before do
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive_messages(:authentication_check => [true, ""])
       allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
+      allow_any_instance_of(MiqWorker::Runner).to receive(:worker_settings).and_return({})
     end
 
     it "numeric port" do

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_catcher/runner_spec.rb
@@ -1,0 +1,115 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner do
+  let(:ems)      { FactoryGirl.create(:ems_vmware, :hostname => "hostname") }
+  let(:catcher)  { ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner.new(:ems_id => ems.id) }
+  let(:settings) { {:flooding_monitor_enabled => false} }
+
+  before do
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
+    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
+    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_settings).and_return(settings)
+  end
+
+  describe "#event_dedup_key" do
+    let(:test_event1) do
+      {
+        "key"                  => "9418",
+        "chainId"              => "9418",
+        "createdTime"          => "2015-12-10T17:11:26.485713Z",
+        "userName"             => "root",
+        "datacenter"           => {"name" => "VC0DC0",       "datacenter"      => "datacenter-2"},
+        "computeResource"      => {"name" => "VC0DC0_C7",    "computeResource" => "domain-c842"},
+        "host"                 => {"name" => "VC0DC0_C7_H2", "host"            => "host-849"},
+        "fullFormattedMessage" => "Task: Power On virtual machine",
+        "eventType"            => "TaskEvent",
+        "vm"                   =>
+          {
+            "name" => "VC0DC0_C7_RP4_VM12",
+            "vm"   => "vm-952",
+            "path" => "[GlobalDS_0] VC0DC0_C7_RP4_VM12/VC0DC0_C7_RP4_VM12.vmx"
+          },
+        "info"                =>
+          {
+            "key"           => "task-575",
+            "task"          => "task-575",
+            "name"          => "PowerOnVM_Task",
+            "descriptionId" => "VirtualMachine.powerOn",
+            "entity"        => "vm-952",
+            "entityName"    => "VC0DC0_C7_RP4_VM12",
+            "state"         => "queued",
+            "cancelled"     => "false",
+            "cancelable"    => "false",
+            "reason"        => {"userName" => "root"},
+            "queueTime"     => "2015-12-10T17:11:26.479554Z",
+            "eventChainId"  => "9418"
+          }
+      }
+    end
+
+    let(:test_event2) do
+      test_event1.tap do |event|
+        event.merge(
+          "key"         => "9419",
+          "chainId"     => "9419",
+          "createdTime" => "2015-12-10T17:12:26.485713Z",
+        )
+        event["info"].merge(
+          "key"          => "task-576",
+          "task"         => "task-576",
+          "queueTime"    => "2015-12-10T17:11:27.479554Z",
+          "eventChainId" => "9419"
+        )
+      end
+    end
+
+    let(:test_event3) do
+      test_event1.tap do |event|
+        event["userName"] = "admin"
+      end
+    end
+
+    context "events differ only from neglected attributes" do
+      it "creates the same dedup key" do
+        expect(catcher.event_dedup_key(test_event1)).to eq(catcher.event_dedup_key(test_event2))
+      end
+    end
+
+    context "events differ from non-neglected attributes" do
+      it "creates different dedup keys" do
+        expect(catcher.event_dedup_key(test_event1)).not_to eq(catcher.event_dedup_key(test_event3))
+      end
+    end
+  end
+
+  describe "#queue_event" do
+    before do
+      ManageIQ::Providers::Vmware::InfraManager::EventCatcher.send(:remove_const, :Runner)
+      load 'app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb'
+    end
+
+    context "event flooding monitor is enabled" do
+      let(:settings) do
+        {
+          :flooding_monitor_enabled   => true,
+          :flooding_monitor_threshold => 0,
+          :flooding_monitor_window    => 1,
+          :flooding_monitor_slot_size => 0.1,
+          :flooded_log_count          => 1
+        }
+      end
+
+      it "does not place the flooded event to the queue" do
+        expect(EmsEvent).not_to receive(:add_queue)
+        catcher.queue_event(:name => "some event")
+      end
+    end
+
+    context "event flooding monitor is disabled" do
+      it "places every event to the queue" do
+        expect(EmsEvent).to receive(:add_queue)
+        catcher.queue_event(:name => "some event")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Mix `DuplicateBlocker` in `ManageIQ::Providers::BaseManager::EventCatcher::Runner` to block duplicated events when there are too many duplicates in a short time.

1. Split  `process_event(event)` into `filtered?(event)` and `queue_event(event)`
2. Monitor `queue_event(event)`. Do not place the event to the queue if the event is considered a duplicate that exceeds the count threshold.
3. Every provider's `EventCatcher::Runner` needs to implement `event_dedup_key(event)`. It should generate an object that helps to distinguish whether an event is a duplicate. For example in the VMware implementation, timestamps and sequence numbers are removed while other event contents are preserved.
4. Every provider's `EventCatcher::Runner` needs to implement `event_dedup_descriptor(event)`. It should return a string to describe an event, not only the event type, but other details. The string will be logged to tell the user what event has been blocked due to too many duplicates.
5. Parameters such as time window to monitor and duplicate count threshold are initialized in `event_handling.tmpl.yml` under `workers/worker_base/event_catcher/defaults`. These parameters are valid for all providers. However each provider can overwrite each particular parameter. By default the blocking feature is disabled. User needs to turn it on.
6. With this PR `event_dedup_key(event)` and `event_dedup_descriptor(event)` are implemented only for VMware. Additional work should be done to other providers.
7. Added spec tests.