### PR TITLE
Add a migration stub for DefaultProviderVerifySsl

### DIFF
--- a/db/migrate/20150501193927_default_provider_verify_ssl.rb
+++ b/db/migrate/20150501193927_default_provider_verify_ssl.rb
@@ -1,4 +1,8 @@
 class DefaultProviderVerifySsl < ActiveRecord::Migration
+  class Provider < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
   def up
     say_with_time "Setting Provider verify_ssl values for nils" do
       Provider.where(:verify_ssl => nil).update_all(:verify_ssl => OpenSSL::SSL::VERIFY_PEER)

--- a/spec/migrations/20150501193927_default_provider_verify_ssl_spec.rb
+++ b/spec/migrations/20150501193927_default_provider_verify_ssl_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+require Rails.root.join("db/migrate/20150501193927_default_provider_verify_ssl")
+
+describe DefaultProviderVerifySsl do
+  migration_context :up do
+    let(:provider_stub) { migration_stub(:Provider) }
+
+    it "resets nil values to OpenSSL::SSL::VERIFY_PEER" do
+      changed = provider_stub.create!(:verify_ssl => nil)
+      ignored = provider_stub.create!(:verify_ssl => OpenSSL::SSL::VERIFY_NONE)
+
+      migrate
+
+      expect(changed.reload.verify_ssl).to eq OpenSSL::SSL::VERIFY_PEER
+      expect(ignored.reload.verify_ssl).to eq OpenSSL::SSL::VERIFY_NONE
+    end
+  end
+end


### PR DESCRIPTION
Otherwise this hits the real model which is bad.  In addition, hitting
the model causes the STI checker to be enabled, which made this migration
take 1.2s to run.  Now it takes 0.003s.

@kbrock Please review.  I also added a spec which this should have had in the first place since it's a data migration.