### PR TITLE
fix_auth always cleanup all keys

### DIFF
--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -53,13 +53,7 @@ describe FixAuth::AuthModel do
 
     it "should build selection criteria (non selects)" do
       expect(subject.selection_criteria).to match(/OR/)
-      expect(subject.selection_criteria).to match(/password.*!~ 'v2.*OR.*auth_key.*!~ 'v2/)
-    end
-
-    it "should build selection criteria (non selects)" do
-      expect(subject.selection_criteria(true)).to match(/OR/)
-      expect(subject.selection_criteria(true)).not_to match(/password.*!~ 'v2.*OR.*auth_key.*!~ 'v2/)
-      expect(subject.selection_criteria(true)).to match(/password.*<>.*''.*OR.*auth_key.*<>.*''/)
+      expect(subject.selection_criteria).to match(/password.*<>.*''.*OR.*auth_key.*<>.*''/)
     end
 
     it "should not find empty records" do
@@ -69,13 +63,8 @@ describe FixAuth::AuthModel do
 
     it "should find records with encrypted passwords" do
       [v1, v2, leg, nls].each(&:save!)
-      expect(contenders).to include(v1.name, leg.name)
-      expect(contenders).not_to include(v2.name, nls.name)
-    end
-
-    it "finds records already encryped when requested" do
-      [v1, v2].each(&:save!)
-      expect(subject.contenders(true).collect(&:name)).to include(v2.name)
+      expect(contenders).to include(v1.name, leg.name, v2.name)
+      expect(contenders).not_to include(nls.name)
     end
 
     it "should find viable records among mixed mode records" do

--- a/spec/tools/fix_auth/cli_spec.rb
+++ b/spec/tools/fix_auth/cli_spec.rb
@@ -66,16 +66,8 @@ describe FixAuth::Cli do
     end
 
     describe "v2" do
-      it "defaults to true" do
-        expect(described_class.new.parse(%w()).options[:v2]).to be_true
-      end
-
-      it "allows v2 to be passed" do
-        expect(described_class.new.parse(%w(--v2)).options[:v2]).to be_true
-      end
-
-      it "allows v2 to be negative" do
-        expect(described_class.new.parse(%w(--no-v2)).options[:v2]).to be_false
+      it "exists" do
+        expect { described_class.new.parse(%w(--v2)) }.not_to raise_error
       end
     end
   end

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -18,7 +18,7 @@ module FixAuth
         opt :hardcode, "Password to use for all passwords",     :type => :string, :short => "P"
         opt :invalid,  "Password to use for invalid passwords", :type => :string, :short => "i"
         opt :key,      "Generate key",      :type => :boolean, :short => "k"
-        opt :v2,       "Fix V2 passwords also", :type => :boolean, :short => "f", :default => true
+        opt :v2,       "ignored, available for backwards compatibility", :type => :boolean, :short => "f"
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
         opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -26,7 +26,7 @@ module FixAuth
     end
 
     def run_options
-      options.slice(:verbose, :dry_run, :hardcode, :invalid, :v2)
+      options.slice(:verbose, :dry_run, :hardcode, :invalid)
     end
 
     def databases

--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -32,7 +32,7 @@ module FixAuth
 
     # only bring back columns that store passwords
     # we want to use joins, but using joins makes this readonly, so we're using includes instead
-    def self.contenders(_ = nil)
+    def self.contenders
       super.includes(:field).where(:miq_ae_fields => {:datatype => 'password'})
     end
   end
@@ -43,7 +43,7 @@ module FixAuth
     self.password_columns = %w(default_value)
 
     # only fix columns with password values
-    def self.contenders(_ = nil)
+    def self.contenders
       super.where(:datatype => 'password')
     end
   end
@@ -59,7 +59,7 @@ module FixAuth
     end
 
     # only bring back rows that store passwords
-    def self.contenders(_ = nil)
+    def self.contenders
       where("typ = 'vmdb'")
     end
   end
@@ -74,7 +74,7 @@ module FixAuth
     self.symbol_keys = true
     self.table_name = "miq_requests"
 
-    def self.contenders(_ = nil)
+    def self.contenders
       where("options like '%password%'")
     end
   end
@@ -89,7 +89,7 @@ module FixAuth
     self.symbol_keys = true
     self.table_name = "miq_request_tasks"
 
-    def self.contenders(_ = nil)
+    def self.contenders
       where("options like '%password%'")
     end
   end
@@ -121,7 +121,7 @@ module FixAuth
     self.password_fields = %w(password)
     self.available_columns = %w(yaml)
 
-    def self.contenders(_options = {})
+    def self.contenders
       [new(:id => file_name).load]
     end
   end


### PR DESCRIPTION
The --v2 option was an optimization to speed up fixing
old encryption keys. It would only fix keys that had not been
upgraded yet.

Unfortunately it is confusing when users are trying to fix
bad v2 keys. It also did not speed up the process that much.

We have updated it across versions, so now the flag has
different meanings on different versions. very confusing.

This removes the flag.
It leaves the --v2 option in the ui for backwards compatibility, but either way, it upgrades all keys

/cc @Fryguy we talked about removing this flag / simplifying this
/cc @gtanzillo not sure if you care, but keeping you in the loop