### PR TITLE
Use fork instead of spawn to create worker processes for memory/speed savings

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -191,7 +191,7 @@ module Authenticator
     end
 
     def authorize_queue?
-      !MiqEnvironment::Process.is_ui_worker_via_command_line?
+      !defined?(Rails::Server)
     end
 
     def authorize_queue(username, _request, *args)

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -57,7 +57,7 @@ module EmsRefresh
   end
 
   def self.refresh(target, id = nil)
-    EmsRefresh.init_console if MiqEnvironment::Process.is_rails_console?
+    EmsRefresh.init_console if defined?(Rails::Console)
 
     # Handle targets passed as a single class/id pair, an array of class/id pairs, or an array of references
     targets = get_ar_objects(target, id)

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -187,6 +187,7 @@ class MiqServer < ActiveRecord::Base
     wait_for_started_workers
 
     update_attributes(:status => "started")
+    _log.info("Server starting complete")
   end
 
   def self.seed

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -318,9 +318,13 @@ class MiqWorker < ActiveRecord::Base
     )
   end
 
+  def self.after_fork
+    DRb.stop_service
+  end
+
   def start
     pid = fork do
-      DRb.stop_service
+      self.class.after_fork
       self.class::Runner.start_worker(command_line_params)
       exit!
     end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -318,11 +318,19 @@ class MiqWorker < ActiveRecord::Base
     )
   end
 
+  def self.preload
+  end
+
+  def self.before_fork
+    preload
+  end
+
   def self.after_fork
     DRb.stop_service
   end
 
   def start
+    self.class.before_fork
     pid = fork do
       self.class.after_fork
       self.class::Runner.start_worker(command_line_params)

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -320,6 +320,7 @@ class MiqWorker < ActiveRecord::Base
 
   def start
     pid = fork do
+      DRb.stop_service
       self.class::Runner.start_worker(command_line_params)
       exit!
     end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -318,7 +318,7 @@ class MiqWorker < ActiveRecord::Base
   end
 
   def self.before_fork
-    preload if respond_to?(:preload)
+    preload_for_worker_role if respond_to?(:preload_for_worker_role)
   end
 
   def self.after_fork

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -317,11 +317,8 @@ class MiqWorker < ActiveRecord::Base
     )
   end
 
-  def self.preload
-  end
-
   def self.before_fork
-    preload
+    preload if respond_to?(:preload)
   end
 
   def self.after_fork

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -32,6 +32,7 @@ class MiqWorker < ActiveRecord::Base
   STATUSES_ALIVE    = STATUSES_CURRENT_OR_STARTING + [STATUS_STOPPING]
   PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time proportional_set_size)
 
+  PROCESS_TITLE_PREFIX = "MIQ:".freeze
   def self.atStartup
     # Delete and Kill all workers that were running previously
     clean_all_workers

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -494,6 +494,10 @@ class MiqWorker < ActiveRecord::Base
     end
   end
 
+  def worker_options
+    {:guid => guid}
+  end
+
   protected
 
   def self.normalized_type
@@ -516,9 +520,5 @@ class MiqWorker < ActiveRecord::Base
   # TODO: Rename this!!!
   def self.build_command_line(*params)
     params.first || {}
-  end
-
-  def worker_options
-    {:guid => guid}
   end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -516,9 +516,4 @@ class MiqWorker < ActiveRecord::Base
     delta = worker_settings[:nice_delta]
     delta.kind_of?(Integer) ? delta.to_s : "+10"
   end
-
-  # TODO: Rename this!!!
-  def self.build_command_line(*params)
-    params.first || {}
-  end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -4,8 +4,6 @@ class MiqWorker < ActiveRecord::Base
   include UuidMixin
   include ReportableMixin
 
-  before_validation :set_command_line, :on => :create
-
   before_destroy :log_destroy_of_worker_messages
 
   belongs_to :miq_server
@@ -522,9 +520,5 @@ class MiqWorker < ActiveRecord::Base
 
   def worker_options
     {:guid => guid}
-  end
-
-  def set_command_line
-    self.command_line = self.class.build_command_line(worker_options)
   end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -333,7 +333,7 @@ class MiqWorker < ActiveRecord::Base
     self.class.before_fork
     pid = fork do
       self.class.after_fork
-      self.class::Runner.start_worker(command_line_params)
+      self.class::Runner.start_worker(worker_options)
       exit!
     end
 
@@ -520,11 +520,11 @@ class MiqWorker < ActiveRecord::Base
     params.first || {}
   end
 
-  def command_line_params
+  def worker_options
     {:guid => guid}
   end
 
   def set_command_line
-    self.command_line = self.class.build_command_line(command_line_params)
+    self.command_line = self.class.build_command_line(worker_options)
   end
 end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -18,15 +18,7 @@ class MiqWorker::Runner
   SAFE_SLEEP_SECONDS = 60
 
   def self.start_worker(*args)
