### PR TITLE
Fix defaulting of id in create_table

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   class Migration
     def create_table(table_name, options = {})
-      options[:id] ||= :bigserial
+      options[:id] = :bigserial if options[:id].nil?
       super
       return if options[:id] == false
 


### PR DESCRIPTION
@tenderlove Please review.

This fixes an issue I found in #3454 where passing `:id => false` to create_table was overriden with `:id => :bigserial`