### PR TITLE
[WIP] Rename is_available methods

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -972,9 +972,9 @@ class ApplicationHelper::ToolbarBuilder
       when "host_timeline"
         return "No Timeline data has been collected for this Host" unless @record.has_events? || @record.has_events?(:policy_events)
       when "host_shutdown"
-        return @record.is_available_now_error_message(:shutdown) if @record.is_available_now_error_message(:shutdown)
+        return @record.unavailability_reason(:shutdown) if @record.unavailability_reason(:shutdown)
       when "host_restart"
-        return @record.is_available_now_error_message(:reboot) if @record.is_available_now_error_message(:reboot)
+        return @record.unavailability_reason(:reboot) if @record.unavailability_reason(:reboot)
       end
     when "ContainerNodeKubernetes"
       case id
@@ -1109,7 +1109,7 @@ class ApplicationHelper::ToolbarBuilder
         model = model_for_vm(@record).to_s
         return "No Compliance Policies assigned to this #{model == "ManageIQ::Providers::InfraManager::Vm" ? "VM" : ui_lookup(:model => model)}" unless @record.has_compliance_policies?
       when "vm_collect_running_processes"
-        return @record.is_available_now_error_message(:collect_running_processes) if @record.is_available_now_error_message(:collect_running_processes)
+        return @record.unavailability_reason(:collect_running_processes) if @record.unavailability_reason(:collect_running_processes)
       when "vm_console", "vm_vmrc_console"
         if !is_browser?(%w(explorer firefox mozilla chrome)) ||
           !is_browser_os?(%w(windows linux))
@@ -1128,19 +1128,19 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_vnc_console"
         return "The web-based VNC console is not available because the VM is not powered on" if @record.current_state != "on"
       when "vm_guest_startup", "vm_start"
-        return @record.is_available_now_error_message(:start) if @record.is_available_now_error_message(:start)
+        return @record.unavailability_reason(:start) if @record.unavailability_reason(:start)
       when "vm_guest_standby"
-        return @record.is_available_now_error_message(:standby_guest) if @record.is_available_now_error_message(:standby_guest)
+        return @record.unavailability_reason(:standby_guest) if @record.unavailability_reason(:standby_guest)
       when "vm_guest_shutdown"
-        return @record.is_available_now_error_message(:shutdown_guest) if @record.is_available_now_error_message(:shutdown_guest)
+        return @record.unavailability_reason(:shutdown_guest) if @record.unavailability_reason(:shutdown_guest)
       when "vm_guest_restart"
-        return @record.is_available_now_error_message(:reboot_guest) if @record.is_available_now_error_message(:reboot_guest)
+        return @record.unavailability_reason(:reboot_guest) if @record.unavailability_reason(:reboot_guest)
       when "vm_stop"
-        return @record.is_available_now_error_message(:stop) if @record.is_available_now_error_message(:stop)
+        return @record.unavailability_reason(:stop) if @record.unavailability_reason(:stop)
       when "vm_reset"
-        return @record.is_available_now_error_message(:reset) if @record.is_available_now_error_message(:reset)
+        return @record.unavailability_reason(:reset) if @record.unavailability_reason(:reset)
       when "vm_suspend"
-        return @record.is_available_now_error_message(:suspend) if @record.is_available_now_error_message(:suspend)
+        return @record.unavailability_reason(:suspend) if @record.unavailability_reason(:suspend)
       when "instance_retire", "instance_retire_now",
               "vm_retire", "vm_retire_now"
         return "#{@record.kind_of?(ManageIQ::Providers::CloudManager::Vm) ? "Instance" : "VM"} is already retired" if @record.retired == true
@@ -1150,20 +1150,20 @@ class ApplicationHelper::ToolbarBuilder
         return "No Timeline data has been collected for this VM" unless @record.has_events? || @record.has_events?(:policy_events)
       when "vm_snapshot_add"
         if @record.number_of(:snapshots) <= 0
-          return @record.is_available_now_error_message(:create_snapshot) unless @record.supports_operation?(:create_snapshot)
+          return @record.unavailability_reason(:create_snapshot) unless @record.supports_operation?(:create_snapshot)
         else
           unless @record.supports_operation?(:create_snapshot)
