### PR TITLE
Fix non-namespaced workers

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -182,7 +182,7 @@ class MiqWorker < ActiveRecord::Base
 
   def self.corresponding_runner
     @corresponding_runner ||=
-      if const_defined?(:Runner)
+      if const_defined?(:Runner, false)
         self::Runner.name
       else
         settings_name.to_s.camelize


### PR DESCRIPTION
MiqWorker.corresponding_runner attempts to find the correspondind runner (i.e., worker) class that does the actual work.  The method has a conditional that allows it to find the runner for newly namespaced workers and legacy non-namespaced workers.

However, the conditional test wasn't appropriately sending legacy workers to the else block as it should.

Here's a quick example to see why:

> irb> MiqEventCatcherOpenstack.const_defined?(:Runner)
> => true
> irb> MiqEventCatcherOpenstack.const_defined?(:Runner, false)
> => false
> irb> MiqEventCatcherOpenstack::Runner
> => ManageIQ::Providers::BaseManager::EventCatcher::Runner
> irb> ManageIQ::Providers::Vmware::InfraManager::EventCatcher.const_defined(:Runner, false)
> => true
> irb> ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner
> => ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner

Fixes: #3358 

I should add that @matthewd tracked this down.  I'm nowhere near smart enough to find something like this ...