### PR TITLE
Simplify call to MiqAeEngine#resolve_automation_object

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -174,7 +174,7 @@ module ApplicationController::Automate
       :fqclass     => @resolve[:new][:starting_object],
       :message     => @resolve[:new][:object_message]
     )
-    @results = MiqAeEngine.resolve_automation_object(@resolve[:uri], :ws, @resolve[:new][:readonly]).to_expanded_xml
+    @results = MiqAeEngine.resolve_automation_object(@resolve[:uri], @resolve[:new][:readonly]).to_expanded_xml
     @json_tree = ws_tree_from_xml(@results)
   end
 

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -168,13 +168,16 @@ module ApplicationController::Automate
   end
 
   def build_results
-    @resolve[:uri] = MiqAeEngine.create_automation_object(
-      @sb[:name], @sb[:attrs],
+    options = {
       :vmdb_object => @sb[:obj],
       :fqclass     => @resolve[:new][:starting_object],
       :message     => @resolve[:new][:object_message]
-    )
-    @results = MiqAeEngine.resolve_automation_object(@resolve[:uri], @resolve[:new][:readonly]).to_expanded_xml
+    }
+    @results = MiqAeEngine.resolve_automation_object(@sb[:name],
+                                                     @sb[:attrs],
+                                                     options,
+                                                     @resolve[:new][:readonly]).to_expanded_xml
+    @resolve[:uri] = options[:uri]
     @json_tree = ws_tree_from_xml(@results)
   end
 

--- a/app/models/miq_provision/automate.rb
+++ b/app/models/miq_provision/automate.rb
@@ -11,9 +11,8 @@ module MiqProvision::Automate
 
       attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_domains'}
       attrs[MiqAeEngine.create_automation_attribute_key(user)] = MiqAeEngine.create_automation_attribute_value(user) unless user.nil?
-      uri = MiqAeEngine.create_automation_object("REQUEST", attrs)
-      ws  = MiqAeEngine.resolve_automation_object(uri)
 
+      ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs)
       if ws.root.nil?
         _log.warn "- Automate Failed (workspace empty)"
         return nil
@@ -39,8 +38,7 @@ module MiqProvision::Automate
       'message' => 'get_placement'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => self)
-    ws  = MiqAeEngine.resolve_automation_object(uri)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
     reload
 
     {
@@ -56,8 +54,7 @@ module MiqProvision::Automate
       'message' => 'get_availability_zone'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => self)
-    ws  = MiqAeEngine.resolve_automation_object(uri)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["availability_zone"])
   end
@@ -68,8 +65,8 @@ module MiqProvision::Automate
       'message' => 'get_host_and_storage'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => self)
-    ws  = MiqAeEngine.resolve_automation_object(uri)
+
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
     reload
     host      = MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["host"])
     datastore = MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["storage"])
@@ -82,8 +79,7 @@ module MiqProvision::Automate
       'message' => 'get_cluster'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => self)
-    ws  = MiqAeEngine.resolve_automation_object(uri)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["cluster"])
   end
@@ -94,8 +90,7 @@ module MiqProvision::Automate
       'message' => 'get_host'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => self)
-    ws  = MiqAeEngine.resolve_automation_object(uri)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["host"])
   end
@@ -138,8 +133,7 @@ module MiqProvision::Automate
       'message' => 'get_networks'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    uri = MiqAeEngine.create_automation_object("REQUEST", attrs)
-    ws  = MiqAeEngine.resolve_automation_object(uri)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs)
 
     if ws.root.nil?
       _log.warn "- Automate Failed (workspace empty)"

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -13,8 +13,7 @@ module MiqProvision::Naming
         prov_obj.save
         attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'}
         attrs[MiqAeEngine.create_automation_attribute_key(prov_obj.get_user)] = MiqAeEngine.create_automation_attribute_value(prov_obj.get_user) unless prov_obj.get_user.nil?
-        uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => prov_obj)
-        ws  = MiqAeEngine.resolve_automation_object(uri)
+        ws  = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => prov_obj)
         unresolved_vm_name = ws.root("vmname")
         prov_obj.reload
       end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -704,8 +704,7 @@ class MiqRequestWorkflow
 
     input_fields.each { |k| attrs["dialog_input_#{k.to_s.downcase}"] = send(k).to_s }
 
-    uri  = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => @requester)
-    ws   = MiqAeEngine.resolve_automation_object(uri)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => @requester)
 
     if ws && ws.root
       dialog_option_prefix = 'dialog_option_'

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -295,7 +295,9 @@ module MiqAeEngine
     MiqAeUri.join(nil, nil, nil, nil, nil, path, nil, options[:attrs], options[:message])
   end
 
