### PR TITLE
Topology widget for containers provider.

### DIFF
--- a/.brakeman.ignore
+++ b/.brakeman.ignore
@@ -704,6 +704,24 @@
       "user_input":null,
       "confidence":"Weak",
       "note":""
+    },
+    {
+      "warning_type":"Dynamic Render Path",
+      "warning_code":15,
+      "fingerprint":"01d3aa250efb62c0327b77aeb65375943ddda0c06e897aa657998ed7ed0494ee",
+      "message":"Render path contains parameter value",
+      "file":"app/views/ems_container/show.html.haml",
+      "line":4,
+      "link":"http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code":"render(partial => ((((\"config\" or (params[:display] or \"main\")) or \"timeline\") or \"config\") or \"main\"), {})",
+      "render_path":["EmsContainerController#show"],
+      "location":{
+        "type":"template",
+        "template":"ems_container/show (EmsContainerController#show)"
+    },
+      "user_input":"params[:display]",
+      "confidence":"High",
+      "note":""
     }
   ],
   "updated": "2015-08-13 18:47:21 +0200",

--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-bootstrap-datepicker",     "~>1.4.0"
   gem "rails-assets-bootstrap-hover-dropdown", "~>2.0.11"
   gem "rails-assets-bootstrap-select",         "~>1.7.3"
+  gem "rails-assets-kubernetes-topology-graph", "=0.0.16"
 end
 
 #

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,10 @@
 //= require controllers/ops/diagnostics_database_form_controller
 //= require controllers/ops/log_collection_form_controller
 //= require controllers/ops/tenant_form_controller
+//= require controllers/container_topology/container_topology_controller
+//= require d3/d3
+//= require c3/c3
+//= require kubernetes-topology-graph/topology-graph
 //= require miq_application
 //= require miq_dynatree_replacement
 //= require dialog_import_export
@@ -46,8 +50,6 @@
 //= require bootstrap-datepicker
 //= require bootstrap-select
 //= require bootstrap-hover-dropdown
-//= require c3/c3
-//= require d3/d3
 //= require patternfly
 //= require jquery.observe_field
 //= require miq_jquery_ujs_rails3

