### PR TITLE
Fixed id being passed to patternfly_tab_xxx methods.

### DIFF
--- a/vmdb/app/views/miq_ae_class/_all_tabs.html.haml
+++ b/vmdb/app/views/miq_ae_class/_all_tabs.html.haml
@@ -39,10 +39,10 @@
     - if @in_a_form && @edit.key?(:ae_class_id)
       -# class add
       %ul.nav.nav-tabs
-        = patternfly_tab_header("props", @sb[:active_tab]) do
+        = patternfly_tab_header("details", @sb[:active_tab]) do
           = _('Properties')
       .tab-content
-        = patternfly_tab_content("props", @sb[:active_tab]) do
+        = patternfly_tab_content("details", @sb[:active_tab]) do
           = render :partial => "class_add"
     - else
       %ul.nav.nav-tabs

--- a/vmdb/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/vmdb/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -38,4 +38,4 @@
           .note=_('* Select one or more consecutive fields to move up or down.')
 :javascript
   // disable any other tabs on screen when in edit
-  miq_jquery_disable_inactive_tabs('ae_tabs');
+  miq_patternfly_disable_inactive_tabs('#ae_tabs');


### PR DESCRIPTION
patternfly_tab_xxx methods expect id and sb[:active_tab] to be the same to display tab as an active tab. In this case there is only a single tab on the screen so have to make sure both values match.

Issue #3309
 
@mkanoor @dclarizio please review/test.