### PR TITLE
OpenstackInfra OrchestrationStack relation fix

### DIFF
--- a/app/models/orchestration_stack_openstack_infra.rb
+++ b/app/models/orchestration_stack_openstack_infra.rb
@@ -1,4 +1,6 @@
 class OrchestrationStackOpenstackInfra < OrchestrationStack
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::InfraManager"
+
   def raw_update_stack(options)
     planning_data = {}
     ext_management_system.with_provider_connection(:service => "Planning") do |connection|


### PR DESCRIPTION
OpenstackInfra OrchestrationStack relation fix, relation needs
to be tied to ManageIQ::Providers::InfraManager, otherwise the
ext_management_system relation returns nil and scaling fails.