### PR TITLE
Bug vms nulls

### DIFF
--- a/vmdb/app/models/miq_enterprise.rb
+++ b/vmdb/app/models/miq_enterprise.rb
@@ -1,12 +1,12 @@
 class MiqEnterprise < ActiveRecord::Base
-  has_many :miq_regions,            lambda { |_| MiqRegion.scoped }
-  has_many :ext_management_systems, lambda { |_| ExtManagementSystem.scoped }
-  has_many :vms_and_templates,      lambda { |_| VmOrTemplate.where("ems_id IS NOT NULL") }
-  has_many :vms,                    lambda { |_| Vm.where("ems_id IS NOT NULL") }
-  has_many :miq_templates,          lambda { |_| MiqTemplate.where("ems_id IS NOT NULL") }
-  has_many :hosts,                  lambda { |_| Host.where("ems_id IS NOT NULL") }
-  has_many :storages,               lambda { |_| Storage.scoped }
-  has_many :policy_events,          lambda { |_| PolicyEvent.scoped }
+  has_many :miq_regions,            -> { MiqRegion.scoped }
+  has_many :ext_management_systems, -> { ExtManagementSystem.scoped }
+  has_many :vms_and_templates,      -> { VmOrTemplate.where.not(:ems_id => nil) }
+  has_many :vms,                    -> { Vm.where.not(:ems_id => nil) }
+  has_many :miq_templates,          -> { MiqTemplate.where.not(:ems_id => nil) }
+  has_many :hosts,                  -> { Host.where.not(:ems_id => nil) }
+  has_many :storages,               -> { Storage.scoped }
+  has_many :policy_events,          -> { PolicyEvent.scoped }
 
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger

