### PR TITLE
remove session[:eligible_groups]

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -3,7 +3,7 @@ module ApplicationController::CurrentUser
 
   included do
     helper_method :current_user,  :current_userid, :current_username
-    helper_method :current_group, :current_groupid
+    helper_method :current_group, :current_groupid, :eligible_groups
   end
 
   def clear_current_user
@@ -22,7 +22,6 @@ module ApplicationController::CurrentUser
       session[:username]  = nil
     end
     self.current_group  = db_user.try(:current_group)
-    self.current_eligible_groups = db_user.try(:miq_groups)
   end
   protected :current_user=
 
@@ -36,12 +35,12 @@ module ApplicationController::CurrentUser
   end
   private :current_group=
 
-  def current_eligible_groups=(eligible_groups)
-    # Save an array of groups this user is eligible for, if more than 1
+  def eligible_groups
+    eligible_groups = current_user.try(:miq_groups)
     eligible_groups = eligible_groups ? eligible_groups.sort_by { |g| g.description.downcase } : []
-    session[:eligible_groups] = eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
+    eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
   end
-  private :current_eligible_groups=
+  private :eligible_groups
 
   def current_user
     @current_user ||= User.find_by_userid(session[:userid])

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -9,16 +9,16 @@
         %a{:href => "#"}
           = _('Server: %s') % session[:vmdb_name]
 
-      - if session[:eligible_groups].length > 1
+      - if eligible_groups.length > 1
         %li.dropdown-submenu
           %a{:href => "#"}
             = _('Change Group:')
             %ul.dropdown-menu
-              - session[:eligible_groups].each do |group, id|
+              - eligible_groups.each do |group, id|
                 %li
                   %a{:title => _("Select to change to another Group"), :href => "#",
                         :onclick => "miqSparkle(true);miqToggleUserOptions(#{id})"}
-                    = id == session[:group] ? "#{group} (#{_('Current Group')})" : group
+                    = id == current_groupid ? "#{group} (#{_('Current Group')})" : group
       - else
         %li.disabled
           %a{:href => "#"}

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -9,7 +9,6 @@ module AuthHelper
     session[:userid]   = user.userid
     session[:username] = user.name
     session[:group]    = user.current_group.try(:id)
-    session[:eligible_groups] = []
   end
 end
 


### PR DESCRIPTION
No ui change.

Instead of storing the current_user.miq_groups array in the session, just use the current_group.miq_groups to build the group selection drop down on the right hand side.

related to #3170

/cc @dclarizio more work simplifying the session
/cc @Fryguy added those eligible_group specs that you asked me about before