### PR TITLE
Fixed issue in sort_tree method for VMs & Templates tree.

### DIFF
--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -97,7 +97,7 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
 
     tree.sort_by! do |object, _children|
       datacenter = object.kind_of?(EmsFolder) ? object.is_datacenter? : false
-      [SORT_CLASSES.index(object.class.base_class), datacenter, object.name.downcase]
+      [SORT_CLASSES.index(object.class.base_class), datacenter ? 0 : 1, object.name.downcase]
     end
   end
 

--- a/spec/presenters/tree_builder_vms_and_templates_spec.rb
+++ b/spec/presenters/tree_builder_vms_and_templates_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe TreeBuilderVmsAndTemplates do
+  before do
+    ems     = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone))
+    folder  = FactoryGirl.create(:ems_folder, :ext_management_system => ems)
+    subfolder1 = FactoryGirl.create(:ems_folder)
+    subfolder2 = FactoryGirl.create(:ems_folder)
+    subfolder3 = FactoryGirl.create(:datacenter)
+
+    folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder1) }
+    folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder2) }
+    folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder3) }
+
+    @vandt_tree = TreeBuilderVmsAndTemplates.new(ems, {})
+    @tree = {ems => {folder => {subfolder1 => {}, subfolder2 => {}, subfolder3 => {}}}}
+  end
+
+  context "#sort_tree" do
+    it "making sure sort_tree was successful for mixed ems_folder types" do
+      expect {@vandt_tree.send(:sort_tree, @tree)}.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
- Sorting an array by boolean was blowing up with "comparison of Array with Array failed" error, in this case customer's db had 2 EmsFolders at same level 1 was a datacenter and other one was not a datacenter, so in this case second parameter passed in to sort_by call was a boolean as a fix replaced boolean with 0,1
Sorting of arrays containing identical boolean values (ALL true or ALL false) works fine, but if 1 value differs sort throws an exception, as an example [false, true].sort fails in irb
- Added spec test to verify the fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1242459

@Fryguy @dclarizio please review/test.