-            return @record.is_available_now_error_message(:create_snapshot)
+            return @record.unavailability_reason(:create_snapshot)
           else
             return "Select the Active snapshot to create a new snapshot for this VM" unless @active
           end
         end
       when "vm_snapshot_delete"
-        return @record.is_available_now_error_message(:remove_snapshot) unless @record.supports_operation?(:remove_snapshot)
+        return @record.unavailability_reason(:remove_snapshot) unless @record.supports_operation?(:remove_snapshot)
       when "vm_snapshot_delete_all"
-        return @record.is_available_now_error_message(:remove_all_snapshots) unless @record.supports_operation?(:remove_all_snapshots)
+        return @record.unavailability_reason(:remove_all_snapshots) unless @record.supports_operation?(:remove_all_snapshots)
       when "vm_snapshot_revert"
-        return @record.is_available_now_error_message(:revert_to_snapshot) unless @record.supports_operation?(:revert_to_snapshot)
+        return @record.unavailability_reason(:revert_to_snapshot) unless @record.supports_operation?(:revert_to_snapshot)
       end
     when "MiqTemplate"
       case id

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -472,11 +472,11 @@ class ApplicationHelper::ToolbarBuilder
                    (@record.kind_of?(ContainerReplicator) || @record.nil?)
 
     # hide timelines button for Amazon provider and instances
-    # TODO: extend .is_available? support via refactoring task to cover this scenario
+    # TODO: extend .supports_operation? support via refactoring task to cover this scenario
     return true if ['ems_cloud_timeline', 'instance_timeline'].include?(id) && (@record.kind_of?(ManageIQ::Providers::Amazon::CloudManager) || @record.kind_of?(ManageIQ::Providers::Amazon::CloudManager::Vm))
 
     # hide edit button for MiqRequest instances of type ServiceReconfigureRequest/ServiceTemplateProvisionRequest
-    # TODO: extend .is_available? support via refactoring task to cover this scenario
+    # TODO: extend .supports_operation? support via refactoring task to cover this scenario
     return true if id == 'miq_request_edit' &&
                    %w(ServiceReconfigureRequest ServiceTemplateProvisionRequest).include?(@miq_request.try(:type))
 
@@ -642,7 +642,7 @@ class ApplicationHelper::ToolbarBuilder
           "host_enter_maint_mode", "host_exit_maint_mode",
           "host_start", "host_stop", "host_reset"
         btn_id = id.split("_")[1..-1].join("_")
-        return true if !@record.is_available?(btn_id.to_sym)
+        return true if !@record.supports_operation?(btn_id.to_sym)
       when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"
         return true unless @perf_options[:typ] == "realtime"
       end
@@ -756,27 +756,27 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_publish"
         return true if %w(VmMicrosoft ManageIQ::Providers::Redhat::InfraManager::Vm).include?(@record.type)
       when "vm_collect_running_processes"
-        return true if (@record.retired || @record.current_state == "never") && !@record.is_available?(:collect_running_processes)
+        return true if (@record.retired || @record.current_state == "never") && !@record.supports_operation?(:collect_running_processes)
       when "vm_guest_startup", "vm_start", "instance_start", "instance_resume"
-        return true if !@record.is_available?(:start)
+        return true if !@record.supports_operation?(:start)
       when "vm_guest_standby"
-        return true if !@record.is_available?(:standby_guest)
+        return true if !@record.supports_operation?(:standby_guest)
       when "vm_guest_shutdown", "instance_guest_shutdown"
-        return true if !@record.is_available?(:shutdown_guest)
+        return true if !@record.supports_operation?(:shutdown_guest)
       when "vm_guest_restart", "instance_guest_restart"
-        return true if !@record.is_available?(:reboot_guest)
+        return true if !@record.supports_operation?(:reboot_guest)
       when "vm_migrate"
-        return true unless @record.is_available?(:migrate)
+        return true unless @record.supports_operation?(:migrate)
       when "vm_reconfigure"
         return true if @record.vendor.downcase == "redhat"
       when "vm_stop", "instance_stop"
