### PR TITLE
SCVMM handles VMs with no disks

### DIFF
--- a/app/models/ems_refresh/parsers/scvmm.rb
+++ b/app/models/ems_refresh/parsers/scvmm.rb
@@ -434,6 +434,8 @@ module EmsRefresh::Parsers
     end
 
     def process_vm_storages(properties)
+      return if properties[:VirtualHardDisks].nil?
+
       properties[:VirtualHardDisks].collect do |vhd|
         @data_index.fetch_path(:storages, vhd[:Props][:HostVolumeId])
       end.compact.uniq


### PR DESCRIPTION
this handles the case where a SCVMM VM is diskless.

This was tested onsite already.
In order to create a spec test a new static  file of inventory would have to be created which will disrupt the existing spec tests.  Issue: https://github.com/ManageIQ/manageiq/issues/2820  is already open for this.

https://bugzilla.redhat.com/show_bug.cgi?id=1234871