### PR TITLE
fix build assets

### DIFF
--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,6 +1,6 @@
 begin
   ActsAsTenant.default_tenant = Tenant.default_tenant
-rescue ActiveRecord::StatementInvalid
+rescue ActiveRecord::StatementInvalid, PG::ConnectionBad
   # This fails during migration if the tenants table doesn't exist yet
   # Allow migration to proceed
 end


### PR DESCRIPTION
for evm:assets_compile, there is no database.
The acts_as_tenant initializer tries to load the default tenant, but fails.

This accepts the error and continues.

This should cause the nightly build to fail. Not sure if it is showing up there.

/cc @gmcculloug 
/cc @roliveri this is the bug you were seeing on your appliance