-        return true if !@record.is_available?(:stop)
+        return true if !@record.supports_operation?(:stop)
       when "vm_reset", "instance_reset"
-        return true if !@record.is_available?(:reset)
+        return true if !@record.supports_operation?(:reset)
       when "vm_suspend", "instance_suspend"
-        return true if !@record.is_available?(:suspend)
+        return true if !@record.supports_operation?(:suspend)
       when "instance_pause"
-        return true if !@record.is_available?(:pause)
+        return true if !@record.supports_operation?(:pause)
       when "vm_policy_sim", "vm_protect"
         return true if @record.host && @record.host.vmm_product.to_s.downcase == "workstation"
       when "vm_refresh"
@@ -1150,20 +1150,20 @@ class ApplicationHelper::ToolbarBuilder
         return "No Timeline data has been collected for this VM" unless @record.has_events? || @record.has_events?(:policy_events)
       when "vm_snapshot_add"
         if @record.number_of(:snapshots) <= 0
-          return @record.is_available_now_error_message(:create_snapshot) unless @record.is_available?(:create_snapshot)
+          return @record.is_available_now_error_message(:create_snapshot) unless @record.supports_operation?(:create_snapshot)
         else
-          unless @record.is_available?(:create_snapshot)
+          unless @record.supports_operation?(:create_snapshot)
             return @record.is_available_now_error_message(:create_snapshot)
           else
             return "Select the Active snapshot to create a new snapshot for this VM" unless @active
           end
         end
       when "vm_snapshot_delete"
-        return @record.is_available_now_error_message(:remove_snapshot) unless @record.is_available?(:remove_snapshot)
+        return @record.is_available_now_error_message(:remove_snapshot) unless @record.supports_operation?(:remove_snapshot)
       when "vm_snapshot_delete_all"
-        return @record.is_available_now_error_message(:remove_all_snapshots) unless @record.is_available?(:remove_all_snapshots)
+        return @record.is_available_now_error_message(:remove_all_snapshots) unless @record.supports_operation?(:remove_all_snapshots)
       when "vm_snapshot_revert"
-        return @record.is_available_now_error_message(:revert_to_snapshot) unless @record.is_available?(:revert_to_snapshot)
+        return @record.is_available_now_error_message(:revert_to_snapshot) unless @record.supports_operation?(:revert_to_snapshot)
       end
     when "MiqTemplate"
       case id

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -249,15 +249,15 @@ class Host < ActiveRecord::Base
     send("validate_#{request_type}")[:available]
   end
 
-  # is_available_now_error_message
+  # unavailability_reason
   # Returns an error message string if there is an error.
   # Returns nil to indicate no errors.
   # This method is used by the UI along with the supports_operation? methods.
-  def is_available_now_error_message(request_type)
+  def unavailability_reason(request_type)
     send("validate_#{request_type}")[:message]
   end
 
-  def raise_is_available_now_error_message(request_type)
+  def raise_unavailability_reason(request_type)
     msg = send("validate_#{request_type}")[:message]
     raise MiqException::MiqVmError, msg unless msg.nil?
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -238,21 +238,21 @@ class Host < ActiveRecord::Base
   end
   private :raise_cluster_event
 
-  # is_available?
+  # supports_operation?
   # Returns:  true or false
   #
   # The UI calls this method to determine if a feature is supported for this Host
   # and determines if a button should be displayed.  This method should return true
   # even if a function is not 'currently' available due to some condition that is not
   # being met.
-  def is_available?(request_type)
+  def supports_operation?(request_type)
     send("validate_#{request_type}")[:available]
   end
 
   # is_available_now_error_message
   # Returns an error message string if there is an error.
   # Returns nil to indicate no errors.
-  # This method is used by the UI along with the is_available? methods.
+  # This method is used by the UI along with the supports_operation? methods.
   def is_available_now_error_message(request_type)
     send("validate_#{request_type}")[:message]
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1723,7 +1723,7 @@ class VmOrTemplate < ActiveRecord::Base
   #
   # For example: If the VM needs credentials to be scanning, but they are not
   # available this method should still return true.  The UI will call the method
