### PR TITLE
Fix 5.2 -> 5.4 db:migration with replication

### DIFF
--- a/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
+++ b/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
@@ -160,11 +160,11 @@ class FixReplicationOnUpgradeFromVersionFour < ActiveRecord::Migration
       require 'awesome_spawn'
 
       say_with_time("Preparing rubyrep") do
-        AwesomeSpawn.run!("bin/rake evm:dbsync:prepare_replication_without_sync")
+        AwesomeSpawn.run!("bin/rake evm:db:environmentlegacykey evm:dbsync:prepare_replication_without_sync")
       end
 
       say_with_time("Uninstalling rubyrep for renamed tables") do
-        AwesomeSpawn.run!("bin/rake evm:dbsync:uninstall #{RENAMED_TABLES.values.join(" ")}")
+        AwesomeSpawn.run!("bin/rake evm:db:environmentlegacykey evm:dbsync:uninstall #{RENAMED_TABLES.values.join(" ")}")
       end
     end
   end

--- a/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
+++ b/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
@@ -44,8 +44,8 @@ describe FixReplicationOnUpgradeFromVersionFour do
         # them unless we have replication set up, which is not yet possible in a
         # migration spec.
         require 'awesome_spawn'
-        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:dbsync:prepare_replication_without_sync")
-        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:dbsync:uninstall drift_states miq_cim_derived_metrics miq_request_tasks miq_storage_metrics storages_vms_and_templates")
+        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:prepare_replication_without_sync")
+        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:uninstall drift_states miq_cim_derived_metrics miq_request_tasks miq_storage_metrics storages_vms_and_templates")
       end
 
       it "for renamed tables in rr_pending_changes" do


### PR DESCRIPTION
When migrating from 5.2 to 5.4, the replication workers have
the password stored with an old encryption key. This causes the migration to
fail.

This loads legacy keys so those tasks can complete


NOTE: @carbonin was not able to reproduce this error, but were able to track this down to the line that the error occurred for others.

https://bugzilla.redhat.com/show_bug.cgi?id=1238443

/cc @carbonin this should clear up your PR
/cc @Fryguy @chessbyte 