### PR TITLE
Fix flaky test: Push the AR stub class into the migration

### DIFF
--- a/vmdb/spec/migrations/20150109142457_namespace_ems_classes_spec.rb
+++ b/vmdb/spec/migrations/20150109142457_namespace_ems_classes_spec.rb
@@ -2,12 +2,10 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20150109142457_namespace_ems_classes")
 
 describe NamespaceEmsClasses do
-  let(:ems_stub) do
-    Class.new(ActiveRecord::Base) do
-      self.table_name = 'ext_management_systems'
-      self.inheritance_column = :_type_disabled # disable STI
-    end
+  class NamespaceEmsClasses::ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
   end
+  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
     it "migrates a representative row" do

--- a/vmdb/spec/migrations/20150630100251_namespace_ems_amazon_spec.rb
+++ b/vmdb/spec/migrations/20150630100251_namespace_ems_amazon_spec.rb
@@ -2,12 +2,10 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20150630100251_namespace_ems_amazon")
 
 describe NamespaceEmsAmazon do
-  let(:ems_stub) do
-    Class.new(ActiveRecord::Base) do
-      self.table_name = 'ext_management_systems'
-      self.inheritance_column = :_type_disabled # disable STI
-    end
+  class NamespaceEmsAmazon::ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
   end
+  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
     it "migrates a representative row" do


### PR DESCRIPTION
Even though the migration itself doesn't need it (and is thus not defining it), we do need the class to end up in there... that's where `clear_caches` will expect to find it.

I couldn't reproduce the failure locally, so this is admittedly a blind attempt at a fix. But it does sound reasonable: without this change, `ar_stubs` is empty, so we're not resetting the column information.

@Fryguy @kbrock 