-  # 'is_available_now_error_message' to determine if the button should be available
+  # 'unavailability_reason' to determine if the button should be available
   # or greyed-out.  However, if the VM is a type that we cannot scan or we cannot get
   # to the storage to scan it then this method would be expected to return false.
   def supports_operation?(request_type)
@@ -1732,11 +1732,11 @@ class VmOrTemplate < ActiveRecord::Base
 
   # Returns an error message string if there is an error.  Otherwise nil to
   # indicate no errors.
-  def is_available_now_error_message(request_type)
+  def unavailability_reason(request_type)
     return self.send("validate_#{request_type}")[:message]
   end
 
-  def raise_is_available_now_error_message(request_type)
+  def raise_unavailability_reason(request_type)
     msg = self.send("validate_#{request_type}")[:message]
     raise MiqException::MiqVmError, msg unless msg.nil?
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1726,7 +1726,7 @@ class VmOrTemplate < ActiveRecord::Base
   # 'is_available_now_error_message' to determine if the button should be available
   # or greyed-out.  However, if the VM is a type that we cannot scan or we cannot get
   # to the storage to scan it then this method would be expected to return false.
-  def is_available?(request_type)
+  def supports_operation?(request_type)
     return self.send("validate_#{request_type}")[:available]
   end
 

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -37,7 +37,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_snapshot(snapshot_id)
-    raise_is_available_now_error_message(:remove_snapshot)
+    raise_unavailability_reason(:remove_snapshot)
     snapshot = self.snapshots.find_by_id(snapshot_id)
     raise "Requested VM snapshot not found, unable to remove snapshot" unless snapshot
     begin
@@ -93,7 +93,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_snapshot_by_description(description, refresh = false)
-    raise_is_available_now_error_message(:remove_snapshot_by_description)
+    raise_unavailability_reason(:remove_snapshot_by_description)
     run_command_via_parent(:vm_remove_snapshot_by_description, :description => description, :refresh => refresh)
   end
 
@@ -114,7 +114,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_all_snapshots
-    raise_is_available_now_error_message(:remove_all_snapshots)
+    raise_unavailability_reason(:remove_all_snapshots)
     run_command_via_parent(:vm_remove_all_snapshots)
   end
 
@@ -123,7 +123,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_revert_to_snapshot(snapshot_id)
-    raise_is_available_now_error_message(:revert_to_snapshot)
+    raise_unavailability_reason(:revert_to_snapshot)
     snapshot = self.snapshots.find_by_id(snapshot_id)
     raise "Requested VM snapshot not found, unable to RevertTo snapshot" unless snapshot
     run_command_via_parent(:vm_revert_to_snapshot, :snMor => snapshot.uid_ems)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -988,7 +988,7 @@ describe ApplicationHelper do
         context "and id = #{id}" do
           before do
             @id = id
-            @record.stub(:is_available? => false)
+            @record.stub(:supports_operation? => false)
           end
 
           it "and record is not available" do
@@ -996,7 +996,7 @@ describe ApplicationHelper do
           end
 
           it "and record is available" do
-            @record.stub(:is_available? => true)
+            @record.stub(:supports_operation? => true)
             subject.should == false
           end
         end
@@ -1322,22 +1322,22 @@ describe ApplicationHelper do
         before do
           @id = "vm_collect_running_processes"
           @record.stub(:retired => false, :current_state => "new")
-          @record.stub(:is_available?).with(:collect_running_processes).and_return(true)
+          @record.stub(:supports_operation?).with(:collect_running_processes).and_return(true)
         end
 
-        it "and @record.retired & !@record.is_available?(:collect_running_processes)" do
+        it "and @record.retired & !@record.supports_operation?(:collect_running_processes)" do
           @record.stub(:retired => true)
-          @record.stub(:is_available?).with(:collect_running_processes).and_return(false)
+          @record.stub(:supports_operation?).with(:collect_running_processes).and_return(false)
           subject.should == true
         end
 
