### PR TITLE
Implemented heartbeat checking in the replication worker child process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "ruport",                         "=1.7.0",                          :git =>
 
 # Vendored but not required
 gem "net-ldap",                       "~>0.7.0",      :require => false
-gem "rubyrep",                        "=1.2.0",       :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :branch => "rails4"
+gem "rubyrep",                        "=1.2.0",       :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-7"
 gem "simple-rss",                     "~>1.3.1",      :require => false
 gem "winrm",                          "=1.1.3",       :require => false, :git => "git://github.com/ManageIQ/WinRM.git", :tag => "v1.1.3-1"
 gem "ziya",                           "=2.3.0",       :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,10 @@ gem "snmp",                           "~>1.1.0",      :require => false
 gem "uglifier",                       "~>2.7.1",      :require => false
 gem "novnc-rails",                    "~>0.2"
 gem 'spice-html5-rails'
-gem 'sys-proctable',                                  :require => false
+
+if RUBY_PLATFORM =~ /darwin/i # This is only used on Mac
+  gem 'sys-proctable',                                :require => false
+end
 
 
 ### Start of gems excluded from the appliances.

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem "snmp",                           "~>1.1.0",      :require => false
 gem "uglifier",                       "~>2.7.1",      :require => false
 gem "novnc-rails",                    "~>0.2"
 gem 'spice-html5-rails'
+gem 'sys-proctable',                                  :require => false
 
 
 ### Start of gems excluded from the appliances.

--- a/Gemfile
+++ b/Gemfile
@@ -80,10 +80,6 @@ gem "uglifier",                       "~>2.7.1",      :require => false
 gem "novnc-rails",                    "~>0.2"
 gem 'spice-html5-rails'
 
-if RUBY_PLATFORM =~ /darwin/i # This is only used on Mac
-  gem 'sys-proctable',                                :require => false
-end
-
 
 ### Start of gems excluded from the appliances.
 # The gems listed below do not need to be packaged until we find it necessary or useful.

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -511,6 +511,8 @@ workers:
         :options:
           :replication_trace: false
           :debug_sql: false
+          :heartbeat_file: /tmp/rubyrep_hb
+          :heartbeat_threshold: 300
     :schedule_worker:
       :authentication_check_interval: 1.day
       :db_diagnostics_interval: 30.minutes

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -511,7 +511,6 @@ workers:
         :options:
           :replication_trace: false
           :debug_sql: false
-          :heartbeat_file: /tmp/rubyrep_hb
           :heartbeat_threshold: 300
     :schedule_worker:
       :authentication_check_interval: 1.day

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -43,6 +43,10 @@ gem "trollop",                 "~>2.0",             :require => false
 gem "psych",                   "~>2.0.12"
 gem "apipie-bindings",         "~>0.0.12",          :require => false
 
+if RUBY_PLATFORM =~ /darwin/i # This is only used on Mac
+  gem 'sys-proctable',                                :require => false
+end
+
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")
   gem "linux_block_device", ">=0.1.0", :require => false

--- a/gems/pending/util/miq-process.rb
+++ b/gems/pending/util/miq-process.rb
@@ -205,6 +205,13 @@ class MiqProcess
           pids << pid.to_i
         end
       end
+    when :macosx
+      require 'sys/proctable'
+      Sys::ProcTable.ps.select do |p|
+        if p.cmdline && cmd.match(p.cmdline.gsub("\000", " ").strip)
+          pids << p.pid
+        end
+      end
     else
       raise NotImplementedError, "Method MiqProcess.find_pids not implemented on this platform [#{Platform::IMPL}]"
     end

--- a/lib/miq_rubyrep.rb
+++ b/lib/miq_rubyrep.rb
@@ -14,7 +14,6 @@ class MiqRubyrep
   def self.prepare_configuration(config)
     db_conf  = VMDB::Config.new("database").config[Rails.env.to_sym]
 
-    defaults = VMDB::Config.new("vmdb").retrieve_config(:tmpl).fetch_path(:workers, :worker_base, :replication_worker, :replication)
     rp_conf  = MiqReplicationWorker.worker_settings[:replication]
     raise "Replication configuration missing" if rp_conf.blank?
     if db_conf.slice(:host, :port, :database) == rp_conf.slice(:host, :port, :database)
@@ -49,7 +48,7 @@ class MiqRubyrep
     config.options[:right_record_handling]         = :ignore
     config.options[:left_record_handling]          = :insert
     config.options[:sync_conflict_handling]        = :left_wins
