### PR TITLE
Dir.glob is not alphabetical order, enforce alphabetical.

### DIFF
--- a/vmdb/lib/vmdb_extensions.rb
+++ b/vmdb/lib/vmdb_extensions.rb
@@ -1,2 +1,5 @@
 $:.push("#{File.dirname(__FILE__)}/extensions")
-Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), "extensions", "*.rb"))) { |f| require File.basename(f, ".*") }
+Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), "extensions", "*.rb"))).sort.each do |f|
+  # TODO: extensions are order dependent, see #3252
+  require File.basename(f, ".*")
+end


### PR DESCRIPTION
This doesn't fix the issue that vmdb_extensions are order dependent.


Fixes:
```
  [~/devel/manageiq/vmdb]$ bundle exec rails server
  manageiq/vmdb/lib/extensions/ar_types.rb:1:in `<top (required)>': uninitialized constant ActiveRecord::ConnectionAdapters::PostgreSQLAdapter (NameError)
      from manageiq/vmdb/lib/vmdb_extensions.rb:2:in `block in <top (required)>'
      from manageiq/vmdb/lib/vmdb_extensions.rb:2:in `glob'
      from manageiq/vmdb/lib/vmdb_extensions.rb:2:in `<top (required)>'
      from manageiq/vmdb/lib/vmdb_helper.rb:19:in `<top (required)>'
      from manageiq/vmdb/lib/vmdb/logging.rb:2:in `<top (required)>'
      from manageiq/vmdb/config/application.rb:88:in `<class:Application>'
```

Fixes #3252