### PR TITLE
Automate method & Service Template Task Issue

### DIFF
--- a/vmdb/app/models/service_template.rb
+++ b/vmdb/app/models/service_template.rb
@@ -134,7 +134,7 @@ class ServiceTemplate < ActiveRecord::Base
       scaling_min = child_svc_rsc.scaling_min
       1.upto(scaling_min).each do |scaling_idx|
         nh = parent_service_task.attributes.dup
-        %w{created_on updated_on type state status message}.each {|key| nh.delete(key)}
+        %w{id created_on updated_on type state status message}.each {|key| nh.delete(key)}
         nh['options'] = parent_service_task.options.dup
         nh['options'].delete(:child_tasks)
         # Initial Options[:dialog] to an empty hash so we do not pass down dialog values to child services tasks

--- a/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/vmdb/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -131,6 +131,7 @@ begin
   Socket.do_not_reverse_lookup = true  # turn off reverse DNS resolution
 
   require 'drb'
+  require 'yaml'
 
   MIQ_OK    = 0
   MIQ_WARN  = 4


### PR DESCRIPTION
(1) Automate methods will automatically get require 'yaml'
    In Rails 4.2 YAML has to be explicitly required
(2) During service task creation id was not being deleted
    leading to DB duplicate errors