### PR TITLE
Convert style1 to patternfly in customization

### DIFF
--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -1,287 +1,360 @@
 - url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
 #dialog_field_div
-  %fieldset
-    %h3= _('Element Information')
-    %table.style1
-      %tr
-        %td.key= _('Label')
-        %td.wide
-          = text_field_tag("field_label",
-            @edit[:field_label],
-            :maxlength         => MAX_NAME_LEN,
-            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          = javascript_tag(javascript_focus('field_label'))
+  %h3
+    = _('Element Information')
+  %form.form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Label')
+      .col-md-8
+        = text_field_tag("field_label",
+                        @edit[:field_label],
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+        = javascript_tag(javascript_focus('field_label'))
 
-      %tr
-        %td.key= _('Name')
-        %td.wide
-          = text_field_tag("field_name",
-            @edit[:field_name],
-            :maxlength         => MAX_NAME_LEN,
-            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      %tr
-        %td.key= _('Description')
-        %td.wide
-          = text_field_tag("field_description",
-            @edit[:field_description],
-            :maxlength         => 100,
-            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      %tr
-        %td.key= _('Type')
-        %td.wide
-          = select_tag('field_typ',
-            options_for_select(([["<#{_('Choose')}>", nil]]) + Array(@edit[:field_types].invert).sort, @edit[:field_typ]),
-            "data-miq_observe" => {:url => url}.to_json)
-          - if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
-            &nbsp;
-            = _('Only 1 Date or Date/Time element can be present in a Dialog')
+    .form-group
+      %label.col-md-2.control-label
+        = _('Name')
+      .col-md-8
+        = text_field_tag("field_name",
+                        @edit[:field_name],
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
+        = text_field_tag("field_description",
+                        @edit[:field_description],
+                        :maxlength         => 100,
+                        :class => "form-control",
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Type')
+      .col-md-8
+        = select_tag('field_typ',
+                      options_for_select(([["<#{_('Choose')}>", nil]]) + Array(@edit[:field_types].invert).sort, @edit[:field_typ]),
+                      :class    => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("field_typ", "#{url}")
+        - if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
+          &nbsp;
+          = _('Only 1 Date or Date/Time element can be present in a Dialog')
 
-      - if DialogField::DIALOG_FIELD_DYNAMIC_CLASSES.include?(@edit[:field_typ])
-        %tr
-          %td.key= _('Dynamic')
-          %td
-            = check_box_tag('field_dynamic', '1', @edit[:field_dynamic], "data-miq_observe_checkbox" => {:url => url}.to_json)
+    - if DialogField::DIALOG_FIELD_DYNAMIC_CLASSES.include?(@edit[:field_typ])
+      .form-group
+        %label.col-md-2.control-label
+          = _('Dynamic')
+        .col-md-8
+          = check_box_tag('field_dynamic', '1', @edit[:field_dynamic], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
   - unless @edit[:field_typ].nil?
-    %fieldset
-      %h3= _('Options')
-      %table.style1
-        - if @edit[:field_dynamic] == true
-          %tr
-            %td.key= _('Entry Point (NS/Cls/Inst)')
-            %td.wide
-              = text_field_tag('field_entry_point',
-                @edit[:field_entry_point],
-                :onFocus => 'miqShowAE_Tree("field_entry_point");')
-          %tr
-            %td.key= _('Show Refresh Button')
-            %td
-              = check_box_tag('field_show_refresh_button', '1',
-                @edit[:field_show_refresh_button],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
-          - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
-            %tr
-              %td.key= _('Load Values on Init')
-              %td
-                = check_box_tag('field_load_on_init', '1',
-                  @edit[:field_load_on_init],
-                  'data-miq_observe_checkbox' => {:url => url}.to_json)
+    %h3
+      = _('Options')
+    %form.form-horizontal
+      - if @edit[:field_dynamic] == true
+        .form-group
+          %label.col-md-2.control-label
+            = _('Entry Point (NS/Cls/Inst)')
+          .col-md-8
+            = text_field_tag('field_entry_point',
+                              @edit[:field_entry_point],
+                              :class => "form-control",
+                              :onFocus => 'miqShowAE_Tree("field_entry_point");')
+        .form-group
+          %label.col-md-2.control-label
+            = _('Show Refresh Button')
+          .col-md-8
+            = check_box_tag('field_show_refresh_button', '1',
+                            @edit[:field_show_refresh_button],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
+        - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
+          .form-group
+            %label.col-md-2.control-label
+              = _('Load Values on Init')
+            .col-md-8
+              = check_box_tag('field_load_on_init', '1',
+                              @edit[:field_load_on_init],
+                              'data-miq_observe_checkbox' => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Auto refresh')
-            %td
-              = check_box_tag('field_auto_refresh', '1',
-                @edit[:field_auto_refresh],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Auto refresh')
+          .col-md-8
+            = check_box_tag('field_auto_refresh', '1',
+                            @edit[:field_auto_refresh],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Auto Refresh other fields when modified')
-            %td
-              = check_box_tag('field_trigger_auto_refresh', '1',
-                @edit[:field_trigger_auto_refresh],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Auto Refresh other fields when modified')
+          .col-md-8
+            = check_box_tag('field_trigger_auto_refresh', '1',
+                            @edit[:field_trigger_auto_refresh],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
 
-        - elsif @edit[:field_typ] =~ /Text|Check/
-          %tr
-            %td.key= _('Default Value')
-            %td
-              - if @edit[:field_typ] =~ /TextArea/
-                = text_area_tag("field_default_value",
-                  @edit[:field_default_value],
-                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
-                  :maxlength         => 8196,
-                  :size              => "50x6")
-              - elsif @edit[:field_typ] =~ /TextBox/
-                - if @edit[:field_protected]
-                  = password_field_tag('field_default_value__protected',
-                    @edit[:field_default_value],
-                    'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
-                - else
-                  = text_field_tag("field_default_value",
-                    @edit[:field_default_value],
-                    "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
-                    :maxlength         => 50)
+      - elsif @edit[:field_typ] =~ /Text|Check/
+        .form-group
+          %label.col-md-2.control-label
+            = _('Default Value')
+          .col-md-8
+            - if @edit[:field_typ] =~ /TextArea/
+              = text_area_tag("field_default_value",
+                @edit[:field_default_value],
+                "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+                :maxlength         => 8196,
+                :size              => "50x6")
+            - elsif @edit[:field_typ] =~ /TextBox/
+              - if @edit[:field_protected]
+                = password_field_tag('field_default_value__protected',
+                                      @edit[:field_default_value],
+                                      'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
               - else
-                = check_box_tag("field_default_value", "1",
-                  @edit[:field_default_value],
-                  "data-miq_observe_checkbox" => {:url => url}.to_json)
-          - if @edit[:field_typ].include?('TextBox')
-            %tr
-              %td.key= _('Protected')
-              %td
-                = check_box_tag('field_protected', 'true',
-                  @edit[:field_protected],
-                  "data-miq_observe_checkbox" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Required')
-            %td
-              = check_box_tag('field_required', 'true',
-                @edit[:field_required],
-                "data-miq_observe_checkbox" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Read only')
-            %td
-              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+                = text_field_tag("field_default_value",
+                                  @edit[:field_default_value],
+                                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+                                  :class => "form-control",
+                                  :maxlength         => 50)
+            - else
+              = check_box_tag("field_default_value", "1",
+                              @edit[:field_default_value],
+                              "data-miq_observe_checkbox" => {:url => url}.to_json)
+        - if @edit[:field_typ].include?('TextBox')
+          .form-group
+            %label.col-md-2.control-label
+              = _('Protected')
+            .col-md-8
+              = check_box_tag('field_protected', 'true',
+                              @edit[:field_protected],
+                              "data-miq_observe_checkbox" => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label= _('Required')
+          .col-md-8
+            = check_box_tag('field_required', 'true',
+                            @edit[:field_required],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label= _('Read only')
+          .col-md-8
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Auto Refresh other fields when modified')
-            %td
-              = check_box_tag('field_trigger_auto_refresh', '1',
-                @edit[:field_trigger_auto_refresh],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
-          - if @edit[:field_typ].include?('TextBox')
-            %tr
-              %td.key= _('Validator Type')
-              %td
-                = select_tag('field_validator_type',
-                  options_for_select([[_("None"), nil], [_("Regular Expression"), 'regex']], @edit[:field_validator_type]),
-                  "data-miq_sparkle_on" => true,
-                  "data-miq_observe"    => {:url => url}.to_json)
-            %tr
-              %td.key= _('Validator Rule')
-              %td
-                \/
-                = text_field_tag("field_validator_rule",
-                  @edit[:field_validator_rule],
-                  "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
-                  :disabled          => @edit[:field_validator_type].blank?,
-                  :maxlength         => 250)
-                \/
+        .form-group
+          %label.col-md-2.control-label
+            = _('Auto Refresh other fields when modified')
+          .col-md-8
+            = check_box_tag('field_trigger_auto_refresh', '1',
+                            @edit[:field_trigger_auto_refresh],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
+        - if @edit[:field_typ].include?('TextBox')
+          .form-group
+            %label.col-md-2.control-label
+              = _('Validator Type')
+            .col-md-8
+              = select_tag('field_validator_type',
+                            options_for_select([[_("None"), nil], [_("Regular Expression"), 'regex']], @edit[:field_validator_type]),
+                            "data-miq_sparkle_on" => true,
+                            :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_validator_type', "#{url}")
+          .form-group
+            %label.col-md-2.control-label
+              = _('Validator Rule')
+            .col-md-8
+              \/
+              = text_field_tag("field_validator_rule",
+                                @edit[:field_validator_rule],
+                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+                                :disabled          => @edit[:field_validator_type].blank?,
+                                :class => "form-control",
+                                :maxlength         => 250)
+              \/
 
-        - elsif %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
-          %tr
-            %td.key= _('Read only')
-            %td
-              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+      - elsif %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
+        .form-group
+          %label.col-md-2.control-label
+            = _('Read only')
+          .col-md-8
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Auto Refresh other fields when modified')
-            %td
-              = check_box_tag('field_trigger_auto_refresh', '1',
-                @edit[:field_trigger_auto_refresh],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Auto Refresh other fields when modified')
+          .col-md-8
+            = check_box_tag('field_trigger_auto_refresh', '1',
+                            @edit[:field_trigger_auto_refresh],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Show Past Dates')
-            %td
-              = check_box_tag("field_past_dates", "1",
-                @edit[:field_past_dates],
-                "data-miq_observe_checkbox" => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Show Past Dates')
+          .col-md-8
+            = check_box_tag("field_past_dates", "1",
+                            @edit[:field_past_dates],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
 
-        - elsif %w(DialogFieldDropDownList DialogFieldRadioButton).include?(@edit[:field_typ])
-          %tr
-            %td.key= _('Required')
-            %td.wide
-              = select_tag('field_required',
-                options_for_select([[_("True"), true], [_("False"), false]], @edit[:field_required].to_s),
-                "data-miq_sparkle_on" => true,
-                "data-miq_observe" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Read only')
-            %td
-              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+      - elsif %w(DialogFieldDropDownList DialogFieldRadioButton).include?(@edit[:field_typ])
+        .form-group
+          %label.col-md-2.control-label
+            = _('Required')
+          .col-md-8
+            = select_tag('field_required',
+                        options_for_select([[_("True"), true], [_("False"), false]], @edit[:field_required].to_s),
+                        "data-miq_sparkle_on" => true,
+                        :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_required', "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Read only')
+          .col-md-8
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Auto Refresh other fields when modified')
-            %td
-              = check_box_tag('field_trigger_auto_refresh', '1',
-                @edit[:field_trigger_auto_refresh],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Auto Refresh other fields when modified')
+          .col-md-8
+            = check_box_tag('field_trigger_auto_refresh', '1',
+                            @edit[:field_trigger_auto_refresh],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Default Value')
-            %td
-              - none = [["<#{_('None')}>", nil]]
-              - values = @edit[:field_values].empty? ? none : none + @edit[:field_values].collect(&:reverse)
-              - selected = @edit[:field_default_value] || nil
-              = select_tag("field_default_value",
-                options_for_select(values, selected),
-                "data-miq_observe" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Value Type')
-            %td.wide
-              = select_tag('field_data_typ',
-                options_for_select([[_("Integer"), "integer"], [_("String"), "string"]], @edit[:field_data_typ]),
-                "data-miq_sparkle_on" => true,
-                "data-miq_observe"    => {:url => url}.to_json)
-          %tr
-            %td.key= _('Sort By')
-            %td.wide
-              = select_tag('field_sort_by',
-                options_for_select([[_("None"), "none"], [_("Description"), "description"], [_("Value"), "value"]], @edit[:field_sort_by]),
-                "data-miq_observe" => {:url => url}.to_json)
-          - if @edit[:field_sort_by] != "none"
-            %tr
-              %td.key= _('Sort Order')
-              %td.wide
-                = select_tag('field_sort_order',
-                  options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
-                  "data-miq_observe" => {:url => url}.to_json)
-
-        - elsif @edit[:field_typ].include?("TagControl")
-          %tr
-            %td.key= _('Category')
-            %td.wide
-              - none = [["<#{_('Choose')}>", nil]]
-              - values = none + DialogFieldTagControl.allowed_tag_categories.map { |cat| [cat[:description], cat[:id]] }
-              = select_tag('field_category',
-                options_for_select(values, @edit[:field_category]), "data-miq_observe" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Single Select')
-            %td
-              = check_box_tag('field_single_value', true,
-                @edit[:field_single_value],
-                :disabled                   => disable_check_box?,
-                "data-miq_observe_checkbox" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Value Type')
-            %td.wide
-              = select_tag('field_data_typ',
-                options_for_select([[_("Integer"), "integer"], [_("String"), "string"]], @edit[:field_data_typ]),
-                "data-miq_sparkle_on" => true,
-                "data-miq_observe"    => {:url => url}.to_json)
-          %tr
-            %td.key= _('Sort By')
-            %td.wide
-              = select_tag('field_sort_by',
-                options_for_select([[_("None"), "none"], [_("Description"), "description"], [_("Value"), "value"]], @edit[:field_sort_by]),
-                "data-miq_observe" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Sort Order')
-            %td.wide
+        .form-group
+          %label.col-md-2.control-label
+            = _('Default Value')
+          .col-md-8
+            - none = [["<#{_('None')}>", nil]]
+            - values = @edit[:field_values].empty? ? none : none + @edit[:field_values].collect(&:reverse)
+            - selected = @edit[:field_default_value] || nil
+            = select_tag("field_default_value",
+                          options_for_select(values, selected),
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("field_default_value", "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Value Type')
+          .col-md-8
+            = select_tag('field_data_typ',
+                          options_for_select([[_("Integer"), "integer"], [_("String"), "string"]], @edit[:field_data_typ]),
+                          "data-miq_sparkle_on" => true,
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_data_typ', "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Sort By')
+          .col-md-8
+            = select_tag('field_sort_by',
+                          options_for_select([[_("None"), "none"], [_("Description"), "description"], [_("Value"), "value"]], @edit[:field_sort_by]),
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_sort_by', "#{url}")
+        - if @edit[:field_sort_by] != "none"
+          .form-group
+            %label.col-md-2.control-label
+              = _('Sort Order')
+            .col-md-8
               = select_tag('field_sort_order',
-                options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
-                "data-miq_observe" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Required')
-            %td
-              = check_box_tag('field_required', 'true',
-                @edit[:field_required],
-                "data-miq_observe_checkbox" => {:url => url}.to_json)
-          %tr
-            %td.key= _('Read only')
-            %td
-              = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+                            options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
+                            :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_sort_order', "#{url}")
+      - elsif @edit[:field_typ].include?("TagControl")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Category')
+          .col-md-8
+            - none = [["<#{_('Choose')}>", nil]]
+            - values = none + DialogFieldTagControl.allowed_tag_categories.map { |cat| [cat[:description], cat[:id]] }
+            = select_tag('field_category',
+                          options_for_select(values, @edit[:field_category]),
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_category', "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Single Select')
+          .col-md-8
+            = check_box_tag('field_single_value', true,
+                            @edit[:field_single_value],
+                            :disabled                   => disable_check_box?,
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Value Type')
+          .col-md-8
+            = select_tag('field_data_typ',
+                          options_for_select([[_("Integer"), "integer"], [_("String"), "string"]], @edit[:field_data_typ]),
+                          "data-miq_sparkle_on" => true,
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_data_typ', "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Sort By')
+          .col-md-8
+            = select_tag('field_sort_by',
+                          options_for_select([[_("None"), "none"], [_("Description"), "description"], [_("Value"), "value"]], @edit[:field_sort_by]),
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_sort_by', "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Sort Order')
+          .col-md-8
+            = select_tag('field_sort_order',
+                          options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
+                          :class    => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('field_sort_order', "#{url}")
+        .form-group
+          %label.col-md-2.control-label
+            = _('Required')
+          .col-md-8
+            = check_box_tag('field_required', 'true',
+                            @edit[:field_required],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Read only')
+          .col-md-8
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
 
-          %tr
-            %td.key= _('Auto Refresh other fields when modified')
-            %td
-              = check_box_tag('field_trigger_auto_refresh', '1',
-                @edit[:field_trigger_auto_refresh],
-                'data-miq_observe_checkbox' => {:url => url}.to_json)
+        .form-group
+          %label.col-md-2.control-label
+            = _('Auto Refresh other fields when modified')
+          .col-md-8
+            = check_box_tag('field_trigger_auto_refresh', '1',
+                            @edit[:field_trigger_auto_refresh],
+                            'data-miq_observe_checkbox' => {:url => url}.to_json)
 
   - if @edit[:field_typ] =~ /Drop|Radio/ && !@edit[:field_dynamic]
-    = render :partial => 'field_values', :locals => {:entry => nil}
+    = render :partial => 'field_values', :locals=>{:entry=>nil}
   - elsif @edit[:field_typ] && @edit[:field_typ].include?("TagControl") && @edit[:field_category]
     = render :partial => 'tag_field_values', :locals => {:entry => nil}
 
   - unless @edit[:field_typ].nil?
-    %fieldset
-      %h3= _('Advanced')
-      %table.style1
-        %tr
-          %td.key= _('Reconfigurable')
-          %td
-            = check_box_tag('field_reconfigurable', '1',
-              @edit[:field_reconfigurable],
-              "data-miq_observe_checkbox" => {:url => url}.to_json)
+    %h3
+      = _('Advanced')
+    %form.form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Reconfigurable')
+        .col-md-8
+          = check_box_tag('field_reconfigurable', '1',
+                          @edit[:field_reconfigurable],
+                          "data-miq_observe_checkbox" => {:url => url}.to_json)

--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -37,11 +37,13 @@
         = _('Type')
       .col-md-8
         = select_tag('field_typ',
-                      options_for_select(([["<#{_('Choose')}>", nil]]) + Array(@edit[:field_types].invert).sort, @edit[:field_typ]),
+                      options_for_select(([["<#{_('Choose')}>", nil]]) + Array(@edit[:field_types].invert).sort,
+                                        @edit[:field_typ]),
                       :class    => "selectpicker")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("field_typ", "#{url}")
+
         - if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(@edit[:field_typ])
           &nbsp;
           = _('Only 1 Date or Date/Time element can be present in a Dialog')
@@ -51,7 +53,8 @@
         %label.col-md-2.control-label
           = _('Dynamic')
         .col-md-8
-          = check_box_tag('field_dynamic', '1', @edit[:field_dynamic], "data-miq_observe_checkbox" => {:url => url}.to_json)
+          = check_box_tag('field_dynamic', '1', @edit[:field_dynamic],
+                          "data-miq_observe_checkbox" => {:url => url}.to_json)
 
   - unless @edit[:field_typ].nil?
     %h3
@@ -141,8 +144,8 @@
         .form-group
           %label.col-md-2.control-label= _('Read only')
           .col-md-8
-            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
-
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
         .form-group
           %label.col-md-2.control-label
             = _('Auto Refresh other fields when modified')
@@ -156,11 +159,11 @@
               = _('Validator Type')
             .col-md-8
               = select_tag('field_validator_type',
-                            options_for_select([[_("None"), nil], [_("Regular Expression"), 'regex']], @edit[:field_validator_type]),
+                            options_for_select([[_("None"), nil], [_("Regular Expression"), 'regex']],
+                                                @edit[:field_validator_type]),
                             "data-miq_sparkle_on" => true,
                             :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_validator_type', "#{url}")
           .form-group
             %label.col-md-2.control-label
@@ -180,7 +183,8 @@
           %label.col-md-2.control-label
             = _('Read only')
           .col-md-8
-            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
 
         .form-group
           %label.col-md-2.control-label
@@ -208,13 +212,13 @@
                         "data-miq_sparkle_on" => true,
                         :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_required', "#{url}")
         .form-group
           %label.col-md-2.control-label
             = _('Read only')
           .col-md-8
-            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
 
         .form-group
           %label.col-md-2.control-label
@@ -235,18 +239,17 @@
                           options_for_select(values, selected),
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent("field_default_value", "#{url}")
         .form-group
           %label.col-md-2.control-label
             = _('Value Type')
           .col-md-8
             = select_tag('field_data_typ',
-                          options_for_select([[_("Integer"), "integer"], [_("String"), "string"]], @edit[:field_data_typ]),
+                          options_for_select([[_("Integer"), "integer"], [_("String"), "string"]],
+                                              @edit[:field_data_typ]),
                           "data-miq_sparkle_on" => true,
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_data_typ', "#{url}")
         .form-group
           %label.col-md-2.control-label
@@ -256,7 +259,6 @@
                           options_for_select([[_("None"), "none"], [_("Description"), "description"], [_("Value"), "value"]], @edit[:field_sort_by]),
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_sort_by', "#{url}")
         - if @edit[:field_sort_by] != "none"
           .form-group
@@ -267,7 +269,6 @@
                             options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
                             :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_sort_order', "#{url}")
       - elsif @edit[:field_typ].include?("TagControl")
         .form-group
@@ -280,7 +281,6 @@
                           options_for_select(values, @edit[:field_category]),
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_category', "#{url}")
         .form-group
           %label.col-md-2.control-label
@@ -295,11 +295,11 @@
             = _('Value Type')
           .col-md-8
             = select_tag('field_data_typ',
-                          options_for_select([[_("Integer"), "integer"], [_("String"), "string"]], @edit[:field_data_typ]),
+                          options_for_select([[_("Integer"), "integer"], [_("String"), "string"]],
+                                              @edit[:field_data_typ]),
                           "data-miq_sparkle_on" => true,
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_data_typ', "#{url}")
         .form-group
           %label.col-md-2.control-label
@@ -309,7 +309,6 @@
                           options_for_select([[_("None"), "none"], [_("Description"), "description"], [_("Value"), "value"]], @edit[:field_sort_by]),
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_sort_by', "#{url}")
         .form-group
           %label.col-md-2.control-label
@@ -319,7 +318,6 @@
                           options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
                           :class    => "selectpicker")
             :javascript
-              miqInitSelectPicker();
               miqSelectPickerEvent('field_sort_order', "#{url}")
         .form-group
           %label.col-md-2.control-label
@@ -332,7 +330,8 @@
           %label.col-md-2.control-label
             = _('Read only')
           .col-md-8
-            = check_box_tag('field_read_only', '1', @edit[:field_read_only], "data-miq_observe_checkbox" => {:url => url}.to_json)
+            = check_box_tag('field_read_only', '1', @edit[:field_read_only],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
 
         .form-group
           %label.col-md-2.control-label
@@ -343,7 +342,7 @@
                             'data-miq_observe_checkbox' => {:url => url}.to_json)
 
   - if @edit[:field_typ] =~ /Drop|Radio/ && !@edit[:field_dynamic]
-    = render :partial => 'field_values', :locals=>{:entry=>nil}
+    = render :partial => 'field_values', :locals => {:entry => nil}
   - elsif @edit[:field_typ] && @edit[:field_typ].include?("TagControl") && @edit[:field_category]
     = render :partial => 'tag_field_values', :locals => {:entry => nil}
 

--- a/app/views/miq_ae_customization/_dialog_group_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_group_form.html.haml
@@ -1,19 +1,21 @@
 - url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
-%fieldset
-  %h3= _('Box Information')
-  %table.style1
-    %tr
-      %td.key= _('Label')
-      %td.wide
-        = text_field_tag("group_label",
-          @edit[:group_label],
-          :maxlength         => MAX_NAME_LEN,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        = javascript_tag(javascript_focus('group_label'))
-    %tr
-      %td.key= _('Description')
-      %td.wide
-        = text_field_tag("group_description",
-          @edit[:group_description],
-          :maxlength         => 100,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+%h3
+  = _('Box Information')
+%form.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
+      = _('Label')
+    .col-md-8
+      = text_field_tag("group_label",
+                        @edit[:group_label],
+                        :maxlength         => MAX_NAME_LEN,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      = javascript_tag(javascript_focus('group_label'))
+  .form-group
+    %label.col-md-2.control-label
+      = _('Description')
+    .col-md-8
+      = text_field_tag("group_description",
+                        @edit[:group_description],
+                        :maxlength         => 100,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/miq_ae_customization/_dialog_group_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_group_form.html.haml
@@ -9,6 +9,7 @@
       = text_field_tag("group_label",
                         @edit[:group_label],
                         :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       = javascript_tag(javascript_focus('group_label'))
   .form-group
@@ -18,4 +19,5 @@
       = text_field_tag("group_description",
                         @edit[:group_description],
                         :maxlength         => 100,
+                        :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/miq_ae_customization/_dialog_info.html.haml
+++ b/app/views/miq_ae_customization/_dialog_info.html.haml
@@ -1,21 +1,28 @@
 -# if dialogs is selected
 #info_div{:style => display}
-  %h3= _('Basic Information')
-  %table.style1
-    %tbody
-      %tr
-        %td.key= _('Label')
-        %td
-          = h(@record.label)
-      %tr
-        %td.key= _('Description')
-        %td
+  %h3
+    = _('Basic Information')
+  %form.form-horizontal.static
+    .form-group
+      %label.col-md-2.control-label
+        = _('Label')
+      .col-md-8
+        = h(@record.label)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
+        %p.form-control-static
           = h(@record.description)
-      %tr
-        %td.key= _('Created On')
-        %td
+    .form-group
+      %label.col-md-2.control-label
+        = _('Created On')
+      .col-md-8
+        %p.form-control-static
           = h(format_timezone(@record.created_at, Time.zone, "gtl"))
-      %tr
-        %td.key= _('Updated On')
-        %td
+    .form-group
+      %label.col-md-2.control-label
+        = _('Updated On')
+      .col-md-8
+        %p.form-control-static
           = h(format_timezone(@record.updated_at, Time.zone, "gtl"))

--- a/app/views/miq_ae_customization/_dialog_info_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_info_form.html.haml
@@ -1,29 +1,34 @@
 - url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
 -# dialog info form fields
-%fieldset
-  %h3= _('Dialog Information')
-  %table.style1
-    %tr
-      %td.key= _('Label')
-      %td.wide
-        = text_field_tag("label",
-          @edit[:new][:label],
-          :maxlength         => MAX_NAME_LEN,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        = javascript_tag(javascript_focus('label'))
-    %tr
-      %td.key= _('Description')
-      %td.wide
-        = text_field_tag("description",
-          @edit[:new][:description],
-          :maxlength         => 100,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    %tr
-      %td.key= _('Buttons')
-      %td
-        - @edit[:dialog_buttons].each do |b|
-          - checked = !@edit[:new][:buttons].nil? && @edit[:new][:buttons].include?(b) ? true : false
-          = check_box_tag("chkbx_#{b}", "1", checked,
-            "data-miq_observe_checkbox" => {:url => url}.to_json)
-          = h(b.capitalize)
-          &nbsp;
+%h3
+  = _('Dialog Information')
+%form.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
+      = _('Label')
+    .col-md-8
+      = text_field_tag("label",
+                        @edit[:new][:label],
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      = javascript_tag(javascript_focus('label'))
+  .form-group
+    %label.col-md-2.control-label
+      = _('Description')
+    .col-md-8
+      = text_field_tag("description",
+                        @edit[:new][:description],
+                        :maxlength         => 100,
+                        :class => "form-control",
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  .form-group
+    %label.col-md-2.control-label
+      = _('Buttons')
+    .col-md-8
+      - @edit[:dialog_buttons].each do |b|
+        - checked = !@edit[:new][:buttons].nil? && @edit[:new][:buttons].include?(b) ? true : false
+        = check_box_tag("chkbx_#{b}",  "1", checked,
+          "data-miq_observe_checkbox" => {:url => url}.to_json)
+        = h(b.capitalize)
+        &nbsp;

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -14,113 +14,110 @@
             - dt.resource.ordered_dialog_resources.each do |tg|
               -# dialog groups/fields
               - group = tg.resource
-              %fieldset
-                %h3{:title => group.description}
-                  = group.label
-                %table.style1
-                  %tbody
-                    - group.ordered_dialog_resources.each do |g|
-                      - field = g.resource
-                      %tr
-                        %td.key{:title => field.description}
-                          = field.label
-                        %td{:title => field.description}
-                          - case field.type
-                          - when "DialogFieldTextBox"
-                            - if field.protected?
-                              = password_field_tag('field.id', '********', :maxlength => 20, :disabled => true)
-                            - else
-                              = text_field_tag('field.id', field.sample_text, :maxlength => 20, :disabled => true)
+              %h3{:title => group.description}
+                = group.label
+              %form.form-horizontal
+                - group.ordered_dialog_resources.each do |g|
+                  - field = g.resource
+                  .form-group
+                    %label.col-md-2.control-label{:title => field.description}
+                      = field.label
+                    .col-md-8{:title => field.description}
+                      - case field.type
+                      - when "DialogFieldTextBox"
+                        - if field.protected?
+                          = password_field_tag('field.id', '********', :maxlength => 20, :disabled => true)
+                        - else
+                          = text_field_tag('field.id', field.sample_text, :maxlength => 20, :disabled => true)
 
-                          - when "DialogFieldTextAreaBox"
-                            = text_area_tag(field.id, field.sample_text, :size => "50x6", :disabled => true)
+                      - when "DialogFieldCheckBox"
+                        = check_box_tag("field.id", "1", false, :disabled => true)
+                      - when "DialogFieldDateControl", "DialogFieldDateTimeControl"
+                        - if field.show_past_dates
+                          :javascript
+                            ManageIQ.calendar.calDateFrom = undefined;
+                        - else
+                          :javascript
+                            ManageIQ.calendar.calDateFrom = new Date("#{Time.now.in_time_zone(session[:user_tz]).strftime("%Y, %m, %d")}");
+                        - t = Time.now.in_time_zone(session[:user_tz]) + 1.day
+                        - date_val = field.value ? field.value.split(" ") : ["#{t.month}/#{t.day}/#{t.year}"]
+                        = datepicker_input_tag("miq_date_1", h(date_val[0]),
+                          :class    => "css1",
+                          :readonly => "true")
+                        - if field.type == "DialogFieldDateTimeControl"
+                          &nbsp;
+                          = _('at')
+                          &nbsp;
+                          = select_tag("start_hour", options_for_select(Array.new(24) { |i| i }, 0))
+                          \:
+                          = select_tag("start_min", options_for_select(Array.new(12)  { |i| i * 5 }, 0))
 
-                          - when "DialogFieldCheckBox"
-                            = check_box_tag("field.id", "1", false, :disabled => true)
-                          - when "DialogFieldDateControl", "DialogFieldDateTimeControl"
-                            - if field.show_past_dates
-                              :javascript
-                                ManageIQ.calendar.calDateFrom = undefined;
-                            - else
-                              :javascript
-                                ManageIQ.calendar.calDateFrom = new Date("#{Time.now.in_time_zone(session[:user_tz]).strftime("%Y, %m, %d")}");
-                            - t = Time.now.in_time_zone(session[:user_tz]) + 1.day
-                            - date_val = field.value ? field.value.split(" ") : ["#{t.month}/#{t.day}/#{t.year}"]
-                            = datepicker_input_tag("miq_date_1", h(date_val[0]),
-                              :class    => "css1",
-                              :readonly => "true")
-                            - if field.type == "DialogFieldDateTimeControl"
-                              &nbsp;
-                              = _('at')
-                              &nbsp;
-                              = select_tag("start_hour", options_for_select(Array.new(24) { |i| i }, 0))
-                              \:
-                              = select_tag("start_min", options_for_select(Array.new(12)  { |i| i * 5 }, 0))
+                      - when "DialogFieldTextAreaBox"
+                        = text_area_tag(field.id, field.sample_text, :size => "50x6", :disabled => true)
+                      - when "DialogFieldDropDownList", "DialogFieldRadioButton"
+                        - if field.dynamic
+                          - if field.type == "DialogFieldRadioButton"
+                            %input#dialog_field_radio_sample_1{:type => "radio", :name => "dialog_field_radio"}
+                            %label{:for => "dialog_field_radio_sample_1"} Option 1
+                            %input#dialog_field_radio_sample_2{:type => "radio", :name => "dialog_field_radio"}
+                            %label{:for => "dialog_field_radio_sample_2"} Option 2
 
-                          - when "DialogFieldDropDownList", "DialogFieldRadioButton"
-                            - if field.dynamic
-                              - if field.type == "DialogFieldRadioButton"
-                                %input#dialog_field_radio_sample_1{:type => "radio", :name => "dialog_field_radio"}
-                                %label{:for => "dialog_field_radio_sample_1"} Option 1
-                                %input#dialog_field_radio_sample_2{:type => "radio", :name => "dialog_field_radio"}
-                                %label{:for => "dialog_field_radio_sample_2"} Option 2
+                          - if field.type == "DialogFieldDropDownList"
+                            = select_tag("#{field.id}", options_for_select([_("Option 1"), _("Option 2")]))
 
-                              - if field.type == "DialogFieldDropDownList"
-                                = select_tag("#{field.id}", options_for_select([_("Option 1"), _("Option 2")]))
+                          - if field.show_refresh_button?
+                            = button_tag('Refresh', :disabled => true)
 
-                              - if field.show_refresh_button?
-                                = button_tag('Refresh', :disabled => true)
-
-                            - else
-                              - if field.values.length > 1
-                                - if field.sort_by.to_s != "none"
-                                  - if field.data_type == "integer"
-                                    - val = field.values.sort_by { |d| field.sort_by == :value ? d.first.to_i : d.last.to_i }
-                                    - val = val.reverse if field.sort_order == :descending
-                                  - else
-                                    - val = field.values.sort_by { |d| field.sort_by == :value ? d.first : d.last }
-                                    - val = val.reverse if field.sort_order == :descending
-                                - else
-                                  - val = copy_array(field.values)
-
-                                - if field.type == "DialogFieldDropDownList"
-                                  - if field.required
-                                    - if field.default_value.nil?
-                                      = select_tag('field.id',
-                                        options_for_select(val.collect(&:reverse), field.default_value))
-                                    - else
-                                      = select_tag('field.id',
-                                        options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse), field.default_value))
-
-                                  - else
-                                    -# NOT REQUIRED
-                                    = select_tag('field.id',
-                                      options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse), field.default_value))
-
-                                - else
-                                  - val.each_with_index do |rb, i|
-                                    - unless field.required || i != 0
-                                      %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
-                                        :id => "None", :value => "nil", :name => "None"}
-                                      &nbsp; None &nbsp;
-
-                                    %input{:type => "radio", :disabled => true, :checked => (field.default_value == rb[0]),
-                                      :id => rb[0], :value => rb[1], :name => rb[0]}
-                                    &nbsp;
-                                    = rb[1]
-                                    &nbsp;
+                        - else
+                          - if field.values.length > 1
+                            - if field.sort_by.to_s != "none"
+                              - if field.data_type == "integer"
+                                - val = field.values.sort_by { |d| field.sort_by == :value ? d.first.to_i : d.last.to_i }
+                                - val = val.reverse if field.sort_order == :descending
                               - else
-                                = h(field.values[0].last) unless field.values.empty?
-
-                          - when "DialogFieldButton"
-                            = button_tag(_('Save'), :disabled => true)
-                          - when "DialogFieldTagControl"
-                            - category_tags = DialogFieldTagControl.category_tags(field.category).map do |cat|
-                              - [cat[:description], cat[:id]]
-                            - if field.single_value?
-                              = select_tag('field.id', options_for_select(category_tags),
-                                :prompt => field.required? ? "<#{_('Choose')}>" : "<#{_('None')}>")
+                                - val = field.values.sort_by { |d| field.sort_by == :value ? d.first : d.last }
+                                - val = val.reverse if field.sort_order == :descending
                             - else
-                              = select_tag('field.id', options_for_select(category_tags), :multiple => true)
+                              - val = copy_array(field.values)
+
+                            - if field.type == "DialogFieldDropDownList"
+                              - if field.required
+                                - if field.default_value.nil?
+                                  = select_tag('field.id',
+                                    options_for_select(val.collect(&:reverse), field.default_value))
+                                - else
+                                  = select_tag('field.id',
+                                    options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse), field.default_value))
+
+                              - else
+                                -# NOT REQUIRED
+                                = select_tag('field.id',
+                                  options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse), field.default_value))
+
+                            - else
+                              - val.each_with_index do |rb, i|
+                                - unless field.required || i != 0
+                                  %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
+                                    :id => "None", :value => "nil", :name => "None"}
+                                  &nbsp; None &nbsp;
+
+                                %input{:type => "radio", :disabled => true, :checked => (field.default_value == rb[0]),
+                                  :id => rb[0], :value => rb[1], :name => rb[0]}
+                                &nbsp;
+                                = rb[1]
+                                &nbsp;
+                          - else
+                            = h(field.values[0].last) unless field.values.empty?
+
+                      - when "DialogFieldButton"
+                        = button_tag(_('Save'), :disabled => true)
+                      - when "DialogFieldTagControl"
+                        - category_tags = DialogFieldTagControl.category_tags(field.category).map do |cat|
+                          - [cat[:description], cat[:id]]
+                        - if field.single_value?
+                          = select_tag('field.id', options_for_select(category_tags),
+                            :prompt => field.required? ? "<#{_('Choose')}>" : "<#{_('None')}>")
+                        - else
+                          = select_tag('field.id', options_for_select(category_tags), :multiple => true)
 :javascript
   miq_tabs_init("#dialog_tabs");

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -16,7 +16,7 @@
               - group = tg.resource
               %h3{:title => group.description}
                 = group.label
-              %form.form-horizontal
+              %form.form-horizontal.static
                 - group.ordered_dialog_resources.each do |g|
                   - field = g.resource
                   .form-group
@@ -87,12 +87,14 @@
                                     options_for_select(val.collect(&:reverse), field.default_value))
                                 - else
                                   = select_tag('field.id',
-                                    options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse), field.default_value))
+                                              options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse),
+                                                                  field.default_value))
 
                               - else
                                 -# NOT REQUIRED
                                 = select_tag('field.id',
-                                  options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse), field.default_value))
+                                              options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse),
+                                                                  field.default_value))
 
                             - else
                               - val.each_with_index do |rb, i|

--- a/app/views/miq_ae_customization/_dialog_tab_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_tab_form.html.haml
@@ -1,17 +1,19 @@
 - url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || 'new'}")
-%fieldset
-  %h3= _('Tab Information')
-  %table.style1
-    %tr
-      %td.key= _('Label')
-      %td.wide
-        = text_field_tag("tab_label", @edit[:tab_label],
-          :maxlength         => MAX_NAME_LEN,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        = javascript_tag(javascript_focus('tab_label'))
-    %tr
-      %td.key= _('Description')
-      %td.wide
-        = text_field_tag("tab_description", @edit[:tab_description],
-          :maxlength         => 100,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+%h3
+  = _('Tab Information')
+%form.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
+      = _('Label')
+    .col-md-8
+      = text_field_tag("tab_label", @edit[:tab_label],
+                        :maxlength         => MAX_NAME_LEN,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      = javascript_tag(javascript_focus('tab_label'))
+  .form-group
+    %label.col-md-2.control-label
+      = _('Description')
+    .col-md-8
+      = text_field_tag("tab_description", @edit[:tab_description],
+                        :maxlength         => 100,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/miq_ae_customization/_dialog_tab_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_tab_form.html.haml
@@ -8,6 +8,7 @@
     .col-md-8
       = text_field_tag("tab_label", @edit[:tab_label],
                         :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       = javascript_tag(javascript_focus('tab_label'))
   .form-group
@@ -16,4 +17,5 @@
     .col-md-8
       = text_field_tag("tab_description", @edit[:tab_description],
                         :maxlength         => 100,
+                        :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/miq_ae_customization/_old_dialogs_details.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_details.html.haml
@@ -4,19 +4,24 @@
     = render :partial => "old_dialogs_form"
   - else
     = render :partial => "layouts/flash_msg"
-    %h3= _('Basic Information')
-    %table.style1
-      %tbody
-        %tr
-          %td.key= _('Name')
-          %td
+    %h3
+      = _('Basic Information')
+    %form.form-horizontal.static
+      .form-group
+        %label.col-md-2.control-label
+          = _('Name')
+        .col-md-8
+          %p.form-control-static
             = h(@dialog.name)
-        %tr
-          %td.key= _('Description')
-          %td
+      .form-group
+        %label.col-md-2.control-label
+          = _('Description')
+        .col-md-8
+          %p.form-control-static
             = h(@dialog.description)
     %hr
-      %h3= _('Content')
+      %h3
+        = _('Content')
       = text_area("script", "data",
         :value    => h(@dialog.content.to_yaml),
         :readonly => "readonly",

--- a/app/views/miq_ae_customization/_old_dialogs_form.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_form.html.haml
@@ -1,33 +1,44 @@
 - url = url_for(:action => 'old_dialogs_form_field_changed', :id => "#{@dialog.id || 'new'}")
 #form_div
   = render :partial => "layouts/flash_msg"
-  %h3= _('Basic Information')
-  %table.style1
-    %tr
-      %td.key= _('Name')
-      %td.wide
+  %h3
+    = _('Basic Information')
+  %form.form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Name')
+      .col-md-8
         = text_field_tag("name",
-          @edit[:new][:name],
-          :maxlength         => MAX_NAME_LEN,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                          @edit[:new][:name],
+                          :maxlength         => MAX_NAME_LEN,
+                          :class => "form-control",
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         = javascript_tag(javascript_focus('name'))
-    %tr
-      %td.key= _('Description')
-      %td.wide
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
         = text_field_tag("description",
-          @edit[:new][:description],
-          :maxlength         => 100,
-          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    %tr
-      %td.key= _('Type')
-      - dialog_types = @dialog.dialog_type ? MiqDialog::DIALOG_TYPES.sort : [["<#{_('Choose')}>", nil]] + MiqDialog::DIALOG_TYPES.sort
-      %td.wide
+                          @edit[:new][:description],
+                          :maxlength         => 100,
+                          :class => "form-control",
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Type')
+        - miq_dialog_s = MiqDialog::DIALOG_TYPES.sort
+        - dialog_types = @dialog.dialog_type ? miq_dialog_s : [["<#{_('Choose')}>", nil]] + miq_dialog_s
+      .col-md-8
         = select_tag('dialog_type',
-          options_for_select(dialog_types,
-          @edit[:new][:dialog_type]),
-          "data-miq_observe" => {:url => url}.to_json)
+                      options_for_select(dialog_types,
+                                          @edit[:new][:dialog_type]),
+                      :class    => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("dialog_type", "#{url}")
   %hr
-  %h3= _('Content')
+  %h3
+    = _('Content')
   = text_area_tag("content_data",
     @edit[:new][:content],
     :style => "display:none;")


### PR DESCRIPTION
Parent issue: #3139
Convert style1 tables into patternfly in customization views

1.
Before:
![miqaecustomizationadddialogbefore](https://cloud.githubusercontent.com/assets/9535558/8802300/d267a8f0-2fc0-11e5-8d5c-4d1100d610a6.png)

After:
![screenshot from 2015-07-28 13-59-20](https://cloud.githubusercontent.com/assets/9535558/8930785/0a866c06-3531-11e5-8db6-e9274c84cebb.png)



2.
Before:
![miqaecustomizationolddetailsbefore](https://cloud.githubusercontent.com/assets/9535558/8802327/fac851b4-2fc0-11e5-835c-20d4e52bbc16.png)

After:
![miqaecustomizationolddetailsafter](https://cloud.githubusercontent.com/assets/9535558/8802309/e29a8b2a-2fc0-11e5-90da-260bd8c01f99.png)

3.
Before:
![editservicedialogbefore](https://cloud.githubusercontent.com/assets/9535558/8802777/d31bf4f6-2fc3-11e5-8102-d16a17c8c98d.png)

After:
![editservicedialogafter](https://cloud.githubusercontent.com/assets/9535558/8802786/dc36f022-2fc3-11e5-8616-7933645a790e.png)

4.
Before:
![editservicedialog2before](https://cloud.githubusercontent.com/assets/9535558/8826680/8958db2a-3088-11e5-872a-e39d04a52680.png)

After:
![screenshot from 2015-07-28 13-52-21](https://cloud.githubusercontent.com/assets/9535558/8930647/e62a52d8-352f-11e5-8c60-4ac513221930.png)


5.
Before:
![editservicedialog3before](https://cloud.githubusercontent.com/assets/9535558/8826687/8e75b434-3088-11e5-8c95-bc8a87e7e4bd.png)

After:
![screenshot from 2015-07-28 13-51-46](https://cloud.githubusercontent.com/assets/9535558/8930630/d2246e54-352f-11e5-97fe-d520d004066b.png)

6.
Before:
![servecedialogbasicinfobefore](https://cloud.githubusercontent.com/assets/9535558/8902777/a6ce8226-3453-11e5-893b-24ad057a80d1.png)

After:
![servecedialogbasicinfoafter](https://cloud.githubusercontent.com/assets/9535558/8930723/7dcd5108-3530-11e5-96ca-630875afc746.png)


7.
Before:
![servicedialogeditbefore](https://cloud.githubusercontent.com/assets/9535558/8909079/d563aad6-347f-11e5-8c51-cd6089a0b990.png)

After:
![servicedialogeditafter](https://cloud.githubusercontent.com/assets/9535558/8909085/dce5316c-347f-11e5-8d3b-b695ae1b62a7.png)