-        it "and @record.current_state = never & !@record.is_available?(:collect_running_processes)" do
-          @record.stub(:is_available?).with(:collect_running_processes).and_return(false)
+        it "and @record.current_state = never & !@record.supports_operation?(:collect_running_processes)" do
+          @record.stub(:supports_operation?).with(:collect_running_processes).and_return(false)
           @record.stub(:current_state => "never")
           subject.should == true
         end
 
-        it "and @record.is_available?(:collect_running_processes)" do
+        it "and @record.supports_operation?(:collect_running_processes)" do
           subject.should == false
         end
 
@@ -1362,15 +1362,15 @@ describe ApplicationHelper do
         context "and id = #{id}" do
           before do
             @id = id
-            @record.stub(:is_available?).with(:start).and_return(true)
+            @record.stub(:supports_operation?).with(:start).and_return(true)
           end
 
-          it "and !@record.is_available?(:start)" do
-            @record.stub(:is_available?).with(:start).and_return(false)
+          it "and !@record.supports_operation?(:start)" do
+            @record.stub(:supports_operation?).with(:start).and_return(false)
             subject.should == true
           end
 
-          it "and @record.is_available?(:start)" do
+          it "and @record.supports_operation?(:start)" do
             subject.should == false
           end
         end
@@ -1379,15 +1379,15 @@ describe ApplicationHelper do
       context "and id = vm_guest_standby" do
         before do
           @id = "vm_guest_standby"
-          @record.stub(:is_available?).with(:standby_guest).and_return(true)
+          @record.stub(:supports_operation?).with(:standby_guest).and_return(true)
         end
 
-        it "and !@record.is_available?(:standby_guest)" do
-          @record.stub(:is_available?).with(:standby_guest).and_return(false)
+        it "and !@record.supports_operation?(:standby_guest)" do
+          @record.stub(:supports_operation?).with(:standby_guest).and_return(false)
           subject.should == true
         end
 
-        it "and @record.is_available?(:standby_guest)" do
+        it "and @record.supports_operation?(:standby_guest)" do
           subject.should == false
         end
       end
@@ -1395,15 +1395,15 @@ describe ApplicationHelper do
       context "and id = vm_guest_shutdown" do
         before do
           @id = "vm_guest_shutdown"
-          @record.stub(:is_available?).with(:shutdown_guest).and_return(true)
+          @record.stub(:supports_operation?).with(:shutdown_guest).and_return(true)
         end
 
-        it "and !@record.is_available?(:shutdown_guest)" do
-          @record.stub(:is_available?).with(:shutdown_guest).and_return(false)
+        it "and !@record.supports_operation?(:shutdown_guest)" do
+          @record.stub(:supports_operation?).with(:shutdown_guest).and_return(false)
           subject.should == true
         end
 
-        it "and @record.is_available?(:shutdown_guest)" do
+        it "and @record.supports_operation?(:shutdown_guest)" do
           subject.should == false
         end
       end
@@ -1411,15 +1411,15 @@ describe ApplicationHelper do
       context "and id = vm_guest_restart" do
         before do
           @id = "vm_guest_restart"
-          @record.stub(:is_available?).with(:reboot_guest).and_return(true)
+          @record.stub(:supports_operation?).with(:reboot_guest).and_return(true)
         end
 
-        it "and !@record.is_available?(:reboot_guest)" do
-          @record.stub(:is_available?).with(:reboot_guest).and_return(false)
+        it "and !@record.supports_operation?(:reboot_guest)" do
+          @record.stub(:supports_operation?).with(:reboot_guest).and_return(false)
           subject.should == true
         end
 
-        it "and @record.is_available?(:reboot_guest)" do
+        it "and @record.supports_operation?(:reboot_guest)" do
           subject.should == false
         end
       end
@@ -1427,15 +1427,15 @@ describe ApplicationHelper do
       context "and id = vm_stop" do
         before do
           @id = "vm_stop"
-          @record.stub(:is_available?).with(:stop).and_return(true)
+          @record.stub(:supports_operation?).with(:stop).and_return(true)
         end
 
