### PR TITLE
Allow AE service models to have weird names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,8 @@ SpaceInsideHashLiteralBraces:
 #
 AllCops:
   RunRailsCops: true
+ClassAndModuleChildren:
+  Enabled: false
 Documentation:
   Enabled: false
 Encoding:
@@ -82,3 +84,10 @@ TrailingComma:
   Enabled: false
 WhileUntilModifier:
   Enabled: false
+
+ClassAndModuleCamelCase:
+  Exclude:
+    - lib/miq_automation_engine/service_models/*.rb
+FileName:
+  Exclude:
+    - lib/miq_automation_engine/service_models/*.rb


### PR DESCRIPTION
Also, don't insist on explicitly nested module names; the main argument against them is obviated by the Rails autoloader, to the point that they're often actually the more advisable form... even though you may miss having the intermediate scopes.