### PR TITLE
container provider summary screen - remove "managed by zone"

### DIFF
--- a/vmdb/app/helpers/ems_container_helper/textual_summary.rb
+++ b/vmdb/app/helpers/ems_container_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module EmsContainerHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w(name type hostname ipaddress port zone cpu_cores
+    items = %w(name type hostname ipaddress port cpu_cores
                memory_resources)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end


### PR DESCRIPTION
It should only be displyed in "Smart Management"