### PR TITLE
let login_as setup users for specs

### DIFF
--- a/vmdb/spec/controllers/application_controller/tags_spec.rb
+++ b/vmdb/spec/controllers/application_controller/tags_spec.rb
@@ -3,10 +3,11 @@ require "spec_helper"
 describe ApplicationController  do
   describe "#get_tagdata" do
     let(:record) { active_record_instance_double("Host") }
+    let(:user) { FactoryGirl.create(:user, :userid => "testuser") }
 
     before do
-      session[:userid] = "testuser"
-      record.stub(:tagged_with).with(:cat => "testuser").and_return("my tags")
+      login_as user
+      record.stub(:tagged_with).with(:cat => user.userid).and_return("my tags")
       Classification.stub(:find_assigned_entries).with(record).and_return(classifications)
     end
 

--- a/vmdb/spec/controllers/vm_cloud_controller/trees_spec.rb
+++ b/vmdb/spec/controllers/vm_cloud_controller/trees_spec.rb
@@ -6,10 +6,6 @@ describe VmCloudController do
     set_user_privileges
     FactoryGirl.create(:vmdb_database)
     EvmSpecHelper.create_guid_miq_server_zone
-    expect(MiqServer.my_guid).to be
-    expect(MiqServer.my_server).to be
-
-    session[:userid] = User.current_user.userid
   end
 
   context "#tree_select" do

--- a/vmdb/spec/controllers/vm_cloud_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_cloud_controller_spec.rb
@@ -55,8 +55,6 @@ describe VmCloudController do
   context "skip or drop breadcrumb" do
     before do
       session[:settings] = {:views => {}, :perpage => {:list => 10}}
-      session[:userid] = User.current_user.userid
-      session[:eligible_groups] = []
       FactoryGirl.create(:vmdb_database)
       EvmSpecHelper.create_guid_miq_server_zone
       @vmcloud = VmCloud.create(:name     => "test_vmcloud",

--- a/vmdb/spec/controllers/vm_infra_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_infra_controller_spec.rb
@@ -4,8 +4,6 @@ describe VmInfraController do
   before(:each) do
     set_user_privileges
 
-    session[:userid] = User.current_user.userid
-    session[:eligible_groups] = []
     session[:settings] = {:quadicons => nil}
 
     FactoryGirl.create(:vmdb_database)
@@ -52,8 +50,6 @@ describe VmInfraController do
   context "skip or drop breadcrumb" do
     before do
       session[:settings] = {:views => {}, :perpage => {:list => 10}}
-      session[:userid] = User.current_user.userid
-      session[:eligible_groups] = []
       FactoryGirl.create(:vmdb_database)
       @vm = VmInfra.create(:name => "testvm", :location => "testvm_location", :vendor => "vmware")
       get :explorer

--- a/vmdb/spec/controllers/vm_or_template_controller_spec.rb
+++ b/vmdb/spec/controllers/vm_or_template_controller_spec.rb
@@ -118,8 +118,6 @@ describe VmOrTemplateController do
   context "skip or drop breadcrumb" do
     before do
       session[:settings] = {:views => {}, :perpage => {:list => 10}}
-      session[:userid] = User.current_user.userid
-      session[:eligible_groups] = []
       FactoryGirl.create(:vmdb_database)
       EvmSpecHelper.create_guid_miq_server_zone
       @vm_or_template = VmOrTemplate.create(:name     => "test_vm_or_template",


### PR DESCRIPTION
In tests there is no need to set session variables around user login.

No need to verify that the test helper `create_guid_miq_server_zone` does it's job.

/cc @dclarizio 