### PR TITLE
Convert AR::Relation to an array before calling pop.

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -153,6 +153,7 @@ class MiqWorker < ActiveRecord::Base
       if desired > current && enough_resource_to_start_worker?
         (desired - current).times { result[:adds] << self.start_worker.pid }
       elsif desired < current
+        w = w.to_a
         (current - desired).times do
           ww = w.pop
           result[:deletes] << ww.pid

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -1,6 +1,15 @@
 require "spec_helper"
 
 describe MiqWorker do
+  context ".sync_workers" do
+    it "stops extra workers, returning deleted pids" do
+      described_class.any_instance.should_receive(:stop)
+      worker = FactoryGirl.create(:miq_worker, :status => "started")
+      worker.class.workers = 0
+      worker.class.sync_workers.should == {:adds => [], :deletes => [worker.pid]}
+    end
+  end
+
   context ".has_required_role?" do
     def check_has_required_role(worker_role_names, expected_result)
       described_class.stub(:required_roles).and_return(worker_role_names)


### PR DESCRIPTION
Fixes undefined method `pop' for #<MiqWorker::ActiveRecord_Relation>

find_alive and find_current_or_starting return relations.

Found while working on #3500