### PR TITLE
Add vendor/bundle to vmdb/.gitignore

### DIFF
--- a/vmdb/.gitignore
+++ b/vmdb/.gitignore
@@ -104,6 +104,9 @@ public/stylesheets/jmaki-standard-right-sidebar.css
 # tmp/
 tmp/*
 
+# vendor/bundle
+vendor/bundle
+
 # vendor/plugins/
 vendor/plugins/rails-dev-boost
 vendor/plugins/ruby-prof


### PR DESCRIPTION
I like to install my gems locally for source spelunking with
ctags. Typically I'd add an entry in my ~/.gitignore file, but since the
rails project is not at the top level the path is not matched.