### PR TITLE
Include miq_server when retrieving worker

### DIFF
--- a/vmdb/lib/workers/mixins/event_catcher_openstack_mixin.rb
+++ b/vmdb/lib/workers/mixins/event_catcher_openstack_mixin.rb
@@ -14,7 +14,7 @@ module EventCatcherOpenstackMixin
       options[:duration] = self.worker_settings[:duration]
       options[:capacity] = self.worker_settings[:capacity]
 
-      options[:client_ip] = MiqServer.my_server.ipaddress
+      options[:client_ip] = server.ipaddress
       @event_monitor_handle = OpenstackEventMonitor.new(options)
     end
     @event_monitor_handle


### PR DESCRIPTION
To try to make the way the OpenStack event catcher creates binding queues work a little better, the appliance's IP address was looked up and used as part of the binding queue's name.

However, there were a couple of things working against this fix.  First, the appliance's IP address was not readily available to the worker process.  Second, ManageIQ has a DB connection pool with only one connection.  And, threads (i.e., where event catcher workers do all their work) that attempt to run queries are opening a new DB connection.

The original fix never actually tried opening the a new connection.  Instead, it was perfectly happy to get back a nil value for the appliance and try to lookup `Nil#ipaddress`.

This fix gets around this problem by throwing the appliance record (`miq_server`, actually) into an ivar and making that available to the thread.  This keeps the thread from having to query for the `miq_server`, while still giving it access to the `MiqServer#ipaddress`.

Original PR:
https://github.com/ManageIQ/manageiq/pull/3050

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1232484

References:
https://bugzilla.redhat.com/show_bug.cgi?id=1224389
https://bugzilla.redhat.com/show_bug.cgi?id=1223976