### PR TITLE
remove seed_for_miq_queue (per FIXXME)

### DIFF
--- a/vmdb/spec/models/drift_state/purging_spec.rb
+++ b/vmdb/spec/models/drift_state/purging_spec.rb
@@ -30,7 +30,7 @@ describe DriftState do
     end
 
     it "#purge_timer" do
-      EvmSpecHelper.seed_for_miq_queue
+      EvmSpecHelper.create_guid_miq_server_zone
 
       Timecop.freeze(Time.now) do
         described_class.purge_timer
@@ -48,7 +48,7 @@ describe DriftState do
 
     context "#purge_queue" do
       before(:each) do
-        EvmSpecHelper.seed_for_miq_queue
+        EvmSpecHelper.create_guid_miq_server_zone
         described_class.purge_queue(:remaining, 1)
       end
 

--- a/vmdb/spec/models/ems_amazon_spec.rb
+++ b/vmdb/spec/models/ems_amazon_spec.rb
@@ -11,7 +11,7 @@ describe EmsAmazon do
 
   context ".discover" do
     before do
-      EvmSpecHelper.seed_for_miq_queue
+      EvmSpecHelper.create_guid_miq_server_zone
       @ec2_user = "0123456789ABCDEFGHIJ"
       @ec2_pass = "ABCDEFGHIJKLMNO1234567890abcdefghijklmno"
       @ec2_user2 = "testuser"

--- a/vmdb/spec/models/ems_event_spec.rb
+++ b/vmdb/spec/models/ems_event_spec.rb
@@ -186,7 +186,7 @@ describe EmsEvent do
       let(:purge_time) { (Time.now + 10).round }
 
       before(:each) do
-        EvmSpecHelper.seed_for_miq_queue
+        EvmSpecHelper.create_guid_miq_server_zone
         described_class.purge_queue(purge_time)
       end
 

--- a/vmdb/spec/models/ems_refresh_spec.rb
+++ b/vmdb/spec/models/ems_refresh_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe EmsRefresh do
   context ".queue_refresh" do
     before(:each) do
-      guid, server, zone = EvmSpecHelper.seed_for_miq_queue
+      guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems = FactoryGirl.create(:ems_vmware, :zone => zone)
     end
 

--- a/vmdb/spec/models/metric/config_settings_spec.rb
+++ b/vmdb/spec/models/metric/config_settings_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Metric::ConfigSettings do
   before(:each) do
-    EvmSpecHelper.seed_for_miq_queue # TODO: Rename this method
+    EvmSpecHelper.create_guid_miq_server_zone
   end
 
   it ".host_overhead_cpu" do

--- a/vmdb/spec/models/metric/purging_spec.rb
+++ b/vmdb/spec/models/metric/purging_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Metric::Purging do
   context "::Purging" do
     it "#purge_all_timer" do
-      EvmSpecHelper.seed_for_miq_queue
+      EvmSpecHelper.create_guid_miq_server_zone
 
       Timecop.freeze(Time.now) do
         described_class.purge_all_timer

--- a/vmdb/spec/models/miq_report_result/purging_spec.rb
+++ b/vmdb/spec/models/miq_report_result/purging_spec.rb
@@ -65,7 +65,7 @@ describe MiqReportResult do
     end
 
     it "#purge_timer" do
-      EvmSpecHelper.seed_for_miq_queue
+      EvmSpecHelper.create_guid_miq_server_zone
 
       Timecop.freeze(Time.now) do
         described_class.purge_timer
@@ -84,7 +84,7 @@ describe MiqReportResult do
 
     context "#purge_queue" do
       before(:each) do
-        EvmSpecHelper.seed_for_miq_queue
+        EvmSpecHelper.create_guid_miq_server_zone
         described_class.purge_queue(:remaining, 1)
       end
 

--- a/vmdb/spec/models/policy_event/purging_spec.rb
+++ b/vmdb/spec/models/policy_event/purging_spec.rb
@@ -4,7 +4,7 @@ describe PolicyEvent do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.seed_for_miq_queue
+        EvmSpecHelper.create_guid_miq_server_zone
       end
 
       it "with nothing in the queue" do

--- a/vmdb/spec/support/evm_spec_helper.rb
+++ b/vmdb/spec/support/evm_spec_helper.rb
@@ -68,12 +68,6 @@ module EvmSpecHelper
     return guid, server, zone
   end
 
-  # FIXXME - rename uses of this method
-  def self.seed_for_miq_queue
-    MiqRegion.seed
-    create_guid_miq_server_zone
-  end
-
   def self.seed_specific_product_features(*features)
     features.flatten!
     hashes   = YAML.load_file(MiqProductFeature::FIXTURE_YAML)
@@ -90,7 +84,7 @@ module EvmSpecHelper
   private_class_method :filter_specific_features
 
   def self.seed_admin_user_and_friends
-    guid, server, zone = seed_for_miq_queue
+    guid, server, zone = create_guid_miq_server_zone
 
     admin_role = FactoryGirl.create(:miq_user_role,
       #:name       => "EvmRole-administrator",


### PR DESCRIPTION
While going through some queue work, I saw a FIXXME and decided to do just that.

I renamed `seed_for_miq_queue` to `create_guid_miq_server_zone`.
If it is a more complex fix than that, lets just close.

```ruby
# FIXXME - rename uses of this method
def self.seed_for_miq_queue
  MiqRegion.seed
  create_guid_miq_server_zone
end
```