-  def self.resolve_automation_object(uri, readonly = false)
+  def self.resolve_automation_object(uri, attr = nil, options = {}, readonly = false)
+    uri = create_automation_object(uri, attr, options) if attr
+    options[:uri] = uri
     ws = readonly ? MiqAeWorkspaceRuntime.instantiate_readonly(uri) : MiqAeWorkspaceRuntime.instantiate(uri)
     $miq_ae_logger.debug(ws.to_expanded_xml) if $miq_ae_logger.debug?
     return ws

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -264,6 +264,7 @@ module MiqAeEngine
       options[:namespace] ||= "System"
       options[:class]     ||= "Process"
     end
+    options[:instance_name] = name
 
     ae_attrs  = attrs.dup
     ae_attrs['object_name'] = name
@@ -286,9 +287,12 @@ module MiqAeEngine
     array_objects.each do |o|
       ae_attrs[o] = ae_attrs[o].first   if ae_attrs[o].kind_of?(Array)
     end
-
-    path = MiqAePath.new(:ae_namespace => options[:namespace], :ae_class => options[:class], :ae_instance => name).to_s
-    MiqAeUri.join(nil, nil, nil, nil, nil, path, nil, ae_attrs, options[:message])
+    options[:attrs] = ae_attrs
+    options[:message] = ae_attrs[:message]
+    path = MiqAePath.new(:ae_namespace => options[:namespace],
+                         :ae_class     => options[:class],
+                         :ae_instance  => options[:instance_name]).to_s
+    MiqAeUri.join(nil, nil, nil, nil, nil, path, nil, options[:attrs], options[:message])
   end
 
   def self.resolve_automation_object(uri, readonly = false)
@@ -296,5 +300,4 @@ module MiqAeEngine
     $miq_ae_logger.debug(ws.to_expanded_xml) if $miq_ae_logger.debug?
     return ws
   end
-
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -291,10 +291,9 @@ module MiqAeEngine
     MiqAeUri.join(nil, nil, nil, nil, nil, path, nil, ae_attrs, options[:message])
   end
 
-  def self.resolve_automation_object(uri, result_type = :ws, readonly = false)
+  def self.resolve_automation_object(uri, readonly = false)
     ws = readonly ? MiqAeWorkspaceRuntime.instantiate_readonly(uri) : MiqAeWorkspaceRuntime.instantiate(uri)
     $miq_ae_logger.debug(ws.to_expanded_xml) if $miq_ae_logger.debug?
-    return ws.to_xml if result_type == :xml
     return ws
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_provider/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/provision_workflow_spec.rb
@@ -16,7 +16,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
     end
 
     it "pass platform attributes to automate" do
-      MiqAeEngine.should_receive(:resolve_automation_object)
+      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
       MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
         name.should eq("REQUEST")
         attrs.should have_attributes(

--- a/spec/models/miq_provision_amazon_workflow_spec.rb
+++ b/spec/models/miq_provision_amazon_workflow_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
     it "pass platform attributes to automate" do
       MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-      MiqAeEngine.should_receive(:resolve_automation_object)
+      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
       MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
         name.should eq("REQUEST")
         attrs.should have_attributes(

--- a/spec/models/miq_provision_microsoft_workflow_spec.rb
+++ b/spec/models/miq_provision_microsoft_workflow_spec.rb
@@ -16,7 +16,7 @@ describe MiqProvisionMicrosoftWorkflow do
     end
 
     it "pass platform attributes to automate" do
-      MiqAeEngine.should_receive(:resolve_automation_object)
+      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
       MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
         name.should eq("REQUEST")
         attrs.should have_attributes(

--- a/spec/models/miq_provision_openstack_workflow_spec.rb
+++ b/spec/models/miq_provision_openstack_workflow_spec.rb
@@ -10,7 +10,7 @@ describe MiqProvisionOpenstackWorkflow do
 
     it "pass platform attributes to automate" do
       MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-      MiqAeEngine.should_receive(:resolve_automation_object)
+      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
       MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
         name.should eq("REQUEST")
         attrs.should have_attributes(

--- a/spec/models/miq_provision_vmware_workflow_spec.rb
+++ b/spec/models/miq_provision_vmware_workflow_spec.rb
@@ -15,7 +15,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
     end
 
     it "pass platform attributes to automate" do
-      MiqAeEngine.should_receive(:resolve_automation_object)
+      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
       MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
         name.should eq("REQUEST")
         attrs.should have_attributes(


### PR DESCRIPTION
Simplify creating an automatic workspace. This simplifies the access to
a workspace, that will soon be run on a remote machine.

#3258 was causing deadlocks in travis. This PR pulls out most of the refactoring from there. (when we are ready to revisit the remote automate workspace code, we can focus on less code).

before:
```ruby
uri = MiqAeEngine.create_automation_object("REQUEST", attrs)
ws  = MiqAeEngine.resolve_automation_object(uri)
```
after:
```ruby
uri = MiqAeEngine.create_automation_object("REQUEST", attrs)
ws  = MiqAeEngine.resolve_automation_object(uri)

# OR

ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs)
```

https://bugzilla.redhat.com/show_bug.cgi?id=1231939

/cc @mkanoor This pulls out a refactor out of #3258 
/cc @gmcculloug please review. thnx