--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -1,0 +1,37 @@
+angular.module('topologyApp', ['kubernetesUI'])
+.config(['$httpProvider', function($httpProvider) {
+    $httpProvider.defaults.headers.common['X-CSRF-Token'] = jQuery('meta[name=csrf-token]').attr('content');
+}])
+.controller('containerTopologyController', ['$scope', '$http', '$interval', "$location",  function($scope, $http, $interval, $location) {
+    $scope.refresh = function() {
+        var id;
+        if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
+            id = '';
+        }
+        else {
+            id = '/'+ (/container_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
+        }
+
+        var url = '/container_topology/data'+id;
+        $http.get(url).success(function(data) {
+            $scope.items = data.data.items;
+            $scope.relations = data.data.relations;
+            $scope.kinds = data.data.kinds;
+        });
+
+    };
+
+    $scope.refresh();
+    var promise = $interval( $scope.refresh, 1000*60*3);
+
+    $scope.$on('$destroy', function() {
+        $interval.cancel(promise);
+    });
+}])
+
+.run(function($rootScope) {
+    $rootScope.$on("render", function(ev, vertices) {
+        vertices.selectAll("title").text(function(d) { return "Name: " + d.item.metadata.name + "\nType: " + d.item.kind });
+        ev.preventDefault();
+    })
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,4 +19,5 @@
  *= require jqplot
  *= require product_slickgrid
  *= require consoles
+ *= require kubernetes-topology-graph/topology-graph
 */

--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -1,0 +1,48 @@
+kubernetes-topology-graph {
+    border-top: 1px solid #eee;
+    position: fixed;
+    height: 76%;
+    width: 98%;
+    padding: 10px;
+}
+.legend {
+    font-family: sans-serif;
+    font-size: 15px;
+    display: inline-block;
+    padding: 0 10px;
+}
+.legend label {
+    font-weight: 400;
+}
+
+.legend div kubernetes-topology-icon svg.kube-topology circle {
+    stroke: #bbb !important;
+}
+
+.refresh {
+    display: inline-block;
+    width:35px;
+    height:35px;
+    padding:0;
+}
+
+#selected {
+    float: right;
+    display: block;
+    margin-top: 15px;
+}
+
+kubernetes-topology-icon {
+    padding: 7px 6px 12px 21px !important;
+}
+
+.kube-topology line.ServicePod {
+    stroke-linecap: round;
+    stroke-dasharray: 5.5;
+}
+
+kubernetes-topology-icon svg {
+    width: 39px !important;;
+    height: 39px !important;;
+    display: block;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2213,7 +2213,8 @@ class ApplicationController < ActionController::Base
       when "ems_cluster", "ems_infra", "host", "pxe", "repository", "resource_pool", "storage", "vm_infra"
         session[:tab_url][:inf] = inbound_url if ["show", "show_list", "explorer"].include?(action_name)
       when "container", "container_group", "container_node", "container_service", "ems_container",
-           "container_route", "container_project", "container_replicator", "container_image_registry", "container_image"
+           "container_route", "container_project", "container_replicator", "container_image_registry", "container_image",
+           "container_topology"
         session[:tab_url][:cnt] = inbound_url if %w(explorer show show_list).include?(action_name)
       when "miq_request"
         session[:tab_url][:svc] = inbound_url if ["index"].include?(action_name) && request.parameters["typ"] == "vm"

--- a/app/controllers/container_topology_controller.rb
+++ b/app/controllers/container_topology_controller.rb
@@ -1,0 +1,35 @@
+class ContainerTopologyController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def show
+    topology = generate_topology(params[:id])
+    @topologyitems = topology[:items].to_json
+    @topologyrelations = topology[:relations].to_json
+    @topologykinds = topology[:kinds].to_json
+  end
+
+  def index
+    redirect_to :action => 'show'
+  end
+
+  def data
+    render :json => {:data => generate_topology(params[:id])}
+  end
+
+  private
+
+  def get_session_data
+    @layout = "container_topology"
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+  end
+
+  def generate_topology(provider_id)
+    ContainerTopologyService.new(provider_id).build_topology
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -591,7 +591,7 @@ module ApplicationHelper
         %w(about chargeback exception miq_ae_automate_button miq_ae_class miq_ae_export
            miq_ae_tools miq_capacity_bottlenecks miq_capacity_planning miq_capacity_utilization
            miq_capacity_waste miq_policy miq_policy_export miq_policy_rsop ops pxe report rss
-           server_build).include?(@layout) ||
+           server_build container_topology).include?(@layout) ||
         (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
         unless @explorer
           @show_taskbar = true
@@ -1008,6 +1008,7 @@ module ApplicationHelper
 
   GTL_VIEW_LAYOUTS = %w(action availability_zone cim_base_storage_extent cloud_tenant condition container_group
                         container_route container_project container_replicator container_image container_image_registry
+                        container_topology
                         container_node container_service ems_cloud ems_cluster ems_container ems_infra event
                         flavor host miq_schedule miq_template offline ontap_file_share
                         ontap_logical_disk ontap_storage_system ontap_storage_volume orchestration_stack

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -5,6 +5,7 @@ module ApplicationHelper::PageLayouts
          @layout == "report" ||
          @layout == "exception" ||
          @layout == "chargeback" ||
+         @layout == "container_topology" ||
          @layout.starts_with?("miq_request") ||
          %w(about all_tasks all_ui_tasks configuration diagnostics miq_ae_automate_button miq_ae_export
             miq_ae_logs miq_ae_tools miq_policy miq_policy_export miq_policy_logs my_tasks my_ui_tasks

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -399,7 +399,7 @@ class ApplicationHelper::ToolbarChooser
         if %w(availability_zone cloud_tenant container_group container_node container_service ems_cloud ems_cluster
               ems_container container_project container_route container_replicator container_image
               container_image_registry ems_infra flavor host
-              ontap_file_share ontap_logical_disk
+              ontap_file_share ontap_logical_disk container_topology
               ontap_storage_system orchestration_stack repository resource_pool storage storage_manager
               timeline usage security_group).include?(@layout)
           if ["show_list"].include?(@lastaction)

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -24,6 +24,10 @@ module EmsContainerHelper::TextualSummary
     %i(zone tags)
   end
 
+  def textual_group_topology
+    items = %w(topology)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
   #
   # Items
   #
@@ -71,5 +75,12 @@ module EmsContainerHelper::TextualSummary
                  {:value => @ems.last_refresh_error.try(:truncate, 120)}],
       :title => @ems.last_refresh_error
     }
+  end
+
+  def textual_topology
+    {:label => N_('Topology'),
+     :image => 'container_topology',
+     :link  => url_for(:controller => 'container_topology', :action => 'show', :id => @ems.id),
+     :title => N_("Show topology")}
   end
 end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -90,6 +90,8 @@ module Menu
                          'container_image_registry',
                          {:feature => 'container_image_registry_show_list'},
                          '/container_image_registry'),
+          Menu::Item.new('container_topology', N_('Topology'), 'container_topology',
+                         {:feature => 'container_topology', :any => true}, '/container_topology')
         ])
       end
 

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -1,0 +1,80 @@
+class ContainerTopologyService
+  def initialize(provider_id)
+    @provider_id = provider_id
+  end
+
+  def build_topology
+    nodes, services = entities
+    topology = {}
+    topo_items = {}
+    links = []
+    nodes.each do |n|
+      topo_items[n.ems_ref] = build_entity(n.ems_ref, n.name, "Node")
+      n.container_groups.each do |cg|
+        topo_items[cg.ems_ref] = build_entity(cg.ems_ref, cg.name, "Pod")
+        links << build_link(n.ems_ref, cg.ems_ref)
+        cg.containers.each do |c|
+          topo_items[c.ems_ref] = build_entity(c.ems_ref, c.name, "Container")
+          links << build_link(cg.ems_ref, c.ems_ref)
+        end
+      end
+
+      if n.lives_on
+        kind = n.lives_on.kind_of?(Vm) ? "VM" : "Host"
+        topo_items[n.lives_on.uid_ems] = build_entity(n.lives_on.uid_ems, n.lives_on.name, kind)
+        links << build_link(n.ems_ref, n.lives_on.uid_ems)
+        if kind == 'VM' # add link to Host
+          host = n.lives_on.host
+          topo_items[host.uid_ems] = build_entity(host.uid_ems, host.name, "Host")
+          links << build_link(n.lives_on.uid_ems, host.uid_ems)
+        end
+      end
+    end
+
+    services.each do |s|
+      topo_items[s.ems_ref] = build_entity(s.ems_ref, s.name, "Service")
+      s.container_groups.each { |cg| links << build_link(s.ems_ref, cg.ems_ref) } if s.container_groups.size > 0
+    end
+
+    topology[:items] = topo_items
+    topology[:relations] = links
+    topology[:kinds] = build_kinds
+    topology
+  end
+
+  def build_entity(id, name, kind)
+    {:metadata => {:id => id, :name => name}, :kind => kind}
+  end
+
+  def build_link(source, target)
+    {:source => source, :target => target}
+  end
+
+  def entities
+    # provider id is empty when the topology is generated for all the providers together
+    if @provider_id
+      provider = ExtManagementSystem.find(@provider_id.to_i)
+      if provider.kind_of?(ManageIQ::Providers::Openshift::ContainerManager) || provider.kind_of?(ManageIQ::Providers::Kubernetes::ContainerManager)
+        nodes = provider.container_nodes
+        services = provider.container_services
+      else
+        nodes = ContainerNode.all
+        services = ContainerService.all
+      end
+    else
+      nodes = ContainerNode.all
+      services = ContainerService.all
+    end
+    [nodes, services]
+  end
+
+  def build_kinds
+    {:Pod            => '#vertex-Pod',
+     :Container      => '#vertex-Container',
+     :Node           => '#vertex-Node',
+     :Service        => '#vertex-Service',
+     :Host           => '#vertex-Host',
+     :VM             => '#vertex-VM'
+    }
+  end
+end

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -37,7 +37,7 @@
                   .col-md-8
                     %ul#toolbars= render_view_buttons(resource, @edit[:new][:views][resource])
         - if get_vmdb_config[:product][:containers]
