### PR TITLE
Database auto-reconnect feature was dropped when we dropped our fork.

### DIFF
--- a/script/verify_db_config.rb
+++ b/script/verify_db_config.rb
@@ -29,10 +29,6 @@ MiqStdIo.std_io_to_files do
     $db_settings = Marshal.load(Base64.decode64(f_data.split("\n").join))
     from_save = $db_settings.delete(:from_save)
 
-    # force any connection errors to be raised immediately instead of retrying
-    require "active_record/connection_adapters/postgresql_adapter"
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.auto_connect = false
-
     $conn = ActiveRecord::Base.establish_connection($db_settings).connection
 
     tables = $conn.tables


### PR DESCRIPTION
This commit removes a reference to a missing attribute setter.

If it's still needed, we can re-implement it:
https://github.com/ManageIQ/rails/commit/426d57566aa3100c650351349c6a463685f64b17

cc @tenderlove 