### PR TITLE
quote database names before running a select

### DIFF
--- a/vmdb/app/models/miq_database.rb
+++ b/vmdb/app/models/miq_database.rb
@@ -63,8 +63,7 @@ class MiqDatabase < ActiveRecord::Base
   end
 
   def size
-    conn = ActiveRecord::Base.connection
-    conn.select_value("SELECT pg_database_size(#{conn.quote(name)})").to_i
+    ActiveRecord::Base.connection.database_size name
   end
 
   def self.adapter

--- a/vmdb/app/models/miq_database.rb
+++ b/vmdb/app/models/miq_database.rb
@@ -58,29 +58,13 @@ class MiqDatabase < ActiveRecord::Base
     end
   end
 
-  def self.database_name
-    @name ||= begin
-      instance_variable = ActiveRecord::Base.connection.adapter_name == "SQLServer" ? "@connection_options" : "@config"
-      ActiveRecord::Base.connection.instance_variable_get(instance_variable)[:database]
-    end
-  end
-
   def name
-    self.class.database_name
-  end
-
-  def size_postgresql
-    conn = ActiveRecord::Base.connection
-    conn.select_value("SELECT pg_database_size('#{self.name}')").to_i
+    ActiveRecord::Base.connection.current_database
   end
 
   def size
-    adapter = ActiveRecord::Base.connection.adapter_name.downcase
-    case adapter
-    when "postgres", "postgresql"; size_postgresql
-    else
-       raise "#{adapter} is not supported"
-    end
+    conn = ActiveRecord::Base.connection
+    conn.select_value("SELECT pg_database_size(#{conn.quote(name)})").to_i
   end
 
   def self.adapter

--- a/vmdb/app/models/vmdb_database.rb
+++ b/vmdb/app/models/vmdb_database.rb
@@ -31,8 +31,7 @@ class VmdbDatabase < ActiveRecord::Base
   end
 
   def size
-    conn = ActiveRecord::Base.connection
-    conn.select_value("SELECT pg_database_size(#{conn.quote(name)})").to_i
+    ActiveRecord::Base.connection.database_size name
   end
 
   def top_tables_by(sorted_by, limit = nil)

--- a/vmdb/app/models/vmdb_database.rb
+++ b/vmdb/app/models/vmdb_database.rb
@@ -30,17 +30,9 @@ class VmdbDatabase < ActiveRecord::Base
     self.vmdb_database_metrics
   end
 
-  def size_postgresql
-    self.class.connection.select_value("SELECT pg_database_size('#{self.name}')").to_i
-  end
-
   def size
-    adapter = self.class.connection.adapter_name.downcase
-    case adapter
-    when "postgres", "postgresql"; size_postgresql
-    else
-       raise "#{adapter} is not supported"
-    end
+    conn = ActiveRecord::Base.connection
+    conn.select_value("SELECT pg_database_size(#{conn.quote(name)})").to_i
   end
 
   def top_tables_by(sorted_by, limit = nil)

--- a/vmdb/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/vmdb/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -1,6 +1,10 @@
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapter < AbstractAdapter
+      def database_size(name)
+        select_value("SELECT pg_database_size(#{quote(name)})").to_i
+      end
+
       def database_version
         select_value("SELECT version()")
       end

--- a/vmdb/spec/models/miq_database_spec.rb
+++ b/vmdb/spec/models/miq_database_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 describe MiqDatabase do
+  it "has a size" do
+    MiqDatabase.seed
+    db = MiqDatabase.first
+    expect(db.size).to be >= 0
+  end
+
   context ".seed" do
     it "When called multiple times should only create 1 record" do
       3.times { MiqDatabase.seed }

--- a/vmdb/spec/models/vmdb_database_spec.rb
+++ b/vmdb/spec/models/vmdb_database_spec.rb
@@ -7,6 +7,11 @@ describe VmdbDatabase do
     @text  = FactoryGirl.create(:vmdb_table_text, :vmdb_database => @db, :name => 'accounts', :parent_id => @table.id)
   end
 
+  it "#size" do
+    @db.name = ActiveRecord::Base.connection.current_database
+    expect(@db.size).to be >= 0
+  end
+
   it "#evm_tables" do
     @db.evm_tables.should == [@table]
   end


### PR DESCRIPTION
This should clean up some brakeman warnings (I think).  Also I removed
some code that supports SQLServer, and used public API for getting the
database name (rather than `instance_variable_get`)