--- a/vmdb/app/models/storage.rb
+++ b/vmdb/app/models/storage.rb
@@ -418,7 +418,7 @@ class Storage < ActiveRecord::Base
 
   cache_with_timeout(:unmanaged_vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
-      :conditions => ["((template = ? AND ems_id IS NOT NULL) OR host_id IS NOT NULL)", true],
+      :conditions => ["((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true],
       :select     => "COUNT(id) AS vm_count, storage_id",
       :group      => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
@@ -434,7 +434,7 @@ class Storage < ActiveRecord::Base
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
-      :conditions => ["((template = ? AND ems_id IS NULL) OR host_id IS NOT NULL)", true],
+      :conditions => ["((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true],
       :select     => "COUNT(id) AS vm_count, storage_id",
       :group      => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
@@ -450,7 +450,7 @@ class Storage < ActiveRecord::Base
 
   cache_with_timeout(:managed_unregistered_vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
-      :conditions => ["((template = ? AND ems_id IS NOT NULL) OR host_id IS NOT NULL)", true],
+      :conditions => ["((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true],
       :select     => "COUNT(id) AS vm_count, storage_id",
       :group      => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }

--- a/vmdb/app/models/vm_or_template.rb
+++ b/vmdb/app/models/vm_or_template.rb
@@ -1814,13 +1814,13 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   # Return all archived VMs
-  ARCHIVED_CONDITIONS = "ems_id IS NULL AND storage_id IS NULL"
+  ARCHIVED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NULL"
   def self.all_archived
     self.where(ARCHIVED_CONDITIONS).to_a
   end
 
   # Return all orphaned VMs
-  ORPHANED_CONDITIONS = "ems_id IS NULL AND storage_id IS NOT NULL"
+  ORPHANED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NOT NULL"
   def self.all_orphaned
     self.where(ORPHANED_CONDITIONS).to_a
   end

--- a/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -28,6 +28,25 @@ describe VmInfraController do
     end
   end
 
+  context "VMs & Templates #tree_select" do
+    it "renders list Archived nodes in VMs & Templates tree" do
+      FactoryGirl.create(:vm_vmware)
+
+      session[:settings] = {}
+      session[:sandboxes] = {
+        "vm_infra" => {
+          :trees       => {
+            :vandt_tree => {}
+          },
+          :active_tree => :vandt_tree
+        }
+      }
+      post :tree_select, :id => 'xx-arch', :format => :js
+      response.should render_template('layouts/gtl/_list')
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "VMs #tree_select" do
     it "renders list with VMS for vms_filter_tree root node" do
       FactoryGirl.create(:vm_vmware)


### PR DESCRIPTION
@h-kataria I hope this solves your errors when clicking on "Archived" or "Orphaned" folder nodes in the tree on Infrastructure/Virtual Machines, VMs & Templates accordion.

I didn't target your error in particular but aimed for any ambiguous reference of ems being null.

@matthewd I hope this doesn't conflict with your cleanup work too much

```
[----] E, [2015-06-22T17:45:10.664192 #30615:a0f988] ERROR -- : PG::Error: ERROR:  column reference "ems_id" is ambiguous
LINE 1: ...dhat','TemplateVmware','TemplateMicrosoft')) AND (ems_id IS ...
                                                             ^
: SELECT COUNT(DISTINCT "vms"."id") FROM "vms" LEFT OUTER JOIN "hosts" ON "hosts"."id" = "vms"."host_id" LEFT OUTER JOIN "storages" ON "storages"."id" = "vms"."storage_id" LEFT OUTER JOIN "ext_management_systems" ON "ext_management_systems"."id" = "vms"."ems_id" LEFT OUTER JOIN "snapshots" ON "snapshots"."vm_or_template_id" = "vms"."id" LEFT OUTER JOIN "compliances" ON "compliances"."resource_id" = "vms"."id" AND "compliances"."resource_type" = $1 LEFT OUTER JOIN "operating_systems" ON "operating_systems"."vm_or_template_id" = "vms"."id" LEFT OUTER JOIN "hardwares" ON "hardwares"."vm_or_template_id" = "vms"."id" LEFT OUTER JOIN "taggings" ON "taggings"."taggable_id" = "vms"."id" AND "taggings"."taggable_type" = $2 LEFT OUTER JOIN "tags" ON "tags"."id" = "taggings"."tag_id" WHERE (((vms.type IN ('VmMicrosoft','VmVmware','VmRedhat','VmXen','TemplateXen','TemplateRedhat','TemplateVmware','TemplateMicrosoft')) AND (ems_id IS NULL AND storage_id IS NOT NULL)))
[----] F, [2015-06-22T17:45:10.664933 #30615:a0f988] FATAL -- : Error caught: [PG::Error] ERROR:  column reference "ems_id" is ambiguous
LINE 1: ...dhat','TemplateVmware','TemplateMicrosoft')) AND (ems_id IS ...
```

```
/manageiq/vmdb/lib/extensions/ar_virtual.rb:382:in `calculate_with_virtual'
/gems/rails/activerecord/lib/active_record/relation/calculations.rb:42:in `count'
/manageiq/vmdb/app/models/rbac.rb:151:in `compute_total_count'
/manageiq/vmdb/app/models/rbac.rb:182:in `find_targets_filtered_by_ids'
/manageiq/vmdb/app/models/rbac.rb:213:in `find_targets_with_direct_rbac'
/manageiq/vmdb/app/models/rbac.rb:238:in `find_targets_with_rbac'
/manageiq/vmdb/app/models/rbac.rb:404:in `search'
/manageiq/vmdb/app/models/miq_report/search.rb:107:in `paged_view_search'
/manageiq/vmdb/app/controllers/application_controller.rb:1944:in `get_view'
/manageiq/vmdb/app/controllers/application_controller/ci_processing.rb:953:in `process_show_list'
/manageiq/vmdb/app/controllers/vm_common.rb:1499:in `get_node_info'
/manageiq/vmdb/app/controllers/vm_common.rb:1554:in `replace_right_cell'
/manageiq/vmdb/app/controllers/vm_common.rb:1339:in `tree_select'
```