### PR TITLE
Fix catalog nil workflow exceptions

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -520,7 +520,7 @@ module ApplicationController::MiqRequestMethods
   end
 
   def tag_symbol_for_workflow
-    (@edit || @options)[:wf].tag_symbol
+    (@edit || @options)[:wf].try(:tag_symbol) || :vm_tags
   end
 
   def validate_fields


### PR DESCRIPTION
For catalog requests, an exception is thrown when the workflow is nil
It is rare but happens.

While, this just masks the error, it is the same behavior that happened
before introducing this refactoring and seems to be working fine.

(@edit || @options)[:wf] is nil for:

app/controllers/application_controller/miq_request_methods.rb:524:in `tag_symbol_for_workflow'
app/controllers/application_controller/miq_request_methods.rb:761:in `prov_set_show_vars'
app/controllers/catalog_controller.rb:1682:in `get_node_info'
app/controllers/catalog_controller.rb:1770:in `replace_right_cell'
app/controllers/catalog_controller.rb:312:in `tree_select'


fixes #3323

/cc @gmcculloug didn't see this PR from you. putting in there to have the conversation