### PR TITLE
Tenant models for EMSs, providers and VMs

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -25,6 +25,8 @@ class ExtManagementSystem < ActiveRecord::Base
 
   belongs_to :provider
   belongs_to :tenant_owner, :class_name => 'Tenant'
+  has_many :tenant_resources, :as => :resource
+  has_many :tenants, :through => :tenant_resources
 
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate"

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -24,6 +24,7 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   belongs_to :provider
+  belongs_to :tenant_owner, :class_name => 'Tenant'
 
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate"
@@ -47,8 +48,11 @@ class ExtManagementSystem < ActiveRecord::Base
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource  # Destroy will be handled by purger
 
-  validates :name,     :presence => true, :uniqueness => true
-  validates :hostname, :presence => true, :uniqueness => {:case_sensitive => false}, :if => :hostname_required?
+  validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_owner_id]}
+  validates :hostname,
+            :presence   => true,
+            :uniqueness => {:scope => [:tenant_owner_id], :case_sensitive => false},
+            :if         => :hostname_required?
 
   # TODO: Remove all callers of address
   alias_attribute :address, :hostname

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -1,6 +1,7 @@
 class MiqGroup < ActiveRecord::Base
   default_scope { where(self.conditions_for_my_region_default_scope) }
 
+  belongs_to :tenant_owner, :class_name => "Tenant"
   belongs_to :miq_user_role
   belongs_to :role, :class_name => "UiTaskSet", :foreign_key => :ui_task_set_id
   belongs_to :resource, :polymorphic => true

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,7 @@ class Provider < ActiveRecord::Base
   include AsyncDeleteMixin
   include EmsRefresh::Manager
 
+  belongs_to :tenant_owner, :class_name => 'Tenant'
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,6 +8,8 @@ class Provider < ActiveRecord::Base
   belongs_to :tenant_owner, :class_name => 'Tenant'
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
+  has_many :tenant_resources, :as => :resource
+  has_many :tenants, :through => :tenant_resources
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -5,6 +5,10 @@ class Tenant < ActiveRecord::Base
 
   default_value_for :company_name, "My Company"
 
+  has_many :owned_providers,              :foreign_key => :tenant_owner_id, :class_name => 'Provider'
+  has_many :owned_ext_management_systems, :foreign_key => :tenant_owner_id, :class_name => 'ExtManagementSystem'
+  has_many :owned_vm_or_templates,        :foreign_key => :tenant_owner_id, :class_name => 'VmOrTemplate'
+
   # FUTURE: /uploads/tenant/:id/logos/:basename.:extension # may want style
   has_attached_file :logo,
                     :url  => "/uploads/#{HARDCODED_LOGO}",

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -9,6 +9,20 @@ class Tenant < ActiveRecord::Base
   has_many :owned_ext_management_systems, :foreign_key => :tenant_owner_id, :class_name => 'ExtManagementSystem'
   has_many :owned_vm_or_templates,        :foreign_key => :tenant_owner_id, :class_name => 'VmOrTemplate'
 
+  has_many :tenant_resources
+  has_many :vm_or_templates,
+           :through     => :tenant_resources,
+           :source      => :resource,
+           :source_type => "VmOrTemplate"
+  has_many :ext_management_systems,
+           :through     => :tenant_resources,
+           :source      => :resource,
+           :source_type => "ExtManagementSystem"
+  has_many :providers,
+           :through     => :tenant_resources,
+           :source      => :resource,
+           :source_type => "Provider"
+
   # FUTURE: /uploads/tenant/:id/logos/:basename.:extension # may want style
   has_attached_file :logo,
                     :url  => "/uploads/#{HARDCODED_LOGO}",

--- a/app/models/tenant_resource.rb
+++ b/app/models/tenant_resource.rb
@@ -1,0 +1,4 @@
+class TenantResource < ActiveRecord::Base
+  belongs_to :tenant
+  belongs_to :resource, :polymorphic => true
+end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -44,7 +44,6 @@ class VmOrTemplate < ActiveRecord::Base
   POWER_OPS = %w{start stop suspend reset shutdown_guest standby_guest reboot_guest}
 
   validates_presence_of     :name, :location
-  #validates_uniqueness_of   :name
   validates_inclusion_of    :vendor, :in => VENDOR_TYPES.values
 
   has_one                   :miq_server, :foreign_key => :vm_id
@@ -112,7 +111,7 @@ class VmOrTemplate < ActiveRecord::Base
   has_many                  :service_resources, :as => :resource
 #  has_many                  :service_templates, :through => :service_resources, :source => :service_template
   has_many                  :direct_services, :through => :service_resources, :source => :service
-
+  belongs_to                :tenant_owner, :class_name => 'Tenant'
 
   acts_as_miq_taggable
   include ReportableMixin

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -112,6 +112,8 @@ class VmOrTemplate < ActiveRecord::Base
 #  has_many                  :service_templates, :through => :service_resources, :source => :service_template
   has_many                  :direct_services, :through => :service_resources, :source => :service
   belongs_to                :tenant_owner, :class_name => 'Tenant'
