### PR TITLE
Ensure organization is nil when registering to RHSM Hosted

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/rhn.rb
+++ b/vmdb/app/controllers/ops_controller/settings/rhn.rb
@@ -129,7 +129,7 @@ module OpsController::Settings::RHN
     auth    = {:registration =>  {:userid => credentials[:userid], :password => credentials[:password]}}
     options = {:required => [:userid, :password]}
     db.update_authentication(auth, options)
-    db.registration_organization = @edit[:new][:customer_org]
+    db.registration_organization = credentials[:registration_type] == "sm_hosted" ? nil : @edit[:new][:customer_org]
     db.registration_organization_display_name = @edit[:organizations].try(:key, @edit[:new][:customer_org])
 
     begin


### PR DESCRIPTION
Attempting to register to RHSM Hosted with an Organization will fail exiting 255 and cause LinuxAdmin to raise a error:
```
[----] E, [2014-01-06T17:57:59.770383 #6963:aad87c] ERROR -- : MIQ(MiqQueue.deliver)    Message id: [1000000001576], Error: [subscription-manager register exit co
[----] E, [2014-01-06T17:57:59.770742 #6963:aad87c] ERROR -- : [CommandResultError]: subscription-manager register exit code: 255  Method:[rescue in deliver]
```
https://bugzilla.redhat.com/show_bug.cgi?id=1048997
