### PR TITLE
Rails 4 fix - replace has_many with virtual_has_many associations

### DIFF
--- a/vmdb/app/models/miq_enterprise.rb
+++ b/vmdb/app/models/miq_enterprise.rb
@@ -1,16 +1,17 @@
 class MiqEnterprise < ActiveRecord::Base
-  has_many :miq_regions,            -> { MiqRegion.scoped }
-  has_many :ext_management_systems, -> { ExtManagementSystem.scoped }
-  has_many :vms_and_templates,      -> { VmOrTemplate.where.not(:ems_id => nil) }
-  has_many :vms,                    -> { Vm.where.not(:ems_id => nil) }
-  has_many :miq_templates,          -> { MiqTemplate.where.not(:ems_id => nil) }
-  has_many :hosts,                  -> { Host.where.not(:ems_id => nil) }
-  has_many :storages,               -> { Storage.scoped }
-  has_many :policy_events,          -> { PolicyEvent.scoped }
 
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource  # Destroy will be handled by purger
+
+  virtual_has_many :miq_regions,             :class_name => "MiqRegion"
+  virtual_has_many :ext_management_systems,  :class_name => "ExtManagementSystem"
+  virtual_has_many :vms_and_templates,       :class_name => "VmOrTemplate"
+  virtual_has_many :vms,                     :class_name => "Vm"
+  virtual_has_many :miq_templates,           :class_name => "MiqTemplate"
+  virtual_has_many :hosts,                   :class_name => "Host"
+  virtual_has_many :storages,                :class_name => "Storage"
+  virtual_has_many :policy_events,           :class_name => "PolicyEvent"
 
   serialize :settings
 
@@ -55,6 +56,38 @@ class MiqEnterprise < ActiveRecord::Base
 
   def my_zone
     MiqServer.my_zone
+  end
+
+  def miq_regions
+    MiqRegion.all
+  end
+
+  def ext_management_systems
+    ExtManagementSystem.all
+  end
+
+  def vms_and_templates
+    VmOrTemplate.where.not(:ems_id => nil)
+  end
+
+  def vms
+    Vm.where.not(:ems_id => nil)
+  end
+
+  def miq_templates
+    MiqTemplate.where.not(:ems_id => nil)
+  end
+
+  def hosts
+    Host.where.not(:ems_id => nil)
+  end
+
+  def storages
+    Storage.all
+  end
+
+  def policy_events
+    PolicyEvent.all
   end
 
   alias all_vms_and_templates  vms_and_templates

--- a/vmdb/spec/models/miq_enterprise_spec.rb
+++ b/vmdb/spec/models/miq_enterprise_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+
+describe MiqEnterprise do
+  before(:each) { @ent = FactoryGirl.create(:miq_enterprise) }
+
+  context "with all existing records" do
+    it "#miq_regions" do
+      MiqRegion.seed
+
+      expect(@ent.miq_regions.size).to eq(1)
+    end
+
+    it "#ext_management_systems" do
+      ems = [FactoryGirl.create(:ems_vmware), FactoryGirl.create(:ems_vmware)]
+
+      expect(@ent.ext_management_systems).to match_array(ems)
+    end
+
+    it "#storages" do
+      storage = FactoryGirl.create(:storage)
+
+      expect(@ent.storages).to eq([storage])
+    end
+
+    it "#policy_events" do
+      policy_events = [FactoryGirl.create(:policy_event), FactoryGirl.create(:policy_event)]
+
+      expect(@ent.policy_events).to match_array(policy_events)
+    end
+  end
+
+  context "with some existing records" do
+    before(:each) do
+      @ems  = FactoryGirl.create(:ems_vmware)
+    end
+
+    it "#vms_and_templates" do
+      vm_1 = FactoryGirl.create(:vm_vmware, :ext_management_system => @ems)
+      FactoryGirl.create(:vm_vmware)
+
+      template_1 = FactoryGirl.create(:template_vmware, :ext_management_system => @ems)
+      FactoryGirl.create(:template_vmware)
+
+      expect(@ent.vms_and_templates).to match_array([vm_1, template_1])
+    end
+
+    it "#vms" do
+      vm   = [FactoryGirl.create(:vm_vmware, :ext_management_system => @ems),
+              FactoryGirl.create(:vm_vmware, :ext_management_system => @ems)]
+
+      FactoryGirl.create(:vm_vmware)
+
+      expect(@ent.vms).to match_array(vm)
+    end
+
+    it "#miq_templates" do
+      template = FactoryGirl.create(:template_redhat, :ext_management_system => @ems)
+
+      FactoryGirl.create(:template_redhat)
+
+      expect(@ent.miq_templates).to eq([template])
+    end
+
+    it "#hosts" do
+      hosts = [ FactoryGirl.create(:host_vmware, :ext_management_system => @ems),
+                FactoryGirl.create(:host_vmware, :ext_management_system => @ems)]
+
+      FactoryGirl.create(:host_vmware)
+
+      expect(@ent.hosts).to match_array(hosts)
+    end
+  end
+
+end


### PR DESCRIPTION
Fixed Rails 4 ActiveRecord errors when using has_many with lambda forcing AR to assume a nonexistent foreign key association between tables
Added virtual columns to be used by reports functionality
Added  spec for the model

Fixes #3190