### PR TITLE
Show adv_search box for workloads explorer.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2933,5 +2933,13 @@ module ApplicationHelper
     @my_server ||= MiqServer.my_server(true)
   end
 
+  def vm_explorer_tree?
+    [:filter, :images, :instances, :templates_images_filter, :vandt, :vms_instances_filter].include?(x_tree[:type])
+  end
+
+  def show_advanced_search?
+    x_tree && ((vm_explorer_tree? && !@record) || @show_adv_search)
+  end
+
   attr_reader :big_iframe
 end

--- a/app/views/layouts/_dhtmlxlayout_explorer.html.haml
+++ b/app/views/layouts/_dhtmlxlayout_explorer.html.haml
@@ -98,7 +98,7 @@
     -    ["miq_capacity_bottlenecks"].include?(@layout)
       #{layoutb_name}.cells("a").collapse();
 
-    - if x_tree && (([:filter, :images, :instances, :vandt].include?(x_tree[:type]) && !@record) || @show_adv_search)
+    - if show_advanced_search?
       #{javascript_show_if_exists("adv_searchbox_div")}
 
   - else

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4256,4 +4256,79 @@ describe ApplicationHelper do
       result.should be_true
     end
   end
+
+  context "#vm_explorer_tree?" do
+    it 'should return true for VM explorer trees' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :vms_instances_filter_tree,
+                                       :trees       => {
+                                         :vms_instances_filter_tree => {
+                                           :tree => :vms_instances_filter_tree,
+                                           :type => :vms_instances_filter
+                                         }
+                                       }
+                                      )
+      result = controller.vm_explorer_tree?
+      result.should be_true
+    end
+
+    it 'should return false for non-VM explorer trees' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :reports_tree,
+                                       :trees       => {
+                                         :reports_tree => {
+                                           :tree => :reports_tree,
+                                           :type => :reports
+                                         }
+                                       }
+                                      )
+      result = controller.vm_explorer_tree?
+      result.should be_false
+    end
+  end
+
+  context "#show_advanced_search?" do
+    it 'should return true for VM explorer trees' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :vms_instances_filter_tree,
+                                       :trees       => {
+                                         :vms_instances_filter_tree => {
+                                           :tree => :vms_instances_filter_tree,
+                                           :type => :vms_instances_filter
+                                         }
+                                       }
+                                      )
+      result = controller.show_advanced_search?
+      result.should be_true
+    end
+
+    it 'should return false for non-VM explorer trees' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :reports_tree,
+                                       :trees       => {
+                                         :reports_tree => {
+                                           :tree => :reports_tree,
+                                           :type => :reports
+                                         }
+                                       }
+                                      )
+      result = controller.show_advanced_search?
+      result.should be_false
+    end
+
+    it 'should return true for non-VM explorer trees when @show_adv_search is set' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :reports_tree,
+                                       :trees       => {
+                                         :reports_tree => {
+                                           :tree => :reports_tree,
+                                           :type => :reports
+                                         }
+                                       }
+                                      )
+      controller.instance_variable_set(:@show_adv_search, true)
+      result = controller.show_advanced_search?
+      result.should be_true
+    end
+  end
 end


### PR DESCRIPTION
Moved check into a helper method to load advanced search on an initial load of VM explorers. Without this fix, advanced search was missing on initial load of Workloads explorer.

@dclarizio please review, this fix loads advanced search when going to workloads explorer first time or when goign back to workloads explorer.

before:
![workloads_explorer_before_fix](https://cloud.githubusercontent.com/assets/3450808/8556244/c3912caa-24c3-11e5-9ffa-ddc988e00b70.png)

after:
![workloads_explorer_after_fix](https://cloud.githubusercontent.com/assets/3450808/8556247/c82982ee-24c3-11e5-949e-641bc7337080.png)
