### PR TITLE
default tenant reads out of settings not db

### DIFF
--- a/app/models/mixins/paperclip_ar_mixin.rb
+++ b/app/models/mixins/paperclip_ar_mixin.rb
@@ -1,0 +1,31 @@
+# paperclip needs a bunch of AR defined to work
+module PaperclipArMixin
+  extend ActiveSupport::Concern
+
+  included do
+    # Paperclip required model work
+    extend  ActiveModel::Callbacks
+    extend  ActiveModel::Naming
+    include ActiveModel::Model
+    include Paperclip::Glue
+    # Paperclip required callbacks
+    define_model_callbacks :save, :only => [:after]
+    define_model_callbacks :commit, :only => [:after]
+    define_model_callbacks :destroy, :only => [:before, :after]
+  end
+
+  def new_record?
+    false
+  end
+
+  module ClassMethods
+    def save
+      run_callbacks :save
+      true
+    end
+
+    def destroy
+      run_callbacks :destroy
+    end
+  end
+end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -51,6 +51,16 @@ class Tenant < ActiveRecord::Base
 
   before_save :nil_blanks
 
+  # @return [Boolean] Is this a default tenant?
+  def default?
+    subdomain == DEFAULT_URL && domain == DEFAULT_URL
+  end
+
+  # @return [Boolean] Is this a tenant reading out of settings?
+  def settings?
+    false
+  end
+
   def logo?
     !!logo_file_name
   end
@@ -63,9 +73,6 @@ class Tenant < ActiveRecord::Base
     Tenant.find_by(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL)
   end
 
-  def self.seed
-    Tenant.find_or_create_by(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL)
-  end
 
   private
 

--- a/app/models/tenant_default.rb
+++ b/app/models/tenant_default.rb
@@ -1,0 +1,77 @@
+# Default Tenant stores data in the settings not database
+class TenantDefault
+  include PaperclipArMixin
+
+  # original code hardcoded logo names
+  HARDCODED_LOGO = "custom_logo.png"
+  HARDCODED_LOGIN_LOGO = "custom_login_logo.png"
+
+  attr_reader :id # bigint
+
+  def initialize(_options = {})
+    @id = 1
+  end
+
+  has_attached_file :logo,
+                    :url  => "/uploads/#{HARDCODED_LOGO}",
+                    :path => ":rails_root/public/uploads/#{HARDCODED_LOGO}"
+
+  has_attached_file :login_logo,
+                    :url         => "/uploads/#{HARDCODED_LOGIN_LOGO}",
+                    :default_url => ":default_login_logo",
+                    :path        => ":rails_root/public/uploads/#{HARDCODED_LOGIN_LOGO}"
+
+  # session[:customer_name]
+  def company_name
+    settings.fetch_path(:server, :company)
+  end
+
+  # session[:vmdb_name]
+  def appliance_name
+    settings.fetch_path(:server, :name)
+  end
+
+  # session[:custom_logo]
+  def logo?
+    settings.fetch_path(:server, :custom_logo)
+  end
+
+  def login_logo?
+    settings.fetch_path(:server, :custom_login_logo)
+  end
+
+  # @return [Boolean] Is this a default tenant?
+  def default?
+    true
+  end
+
+  # @return [Boolean] Is this a tenant reading out of settings?
+  def settings?
+    true
+  end
+
+  def logo_file_name
+    logo? ? HARDCODED_LOGO : nil
+  end
+
+  def logo_content_type
+    'image/png'
+  end
+
+  def login_logo_file_name
+    login_logo? ? HARDCODED_LOGIN_LOGO : nil
+  end
+
+  def login_logo_content_type
+    'image/png'
+  end
+
+  alias_method :customer_name, :company_name
+  alias_method :vmdb_name, :appliance_name
+
+  private
+
+  def settings
+    @vmdb_config ||= VMDB::Config.new("vmdb").config
+  end
+end

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -4,3 +4,6 @@ rescue ActiveRecord::StatementInvalid, PG::ConnectionBad
   # This fails during migration if the tenants table doesn't exist yet
   # Allow migration to proceed
 end
+
+# fall back on just using config vmdb
+ActsAsTenant.default_tenant ||= TenantDefault.new

--- a/spec/controllers/application_controller/tenancy_spec.rb
+++ b/spec/controllers/application_controller/tenancy_spec.rb
@@ -3,8 +3,6 @@ require "spec_helper"
 describe DashboardController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    Tenant.seed
-    ActsAsTenant.default_tenant = Tenant.default_tenant
   end
 
   context "#with unknown subdomain or domain" do
@@ -12,9 +10,10 @@ describe DashboardController do
       @request.host = "www.example.com"
     end
 
+    # assumes database is empty and has no tenant objects
     it "defaults to default_domain" do
       get :login
-      expect(controller.send(:current_tenant)).to eq(Tenant.default_tenant)
+      expect(controller.send(:current_tenant)).to be_a(TenantDefault)
     end
   end
 

