### PR TITLE
Updated LICENSE.txt paths after rerooted vmdb, comments cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -15,16 +15,16 @@ Builds of ManageIQ are released under GPLv2.
 Third-Party Legal Notices
 =========================
 
-vmdb/app/assets/fonts/ includes files from Font Awesome by Dave Gandy
+app/assets/fonts/ includes files from Font Awesome by Dave Gandy
 (http://fontawesome.io) which are licensed under SIL OFL 1.1
 (http://scripts.sil.org/OFL).
 
 
-vmdb/app/assets/fonts/ includes Open Sans font files which are
+app/assets/fonts/ includes Open Sans font files which are
 licensed under the Apache License 2.0.
 
 
-vmdb/public/javascripts/timeline/* is covered by the following
+public/javascripts/timeline/* is covered by the following
 copyright and license notice:
 
   (c) Copyright The SIMILE Project 2006. All rights reserved.
@@ -55,8 +55,8 @@ copyright and license notice:
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-vmdb/spec/support/with_constants.rb and
-lib/spec/support/with_constants.rb are copyright (c) 2010 Michael
+spec/support/with_constants.rb and
+gems/pending/spec/support/with_constants.rb are copyright (c) 2010 Michael
 Portuesi and released under the MIT license:
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -78,7 +78,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-Portions of vmdb/tools/dba.rb are covered by the following copyright
+Portions of tools/dba.rb are covered by the following copyright
 and license notice:
 
 Copyright (c) 2007-2012 Greg Sabino Mullane <greg@endpoint.com>.
@@ -104,7 +104,7 @@ modification, are permitted provided that the following conditions are met:
  OF SUCH DAMAGE.
 
 
-Portions of lib/util/duplicate_blocker.rb are adapted from code covered by the following
+Portions of gems/pending/util/duplicate_blocker.rb are adapted from code covered by the following
 copyright and license notice:
 
 Copyright (c) 2009, Will Sargent

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,6 @@ module Vmdb
     # Enable the asset pipeline
     config.assets.enabled = true
 
-    # TODO: Move to asset pipeline enabled by moving assets from vmdb/public to vmdb/app/assets
     config.asset_path = "%s"
 
     # Version of your assets, change this if you want to expire all your assets

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -52,7 +52,6 @@ module MiqEnvironment
     def self.is_non_web_server_worker?
       return @is_non_web_server_worker unless @is_non_web_server_worker.nil?
       # ARGV: ["priority_worker", "MiqPriorityWorker", "--queue_name", "generic", "--guid", "33d93972-56ff-11e0-98ac-001f5bee6a67"]
-      # rails runner eats /var/www/miq/vmdb/lib/workers/bin/worker.rb which was ARGV[0]
       klass = ARGV[1].constantize rescue NilClass
       return @is_non_web_server_worker = is_rails_runner? && klass.hierarchy.include?(MiqWorker)
     end

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -19,9 +19,7 @@ module VMDB
     end
 
     def self.compressed_log_patterns
-      # From a log file such as production.log-20090504.gz,
-      # create an array of strings containing the date patterns:
-      # ["/home/jrafaniello/src/trunk/miq/vmdb/log/*20090502.gz", "/home/jrafaniello/src/trunk/miq/vmdb/log/*20090504.gz"]
+      # From a log file create an array of strings containing the date patterns
       log_dir = File.join(Rails.root, "log")
       gz_pattern = File.join(log_dir, "*[0-9][0-9].gz")
       Dir.glob(gz_pattern).inject([]) do |arr, f|


### PR DESCRIPTION
Other part of LICENSE.txt cleanup is already done in PR #3465.

@Fryguy i'm not quite sure, that comments in lib/tasks/test_metrics.rake should be removed, as they are part of [one larger TODO explanation](https://github.com/ManageIQ/manageiq/blob/master/lib/tasks/test_metrics.rake#L46). Other changes were done by your suggestion.