### PR TITLE
Move cloud init to ovirt

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -15,35 +15,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
     get_provider_destination.cloud_init = content
   end
 
-  def configure_memory(rhevm_vm)
-    vm_memory = get_option(:vm_memory).to_i * 1.megabyte
-    set_container_memory(vm_memory, rhevm_vm) unless vm_memory.zero?
-  end
-
-  def configure_memory_reserve(rhevm_vm)
-    memory_reserve = get_option(:memory_reserve).to_i.megabyte
-    set_container_memory_reserve(memory_reserve, rhevm_vm) unless memory_reserve.zero?
-  end
-
-  def configure_cpu(rhevm_vm)
-    sockets = get_option(:number_of_sockets).to_i
-    sockets = 1 if sockets.zero?
-    cores = get_option(:cores_per_socket).to_i
-    cores = 1 if cores.zero?
-    set_container_cpu({:cores => cores, :sockets => sockets}, rhevm_vm)
-  end
-
-  def configure_host_affinity(rhevm_vm)
-    return if dest_host.nil?
-    _log.info("Setting Host Affinity to: #{dest_host.name} with ID=#{dest_host.id}")
-    rhevm_vm.host_affinity = dest_host.ems_ref
-  end
-
   def configure_container
     rhevm_vm = get_provider_destination
 
-    set_container_description(get_option(:vm_description), rhevm_vm)
-
+    configure_container_description(rhevm_vm)
     configure_memory(rhevm_vm)
     configure_memory_reserve(rhevm_vm)
     configure_cpu(rhevm_vm)

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -5,8 +5,14 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
   include_concern 'Network'
 
   def attach_floppy_payload
-    payload = floppy_payload
-    get_provider_destination.attach_floppy(payload) if payload
+    return unless content = customization_template_content
+    filename = customization_template.default_filename
+    get_provider_destination.attach_floppy(filename => content)
+  end
+
+  def configure_cloud_init
+    return unless content = customization_template_content
+    get_provider_destination.cloud_init = content
   end
 
   def configure_memory(rhevm_vm)
@@ -47,11 +53,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
 
   private
 
-  def floppy_payload
-    return nil unless customization_template
-    options  = prepare_customization_template_substitution_options
-    filename = customization_template.default_filename
-    content  = customization_template.script_with_substitution(options)
-    {filename => content}
+  def customization_template_content
+    return unless customization_template
+    options = prepare_customization_template_substitution_options
+    customization_template.script_with_substitution(options)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/container.rb
@@ -1,25 +1,37 @@
 module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Container
-  def set_container_description(description, vm = nil)
+  private
+
+  def configure_container_description(rhevm_vm)
+    description = get_option(:vm_description)
     _log.info "Setting description to:<#{description.inspect}>"
-    vm ||= get_provider_destination
-    vm.description = description
+    rhevm_vm.description = description
   end
 
-  def set_container_memory(memory, vm = nil)
-    _log.info "Setting memory to:<#{memory.inspect}>"
-    vm ||= get_provider_destination
-    vm.memory = memory
+  def configure_memory(rhevm_vm)
+    vm_memory = get_option(:vm_memory).to_i * 1.megabyte
+    return if vm_memory.zero?
+    _log.info "Setting memory to:<#{vm_memory.inspect}>"
+    rhevm_vm.memory = vm_memory
   end
 
-  def set_container_memory_reserve(memory_reserve, vm = nil)
+  def configure_memory_reserve(rhevm_vm)
+    memory_reserve = get_option(:memory_reserve).to_i.megabyte
+    return if memory_reserve.zero?
     _log.info "Setting memory reserve to:<#{memory_reserve.inspect}>"
-    vm ||= get_provider_destination
-    vm.memory_reserve = memory_reserve
+    rhevm_vm.memory_reserve = memory_reserve
   end
 
-  def set_container_cpu(cpu_hash, vm = nil)
+  def configure_cpu(rhevm_vm)
+    sockets  = get_option(:number_of_sockets) || 1
+    cores    = get_option(:cores_per_socket) || 1
+    cpu_hash = {:cores => cores, :sockets => sockets}
     _log.info "Setting cpu to:<#{cpu_hash.inspect}>"
-    vm ||= get_provider_destination
-    vm.cpu_topology = cpu_hash
+    rhevm_vm.cpu_topology = cpu_hash
+  end
+
+  def configure_host_affinity(rhevm_vm)
+    return if dest_host.nil?
+    _log.info("Setting Host Affinity to: #{dest_host.name} with ID=#{dest_host.id}")
+    rhevm_vm.host_affinity = dest_host.ems_ref
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
       _log.info("#{message} #{for_destination}")
       update_and_notify_parent(:message => message)
       configure_container
-      attach_floppy_payload
+      configure_cloud_init
 
       signal :poll_destination_powered_off_in_provider
     end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -30,7 +30,7 @@ gem "memoist",                 "~>0.11.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>1.2.0",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
-gem "ovirt",                   "~>0.4.2",           :require => false
+gem "ovirt",                   "~>0.5.0",           :require => false
 gem "kubeclient",              "=0.1.17",           :require => false
 gem "openshift_client",        "=0.0.8",            :require => false
 gem "rest-client",                                  :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -58,6 +58,7 @@ FactoryGirl.define do
   end
 
   factory :host_redhat, :parent => :host, :class => "ManageIQ::Providers::Redhat::InfraManager::Host" do
+    sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
     vmm_vendor "redhat"
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_provider/provision/configuration_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/provision/configuration_spec.rb
@@ -24,13 +24,26 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration do
       script = '#cloudinit'
       template = FactoryGirl.create(:customization_template_cloud_init, :script => script)
 