-        it "and !@record.is_available?(:stop)" do
-          @record.stub(:is_available?).with(:stop).and_return(false)
+        it "and !@record.supports_operation?(:stop)" do
+          @record.stub(:supports_operation?).with(:stop).and_return(false)
           subject.should == true
         end
 
-        it "and @record.is_available?(:stop)" do
+        it "and @record.supports_operation?(:stop)" do
           subject.should == false
         end
       end
@@ -1443,15 +1443,15 @@ describe ApplicationHelper do
       context "and id = vm_reset" do
         before do
           @id = "vm_reset"
-          @record.stub(:is_available?).with(:reset).and_return(true)
+          @record.stub(:supports_operation?).with(:reset).and_return(true)
         end
 
-        it "and !@record.is_available?(:reset)" do
-          @record.stub(:is_available?).with(:reset).and_return(false)
+        it "and !@record.supports_operation?(:reset)" do
+          @record.stub(:supports_operation?).with(:reset).and_return(false)
           subject.should == true
         end
 
-        it "and @record.is_available?(:reset)" do
+        it "and @record.supports_operation?(:reset)" do
           subject.should == false
         end
       end
@@ -1459,15 +1459,15 @@ describe ApplicationHelper do
       context "and id = vm_suspend" do
         before do
           @id = "vm_suspend"
-          @record.stub(:is_available?).with(:suspend).and_return(true)
+          @record.stub(:supports_operation?).with(:suspend).and_return(true)
         end
 
-        it "and !@record.is_available?(:suspend)" do
-          @record.stub(:is_available?).with(:suspend).and_return(false)
+        it "and !@record.supports_operation?(:suspend)" do
+          @record.stub(:supports_operation?).with(:suspend).and_return(false)
           subject.should == true
         end
 
-        it "and @record.is_available?(:suspend)" do
+        it "and @record.supports_operation?(:suspend)" do
           subject.should == false
         end
       end
@@ -2351,24 +2351,24 @@ describe ApplicationHelper do
         context "and id = vm_snapshot_add" do
           before do
             @id = "vm_snapshot_add"
-            @record.stub(:is_available?).with(:create_snapshot).and_return(false)
+            @record.stub(:supports_operation?).with(:create_snapshot).and_return(false)
           end
 
           context "when number of snapshots <= 0" do
-            before { @record.stub(:is_available?).with(:create_snapshot).and_return(false) }
+            before { @record.stub(:supports_operation?).with(:create_snapshot).and_return(false) }
             it_behaves_like 'record with error message', 'create_snapshot'
           end
 
           context "when number of snapshots > 0" do
             before do
               @record.stub(:number_of).with(:snapshots).and_return(4)
-              @record.stub(:is_available?).with(:create_snapshot).and_return(false)
+              @record.stub(:supports_operation?).with(:create_snapshot).and_return(false)
             end
 
             it_behaves_like 'record with error message', 'create_snapshot'
 
             it "when no available message but active" do
-                @record.stub(:is_available?).with(:create_snapshot).and_return(false)
+                @record.stub(:supports_operation?).with(:create_snapshot).and_return(false)
                 @active = true
               subject.should == "The VM is not connected to a Host"
             end
@@ -2379,7 +2379,7 @@ describe ApplicationHelper do
         context "and id = vm_snapshot_delete" do
           before { @id = "vm_snapshot_delete" }
           context "when with available message" do
-            before { @record.stub(:is_available?).with(:remove_snapshot).and_return(false) }
+            before { @record.stub(:supports_operation?).with(:remove_snapshot).and_return(false) }
             it_behaves_like 'record with error message', 'remove_snapshot'
           end
           context "when without snapshots" do
@@ -2395,7 +2395,7 @@ describe ApplicationHelper do
         context "and id = vm_snapshot_delete_all" do
           before { @id = "vm_snapshot_delete_all" }
           context "when with available message" do
-            before { @record.stub(:is_available?).with(:remove_all_snapshots).and_return(false) }
+            before { @record.stub(:supports_operation?).with(:remove_all_snapshots).and_return(false) }
             it_behaves_like 'record with error message', 'remove_all_snapshots'
           end
           context "when without snapshots" do
