### PR TITLE
Custom buttons not visible in second row

### DIFF
--- a/app/assets/javascripts/miq_dhtmlxlayout.js
+++ b/app/assets/javascripts/miq_dhtmlxlayout.js
@@ -14,7 +14,7 @@ function miqResizeTaskbarCell() {
     return;
   }
   $('#taskbar_buttons_div').children('div').each(function () {
-    if (this.offsetTop > 0) {
+    if (this.offsetTop > 1) {
       dhxLayoutB.cells("a").setHeight(64);
       return false;
     } else {

--- a/app/assets/javascripts/miq_dhtmlxtoolbar.js
+++ b/app/assets/javascripts/miq_dhtmlxtoolbar.js
@@ -8,6 +8,7 @@ function miqInitToolbars() {
   $.each(miq_toolbars, function (key) {
     miqInitToolbar(miq_toolbars[key]);
   });
+  miqResizeTaskbarCell();
 }
 
 // Initialize a single toolbar

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -172,7 +172,8 @@ class ExplorerPresenter
     @out << @options[:extra_js].join("\n")
 
     # Position the clear_search link
-    @out << "$('.dhtmlxInfoBarLabel').filter(':visible').append($('#clear_search')[0]);"
+    @out << "$('.dhtmlxInfoBarLabel').filter(':visible').append($('#clear_search')[0]);
+    miqResizeTaskbarCell();"
 
     @out << "$('#clear_search').#{@options[:clear_search_show_or_hide]}();" if @options[:clear_search_show_or_hide]
 

--- a/app/views/layouts/_dhtmlxlayout_explorer.html.haml
+++ b/app/views/layouts/_dhtmlxlayout_explorer.html.haml
@@ -64,7 +64,7 @@
 
     #{layoutb_name} = new dhtmlXLayoutObject(#{layout_name}.cells("b"), "3E");
     #{layoutb_name}._minHeight = 20;
-    #{layoutb_name}.cells("a").setHeight(32);
+    #{layoutb_name}.cells("a").setHeight(64);
     #{layoutb_name}.cells("c").setHeight(32);
     #{layoutb_name}.cells("a").hideHeader();
     #{layoutb_name}.cells("c").hideHeader();

--- a/app/views/layouts/_dhtmlxlayout_explorer.html.haml
+++ b/app/views/layouts/_dhtmlxlayout_explorer.html.haml
@@ -64,7 +64,7 @@
 
     #{layoutb_name} = new dhtmlXLayoutObject(#{layout_name}.cells("b"), "3E");
     #{layoutb_name}._minHeight = 20;
-    #{layoutb_name}.cells("a").setHeight(64);
+    #{layoutb_name}.cells("a").setHeight(32);
     #{layoutb_name}.cells("c").setHeight(32);
     #{layoutb_name}.cells("a").hideHeader();
     #{layoutb_name}.cells("c").hideHeader();


### PR DESCRIPTION
@dclarizio  - please review

When having multiple VM custom button groups that would cause them to be displayed on the next line, they are not visible until the window is resized.
This change modifies the height for the cell in the layout to allow for the initial display.

https://bugzilla.redhat.com/show_bug.cgi?id=1234987

![1234987_after](https://cloud.githubusercontent.com/assets/12769982/8534209/2db3571e-2408-11e5-9096-06e0c2972699.png)
![1234987_before](https://cloud.githubusercontent.com/assets/12769982/8534208/2db0e150-2408-11e5-931d-4171ab4a7fc0.png)
