### PR TITLE
Handle cases where RHEV is slow to start VM's

### DIFF
--- a/vmdb/app/models/miq_provision_redhat_via_iso/state_machine.rb
+++ b/vmdb/app/models/miq_provision_redhat_via_iso/state_machine.rb
@@ -21,10 +21,7 @@ module MiqProvisionRedhatViaIso::StateMachine
       $log.info("MIQ(#{self.class.name}#boot_from_cdrom) #{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else
-      # Temporarily set the database raw_power_state in case the refresh has not come along yet.
-      destination.update_attributes(:raw_power_state => "wait_for_launch")
-
-      signal :poll_destination_powered_off_in_provider
+      signal :poll_destination_powered_on_in_provider
     end
   end
 

--- a/vmdb/app/models/miq_provision_redhat_via_pxe/state_machine.rb
+++ b/vmdb/app/models/miq_provision_redhat_via_pxe/state_machine.rb
@@ -28,10 +28,7 @@ module MiqProvisionRedhatViaPxe::StateMachine
       $log.info("MIQ(#{self.class.name}#boot_from_network) #{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else
-      # Temporarily set the database raw_power_state in case the refresh has not come along yet.
-      destination.update_attributes(:raw_power_state => "wait_for_launch")
-
-      signal :poll_destination_powered_off_in_provider
+      signal :poll_destination_powered_on_in_provider
     end
   end
 

--- a/vmdb/spec/models/miq_provision_redhat/state_machine_spec.rb
+++ b/vmdb/spec/models/miq_provision_redhat/state_machine_spec.rb
@@ -71,5 +71,31 @@ describe MiqProvisionRedhat do
 
       @task.poll_destination_powered_off_in_provider
     end
+
+    context "#poll_destination_powered_on_in_provider" do
+      it "requeues if the VM didn't start" do
+        VmRedhat.any_instance.stub(:with_provider_object => {:state => "down"})
+        expect(@task).to receive(:requeue_phase)
+
+        @task.poll_destination_powered_on_in_provider
+
+        expect(@task.phase_context[:power_on_wait_count]).to eq(1)
+      end
+
+      it "moves on if the vm started" do
+        VmRedhat.any_instance.stub(:with_provider_object => {:state => "up"})
+        expect(@task).to receive(:poll_destination_powered_off_in_provider)
+
+        @task.poll_destination_powered_on_in_provider
+
+        expect(@task.phase_context[:power_on_wait_count]).to be_nil
+      end
+
+      it "raises if the vm failed to start" do
+        @task.phase_context[:power_on_wait_count] = 121
+
+        expect { @task.poll_destination_powered_on_in_provider }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Create a loop in the state machine after requesting the VM boot.
Requeue 120 times, if the VM still hasn't started raise an error to fail
the provision.

https://bugzilla.redhat.com/show_bug.cgi?id=1235822