### PR TITLE
Fix migration spec issue where AR schema cache may have cached table data

### DIFF
--- a/spec/support/migration_spec_helper.rb
+++ b/spec/support/migration_spec_helper.rb
@@ -54,6 +54,7 @@ module MigrationSpecHelper
 
       s.inheritance_column = i
     end
+    ActiveRecord::Base.connection.schema_cache.clear!
   end
 
   def clearing_caches

--- a/spec/support/migration_spec_helper.rb
+++ b/spec/support/migration_spec_helper.rb
@@ -45,15 +45,7 @@ module MigrationSpecHelper
   # Clears any cached column information on stubs, since the migrations
   # themselves will not expect anything to be cached.
   def clear_caches
-    ar_stubs.each do |s|
-      # inheritance_column changes done by migrations (e.g. to disable STI) are
-      # lost on reset_column_information, so we need to restore those changes.
-      i = s.inheritance_column
-
-      s.reset_column_information
-
-      s.inheritance_column = i
-    end
+    ar_stubs.each(&:reset_column_information)
     ActiveRecord::Base.connection.schema_cache.clear!
   end
 


### PR DESCRIPTION
Also, Rails 4 doesn't blow away inheritance column changes so remove the hack.

@tenderlove Please review.