### PR TITLE
Fixed a typo when requiring Codemirror XML mode

### DIFF
--- a/vmdb/app/views/layouts/_my_code_mirror.html.haml
+++ b/vmdb/app/views/layouts/_my_code_mirror.html.haml
@@ -16,7 +16,7 @@
   = javascript_include_tag "codemirror/modes/javascript"
   = javascript_include_tag "codemirror/modes/css"
   = javascript_include_tag "codemirror/modes/#{mode}"
-  = javascript_include_tag "codemirror/mode/xml"
+  = javascript_include_tag "codemirror/modes/xml"
 - else
   = javascript_include_tag "codemirror/modes/#{mode}"
 - unless theme == "default"


### PR DESCRIPTION
It can be verified under the service catalogs explorer.