### PR TITLE
Fix flaky spec: Give the blocked connection some time to notice

### DIFF
--- a/spec/models/vmdb_database_connection_spec.rb
+++ b/spec/models/vmdb_database_connection_spec.rb
@@ -67,8 +67,12 @@ describe VmdbDatabaseConnection do
 
     connections = VmdbDatabaseConnection.all
 
-    blocked_conn = connections.detect(&:blocked_by)
-    expect(blocked_conn).to be
+    give_up = 10.seconds.from_now
+    until (blocked_conn = connections.detect(&:blocked_by))
+      raise "Lock is not blocking" if Time.current > give_up
+      sleep 1
+    end
+
     blocked_by = connections.detect { |conn| conn.spid == blocked_conn.blocked_by }
     expect(blocked_by).to be
     expect(blocked_conn.spid).not_to eq(blocked_by.spid)


### PR DESCRIPTION
Our thread can go to sleep before the block actually manifests, leading to a possible spec failure.

If it's not where we expect it to be, we can just keep trying. 10 seconds is an entirely arbitrary choice of value for "practically forever".

cc @tenderlove 