### PR TITLE
Persist env

### DIFF
--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -2,5 +2,6 @@ class ContainerDefinition < ActiveRecord::Base
   # :name, :image, :image_pull_policy, :memory, :cpu
   belongs_to :container_group
   has_many :container_port_configs, :dependent => :destroy
+  has_many :container_env_vars,     :dependent => :destroy
   has_one :container
 end

--- a/app/models/container_env_var.rb
+++ b/app/models/container_env_var.rb
@@ -1,0 +1,2 @@
+class ContainerEnvVar < ActiveRecord::Base
+end

--- a/app/models/ems_refresh/parsers/kubernetes.rb
+++ b/app/models/ems_refresh/parsers/kubernetes.rb
@@ -309,6 +309,11 @@ module EmsRefresh::Parsers
       new_result[:container_port_configs] = Array(ports).collect do |port_entry|
         parse_container_port_config(port_entry, pod_id, container_def.name)
       end
+      env = container_def.env
+      new_result[:container_env_vars] = Array(env).collect do |env_var|
+        parse_container_env_var(env_var)
+      end
+
       new_result
     end
 
@@ -342,6 +347,14 @@ module EmsRefresh::Parsers
         :port        => port_config.port,
         :target_port => port_config.targetPort,
         :protocol    => port_config.protocol
+      }
+    end
+
+    def parse_container_env_var(env_var)
+      {
+        :name       => env_var.name,
+        :value      => env_var.value,
+        :field_path => env_var.valueFrom.try(:fieldRef).try(:fieldPath)
       }
     end
 

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -145,7 +145,7 @@ module EmsRefresh::SaveInventoryContainer
               end
 
     save_inventory_multi(:container_definitions, container_group, hashes, deletes,
-                         [:ems_ref], [:container_port_configs, :container])
+                         [:ems_ref], [:container_port_configs, :container_env_vars, :container])
     store_ids_for_new_records(container_group.container_definitions, hashes, :ems_ref)
   end
 
@@ -175,6 +175,19 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(:container_service_port_configs, container_service, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(container_service.container_service_port_configs, hashes, :ems_ref)
+  end
+
+  def save_container_env_vars_inventory(container_definition, hashes, target = nil)
+    return if hashes.nil?
+    container_definition.container_env_vars(true)
+    deletes = if target.kind_of?(ExtManagementSystem)
+                container_definition.container_env_vars.dup
+              else
+                []
+              end
+
+    save_inventory_multi(:container_env_vars, container_definition, hashes, deletes, [:name, :value, :field_path])
+    store_ids_for_new_records(container_definition.container_env_vars, hashes, [:name, :value, :field_path])
   end
 
   def save_container_inventory(container_definition, hash, _target = nil)

--- a/db/migrate/20150519123317_create_container_env_vars.rb
+++ b/db/migrate/20150519123317_create_container_env_vars.rb
@@ -1,0 +1,14 @@
+class CreateContainerEnvVars < ActiveRecord::Migration
+  def up
+    create_table :container_env_vars do |t|
+      t.string     :name
+      t.text       :value
+      t.string     :field_path
+      t.belongs_to :container_definition, :type => :bigint
+    end
+  end
+
+  def down
+    drop_table :container_env_vars
+  end
+end

--- a/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -41,6 +41,7 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
     Container.count.should == 3
     ContainerService.count.should == 6
     ContainerPortConfig.count.should == 2
+    ContainerEnvVar.count.should == 5
     ContainerDefinition.count.should == 3
     ContainerReplicator.count.should == 2
     ContainerProject.count.should == 1


### PR DESCRIPTION
kubernetes: persist env section in container definition
    
Container's environment variables are used to tune
or pass arguments to the applications in docker images.
These variables are useful to have a full view of how
the pod is configured.
    
A ContainerEnvVar must have exactly one of value, field_path.