--- a/spec/models/tenant_default_spec.rb
+++ b/spec/models/tenant_default_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe TenantDefault do
+  let(:settings) { {} }
+  let(:tenant) { described_class.new }
+  before do
+    allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
+  end
+
+  describe "#default?" do
+    it "is default" do
+      expect(tenant).to be_default
+    end
+  end
+
+  describe "#default?" do
+    it "is using settings" do
+      expect(tenant).to be_settings
+    end
+  end
+
+  describe "#logo (with custom logo)" do
+    let(:settings) { {:server => {:custom_logo => true}} }
+
+    # for now, we are hard coding to uploads directory
+    it "has the hardcoded logo url" do
+      expect(tenant.logo.url).to eq("/uploads/custom_logo.png")
+    end
+
+    it "points to the hardcoded logo file" do
+      expect(tenant.logo.path).to eq(Rails.root.join("public/uploads/custom_logo.png").to_s)
+    end
+  end
+
+  describe "#logo?" do
+    it "knows when there is no logo" do
+      expect(tenant).not_to be_logo
+    end
+
+    context "with custom logo" do
+      let(:settings) { {:server => {:custom_logo => true}} }
+
+      it "knows when there a logo" do
+        expect(tenant).to be_logo
+      end
+    end
+  end
+
+  describe "#login_logo" do
+    # NOTE: initializers/paperclip.rb sets up :default_login_logo
+
+    it "has a default login image" do
+      expect(tenant.login_logo.url).to match(/login-screen-logo.png/)
+    end
+
+    context "with custom login logo" do
+      let(:settings) { {:server => {:custom_login_logo => true}} }
+
+      it "has custom login logo" do
+        expect(tenant.login_logo.url).to match(/custom_login_logo.png/)
+      end
+    end
+  end
+
+  describe "#login_logo?" do
+    it "knows when there is no login logo" do
+      expect(tenant).not_to be_login_logo
+    end
+
+    context "with custom login logo" do
+      let(:settings) { {:server => {:custom_login_logo => true}} }
+
+      it "knows when there is a login logo" do
+        expect(tenant).to be_login_logo
+      end
+    end
+  end
+
+  context "temporary names" do
+    let(:settings) do
+      {
+        :server => {
+          :company => "company",
+          :name    => "vmdb",
+        }
+      }
+    end
+    it "supports legacy vmdb_name" do
+      expect(described_class.new.customer_name).to eq('company')
+    end
+
+    it "supports legacy appliance_name" do
+      expect(described_class.new.vmdb_name).to eq('vmdb')
+    end
+  end
+end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe Tenant do
-  context "#default_tenant" do
+  describe "#default_tenant" do
     before do
-      Tenant.seed
+      Tenant.create
     end
 
     it "has a default tenant" do
@@ -11,7 +11,27 @@ describe Tenant do
     end
   end
 
-  context "#logo" do
+  describe "#default?" do
+    before do
+      Tenant.create
+    end
+
+    it "is default" do
+      expect(described_class.default_tenant).to be_default
+    end
+
+    it "is not default" do
+      expect(FactoryGirl.build(:tenant, :domain => 'x.com')).not_to be_default
+    end
+  end
+
+  describe "#settings?" do
+    it "is false" do
+      expect(described_class.new).not_to be_settings
+    end
+  end
+
+  describe "#logo" do
     let(:tenant) { FactoryGirl.create(:tenant, :logo_file_name => "image.png") }
 
     # NOTE: this currently returns a bogus url.
@@ -27,7 +47,7 @@ describe Tenant do
     end
   end
 
-  context "#logo?" do
+  describe "#logo?" do
     it "knows when there is a logo" do
       expect(described_class.new(:logo_file_name => "image.png")).to be_logo
     end
@@ -37,7 +57,7 @@ describe Tenant do
     end
   end
 
-  context "#login_logo" do
+  describe "#login_logo" do
     # NOTE: initializers/paperclip.rb sets up :default_login_logo
 
     let(:tenant) { FactoryGirl.create(:tenant) }
@@ -47,7 +67,7 @@ describe Tenant do
     end
   end
 
-  context "#login_logo?" do
+  describe "#login_logo?" do
     it "knows when there is a login logo" do
       expect(described_class.new(:login_logo_file_name => "image.png")).to be_login_logo
     end
@@ -57,7 +77,7 @@ describe Tenant do
     end
   end
 
-  context "#nil_blanks" do
+  describe "#nil_blanks" do
     it "nulls out blank domain" do
       expect(described_class.create(:domain => "  ").domain).to be_nil
     end


### PR DESCRIPTION
Up until now, most of the branding information is stored in vmdb configuration (aka `Configuration`, `vmdb.yml`, `vmdb.tmpl.yml`)

This introduced an object that looks like tenant, but reads the values out of `vmdb.yaml`. This will allow us to slowly migrate our code over to using the `tenants` table.

Since we are using paperclip, I needed to introduce a concern to let tenant (a non active record model) act enough like an ar model

Unsure what the tenant_id value should be, but we can probably solve that at a later time.

/cc @gmcculloug @chessbyte 