### PR TITLE
Added methods my_server_id, my_zone_name to replace variables in sandbox

### DIFF
--- a/vmdb/app/controllers/ops_controller.rb
+++ b/vmdb/app/controllers/ops_controller.rb
@@ -127,14 +127,14 @@ class OpsController < ApplicationController
       self.x_active_accord ||= 'diagnostics'
       self.x_active_tree   ||= 'diagnostics_tree'
       @built_trees << diagnostics_build_tree
-      x_node_set("svr-#{to_cid(@sb[:my_server_id])}", :diagnostics_tree) unless x_node(:diagnostics_tree)
+      x_node_set("svr-#{to_cid(my_server_id)}", :diagnostics_tree) unless x_node(:diagnostics_tree)
       @sb[:active_tab] ||= "diagnostics_summary"
     end
     if get_vmdb_config[:product][:analytics]
       @accords.push(:name => "analytics", :title => "Analytics", :container => "analytics_tree_div")
       self.x_active_accord ||= 'analytics'
       @built_trees << analytics_build_tree
-      x_node_set("svr-#{to_cid(@sb[:my_server_id])}", :analytics_tree) unless x_node(:analytics_tree)
+      x_node_set("svr-#{to_cid(my_server_id)}", :analytics_tree) unless x_node(:analytics_tree)
     end
     if role_allows(:feature => "ops_db")
       @accords.push(:name => "vmdb", :title => "Database", :container => "vmdb_tree_div")
@@ -327,7 +327,7 @@ class OpsController < ApplicationController
         record_id = @record && @record.id ? @record.id : "new"
       else
         action_url = "old_dialogs_update"
-        record_id = @sb[:my_server_id]
+        record_id = my_server_id
       end
     elsif x_active_tree == :settings_tree
       if %w(settings_import settings_import_tags).include?(@sb[:active_tab])
@@ -657,12 +657,12 @@ class OpsController < ApplicationController
               end
               active_id = from_cid(x_node.split("-").last)
               # server node
-              if x_node.split("-").first == "svr" && @sb[:my_server_id] == active_id.to_i
+              if x_node.split("-").first == "svr" && my_server_id == active_id.to_i
                 #show all the tabs if on current server node
                 @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
                 page << "miqOneTrans = 0;"          #resetting miqOneTrans when tab loads
                 page << "miqIEButtonPressed = true" if %w(save reset).include?(params[:button]) && is_browser_ie?
-              elsif x_node.split("-").first.split("__")[1] == "svr" && @sb[:my_server_id] != active_id.to_i
+              elsif x_node.split("-").first.split("__")[1] == "svr" && my_server_id != active_id.to_i
                 #show only 4 tabs if not on current server node
                 @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
               end

--- a/vmdb/app/controllers/ops_controller/analytics.rb
+++ b/vmdb/app/controllers/ops_controller/analytics.rb
@@ -31,13 +31,13 @@ module OpsController::Analytics
       zone = Zone.find_by_id(from_cid(x_node.split('-').last))
       @sb[:rpt_title] = "Analytics Report for '#{zone.description}'"
       msg = zone.name ? _("%{typ} %{model} \"%{name}\" (current)") : _("%{typ} %{model} \"%{name}\"")
-      @right_cell_text = @sb[:my_zone] == msg %
+      @right_cell_text = my_zone_name == msg %
         {:typ => "Diagnostics", :model => ui_lookup(:model => zone.class.to_s), :name => zone.description}
     elsif x_node.split('-').first == "svr"
       svr = MiqServer.find(from_cid(nodetype.downcase.split("-").last))
       @sb[:rpt_title] = "Analytics Report for '#{svr.name} [#{svr.id}]'"
       msg = svr.id ? _("%{typ} %{model} \"%{name}\" (current)") : _("%{typ} %{model} \"%{name}\"")
-      @right_cell_text = @sb[:my_server_id] == msg %
+      @right_cell_text = my_server_id == msg %
         {:typ => "Diagnostics", :model => ui_lookup(:model => svr.class.to_s), :name => "#{svr.name} [#{svr.id}]"}
     else
       @right_cell_text = _("%{model} \"%{name}\"") % {:name=>"Enterprise", :model=>"Analytics"}

