### PR TITLE
Add .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+languages:
+  Ruby: true
+  JavaScript: true
+exclude_paths:
+- "app/assets/javascripts/bootstrap-hover-dropdown/*"
+- "app/assets/javascripts/bootstrap-ui-components/*"
+- "app/assets/javascripts/dhtmlx*/*"
+- "app/assets/javascripts/dynatree*/*"
+- "app/assets/javascripts/SlickGrid*/*"
+- "gems/pendings/spec/*"
+- "gems/pending/test/*"
+- "gems/pending/*/test/*"
+- "public/javascripts/timeline/*"
+- "spec/*"
+- "test/*"


### PR DESCRIPTION
@jrafanie @chessbyte Please review.

Not having this contributed to the fact that our score dropped a significant amount. 

- When we re-rooted, the exclusions we had in place no longer applied
- Code Climate no longer supports exclusions directly on their site and now expect this file in the repo.

@skateman @martinpovolny @h-kataria @dclarizio Just wanted to ping you guys on this because of the third party library exclusions.  As you rip them out into gems, you can remove them from here.  If you add new vendored javascript you will want to add them to here.