-          - if has_any_role?(%w(ems_container_show_list container_group_show_list container_node_show_list container_route_show_list container_project_show_list container_replicator_show_list container_image_show_list container_image_registry_show_list container_service_accord containers_filter_accord containers_accord))
+          - if has_any_role?(%w(ems_container_show_list container_group_show_list container_node_show_list container_route_show_list container_project_show_list container_replicator_show_list container_image_show_list container_image_registry_show_list container_service_accord containers_filter_accord containers_accord container_topology))
             %fieldset
               %h3
                 = _('Containers')
@@ -50,7 +50,8 @@
                         :containerreplicator    => "container_replicator",
                         :containerimage         => "container_image",
                         :containerimageregistry => "container_image_registry",
-                        :container              => "container"}
+                        :container              => "container",
+                        :containertopology      => "container_topology"}
               - keys.each do |resource, table_view_name|
                 .form-group
                   %label.col-md-3.control-label

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -1,0 +1,68 @@
+%div{'data-ng-app' => "topologyApp", 'ng-controller' => "containerTopologyController"}
+  = stylesheet_link_tag 'container_topology'
+  %image{:src => "/images/toolbars/refresh.png", 'ng-click' => "refresh()", :class => "btn btn-default refresh"}
+  %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
+
+  .legend
+    %label#selected
+    %div{'ng-if' => "kinds"}
+      %kubernetes-topology-icon{:kind => "Pod"}
+        %svg.kube-topology
+          %use{'xlink:href' => "#vertex-Pod", :x => "19", :y => "19"}
+
+      %label
+        Pods
+      %kubernetes-topology-icon{:kind => "Container"}
+        %svg.kube-topology
+          %use{'xlink:href' => "#vertex-Container", :x => "19", :y => "19"}
+
+      %label
+        Containers
+      %kubernetes-topology-icon{:kind => "Service"}
+        %svg.kube-topology
+          %use{'xlink:href' => "#vertex-Service", :x => "19", :y => "19"}
+      %label
+        Services
+      %kubernetes-topology-icon{:kind => "Node"}
+        %svg.kube-topology
+          %use{'xlink:href' => "#vertex-Node", :x => "19", :y => "19"}
+
+      %label
+        Nodes
+      %kubernetes-topology-icon{:kind => "VM"}
+        %svg.kube-topology
+          %use{'xlink:href' => "#vertex-VM", :x => "19", :y => "19"}
+
+      %label
+        VMs
+      %kubernetes-topology-icon{:kind => "Host"}
+        %svg.kube-topology
+          %use{'xlink:href' => "#vertex-Host", :x => "19", :y => "19"}
+
+      %label
+        Hosts
+
+  %svg.kube-topology{:hidden => 'hidden'}
+    %defs
+      %g.Node#vertex-Node
+        %circle{:r => "18"}
+        %image{'xlink:href' => "/images/icons/new/container_node.png", :width => "18", :height => "18",
+        :x => "-9", :y => "-9"}
+      %g.Pod#vertex-Pod
+        %circle{:r => "18"}
+        %image{'xlink:href' => "/images/icons/new/container_group.png", :width => "18", :height => "18",
+        :x => "-9", :y => "-9"}
+      %g.Service#vertex-Service
+        %circle{:r => "18"}
+        %image{'xlink:href' => "/images/icons/new/container_service.png", :width => "18", :height => "18",
+        :x => "-9", :y => "-9"}
+      %g.Container#vertex-Container
+        %circle{:r => "18"}
+        %image{'xlink:href' => "/images/icons/new/container.png", :width => "18", :height => "18",
+        :x => "-9", :y => "-9"}
+      %g.VM#vertex-VM
+        %circle{:r => "18"}
+        %image{'xlink:href' => "/images/icons/new/vm.png", :width => "18", :height => "18", :x => "-9", :y => "-9"}
+      %g.Host#vertex-Host
+        %circle{:r => "18"}
+        %image{'xlink:href' => "/images/icons/new/host.png", :width => "18", :height => "18", :x => "-9", :y => "-9"}

