### PR TITLE
give automate the ability to bypass miq queue

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   config.include AuthHelper,  :type => :helper
   config.include AuthRequestHelper, :type => :request
   config.include UiConstants, :type => :view
+  config.include QueueSpecHelper, :type => :automation
 
   config.include AutomationSpecHelper, :type => :automation
   config.include PresenterSpecHelper, :type => :presenter, :example_group => {

--- a/vmdb/spec/support/queue_spec_helper.rb
+++ b/vmdb/spec/support/queue_spec_helper.rb
@@ -1,0 +1,12 @@
+module QueueSpecHelper
+  # auto deliver queue methods (to avoid using a worker)
+  # you can pass in a requester, or provide a block that will determine the requester
+  def auto_deliver_queue(default_requester = nil)
+    queue_put = MiqQueue.method(:put)
+    expect(MiqQueue).to receive(:put) do |*args|
+      msg = queue_put.call(*args)
+      requester = block_given? && yield(msg) || default_requester
+      msg.deliver(requester)
+    end
+  end
+end


### PR DESCRIPTION
Currently, there is no way to just say "just deliver the queue message please"

this allows the messages to be processed and delivered inline.

/cc @gmcculloug @mkanoor 