-    config.options[:heartbeat_file]                = rp_conf.fetch_path(:options, :heartbeat_file) || defaults.fetch_path(:options, :heartbeat_file)
+    config.options[:heartbeat_file]                = heartbeat_file
 
     rp_conf[:include_tables] ||= %w{.+}
     include_tables = rp_conf[:include_tables].to_a.join("|")
@@ -79,5 +78,9 @@ class MiqRubyrep
         :exclude_tables => exclude_tables,
         :options        => config.options
       })
+  end
+
+  def self.heartbeat_file
+    Rails.root.join('tmp/rubyrep_hb')
   end
 end

--- a/lib/workers/replication_worker.rb
+++ b/lib/workers/replication_worker.rb
@@ -178,7 +178,7 @@ class ReplicationWorker < WorkerBase
                           .fetch_path(:workers, :worker_base, :replication_worker, :replication)
     worker_settings ||= @default_settings
     {
-      :file => worker_settings.fetch_path(:options, :heartbeat_file) ||
+      :file      => worker_settings.fetch_path(:options, :heartbeat_file) ||
         @default_settings.fetch_path(:options, :heartbeat_file),
       :threshold => worker_settings.fetch_path(:options, :heartbeat_threshold).to_i ||
         @default_settings.fetch_path(:options, :heartbeat_threshold).to_i

--- a/lib/workers/replication_worker.rb
+++ b/lib/workers/replication_worker.rb
@@ -178,8 +178,7 @@ class ReplicationWorker < WorkerBase
                           .fetch_path(:workers, :worker_base, :replication_worker, :replication)
     worker_settings ||= @default_settings
     {
-      :file      => worker_settings.fetch_path(:options, :heartbeat_file) ||
-        @default_settings.fetch_path(:options, :heartbeat_file),
+      :file      => MiqRubyrep.heartbeat_file,
       :threshold => worker_settings.fetch_path(:options, :heartbeat_threshold).to_i ||
         @default_settings.fetch_path(:options, :heartbeat_threshold).to_i
     }

--- a/lib/workers/replication_worker.rb
+++ b/lib/workers/replication_worker.rb
@@ -148,8 +148,8 @@ class ReplicationWorker < WorkerBase
 
     return true unless pid_state.nil? || pid_state == :zombie || !child_process_recently_active?
     $log.info(
-        "#{self.log_prefix} rubyrep Process with pid=#{@pid} child has not heartbeat since #{child_process_last_heartbeat.to_s}"
-    ) if !child_process_recently_active?
+      "#{log_prefix} rubyrep Process with pid=#{@pid} child has not heartbeat since #{child_process_last_heartbeat}"
+    ) unless child_process_recently_active?
 
     if pid_state == :zombie
       pid, status = Process.waitpid2(@pid)
@@ -170,18 +170,18 @@ class ReplicationWorker < WorkerBase
 
   def child_process_last_heartbeat
     hb_file = child_process_heartbeat_settings[:file]
-    File.exists?(hb_file) ? File.mtime(hb_file).utc : nil
+    File.exist?(hb_file) ? File.mtime(hb_file).utc : nil
   end
 
   def child_process_heartbeat_settings
-    @default_settings ||= VMDB::Config.new("vmdb").retrieve_config(:tmpl).
-                          fetch_path(:workers, :worker_base, :replication_worker, :replication)
-    worker_settings   ||= @default_settings
+    @default_settings ||= VMDB::Config.new("vmdb").retrieve_config(:tmpl)
+                          .fetch_path(:workers, :worker_base, :replication_worker, :replication)
+    worker_settings ||= @default_settings
     {
-      :file      => worker_settings.fetch_path(:options, :heartbeat_file) ||
-                    @default_settings.fetch_path(:options, :heartbeat_file),
+      :file => worker_settings.fetch_path(:options, :heartbeat_file) ||
+        @default_settings.fetch_path(:options, :heartbeat_file),
       :threshold => worker_settings.fetch_path(:options, :heartbeat_threshold).to_i ||
-                    @default_settings.fetch_path(:options, :heartbeat_threshold).to_i
+        @default_settings.fetch_path(:options, :heartbeat_threshold).to_i
     }
   end
 

--- a/lib/workers/replication_worker.rb
+++ b/lib/workers/replication_worker.rb
@@ -146,7 +146,10 @@ class ReplicationWorker < WorkerBase
       return false
     end
 
