### PR TITLE
Removed leftover code from Resource Pool listnav

### DIFF
--- a/app/views/layouts/listnav/_resource_pool.html.haml
+++ b/app/views/layouts/listnav/_resource_pool.html.haml
@@ -4,8 +4,7 @@
     = patternfly_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
       = render :partial => "layouts/quadicon", :locals => {:mode => :icon, :item => @record, :size => 72, :typ => :listnav}
 
-    = patternfly_accordion_panel(_("Properties"),
-      @panels["resource_pool_prop"].nil? || @panels["resource_pool_prop"] == false, "resource_pool_prop") do
+    = patternfly_accordion_panel(_("Properties"), false, "resource_pool_prop") do
       %ul.nav.nav-pills.nav-stacked
         %li
           = link_to(_('Summary'),


### PR DESCRIPTION
Removed leftover code from Resource Pool listnav that was causing Properties section to show as opened when going to screen first time.

https://bugzilla.redhat.com/show_bug.cgi?id=1246558

@dclarizio please review.