### PR TITLE
Use gem version of default_value_for

### DIFF
--- a/vmdb/Gemfile
+++ b/vmdb/Gemfile
@@ -42,7 +42,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # See miq_expression_spec Date/Time Support examples.
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
-gem "default_value_for",             :git => 'https://github.com/FooBarWidget/default_value_for.git'
+gem "default_value_for",              "~>3.0.1"
 gem "thin",                           "~>1.3.1"  # Used by rails server through rack
 gem 'bcrypt-ruby', '3.1.2'
 gem 'outfielding-jqplot-rails',       "= 1.0.8"


### PR DESCRIPTION
github version reference was introduced in d05fa221

On github, It looks like [3.0.1] is equivalent to github's [head]

@tenderlove Is there a reason to point to [head] for the `default_value_for` gem?

[3.0.1]: https://rubygems.org/gems/default_value_for
[head]: https://github.com/FooBarWidget/default_value_for/releases