### PR TITLE
After changes to replace the @temp vars, adding a new custom button fails

### DIFF
--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -62,7 +62,7 @@
       :ae_custom_button          => true,
       :field_changed_url         => "automate_button_field_changed"})
   = render(:partial => "layouts/role_visibility",
-           :locals  => {:rec_id => @custom_button.id, :action => "automate_button_field_changed"})
+           :locals  => {:rec_id => @custom_button ? @custom_button.id : 'new', :action => "automate_button_field_changed"})
 :javascript
   miqInitSelectPicker();
   miqSelectPickerEvent("button_image", "#{url}")

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -2,6 +2,9 @@ require "spec_helper"
 include UiConstants
 
 describe MiqAeCustomizationController do
+  before(:each) do
+    set_user_privileges
+  end
   context "::CustomButtons" do
     context "#ab_get_node_info" do
       it "correct target class gets set when assigned button node is clicked" do
@@ -12,6 +15,34 @@ describe MiqAeCustomizationController do
         controller.send(:ab_get_node_info, "xx-ab_Host_cbg-10r95_cb-#{custom_button.id}")
         assigns(:resolve)[:new][:target_class].should == "Host"
       end
+    end
+  end
+  render_views
+  describe "#ab_form" do
+    it "displays the layout" do
+      FactoryGirl.create(:vmdb_database)
+      MiqAeClass.stub(:find_distinct_instances_across_domains => [double(:name => "foo")])
+      @sb = {:active_tree => :ab_tree,
+             :trees       => {:ab_tree => {:tree => :ab_tree}},
+             :params      => {:instance_name => 'CustomButton_1'}
+      }
+      controller.instance_variable_set(:@sb, @sb)
+      controller.instance_variable_set(:@breadcrumbs, [])
+
+      edit = {
+               :new => {:button_images => %w(01 02 03), :available_dialogs => {:id => '01', :name => '02'},
+                         :instance_name => 'CustomButton_1',
+                         :attrs => [%w(Attr1 01), %w(Attr2 02),  %w(Attr3 03), %w(Attr4 04), %w(Attr5 05)],
+                         :visibility_typ => 'Type1'},
+               :instance_names => %w(CustomButton_1 CustomButton_2),
+               :visibility_types => %w(Type1 Type2),
+               :current => {}
+      }
+      controller.instance_variable_set(:@edit, edit)
+      session[:edit] = edit
+      session[:resolve] = {}
+      post :automate_button_field_changed, :instance_name => 'CustomButton', :name => 'test', :button_image => '01'
+      expect(response.status).to eq(200)
     end
   end
 end


### PR DESCRIPTION
@dclarizio - this is the fix for the failure to add a new custom button. It is only for upstream. This is WIP, until I add the rspecs.

Modified rendering for the custom buttons dialog to account for a nil @custom_button