--- a/vmdb/app/controllers/ops_controller/diagnostics.rb
+++ b/vmdb/app/controllers/ops_controller/diagnostics.rb
@@ -842,7 +842,7 @@ module OpsController::Diagnostics
       end
       cu_repair_set_form_vars if @sb[:active_tab] == "diagnostics_cu_repair"
       diagnostics_server_list if @sb[:active_tab] == "diagnostics_server_list"
-      @right_cell_text = @sb[:my_zone] == @selected_server.name ?
+      @right_cell_text = my_zone_name == @selected_server.name ?
         _("%{typ} %{model} \"%{name}\" (current)") % {:typ=>"Diagnostics", :name=>@selected_server.description, :model=>ui_lookup(:model=>@selected_server.class.to_s)} :
         _("%{typ} %{model} \"%{name}\"") % {:typ=>"Diagnostics", :name=>@selected_server.description, :model=>ui_lookup(:model=>@selected_server.class.to_s)}
     elsif x_node == "root"
@@ -870,7 +870,7 @@ module OpsController::Diagnostics
       @right_cell_text = _("%{typ} %{model} \"%{name}\"") % {:typ=>"Diagnostics", :name=>"#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]", :model=>ui_lookup(:model=>"MiqRegion")}
     elsif active_node && active_node.split('-').first == "svr"
       @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
-      if @sb[:selected_server_id] == @sb[:my_server_id]
+      if @sb[:selected_server_id] == my_server_id
         if @sb[:active_tab] == "diagnostics_evm_log"
           @log = $log.contents(120,1000)
           add_flash(_("Logs for this CFME Server are not available for viewing"), :warning) if @log.blank?
@@ -903,7 +903,7 @@ module OpsController::Diagnostics
           @sb[:selected_server_id] = @selected_server.id
           @sb[:selected_typ] = "miq_server"
         end
-      elsif @sb[:selected_server_id] == @sb[:my_server_id]  || @selected_server.started?
+      elsif @sb[:selected_server_id] == my_server_id  || @selected_server.started?
         if @sb[:active_tab] == "diagnostics_workers"
           pm_get_workers
           @record = @selected_server
@@ -928,7 +928,7 @@ module OpsController::Diagnostics
           @sb[:selected_typ] = "miq_server"
         end
       end
-      @right_cell_text = @sb[:my_server_id] == @sb[:selected_server_id] ?
+      @right_cell_text = my_server_id == @sb[:selected_server_id] ?
         _("%{typ} %{model} \"%{name}\" (current)") % {:typ=>"Diagnostics", :name=>"#{@selected_server.name} [#{@selected_server.id}]", :model=>ui_lookup(:model=>@selected_server.class.to_s)} :
         _("%{typ} %{model} \"%{name}\"") % {:typ=>"Diagnostics", :name=>"#{@selected_server.name} [#{@selected_server.id}]", :model=>ui_lookup(:model=>@selected_server.class.to_s)}
     end

--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -752,11 +752,11 @@ module OpsController::Settings::Common
 
   def settings_set_form_vars
     if x_node.split("-").first == "z"
-      @right_cell_text = @sb[:my_zone] == @selected_zone.name ?
+      @right_cell_text = my_zone_name == @selected_zone.name ?
         _("%{typ} %{model} \"%{name}\" (current)") % {:typ=>"Settings", :name=>@selected_zone.description, :model=>ui_lookup(:model=>@selected_zone.class.to_s)} :
         _("%{typ} %{model} \"%{name}\"") % {:typ=>"Settings", :name=>@selected_zone.description, :model=>ui_lookup(:model=>@selected_zone.class.to_s)}
     else
-      @right_cell_text = @sb[:my_server_id] == @sb[:selected_server_id] ?
+      @right_cell_text = my_server_id == @sb[:selected_server_id] ?
         _("%{typ} %{model} \"%{name}\" (current)") % {:typ=>"Settings", :name=>"#{@selected_server.name} [#{@selected_server.id}]", :model=>ui_lookup(:model=>@selected_server.class.to_s)} :
         _("%{typ} %{model} \"%{name}\"") % {:typ=>"Settings", :name=>"#{@selected_server.name} [#{@selected_server.id}]", :model=>ui_lookup(:model=>@selected_server.class.to_s)}
     end
@@ -1042,7 +1042,7 @@ module OpsController::Settings::Common
         @servers = Array.new
         @record = @zone = @selected_zone = Zone.find(from_cid(nodes.last))
         @sb[:tab_label] = @selected_zone.description
