### PR TITLE
Fix already initialized constants warnings in appliance_console code

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -56,7 +56,7 @@ $terminal.wrap_at = 80
 $terminal.page_at = 21
 
 
-require 'appliance_console/errors.rb'
+require 'appliance_console/errors'
 
 [:INT, :TERM, :ABRT, :TSTP].each { |s| trap(s) { raise MiqSignalError } }
 

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -4,9 +4,9 @@ require 'linux_admin'
 require 'pathname'
 require 'util/miq-password'
 require 'fileutils'
-require_relative "errors"
-require_relative "utilities"
-require_relative "logging"
+require 'appliance_console/errors'
+require 'appliance_console/utilities'
+require 'appliance_console/logging'
 
 RAILS_ROOT ||= Pathname.new(__dir__).join("../../..")
 

--- a/gems/pending/appliance_console/external_httpd_authentication.rb
+++ b/gems/pending/appliance_console/external_httpd_authentication.rb
@@ -1,5 +1,5 @@
-require_relative "external_httpd_configuration"
-require_relative "principal"
+require "appliance_console/external_httpd_configuration"
+require "appliance_console/principal"
 
 module ApplianceConsole
   class ExternalHttpdAuthentication

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -1,5 +1,5 @@
-require_relative "database_configuration"
-require_relative "service_group"
+require "appliance_console/database_configuration"
+require "appliance_console/service_group"
 
 module ApplianceConsole
   class InternalDatabaseConfiguration < DatabaseConfiguration

--- a/gems/pending/appliance_console/temp_storage_configuration.rb
+++ b/gems/pending/appliance_console/temp_storage_configuration.rb
@@ -1,4 +1,4 @@
-require_relative "logging"
+require "appliance_console/logging"
 
 module ApplianceConsole
   class TempStorageConfiguration


### PR DESCRIPTION
When you run `appliance_console` on a new appliance, you'll see this:

![screen shot 2015-07-14 at 6 02 19 pm](https://cloud.githubusercontent.com/assets/19339/8686551/581eb0cc-2a55-11e5-9ce1-df2bbfde09fc.png)

The fix was to use the appliance_console namespace with require instead of require_relative.  I think it makes sense to make this change regardless.

But, it's very interesting that warnings are reporting the files from two different locations:

`warning: already initialized constant ApplianceConsole::Logging::LOGFILE`

**One from the real path**: 
/var/www/miq/vmdb/gems/pending/appliance_console/logging.rb:9

**One from the symlinked path**:
/var/www/miq/lib/appliance_console/logging.rb:9

Because we symlink to the new location:
````
[root@localhost miq]# ls -l /var/www/miq/lib
lrwxrwxrwx. 1 root root 30 Jul 10 20:13 /var/www/miq/lib -> /var/www/miq/vmdb/gems/pending
```


To illustrate this more:

```ruby
irb(main):002:0> require './lib/appliance_console/errors'
=> true
irb(main):003:0> require './vmdb/gems/pending/appliance_console/errors'
=> true
irb(main):004:0> $LOADED_FEATURES.grep(/appliance_console/)
=> ["/var/www/miq/lib/appliance_console/errors.rb", "/var/www/miq/vmdb/gems/pending/appliance_console/errors.rb"]
```

The errors file is the same file.  @tenderlove Is this expected?