### PR TITLE
UiConstants should not call EmsEvent class methods

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -278,8 +278,9 @@ module ApplicationController::Timelines
   end
 
   def tl_build_filter(grp_name)             # hidden fields to highlight bands in timeline
-    arr = TL_ETYPE_GROUPS[grp_name][@tl_options[:fl_typ].downcase.to_sym]
-    arr.push(TL_ETYPE_GROUPS[grp_name][:critical]) if @tl_options[:fl_typ].downcase == "detail"
+    event_groups = EmsEvent.event_groups
+    arr = event_groups[grp_name][@tl_options[:fl_typ].downcase.to_sym]
+    arr.push(event_groups[grp_name][:critical]) if @tl_options[:fl_typ].downcase == "detail"
     filter = "(" << arr.join(")|(") << ")"
     return filter
   end
@@ -356,7 +357,7 @@ module ApplicationController::Timelines
     else
       @tl_options[:groups] = Array.new
       @tl_groups_hash = Hash.new
-      TL_ETYPE_GROUPS.each do |gname,list|
+      EmsEvent.event_groups.each do |gname,list|
         @tl_options[:groups].push(list[:name].to_s)
         @tl_groups_hash[list[:name].to_s] = gname
       end
@@ -435,23 +436,24 @@ module ApplicationController::Timelines
           end
         end
       else
+        event_groups = EmsEvent.event_groups
         if (!@tl_options[:filter1].nil? && @tl_options[:filter1] != "") ||
             (!@tl_options[:filter2].nil? && @tl_options[:filter2] != "") ||
             (!@tl_options[:filter3].nil? && @tl_options[:filter3] != "")
           if !@tl_options[:filter1].nil? && @tl_options[:filter1] != ""
-            event_set.push(TL_ETYPE_GROUPS[@tl_groups_hash[@tl_options[:filter1]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_groups_hash[@tl_options[:filter1]]
-            event_set.push(TL_ETYPE_GROUPS[@tl_groups_hash[@tl_options[:filter1]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+            event_set.push(event_groups[@tl_groups_hash[@tl_options[:filter1]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_groups_hash[@tl_options[:filter1]]
+            event_set.push(event_groups[@tl_groups_hash[@tl_options[:filter1]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
           end
           if !@tl_options[:filter2].nil? && @tl_options[:filter2] != ""
-            event_set.push(TL_ETYPE_GROUPS[@tl_groups_hash[@tl_options[:filter2]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_groups_hash[@tl_options[:filter2]]
-            event_set.push(TL_ETYPE_GROUPS[@tl_groups_hash[@tl_options[:filter2]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+            event_set.push(event_groups[@tl_groups_hash[@tl_options[:filter2]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_groups_hash[@tl_options[:filter2]]
+            event_set.push(event_groups[@tl_groups_hash[@tl_options[:filter2]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
           end
           if !@tl_options[:filter3].nil? && @tl_options[:filter3] != ""
-            event_set.push(TL_ETYPE_GROUPS[@tl_groups_hash[@tl_options[:filter3]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_groups_hash[@tl_options[:filter3]]
-            event_set.push(TL_ETYPE_GROUPS[@tl_groups_hash[@tl_options[:filter3]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+            event_set.push(event_groups[@tl_groups_hash[@tl_options[:filter3]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_groups_hash[@tl_options[:filter3]]
+            event_set.push(event_groups[@tl_groups_hash[@tl_options[:filter3]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
           end
         else
-          event_set.push(TL_ETYPE_GROUPS[:power][@tl_options[:fl_typ].to_sym])
+          event_set.push(event_groups[:power][@tl_options[:fl_typ].to_sym])
         end
       end
 

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -667,7 +667,7 @@ class MiqCapacityController < ApplicationController
     end
     @sb[:bottlenecks][:groups] = Array.new
     @tl_groups_hash = Hash.new
-    BOTTLENECK_TL_ETYPE_GROUPS.each do |gname,list|
+    EmsEvent.bottleneck_event_groups.each do |gname,list|
       @sb[:bottlenecks][:groups].push(list[:name].to_s)
       @tl_groups_hash[gname] ||= Array.new
       @tl_groups_hash[gname].concat(list[:detail]).uniq!

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -420,7 +420,7 @@ module MiqPolicyController::Alerts
     unless @sb[:alert][:events] # Only create this once
       vm_events = MiqAlert.expression_options("event_threshold").find{|eo|eo[:name]==:event_types}[:values] # Get the allowed events
       @sb[:alert][:events] ||= Hash.new
-      TL_ETYPE_GROUPS.each do |k,v|
+      EmsEvent.event_groups.each do |k,v|
         name = v[:name]
         v[:detail].each do |d|
           @sb[:alert][:events][d] = name + ": " + d if vm_events.include?(d)

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -273,12 +273,6 @@ module UiConstants
 
   VIEW_RESOURCES = DEFAULT_SETTINGS[:views].keys.each_with_object({}) { |value, acc| acc[value.to_s] = value }.freeze
 
-  # Options for timeline event groups for pulldowns and where clause
-  TL_ETYPE_GROUPS = EmsEvent.event_groups
-
-  # Options for timeline event groups for pulldowns and where clause
-  BOTTLENECK_TL_ETYPE_GROUPS = EmsEvent.bottleneck_event_groups
-
   TIMER_DAYS = [
     ["Day", "1"],
     ["2 Days", "2"],

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -41,19 +41,19 @@ class EmsEvent < ActiveRecord::Base
   end
 
   def self.task_final_events
-    return VMDB::Config.new('event_handling').config[:task_final_events]
+    @task_final_events ||= VMDB::Config.new('event_handling').config[:task_final_events]
   end
 
   def self.event_groups
-    return VMDB::Config.new('event_handling').config[:event_groups]
+    @event_groups ||= VMDB::Config.new('event_handling').config[:event_groups]
   end
 
   def self.bottleneck_event_groups
-    return VMDB::Config.new('event_handling').config[:bottleneck_event_groups]
+    @bottleneck_event_groups ||= VMDB::Config.new('event_handling').config[:bottleneck_event_groups]
   end
 
   def self.filtered_events
-    return VMDB::Config.new('event_handling').config[:filtered_events]
+    @filtered_events ||= VMDB::Config.new('event_handling').config[:filtered_events]
   end
 
   def self.group_and_level(event_type)


### PR DESCRIPTION
Currently, UiConstants cache EmsEvent configuration values.
Unfortunately, it gets loaded early in our process and loads the database models.

1. memoize 2 `EmsEvent` config variables in `EmsEvent` rather than in `UIConstant`.
2. leverage `.present?` instead of `!x.nil? || x == ""`, and `.presence` which is basically `x.blank? ? nil : x`
3. reduce duplication when composing the `event_set`.

/cc @lfu this should fix the migrations spec for #1527 
/cc @gmcculloug Let me know if this is too intrusive. While a few were obvious, and a few were more tame that we could have gone, it still is a bit of change
/cc @gmcculloug `tl_filter_options` pushes an array when a `:critical` or `:detail` value. so it will be `[a,b,[c,d]]` - which doesn't quite look right to me, but I didn't want to change.
/cc @Fryguy do you like the memoization?
/cc @dclarizio This changes `UIConstants`. Think @chessbyte would like to reduce that class a bit.