@@ -2411,7 +2411,7 @@ describe ApplicationHelper do
         context "id = vm_snapshot_revert" do
           before { @id = "vm_snapshot_revert" }
           context "when with available message" do
-            before { @record.stub(:is_available?).with(:revert_to_snapshot).and_return(false) }
+            before { @record.stub(:supports_operation?).with(:revert_to_snapshot).and_return(false) }
             it_behaves_like 'record with error message', 'revert_to_snapshot'
           end
           context "when without snapshots" do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2085,7 +2085,7 @@ describe ApplicationHelper do
       context "and id = host_shutdown" do
         before do
           @id = "host_shutdown"
-          @record.stub(:is_available_now_error_message => false)
+          @record.stub(:unavailability_reason => false)
         end
         it_behaves_like 'record with error message', 'shutdown'
         it_behaves_like 'default case'
@@ -2094,7 +2094,7 @@ describe ApplicationHelper do
       context "and id = host_restart" do
         before do
           @id = "host_restart"
-          @record.stub(:is_available_now_error_message => false)
+          @record.stub(:unavailability_reason => false)
         end
 
         it_behaves_like 'record with error message', 'reboot'
@@ -2196,7 +2196,7 @@ describe ApplicationHelper do
       context "id = vm_collect_running_processes" do
         before do
           @id = "vm_collect_running_processes"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'collect_running_processes'
         it_behaves_like 'default case'
@@ -2242,7 +2242,7 @@ describe ApplicationHelper do
       context "and id = vm_guest_startup" do
         before do
           @id = "vm_guest_startup"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'start'
         it_behaves_like 'default case'
@@ -2251,7 +2251,7 @@ describe ApplicationHelper do
       context "and id = vm_start" do
         before do
           @id = "vm_start"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'start'
         it_behaves_like 'default case'
@@ -2260,7 +2260,7 @@ describe ApplicationHelper do
       context "and id = vm_guest_standby" do
         before do
           @id = "vm_guest_standby"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'standby_guest'
         it_behaves_like 'default case'
@@ -2269,7 +2269,7 @@ describe ApplicationHelper do
       context "and id = vm_guest_shutdown" do
         before do
           @id = "vm_guest_shutdown"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'shutdown_guest'
         it_behaves_like 'default case'
@@ -2278,7 +2278,7 @@ describe ApplicationHelper do
       context "and id = vm_guest_restart" do
         before do
           @id = "vm_guest_restart"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'reboot_guest'
         it_behaves_like 'default case'
@@ -2287,7 +2287,7 @@ describe ApplicationHelper do
       context "and id = vm_stop" do
         before do
           @id = "vm_stop"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'stop'
         it_behaves_like 'default case'
@@ -2296,7 +2296,7 @@ describe ApplicationHelper do
       context "and id = vm_reset" do
         before do
           @id = "vm_reset"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'reset'
         it_behaves_like 'default case'
@@ -2305,7 +2305,7 @@ describe ApplicationHelper do
       context "and id = vm_suspend" do
         before do
           @id = "vm_suspend"
-          @record.stub(:is_available_now_error_message).and_return(false)
+          @record.stub(:unavailability_reason).and_return(false)
         end
         it_behaves_like 'record with error message', 'suspend'
         it_behaves_like 'default case'

--- a/spec/models/manageiq/providers/redhat/infra_provider/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/vm_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Redhat::InfraManager::Vm do
-  context "#is_available?" do
+  context "#supports_operation?" do
     let(:ems)  { FactoryGirl.create(:ems_redhat) }
     let(:host) { FactoryGirl.create(:host_redhat, :ext_management_system => ems) }
     let(:vm)   { FactoryGirl.create(:vm_redhat, :ext_management_system => ems, :host => host) }

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Vmware::InfraManager::Vm do
-  context "#is_available?" do
+  context "#supports_operation?" do
     let(:ems)  { FactoryGirl.create(:ems_vmware) }
     let(:host) { FactoryGirl.create(:host_vmware_esx, :ext_management_system => ems) }
     let(:vm)   { FactoryGirl.create(:vm_vmware, :ext_management_system => ems, :host => host) }

