### PR TITLE
Foreman tagging now applied during provisioning 

### DIFF
--- a/vmdb/app/controllers/application_controller/miq_request_methods.rb
+++ b/vmdb/app/controllers/application_controller/miq_request_methods.rb
@@ -521,7 +521,7 @@ module ApplicationController::MiqRequestMethods
   end
 
   def tag_symbol_for_workflow
-    (@edit || @options)[:wf].kind_of?(MiqHostProvisionWorkflow) ? :tag_ids : :vm_tags
+    (@edit || @options)[:wf].tag_symbol
   end
 
   def validate_fields

--- a/vmdb/app/models/miq_provision_task_configured_system_foreman/state_machine.rb
+++ b/vmdb/app/models/miq_provision_task_configured_system_foreman/state_machine.rb
@@ -65,6 +65,7 @@ module MiqProvisionTaskConfiguredSystemForeman::StateMachine
   end
 
   def post_provision
+    update_and_notify_parent(:message => "Applying tags on #{source.name}")
     apply_tags(source)
 
     signal :mark_as_completed

--- a/vmdb/app/models/miq_provision_virt_workflow.rb
+++ b/vmdb/app/models/miq_provision_virt_workflow.rb
@@ -506,6 +506,10 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
   end
 
+  def tag_symbol
+    :vm_tags
+  end
+
   def self.allowed_templates_vendor
     nil
   end

--- a/vmdb/app/models/miq_request_workflow.rb
+++ b/vmdb/app/models/miq_request_workflow.rb
@@ -644,6 +644,10 @@ class MiqRequestWorkflow
     tag_cats
   end
 
+  def tag_symbol
+    :tag_ids
+  end
+
   def build_ci_hash_struct(ci, props)
     nh = MiqHashStruct.new(:id => ci.id, :evm_object_class => ci.class.base_class.name.to_sym)
     props.each { |p| nh.send("#{p}=", ci.send(p)) }

--- a/vmdb/app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml
+++ b/vmdb/app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml
@@ -21,7 +21,7 @@
         :label                      => _("Manager"),
         :keys                       => keys})
   - when :purpose
-    - keys = [:vm_tags]
+    - keys = [:tag_ids]
     = render(:partial => "#{pfx}prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,

--- a/vmdb/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
+++ b/vmdb/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
@@ -112,7 +112,7 @@
     :purpose:
       :description: Purpose
       :fields:
-        :vm_tags:
+        :tag_ids:
           :required_method: :validate_tags
           :description: Tags
           :required: false


### PR DESCRIPTION
We were able to provision a Host, but the tags were not getting applied.

Turns out the key for tags varies across workflows and requests/tasks. In some places it is `:vm_tags`, while other places use `:tag_ids`. The desired behavior is to use `:tag_ids` everywhere but vm provisioning.

The foreman provisioning dialog was putting the tags into `:vm_tags`.
The foreman request was reading the tags from `:tag_ids`. since the tags were not stored there, no tags were applied to the newly configured system.

The solution is straight forward:
- better state where the tags should be stored in the workflow.
- update the foreman ui to store the tags in the proper place.

https://bugzilla.redhat.com/show_bug.cgi?id=1227211
 /cc @gmcculloug @brandondunne I am having trouble testing this.