### PR TITLE
Convert Fixnum to AS::Duration before calling 'ago'.

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -368,8 +368,14 @@ class EmsEvent < ActiveRecord::Base
   # Purging methods
   #
 
+  def self.keep_ems_events
+    VMDB::Config.new("vmdb").config.fetch_path(:ems_events, :history, :keep_ems_events)
+  end
+
   def self.purge_date
-    (VMDB::Config.new("vmdb").config.fetch_path(:ems_events, :history, :keep_ems_events) || 6.months).to_i_with_method.ago.utc
+    keep = keep_ems_events.to_i_with_method.seconds
+    keep = 6.months if keep == 0
+    keep.ago.utc
   end
 
   def self.purge_window_size

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -182,6 +182,20 @@ describe EmsEvent do
       end
     end
 
+    context ".purge_date" do
+      it "using '3.month' syntax" do
+        described_class.stub(:keep_ems_events => "3.months")
+
+        # Exposes 3.months.seconds.ago.utc != 3.months.ago.utc
+        described_class.purge_date.should be_within(2.days).of(3.months.ago.utc)
+      end
+
+      it "defaults to 6 months" do
+        described_class.stub(:keep_ems_events => nil)
+        described_class.purge_date.should be_within(1.day).of(6.months.ago.utc)
+      end
+    end
+
     context "#purge_queue" do
       let(:purge_time) { (Time.now + 10).round }
 


### PR DESCRIPTION
Rails 4 removed 'ago' monkey patch from Fixnum.

Fixes #3523