### PR TITLE
Don't log provisioning passwords from options

### DIFF
--- a/app/models/miq_provision_amazon/cloning.rb
+++ b/app/models/miq_provision_amazon/cloning.rb
@@ -51,7 +51,7 @@ module MiqProvisionAmazon::Cloning
     _log.info("Cloud Watch:                     [#{clone_options[:monitoring_enabled].inspect}]")
 
     dumpObj(clone_options, "#{log_header} Clone Options: ", $log, :info)
-    dumpObj(options, "#{log_header} Prov Options:  ", $log, :info)
+    dumpObj(options, "#{log_header} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def start_clone(clone_options)

--- a/app/models/miq_provision_microsoft/cloning.rb
+++ b/app/models/miq_provision_microsoft/cloning.rb
@@ -6,7 +6,7 @@ module MiqProvisionMicrosoft::Cloning
     _log.info("Source Image:                    [#{clone_options[:image_ref]}]")
 
     dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
-    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info)
+    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def clone_complete?

--- a/app/models/miq_provision_openstack/cloning.rb
+++ b/app/models/miq_provision_openstack/cloning.rb
@@ -32,7 +32,7 @@ module MiqProvisionOpenstack::Cloning
     _log.info("Network:                         [#{clone_options[:nics]}]")
 
     dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
-    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info)
+    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def start_clone(clone_options)

--- a/app/models/miq_provision_redhat/cloning.rb
+++ b/app/models/miq_provision_redhat/cloning.rb
@@ -53,7 +53,7 @@ module MiqProvisionRedhat::Cloning
     _log.info("Destination Datastore:      [#{dest_datastore.name} (#{dest_datastore.ems_ref})]") unless dest_datastore.nil?
 
     dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
-    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info)
+    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def start_clone(clone_options)

--- a/app/models/miq_provision_vmware/cloning.rb
+++ b/app/models/miq_provision_vmware/cloning.rb
@@ -78,7 +78,7 @@ module MiqProvisionVmware::Cloning
     dumpObj(clone_options[:transform], "#{_log.prefix} Transform: ",          $log, :info)
     dumpObj(clone_options[:config],    "#{_log.prefix} Config spec: ",        $log, :info)
     dumpObj(cust_dump,                 "#{_log.prefix} Customization spec: ", $log, :info, :protected => {:path => /[Pp]assword\]\[value\]/})
-    dumpObj(options,                   "#{_log.prefix} Prov Options: ",       $log, :info)
+    dumpObj(options,                   "#{_log.prefix} Prov Options: ",       $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def start_clone(clone_options)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -22,6 +22,10 @@ class MiqRequestWorkflow
     []
   end
 
+  def self.encrypted_options_field_regs
+    encrypted_options_fields.map { |f| /\[:#{f}\]/ }
+  end
+
   def self.all_encrypted_options_fields
     descendants.flat_map(&:encrypted_options_fields).uniq
   end

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -77,8 +77,12 @@ module MiqProvisionMixin
     end
   end
 
+  def workflow_class
+    MiqProvisionWorkflow.class_for_source(source)
+  end
+
   def workflow(prov_options = options, flags = {})
-    MiqProvisionWorkflow.class_for_source(source).new(prov_options, userid, flags)
+    workflow_class.new(prov_options, userid, flags)
   end
 
   def eligible_resources(rsc_type)

--- a/spec/models/miq_provision_redhat_spec.rb
+++ b/spec/models/miq_provision_redhat_spec.rb
@@ -98,6 +98,22 @@ describe MiqProvisionRedhat do
         end
       end
 
+      context "#log_clone_options" do
+        let(:ems_cluster) { FactoryGirl.create(:ems_cluster, :ems_ref => "test_ref") }
+        before do
+          @vm_prov.stub(:dest_cluster).and_return(ems_cluster)
+        end
+
+        it "doesnt display passwords for clone options" do
+          # dest_cluster
+          @vm_prov.options[:root_password] = "HIDDEN_PASSWORD"
+          clone_options = @vm_prov.prepare_for_clone_task
+
+          expect($log).not_to receive(:info).with(/HIDDEN_PASSWORD/)
+          @vm_prov.log_clone_options(clone_options)
+        end
+      end
+
       context "with a destination vm" do
         before do
           rhevm_vm = double(:attributes => {:status => {:state => "down"}})


### PR DESCRIPTION
leverage workflow's encryption_option_fields to filter
options sent to dumpObject. With these options sent in, passwords don't end up in the logs.

https://bugzilla.redhat.com/show_bug.cgi?id=1238391

/cc @gmcculloug