### PR TITLE
Make PidFile#pid return nil for non-numeric pid file contents

### DIFF
--- a/lib/pid_file.rb
+++ b/lib/pid_file.rb
@@ -16,7 +16,7 @@ class PidFile
   def pid
     return nil unless File.file?(@fname)
     data = IO.read(@fname).strip
-    return nil if data.empty?
+    return nil if data.empty? || !/\d+/.match(data)
     data.to_i
   end
 

--- a/spec/lib/pid_file_spec.rb
+++ b/spec/lib/pid_file_spec.rb
@@ -23,6 +23,11 @@ describe PidFile do
         @pid_file.pid.should be_nil
       end
 
+      it "returns nil when file contents are non numeric" do
+        IO.stub(:read).with(@fname).and_return("text")
+        @pid_file.pid.should be_nil
+      end
+
       it "returns pid when file contents have pid" do
         pid = 42
         IO.stub(:read).with(@fname).and_return("#{pid} ")


### PR DESCRIPTION
If we return a non-numeric pid from PidFile#pid MiqProcess.command_line will cause ps(1)
to output a usage message.
This usage message was seen during the upgrade process if the server was started
through the command line.

https://bugzilla.redhat.com/show_bug.cgi?id=1238423