### PR TITLE
Avoid fog-core v1.31.1

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -25,6 +25,7 @@ gem "facade",               "~>1.0.5",       :require => false  # Used by util/p
 gem "ffi",                  "~>1.9.3",       :require => false
 gem "ffi-vix_disk_lib",     "~>1.0.1",       :require => false  # used by lib/VixDiskLib
 gem "fog",                  "~>1.29.0",      :require => false
+gem "fog-core",             "!=1.31.1",      :require => false
 gem "httpclient",           "~>2.5.3",       :require => false
 gem "linux_admin",          ">=0.10.1", "<1", :require => false
 gem "log4r",                "=1.1.8",        :require => false

--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -17,34 +17,34 @@ gem "activerecord",  RAILS_VERSION
 #       this file, the directories resolve correctly.
 
 # Not locally modified and not required
-gem "awesome_spawn",        "~> 1.3",        :require => false
-gem "binary_struct",        "~> 2.0",        :require => false
-gem "excon",                "~>0.40",        :require => false
-gem "ezcrypto",             "=0.7",          :require => false
-gem "facade",               "~>1.0.5",       :require => false  # Used by util/pathname2.rb
-gem "ffi",                  "~>1.9.3",       :require => false
-gem "ffi-vix_disk_lib",     "~>1.0.1",       :require => false  # used by lib/VixDiskLib
-gem "fog",                  "~>1.29.0",      :require => false
-gem "fog-core",             "!=1.31.1",      :require => false
-gem "httpclient",           "~>2.5.3",       :require => false
-gem "linux_admin",          ">=0.10.1", "<1", :require => false
-gem "log4r",                "=1.1.8",        :require => false
-gem "memoist",              "~>0.11.0",      :require => false
-gem "memory_buffer",        ">=0.1.0",       :require => false
-gem "more_core_extensions", "~>1.2.0",       :require => false
-gem "nokogiri",             "~>1.6.0",       :require => false
-gem "ovirt",                "~>0.4.2",        :require => false
-gem "kubeclient",           ">=0.1.16",       :require => false
-gem "openshift_client",     ">=0.0.5",        :require => false
-gem "rest-client",                           :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
-gem "parallel",             "~>0.5.21",      :require => false
-gem "Platform",             "=0.4.0",        :require => false
-gem "rubyzip",              "=0.9.5",        :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646
-gem "rufus-lru",            "~>1.0.3",       :require => false
-gem "uuidtools",            "~>2.1.3",       :require => false
-gem "trollop",              "~>2.0",      :require => false
-gem "psych",                "~>2.0.12"
-gem "apipie-bindings",      "~>0.0.12",      :require => false
+gem "awesome_spawn",           "~> 1.3",            :require => false
+gem "binary_struct",           "~> 2.0",            :require => false
+gem "excon",                   "~>0.40",            :require => false
+gem "ezcrypto",                "=0.7",              :require => false
+gem "facade",                  "~>1.0.5",           :require => false  # Used by util/pathname2.rb
+gem "ffi",                     "~>1.9.3",           :require => false
+gem "ffi-vix_disk_lib",        "~>1.0.1",           :require => false  # used by lib/VixDiskLib
+gem "fog",                     "~>1.29.0",          :require => false
+gem "fog-core",                "!=1.31.1",          :require => false
+gem "httpclient",              "~>2.5.3",           :require => false
+gem "linux_admin",             ">=0.10.1", "<1",    :require => false
+gem "log4r",                   "=1.1.8",            :require => false
+gem "memoist",                 "~>0.11.0",          :require => false
+gem "memory_buffer",           ">=0.1.0",           :require => false
+gem "more_core_extensions",    "~>1.2.0",           :require => false
+gem "nokogiri",                "~>1.6.0",           :require => false
+gem "ovirt",                   "~>0.4.2",           :require => false
+gem "kubeclient",              ">=0.1.16",          :require => false
+gem "openshift_client",        ">=0.0.5",           :require => false
+gem "rest-client",                                  :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
+gem "parallel",                "~>0.5.21",          :require => false
+gem "Platform",                "=0.4.0",            :require => false
+gem "rubyzip",                 "=0.9.5",            :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646
+gem "rufus-lru",               "~>1.0.3",           :require => false
+gem "uuidtools",               "~>2.1.3",           :require => false
+gem "trollop",                 "~>2.0",             :require => false
+gem "psych",                   "~>2.0.12"
+gem "apipie-bindings",         "~>0.0.12",          :require => false
 
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")
@@ -59,13 +59,13 @@ end
 # where the qpid-cpp-client-devel package is not available.  This includes
 # OSX, Windows, and CruiseControl machines.
 group :qpid do