--- a/app/views/ems_container/_main.html.haml
+++ b/app/views/ems_container/_main.html.haml
@@ -1,1 +1,13 @@
-= render :partial => "shared/views/ems_common/main"
+= render :partial => "layouts/flash_msg"
+.row
+  .col-sm-12.col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"),
+                                                               :items => textual_group_properties}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Status"), :items => textual_group_status}
+  .col-sm-12.col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
+                                                               :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Topology"),
+                                                               :items => textual_group_topology}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
+                                                                    :items => textual_group_smart_management}

--- a/app/views/ems_container/show.html.haml
+++ b/app/views/ems_container/show.html.haml
@@ -1,1 +1,5 @@
-= render :partial => "shared/views/ems_common/show"
+- if %w(containers container_groups container_services container_routes container_replicators container_nodes container_projects container_images container_image_registries).include?(@display)
+  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+- else
+  = render :partial => @showtype
+

--- a/app/views/layouts/_view_buttons.html.haml
+++ b/app/views/layouts/_view_buttons.html.haml
@@ -6,7 +6,7 @@
   - elsif @lastaction == "drift"
     = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "drift_view_tb"}
   - elsif !%w(all_tasks all_ui_tasks timeline diagnostics my_tasks my_ui_tasks miq_server usage).include?(@layout) |
