### PR TITLE
Provisioning - Miq request task change for state percolation.

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -62,6 +62,11 @@ class MiqRequestTask < ActiveRecord::Base
     # Determine status to report
     req_status = status.slice('Error', 'Timeout', 'Warn').keys.first || 'Ok'
 
+    if req_state == "finished" && state != "finished"
+      req_state = (req_status == 'Ok') ? 'provisioned' : "finished"
+      $log.info("Child tasks finished but current task still processing. Setting state to: [#{req_state}]...")
+    end
+
     if req_state == "finished"
       msg = (req_status == 'Ok') ? "Task complete" : "Task completed with errors"
     end

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -64,13 +64,15 @@ describe ServiceTemplateProvisionRequest do
     it "partial tasks finished" do
       @task_1_1.update_and_notify_parent({:state => "finished", :status => "Ok", :message => "Test Message"})
       @request.reload
-      @request.message.should == "Finished = 2; Pending = 2"
+      @request.message.should == "Finished = 1; Pending = 2; Provisioned = 1"
       @request.state.should   == "active"
       @request.status.should  == "Ok"
     end
 
     it "finished state" do
+      @task_1.update_attributes(:state => "finished")
       @task_1_1.update_and_notify_parent({:state => "finished", :status => "Ok", :message => "Test Message"})
+      @task_2.update_attributes(:state => "finished")
       @task_2_1.update_and_notify_parent({:state => "finished", :status => "Ok", :message => "Test Message"})
       @request.reload
       @request.message.should == "Request complete"
@@ -96,7 +98,7 @@ describe ServiceTemplateProvisionRequest do
 
     it "finished with errors state" do
       @task_1_1.update_and_notify_parent({:state => "finished", :status => "Error", :message => "Error Message"})
-      @task_2_1.update_and_notify_parent({:state => "finished", :status => "Ok", :message => "Test Message"})
+      @task_2_1.update_and_notify_parent(:state => "finished", :status => "Error", :message => "Test Message")
       @request.reload
       @request.message.should == "Request completed with errors"
       @request.state.should   == "finished"


### PR DESCRIPTION
The automate model provisioning statemachine sets the task "finished" state as the last step in the statemachine.  The update_request_status method sets the task state to "finished" if the task has a single child that has a finished state.  The state set by update_request_state resulted in a service catalog bundle task getting "finished" prior to its children being "finished" by the statemachine. This caused premature statemachine post processing on the bundle.  The update_request_status needs to check itself to be finished in addition to its children to be finished in order to set the state to finished.  If the child(ren) are finished and it is not finished, it sets its state to "provisioned".  An additional benefit of this change is that status information displayed on the service request page will be more accurate.

https://bugzilla.redhat.com/show_bug.cgi?id=1233944


