### PR TITLE
Remove unnecessary stuff from automate specs

### DIFF
--- a/vmdb/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/vmdb/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -1,10 +1,7 @@
 require "spec_helper"
-require "timecop"
-include AutomationSpecHelper
 
 describe "MiqAeStateMachineRetry" do
   before do
-    MiqAeDatastore.reset_default_namespace
     @method_name     = 'MY_RETRY_METHOD'
     @method_instance = 'MY_RETRY_INSTANCE'
     @retry_class     = 'MY_RETRY_CLASS'

--- a/vmdb/spec/automation/unit/engine_validation/miq_ae_state_machine_steps_spec.rb
+++ b/vmdb/spec/automation/unit/engine_validation/miq_ae_state_machine_steps_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe "MiqAeStateMachineSteps" do
   before do
-    MiqAeDatastore.reset_default_namespace
     @instance1           = 'instance1'
     @instance2           = 'instance2'
     @instance3           = 'instance3'


### PR DESCRIPTION
@mkanoor Please review.

- The automation specs use a before(:suite) to import the manageiq domain, so no need to reset it again...it's just overhead.
- AutomationSpecHelper is included in every automation spec, so no need to include globally.