### PR TITLE
Fix Openstack amqp event monitor sort

### DIFF
--- a/gems/pending/openstack/amqp/openstack_null_event_monitor.rb
+++ b/gems/pending/openstack/amqp/openstack_null_event_monitor.rb
@@ -5,6 +5,11 @@ class OpenstackNullEventMonitor < OpenstackEventMonitor
     false
   end
 
+  def self.plugin_priority
+    # make the null event monitor the lowest priority
+    DEFAULT_PLUGIN_PRIORITY - 1
+  end
+
   def initialize(options = {})
     @options = options
   end

--- a/gems/pending/openstack/amqp/openstack_qpid_event_monitor.rb
+++ b/gems/pending/openstack/amqp/openstack_qpid_event_monitor.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 
 require_relative '../openstack_event_monitor'

--- a/gems/pending/openstack/openstack_event_monitor.rb
+++ b/gems/pending/openstack/openstack_event_monitor.rb
@@ -27,7 +27,7 @@ class OpenstackEventMonitor
   # ordering of plugins.
   def self.subclasses
     # sort plugins on plugin_priorty
-    super.sort_by(&:plugin_priority)
+    super.sort_by(&:plugin_priority).reverse
   end
 
   # TODO: when ceilometer event integration is in place, this will likely have

--- a/gems/pending/spec/openstack/openstack_event_monitor_spec.rb
+++ b/gems/pending/spec/openstack/openstack_event_monitor_spec.rb
@@ -66,4 +66,11 @@ describe OpenstackEventMonitor do
     instance = OpenstackEventMonitor.new(rabbit_options)
     instance.should eq rabbit_instance
   end
+
+  it "orders the event monitor plugins correctly" do
+    plugins = OpenstackEventMonitor.subclasses
+
+    plugins.first.should eq OpenstackRabbitEventMonitor
+    plugins.last.should eq OpenstackNullEventMonitor
+  end
 end


### PR DESCRIPTION
When trying out different event monitors for rabbit and qpid clients, the `plugin_priority` is supposed to govern which event monitor plugins are tried first.

According to the `plugin_priority` method, subclasses can override the `plugin_priority` method to make their plugin take a higher priority by returning a number greater than 0.

However, the `subclasses` method (which returns the ordered list of plugins) was returning the plugins in ascending order.