### PR TITLE
Rails 4 Regression: undefined method `diff' for #<Hash:0x0000001b7761e8>

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/schedules.rb
+++ b/vmdb/app/controllers/ops_controller/settings/schedules.rb
@@ -235,7 +235,8 @@ module OpsController::Settings::Schedules
     msg   = "[#{name}] Record #{add ? "added" : "updated"} ("
     event = "#{new_schedule.class.to_s.downcase}_record_#{add ? "add" : "update"}"
 
-    attribute_difference = old_schedule_attributes.diff(new_schedule.attributes)
+    attribute_difference = new_schedule.attributes.to_a - old_schedule_attributes.to_a
+    attribute_difference = Hash[*attribute_difference.flatten]
 
     difference_messages = []
 

--- a/vmdb/spec/controllers/ops_controller_spec.rb
+++ b/vmdb/spec/controllers/ops_controller_spec.rb
@@ -177,6 +177,28 @@ describe OpsController do
     end
 
   end
+
+  it "executes action schedule_edit" do
+    schedule = FactoryGirl.create(:miq_schedule, :name => "test_schedule", :description => "old_schedule_desc")
+    controller.stub(:get_node_info)
+    controller.stub(:replace_right_cell)
+    controller.stub(:render)
+
+    post :schedule_edit,
+         :id                 => schedule.id,
+         :button             => "save",
+         :name               => "test_schedule",
+         :description        => "new_description",
+         :action_typ         => "vm",
+         :miq_angular_date_1 => "06/25/2015",
+         :timer_typ          => "Once",
+         :timer_value        => ""
+
+    expect(response.status).to eq(200)
+
+    audit_event = AuditEvent.where(:target_id => schedule.id).first
+    expect(audit_event.attributes['message']).to include("description changed to new_description")
+  end
 end
 
 describe OpsController do


### PR DESCRIPTION
Apparently Rails 4.2.2 does not support the ```.diff``` method for hashes.

Used an alternate approach to get the hash difference.