### PR TITLE
Back off on the guard clause / conditional modifier cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,10 @@ Documentation:
   Enabled: false
 Encoding:
   Enabled: false
+GuardClause:
+  Enabled: false
+IfUnlessModifier:
+  Enabled: false
 SingleLineBlockParams:
   Enabled: false
 SingleSpaceBeforeFirstArg:
@@ -75,4 +79,6 @@ StringLiterals:
 StringLiteralsInInterpolation:
   Enabled: false
 TrailingComma:
+  Enabled: false
+WhileUntilModifier:
   Enabled: false


### PR DESCRIPTION
It's important to know they're available as options, but the resulting readability can be pretty hit or miss.

To pick on a very recent example, we ended up with [this complaint-free version](https://github.com/ManageIQ/manageiq/blob/9d09b5e1dd30bc9beb58bd18a4b087442632bed2/app/controllers/application_controller.rb#L2456):

```ruby
  def log_data_size(el, value, indent)
    # ..
    $log.warn("MIQ(#{controller_name}_controller-#{action_name}): " + line)

    return if value.kind_of?(Hash) || value.kind_of?(Array) || value.kind_of?(ActiveRecord::Base)

    $log.debug { "Value #{value.inspect[0...2000]}" }
  end
```

in preference to @eclarizio's first (IMO, superior) take:

```ruby
  def log_data_size(el, value, indent)
    # ..
    $log.warn("MIQ(#{controller_name}_controller-#{action_name}): " + line)

    unless value.kind_of?(Hash) || value.kind_of?(Array) || value.kind_of?(ActiveRecord::Base)
      $log.debug { "Value #{value.inspect[0...2000]}" }
    end
  end
```

---

Guard clauses can absolutely improve readability, as can using `if`/`unless`/`while`/`until` modifiers instead of their block forms.

But to me, those all have subtle semantic undertones -- in contrast to, say, `kind_of?`-vs-`is_a?`, or hash syntax, where they're merely alternative spellings of the same thing.

Sometimes I do want my loop to contain:

```ruby
next unless foo
bar
baz
```

but it's just as likely it'll read better (depending on the "foo", the "bar", and the "baz") as:

```ruby
if foo
  bar
  baz
end
```

---

Likewise, not infrequently, the best presentation really is:

```ruby
if foo
  bar
end
```

even if it would've all squeezed in under 120 characters as:

```ruby
bar if foo
```