-        @right_cell_text = @sb[:my_zone] == @selected_zone.name ?
+        @right_cell_text = my_zone_name == @selected_zone.name ?
             _("%{typ} %{model} \"%{name}\" (current)") % {:typ=>"Settings", :name=>@selected_zone.description, :model=>ui_lookup(:model=>@selected_zone.class.to_s)} :
             _("%{typ} %{model} \"%{name}\"") % {:typ=>"Settings", :name=>@selected_zone.description, :model=>ui_lookup(:model=>@selected_zone.class.to_s)}
         MiqServer.all.each do |ms|

--- a/vmdb/app/helpers/application_helper.rb
+++ b/vmdb/app/helpers/application_helper.rb
@@ -2921,5 +2921,17 @@ module ApplicationHelper
     !%w(accordion_select tree_select).include?(action_name)
   end
 
+  def my_server_id
+    my_server.id
+  end
+
+  def my_zone_name
+    my_server.my_zone
+  end
+
+  def my_server
+    @my_server ||= MiqServer.my_server(true)
+  end
+
   attr_reader :big_iframe
 end

--- a/vmdb/app/presenters/tree_builder.rb
+++ b/vmdb/app/presenters/tree_builder.rb
@@ -281,12 +281,9 @@ class TreeBuilder
 
   # Return a tree node for the passed in object
   def x_build_node(object, pid, options)    # Called with object, tree node parent id, tree options
-    my_server_id = MiqServer.my_server(true).id      if object.kind_of?(MiqServer)
-    my_zone      = MiqServer.my_server(true).my_zone if object.kind_of?(Zone)
-
     options[:is_current] =
-        ((object.kind_of?(MiqServer) && my_server_id == object.id) ||
-         (object.kind_of?(Zone)      && my_zone      == object.name))
+        ((object.kind_of?(MiqServer) && MiqServer.my_server(true).id == object.id) ||
+         (object.kind_of?(Zone)      && MiqServer.my_server(true).my_zone == object.name))
 
     # # open nodes to show selected automate entry point
     # x_tree[:open_nodes] = @temp[:open_nodes].dup if @temp && @temp[:open_nodes]

--- a/vmdb/app/views/ops/_all_tabs.html.haml
+++ b/vmdb/app/views/ops/_all_tabs.html.haml
@@ -18,12 +18,12 @@
           = _("Authentication")
         = patternfly_tab_header("settings_workers", @sb[:active_tab]) do
           = _("Workers")
-        - if cur_svr_id == @sb[:my_server_id]
+        - if cur_svr_id == my_server_id
           = patternfly_tab_header("settings_database", @sb[:active_tab]) do
             = _("Database")
           = patternfly_tab_header("settings_custom_logos", @sb[:active_tab]) do
             = _("Custom Logos")
-        - if cur_svr_id == @sb[:my_server_id]
+        - if cur_svr_id == my_server_id
           = patternfly_tab_header("settings_advanced", @sb[:active_tab]) do
             = _("Advanced")
       .tab-content
@@ -33,12 +33,12 @@
           = render :partial => "settings_authentication_tab"
         = patternfly_tab_content("settings_workers", @sb[:active_tab]) do
           = render :partial => "settings_workers_tab"
-        - if cur_svr_id == @sb[:my_server_id]
+        - if cur_svr_id == my_server_id
           = patternfly_tab_content("settings_database", @sb[:active_tab]) do
             = render :partial => "settings_database_tab"
           = patternfly_tab_content("settings_custom_logos", @sb[:active_tab]) do
             = render :partial => "settings_custom_logos_tab"
-        - if cur_svr_id == @sb[:my_server_id]
+        - if cur_svr_id == my_server_id
           = patternfly_tab_content("settings_advanced", @sb[:active_tab]) do
             = render :partial => "settings_advanced_tab"
     - else
@@ -106,14 +106,14 @@
           = render :partial => "diagnostics_cu_repair_tab"
     - elsif x_node.split("__").last.split("-")[0] == "svr"
       %ul.nav.nav-tabs
-        - if @sb[:selected_server_id] == @sb[:my_server_id] || @selected_server.started?
+        - if @sb[:selected_server_id] == my_server_id || @selected_server.started?
           = patternfly_tab_header("diagnostics_summary", @sb[:active_tab]) do
             = _("Summary")
           = patternfly_tab_header("diagnostics_workers", @sb[:active_tab]) do
             = _("Workers")
         = patternfly_tab_header("diagnostics_collect_logs", @sb[:active_tab]) do
           = _("Collect Logs")