-      template_options = {'key' => 'value'}
-      @task.should_receive(:prepare_customization_template_substitution_options).and_return(template_options)
+      @task.should_receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
 
       @task.options[:customization_template_id] = template.id
       @rhevm_vm.should_receive(:attach_floppy).with(template.default_filename => script)
 
       @task.attach_floppy_payload
+    end
+  end
+
+  context "#configure_cloud_init" do
+    it "should configure cloudinit if customization template provided" do
+      script = '#cloudinit'
+      template = FactoryGirl.create(:customization_template_cloud_init, :script => script)
+
+      @task.should_receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+
+      @task.options[:customization_template_id] = template.id
+      @rhevm_vm.should_receive(:cloud_init=).with(script)
+
+      @task.configure_cloud_init
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_provider/provision/configuration_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/provision/configuration_spec.rb
@@ -2,57 +2,61 @@ require "spec_helper"
 require "ovirt"
 
 describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration do
-  before do
-    ems       = FactoryGirl.create(:ems_redhat_with_authentication)
-    template  = FactoryGirl.create(:template_redhat, :ext_management_system => ems)
-    vm        = FactoryGirl.create(:vm_redhat)
-    options   = {:src_vm_id => template.id}
-    @task     = FactoryGirl.create(:miq_provision_redhat,
-                                   :source      => template,
-                                   :destination => vm,
-                                   :state       => 'pending',
-                                   :status      => 'Ok',
-                                   :options     => options)
-    @task.stub(:dest_cluster => FactoryGirl.create(:ems_cluster, :ext_management_system => ems))
+  let(:cust_template) { FactoryGirl.create(:customization_template_cloud_init, :script => '#some_script') }
+  let(:ems)           { FactoryGirl.create(:ems_redhat_with_authentication) }
+  let(:host)          { FactoryGirl.create(:host_redhat) }
+  let(:rhevm_vm)      { instance_double("Ovirt::Vm") }
+  let(:task)          { FactoryGirl.create(:miq_provision_redhat, :state => 'pending', :status => 'Ok', :options => {:src_vm_id => template.id}) }
+  let(:template)      { FactoryGirl.create(:template_redhat, :ext_management_system => ems) }
+  let(:vm)            { FactoryGirl.create(:vm_redhat) }
 
-    @rhevm_vm = double('rhevm_vm').as_null_object
-    @task.stub(:get_provider_destination => @rhevm_vm)
-  end
+  before { task.stub(:get_provider_destination => rhevm_vm) }
 
   context "#attach_floppy_payload" do
     it "should attach floppy if customization template provided" do
-      script = '#cloudinit'
-      template = FactoryGirl.create(:customization_template_cloud_init, :script => script)
+      task.options[:customization_template_id] = cust_template.id
 
-      @task.should_receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+      expect(task).to     receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+      expect(rhevm_vm).to receive(:attach_floppy).with(cust_template.default_filename => '#some_script')
 
-      @task.options[:customization_template_id] = template.id
-      @rhevm_vm.should_receive(:attach_floppy).with(template.default_filename => script)
-
-      @task.attach_floppy_payload
+      task.attach_floppy_payload
     end
   end
 
   context "#configure_cloud_init" do
     it "should configure cloudinit if customization template provided" do
-      script = '#cloudinit'
-      template = FactoryGirl.create(:customization_template_cloud_init, :script => script)
+      task.options[:customization_template_id] = cust_template.id
 
-      @task.should_receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+      expect(task).to     receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+      expect(rhevm_vm).to receive(:cloud_init=).with('#some_script')
 
-      @task.options[:customization_template_id] = template.id
-      @rhevm_vm.should_receive(:cloud_init=).with(script)
-
-      @task.configure_cloud_init
+      task.configure_cloud_init
     end
   end
 
   context "#configure_container" do
-    it "should configure the memory reserve if provided" do
-      memory_reserve_in_mb = 1024
-      @task.options[:memory_reserve] = memory_reserve_in_mb
-      @rhevm_vm.should_receive(:memory_reserve=).with(memory_reserve_in_mb.megabytes)
-      @task.configure_container
+    it "with options set" do
+      task.options[:cores_per_socket]  = 4
+      task.options[:dest_host]         = host.id
+      task.options[:memory_reserve]    = 1024
+      task.options[:number_of_sockets] = 2
+      task.options[:vm_description]    = "abc"
+      task.options[:vm_memory]         = 2048
+
+      expect(rhevm_vm).to receive(:description=).with("abc")
+      expect(rhevm_vm).to receive(:memory=).with(2147483648)
+      expect(rhevm_vm).to receive(:memory_reserve=).with(1073741824)
+      expect(rhevm_vm).to receive(:cpu_topology=).with(:cores => 4, :sockets => 2)
+      expect(rhevm_vm).to receive(:host_affinity=).with(host.ems_ref)
+
+      task.configure_container
+    end
+
+    it "without options" do
+      expect(rhevm_vm).to receive(:description=).with(nil)
+      expect(rhevm_vm).to receive(:cpu_topology=).with(:cores => 1, :sockets => 1)
+
+      task.configure_container
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_provider/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/provision/state_machine_spec.rb
@@ -59,7 +59,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       @task.stub(:update_and_notify_parent)
 
       @task.should_receive(:configure_container)
-      @task.should_receive(:attach_floppy_payload)
+      @task.should_receive(:configure_cloud_init)
       @task.should_receive(:poll_destination_powered_off_in_provider)
 
       @task.customize_destination


### PR DESCRIPTION
Move cloud-init attachment out of ManageIQ state machine and into Ovirt Gem.  Refactor and improve related tests.

Depends on a new version of Ovirt gem with PR https://github.com/ManageIQ/ovirt/pull/31
https://bugzilla.redhat.com/show_bug.cgi?id=1238390