### PR TITLE
Convert style1 to patternfly in chargeback

### DIFF
--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -2,12 +2,14 @@
 = render :partial => "layouts/flash_msg"
 #form_div
   %h3=_('Basic Info')
-  %table.style1
-    %tr
-      %td.key=_('Description')
-      %td
+  %form.form-horizontal.static
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
         = text_field_tag("description", @edit[:new][:description],
-          :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                        :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+                        :class => "form-control")
         = javascript_tag(javascript_focus('description'))
 
   %hr

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -3,11 +3,13 @@
   = render :partial => "cb_rate_edit"
 - else
   %h3=_('Basic Info')
-  %table.style1
-    %tr
-      %td.key=_('Description')
-      %td
-        = h(@record.description)
+  %form.form-horizontal.static
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
+        %p.form-control-static
+          = h(@record.description)
   %hr
   %h3=_('Rate Details')
   %table.table.table-bordered

--- a/app/views/chargeback/_chargeback_rates.html.haml
+++ b/app/views/chargeback/_chargeback_rates.html.haml
@@ -1,13 +1,14 @@
 #chargeback_rates_div{:style => "width: 100%; height: 100%; overflow: auto;"}
   - if @sb[:chargeback][:report]
     %h3=_('Current Rates')
-    %table.style1
+    %form.form-horizontal.static
       - Chargeback::default_rates().sort_by{ |a| a.description.downcase }.each do |r|
-        %tr
-          %td.key{:style => "width: 250px;"}
+        .form-group
+          %label.col-md-2.control-label
             = h(r.description)
-          %td
-            = h(r.friendly_rate)
+          .col-md-8
+            %p.form-control-static
+              = h(r.friendly_rate)
 
   - unless @sb[:chargeback][:report]
     = render :partial =>"chargeback_instructions"


### PR DESCRIPTION
Parent issue: #3139
Convert style1 tables into patternfly in chargeback views

Before:
![chargebackeditbefore](https://cloud.githubusercontent.com/assets/9535558/8799218/ccbcb69c-2fa8-11e5-950a-b67491f9e4ef.png)

After:
![chargebackeditafter](https://cloud.githubusercontent.com/assets/9535558/8799279/40a4c48c-2fa9-11e5-90e6-7287bc3f8558.png)



Before:
![chargebackshowbefore](https://cloud.githubusercontent.com/assets/9535558/8799303/73521a92-2fa9-11e5-94ee-6f2af3f33d85.png)



After:
![chargebackshowafter](https://cloud.githubusercontent.com/assets/9535558/8799226/db1f364c-2fa8-11e5-8c19-9314ec333421.png)

@epwinchell can you read this please?