### PR TITLE
Use released Rails gems

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -2,19 +2,19 @@ raise "Ruby versions less than 2.0 are unsupported!" if RUBY_VERSION < "2.0.0"
 
 source 'https://rubygems.org'
 
-gem "bundler", "~>1.3"
-gem "rake",    "~>10.1"
+gem "bundler",       "~>1.3"
+gem "rake",          "~>10.1"
 gem "iniparse"
+
+RAILS_VERSION = "~>4.2.3"
+gem "activesupport", RAILS_VERSION
+
+# ActiveRecord is used by appliance_console
+gem "activerecord",  RAILS_VERSION
 
 
 # NOTE: Must use fully qualified paths here so that when vmdb/Gemfile pulls in
 #       this file, the directories resolve correctly.
-
-# Locally modified and required
-gem "activesupport", :git => "git://github.com/rails/rails.git", :branch => "4-2-stable"
-
-# ActiveRecord is used by appliance_console
-gem "activerecord",  :git => "git://github.com/rails/rails.git", :branch => "4-2-stable"
 
 # Not locally modified and not required
 gem "awesome_spawn",        "~> 1.3",        :require => false

--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -7,6 +7,9 @@ MiqBundler.include_gemfile("../lib/Gemfile", binding)
 # VMDB specific gems
 #
 
+gem "rails",                           RAILS_VERSION
+gem "activerecord-deprecated_finders", "~>1.0.4",     :require => "active_record/deprecated_finders"
+
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '=1.2.4'
 gem 'jquery-rails', "=2.2.2"
@@ -21,9 +24,7 @@ gem 'patternfly-sass', "~>1.3.1"
 
 # Vendored and required
 # TODO: Fix AWS tests now that our api specs and the soap4r 1.6.0 specs pass on 1.8.7/1.9.3
-gem "rails",                          :git => "git://github.com/rails/rails.git", :branch => "4-2-stable"
 gem "ruport",                         "=1.7.0",                          :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-2"
-gem 'activerecord-deprecated_finders', :require => 'active_record/deprecated_finders', :git => "git://github.com/rails/activerecord-deprecated_finders"
 
 # Vendored but not required
 #gem "actionwebservice",               "=3.1.0",       :require => false, :git => "git://github.com/ManageIQ/actionwebservice.git", :tag => "v3.1.0-1"


### PR DESCRIPTION
Conveniently, this should fix CI, too... whatever just broke our preloader hax on 4-2-stable (presumably https://github.com/rails/rails/pull/20356) didn't make it into the release.