### PR TITLE
Provisioning Dialogs accordion needs updates

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -85,7 +85,17 @@ class ApplicationHelper::ToolbarBuilder
             props["enabled"] = "false"
             props["title"] = _("No records found for this report")
           end
-
+          if bgi[:buttonSelect] == "host_vmdb_choice" && x_active_tree == :old_dialogs_tree && @record && @record[:default]
+            bgi[:items].each do |bgsi|
+              if bgsi[:button] == "old_dialogs_edit"
+                bgsi[:enabled] = 'false'
+                bgsi[:title] = _('Default dialogs cannot be edited')
+              elsif bgsi[:button] == "old_dialogs_delete"
+                bgsi[:enabled] = 'false'
+                bgsi[:title] = _('Default dialogs cannot be removed from the VMDB')
+              end
+            end
+          end
           # Add a separator, if needed, before this buttonSelect
           if !sep_added && sep_needed
             if groups_added.include?(bg_idx) && groups_added.length > 1

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -115,7 +115,7 @@ class ApplicationHelper::ToolbarChooser
   end
 
   def center_toolbar_filename_automate_customization
-    if x_active_tree == :old_dialogs_tree && x_node != "root"
+    if x_active_tree == :old_dialogs_tree
       return @dialog ? "miq_dialog_center_tb" : "miq_dialogs_center_tb"
     elsif x_active_tree == :dialogs_tree
       if x_node == "root"

--- a/product/views/MiqDialog.yaml
+++ b/product/views/MiqDialog.yaml
@@ -46,7 +46,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- description
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/MiqDialog.yaml
+++ b/product/views/MiqDialog.yaml
@@ -21,19 +21,22 @@ db: MiqDialog
 cols:
 - name
 - description
+- default
 
 # Included tables (joined, has_one, has_many) and columns
 include:
 
 # Order of columns (from all tables)
 col_order: 
-- name
 - description
+- name
+- default
 
 # Column titles, in order
 headers:
-- Name
 - Description
+- Name
+- Default
 
 # Condition(s) string for the SQL query
 conditions: 

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -5,7 +5,11 @@ describe MiqAeCustomizationController do
   context "::Dialogs" do
     context "#dialog_delete" do
       before do
+        FactoryGirl.create(:vmdb_database)
+        EvmSpecHelper.create_guid_miq_server_zone
         seed_specific_product_features("dialog_delete")
+        described_class.any_instance.stub(:set_user_time_zone)
+        controller.stub(:check_privileges).and_return(true)
       end
 
       it "flash message displays Dialog Label being deleted" do
@@ -20,7 +24,9 @@ describe MiqAeCustomizationController do
                                          },
                                           :active_tree => :dlg_tree
                                          })
+        session[:settings] = {:display   => {:locale => 'default'}}
 
+        controller.instance_variable_set(:@settings, :display => {:locale => 'default'})
         controller.stub(:replace_right_cell)
 
         # Now delete the Dialog

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -151,6 +151,8 @@ describe MiqAeCustomizationController do
     let(:sandbox_flash_messages) { nil }
 
     before do
+      session[:settings] =  {:display => {:locale => 'default'}}
+      controller.instance_variable_set(:@settings, :display => {:locale => 'default'})
       controller.instance_variable_set(:@sb, {:flash_msg => sandbox_flash_messages})
       bypass_rescue
     end


### PR DESCRIPTION
Update the list for provisioning dialogs for 'All Dialogs' tab to list all dialogs not the categories.
The Configuration toolbar menu for 'Default' Dialogs modified to not allow Edit and remove.
Add the "Default' column to the dialogs list and reorder the columns.

https://bugzilla.redhat.com/show_bug.cgi?id=1230690

@dclarizio - this is WIP as I need to add the before/after screenshots