### PR TITLE
SCVMM 2012 SP1 cmdlets requires extra parameters

### DIFF
--- a/app/models/miq_provision_microsoft/cloning.rb
+++ b/app/models/miq_provision_microsoft/cloning.rb
@@ -116,6 +116,9 @@ module MiqProvisionMicrosoft::Cloning
 
   def build_ps_script
     <<-PS_SCRIPT
+      Import-Module VirtualMachineManager | Out-Null; \
+      Get-SCVMMServer localhost | Out-Null;\
+
       $vm = New-SCVirtualMachine \
         -Name #{dest_name} \
         -VMHost #{dest_host} \


### PR DESCRIPTION
For SCVMM 2012 SP1 environments we need to load the VMM Server into the shell before we can run any Powershell cmdlets.

https://bugzilla.redhat.com/show_bug.cgi?id=1234904