-    return true unless pid_state.nil? || pid_state == :zombie
+    return true unless pid_state.nil? || pid_state == :zombie || !child_process_recently_active?
+    $log.info(
+        "#{self.log_prefix} rubyrep Process with pid=#{@pid} child has not heartbeat since #{child_process_last_heartbeat.to_s}"
+    ) if !child_process_recently_active?
 
     if pid_state == :zombie
       pid, status = Process.waitpid2(@pid)
@@ -157,10 +160,37 @@ class ReplicationWorker < WorkerBase
     return false
   end
 
+  def child_process_heartbeat_file_init
+    FileUtils.touch(child_process_heartbeat_settings[:file]) if child_process_heartbeat_settings[:file]
+  end
+
+  def child_process_recently_active?
+    child_process_last_heartbeat && (child_process_last_heartbeat >= child_process_heartbeat_settings[:threshold].seconds.ago.utc)
+  end
+
+  def child_process_last_heartbeat
+    hb_file = child_process_heartbeat_settings[:file]
+    File.exists?(hb_file) ? File.mtime(hb_file).utc : nil
+  end
+
+  def child_process_heartbeat_settings
+    @default_settings ||= VMDB::Config.new("vmdb").retrieve_config(:tmpl).
+                          fetch_path(:workers, :worker_base, :replication_worker, :replication)
+    worker_settings   ||= @default_settings
+    {
+      :file      => worker_settings.fetch_path(:options, :heartbeat_file) ||
+                    @default_settings.fetch_path(:options, :heartbeat_file),
+      :threshold => worker_settings.fetch_path(:options, :heartbeat_threshold).to_i ||
+                    @default_settings.fetch_path(:options, :heartbeat_threshold).to_i
+    }
+  end
+
   def rubyrep_run(verb)
     verb = :local_uninstall if verb == :uninstall
 
     $log.info("#{self.log_prefix} rubyrep process for verb=#{verb} starting")
+
+    child_process_heartbeat_file_init
 
     require 'open4'
     pid, stdin, stdout, stderr = Open4.popen4(*(MiqEnvironment::Command.rake_command).split, "evm:dbsync:#{verb}")

--- a/lib/workers/worker_base.rb
+++ b/lib/workers/worker_base.rb
@@ -147,7 +147,7 @@ class WorkerBase
   end
 
   def log_prefix
-    @log_prefix ||= ""
+    @log_prefix ||= "MIQ(#{self.class.name})"
   end
 
   #

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -9,7 +9,7 @@ describe ReplicationWorker do
   end
 
   context "testing rubyrep_alive?" do
-    before(:each) do
+    before do
       Process.stub(:waitpid2)
       @worker.stub(:child_process_recently_active?).and_return(true)
       @worker.instance_variable_set(:@pid, 123)
@@ -27,6 +27,10 @@ describe ReplicationWorker do
   end
 
   context "testing child process heartbeat" do
+    after do
+      File.delete('/tmp/rubyrep_hb') if File.exist?('/tmp/rubyrep_hb')
+    end
+
     it "should be alive if heartbeat within threshold" do
       Timecop.freeze(Time.current.utc)
 
@@ -42,10 +46,6 @@ describe ReplicationWorker do
       Timecop.freeze(301.seconds.from_now.utc)
 
       expect(@worker.child_process_recently_active?).to be_false
-    end
-
-    after do
-      File.delete('/tmp/rubyrep_hb') if File.exist?('/tmp/rubyrep_hb')
     end
   end
 end

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -32,7 +32,7 @@ describe ReplicationWorker do
     end
 
     it "should be alive if heartbeat within threshold" do
-      Timecop.freeze(Time.now.utc)
+      Timecop.freeze(Time.zone.now.utc)
 
       expect(@worker.child_process_recently_active?).to be_true
     end

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+require "workers/replication_worker"
+
+describe ReplicationWorker do
+  before(:each) do
+    ReplicationWorker.any_instance.stub(:worker_initialization)
+    @worker = ReplicationWorker.new
+  end
+
+  context "testing rubyrep_alive?" do
+    before(:each) do
+      Process.stub(:waitpid2)
+      @worker.stub(:child_process_recently_active?).and_return(true)
+      @worker.instance_variable_set(:@pid, 123)
+    end
+
+    it "should be alive if process is alive" do
+      MiqProcess.stub(:state).and_return(:sleeping)
+      expect(@worker.rubyrep_alive?).to be_true
+    end
+
+    it "should not be alive if process is zombie" do
+      MiqProcess.stub(:state).and_return(:zombie)
+      expect(@worker.rubyrep_alive?).to be_false
+    end
+  end
+
+  context "testing child process heartbeat" do
+    before(:each) do
+      FileUtils.touch('/tmp/rubyrep_hb')
+    end
+
+    it "should be alive if heartbeat within threshold" do
+      Timecop.freeze(Time.now)
+
+      expect(@worker.child_process_recently_active?).to be_true
+    end
+
+    it "should not be alive if heartbeat beyond threshold" do
+      Timecop.freeze(301.seconds.from_now)
+
+      expect(@worker.child_process_recently_active?).to be_false
+    end
+  end
+end

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -27,17 +27,18 @@ describe ReplicationWorker do
   end
 
   context "testing child process heartbeat" do
