### PR TITLE
Remove session[:base_miq]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1730,7 +1730,6 @@ class ApplicationController < ActionController::Base
     else
       prefix = "check" if prefix == nil
       items = Array.new
-      session[:base_miq] = ""
       params.each do |var, val|
         vars = var.to_s.split("_")
         if vars[0]==prefix && val=="1"


### PR DESCRIPTION
There are only setters in the code and no getters.

$ git grep base_miq
app/controllers/application_controller.rb:      session[:base_miq] = ""