### PR TITLE
Add gettext to Retirement Entry Catalog Title

### DIFF
--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -104,7 +104,7 @@
                       :remote => true,
                       :title => _("Remove this Reconfigure Entry Point"))
         %tr
-          %td.key{:title => "Retirement Entry Point (NameSpace/Class/Instance)"}
+          %td.key{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
             =_('Retirement Entry Point')
             %br
             =_('State Machine (NS/Cls/Inst)')


### PR DESCRIPTION
@dclarizio  - as discussed - the gettext was missing form one Catalog Item Title

I18N issue -adding  missing gettext to Retirement Entry Catalog Title