### PR TITLE
Add shared status to cloud networks

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -7,6 +7,7 @@ class CloudTenant < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::CloudManager"
   has_many   :security_groups
   has_many   :cloud_networks
+  has_many   :shared_cloud_networks, -> { where :shared => true }, :through => :ext_management_system, :source => :cloud_networks
   has_many   :vms
   has_many   :vms_and_templates
   has_many   :miq_templates
@@ -18,9 +19,15 @@ class CloudTenant < ActiveRecord::Base
   has_many   :cloud_object_store_objects
   has_many   :cloud_resource_quotas
 
+  alias_method :direct_cloud_networks, :cloud_networks
+
   acts_as_miq_taggable
 
   virtual_column :total_vms, :type => :integer, :uses => :vms
+
+  def all_cloud_networks
+    direct_cloud_networks + shared_cloud_networks
+  end
 
   def total_vms
     vms.size

--- a/app/models/ems_refresh/parsers/openstack.rb
+++ b/app/models/ems_refresh/parsers/openstack.rb
@@ -367,6 +367,7 @@ module EmsRefresh::Parsers
       new_result = {
         :name                => network.name,
         :ems_ref             => uid,
+        :shared              => network.shared,
         :status              => status,
         :enabled             => network.admin_state_up,
         :external_facing     => network.router_external,

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -18,6 +18,8 @@ class CloudManager < BaseManager
   has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
   has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
 
+  alias_method :all_cloud_networks, :cloud_networks
+
   include HasManyOrchestrationStackMixin
 
   # Development helper method for Rails console for opening a browser to the EMS.

--- a/app/models/miq_provision_cloud_workflow.rb
+++ b/app/models/miq_provision_cloud_workflow.rb
@@ -12,7 +12,7 @@ class MiqProvisionCloudWorkflow < MiqProvisionVirtWorkflow
   def allowed_cloud_networks(_options = {})
     return {} unless (src_obj = provider_or_tenant_object)
 
-    src_obj.cloud_networks.each_with_object({}) do |cn, hash|
+    src_obj.all_cloud_networks.each_with_object({}) do |cn, hash|
       hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
     end
   end

--- a/db/migrate/20150701191241_add_shared_to_cloud_network.rb
+++ b/db/migrate/20150701191241_add_shared_to_cloud_network.rb
@@ -1,0 +1,5 @@
+class AddSharedToCloudNetwork < ActiveRecord::Migration
+  def change
+    add_column :cloud_networks, :shared, :boolean
+  end
+end

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe CloudTenant do
+  it "#all_cloud_networks" do
+    ems     = FactoryGirl.create(:ems_openstack)
+    tenant1 = FactoryGirl.create(:cloud_tenant,  :ext_management_system => ems)
+    tenant2 = FactoryGirl.create(:cloud_tenant,  :ext_management_system => ems)
+    net1    = FactoryGirl.create(:cloud_network, :ext_management_system => ems, :shared => true)
+    net2    = FactoryGirl.create(:cloud_network, :ext_management_system => ems, :cloud_tenant => tenant1)
+    _net3   = FactoryGirl.create(:cloud_network, :ext_management_system => ems, :cloud_tenant => tenant2)
+
+    expect(tenant1.all_cloud_networks).to match_array([net1, net2])
+  end
+end


### PR DESCRIPTION
When provisioning to an Openstack tenant, the user should see both CloudNetworks directly owned by the tenant and CloudNetworks owned by other tenants that are shared.

https://bugzilla.redhat.com/show_bug.cgi?id=1189157