### PR TITLE
Fix regression issue: dialog_ prefix no longer automatically added

### DIFF
--- a/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/vmdb/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -52,6 +52,7 @@ end
 def generic_dialog_value(dialog_key, dialog_value, options_hash)
   return false unless /^dialog_(?<option_key>.*)/i =~ dialog_key
   add_hash_value(0, option_key.to_sym, dialog_value, options_hash)
+  add_hash_value(0, dialog_key.to_sym, dialog_value, options_hash)
   true
 end
 


### PR DESCRIPTION
Preserve the "dialog_" prefix on generic dialog options.
Save generic dialog options with and without the dialog_ prefix for backward compatibility.

https://bugzilla.redhat.com/show_bug.cgi?id=1236655

Issue reported in 5.4: 
https://bugzilla.redhat.com/show_bug.cgi?id=1235975