### PR TITLE
host/create: Set host custom attributes only when *not* validating

### DIFF
--- a/vmdb/app/controllers/host_controller.rb
+++ b/vmdb/app/controllers/host_controller.rb
@@ -958,7 +958,7 @@ class HostController < ApplicationController
   # Set record variables to new values
   def set_record_vars(host, mode = nil)
     host.name             = @edit[:new][:name]
-    host.hostname         = @edit[:new][:hostname].strip
+    host.hostname         = @edit[:new][:hostname].to_s.strip
     host.ipmi_address     = @edit[:new][:ipmi_address]
     host.mac_address      = @edit[:new][:mac_address]
     host.custom_1         = @edit[:new][:custom_1] unless mode == :validate

--- a/vmdb/app/controllers/host_controller.rb
+++ b/vmdb/app/controllers/host_controller.rb
@@ -274,7 +274,6 @@ class HostController < ApplicationController
         render :update do |page|
           page.redirect_to :action=>'show_list', :flash_msg=>_("%{model} \"%{name}\" was added") % {:model=>ui_lookup(:model=>"Host"), :name=>add_host.name}
         end
-        return
       else
         @in_a_form = true
         @edit[:errors].each { |msg| add_flash(msg, :error) }
@@ -962,7 +961,7 @@ class HostController < ApplicationController
     host.hostname         = @edit[:new][:hostname].strip
     host.ipmi_address     = @edit[:new][:ipmi_address]
     host.mac_address      = @edit[:new][:mac_address]
-    host.custom_1         = @edit[:new][:custom_1]
+    host.custom_1         = @edit[:new][:custom_1] unless mode == :validate
     host.user_assigned_os = @edit[:new][:user_assigned_os]
     host.scan_frequency   = @edit[:new][:scan_frequency]
 

--- a/vmdb/spec/controllers/host_controller_spec.rb
+++ b/vmdb/spec/controllers/host_controller_spec.rb
@@ -84,6 +84,26 @@ describe HostController do
     end
   end
 
+  context "#create" do
+    it "can create a host with custom id and no host name" do
+      set_user_privileges
+      controller.instance_variable_set(:@breadcrumbs, [])
+      controller.new
+
+      edit = {:new => {:name     => 'foobar',
+                       :hostname => nil,
+                       :custom_1 => 'bar'},
+              :key => 'host_edit__new'}
+      controller.instance_variable_set(:@edit, edit)
+      session[:edit] = edit
+
+      expect_any_instance_of(Host).to receive(:save).and_call_original
+      post :create, :button => "add", :id => 'new '
+      expect(response.status).to eq(200)
+      expect(response.body).to match(/window.location.href.*host\/show_list.*foobar.*added/)
+    end
+  end
+
   context "#set_record_vars" do
     it "strips leading/trailing whitespace from hostname/ipaddress when adding infra host" do
       set_user_privileges


### PR DESCRIPTION
Possibly rails4 related, adding a new host with a custom attribute
(Custom Identifier) would trigger an exception
([ActiveRecord::RecordNotSaved] You cannot call create unless the parent is saved).

Since set_record_vars is called with mode=:validate, then saved and then
set_record_vars is called without validate, we can simply hold off
setting the custom attribute until we're not validating.

https://bugzilla.redhat.com/show_bug.cgi?id=1232281