-  gem "qpid_messaging", "~>0.20.0",    :require => false
+  gem "qpid_messaging", "~>0.20.0", :require => false
 end
 
 # Grouping this mainly to stay consistent with qpid--the other amqp library.  In
 # a production build, the qpid and rabbit groups should be included
 group :rabbit do
-  gem "bunny",          "~>1.0.4",    :require => false
+  gem "bunny", "~>1.0.4", :require => false
 end
 
 group :appliance do
@@ -75,8 +75,8 @@ group :appliance do
 end
 
 # Locally modified but not required
-gem "handsoap",    "~>0.2.5",   :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-2"
-gem "rubywbem",    :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
+gem "handsoap", "~>0.2.5", :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-2"
+gem "rubywbem",            :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
 
 # Windows only. Do not put in Gemfile.lock on other platforms.
 if Gem.win_platform?
@@ -89,14 +89,14 @@ end
 #
 unless ENV['APPLIANCE']
   group :test do
-    gem "test-unit",              :require => false
-    gem "camcorder",              :require => false
-    gem "jasmine",                :require => false, :git => "git://github.com/jasmine/jasmine-gem.git", :ref => "c726fe1"
-    gem "rspec",      "~>2.14.0", :require => false
-    gem "rspec-fire", "~>1.3.0",  :require => false
-    gem "timecop",    "~>0.7.3",  :require => false
-    gem "xml-simple", "=1.0.12",  :require => false  # Used by test/xml/tc_xmlhash_methods.rb
-    gem "vcr",        "~>2.6",    :require => false  # Used by manageiq-foreman
-    gem "webmock",                :require => false  # Used by vcr / manageiq-foreman
+    gem "test-unit",                    :require => false
+    gem "camcorder",                    :require => false
+    gem "jasmine",                      :require => false, :git => "git://github.com/jasmine/jasmine-gem.git", :ref => "c726fe1"
+    gem "rspec",         "~>2.14.0",    :require => false
+    gem "rspec-fire",    "~>1.3.0",     :require => false
+    gem "timecop",       "~>0.7.3",     :require => false
+    gem "xml-simple",    "=1.0.12",     :require => false  # Used by test/xml/tc_xmlhash_methods.rb
+    gem "vcr",           "~>2.6",       :require => false  # Used by manageiq-foreman
+    gem "webmock",                      :require => false  # Used by vcr / manageiq-foreman
   end
 end

--- a/lib/openstack/openstack_handle/handle.rb
+++ b/lib/openstack/openstack_handle/handle.rb
@@ -70,9 +70,8 @@ module OpenstackHandle
       else
         Fog.const_get(service).new(opts)
       end
-    rescue ArgumentError, Fog::Errors::NotFound => err
+    rescue Fog::Errors::NotFound => err
       raise MiqException::ServiceNotAvailable if err.message.include?("Could not find service")
-      raise MiqException::ServiceNotAvailable if err.message =~ /\w+ has no \w+ service/
       raise
     end
 


### PR DESCRIPTION
fog-core v1.31.1 started raising ArgumentErrors when it was unable to make a connection.  I made a fix for upstream here https://github.com/fog/fog-core/pull/156 which has been merged, We should block this version of fog-core because the ArgumentErrors can cause so many problems in our OpenstackHandle code.  Also reverting GM's commit that attempts to handle the errors since it doesn't handle all cases.