### PR TITLE
Move NtUtil.NtToRubyTime to gems/pending/util/win32

### DIFF
--- a/gems/pending/fs/ntfs/NtUtil.rb
+++ b/gems/pending/fs/ntfs/NtUtil.rb
@@ -2,17 +2,6 @@
 
 module NtUtil
 
-  def NtUtil.NtToRubyTime(ntTime)
-    # Convert an NT FILETIME to a Ruby Time object.
-    begin
-      ntTime = ntTime / 10000000 - 11644495200
-      ntTime = 0 if ntTime < 0
-      Time.at(ntTime).gmtime
-    rescue RangeError
-      ntTime
-    end
-  end
-
   # Make a reference (upper two bytes are seq num, lower six are entry).
   def NtUtil.MkRef(ref)
     ref.divmod(2 ** 48)

--- a/gems/pending/fs/ntfs/NtfsAttribFileName.rb
+++ b/gems/pending/fs/ntfs/NtfsAttribFileName.rb
@@ -1,4 +1,5 @@
 require 'fs/ntfs/NtUtil'
+require 'util/win32/nt_util'
 
 require 'binary_struct'
 require 'util/miq-unicode'

--- a/gems/pending/fs/ntfs/NtfsAttribFileName.rb
+++ b/gems/pending/fs/ntfs/NtfsAttribFileName.rb
@@ -79,15 +79,15 @@ module NTFS
 		end
 		
     def mTime
-      @mTime ||= NtUtil.NtToRubyTime(@afn['time_altered'])
+      @mTime ||= NtUtil.nt_filetime_to_ruby_time(@afn['time_altered'])
     end
 
     def aTime
-			@aTime ||= NtUtil.NtToRubyTime(@afn['time_read'])
+			@aTime ||= NtUtil.nt_filetime_to_ruby_time(@afn['time_read'])
     end
 
     def cTime
-			@cTime ||= NtUtil.NtToRubyTime(@afn['time_created'])
+			@cTime ||= NtUtil.nt_filetime_to_ruby_time(@afn['time_created'])
     end
 
 		# Returns nil if not directory.
@@ -100,7 +100,7 @@ module NTFS
 			out << "  Parent dir : seq #{@refParent[0]}, entry #{@refParent[1]}\n"
 			out << "  Created    : #{@cTime}\n"
 			out << "  Modified   : #{@mTime}\n"
-			out << "  MFT changed: #{NtUtil.NtToRubyTime(@afn['time_mft_changed'])}\n"
+			out << "  MFT changed: #{NtUtil.nt_filetime_to_ruby_time(@afn['time_mft_changed'])}\n"
 			out << "  Accessed   : #{@aTime}\n"
 			out << "  Allocated  : #{@afn['allocated_size']}\n"
 			out << "  Real size  : #{@length}\n"

--- a/gems/pending/fs/ntfs/NtfsAttribStandardInformation.rb
+++ b/gems/pending/fs/ntfs/NtfsAttribStandardInformation.rb
@@ -83,9 +83,9 @@ module NTFS
 			
 			buf          = buf.read(buf.length) if buf.kind_of?(DataRun)
 			@asi         = ATTRIB_STANDARD_INFORMATION.decode(buf)
-			@mTime       = NtUtil.NtToRubyTime(@asi['time_altered'])
-			@aTime       = NtUtil.NtToRubyTime(@asi['time_read'])
-			@cTime       = NtUtil.NtToRubyTime(@asi['time_created'])
+			@mTime       = NtUtil.nt_filetime_to_ruby_time(@asi['time_altered'])
+			@aTime       = NtUtil.nt_filetime_to_ruby_time(@asi['time_read'])
+			@cTime       = NtUtil.nt_filetime_to_ruby_time(@asi['time_created'])
 			@permissions = @asi['dos_permissions']
 		end
 	  
@@ -93,7 +93,7 @@ module NTFS
 			out = "\#<#{self.class}:0x#{'%08x' % self.object_id}>\n"
 			out << "  Time created    : #{@cTime}\n"
 			out << "  Time altered    : #{@mTime}\n"
