### PR TITLE
Remove rpt_type = Custom from containers reports

### DIFF
--- a/product/reports/170_Configuration Management - Containers/010_Nodes by Capacity.yaml
+++ b/product/reports/170_Configuration Management - Containers/010_Nodes by Capacity.yaml
@@ -1,6 +1,5 @@
 title: Nodes By Capacity
 rpt_group: Custom
-rpt_type: Custom
 priority:
 db: ContainerNode
 cols:

--- a/product/reports/170_Configuration Management - Containers/020_Nodes by CPU Usage.yaml
+++ b/product/reports/170_Configuration Management - Containers/020_Nodes by CPU Usage.yaml
@@ -1,6 +1,5 @@
 title: Nodes By CPU Usage
 rpt_group: Custom
-rpt_type: Custom
 priority:
 db: ContainerNode
 cols:

--- a/product/reports/170_Configuration Management - Containers/030_Nodes by Memory Usage.yaml
+++ b/product/reports/170_Configuration Management - Containers/030_Nodes by Memory Usage.yaml
@@ -1,6 +1,5 @@
 title: Nodes By Memory Usage
 rpt_group: Custom
-rpt_type: Custom
 priority:
 db: ContainerNode
 cols:

--- a/product/reports/170_Configuration Management - Containers/040_Recently Discovered Container Groups.yaml
+++ b/product/reports/170_Configuration Management - Containers/040_Recently Discovered Container Groups.yaml
@@ -1,6 +1,5 @@
 title: Recently Discovered Container Groups
 rpt_group: Custom
-rpt_type: Custom
 priority:
 db: ContainerGroup
 cols:

--- a/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
+++ b/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
@@ -1,6 +1,5 @@
 title: Number of Nodes per CPU Cores
 rpt_group: Custom
-rpt_type: Custom
 priority:
 db: ContainerNode
 cols:

--- a/product/reports/170_Configuration Management - Containers/060_Container Groups per Ready Status.yaml
+++ b/product/reports/170_Configuration Management - Containers/060_Container Groups per Ready Status.yaml
@@ -1,6 +1,5 @@
 title: Container Groups per Ready Status
 rpt_group: Custom
-rpt_type: Custom
 priority:
 db: ContainerGroup
 cols:


### PR DESCRIPTION
This caused the attempt to "re-add" the containers reports from file on system startup every time, as custom reports weren't saved/fetched from db (only rpt_type = Default).
The rest of the reports have no rpt_type in their yaml file.