-    cfg = {}
-    opts = OptionParser.new
-    self::OPTIONS_PARSER_SETTINGS.each do |key, desc, type|
-      opts.on("--#{key} VAL", desc, type) { |v| cfg[key] = v }
-    end
-    opts.parse(*args)
-
-    # Start the worker object
-    new(cfg).start
+    new(*args).start
   end
 
   def poll_method

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -464,8 +464,6 @@ class MiqWorker::Runner
   end
 
   def set_process_title
-    return unless Process.respond_to?(:setproctitle)
-
     type   = @worker.type.sub(/^ManageIQ::Providers::/, "")
     title  = "#{type} id: #{@worker.id}"
     title << ", queue: #{@worker.queue_name}" if @worker.queue_name

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -465,7 +465,7 @@ class MiqWorker::Runner
 
   def set_process_title
     type   = @worker.type.sub(/^ManageIQ::Providers::/, "")
-    title  = "#{type} id: #{@worker.id}"
+    title  = "#{MiqWorker::PROCESS_TITLE_PREFIX} #{type} id: #{@worker.id}"
     title << ", queue: #{@worker.queue_name}" if @worker.queue_name
     title << ", uri: #{@worker.uri}" if @worker.uri
 

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -37,10 +37,6 @@ module MiqWebServerRunnerMixin
 
       _log.info("With options: #{options.inspect}")
       Rails::Server.new(options).tap do |server|
-        # Use the already created Vmdb::Application, don't use a new one
-        # as it will require configuring the session store/secret and ???
-        # TODO: There has to be a way to create a Rails::Server with an existing Rails::Application.
-        server.instance_variable_set(:@app, Vmdb::Application)
         Dir.chdir(Vmdb::Application.root)
         server.start
       end

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -24,7 +24,7 @@ module MiqWebServerRunnerMixin
       worker.prepare
 
       # TODO: Need to rename build_command_line to options_hash or something
-      options = corresponding_model.build_command_line(:port => args.first[:port])
+      options = corresponding_model.build_command_line(:Port => args.first[:Port])
 
       # The heartbeating will be done in a separate thread
       Thread.new { worker.run }

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -14,4 +14,36 @@ module MiqWebServerRunnerMixin
     # Since puma/thin traps interrupts, log that we're going away and update our worker row
     at_exit { do_exit("Exit request received.") }
   end
+
+  module ClassMethods
+    def start_worker(*args)
+      worker = self.new(*args)
+      _log.info("URI: #{worker.worker.uri}")
+
+      # Do all the SQL worker preparation in the main thread
+      worker.prepare
+
+      # TODO: Need to rename build_command_line to options_hash or something
+      options = corresponding_model.build_command_line(:port => args.first[:port])
+
+      # The heartbeating will be done in a separate thread
+      Thread.new { worker.run }
+
+      start_rails_server(options)
+    end
+
+    def start_rails_server(options)
+      require "rails/commands/server"
+
+      _log.info("With options: #{options.inspect}")
+      Rails::Server.new(options).tap do |server|
+        # Use the already created Vmdb::Application, don't use a new one
+        # as it will require configuring the session store/secret and ???
+        # TODO: There has to be a way to create a Rails::Server with an existing Rails::Application.
+        server.instance_variable_set(:@app, Vmdb::Application)
+        Dir.chdir(Vmdb::Application.root)
+        server.start
+      end
+    end
+  end
 end

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -26,6 +26,7 @@ module MiqWebServerRunnerMixin
       # The heartbeating will be done in a separate thread
       Thread.new { runner.run }
 
+      runner.worker.class.configure_secret_token
       start_rails_server(runner.worker.rails_server_options)
     end
 

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -17,17 +17,17 @@ module MiqWebServerRunnerMixin
 
   module ClassMethods
     def start_worker(*args)
-      worker = self.new(*args)
-      _log.info("URI: #{worker.worker.uri}")
+      runner = self.new(*args)
+      _log.info("URI: #{runner.worker.uri}")
 
       # Do all the SQL worker preparation in the main thread
-      worker.prepare
+      runner.prepare
 
       # TODO: Need to rename build_command_line to options_hash or something
       options = corresponding_model.build_command_line(:Port => args.first[:Port])
 
       # The heartbeating will be done in a separate thread
-      Thread.new { worker.run }
+      Thread.new { runner.run }
 
       start_rails_server(options)
     end

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -23,13 +23,10 @@ module MiqWebServerRunnerMixin
       # Do all the SQL worker preparation in the main thread
       runner.prepare
 
-      # TODO: Need to rename build_command_line to options_hash or something
-      options = corresponding_model.build_command_line(:Port => args.first[:Port])
-
       # The heartbeating will be done in a separate thread
       Thread.new { runner.run }
 
