### PR TITLE
Prevent const reassignment of GEMS_PENDING_ROOT

### DIFF
--- a/gems/pending/bundler_setup.rb
+++ b/gems/pending/bundler_setup.rb
@@ -1,5 +1,7 @@
-GEMS_PENDING_ROOT = File.expand_path(__dir__)
-$LOAD_PATH << GEMS_PENDING_ROOT
+unless defined?(GEMS_PENDING_ROOT)
+  GEMS_PENDING_ROOT = File.expand_path(__dir__)
+  $LOAD_PATH << GEMS_PENDING_ROOT
+end
 ENV['BUNDLE_GEMFILE'] ||= File.join(GEMS_PENDING_ROOT, "Gemfile")
 
 require 'rubygems'


### PR DESCRIPTION
When launched through the vmdb application, GEM_PENDING_ROOT is already
set.  This setup is mainly for testing and bootstrapping things in
gems/pending and will go away when they are gemified.

@chessbyte Please review.