### PR TITLE
Don't try to trap SIGKILL since it can't be trapped/ignored.

### DIFF
--- a/lib/appliance_console.rb
+++ b/lib/appliance_console.rb
@@ -102,7 +102,7 @@ $MIQDEBUG_FILES = %W(#{ROOT}/lib/appliance_console.rb
 
 require 'appliance_console/errors.rb'
 
-[:INT, :TERM, :KILL, :ABRT, :TSTP].each { |s| trap(s) { raise MiqSignalError } } if LOCK_CONSOLE
+[:INT, :TERM, :ABRT, :TSTP].each { |s| trap(s) { raise MiqSignalError } } if LOCK_CONSOLE
 
 # Disabled in order to allow rescue of timeout error
 HighLine.track_eof = false


### PR DESCRIPTION
Fixes `appliance_console.rb:105 in `trap': invalid argument - SIGKILL`

Ruby 2.1 and earlier lets you trap SIGKILL even though it's useless.
Ruby 2.2 won't let you try to trap it.

![screen shot 2015-06-25 at 5 32 26 pm](https://cloud.githubusercontent.com/assets/19339/8366145/35705f02-1b60-11e5-85d0-5ab05a708b90.png)


