### PR TITLE
Define inspect method for MiqAeServiceObject

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -441,5 +441,10 @@ module MiqAeMethodService
     def to_s
       self.name
     end
+
+    def inspect
+      hex_id = (object_id << 1).to_s(16).rjust(14, '0')
+      "#<#{self.class.name}:0x#{hex_id} name: #{name.inspect}>"
+    end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -31,6 +31,14 @@ module MiqAeServiceSpec
         @object.attributes.should == original_attributes
       end
     end
+
+    context "#inspect" do
+      it "returns the class, id and name" do
+        @object.stub(:object_name).and_return('fred')
+        regex = /#<MiqAeMethodService::MiqAeServiceObject:0x(\w+) name:.\"(?<name>\w+)\">/
+        match = regex.match(@service_object.inspect)
+        match[:name].should eq('fred')
+      end
+    end
   end
 end
-


### PR DESCRIPTION
Notes from ruby 2.0 incompatibilities
Object#inspect does always return a string like #<ClassName:0x…> instead
of delegating to #to_s. [#2152]

Since we didn't have the inspect method defined it would call the
Object#inspect causing the entire workspace and rest of automate objects
to be added as strings generating data over 27MB when an inspect is
called in any of the Drb returned objects. The automate methods would
then try to log this string and get the error [too large packet xxxxxxxx]

https://bugzilla.redhat.com/show_bug.cgi?id=1245724