### PR TITLE
Add support for VERBOSE environmental variable during migration test.

### DIFF
--- a/spec/support/migration_spec_helper.rb
+++ b/spec/support/migration_spec_helper.rb
@@ -26,7 +26,7 @@ module MigrationSpecHelper
 
   def migrate(options = {})
     clearing_caches do
-      if options[:verbose]
+      if options[:verbose] || ENV['VERBOSE']
         migrate_under_test
       else
         suppress_migration_messages { migrate_under_test }


### PR DESCRIPTION
So messages will be displayed with commands like VERBOSE=true rake test:migrations.