### PR TITLE
host/create - validate_credentials_ws on Host throws *catchable* exception

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -849,7 +849,7 @@ class Host < ActiveRecord::Base
   end
 
   def verify_credentials_with_ws(_auth_type = nil, _options = {})
-    raise NotImplementedError, "#{__method__} not implemented in #{self.class.name}"
+    raise MiqException::MiqHostError, "Web Services authentication is not supported for hosts of this type."
   end
 
   def verify_credentials_with_ssh(auth_type=nil, options={})

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -102,6 +102,26 @@ describe HostController do
       expect(response.status).to eq(200)
       expect(response.body).to match(/window.location.href.*host\/show_list.*foobar.*added/)
     end
+
+    it "doesn't crash when trying to validate a new host" do
+      set_user_privileges
+      controller.instance_variable_set(:@breadcrumbs, [])
+      controller.new
+
+      edit = {:new => {:name             => 'foobar',
+                       :hostname         => '127.0.0.1',
+                       :default_userid   => "abc",
+                       :default_password => "def",
+                       :default_verify   => "def",
+                       :user_assigned_os => "linux_generic"},
+              :key => 'host_edit__new',
+              :host_id => nil}
+      controller.instance_variable_set(:@edit, edit)
+      session[:edit] = edit
+
+      post :create, :button => "validate", :type => "default", :id => "new"
+      expect(response.status).to eq(200)
+    end
   end
 
   context "#set_record_vars" do


### PR DESCRIPTION
If NotImplementedError is thrown, the validate call fails with a 500
error and does not produce a flash message.

Replaced by MiqHostError, which does.

https://bugzilla.redhat.com/show_bug.cgi?id=1233188