### PR TITLE
inspect of Timestamp fails in Automate Methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -133,6 +133,8 @@ begin
   require 'drb'
   require 'yaml'
 
+  Time.zone = 'UTC'
+
   MIQ_OK    = 0
   MIQ_WARN  = 4
   MIQ_ERROR = 8

--- a/vmdb/spec/automation/unit/method_validation/inspect_me_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/inspect_me_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "InspectMe Automate Method" do
-  before(:each) do
+  before do
     @guid = MiqUUID.new_guid
     MiqServer.stub(:my_guid).and_return(@guid)
     @zone       = FactoryGirl.create(:zone)

--- a/vmdb/spec/automation/unit/method_validation/inspect_me_spec.rb
+++ b/vmdb/spec/automation/unit/method_validation/inspect_me_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe "InspectMe Automate Method" do
+  before(:each) do
+    @guid = MiqUUID.new_guid
+    MiqServer.stub(:my_guid).and_return(@guid)
+    @zone       = FactoryGirl.create(:zone)
+    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
+  end
+
+  def run_automate_method
+    attrs = []
+    attrs << "MiqServer::miq_server=#{@miq_server.id}"
+
+    MiqAeEngine.instantiate("/System/Request/Call_Instance_With_Message?" \
+                            "namespace=System&class=Request" \
+                            "&instance=InspectMe&" \
+                            "#{attrs.join('&')}")
+  end
+
+  context "InspectMe" do
+    it "with miq_server" do
+      run_automate_method
+    end
+  end
+end


### PR DESCRIPTION
The Automate methods log the timestamp fields using
the inspect method. This fails on Rails 4.x because of
uninitialized Time.zone. Initialize the Time.zone to UTC
in the method preamble. Added a spec for InspectMe method

Fixes #3242