### PR TITLE
Provision VMs even if they have no EMS

### DIFF
--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -12,7 +12,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
   def self.class_for_source(source_or_id)
     source = VmOrTemplate.find_by_id(source_or_id)
     return nil if source.nil?
-    source.ext_management_system.class.provision_workflow_class
+    source.class.manager_class.provision_workflow_class
   end
 
   def self.encrypted_options_fields

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -259,6 +259,14 @@ class VmOrTemplate < ActiveRecord::Base
   include FilterableMixin
   include StorageMixin
 
+  def self.manager_class
+    if parent == Object
+      "Ems#{model_suffix}".constantize
+    else
+      parent
+    end
+  end
+
   def to_s
     self.name
   end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -74,4 +74,26 @@ describe MiqProvisionWorkflow do
       it("with class #{sub_klass}") { sub_klass.encrypted_options_fields.should include(:root_password) }
     end
   end
+
+  context '.class_for_source' do
+    let(:provider)       { FactoryGirl.create(:ems_amazon) }
+    let(:template)       { FactoryGirl.create(:template_amazon, :name => "template") }
+    let(:workflow_class) { provider.class.provision_workflow_class }
+
+    it 'with valid source' do
+      template.update_attributes(:ext_management_system => provider)
+      expect(described_class.class_for_source(template.id)).to eq(workflow_class)
+    end
+
+    it 'with orphaned source' do
+      template.stub(:storage).and_return([])
+      expect(template.orphaned?).to be_true
+      expect(described_class.class_for_source(template.id)).to eq(workflow_class)
+    end
+
+    it 'with archived source' do
+      expect(template.archived?).to be_true
+      expect(described_class.class_for_source(template.id)).to eq(workflow_class)
+    end
+  end
 end


### PR DESCRIPTION
Orphaned VMs (or, perhaps more likely, templates) still need to be able to find their provisioning workflow class. So, traverse classes instead of instances.

Fixes #3430