### PR TITLE
MiqTask#generic_action_with_callback fix

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -193,7 +193,13 @@ class MiqTask < ActiveRecord::Base
     #   :role (role of the server to run the action)
     #   :msg_timeout => how long you want to wait before pulling the plug on the action (seconds)
 
-    task = MiqTask.create(:name => options[:action], :userid => options[:userid])
+    msg =  "Queued the action: [#{options[:action]}] being run for user: [#{options[:userid]}]"
+    task = MiqTask.create(
+      :name    => options[:action],
+      :userid  => options[:userid],
+      :state   => STATE_QUEUED,
+      :status  => STATUS_OK,
+      :message => msg)
 
     # Set the callback for this task to set the status based on the results of the actions
     queue_options[:miq_callback] = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback, :args => ['Finished']}
@@ -202,8 +208,6 @@ class MiqTask < ActiveRecord::Base
     MiqQueue.put(queue_options)
 
     # return task id to the UI
-    msg =  "Queued the action: [#{options[:action]}] being run for user: [#{options[:userid]}]"
-    task.update_status(STATE_QUEUED, STATUS_OK, msg)
     _log.info("Task: [#{task.id}] #{msg}")
     task.id
   end


### PR DESCRIPTION
When stubbing out miq_queue to auto deliver objects, a race condition was revealed.

This code creates a task and adds it to the queue.
The queue runs the job, changing the task status to done.
This code changes the task status to ready (expecting the queue to change it to done)

If the queue takes a while to process the task, then this code will have time to set the status to ready before the queue marks it as done.
If the queue processes the task too quickly, then it will be marked as done before this code marks it as ready, never to be marked as done. This will cause `wait_for_taskid` to block forever. 

The reason for the concern is it will block the wait for task item call indefinitely
1. Change 2 sql query into 1: avoiding insert and update.
2. Avoids race condition where queue insert/delivery are super quick

/cc @gmcculloug @mkanoor 