### PR TITLE
Remove unused WorkerBase methods

### DIFF
--- a/vmdb/lib/workers/worker_base.rb
+++ b/vmdb/lib/workers/worker_base.rb
@@ -414,26 +414,6 @@ class WorkerBase
     end
   end
 
-  def parent_is_alive?(parent)
-    return false unless parent && parent.last_heartbeat
-    $log.info("#{self.log_prefix} Checking parent #{parent.class.name}. time_threshold [#{self.worker_settings[:parent_time_threshold].seconds.ago.utc}] last_heartbeat [#{parent.last_heartbeat}]")
-    self.worker_settings[:parent_time_threshold].seconds.ago.utc < parent.last_heartbeat
-  end
-
-  def check_parent_process
-    # ensure attributes like "last_heartbeat" are up to date
-    server.reload if server
-    return if self.parent_is_alive?(server)
-    if server.nil?
-      svr_msg = "Unable to find instance for parent MiqServer guid [#{MiqServer.my_guid}]."
-    else
-      svr_msg = "Parent MiqServer ID [#{server.id}] GUID [#{server.guid}] has not responded in #{self.worker_settings[:parent_time_threshold]} seconds."
-    end
-    $log.warn("#{self.log_prefix} #{svr_msg}")
-
-    do_exit("#{svr_msg}", 1)
-  end
-
   def clean_broker_connection
     begin
       if $vim_broker_client

--- a/vmdb/spec/lib/workers/worker_base_spec.rb
+++ b/vmdb/spec/lib/workers/worker_base_spec.rb
@@ -3,39 +3,6 @@ require "spec_helper"
 require 'workers/worker_base'
 
 describe WorkerBase do
-  context "#check_parent_process" do
-    before(:each) do
-      _guid, @miq_server, _zone = EvmSpecHelper.create_guid_miq_server_zone
-
-      @worker_guid = MiqUUID.new_guid
-      @worker = FactoryGirl.create(:miq_worker, :guid => @worker_guid, :miq_server_id => @miq_server.id)
-
-      WorkerBase.any_instance.stub(:worker_initialization)
-      @worker_base = WorkerBase.new(:guid => @worker_guid)
-    end
-
-    it "will exit if parent has never heartbeated" do
-      @miq_server.update_attribute(:last_heartbeat, nil)
-      @worker_base.worker_settings = {:parent_time_threshold => 3.minutes }
-      @worker_base.should_receive(:do_exit)
-      @worker_base.send(:check_parent_process)
-    end
-
-    it "will exit if parent hasn't hearbeated within threshold" do
-      @miq_server.update_attribute(:last_heartbeat, 4.minutes.ago.utc)
-      @worker_base.worker_settings = {:parent_time_threshold => 3.minutes }
-      @worker_base.should_receive(:do_exit)
-      @worker_base.send(:check_parent_process)
-    end
-
-    it "will NOT exit if parent has hearbeated within threshold" do
-      @miq_server.update_attribute(:last_heartbeat, 2.minutes.ago.utc)
-      @worker_base.worker_settings = {:parent_time_threshold => 3.minutes }
-      @worker_base.should_receive(:do_exit).never
-      @worker_base.send(:check_parent_process)
-    end
-  end
-
   context "#start" do
     before do
       WorkerBase.any_instance.stub(:worker_initialization)


### PR DESCRIPTION
1. Remove WorkerBase#check_parent_process.  This was last used for sql-based workers but was never removed when that functionality was removed in favor of drb-based workers.

2. Remove WorkerBase#parent_is_alive?.  The last caller of this method was removed in 2010.

More discussion:
https://github.com/ManageIQ/manageiq/pull/3244#discussion_r33086997