--- a/spec/models/vm_amazon_spec.rb
+++ b/spec/models/vm_amazon_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Amazon::CloudManager::Vm do
-  context "#is_available?" do
+  context "#supports_operation?" do
     let(:ems)                   { FactoryGirl.create(:ems_amazon) }
     let(:vm)                    { FactoryGirl.create(:vm_amazon, :ext_management_system => ems) }
     let(:power_state_on)        { "running" }

--- a/spec/models/vm_openstack_spec.rb
+++ b/spec/models/vm_openstack_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe VmOpenstack do
-  context "#is_available?" do
+  context "#supports_operation?" do
     let(:ems) { FactoryGirl.create(:ems_openstack) }
     let(:vm)  { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
     let(:power_state_on)        { "ACTIVE" }

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -443,15 +443,15 @@ describe VmOrTemplate do
     end
   end
 
-  context "#is_available?" do
+  context "#supports_operation?" do
     it "returns true for SCVMM VM" do
       vm =  FactoryGirl.create(:vm_vmware)
-      expect(vm.is_available?(:migrate)).to eq(true)
+      expect(vm.supports_operation?(:migrate)).to eq(true)
     end
 
     it "returns true for vmware VM" do
       vm =  FactoryGirl.create(:vm_microsoft)
-      expect(vm.is_available?(:migrate)).to_not eq(true)
+      expect(vm.supports_operation?(:migrate)).to_not eq(true)
     end
   end
 

--- a/spec/support/examples_group/shared_examples_for_application_helper.rb
+++ b/spec/support/examples_group/shared_examples_for_application_helper.rb
@@ -23,7 +23,7 @@ end
 shared_examples_for 'record with error message' do |name|
   it "returns the #{name} error message" do
     message = "xx #{name} message"
-    @record.stub(:is_available_now_error_message).with(name.to_sym).and_return(message)
+    @record.stub(:unavailability_reason).with(name.to_sym).and_return(message)
     subject.should == message
   end
 end

--- a/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
+++ b/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
@@ -25,6 +25,6 @@ end
 shared_examples_for "Vm operation is not supported" do
   it "is not available" do
     vm.supports_operation?(state).should be_false
-    vm.is_available_now_error_message(state).should include("not available")
+    vm.unavailability_reason(state).should include("not available")
   end
 end

--- a/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
+++ b/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
@@ -1,30 +1,30 @@
-shared_examples_for "Vm operation is available when not powered on" do
+shared_examples_for "Vm operation is supported when not powered on" do
   it "when powered on" do
     vm.update_attributes(:raw_power_state => power_state_on)
-    vm.is_available?(state).should be_false
+    vm.supports_operation?(state).should be_false
   end
 
   it "when not powered on" do
     vm.update_attributes(:raw_power_state => power_state_suspended)
-    vm.is_available?(state).should be_true
+    vm.supports_operation?(state).should be_true
   end
 end
 
-shared_examples_for "Vm operation is available when powered on" do
+shared_examples_for "Vm operation is supported when powered on" do
   it "when powered on" do
     vm.update_attributes(:raw_power_state => power_state_on)
-    vm.is_available?(state).should be_true
+    vm.supports_operation?(state).should be_true
   end
 
   it "when not powered on" do
     vm.update_attributes(:raw_power_state => power_state_suspended)
-    vm.is_available?(state).should be_false
+    vm.supports_operation?(state).should be_false
   end
 end
 
-shared_examples_for "Vm operation is not available" do
+shared_examples_for "Vm operation is not supported" do
   it "is not available" do
-    vm.is_available?(state).should be_false
+    vm.supports_operation?(state).should be_false
     vm.is_available_now_error_message(state).should include("not available")
   end
 end


### PR DESCRIPTION
@chessbyte I renamed two of the methods (though they were not predicates returning stuff as you thought).  It is a pure rename with no code changes.  Is this what you wanted?  Are the method names ok?

The other half of this is to rename the validate_* methods.  I was thinking availability_state_for(operation), which would return the Hash it currently returns.  I'm not sure, so I wanted to open this WIP PR to start discussing.