### PR TITLE
link url to tenant_object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'mime-types'
 gem "jbuilder",                       "~>2.0.7"
 gem "gettext_i18n_rails"
 gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master'
+gem 'acts_as_tenant',                 "~>0.3.9"
 gem 'paperclip',                      "~>4.3.0"
 
 # Not vendored and not required

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,7 @@ class ApplicationController < ActionController::Base
   include_concern 'Automate'
   include_concern 'CiProcessing'
   include_concern 'Compare'
+  include_concern 'CurrentUser'
   include_concern 'Buttons'
   include_concern 'DialogRunner'
   include_concern 'Explorer'
@@ -37,11 +38,12 @@ class ApplicationController < ActionController::Base
   include_concern 'Performance'
   include_concern 'PolicySupport'
   include_concern 'Tags'
+  include_concern 'Tenancy'
   include_concern 'Timelines'
   include_concern 'TreeSupport'
   include_concern 'SysprepAnswerFile'
-  include_concern 'CurrentUser'
 
+  before_filter :set_session_tenant, :except => [:window_sizes]
   before_filter :get_global_session_data, :except => [:window_sizes, :authenticate]
   before_filter :set_user_time_zone
   before_filter :set_gettext_locale
@@ -2352,11 +2354,6 @@ class ApplicationController < ActionController::Base
         add_flash(params[:flash_msg])
       end
     end
-
-    # Get customer name
-    session[:customer_name] = get_vmdb_config[:server][:company] if session[:customer_name] == nil
-    session[:vmdb_name] = get_vmdb_config[:server][:name] if session[:vmdb_name] == nil
-    session[:custom_logo] = get_vmdb_config[:server][:custom_logo] if session[:custom_logo] == nil
 
     # Get settings hash from the session
     @settings = session[:settings]

--- a/app/controllers/application_controller/tenancy.rb
+++ b/app/controllers/application_controller/tenancy.rb
@@ -1,0 +1,19 @@
+module ApplicationController::Tenancy
+  extend ActiveSupport::Concern
+
+  included do
+    set_current_tenant_by_subdomain_or_domain(:tenant)
+  end
+
+  # NOTE: remove when these session vars are removed
+  def set_session_tenant(tenant = current_tenant)
+    session[:customer_name] = tenant.try(:company_name)
+    session[:vmdb_name]     = tenant.try(:appliance_name)
+    session[:custom_logo]   = tenant.try(:logo?)
+    tenant
+  end
+  private :set_session_tenant
+
+  alias_method :refresh_session_tenant, :set_session_tenant
+  protected :refresh_session_tenant
+end

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,0 +1,6 @@
+begin
+  ActsAsTenant.default_tenant = Tenant.default_tenant
+rescue ActiveRecord::StatementInvalid
+  # This fails during migration if the tenants table doesn't exist yet
+  # Allow migration to proceed
+end

--- a/spec/controllers/application_controller/tenancy_spec.rb
+++ b/spec/controllers/application_controller/tenancy_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe DashboardController do
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+    Tenant.seed
+    ActsAsTenant.default_tenant = Tenant.default_tenant
+  end
+
+  context "#with unknown subdomain or domain" do
+    before do
+      @request.host = "www.example.com"
+    end
+
+    it "defaults to default_domain" do
+      get :login
+      expect(controller.send(:current_tenant)).to eq(Tenant.default_tenant)
+    end
+  end
+
+  context "#with known subdomain" do
+    let(:tenant) { Tenant.create(:subdomain => "subdomain") }
+    before do
+      @request.host = "#{tenant.subdomain}.example.com"
+    end
+
+    it "detects tenant by subdomain" do
+      get :login
+      expect(controller.send(:current_tenant)).to eq(tenant)
+    end
+  end
+
+  context "#with known domain" do
+    let(:tenant) { Tenant.create(:domain => "domain.com") }
+    before do
+      @request.host = "www.#{tenant.domain}"
+    end
+
+    it "detects tenant by subdomain" do
+      get :login
+      expect(controller.send(:current_tenant)).to eq(tenant)
+    end
+  end
+end


### PR DESCRIPTION
**STATUS:** rebasing has caused some issues. need to rework and test again.

This maps the url to the current tenant.

`acts_as_tenant` determines the tenant by the [domain or subdomain] of the url and sets a global `tenant` variable.

The [current_tenant] helper method gives controllers, views, and models access to the current tenant to implement filtering how ever we see fit.


/cc @gmcculloug @Fryguy 

---

This PR is only interested in the url to tenant mapping, but I know there are a bunch of questions around the `acts_as_tenant` gem in general. I'll include a few more details about that gem, but if possible, I'd like to focus on the url mapping and move the conversation about our walls and sharing mechanism to when we actually implement it. This current PR does not limit models in any way.

Out of the box, `act_as_tenant` does provide the ability to set hard walls based upon the current tenant by adding a [default query] to filter queries by tenant. It also [sets the tenant_id] in models when they are created. In the short term we may want to leverage this until we nail down actual requirements.

Of note, there are other plugins that have different sharing policy. [acts_as_loose_tenant] has a model associated with many tenants. Take away: we can implement what ever sharing mechanism we see fit and are not limited to `acts_as_tenant`'s default implementation.

---
update: added acts_as_tenant description in response to @Fryguy 
update: added `default_scope` in response to @matthewd 
update: pulled out tenant_object into separate PR
update: rewrote acts_as_tenant description with links to actual plugin source code.

[here]: https://github.com/rpearce/acts_as_loose_tenant/blob/master/lib/acts_as_loose_tenant.rb
[domain or subdomain]: https://github.com/ErwinM/acts_as_tenant/blob/master/lib/acts_as_tenant/controller_extensions.rb#L48
[current_tenant]: https://github.com/ErwinM/acts_as_tenant/blob/master/lib/acts_as_tenant/controller_extensions.rb#L51-L53
[default query]: https://github.com/ErwinM/acts_as_tenant/blob/master/lib/acts_as_tenant/model_extensions.rb#L56-L65
[acts_as_loose_tenant]: https://github.com/rpearce/acts_as_loose_tenant/blob/master/lib/acts_as_loose_tenant.rb#L22-L24
[sets the tenant_id]: https://github.com/ErwinM/acts_as_tenant/blob/master/lib/acts_as_tenant/model_extensions.rb#L71-L75