-    && !@layout.starts_with?("miq_request") && !@treesize_buttons |
+    && (!@layout.starts_with?("miq_request")) && !@treesize_buttons |
     && @display == "main" && @showtype == "main" && !@in_a_form |
     = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "view_tb", :tb_yaml => "summary_view_tb"}
   - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -534,6 +534,13 @@ Vmdb::Application.routes.draw do
       ) + adv_search_post + exp_post + save_post
     },
 
+    :container_topology => {
+      :get => %w(
+        show
+        data
+      )
+    },
+
     :dashboard => {
       :get => %w(
         auth_error

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3957,6 +3957,17 @@
       :feature_type: control
       :identifier: container_tag
 
+  # Container Topology
+  - :name: Containers Topology
+    :description: Containers Topology
+    :feature_type: node
+    :identifier: container_topology
+    :children:
+      - :name: View
+        :description: View Containers Topology
+        :feature_type: view
+        :identifier: container_topology_view
+
 # Foreman
 - :name: Configuration Management
   :description: Everything under Configuration Management

--- a/spec/controllers/container_topology_controller_spec.rb
+++ b/spec/controllers/container_topology_controller_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe ContainerTopologyController do
+  render_views
+  before(:each) do
+    set_user_privileges
+  end
+
+  it "renders index" do
+    get :index
+    expect(response.status).to eq(302)
+    response.should redirect_to(:action => 'show')
+  end
+
+  it "renders show screen per provider id" do
+    EvmSpecHelper.create_guid_miq_server_zone
+    ems = FactoryGirl.create(:ems_kubernetes)
+    get :show, :id => ems.id
+    expect(response.status).to eq(200)
+    expect(response.body).to_not be_empty
+    expect(response).should render_template('container_topology/show')
+  end
+
+  it "renders show screen for all providers" do
+    EvmSpecHelper.create_guid_miq_server_zone
+    get :show
+    expect(response.status).to eq(200)
+    expect(response.body).to_not be_empty
+    expect(response).should render_template('container_topology/show')
+  end
+end

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -5,14 +5,14 @@ describe MiqProductFeature do
     it "empty table" do
       MiqRegion.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(844)
+      MiqProductFeature.count.should eq(846)
     end
 
     it "run twice" do
       MiqRegion.seed
       MiqProductFeature.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(844)
+      MiqProductFeature.count.should eq(846)
     end
 
     it "with existing records" do
@@ -23,7 +23,7 @@ describe MiqProductFeature do
 
       MiqRegion.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(844)
+      MiqProductFeature.count.should eq(846)
       expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
       changed.reload.name.should == "About"
       unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+describe ContainerTopologyService do
+  let(:container_topology_service) { described_class.new(nil) }
+
+  describe "#build_kinds" do
+    it "creates the expected number of entity types" do
+      container_topology_service.build_kinds.size.should eql 6
+    end
+
+    it "kinds contains an expected key" do
+      container_topology_service.build_kinds.key?(:Pod).should be_true
+    end
+  end
+
+  describe "#build_link" do
+    it "creates link between source to target" do
+      container_topology_service.build_link("95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                            "96c35f65-3e00-11e5-a0d2-18037327aaeb").size.should eql 2
+      container_topology_service.build_link("95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                            "96c35f65-3e00-11e5-a0d2-18037327aaeb").key?(:source).should be_true
+      container_topology_service.build_link("95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                            "96c35f65-3e00-11e5-a0d2-18037327aaeb").key?(:target).should be_true
+      container_topology_service.build_link("95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                            "96c35f65-3e00-11e5-a0d2-18037327aaeb")[:source].should eq "95e49048-3e00-11e5-a0d2-18037327aaeb"
+      container_topology_service.build_link("95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                            "96c35f65-3e00-11e5-a0d2-18037327aaeb")[:target].should eq "96c35f65-3e00-11e5-a0d2-18037327aaeb"
+    end
+  end
+
+  describe "#build_topology" do
+    it "topology contains expected number of keys" do
+      container_topology_service.build_topology.size.should eql 3
+    end
+
+    it "topology contains expected keys" do
+      container_topology_service.build_topology.key?(:items).should be_true
+      container_topology_service.build_topology.key?(:relations).should be_true
+      container_topology_service.build_topology.key?(:kinds).should be_true
+    end
+
+    it "topology contains the expected structure and content" do
+      ems = FactoryGirl.create(:ems_kubernetes)
+      container_node = ContainerNode.create(:ext_management_system => ems, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb")
+      container_group = ContainerGroup.create(:ext_management_system => ems, :container_node => container_node, :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb")
+      container_service = ContainerService.create(:ext_management_system => ems, :container_groups => [container_group], :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                              :name => "service1")
+
+      container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
+      container_topology_service.build_topology[:items].size.should eql 3
+      container_topology_service.build_topology[:relations].size.should eql 2
+
+      container_topology_service.build_topology[:items].key? "905c90ba-3e00-11e5-a0d2-18037327aaeb"
+      container_topology_service.build_topology[:items]["905c90ba-3e00-11e5-a0d2-18037327aaeb"].should eql({:metadata => {:id => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :name => "127.0.0.1"}, :kind => "Node"})
+    end
+  end
+
+  describe "#entities" do
+    it "returns correct number of entity types" do
+      container_topology_service.entities.size.should eql 2
+    end
+  end
+end


### PR DESCRIPTION
Displays a graph of container related entities and
their relationships, as well as cross provider relationships
with vms and hosts if such exist.
The patch adds a new UI screen, menu, navigation and backend
logic that enables the topology.

![topologylatest](https://cloud.githubusercontent.com/assets/6277245/8766604/1eebb3ee-2e48-11e5-9932-7e524ad0482f.png)
