### PR TITLE
Don't display asset names in test

### DIFF
--- a/lib/vmdb/productization.rb
+++ b/lib/vmdb/productization.rb
@@ -26,19 +26,17 @@ module Vmdb
     def prepare_asset_precompilation
       Rails.application.config.assets.precompile = [
         Proc.new do |path|
-          include =
+          file =
             !File.extname(path).in?(['.js', '.css', '']) ||
             path =~ /(?:\/|\\|\A)(application|productization)\.(css|js)$/
 
-          resolved = Rails.application.assets.resolve(path)
-          resolved = resolved.relative_path_from(Rails.root) if resolved.to_s.start_with?(Rails.root.to_s)
-          if include
-            puts "+ #{resolved}"
-          elsif
-            puts "- #{resolved}"
+          if ENV["DEBUG_PRECOMPILE"]
+            resolved = Rails.application.assets.resolve(path)
+            resolved = resolved.relative_path_from(Rails.root) if resolved.to_s.start_with?(Rails.root.to_s)
+            puts " #{file ? "+" : "-"} #{resolved}"
           end
 
-          include
+          file
         end
       ]
     end

--- a/lib/vmdb/productization/directive_processor.rb
+++ b/lib/vmdb/productization/directive_processor.rb
@@ -44,12 +44,10 @@ module Vmdb
 
       private
 
-      def log_resolved_asset(path, include = true)
-        resolved = resolved_asset(path)
-        if include
-          puts "  + #{resolved}"
-        elsif ENV["DEBUG_PRECOMPILE"]
-          puts "  - #{resolved}"
+      def log_resolved_asset(path, included = true)
+        if ENV["DEBUG_PRECOMPILE"]
+          resolved = resolved_asset(path)
+          puts "  #{included ? "+" : "-"} #{resolved}"
         end
       end
 


### PR DESCRIPTION
No need to display all of the assets while running tests.

```
+ app/assets/stylesheets/main.scss
  + app/assets/stylesheets/slick.grid.css
  + vendor/bundle/ruby/2.2.0/gems/outfielding-jqplot-rails-1.0.8/vendor/assets/javascripts/jquery.jqplot.js
  + app/assets/javascripts/automate_import_export.js
  + app/assets/javascripts/dialog_import_export.js
  + app/assets/stylesheets/dialog_fields.css
  + app/assets/javascripts/widget_import_export.js
  + app/assets/stylesheets/angular.css
  + app/assets/stylesheets/miq_timeline.css
...
```