### PR TITLE
Update server's zone when changing basic information/zone.

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -280,7 +280,13 @@ module OpsController::Settings::Common
       end
       @edit[:new][:authentication][:ldaphost].reject!(&:blank?) if @edit[:new][:authentication][:ldaphost]
       @changed = (@edit[:new] != @edit[:current].config)
-      @update = MiqServer.find(@sb[:selected_server_id]).get_config("vmdb")
+      server = MiqServer.find(@sb[:selected_server_id])
+      zone = Zone.find_by_name(@edit[:new][:server][:zone])
+      unless zone.nil? || server.zone == zone
+        server.zone = zone
+        server.save
+      end
+      @update = server.get_config("vmdb")
     when "settings_workers"                                   # Workers Settings
       @changed = (@edit[:new] != @edit[:current].config)
       qwb = @edit[:new].config[:workers][:worker_base][:queue_worker_base]

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -207,7 +207,7 @@ describe OpsController do
         server = MiqServer.first
 
         zone = FactoryGirl.create(:zone,
-                                  :name => "not the default",
+                                  :name        => "not the default",
                                   :description => "Not the Default Zone")
 
         current = double("current", :[] => {:server => {:zone => "default"}}).as_null_object


### PR DESCRIPTION
Addresses an issue when changing the zone in configure -> configuration
-> zones -> <zone> -> <server>. Before, updating the zone reports that
it was successful, but does not change the zone of the server.

Note: this is a work in progress. The implementation and especially the test feel extremely gross to me, but since the codebase is still fairly new to me I tried to do the most conservative thing that would work. Feedback welcome!

https://bugzilla.redhat.com/show_bug.cgi?id=1237110