### PR TITLE
Fix unnecessary saving reports files to db on startup

### DIFF
--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -61,7 +61,11 @@ module MiqReport::Seeding
       rpt[:rpt_group] = File.basename(File.dirname(filename)).split("_").last
       rpt[:rpt_type] = "Default"
       rpt[:filename] = filename.sub(dir + "/", "")
-      rpt[:file_mtime] = File.mtime(filename).utc
+      # DB and filesystem have different precision
+      # so calling round is done in order to eliminate the second fractions diff
+      # otherwise the comparison of the file time and the report time from db
+      # will always be different
+      rpt[:file_mtime] = File.mtime(filename).utc.round
       rpt[:priority] = File.basename(filename).split("_").first.to_i
       # rec = self.find_by_name_and_rpt_group(rpt[:name], rpt[:rpt_group])
       # rec = self.find_by_name_and_filename(rpt[:name], rpt[:filename])


### PR DESCRIPTION
Fixed the comparison of the timestamps from file and db that was always
returning that the file is newer due to comparison that considered
fractions of a second.
This reduces the server startup time in 5-6 seconds.

comparing with utc as it was done before this change reveals they "look" identical
rec.file_mtime.utc 2015-07-12 12:00:39 UTC: rpt[:file_mtime] [2015-07-12 12:00:39 UTC]

comparing with to_i also shows they "look" identical
rec.file_mtime.utc 1436990151: rpt[:file_mtime] [1436990151]

comparing with to_f reveals a minor difference (fractions of second) that was the reason which leads to the < comparison always to return true and update all reports in the db.
rec.file_mtime.utc 1436990151.7722821: rpt[:file_mtime] [1436990151.7722828]