### PR TITLE
use latest fog

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -21,7 +21,7 @@ gem "ezcrypto",                "=0.7",              :require => false
 gem "facade",                  "~>1.0.5",           :require => false  # Used by util/pathname2.rb
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.1",           :require => false  # used by lib/VixDiskLib
-gem "fog",                     "~>1.29.0",          :require => false
+gem "fog",                     "~>1.32.0",          :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "linux_admin",             ">=0.10.1", "<1",    :require => false

--- a/gems/pending/openstack/openstack_handle/identity_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/identity_delegate.rb
@@ -25,7 +25,7 @@ module OpenstackHandle
         )
       end
       body = Fog::JSON.decode(response.body)
-      vtenants = Fog::Identity::OpenStack::Tenants.new
+      vtenants = Fog::Compute::OpenStack::Tenants.new
       vtenants.load(body['tenants'])
       vtenants
     end


### PR DESCRIPTION
Upgrade fog gem.

Hoping it will remove deprecation warnings.

```
[fog][DEPRECATION] Calling OpenStack[:compute].list_security_groups(server_id) is deprecated, use .list_security_groups(:server_id => value) instead
[fog][DEPRECATION] Calling OpenStack[:compute].list_security_groups(server_id) is deprecated, use .list_security_groups(:server_id => value) instead
```

It looks like updating fog does fix that deprecation warning. But it does look like some identity work moved over to the compute package.

/cc @blomquisg 