### PR TITLE
Added a check to only build replace tree if all conditions are met.

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -733,7 +733,7 @@ class OpsController < ApplicationController
         :locals  => {:tree => tree,
                      :name => tree.name.to_s
         }
-      ]
+      ] if tree
     end
   end
 


### PR DESCRIPTION
- Only set replace_partials hash in for the trees that were actually built, replace_trees has a key to replace analytics tree but that only gets built if user has a product flag set to display Analytics accordion.
- Added a spec test to verify fix.

@dclarizio please review/test. To recreate try adding or deleting a Zone in OPS controller. This issue was introduced with ExplorerPresenter conversion of OPS controller.