### PR TITLE
Fix OpenStack 404 errors

### DIFF
--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -318,7 +318,7 @@ module OpenstackHandle
         not_found_error = Fog.const_get(service)::OpenStack::NotFound
 
         rv = begin
-          svc.send(accessor)
+          array_accessor ? svc.send(accessor).to_a : svc.send(accessor)
         rescue not_found_error => e
           $fog_log.warn("MIQ(#{self.class.name}.#{__method__}) HTTP 404 Error during OpenStack request. " \
                         "Skipping inventory item #{service} #{accessor}\n#{e}")
@@ -326,11 +326,7 @@ module OpenstackHandle
         end
 
         if rv
-          if array_accessor
-            ra.concat(rv.to_a)
-          else
-            ra << rv
-          end
+          array_accessor ? ra.concat(rv) : ra << rv
         end
       end
       return ra unless uniq_id

--- a/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
+++ b/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
@@ -14,14 +14,27 @@ describe OpenstackHandle::Handle do
 
   context "errors from services" do
 
+    before do
+      @openstack_svc = double('network_service')
+
+      @handle = OpenstackHandle::Handle.new("dummy", "dummy", "dummy")
+      @handle.stub(:service_for_each_accessible_tenant).and_yield(@openstack_svc)
+    end
+
     it "ignores 404 errors from services" do
-      openstack_svc = double('newtork_service')
-      expect(openstack_svc).to receive(:security_groups).and_raise(Fog::Network::OpenStack::NotFound)
+      expect(@openstack_svc).to receive(:security_groups).and_raise(Fog::Network::OpenStack::NotFound)
 
-      handle = OpenstackHandle::Handle.new("dummy", "dummy", "dummy")
-      expect(handle).to receive(:service_for_each_accessible_tenant).and_yield(openstack_svc)
+      data = @handle.accessor_for_accessible_tenants("Network", :security_groups, :id)
+      data.should be_empty
+    end
 
-      data = handle.accessor_for_accessible_tenants("Network", :security_groups, :id)
+    it "ignores 404 errors from services returning arrays" do
+      security_groups = double("security_groups").as_null_object
+      expect(security_groups).to receive(:to_a).and_raise(Fog::Network::OpenStack::NotFound)
+
+      expect(@openstack_svc).to receive(:security_groups).and_return(security_groups)
+
+      data = @handle.accessor_for_accessible_tenants("Network", :security_groups, :id)
       data.should be_empty
     end
   end


### PR DESCRIPTION
This was originally fixed with #583 but was later unfixed with #681.

Specifically, [here](https://github.com/ManageIQ/manageiq/pull/681/files#diff-9b676475e04ca557fb3f16404b5822a8R248) and [here](https://github.com/ManageIQ/manageiq/pull/681/files#diff-9b676475e04ca557fb3f16404b5822a8R257).

The `to_a` needs to be inside the begin-rescue block in order to catch lazy loaded resources that can produce an HTTP 404 error.

https://bugzilla.redhat.com/show_bug.cgi?id=1140191