### PR TITLE
Fix rails asset precompile without database.yml

### DIFF
--- a/vmdb/config/environments/patches/database_configuration.rb
+++ b/vmdb/config/environments/patches/database_configuration.rb
@@ -2,16 +2,8 @@
 # mode for security purposes.  Also, adds support to handle encrypted
 # password fields as strings without ERB.
 #
-# The original implementation is as follows:
-#
-#    def database_configuration
-#      require 'erb'
-#      YAML::load(ERB.new(IO.read(paths["config/database"].first)).result)
-#    end
 require 'rails/application/configuration'
 Rails::Application::Configuration.module_eval do
-  # sorry for the multi line {}
-  # block needs to be associated with module not prepend
   prepend Module.new {
     def database_configuration
       path = paths["config/database"].existent.first

--- a/vmdb/config/environments/patches/database_configuration.rb
+++ b/vmdb/config/environments/patches/database_configuration.rb
@@ -8,13 +8,20 @@
 #      require 'erb'
 #      YAML::load(ERB.new(IO.read(paths["config/database"].first)).result)
 #    end
-module Rails
-  class Application
-    class Configuration
-      def database_configuration
-        data = IO.read(paths["config/database"].first)
-        Vmdb::ConfigurationEncoder.load(data, false)
+require 'rails/application/configuration'
+Rails::Application::Configuration.module_eval do
+  # sorry for the multi line {}
+  # block needs to be associated with module not prepend
+  prepend Module.new {
+    def database_configuration
+      path = paths["config/database"].existent.first
+      yaml = Pathname.new(path) if path
+
+      if yaml && yaml.exist?
+        Vmdb::ConfigurationEncoder.load(IO.read(yaml), false)
+      else
+        super
       end
     end
-  end
+  }
 end

--- a/vmdb/spec/lib/extensions/database_configuration_spec.rb
+++ b/vmdb/spec/lib/extensions/database_configuration_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe "DatabaseConfiguration patch" do
+  before(:each) do
+    Rails.stub(:env => ActiveSupport::StringInquirer.new("production"))
+
+    @app = Vmdb::Application.new
+    @app.config.paths["config/database"] = "does/not/exist" # ignore real database.yml
+  end
+
+  context "ERB in the template" do
+    before(:each) do
+      @tempfile = Tempfile.new('yml').tap do |f|
+        f.write database_config
+        f.close
+      end
+      @app.config.paths["config/database"].unshift @tempfile.path
+    end
+
+    let(:database_config) { "---\nvalue: <%= 1 %>\n" }
+
+    it "doesn't execute" do
+      expect(@app.config.database_configuration).to eq('value' => '<%= 1 %>')
+    end
+  end
+
+  context "when DATABASE_URL is set" do
+    around(:each) do |example|
+      old_env, ENV['DATABASE_URL'] = ENV['DATABASE_URL'], 'postgres://'
+      example.run
+      ENV['DATABASE_URL'] = old_env
+    end
+
+    it "ignores a missing file" do
+      expect(@app.config.database_configuration).to eq({})
+    end
+  end
+
+  context "with no source of configuration" do
+    it "explains the problem" do
+      expect { @app.config.database_configuration }.to raise_error(/Could not load database configuration/)
+    end
+  end
+end


### PR DESCRIPTION
We currently override Rails `database_configuration`
This new version more closely mimics the rails [behavior], allowing
us to precompile assets without a `database.yml` file.

In our case, it respects `ENV['DATABASE_URL']`.

Fixes #3285 

2 ways to run:
```bash
rake evm:compile_assets
rake assets:precompile DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname
```

[behavior]: https://github.com/rails/rails/blob/master/railties/lib/rails/application/configuration.rb#L87-L101

/cc @matthewd @tenderlove @jrafanie @Fryguy Let me know if you have another approach.