### PR TITLE
Don't force an RSpec output format

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --order random
---format documentation


### PR DESCRIPTION
If we leave this parameter out, it will respect the user's local `~/.rspec` preference.

Personally, I prefer the default "progress" (lots of dots) output, for a greater overview of how much is passing, plus superior visibility of deprecation warnings.

Presumably some people specifically prefer the current "documentation" output... but by forcing it for everyone, we're fighting RSpec's built-in per-user customizability, and making it very difficult to override.