### PR TITLE
Session reset

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -648,7 +648,7 @@ class DashboardController < ApplicationController
     db_user.update_attributes(:current_group => MiqGroup.find_by_id(params[:to_group]))
 
     # Rebuild the session
-    session_reset(db_user)
+    session_reset
     session_init(db_user)
     session[:group_changed] = true
     url = start_url_for_user(nil) || url_for(:controller => params[:controller], :action => 'show')
@@ -693,8 +693,7 @@ class DashboardController < ApplicationController
     @settings[:display][:startpage]
   end
 
-  # Reset and set the user vars in the session object
-  def session_reset(db_user)  # User record
+  def session_reset
     # Clear session hash just to be sure nothing is left (but copy over some fields)
     winh    = session[:winH]
     winw    = session[:winW]
@@ -706,8 +705,6 @@ class DashboardController < ApplicationController
     session[:winW]     = winw
     session['referer'] = referer
 
-    self.current_user = db_user
-
     # Clear instance vars that end up in the session
     @sb = @edit = @view = @settings = @lastaction = @perf_options = @assign = nil
     @current_page = @search_text = @detail_sortcol = @detail_sortdir = @exp_key = nil
@@ -716,6 +713,8 @@ class DashboardController < ApplicationController
 
   # Initialize session hash variables for the logged in user
   def session_init(db_user)
+    self.current_user = db_user
+
     # Load settings for this user, if they exist
     @settings = copy_hash(DEFAULT_SETTINGS)             # Start with defaults
     unless db_user == nil || db_user.settings == nil    # If the user has saved settings

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -712,9 +712,6 @@ class DashboardController < ApplicationController
     @sb = @edit = @view = @settings = @lastaction = @perf_options = @assign = nil
     @current_page = @search_text = @detail_sortcol = @detail_sortdir = @exp_key = nil
     @server_options = @tl_options = @pp_choices = @panels = @breadcrumbs = nil
-
-    db_user && db_user.userid &&
-      db_user.current_group && db_user.current_group.miq_user_role && true
   end
 
   # Initialize session hash variables for the logged in user

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -33,6 +33,7 @@ class UserValidationService
       end
     end
 
+    start_url = session[:start_url] # Hang on to the initial start URL
     db_user = User.find_by_userid(user[:name])
     return ValidateResult.new(
       :fail,
@@ -40,7 +41,6 @@ class UserValidationService
       (session[:group] ? "Role" : "Group")
     ) unless session_reset(db_user) # Reset/recreate the session hash
 
-    start_url = session[:start_url] # Hang on to the initial start URL
 
     # Don't allow logins until there's some content in the system
     return ValidateResult.new(

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -35,7 +35,7 @@ class UserValidationService
 
     start_url = session[:start_url] # Hang on to the initial start URL
     db_user = User.find_by_userid(user[:name])
-    session_reset(db_user)
+    session_reset
     feature = missing_user_features(db_user)
     return ValidateResult.new(
       :fail,
@@ -43,14 +43,13 @@ class UserValidationService
       feature
     ) if feature
 
+    session_init(db_user)
 
     # Don't allow logins until there's some content in the system
     return ValidateResult.new(
       :fail,
       "Logins not allowed, no providers are being managed yet. Please contact the administrator"
     ) unless user_is_super_admin? || Vm.first || Host.first
-
-    session_init(db_user) # Initialize the session hash variables
 
     return validate_user_handle_not_ready if MiqServer.my_server(true).logon_status != :ready
 


### PR DESCRIPTION
No visual ui changes.

1. I'm not sure how the `start_url` code could have ever worked. We are clearing it out of the session before we even read it.
2. `session_reset` now resets the session, and `session_init` now sets it.
3. Logic about what is wrong with a session is moved into `user_validation_service`, the code that actually uses this information.

I split this up into 3 commits to show the steps of the refactoring. Let me know if this is not clear.

/cc @dclarizio 