-    before(:each) do
-      FileUtils.touch('/tmp/rubyrep_hb')
-    end
-
     it "should be alive if heartbeat within threshold" do
-      Timecop.freeze(Time.zone.now.utc)
+      Timecop.freeze(Time.current.utc)
 
+      FileUtils.touch('/tmp/rubyrep_hb')
       expect(@worker.child_process_recently_active?).to be_true
     end
 
     it "should not be alive if heartbeat beyond threshold" do
+      Timecop.freeze(Time.current.utc)
+
+      FileUtils.touch('/tmp/rubyrep_hb')
+
       Timecop.freeze(301.seconds.from_now.utc)
 
       expect(@worker.child_process_recently_active?).to be_false

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -6,6 +6,7 @@ describe ReplicationWorker do
   before do
     ReplicationWorker.any_instance.stub(:worker_initialization)
     @worker = ReplicationWorker.new
+    @hb_file = Rails.root.join('tmp/rubyrep_hb')
   end
 
   context "testing rubyrep_alive?" do
@@ -28,20 +29,20 @@ describe ReplicationWorker do
 
   context "testing child process heartbeat" do
     after do
-      File.delete('/tmp/rubyrep_hb') if File.exist?('/tmp/rubyrep_hb')
+      File.delete(@hb_file) if File.exist?(@hb_file)
     end
 
     it "should be alive if heartbeat within threshold" do
       Timecop.freeze(Time.current.utc)
 
-      FileUtils.touch('/tmp/rubyrep_hb')
+      FileUtils.touch(@hb_file)
       expect(@worker.child_process_recently_active?).to be_true
     end
 
     it "should not be alive if heartbeat beyond threshold" do
       Timecop.freeze(Time.current.utc)
 
-      FileUtils.touch('/tmp/rubyrep_hb')
+      FileUtils.touch(@hb_file)
 
       Timecop.freeze(301.seconds.from_now.utc)
 

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 require "workers/replication_worker"
 
 describe ReplicationWorker do
-  before(:each) do
+  before do
     ReplicationWorker.any_instance.stub(:worker_initialization)
     @worker = ReplicationWorker.new
   end
@@ -42,6 +42,10 @@ describe ReplicationWorker do
       Timecop.freeze(301.seconds.from_now.utc)
 
       expect(@worker.child_process_recently_active?).to be_false
+    end
+
+    after do
+      File.delete('/tmp/rubyrep_hb') if File.exist?('/tmp/rubyrep_hb')
     end
   end
 end

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -32,13 +32,13 @@ describe ReplicationWorker do
     end
 
     it "should be alive if heartbeat within threshold" do
-      Timecop.freeze(Time.now)
+      Timecop.freeze(Time.now.utc)
 
       expect(@worker.child_process_recently_active?).to be_true
     end
 
     it "should not be alive if heartbeat beyond threshold" do
-      Timecop.freeze(301.seconds.from_now)
+      Timecop.freeze(301.seconds.from_now.utc)
 
       expect(@worker.child_process_recently_active?).to be_false
     end


### PR DESCRIPTION
This PR is for implementing a heartbeat in the chile process of a replication worker. The replication worker is unique in that it spawns an additional process to do the actually replication work. While the main process does a normal worker heartbeat there was still no way to know if the child process was doing work. The parent process was only detecting that the child process was still alive.

We discovered a case were the the child process was alive but was not doing any work. The parent process was fat and happy in its assumption that the child was alive and working when it actually wasn't causing the replication backlog to grow continuously.

This code change addresses that case.

https://bugzilla.redhat.com/show_bug.cgi?id=1127855

This change depends on a the corresponding change in rubyrep https://github.com/ManageIQ/rubyrep/pull/6

TODO:
- [x] Need to add tests