### PR TITLE
Fix issue with MiqServer#get_config when there is no config record

### DIFF
--- a/vmdb/app/controllers/ops_controller/settings/common.rb
+++ b/vmdb/app/controllers/ops_controller/settings/common.rb
@@ -773,7 +773,6 @@ module OpsController::Settings::Common
     when "settings_server"                                  # Server Settings tab
       @edit = Hash.new
       @edit[:new] = Hash.new
-      @edit[:current] = Hash.new
       @edit[:current] = MiqServer.find(@sb[:selected_server_id]).get_config("vmdb")
       @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
       @sb[:new_to] = nil

--- a/vmdb/app/models/miq_server/configuration_management.rb
+++ b/vmdb/app/models/miq_server/configuration_management.rb
@@ -21,14 +21,18 @@ module MiqServer::ConfigurationManagement
 
   def get_config(typ = "vmdb", force_reload = false)
     VMDB::Config.invalidate(typ) if force_reload
-    if self.is_local?
-      cfg        = VMDB::Config.new(typ)
-    else
-      cfg        = VMDB::Config.new(typ, false)
-      c          = configurations.find_by_typ(typ)
-      cfg.config = c.settings unless c.nil?
+
+    config = nil
+
+    if self.is_remote?
+      record = configurations.find_by_typ(typ)
+      if record
+        config = VMDB::Config.new(typ, false)
+        config.config = record.settings
+      end
     end
-    cfg
+
+    config || VMDB::Config.new(typ)
   end
 
   def set_config(cfg)

--- a/vmdb/spec/factories/configuration.rb
+++ b/vmdb/spec/factories/configuration.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :configuration do
+  end
+end

--- a/vmdb/spec/factories/zone.rb
+++ b/vmdb/spec/factories/zone.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :zone do
-    name        "default"
-    description "Default Zone"
+    sequence(:name)        { |n| Zone.exists? ? "Zone #{n}" : "default" }
+    sequence(:description) { |n| Zone.exists? ? "Zone #{n}" : "Default Zone" }
   end
 end

--- a/vmdb/spec/models/miq_server/configuration_management_spec.rb
+++ b/vmdb/spec/models/miq_server/configuration_management_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe MiqServer do
+  describe "ConfigurationManagement" do
+    describe "#get_config" do
+      before do
+        _guid, @local_server, _zone = EvmSpecHelper.local_guid_miq_server_zone
+      end
+
+      context "local server" do
+        it "with no changes in the database" do
+          expect(@local_server.get_config("vmdb").config).to be_kind_of(Hash)
+        end
+
+        it "with changes in the database" do
+          c = YAML.load_file(Rails.root.join("config/vmdb.tmpl.yml"))
+          c.store_path("server", "name", "XXX")
+          FactoryGirl.create(:configuration, :miq_server => @local_server, :typ => "vmdb", :settings => c)
+
+          actual = @local_server.get_config("vmdb").config.fetch_path(:server, :name)
+          expect(actual).to eq "XXX"
+        end
+      end
+
+      context "remote server" do
+        before do
+          _guid, @remote_server, _zone = EvmSpecHelper.remote_guid_miq_server_zone
+        end
+
+        it "with no changes in the database" do
+          expect(@remote_server.get_config("vmdb").config).to be_kind_of(Hash)
+        end
+
+        it "with changes in the database" do
+          c = YAML.load_file(Rails.root.join("config/vmdb.tmpl.yml"))
+          c.store_path("server", "name", "XXX")
+          FactoryGirl.create(:configuration, :miq_server => @remote_server, :typ => "vmdb", :settings => c)
+
+          actual = @remote_server.get_config("vmdb").config.fetch_path(:server, :name)
+          expect(actual).to eq "XXX"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Error message from UI was:
[NoMethodError] undefined method `[]' for nil:NilClass
  manageiq/vmdb/app/controllers/ops_controller/settings/common.rb:786:in `settings_set_form_vars'

---

@gtanzillo Please review.  I'm not 100% sure that this can happen in production, but a "missing" record from configurations just means that a server's configuration was never changed (and thus the template should be used).  In development this could happen in a number of ways.