-			out << "  Time mft changed: #{NtUtil.NtToRubyTime(@asi['time_mft_changed'])}\n"
+			out << "  Time mft changed: #{NtUtil.nt_filetime_to_ruby_time(@asi['time_mft_changed'])}\n"
 			out << "  Time read       : #{@aTime}\n"
 			out << "  Permissions     : 0x#{'%08x' % @permissions}\n"
 			out << "  Max versions    : #{@asi['max_versions']}\n"

--- a/gems/pending/fs/ntfs/NtfsAttribStandardInformation.rb
+++ b/gems/pending/fs/ntfs/NtfsAttribStandardInformation.rb
@@ -1,4 +1,4 @@
-require 'fs/ntfs/NtUtil'
+require 'util/win32/nt_util'
 
 require 'binary_struct'
 

--- a/gems/pending/util/win32/nt_util.rb
+++ b/gems/pending/util/win32/nt_util.rb
@@ -1,0 +1,15 @@
+# encoding: US-ASCII
+
+module NtUtil
+
+  def NtUtil.NtToRubyTime(ntTime)
+    # Convert an NT FILETIME to a Ruby Time object.
+    begin
+      ntTime = ntTime / 10000000 - 11644495200
+      ntTime = 0 if ntTime < 0
+      Time.at(ntTime).gmtime
+    rescue RangeError
+      ntTime
+    end
+  end
+end

--- a/gems/pending/util/win32/nt_util.rb
+++ b/gems/pending/util/win32/nt_util.rb
@@ -1,15 +1,12 @@
 # encoding: US-ASCII
 
 module NtUtil
-
-  def NtUtil.NtToRubyTime(ntTime)
+  def self.nt_filetime_to_ruby_time(nt_time)
     # Convert an NT FILETIME to a Ruby Time object.
-    begin
-      ntTime = ntTime / 10000000 - 11644495200
-      ntTime = 0 if ntTime < 0
-      Time.at(ntTime).gmtime
-    rescue RangeError
-      ntTime
-    end
+    nt_time = nt_time / 10_000_000 - 11_644_495_200
+    nt_time = 0 if nt_time < 0
+    Time.at(nt_time).gmtime
+  rescue RangeError
+    nt_time
   end
 end

--- a/gems/pending/util/win32/wim_parser.rb
+++ b/gems/pending/util/win32/wim_parser.rb
@@ -13,7 +13,7 @@ require "binary_struct"
 #       http://msdn.microsoft.com/en-us/library/windows/desktop/aa373931%28v=vs.85%29.aspx
 #       http://stackoverflow.com/questions/679381/accessing-guid-members-in-c-sharp
 class WimParser
-  autoload :NtUtil,   "#{File.dirname(__FILE__)}/../../fs/ntfs/NtUtil"
+  autoload :NtUtil,   "util/win32/nt_util"
   autoload :Nokogiri, "nokogiri"
 
   HEADER_V1_STRUCT = BinaryStruct.new([

--- a/gems/pending/util/win32/wim_parser.rb
+++ b/gems/pending/util/win32/wim_parser.rb
@@ -97,11 +97,11 @@ class WimParser
       #   to an integer, and then converting that to a time object.
       high_part     = i.xpath("./CREATIONTIME/HIGHPART").text[2..-1].rjust(8, '0')
       low_part      = i.xpath("./CREATIONTIME/LOWPART").text[2..-1].rjust(8, '0')
-      creation_time = NtUtil.NtToRubyTime("#{high_part}#{low_part}".to_i(16))
+      creation_time = NtUtil.nt_filetime_to_ruby_time("#{high_part}#{low_part}".to_i(16))
 
       high_part     = i.xpath("./LASTMODIFICATIONTIME/HIGHPART").text[2..-1].rjust(8, '0')
       low_part      = i.xpath("./LASTMODIFICATIONTIME/LOWPART").text[2..-1].rjust(8, '0')
-      last_mod_time = NtUtil.NtToRubyTime("#{high_part}#{low_part}".to_i(16))
+      last_mod_time = NtUtil.nt_filetime_to_ruby_time("#{high_part}#{low_part}".to_i(16))
 
       {
         "index"                  => i["INDEX"].to_i,


### PR DESCRIPTION
Turns out that `gems/pending/util/win32/wim_parser.rb` uses this method and, because of that, it does not belong in `gems/pending/fs/ntfs`.