-      start_rails_server(options)
+      start_rails_server(runner.worker.rails_server_options)
     end
 
     def start_rails_server(options)

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -17,12 +17,6 @@ module MiqWebServerWorkerMixin
       VMDB::Config.new("vmdb").config.fetch_path(:server, :rails_server) || "thin"
     end
 
-    def self.rails_server_command_line
-      @rails_server_command_line ||= begin
-        "#{nice_prefix} #{Rails.root.join("bin", "rails")} server #{rails_server}".freeze
-      end
-    end
-
     def self.build_command_line(*params)
       params = params.first || {}
 
@@ -51,10 +45,7 @@ module MiqWebServerWorkerMixin
       #
       #      -h, --help                       Show this help message.
       #
-      cl = rails_server_command_line.dup
-
-      params.each { |k, v| cl << " --#{k} \"#{v}\"" unless v.blank? }
-      cl
+      params
     end
 
     def self.all_ports_in_use
@@ -176,7 +167,7 @@ module MiqWebServerWorkerMixin
     end
 
     def command_line_params
-      params = {}
+      params = super
       params[:port] = port if port.kind_of?(Numeric)
       params
     end
@@ -184,6 +175,7 @@ module MiqWebServerWorkerMixin
     def start
       delete_pid_file
       ENV['PORT'] = port.to_s
+      ENV['MIQ_GUID'] = guid
       super
     end
 

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -21,30 +21,49 @@ module MiqWebServerWorkerMixin
       params = params.first || {}
 
       defaults = {
-        :port        => 3000,
-        :binding     => binding_address,
+        :Port        => 3000,
+        :Host        => binding_address,
         :environment => Rails.env.to_s,
-        :config      => Rails.root.join("config.ru")
+        :config      => Rails.root.join("config.ru").to_s
       }
 
       params = defaults.merge(params)
-      params[:pid] = pid_file(params[:port])
+      params[:pid] = pid_file(params[:Port]).to_s
 
-      # Usage: rails server [mongrel, thin, etc] [options]
-      #      -p, --port=port                  Runs Rails on the specified port.
-      #                                       Default: 3000
-      #      -b, --binding=ip                 Binds Rails to the specified ip.
-      #                                       Default: 0.0.0.0
-      #      -c, --config=file                Use custom rackup configuration file
-      #      -d, --daemon                     Make server run as a Daemon.
-      #      -u, --debugger                   Enable ruby-debugging for the server.
-      #      -e, --environment=name           Specifies the environment to run this server under (test/development/production).
-      #                                       Default: development
-      #      -P, --pid=pid                    Specifies the PID file.
-      #                                       Default: tmp/pids/server.pid
-      #
-      #      -h, --help                       Show this help message.
-      #
+      # Rack::Server options:
+
+      # Options may include:
+      # * :app
+      #     a rack application to run (overrides :config)
+      # * :config
+      #     a rackup configuration file path to load (.ru)
+      # * :environment
+      #     this selects the middleware that will be wrapped around
+      #     your application. Default options available are:
+      #       - development: CommonLogger, ShowExceptions, and Lint
+      #       - deployment: CommonLogger
+      #       - none: no extra middleware
+      #     note: when the server is a cgi server, CommonLogger is not included.
+      # * :server
+      #     choose a specific Rack::Handler, e.g. cgi, fcgi, webrick
+      # * :daemonize
+      #     if true, the server will daemonize itself (fork, detach, etc)
+      # * :pid
+      #     path to write a pid file after daemonize
+      # * :Host
+      #     the host address to bind to (used by supporting Rack::Handler)
+      # * :Port
+      #     the port to bind to (used by supporting Rack::Handler)
+      # * :AccessLog
+      #     webrick access log options (or supporting Rack::Handler)
+      # * :debug
+      #     turn on debug output ($DEBUG = true)
+      # * :warn
+      #     turn on warnings ($-w = true)
+      # * :include
+      #     add given paths to $LOAD_PATH
+      # * :require
+      #     require the given libraries
       params
     end
 
@@ -168,7 +187,7 @@ module MiqWebServerWorkerMixin
 
     def command_line_params
       params = super
-      params[:port] = port if port.kind_of?(Numeric)
+      params[:Port] = port if port.kind_of?(Numeric)
       params
     end
 

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -24,7 +24,7 @@ module MiqWebServerWorkerMixin
         :Port        => 3000,
         :Host        => binding_address,
         :environment => Rails.env.to_s,
-        :config      => Rails.root.join("config.ru").to_s
+        :app         => Vmdb::Application
       }
 
       params = defaults.merge(params)

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -13,6 +13,15 @@ module MiqWebServerWorkerMixin
       BINDING_ADDRESS
     end
 