+  has_many                  :tenant_resources, :as => :resource
+  has_many                  :tenants, :through => :tenant_resources
 
   acts_as_miq_taggable
   include ReportableMixin

--- a/db/migrate/20150701142710_associate_tenant_vm.rb
+++ b/db/migrate/20150701142710_associate_tenant_vm.rb
@@ -1,0 +1,8 @@
+class AssociateTenantVm < ActiveRecord::Migration
+  def change
+    add_column :providers, :tenant_owner_id, :bigint
+    add_column :vms, :tenant_owner_id, :bigint
+    add_column :ext_management_systems, :tenant_owner_id, :bigint
+    add_column :miq_groups, :tenant_owner_id, :bigint
+  end
+end

--- a/db/migrate/20150708120923_create_tenant_resources.rb
+++ b/db/migrate/20150708120923_create_tenant_resources.rb
@@ -1,0 +1,8 @@
+class CreateTenantResources < ActiveRecord::Migration
+  def change
+    create_table :tenant_resources do |t|
+      t.belongs_to :tenant, :type => :bigint
+      t.belongs_to :resource, :type => :bigint, :polymorphic => true
+    end
+  end
+end

--- a/spec/factories/tenant.rb
+++ b/spec/factories/tenant.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :tenant do
+    sequence(:subdomain) { |n| "tenant#{n}" }
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -193,4 +193,13 @@ describe ExtManagementSystem do
       expect(tenant.owned_ext_management_systems).to include(ems)
     end
   end
+
+  context "#tenants" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant owner" do
+      ems = FactoryGirl.create(:ext_management_system)
+      ems.tenants << tenant
+      expect(tenant.ext_management_systems).to include(ems)
+    end
+  end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -166,7 +166,31 @@ describe ExtManagementSystem do
           end
         end
       end
+
+      it "allows duplicate name across tenants" do
+        tenant = FactoryGirl.create(:tenant)
+        expect do
+          FactoryGirl.create(:ems_vmware,
+                             :name         => @ems.name,
+                             :hostname     => @different_host_name,
+                             :tenant_owner => tenant)
+        end.not_to raise_error
+      end
+
+      it "allows duplicate hostname across tenants" do
+        tenant = FactoryGirl.create(:tenant)
+        expect do
+          FactoryGirl.create(:ems_vmware, :hostname => @same_host_name, :tenant_owner => tenant)
+        end.not_to raise_error
+      end
     end
   end
 
+  context "#tenant_owner" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant owner" do
+      ems = FactoryGirl.create(:ext_management_system, :tenant_owner => tenant)
+      expect(tenant.owned_ext_management_systems).to include(ems)
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -55,4 +55,13 @@ describe Provider do
       expect(tenant.owned_providers).to include(provider)
     end
   end
+
+  context "#tenants" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant owner" do
+      provider = FactoryGirl.create(:provider)
+      provider.tenants << tenant
+      expect(tenant.providers).to include(provider)
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -47,4 +47,12 @@ describe Provider do
       end
     end
   end
+
+  context "#tenant_owner" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant owner" do
+      provider = FactoryGirl.create(:provider, :tenant_owner => tenant)
+      expect(tenant.owned_providers).to include(provider)
+    end
+  end
 end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -12,7 +12,7 @@ describe Tenant do
   end
 
   context "#logo" do
-    let(:tenant) { described_class.create(:logo_file_name => "image.png") }
+    let(:tenant) { FactoryGirl.create(:tenant, :logo_file_name => "image.png") }
 
     # NOTE: this currently returns a bogus url.
     # it { expect(described_class.create.logo.url).to be_nil }
@@ -40,7 +40,7 @@ describe Tenant do
   context "#login_logo" do
     # NOTE: initializers/paperclip.rb sets up :default_login_logo
 
-    let(:tenant) { described_class.create }
+    let(:tenant) { FactoryGirl.create(:tenant) }
 
     it "has a default login image" do
       expect(tenant.login_logo.url).to match(/login-screen-logo.png/)

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -433,4 +433,13 @@ describe VmOrTemplate do
       expect(tenant.owned_vm_or_templates).to include(vm)
     end
   end
+
+  context "#tenants" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant owner" do
+      vm = FactoryGirl.create(:vm_vmware)
+      vm.tenants << tenant
+      expect(tenant.vm_or_templates).to include(vm)
+    end
+  end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -425,4 +425,12 @@ describe VmOrTemplate do
       end
     end
   end
+
+  context "#tenant_owner" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant owner" do
+      vm = FactoryGirl.create(:vm_vmware, :tenant_owner => tenant)
+      expect(tenant.owned_vm_or_templates).to include(vm)
+    end
+  end
 end


### PR DESCRIPTION
Associate a tenant with a vm.

A vm has a tenant owner, so we know how to set quotas and chargebacks.
The ems name can be the same across multiple tenant owners.

Also, a vm is visible to many tenants, a `tenant_resource` table is added for these purposes.
In the future we may swap with `tagging` model, which has the same structure.

/cc @gmcculloug @chessbyte 