### PR TITLE
rails-assets requires bundler >= 1.8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
   postgresql: '9.3'
 before_install:
 - "echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc"
+- gem uninstall -x -i $GEM_HOME@global bundler
+- travis_retry gem install bundler -v ">= 1.8.4"
 - echo "1" > REGION
 - cp config/database.pg.yml config/database.yml
 - psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -2,7 +2,8 @@ raise "Ruby versions less than 2.0 are unsupported!" if RUBY_VERSION < "2.0.0"
 
 source 'https://rubygems.org'
 
-gem "bundler",       "~>1.3"
+# rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
+gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
 gem "iniparse"
 


### PR DESCRIPTION
We started using rails-assets in 27e446dd.

Fixes an issue seen on our CI with bundler 1.7.7 when you need to
bundle/bundle update from an older jquery-rails:

`Could not find gem 'jquery-rails (~> 4.0.4) ruby' in the gems available on this machine.`

cc @skateman @brandondunne @Fryguy (we'll need to upgrade our bundlers to at least 1.8.4 everywhere running master code)