### PR TITLE
Fix sporadic ordering failure

### DIFF
--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -155,7 +155,7 @@ describe DialogFieldTagControl do
       it "automate_output_value with multiple values" do
         tags = [Classification.first, Classification.last]
         @df.value = tags.collect(&:id).join(",")
-        @df.automate_output_value.should == tags.collect{|tag| "#{tag.class.name}::#{tag.id}"}.join(",")
+        @df.automate_output_value.split(",").should match_array tags.collect{|tag| "#{tag.class.name}::#{tag.id}"}
       end
     end
   end


### PR DESCRIPTION
@gmcculloug  Please review.

The way that DialogFieldTagControl#automate_output_value works is that it queries the DB for the values in value.split(","), then combines them.  They can come back in various orders, so the test needs to be flexible on that.