### PR TITLE
BZ 1238179 - VM Utilization screen generating charts throws internal server error after Rails 4

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -445,7 +445,7 @@ module Rbac
   def self.method_with_scope(ar_scope, options)
     if ar_scope == VmdbDatabaseConnection
       ar_scope.all
-    elsif ar_scope < ActsAsArModel || ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?
+    elsif ar_scope < ActsAsArModel || (ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?)
       ar_scope.find(:all, options)
     else
       ar_scope.apply_legacy_finder_options(options)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -445,7 +445,7 @@ module Rbac
   def self.method_with_scope(ar_scope, options)
     if ar_scope == VmdbDatabaseConnection
       ar_scope.all
-    elsif ar_scope < ActsAsArModel
+    elsif ar_scope < ActsAsArModel || ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?
       ar_scope.find(:all, options)
     else
       ar_scope.apply_legacy_finder_options(options)

--- a/lib/extensions/ar_merge_conditions.rb
+++ b/lib/extensions/ar_merge_conditions.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       when Symbol, String
         arr << includes.to_sym
       when Array
-      includes.each do |assoc|
+        includes.each do |assoc|
           _included_associations assoc, arr
         end
       when Hash

--- a/lib/extensions/ar_merge_conditions.rb
+++ b/lib/extensions/ar_merge_conditions.rb
@@ -44,7 +44,7 @@ module ActiveRecord
     end
 
     def self.reflection_is_polymorphic?(name)
-      reflection = self._reflect_on_association(name)
+      reflection = _reflect_on_association(name)
       reflection ? reflection.polymorphic? : false
     end
 
@@ -56,17 +56,17 @@ module ActiveRecord
 
     def self._included_associations(includes, arr)
       case includes
-        when Symbol, String
-          arr << includes.to_sym
-        when Array
-          includes.each do |assoc|
-            _included_associations assoc, arr
-          end
-        when Hash
-          includes.each do |k,v|
-            cache = arr << k
-            _included_associations v, cache
-          end
+      when Symbol, String
+        arr << includes.to_sym
+      when Array
+      includes.each do |assoc|
+          _included_associations assoc, arr
+        end
+      when Hash
+        includes.each do |k, v|
+          cache = arr << k
+          _included_associations v, cache
+        end
       end
     end
   end

--- a/spec/lib/extensions/ar_merge_conditions_spec.rb
+++ b/spec/lib/extensions/ar_merge_conditions_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe ActiveRecord::Base do
+  context "calling apply_legacy_finder_options" do
+    before(:each) do
+      @vm = FactoryGirl.create(:vm_vmware)
+      @perf = FactoryGirl.create(
+        :metric_rollup_vm_daily,
+        :resource_id  => @vm.id,
+        :timestamp    => "2010-04-14T00:00:00Z",
+        :time_profile => @time_profile
+      )
+
+      # Typical includes for rendering daily metrics charts
+      @include = {
+        :max_derived_cpu_available => {},
+        :max_derived_cpu_reserved => {},
+        :min_cpu_usagemhz_rate_average => {},
+        :max_cpu_usagemhz_rate_average => {},
+        :min_cpu_usage_rate_average => {},
+        :max_cpu_usage_rate_average => {},
+        :v_pct_cpu_ready_delta_summation => {},
+        :v_pct_cpu_wait_delta_summation => {},
+        :v_pct_cpu_used_delta_summation => {},
+        :max_derived_memory_available => {},
+        :max_derived_memory_reserved => {},
+        :min_derived_memory_used => {},
+        :max_derived_memory_used => {},
+        :min_disk_usage_rate_average => {},
+        :max_disk_usage_rate_average => {},
+        :min_net_usage_rate_average => {},
+        :max_net_usage_rate_average => {},
+        :v_derived_storage_used => {},
+        :resource => {}
+
+      }
+    end
+    it "should not raise an error when a polymorphic reflection is included" do
+      result = nil
+      expect do
+        result = MetricRollup.apply_legacy_finder_options(:include => @include).to_a
+      end.not_to raise_error
+
+      result.length.should == 1
+    end
+  end
+end
+

--- a/spec/lib/extensions/ar_merge_conditions_spec.rb
+++ b/spec/lib/extensions/ar_merge_conditions_spec.rb
@@ -13,25 +13,25 @@ describe ActiveRecord::Base do
 
       # Typical includes for rendering daily metrics charts
       @include = {
-        :max_derived_cpu_available => {},
-        :max_derived_cpu_reserved => {},
-        :min_cpu_usagemhz_rate_average => {},
-        :max_cpu_usagemhz_rate_average => {},
-        :min_cpu_usage_rate_average => {},
-        :max_cpu_usage_rate_average => {},
+        :max_derived_cpu_available       => {},
+        :max_derived_cpu_reserved        => {},
+        :min_cpu_usagemhz_rate_average   => {},
+        :max_cpu_usagemhz_rate_average   => {},
+        :min_cpu_usage_rate_average      => {},
+        :max_cpu_usage_rate_average      => {},
         :v_pct_cpu_ready_delta_summation => {},
-        :v_pct_cpu_wait_delta_summation => {},
-        :v_pct_cpu_used_delta_summation => {},
-        :max_derived_memory_available => {},
-        :max_derived_memory_reserved => {},
-        :min_derived_memory_used => {},
-        :max_derived_memory_used => {},
-        :min_disk_usage_rate_average => {},
-        :max_disk_usage_rate_average => {},
-        :min_net_usage_rate_average => {},
-        :max_net_usage_rate_average => {},
-        :v_derived_storage_used => {},
-        :resource => {}
+        :v_pct_cpu_wait_delta_summation  => {},
+        :v_pct_cpu_used_delta_summation  => {},
+        :max_derived_memory_available    => {},
+        :max_derived_memory_reserved     => {},
+        :min_derived_memory_used         => {},
+        :max_derived_memory_used         => {},
+        :min_disk_usage_rate_average     => {},
+        :max_disk_usage_rate_average     => {},
+        :min_net_usage_rate_average      => {},
+        :max_net_usage_rate_average      => {},
+        :v_derived_storage_used          => {},
+        :resource                        => {}
 
       }
     end
