### PR TITLE
Removed leftover(from HAML conversion) fourth argument from link_to

### DIFF
--- a/vmdb/app/views/layouts/listnav/_container_route.html.haml
+++ b/vmdb/app/views/layouts/listnav/_container_route.html.haml
@@ -19,5 +19,4 @@
           %li
             = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.ext_management_system.name}",
                 {:controller => "ems_container", :action => 'show', :id => @record.ext_management_system.id.to_s},
-                {:title => _("Show this container service's parent %s") % ui_lookup(:table => "ems_container")},
-                '/images/icons/16/link_external.gif')
+                {:title => _("Show this container service's parent %s") % ui_lookup(:table => "ems_container")})

--- a/vmdb/app/views/layouts/listnav/_host.html.haml
+++ b/vmdb/app/views/layouts/listnav/_host.html.haml
@@ -107,16 +107,14 @@
           %li
             = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
               {:controller => "ems_infra", :action => 'show', :id => @record.ext_management_system.id.to_s},
-              {:title => _("Show this %s parent %s") % ["#{host_title}'s", ui_lookup(:table => "ems_infra")]},
-              '/images/icons/16/link_external.gif')
+              {:title => _("Show this %s parent %s") % ["#{host_title}'s", ui_lookup(:table => "ems_infra")]})
 
         - if role_allows(:feature => "ems_cluster_show") && !@record.ems_cluster.nil?
           - cluster_title = title_for_cluster
           %li
             = link_to("#{cluster_title}: #{@record.ems_cluster.name}",
               {:controller => "ems_cluster", :action => 'show', :id => @record.ems_cluster.id.to_s},
-              {:title => _("Show %s parent %s") % ["#{host_title}'s", cluster_title]},
-              '/images/icons/16/link_external.gif')
+              {:title => _("Show %s parent %s") % ["#{host_title}'s", cluster_title]})
 
         - if role_allows(:feature => "storage_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:storages),


### PR DESCRIPTION
Removed leftover(from HAML conversion) fourth argument from link_to calls that was causing screen to blow up with FATAL -- : Error caught: [ArgumentError] wrong number of arguments (4 for 0..3) after Rails 4 upgrade.

@dclarizio @epwinchell please review/test. This can be recreated by going to Host summary screen for the Host that belongs to a Provider or a Cluster.