-        - if @sb[:selected_server_id] == @sb[:my_server_id]
+        - if @sb[:selected_server_id] == my_server_id
           = patternfly_tab_header("diagnostics_evm_log", @sb[:active_tab]) do
             = _("CFME Log")
           = patternfly_tab_header("diagnostics_audit_log", @sb[:active_tab]) do
@@ -126,14 +126,14 @@
         = patternfly_tab_header("diagnostics_timelines", @sb[:active_tab]) do
           = _("Timelines")
       .tab-content
-        - if @sb[:selected_server_id] == @sb[:my_server_id] || @selected_server.started?
+        - if @sb[:selected_server_id] == my_server_id || @selected_server.started?
           = patternfly_tab_content("diagnostics_summary", @sb[:active_tab]) do
             = render :partial => "diagnostics_summary_tab"
           = patternfly_tab_content("diagnostics_workers", @sb[:active_tab]) do
             = render :partial => "diagnostics_workers_tab"
         = patternfly_tab_content("diagnostics_collect_logs", @sb[:active_tab]) do
           = render :partial => "diagnostics_collect_logs_tab"
-        - if @sb[:selected_server_id] == @sb[:my_server_id]
+        - if @sb[:selected_server_id] == my_server_id
           = patternfly_tab_content("diagnostics_evm_log", @sb[:active_tab]) do
             = render :partial => "diagnostics_evm_log_tab"
           = patternfly_tab_content("diagnostics_audit_log", @sb[:active_tab]) do

--- a/vmdb/app/views/ops/_diagnostics_zones_tab.html.haml
+++ b/vmdb/app/views/ops/_diagnostics_zones_tab.html.haml
@@ -11,7 +11,7 @@
               %td.narrow
                 %img{:src => "/images/icons/new/zone.png"}/
               %td
-                - if @sb[:my_zone] == z.name
+                - if my_zone_name == z.name
                   %b
                     = h(ui_lookup(:model => z.class.to_s))
                     = ": #{h(z.description)}"

--- a/vmdb/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/vmdb/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -39,7 +39,7 @@
               %td.narrow
                 %img{:src => "/images/icons/new/miq_server.png"}/
               %td
-                - if @sb[:my_server_id] == s.id
+                - if my_server_id == s.id
                   %b
                     = h(ui_lookup(:model=>s.class.to_s))
                     \: #{h(s.name)} [#{h(s.id)}] (current)

--- a/vmdb/app/views/ops/_settings_list_tab.html.haml
+++ b/vmdb/app/views/ops/_settings_list_tab.html.haml
@@ -12,7 +12,7 @@
               %td.narrow
                 %img{:src => "/images/icons/new/zone.png"}/
               %td
-                - if @sb[:my_zone] == z.name
+                - if my_zone_name == z.name
                   %b
                     = h(ui_lookup(:model=>z.class.to_s)) + ":"
                     = h(z.description) + _(" (current)")

--- a/vmdb/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/vmdb/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -3,6 +3,8 @@ include UiConstants
 
 shared_examples "logs_collect" do |type|
   let(:klass) { type.classify.constantize }
+  let(:zone) { active_record_instance_double("Zone", :name => "foo") }
+  let(:server) { active_record_instance_double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
   before do
     sb_hash = {
       :trees            => {:diagnostics_tree => {:active_node => active_node}},
@@ -11,6 +13,7 @@ shared_examples "logs_collect" do |type|
       :active_tab       => "diagnostics_roles_servers"
     }
     controller.instance_variable_set(:@sb, sb_hash)
+    MiqServer.stub(:my_server).with(true).and_return(server)
   end
 
   it "not running" do


### PR DESCRIPTION
These were removed from tree_builder code that are needed to show correct tabs on current server/zone nodes, these are also needed to set right_cell_text.

 @martinpovolny this was caused by changes in commit: 78382cbb
@dclarizio please review.

Before fix:
![before_fix](https://cloud.githubusercontent.com/assets/3450808/8340520/10abb474-1a8d-11e5-8bb4-40d8c0c332af.png)


after fix:
![after_fix](https://cloud.githubusercontent.com/assets/3450808/8340501/ee2e3b6a-1a8c-11e5-92d0-94594dc49c69.png)
