### PR TITLE
Upgrade angular to 1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "activerecord-deprecated_finders", "~>1.0.4",     :require => "active_record
 
 # Client-side dependencies
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
-gem 'angularjs-rails', '~>1.3.15'
+gem 'angularjs-rails', '~>1.4.3'
 gem 'angular-ui-bootstrap-rails', '~> 0.13.0'
 gem 'momentjs-rails', '~> 2.10.3'
 gem 'jquery-rails', "~>4.0.4"

--- a/app/assets/javascripts/controllers/angular-bootstrap/DatepickerCtrl.js
+++ b/app/assets/javascripts/controllers/angular-bootstrap/DatepickerCtrl.js
@@ -1,11 +1,11 @@
-ManageIQ.angularApplication.controller('DatepickerCtrl', function ($scope) {
-  if($scope.$parent.formId == "new")
+ManageIQ.angularApplication.controller('DatepickerCtrl', ['$scope', function ($scope) {
+  if ($scope.$parent.formId == "new")
     $scope.minDate = new Date();
 
-  $scope.open = function($event) {
+  $scope.open = function ($event) {
     $event.preventDefault();
     $event.stopPropagation();
 
     $scope.opened = true;
   };
-});
+}]);

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -1,90 +1,87 @@
 ManageIQ.angularApplication.controller('diagnosticsDatabaseFormController', ['$http', '$scope', '$attrs', 'miqService', 'miqDBBackupService', function($http, $scope, $attrs, miqService, miqDBBackupService) {
-    var init = function() {
+  var init = function() {
 
-        $scope.diagnosticsDatabaseModel = {
-          action_typ: 'db_backup',
-          backup_schedule_type: '',
-          depot_name: '',
-          uri: '',
-          uri_prefix: '',
-          log_protocol: '',
-          log_userid: '',
-          log_password: '',
-          log_verify: ''
-        };
-        $scope.afterGet = true;
-        $scope.modelCopy = angular.copy( $scope.diagnosticsDatabaseModel );
-        $scope.dbBackupFormFieldChangedUrl = $attrs.dbBackupFormFieldChangedUrl;
-        $scope.submitUrl = $attrs.submitUrl;
-
-        ManageIQ.angularApplication.$scope = $scope;
-
-        $scope.$watch("diagnosticsDatabaseModel.depot_name", function() {
-            $scope.form = $scope.angularForm;
-            $scope.miqService = miqService;
-            $scope.miqDBBackupService = miqDBBackupService;
-        });
+    $scope.diagnosticsDatabaseModel = {
+      action_typ: 'db_backup',
+      backup_schedule_type: '',
+      depot_name: '',
+      uri: '',
+      uri_prefix: '',
+      log_protocol: '',
+      log_userid: '',
+      log_password: '',
+      log_verify: ''
     };
+    $scope.afterGet = true;
+    $scope.modelCopy = angular.copy( $scope.diagnosticsDatabaseModel );
+    $scope.dbBackupFormFieldChangedUrl = $attrs.dbBackupFormFieldChangedUrl;
+    $scope.submitUrl = $attrs.submitUrl;
 
-    $scope.backupScheduleTypeChanged = function() {
-      if($scope.diagnosticsDatabaseModel.backup_schedule_type == '') {
-        $scope.diagnosticsDatabaseModel.depot_name = '';
-        $scope.diagnosticsDatabaseModel.uri = '';
-        $scope.diagnosticsDatabaseModel.uri_prefix = '';
-        $scope.diagnosticsDatabaseModel.log_userid = '';
-        $scope.diagnosticsDatabaseModel.log_password = '';
-        $scope.diagnosticsDatabaseModel.log_verify = '';
-        $scope.diagnosticsDatabaseModel.log_protocol = '';
-        return;
-      }
+    ManageIQ.angularApplication.$scope = $scope;
 
-      miqService.sparkleOn();
+    $scope.$watch("diagnosticsDatabaseModel.depot_name", function() {
+        $scope.form = $scope.angularForm;
+        $scope.miqService = miqService;
+        $scope.miqDBBackupService = miqDBBackupService;
+    });
+  };
 
-      url = $scope.dbBackupFormFieldChangedUrl;
-      $http.post(url + $scope.diagnosticsDatabaseModel.backup_schedule_type).success(function(data) {
-        $scope.diagnosticsDatabaseModel.depot_name = data.depot_name;
-        $scope.diagnosticsDatabaseModel.uri = data.uri;
-        $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
-        $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
-        $scope.diagnosticsDatabaseModel.log_password = data.log_password;
-        $scope.diagnosticsDatabaseModel.log_verify = data.log_verify;
-
-        if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
-          $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
-        else
-          $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
-
-        $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
-
-        miqService.sparkleOff();
-      });
-    };
-
-    $scope.showSubmitButton = function() {
-      return true;
+  $scope.backupScheduleTypeChanged = function() {
+    if($scope.diagnosticsDatabaseModel.backup_schedule_type == '') {
+      $scope.diagnosticsDatabaseModel.depot_name = '';
+      $scope.diagnosticsDatabaseModel.uri = '';
+      $scope.diagnosticsDatabaseModel.uri_prefix = '';
+      $scope.diagnosticsDatabaseModel.log_userid = '';
+      $scope.diagnosticsDatabaseModel.log_password = '';
+      $scope.diagnosticsDatabaseModel.log_verify = '';
+      $scope.diagnosticsDatabaseModel.log_protocol = '';
+      return;
     }
 
-    $scope.isBasicInfoValid = function() {
-        if($scope.angularForm.depot_name.$valid &&
-            $scope.angularForm.uri.$valid &&
-            $scope.angularForm.log_userid.$valid &&
-            $scope.angularForm.log_password.$valid &&
-            $scope.angularForm.log_verify.$valid)
-            return true;
-        else
-            return false;
-    };
+    miqService.sparkleOn();
 
-    $scope.submitButtonClicked = function(confirm_msg) {
-      if (confirm(confirm_msg)) {
-        miqService.sparkleOn();
-        url = $scope.submitUrl;
-        miqService.miqAjaxButton(url, true);
-      }
-    };
+    url = $scope.dbBackupFormFieldChangedUrl;
+    $http.post(url + $scope.diagnosticsDatabaseModel.backup_schedule_type).success(function(data) {
+      $scope.diagnosticsDatabaseModel.depot_name = data.depot_name;
+      $scope.diagnosticsDatabaseModel.uri = data.uri;
+      $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
+      $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
+      $scope.diagnosticsDatabaseModel.log_password = data.log_password;
+      $scope.diagnosticsDatabaseModel.log_verify = data.log_verify;
 
-    init();
+      if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
+        $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
+      else
+        $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
+
+      $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
+
+      miqService.sparkleOff();
+    });
+  };
+
+  $scope.showSubmitButton = function() {
+    return true;
+  }
+
+  $scope.isBasicInfoValid = function() {
+    if($scope.angularForm.depot_name.$valid &&
+      $scope.angularForm.uri.$valid &&
+      $scope.angularForm.log_userid.$valid &&
+      $scope.angularForm.log_password.$valid &&
+      $scope.angularForm.log_verify.$valid)
+      return true;
+    else
+      return false;
+  };
+
+  $scope.submitButtonClicked = function(confirm_msg) {
+    if (confirm(confirm_msg)) {
+      miqService.sparkleOn();
+      url = $scope.submitUrl;
+      miqService.miqAjaxButton(url, true);
+    }
+  };
+
+  init();
 }]);
-
-
-

--- a/app/assets/javascripts/directives/scheduler/updateDropdownForFilter.js
+++ b/app/assets/javascripts/directives/scheduler/updateDropdownForFilter.js
@@ -1,4 +1,4 @@
-ManageIQ.angularApplication.directive('updateDropdownForFilter', function($timeout) {
+ManageIQ.angularApplication.directive('updateDropdownForFilter', ['$timeout', function($timeout) {
   return {
     require: 'ngModel',
     link: function (scope, elem, attr, ctrl) {
@@ -38,7 +38,7 @@ ManageIQ.angularApplication.directive('updateDropdownForFilter', function($timeo
       });
     }
   }
-});
+}]);
 
 var selectListElement = function(scope, timeout, ctrl, refresh) {
   timeout(function(){

--- a/app/assets/javascripts/directives/scheduler/updateDropdownForTimer.js
+++ b/app/assets/javascripts/directives/scheduler/updateDropdownForTimer.js
@@ -1,4 +1,4 @@
-ManageIQ.angularApplication.directive('updateDropdownForTimer', function($timeout) {
+ManageIQ.angularApplication.directive('updateDropdownForTimer', ['$timeout', function($timeout) {
   return {
     require: 'ngModel',
       link: function (scope, elem, attr, ctrl) {
@@ -38,4 +38,4 @@ ManageIQ.angularApplication.directive('updateDropdownForTimer', function($timeou
         };
       }
     }
-});
+}]);

--- a/app/views/ops/_diagnostics_database_tab.html.haml
+++ b/app/views/ops/_diagnostics_database_tab.html.haml
@@ -115,4 +115,4 @@
                 :title                => caption)                                                            |
 
 :javascript
-  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication']);
+  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication'], { strictDi: true });

--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -49,4 +49,4 @@
 
 :javascript
   ManageIQ.angularApplication.value('serverId', '#{@record.id || "new"}');
-  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication']);
+  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication'], { strictDi: true });

--- a/app/views/ops/_schedule_form.html.haml
+++ b/app/views/ops/_schedule_form.html.haml
@@ -61,4 +61,4 @@
                               {year: '#{@one_month_ago[:year]}',
                                month: '#{@one_month_ago[:month]}',
                                date: '#{@one_month_ago[:date]}'});
-  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication']);
+  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication'], { strictDi: true });

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -40,4 +40,4 @@
 
 :javascript
   ManageIQ.angularApplication.value('providerForemanFormId', '#{@provider_foreman.id || "new"}');
-  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication']);
+  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication'], { strictDi: true });

--- a/app/views/repository/_form.html.haml
+++ b/app/views/repository/_form.html.haml
@@ -25,4 +25,4 @@
 
 :javascript
   ManageIQ.angularApplication.value('repositoryFormId', '#{@repo.id || "new"}');
-  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication']);
+  angular.bootstrap(jQuery('#form_div'), ['ManageIQ.angularApplication'], { strictDi: true });

--- a/spec/javascripts/directives/scheduler/updateDropdownForTimer_spec.js
+++ b/spec/javascripts/directives/scheduler/updateDropdownForTimer_spec.js
@@ -1,37 +1,36 @@
 describe('update-drop-down-for-timer initialization', function() {
-  var $scope, form;
+  var $scope, form, model;
   beforeEach(module('ManageIQ.angularApplication'));
   beforeEach(inject(function($compile, $rootScope) {
     $scope = $rootScope;
     var element = angular.element(
       '<form name="angularForm">' +
       '<select id="timer_typ" name="timer_typ" ng-model="scheduleModel.timer_typ"><option>Once</option><option>Weekly</option></select>' +
-      '<select id="timer_value" name="timer_value" update-dropdown-for-timer dropdown-model="scheduleModel" timer-hide="timerTypeOnce" ng-model="scheduleModel.timer_value"><option value="0" label="Week">Week</option><option value="1" label="2 Weeks">2 Weeks</option>' +
-      '</select>' +
+      '<select id="timer_value" name="timer_value" update-dropdown-for-timer dropdown-model="scheduleModel" timer-hide="timerTypeOnce" ng-model="scheduleModel.timer_value" ng-options="timerItem.value as timerItem.text for timerItem in timer_items"></select>' +
       '</form>'
     );
 
-    $scope.timer_items = [{text:'Week', value: '0'},
-                          {text:'2 Weeks', value: '1'}];
+    $scope.timer_items = [{text:'Week', value: 0},
+                          {text:'2 Weeks', value: 1}];
 
-
-
-    $scope.miqService = { miqFlashClear: function (){}};
+    $scope.miqService = { miqFlashClear: function (){} };
+    $scope.scheduleModel = {};
     spyOn($scope.miqService, 'miqFlashClear');
     elem = $compile(element)($rootScope);
     form = $scope.angularForm;
+    model = $scope.scheduleModel;
   }));
 
   describe("When timer_value is not Once", function () {
     it('it attaches selectpicker classes to the timer_value dropdown', inject(function($timeout) {
       $scope.timerTypeOnce = false;
-      form.timer_value.$setViewValue('0');
-      $scope.scheduleModel.timer_value = '0';
+      model.timer_value = 0;
       $timeout.flush();
       expect(elem[0][2].className).toMatch(/selectpicker/);
       expect(elem[0][2].className).toMatch(/btn-default/);
       expect(elem[0][2].parentElement.attributes['style']['value']).not.toMatch(/display: none/);
-      expect($scope.angularForm.timer_value.$viewValue).toBe("0");
+      expect(form.timer_value.$viewValue).toBe(0);
+      expect(model.timer_value).toBe(0);
     }));
   });
 
@@ -41,7 +40,7 @@ describe('update-drop-down-for-timer initialization', function() {
       $scope.timer_items = [];
       $timeout.flush();
       expect(elem[0][2].parentElement.attributes['style']['value']).toMatch(/display: none/);
-      expect($scope.angularForm.timer_value.$viewValue).toBeUndefined();
+      expect(form.timer_value.$viewValue).toBeUndefined();
     }));
   });
 });


### PR DESCRIPTION
According to my reading of [the migration guide](https://docs.angularjs.org/guide/migration#migrating-from-1-3-to-1-4), the only possible change that could affect us is that option matching without `ng-options` is now done using strict comparison and thus model values for `<select>` elements must be strings (or the `<option>`s must be rewritten to use `ng-options` instead).

Closes #3489.