### PR TITLE
Remove pending specs

### DIFF
--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -24,17 +24,6 @@ describe VmInfraController do
         res.should == active_node
       end
 
-      it "invalid node" do
-        pending("handling invalid nodes") do
-          active_node = "xxx"
-
-          controller.instance_variable_set(:@sb, {:trees => {active_tree => {:active_node => active_node}}, :active_tree => active_tree})
-          res = controller.send(:valid_active_node, active_node)
-          controller.send(:flash_errors?).should be_true
-          res.should == "root"
-        end
-      end
-
       it "node no longer exists" do
         rec = FactoryGirl.create(:service_template_catalog)
         active_node = "stc-#{rec.id + 1}"

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -55,21 +55,6 @@ describe MiqAeCustomizationController do
         expect(response.body).to include("flash")
       end
     end
-
-    context "all buttons selected" do
-      pending "for when we redesign rotate functionality" do
-        it "moves up and rotate whole group" do
-          post :group_reorder_field_changed, :id => 'seq', :button => 'up', 'selected_fields'=> ['100','101','102','103']
-          expect(controller.instance_variable_get(:@edit)).to eql({:new => {:fields => [['test1',101], ['test2',102], ['test3',103], ['test', 100]] }} )
-        end
-
-        it "moves down and rotate opposite whole group" do
-          post :group_reorder_field_changed, :id => 'seq', :button => 'down', 'selected_fields'=> ['100','101','102','103']
-          expect(controller.instance_variable_get(:@edit)).to eql({:new => {:fields => [['test3',103], ['test',100], ['test1',101], ['test2', 102]] }} )
-        end
-      end
-    end
-
   end
 
   describe "#group_form_field_changed" do
@@ -125,18 +110,6 @@ describe MiqAeCustomizationController do
       end
 
       context "all buttons selected" do
-        pending "for when we redesign rotate functionality" do
-          it "moves up and rotate whole group" do
-            post :group_form_field_changed, :button => 'up', 'selected_fields'=> ['100','101','102','103']
-            expect(controller.instance_variable_get(:@edit)).to eql({:new => {:fields => [['value1',101], ['value2',102], ['value3',103], ['value', 100]] }} )
-          end
-
-          it "moves down and rotate opposite whole group" do
-            post :group_form_field_changed, :button => 'down', 'selected_fields'=> ['100','101','102','103']
-            expect(controller.instance_variable_get(:@edit)).to eql({:new => {:fields => [['value3',103], ['value',100], ['value1',101], ['value2', 102]] }} )
-          end
-        end
-
         it "moves to the top and nothing happen" do
           post :group_form_field_changed, :button => 'top', 'selected_fields'=> ['100','101','102','103']
           expect(controller.instance_variable_get(:@edit)).to eql({:new => {:fields => [['value',100], ['value1',101], ['value2',102], ['value3', 103]] }} )


### PR DESCRIPTION
remove 2 controller pending tests that are not needed

Thanks @h-kataria for researching customization controller test.
looks like 2ee72976 removed that functionality. when we add the functionality, we can add specs for that.

looks like the explorer spec was introduced around 50537664 (2013) and am unsure if it was ever not pending.

/cc @h-kataria @dclarizio 