### PR TITLE
Don't display toolbar buttons when user has no privilege

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -841,6 +841,8 @@ class ApplicationHelper::ToolbarBuilder
         return true if !@report
       when "timeline_txt"
         return true if !@report
+      else
+        return !role_allows(:feature => id)
       end
     end
     return false  # No reason to hide, allow the button to show


### PR DESCRIPTION
User is able to see/click on the toolbar buttons in the list view
of Catalog Items [under Services], although he has no privilege
for those actions.

After the fix, user doesn't see those actions.