### PR TITLE
better error message when file has a syntax error

### DIFF
--- a/vmdb/lib/extensions/as_const_missing_with_sti.rb
+++ b/vmdb/lib/extensions/as_const_missing_with_sti.rb
@@ -29,6 +29,9 @@ module AsConstMissingWithSti
     parsed = RubyParser.for_current_ruby.parse(content)
 
     collect_classes(parsed)
+  rescue Racc::ParseError
+    puts "\nSyntax error in #{filename}\n\n"
+    raise
   end
 
   # Rails +const_missing+ only loads the requested constant and any of its


### PR DESCRIPTION
When I had a syntax error in a ruby file, I got a cryptic error with no notice for what the error was nor where it was located.
This is due to the new way we look up missing constants (introduced today for pluggable providers)

```
/opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/racc/parser.rb:529:in `on_error': (string):61 :: parse error on value ["end", 61] (kEND) (Racc::ParseError)
	from /Users/kbrock/.gem/ruby/2.1.5/gems/ruby_parser-3.7.0/lib/ruby_parser_extras.rb:1124:in `on_error'
```

This PR adds the following text:

```
Syntax error in /Users/kbrock/src/manageiq/vmdb/app/models/user_identity.rb
```

The resulting output:

```
bundle exec rspec spec/lib/miq_automation_engine/miq_ae_engine_spec.rb:688

Syntax error in /Users/kbrock/src/manageiq/vmdb/app/models/user_identity.rb
/opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/racc/parser.rb:529:in `on_error': (string):61 :: parse error on value ["end", 61] (kEND) (Racc::ParseError)
	from /Users/kbrock/.gem/ruby/2.1.5/gems/ruby_parser-3.7.0/lib/ruby_parser_extras.rb:1124:in `on_error'
	from /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/racc/parser.rb:258:in `_racc_do_parse_c'
	from /opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/racc/parser.rb:258:in `do_parse'
```
