### PR TITLE
Tree naming mess

### DIFF
--- a/vmdb/app/presenters/tree_builder.rb
+++ b/vmdb/app/presenters/tree_builder.rb
@@ -81,10 +81,11 @@ class TreeBuilder
     @sb = sandbox # FIXME: some subclasses still access @sb
 
     @locals_for_render  = {}
-    @name               = name.to_sym
+    @name               = name.to_sym                     # includes _tree
     @options            = tree_init_options(name.to_sym)
     @tree_nodes         = {}
-    @type               = type.to_sym
+    # FIXME: remove @name or @tree, unify
+    @type               = type.to_sym                     # *usually* same as @name but w/o _tree
 
     add_to_sandbox
     build_tree if build
@@ -95,10 +96,10 @@ class TreeBuilder
     model, rec_id, prefix = self.class.extract_node_model_and_id(id)
     object = if model == "Hash"
                {:type => prefix, :id => rec_id, :full_id => id}
-             elsif model.nil? && [:sandt, :svccat, :stcat].include?(options[:tree])
+             elsif model.nil? && [:sandt, :svccat, :stcat].include?(@type)
                # Creating empty record to show items under unassigned catalog node
                ServiceTemplateCatalog.new
-             elsif model.nil? && [:foreman_providers_tree].include?(x_active_tree)
+             elsif model.nil? && [:foreman_providers_tree].include?(@name)
                # Creating empty record to show items under unassigned catalog node
                ConfigurationProfile.new
              else

--- a/vmdb/app/presenters/tree_builder_iso_datastores.rb
+++ b/vmdb/app/presenters/tree_builder_iso_datastores.rb
@@ -22,12 +22,12 @@ class TreeBuilderIsoDatastores < TreeBuilder
   def x_get_tree_iso_datastore_kids(object,options)
     iso_images = object.iso_images
     if options[:count_only]
-      x_tree[:open_nodes].push("xx-isd_xx-#{to_cid(object.id)}")
+      @tree_state.x_tree(@name)[:open_nodes].push("xx-isd_xx-#{to_cid(object.id)}")
       iso_images.size
     else
       objects = []
       if iso_images.size > 0
-        x_tree(options[:tree])[:open_nodes].push("isd_xx-#{to_cid(object.id)}")
+        @tree_state.x_tree(@name)[:open_nodes].push("isd_xx-#{to_cid(object.id)}")
         objects.push(
           :id    => "isd_xx-#{to_cid(object.id)}",
           :text  => "ISO Images",

--- a/vmdb/app/presenters/tree_builder_pxe_servers.rb
+++ b/vmdb/app/presenters/tree_builder_pxe_servers.rb
@@ -22,18 +22,19 @@ class TreeBuilderPxeServers < TreeBuilder
   def x_get_tree_pxe_server_kids(object,options)
     pxe_images = object.pxe_images
     win_images = object.windows_images
+    open_nodes = @tree_state.x_tree(@name)[:open_nodes]
     if options[:count_only]
-      x_tree[:open_nodes].push("xx-pxe_xx-#{to_cid(object.id)}") unless x_tree[:open_nodes].include?("xx-pxe_xx-#{to_cid(object.id)}")
-      x_tree[:open_nodes].push("xx-win_xx-#{to_cid(object.id)}") unless x_tree[:open_nodes].include?("xx-win_xx-#{to_cid(object.id)}")
+      open_nodes.push("xx-pxe_xx-#{to_cid(object.id)}") unless open_nodes.include?("xx-pxe_xx-#{to_cid(object.id)}")
+      open_nodes.push("xx-win_xx-#{to_cid(object.id)}") unless open_nodes.include?("xx-win_xx-#{to_cid(object.id)}")
       pxe_images.size + win_images.size
     else
       objects = []
       if pxe_images.size > 0
-        x_tree[:open_nodes].push("pxe_xx-#{to_cid(object.id)}") unless x_tree[:open_nodes].include?("pxe_xx-#{to_cid(object.id)}")
+        open_nodes.push("pxe_xx-#{to_cid(object.id)}") unless open_nodes.include?("pxe_xx-#{to_cid(object.id)}")
         objects.push(:id => "pxe_xx-#{to_cid(object.id)}", :text => "PXE Images", :image => "folder", :tip => "PXE Images")
       end
       if win_images.size > 0
-        x_tree[:open_nodes].push("win_xx-#{to_cid(object.id)}") unless x_tree[:open_nodes].include?("win_xx-#{to_cid(object.id)}")
+        open_nodes.push("win_xx-#{to_cid(object.id)}") unless open_nodes.include?("win_xx-#{to_cid(object.id)}")
         objects.push(:id => "win_xx-#{to_cid(object.id)}", :text => "Windows Images", :image => "folder", :tip => "Windows Images")
       end
       objects


### PR DESCRIPTION
* fix a regression by unifying tests for tree name and type
* fix tests for tree_open nodes to explicitly ask for the tree being built and not assuming that we are building the active tree

ping @himdel 