### PR TITLE
[api] /api/providers scale action is not implemented.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -367,8 +367,6 @@
         :identifier: ems_infra_refresh
       - :name: delete
         :identifier: ems_infra_delete
-      - :name: scale
-        :identifier: ems_infra_scale
     :resource_actions:
       :post:
       - :name: edit


### PR DESCRIPTION
- The /api/providers "scale" action declaration was
merged in by PR# 2028 and should not have been as that was
not an API PR. Removing the definition in the api.yml file.