### PR TITLE
upgrade bcrypt gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 gem "american_date"
 gem "default_value_for",              "~>3.0.1"
 gem "puma"
-gem 'bcrypt-ruby', '3.1.2'
+gem "bcrypt",                         "3.1.10"
 gem 'outfielding-jqplot-rails',       "= 1.0.8"
 gem "responders",                     "~> 2.0"
 gem 'secure_headers'


### PR DESCRIPTION
The gem has been renamed from `ruby_bcrypt` to just plain `bcrypt`

/cc @chessbyte 