+    def self.preload
+      super
+
+      require 'hamlit-rails'
+
+      # Make these constants globally available
+      ::UiConstants
+    end
+
     def self.rails_server
       VMDB::Config.new("vmdb").config.fetch_path(:server, :rails_server) || "thin"
     end

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -19,7 +19,16 @@ module MiqWebServerWorkerMixin
       # Make these constants globally available
       ::UiConstants
 
+      configure_secret_token
+    end
+
+    def self.configure_secret_token
       Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
+
+      # To set a secret token after the Vmdb::Application is initialized?,
+      # we need to reset the secrets since they are cached:
+      # https://github.com/rails/rails/blob/4-2-stable/railties/lib/rails/application.rb#L386-L401
+      Vmdb::Application.secrets = nil if Vmdb::Application.initialized?
     end
 
     def self.rails_server
@@ -147,7 +156,6 @@ module MiqWebServerWorkerMixin
     def rails_server_options
       # See Rack::Server options which is what Rails::Server uses:
       # https://github.com/rack/rack/blob/1.6.4/lib/rack/server.rb#L152-L183
-
       params = {
         :Host        => self.class.binding_address,
         :environment => Rails.env.to_s,

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -194,7 +194,7 @@ module MiqWebServerWorkerMixin
       end
     end
 
-    def command_line_params
+    def worker_options
       params = super
       params[:Port] = port if port.kind_of?(Numeric)
       params

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -145,6 +145,9 @@ module MiqWebServerWorkerMixin
     end
 
     def rails_server_options
+      # See Rack::Server options which is what Rails::Server uses:
+      # https://github.com/rack/rack/blob/1.6.4/lib/rack/server.rb#L152-L183
+
       params = {
         :Host        => self.class.binding_address,
         :environment => Rails.env.to_s,
@@ -154,40 +157,6 @@ module MiqWebServerWorkerMixin
       params[:Port] = port.kind_of?(Numeric) ? port : 3000
       params[:pid]  = self.class.pid_file(params[:Port]).to_s
 
-      # Rack::Server options:
-
-      # Options may include:
-      # * :app
-      #     a rack application to run (overrides :config)
-      # * :config
-      #     a rackup configuration file path to load (.ru)
-      # * :environment
-      #     this selects the middleware that will be wrapped around
-      #     your application. Default options available are:
-      #       - development: CommonLogger, ShowExceptions, and Lint
-      #       - deployment: CommonLogger
-      #       - none: no extra middleware
-      #     note: when the server is a cgi server, CommonLogger is not included.
-      # * :server
-      #     choose a specific Rack::Handler, e.g. cgi, fcgi, webrick
-      # * :daemonize
-      #     if true, the server will daemonize itself (fork, detach, etc)
-      # * :pid
-      #     path to write a pid file after daemonize
-      # * :Host
-      #     the host address to bind to (used by supporting Rack::Handler)
-      # * :Port
-      #     the port to bind to (used by supporting Rack::Handler)
-      # * :AccessLog
-      #     webrick access log options (or supporting Rack::Handler)
-      # * :debug
-      #     turn on debug output ($DEBUG = true)
-      # * :warn
-      #     turn on warnings ($-w = true)
-      # * :include
-      #     add given paths to $LOAD_PATH
-      # * :require
-      #     require the given libraries
       params
     end
 

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -20,6 +20,8 @@ module MiqWebServerWorkerMixin
 
       # Make these constants globally available
       ::UiConstants
+
+      Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
     end
 
     def self.rails_server

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -13,7 +13,7 @@ module MiqWebServerWorkerMixin
       BINDING_ADDRESS
     end
 
-    def self.preload
+    def self.preload_for_worker_role
       require 'hamlit-rails'
 
       # Make these constants globally available

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -14,8 +14,6 @@ module MiqWebServerWorkerMixin
     end
 
     def self.preload
-      super
-
       require 'hamlit-rails'
 
       # Make these constants globally available

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -26,56 +26,6 @@ module MiqWebServerWorkerMixin
       VMDB::Config.new("vmdb").config.fetch_path(:server, :rails_server) || "thin"
     end
 
-    def self.build_command_line(*params)
-      params = params.first || {}
-
-      defaults = {
-        :Port        => 3000,
-        :Host        => binding_address,
-        :environment => Rails.env.to_s,
-        :app         => Vmdb::Application
-      }
-
-      params = defaults.merge(params)
-      params[:pid] = pid_file(params[:Port]).to_s
-
-      # Rack::Server options:
-
-      # Options may include:
-      # * :app
-      #     a rack application to run (overrides :config)
-      # * :config
-      #     a rackup configuration file path to load (.ru)
-      # * :environment
-      #     this selects the middleware that will be wrapped around
-      #     your application. Default options available are:
-      #       - development: CommonLogger, ShowExceptions, and Lint
-      #       - deployment: CommonLogger
-      #       - none: no extra middleware
-      #     note: when the server is a cgi server, CommonLogger is not included.
-      # * :server
-      #     choose a specific Rack::Handler, e.g. cgi, fcgi, webrick
-      # * :daemonize
-      #     if true, the server will daemonize itself (fork, detach, etc)
-      # * :pid
-      #     path to write a pid file after daemonize
-      # * :Host
-      #     the host address to bind to (used by supporting Rack::Handler)
-      # * :Port
-      #     the port to bind to (used by supporting Rack::Handler)
-      # * :AccessLog
-      #     webrick access log options (or supporting Rack::Handler)
-      # * :debug
-      #     turn on debug output ($DEBUG = true)
-      # * :warn
-      #     turn on warnings ($-w = true)
-      # * :include
-      #     add given paths to $LOAD_PATH
-      # * :require
-      #     require the given libraries
-      params
-    end
-
     def self.all_ports_in_use
       server_scope.select(&:enabled_or_running?).collect(&:port)
     end
@@ -194,9 +144,50 @@ module MiqWebServerWorkerMixin
       end
     end
 
-    def worker_options
-      params = super
-      params[:Port] = port if port.kind_of?(Numeric)
+    def rails_server_options
+      params = {
+        :Host        => self.class.binding_address,
+        :environment => Rails.env.to_s,
+        :app         => Vmdb::Application
+      }
+
+      params[:Port] = port.kind_of?(Numeric) ? port : 3000
+      params[:pid]  = self.class.pid_file(params[:Port]).to_s
+
+      # Rack::Server options:
+
+      # Options may include:
+      # * :app
+      #     a rack application to run (overrides :config)
+      # * :config
+      #     a rackup configuration file path to load (.ru)
+      # * :environment
+      #     this selects the middleware that will be wrapped around
+      #     your application. Default options available are:
+      #       - development: CommonLogger, ShowExceptions, and Lint
+      #       - deployment: CommonLogger
+      #       - none: no extra middleware
+      #     note: when the server is a cgi server, CommonLogger is not included.
+      # * :server
+      #     choose a specific Rack::Handler, e.g. cgi, fcgi, webrick
+      # * :daemonize
+      #     if true, the server will daemonize itself (fork, detach, etc)
+      # * :pid
+      #     path to write a pid file after daemonize
+      # * :Host
+      #     the host address to bind to (used by supporting Rack::Handler)
+      # * :Port
+      #     the port to bind to (used by supporting Rack::Handler)
+      # * :AccessLog
+      #     webrick access log options (or supporting Rack::Handler)
+      # * :debug
+      #     turn on debug output ($DEBUG = true)
+      # * :warn
+      #     turn on warnings ($-w = true)
+      # * :include
+      #     add given paths to $LOAD_PATH
+      # * :require
+      #     require the given libraries
       params
     end
 

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -5,8 +5,6 @@ module PerEmsWorkerMixin
     class_eval do
       self.check_for_minimal_role = false
       self.workers = -> { desired_queue_names.length }
-
-      alias_method_chain :command_line_params, :ems_id
     end
   end
 
@@ -122,7 +120,7 @@ module PerEmsWorkerMixin
     self.class.ems_from_queue_name(queue_name)
   end
 
-  def command_line_params_with_ems_id
-    command_line_params_without_ems_id.merge(:ems_id => ems_id)
+  def command_line_params
+    super.merge(:ems_id => ems_id)
   end
 end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -120,7 +120,7 @@ module PerEmsWorkerMixin
     self.class.ems_from_queue_name(queue_name)
   end
 
-  def command_line_params
+  def worker_options
     super.merge(:ems_id => ems_id)
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 if !Rails.env.development? && !Rails.env.production?
   Vmdb::Application.config.session_store :memory_store
-elsif MiqEnvironment::Process.is_web_server_worker?
+else
   session_options = {}
   if MiqEnvironment::Command.is_appliance?
     session_options[:secure]   = true

--- a/db/migrate/20160105170524_remove_miq_worker_command_line.rb
+++ b/db/migrate/20160105170524_remove_miq_worker_command_line.rb
@@ -1,0 +1,9 @@
+class RemoveMiqWorkerCommandLine < ActiveRecord::Migration
+  def up
+    remove_column :miq_workers, :command_line
+  end
+
+  def down
+    add_column :miq_workers, :command_line, :string, :limit => 512
+  end
+end

--- a/gems/pending/util/miq-process.rb
+++ b/gems/pending/util/miq-process.rb
@@ -160,7 +160,7 @@ class MiqProcess
 
   def self.is_worker?(pid)
     command_line = self.command_line(pid)
-    command_line && command_line =~ /^ruby.+(runner|mongrel_rails)/
+    command_line.include?(MiqWorker::PROCESS_TITLE_PREFIX)
   end
 
   LINUX_STATES = {

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -1,62 +1,6 @@
 require 'sys-uname'
 
 module MiqEnvironment
-  class Process
-    def self.is_rails_server?
-      return @is_rails_server unless @is_rails_server.nil?
-      @is_rails_server = File.basename($PROGRAM_NAME) =~ /rackup|puma|thin/ || (File.basename($PROGRAM_NAME) == "rails" && !!defined?(Rails::Server))
-    end
-
-    def self.is_rails_console?
-      return @is_rails_console unless @is_rails_console.nil?
-      @is_rails_console = File.basename($PROGRAM_NAME) == "rails" && !!defined?(Rails::Console)
-    end
-
-    def self.is_rails_runner?
-      return @is_rails_runner unless @is_rails_runner.nil?
-      @is_rails_runner = !is_rails_server? && !is_rails_console?
-    end
-
-    def self.is_ui_worker_via_command_line?
-      return @is_ui_worker_via_command_line unless @is_ui_worker_via_command_line.nil?
-      # TODO: Support rdebug-ide
-      @is_ui_worker_via_command_line = (is_rails_server? && ENV['PORT'].to_s.empty?) || !ENV['SPEC_UI'].to_s.empty?
-    end
-
-    def self.is_ui_worker_via_evm_server?
-      return @is_ui_worker_via_evm_server unless @is_ui_worker_via_evm_server.nil?
-      @is_ui_worker_via_evm_server = is_rails_server? && ENV['PORT'].to_s =~ /^3[0-9]+/
-    end
-
-    def self.is_ui_worker?
-      return @is_ui_worker unless @is_ui_worker.nil?
-      @is_ui_worker = is_ui_worker_via_command_line? || is_ui_worker_via_evm_server?
-    end
-
-    def self.is_web_service_worker?
-      return @is_web_service_worker unless @is_web_service_worker.nil?
-      @is_web_service_worker = is_rails_server? && ENV['PORT'].to_s =~ /^4[0-9]+/
-    end
-    class << self; alias_method :is_web_service_worker_via_evm_server?, :is_web_service_worker?; end
-
-    def self.is_web_server_worker?
-      return @is_web_server_worker unless @is_web_server_worker.nil?
-      @is_web_server_worker = is_ui_worker? || is_web_service_worker?
-    end
-
-    def self.is_worker?
-      return @is_worker unless @is_worker.nil?
-      @is_worker = is_non_web_server_worker? || is_web_server_worker?
-    end
-
-    def self.is_non_web_server_worker?
-      return @is_non_web_server_worker unless @is_non_web_server_worker.nil?
-      # ARGV: ["priority_worker", "MiqPriorityWorker", "--queue_name", "generic", "--guid", "33d93972-56ff-11e0-98ac-001f5bee6a67"]
-      klass = ARGV[1].constantize rescue NilClass
-      @is_non_web_server_worker = is_rails_runner? && klass < MiqWorker
-    end
-  end
-
   class Command
     EVM_KNOWN_COMMANDS = %w( memcached memcached-tool service apachectl nohup)
 

--- a/lib/report_formatter.rb
+++ b/lib/report_formatter.rb
@@ -3,8 +3,6 @@
 # singleton constants don't play nice with Rails class reloading in dev mode.
 # Either access the constants through the UiConstants namespace or get it to
 # work with including it in all the views/controllers via application_helper.
-UiConstants unless MiqEnvironment::Process.is_web_server_worker?
-
 include ActionView::Helpers::NumberHelper
 
 require 'report_formatter/report_renderer'

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -5,12 +5,8 @@ module Vmdb
 
       Vmdb::Loggers.apply_config
 
-      if MiqEnvironment::Process.is_web_server_worker?
-        require 'hamlit-rails'
-
-        # Make these constants globally available
-        ::UiConstants
-      end
+      # For `rails server` invocation.  The server calls this before forking UI or Web Service Workers.
+      MiqUiWorker.preload if MiqEnvironment::Process.is_ui_worker_via_command_line?
 
       # When these classes are deserialized in ActiveRecord (e.g. EmsEvent, MiqQueue), they need to be preloaded
       require 'VimTypes'

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -31,9 +31,8 @@ module Vmdb
         MiqServer.my_server.update_attributes(:status => "started")
       end
 
-      if MiqEnvironment::Process.is_web_server_worker?
-        Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
-      end
+      MiqDatabase.seed
+      Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
     end
   end
 end

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -34,26 +34,6 @@ module Vmdb
       if MiqEnvironment::Process.is_web_server_worker?
         Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
       end
-
-      ####################################################
-      # If this is intended to field Rails requests (called via mongrel_rails start),
-      # Then start a UiWorker, so that it can be monitored
-      ####################################################
-      if MiqEnvironment::Process.is_ui_worker_via_evm_server?
-        # Do all the SQL worker preparation in the main thread
-        ui_worker = MiqUiWorker::Runner.new.prepare
-
-        # The heartbeating will be done in a separate thread
-        Thread.new { ui_worker.run }
-      end
-
-      if MiqEnvironment::Process.is_web_service_worker_via_evm_server?
-        # Do all the SQL worker preparation in the main thread
-        ws_worker = MiqWebServiceWorker::Runner.new.prepare
-
-        # The heartbeating will be done in a separate thread
-        Thread.new { ws_worker.run }
-      end
     end
   end
 end

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -5,23 +5,14 @@ module Vmdb
 
       Vmdb::Loggers.apply_config
 
-      # For `rails server` invocation.  The server calls this before forking UI or Web Service Workers.
-      MiqUiWorker.preload if MiqEnvironment::Process.is_ui_worker_via_command_line?
-
       # When these classes are deserialized in ActiveRecord (e.g. EmsEvent, MiqQueue), they need to be preloaded
       require 'VimTypes'
 
-      ####################################################
-      # If UiWorker called in Development Mode
-      #   invoked via command line -- script/server
-      #   invoked via debugger     -- using rdebug-ide gem
-      #
-      # Then, set up VMDB as if called from MiqServer:
-      #   1. SEED the MUST-HAVE classes
-      #   2. Mark current server as started
-      #
-      ####################################################
+      # UiWorker called in Development Mode
+      #   * command line(rails server)
+      #   * debugger
       if MiqEnvironment::Process.is_ui_worker_via_command_line?
+        MiqUiWorker.preload
         EvmDatabase.seed_primordial
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update_attributes(:status => "started")

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -11,7 +11,7 @@ module Vmdb
       # UiWorker called in Development Mode
       #   * command line(rails server)
       #   * debugger
-      if MiqEnvironment::Process.is_ui_worker_via_command_line?
+      if defined?(Rails::Server)
         MiqUiWorker.preload_for_worker_role
         EvmDatabase.seed_primordial
         MiqServer.my_server.starting_server_record

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -26,9 +26,6 @@ module Vmdb
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update_attributes(:status => "started")
       end
-
-      MiqDatabase.seed
-      Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
     end
   end
 end

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -12,7 +12,7 @@ module Vmdb
       #   * command line(rails server)
       #   * debugger
       if MiqEnvironment::Process.is_ui_worker_via_command_line?
-        MiqUiWorker.preload
+        MiqUiWorker.preload_for_worker_role
         EvmDatabase.seed_primordial
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update_attributes(:status => "started")

--- a/lib/workers/bin/evm_server.rb
+++ b/lib/workers/bin/evm_server.rb
@@ -1,5 +1,5 @@
-require "workers/evm_server"
-if MiqEnvironment::Process.is_rails_runner?
+if defined?(Vmdb::Application) && Vmdb::Application.initialized?
+  require "workers/evm_server"
   EvmServer.start(*ARGV)
 else
   puts "run with rails runner evm_server.rb"

--- a/lib/workers/bin/worker.rb
+++ b/lib/workers/bin/worker.rb
@@ -1,2 +1,0 @@
-type = ARGV.shift
-type.constantize.start_worker(*ARGV)

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -1,13 +1,6 @@
 require "spec_helper"
 
 describe MiqUiWorker do
-  it ".build_command_line" do
-    run1 = MiqUiWorker.build_command_line(:arg1 => true)
-    run2 = MiqUiWorker.build_command_line(:arg1 => true)
-    expect(run1).to eq(run2)         # same values
-    expect(run1).not_to equal run2  # different Objects
-  end
-
   context ".all_ports_in_use" do
     before do
       require 'util/miq-process'

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -253,6 +253,10 @@ describe MiqWorker do
       @worker = FactoryGirl.create(:miq_worker)
     end
 
+    it "#worker_options" do
+      expect(@worker.worker_options).to eq(:guid => @worker.guid)
+    end
+
     it "is_current? false when starting" do
       @worker.update_attribute(:status, described_class::STATUS_STARTING)
       expect(@worker.is_current?).not_to be_truthy

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -37,7 +37,6 @@ describe MiqWorker do
 
     context "clean_active_messages" do
       before do
-        allow_any_instance_of(MiqWorker).to receive(:set_command_line)
         @worker = FactoryGirl.create(:miq_worker, :miq_server => @server)
         @message = FactoryGirl.create(:miq_queue, :handler => @worker, :state => 'dequeue')
       end

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -9,4 +9,9 @@ describe MiqWebServerWorkerMixin do
     allow(test_class).to receive_messages(:binding_address => "::1")
     expect(test_class.build_uri(123)).to eq "http://[::1]:123"
   end
+
+  it "#worker_options" do
+    w = FactoryGirl.create(:miq_ui_worker, :uri => "http://127.0.0.1:3000")
+    expect(w.worker_options).to eq(:guid => w.guid, :Port => 3000)
+  end
 end

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -14,4 +14,13 @@ describe MiqWebServerWorkerMixin do
     w = FactoryGirl.create(:miq_ui_worker, :uri => "http://127.0.0.1:3000")
     expect(w.worker_options).to eq(:guid => w.guid, :Port => 3000)
   end
+
+  it ".build_command_line" do
+    expect(MiqUiWorker.build_command_line(:Port => 3000)).to have_attributes(
+      :Port        => 3000,
+      :Host        => "0.0.0.0",
+      :environment => "test",
+      :app         => Vmdb::Application
+    )
+  end
 end

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -10,16 +10,12 @@ describe MiqWebServerWorkerMixin do
     expect(test_class.build_uri(123)).to eq "http://[::1]:123"
   end
 
-  it "#worker_options" do
+  it "#rails_server_options" do
     w = FactoryGirl.create(:miq_ui_worker, :uri => "http://127.0.0.1:3000")
-    expect(w.worker_options).to eq(:guid => w.guid, :Port => 3000)
-  end
-
-  it ".build_command_line" do
-    expect(MiqUiWorker.build_command_line(:Port => 3000)).to have_attributes(
+    expect(w.rails_server_options).to have_attributes(
       :Port        => 3000,
-      :Host        => "0.0.0.0",
-      :environment => "test",
+      :Host        => w.class.binding_address,
+      :environment => Rails.env.to_s,
       :app         => Vmdb::Application
     )
   end

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -17,8 +17,8 @@ describe PerEmsWorkerMixin do
     expect(@worker_class.queue_name_for_ems(@ems)).to eq(@ems_queue_name)
   end
 
-  it ".worker_options" do
-    expect(@worker_record.send(:worker_options)).to eq(:guid => @worker_record.guid, :ems_id => @ems.id)
+  it "#worker_options" do
+    expect(@worker_record.worker_options).to eq(:guid => @worker_record.guid, :ems_id => @ems.id)
   end
 
   context ".start_worker_for_ems" do

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -17,6 +17,10 @@ describe PerEmsWorkerMixin do
     expect(@worker_class.queue_name_for_ems(@ems)).to eq(@ems_queue_name)
   end
 
+  it ".command_line_params" do
+    expect(@worker_record.send(:command_line_params)).to eq(:guid => @worker_record.guid, :ems_id => @ems.id)
+  end
+
   context ".start_worker_for_ems" do
     it "works when queue name is passed" do
       queue_name = "foo"

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -17,8 +17,8 @@ describe PerEmsWorkerMixin do
     expect(@worker_class.queue_name_for_ems(@ems)).to eq(@ems_queue_name)
   end
 
-  it ".command_line_params" do
-    expect(@worker_record.send(:command_line_params)).to eq(:guid => @worker_record.guid, :ems_id => @ems.id)
+  it ".worker_options" do
+    expect(@worker_record.send(:worker_options)).to eq(:guid => @worker_record.guid, :ems_id => @ems.id)
   end
 
   context ".start_worker_for_ems" do


### PR DESCRIPTION
Replaces #1070 

Using Kernel.fork instead of Kernel.spawn when the main server process creates child processes allows us to take advantage of copy on write friendly ruby 2.0+ to share memory (in the future) and much faster worker creation since many of the files are already required and loaded in memory.

MiqServer#start is now **3 times faster: 45 -> 15 seconds**

For non-code related discussion, see the [talk.manageiq.org thread](http://talk.manageiq.org/t/use-process-fork-to-create-workers/1152)

TODO list done outside of this PR:
- [x] Add [Proportional set size](https://github.com/ManageIQ/manageiq/pull/6112) for measuring forked process memory usage more accurately 
- [x] Add [smem utility to appliances](https://github.com/ManageIQ/manageiq-appliance-build/pull/84)
- [ ] LATER: In [MiqServer#sync_workers, separate the calculation of workers needed per worker class from the actual starting/stopping of said workers](https://github.com/ManageIQ/manageiq/pull/6160)

TODO list:
- [x] Change base workers to fork instead of spawn
- [x] Change UI/Web Service workers to run Rails::Server after they fork
- [x] Add pre_fork hook to contain the future logic for preloading gems, files, etc. (actual preloading to occur in a followup PR
- [x] Add after_fork hook to stop the server's DRb::Service in all forked children
- [x] Change the worker setproctitle to a common worker prefix to make it easier to detect them in ps, top, and MiqProcess
- [x] Remove now unused `command_line` column and `build_command_line` related methods
- [x] Close raw pg sockets inherited in the forked child process
- [x] Change memory threshold tests to use PSS (on linux) instead of RSS to determine if a worker has exceeded it's limits.
- [x] Fix `MiqEnvironment::Process.is_x?` methods to work with forked worker processes that don't go through initialization code like before - REMOVED CALLERS AND DELETED :scissors: 
- [x] Fix not set secret_token `Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token` because we call this too late now

This pull request only forks and does not attempt to decrease memory usage by preloading code before we fork.  Therefore, we might actually use more memory with this PR.


