### PR TITLE
checkchange.js - use lodash for deep copy and deep compare, check that modelCopy exists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 gem "rails",                           RAILS_VERSION
 gem "activerecord-deprecated_finders", "~>1.0.4",     :require => "active_record/deprecated_finders"
 
+# Client-side dependencies
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
 gem 'angularjs-rails', '~>1.3.15'
 gem 'angular-ui-bootstrap-rails', '~> 0.13.0'
@@ -14,6 +15,7 @@ gem 'momentjs-rails', '~> 2.10.3'
 gem 'jquery-rails', "~>4.0.4"
 gem 'jquery-hotkeys-rails'
 gem 'codemirror-rails', "=4.2"
+gem 'lodash-rails', '~> 3.10.0'
 
 # On MS Windows run "bundle config --local build.libv8 --with-system-v8" first
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -64,3 +64,4 @@
 //= require codemirror/modes/yaml
 //= require spin
 //= require jquery-hotkeys
+//= require lodash

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -11,6 +11,7 @@ miqAngularApplication.controller('providerForemanFormController', ['$http', '$sc
       $scope.formId = providerForemanFormId;
       $scope.afterGet = false;
       $scope.modelCopy = angular.copy( $scope.providerForemanModel );
+      $scope.model = 'providerForemanModel';
 
       miqAngularApplication.$scope = $scope;
 

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -68,18 +68,18 @@ var viewModelDateComparison = function(scope, ctrl) {
 };
 
 var checkForOverallFormPristinity = function(scope, ctrl) {
-  var modelCopyObject = JSON.parse(JSON.stringify(scope.modelCopy));
+  // don't do anything before the model and modelCopy are actually initialized
+  if (! ('modelCopy' in scope) || ! scope.modelCopy || ! scope.model || ! (scope.model in scope))
+    return;
+
+  var modelCopyObject = _.cloneDeep(scope.modelCopy);
   delete modelCopyObject[ctrl.$name];
 
-  var modelObject = JSON.parse(JSON.stringify(scope[scope.model]))
+  var modelObject = _.cloneDeep(scope[scope.model]);
   delete modelObject[ctrl.$name];
 
-  if(JSON.stringify(modelCopyObject) != JSON.stringify(modelObject)) {
-    scope.angularForm.$pristine = false;
-  }
-  else {
-    scope.angularForm.$pristine = true;
-  }
-  if(scope.angularForm.$pristine)
+  scope.angularForm.$pristine = _.isEqual(modelCopyObject, modelObject);
+
+  if (scope.angularForm.$pristine)
     scope.angularForm.$setPristine(true);
 };


### PR DESCRIPTION
This fixes a bug introduced in #3347, for more details see there.

This introduces [lodash](https://lodash.com/docs) and uses it for deep object copy and compare.

This also makes `providerForemanFormController` define `scope.model` pointing to the real model object, meaning checkchange should actually work again.