@@ -45,4 +45,3 @@ describe ActiveRecord::Base do
     end
   end
 end
-

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -5,16 +5,18 @@ describe MetricRollup do
     it "should not raise an error when a polymorphic reflection is included and references are specified in a query" do
       pending "until ActiveRecord is fixed"
       # TODO: A fix in ActiveRecord will make this test pass
-      expect {
-        MetricRollup.where(:id=>1000000544893).includes(:resource=>{}, :time_profile=>{}).references(:time_profile=>{}).last
-      }.not_to raise_error
+      expect do
+        MetricRollup.where(:id => 1000000544893)
+            .includes(:resource => {}, :time_profile => {})
+            .references(:time_profile => {}).last
+      end.not_to raise_error
 
-      # TODO: Also, there is a bug that exists in only the manageiq repo and not rails that causes the error "ActiveRecord::ConfigurationError: nil"
+      # TODO: Also, there is a bug that exists in only the manageiq repo and not rails
+      # TODO: that causes the error "ActiveRecord::ConfigurationError: nil"
       # TODO: instead of the expected "ActiveRecord::EagerLoadPolymorphicError" error.
-      expect {
+      expect do
         Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table => {}).to_a
-      }.to raise_error ActiveRecord::EagerLoadPolymorphicError
+      end.to raise_error ActiveRecord::EagerLoadPolymorphicError
     end
   end
 end
-

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -3,10 +3,11 @@ require "spec_helper"
 describe MetricRollup do
   context "test" do
     it "should not raise an error when a polymorphic reflection is included and references are specified in a query" do
+      pending "until ActiveRecord is fixed"
       # TODO: A fix in ActiveRecord will make this test pass
-      # expect {
-      #   MetricRollup.where(:id=>1000000544893).includes(:resource=>{}, :time_profile=>{}).references(:time_profile=>{}).last
-      # }.not_to raise_error
+      expect {
+        MetricRollup.where(:id=>1000000544893).includes(:resource=>{}, :time_profile=>{}).references(:time_profile=>{}).last
+      }.not_to raise_error
 
       # TODO: Also, there is a bug that exists in only the manageiq repo and not rails that causes the error "ActiveRecord::ConfigurationError: nil"
       # TODO: instead of the expected "ActiveRecord::EagerLoadPolymorphicError" error.

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe MetricRollup do
+  context "test" do
+    it "should not raise an error when a polymorphic reflection is included and references are specified in a query" do
+      # TODO: A fix in ActiveRecord will make this test pass
+      # expect {
+      #   MetricRollup.where(:id=>1000000544893).includes(:resource=>{}, :time_profile=>{}).references(:time_profile=>{}).last
+      # }.not_to raise_error
+
+      # TODO: Also, there is a bug that exists in only the manageiq repo and not rails that causes the error "ActiveRecord::ConfigurationError: nil"
+      # TODO: instead of the expected "ActiveRecord::EagerLoadPolymorphicError" error.
+      expect {
+        Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table => {}).to_a
+      }.to raise_error ActiveRecord::EagerLoadPolymorphicError
+    end
+  end
+end
+

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -6,9 +6,9 @@ describe MetricRollup do
       pending "until ActiveRecord is fixed"
       # TODO: A fix in ActiveRecord will make this test pass
       expect do
-        MetricRollup.where(:id => 1000000544893)
-            .includes(:resource => {}, :time_profile => {})
-            .references(:time_profile => {}).last
+        MetricRollup.where(:id => 1)
+          .includes(:resource => {}, :time_profile => {})
+          .references(:time_profile => {}).last
       end.not_to raise_error
 
       # TODO: Also, there is a bug that exists in only the manageiq repo and not rails


### PR DESCRIPTION
Treat classes that have "derived" instances (instances_are_derived? => true) the same as classes that derive from ActsAsArModel and call custom find method in brace search. Also added a test that exposes an ActiveRecord bug where a query like "Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table => {}).to_a" raises an error. The AR error is preventing this bug from being fixed. See (https://github.com/rails/rails/compare/master...gtanzillo:includes_references_with_polymorphic?w=1)

https://bugzilla.redhat.com/show_bug.cgi?id=1238179