### PR TITLE
HostOpenstackInfra make validate button work

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -40,6 +40,10 @@ class Authentication < ActiveRecord::Base
     self.authtype.nil? ? :default : self.authtype.to_sym
   end
 
+  def available?
+    password.present? || auth_key.present?
+  end
+
   # The various status types:
   #   valid, invalid
   #   incomplete  (???)

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -10,18 +10,19 @@ FactoryGirl.define do
     authtype    "ipmi"
   end
 
-  factory :authentication_ssh_keypair, :parent => :authentication do
+  factory :authentication_ws, :parent => :authentication do
+    authtype    "ws"
+  end
+
+  factory :authentication_ssh_keypair, :parent => :authentication, :class => 'ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair' do
     authtype    "ssh_keypair"
     userid      "testuser"
     password    nil
     auth_key    'private_key_content'
   end
 
-  factory :authentication_ssh_keypair_root, :parent => :authentication do
-    authtype    "ssh_keypair"
+  factory :authentication_ssh_keypair_root, :parent => :authentication_ssh_keypair do
     userid      "root"
-    password    nil
-    auth_key    'private_key_content'
   end
 
   factory :authentication_ssh_keypair_without_key, :parent => :authentication_ssh_keypair do


### PR DESCRIPTION
HostOpenstackInfra make validate button work, allowing to add
defailt password, which will owerwrite the parent auth. By
deleting the passwords it will use parent auth.

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1230831