### PR TITLE
Switch Application Server from Thin to Puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "default_value_for",              "~>3.0.1"
-gem "thin",                           "~>1.3.1"  # Used by rails server through rack
+gem "puma"
 gem 'bcrypt-ruby', '3.1.2'
 gem 'outfielding-jqplot-rails',       "= 1.0.8"
 gem "responders",                     "~> 2.0"

--- a/config/database.pg.yml
+++ b/config/database.pg.yml
@@ -15,7 +15,7 @@ base: &base
   adapter: postgresql
   encoding: utf8
   username: root
-  pool: 1
+  pool: 5
   wait_timeout: 5
   min_messages: warning
 

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -65,7 +65,8 @@ module Vmdb
                                   :path           => locale_path,
                                   :type           => :po,
                                   :report_warning => false)
-      FastGettext.available_locales = find_available_locales
+
+      FastGettext.default_available_locales = find_available_locales
 
       # temporary hack to fix a problem with locales including "_"
       fix_i18n_available_locales

--- a/lib/workers/mixins/web_server_worker_mixin.rb
+++ b/lib/workers/mixins/web_server_worker_mixin.rb
@@ -11,7 +11,7 @@ module WebServerWorkerMixin
   def do_before_work_loop
     @worker.release_db_connection
 
-    # Since thin traps interrupts, log that we're going away and update our worker row
+    # Since puma traps interrupts, log that we're going away and update our worker row
     at_exit { do_exit("Exit request received.") }
   end
 end

--- a/spec/lib/vmdb/fast_gettext_helper_spec.rb
+++ b/spec/lib/vmdb/fast_gettext_helper_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+
+describe Vmdb::FastGettextHelper do
+  describe ".register_locales" do
+    it "registers locales across all threads" do
+      Thread.new { I18n.locale = 'en-US'; expect(I18n.locale).to eq(:en) }.join
+    end
+  end
+end


### PR DESCRIPTION
 Switch webserver from thin to puma.

Removes thin from the gemfile and replaces with puma. In particular,
this change replaces all references to thin with puma, or removes them
altogether. The pid path was made more generic i.e. "rails_server".

https://trello.com/c/g1xFgj5F