### PR TITLE
for migration specs: don't shell out to copy data

### DIFF
--- a/db/migrate/20111227190500_copy_vim_performances_data_to_metrics_subtables_on_postgres.rb
+++ b/db/migrate/20111227190500_copy_vim_performances_data_to_metrics_subtables_on_postgres.rb
@@ -31,13 +31,13 @@ class CopyVimPerformancesDataToMetricsSubtablesOnPostgres < ActiveRecord::Migrat
 
   def self.copy_vim_performances_data_to_metrics_subtables
     (0..23).each do |n|
-      copy_data :vim_performances, subtable_name(:metrics, n), :via => :bulk_copy, :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", n]
+      copy_data :vim_performances, subtable_name(:metrics, n), :via => :insert_select_direct, :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", n]
     end
   end
 
   def self.copy_vim_performances_data_to_metric_rollups_subtables
     (1..12).each do |n|
-      copy_data :vim_performances, subtable_name(:metric_rollups, n), :via => :bulk_copy, :conditions => ["capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?", "realtime", n]
+      copy_data :vim_performances, subtable_name(:metric_rollups, n), :via => :insert_select_direct, :conditions => ["capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?", "realtime", n]
     end
   end
 


### PR DESCRIPTION
Currently we shell out 648 times to copy data in our migrations.

This just runs an `insert select` statement.
Performance is marginally quicker too.

My hypothesis is that some of these spawned out processes are failing on travis.