### PR TITLE
Display collected container labels and selectors in the UI

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -47,7 +47,19 @@ module ContainerSummaryHelper
     textual_link(@record.container_node)
   end
 
+  def textual_container_labels
+    textual_key_value(@record.labels.to_a)
+  end
+
+  def textual_container_selectors
+    textual_key_value(@record.selector_parts.to_a)
+  end
+
   private
+
+  def textual_key_value(items)
+    items.collect { |item| {:label => item.name.to_s, :value => item.value.to_s} }.flatten.compact
+  end
 
   def textual_link(target, **opts, &blk)
     case target

--- a/app/views/container_group/_main.html.haml
+++ b/app/views/container_group/_main.html.haml
@@ -2,6 +2,6 @@
 .row
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"), :items => textual_container_labels}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-

--- a/app/views/container_replicator/_main.html.haml
+++ b/app/views/container_replicator/_main.html.haml
@@ -2,6 +2,8 @@
 .row
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"), :items => textual_container_labels}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Selector"), :items => textual_container_selectors}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
 

--- a/app/views/container_service/_main.html.haml
+++ b/app/views/container_service/_main.html.haml
@@ -3,6 +3,8 @@
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Port Configurations"), :items => textual_group_port_configs}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"), :items => textual_container_labels}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Selector"), :items => textual_container_selectors}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
 


### PR DESCRIPTION
Labels table was added in the views of the following entities:
* Container Groups (pods)
* Replication Controllers
* Services
    
Selector table was added in the views of the following entities:
* Replication Controllers
* Services
    
Please notice it was added in container_summary_helper for code reusability.

![replicatorslabels](https://cloud.githubusercontent.com/assets/6347577/8903073/f52a46c6-345d-11e5-9b28-947f5c330df9.png)
![serviceslabels](https://cloud.githubusercontent.com/assets/6347577/8903071/f416fa54-345d-11e5-8873-61fb38091c23.png)
![podslabels](https://cloud.githubusercontent.com/assets/6347577/8894432/9505d240-33bf-11e5-80e7-3fd82b06b134.png)
