### PR TITLE
Fix the relation between container group and container

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -2,7 +2,7 @@ class Container < ActiveRecord::Base
   include ReportableMixin
   include NewWithTypeStiMixin
 
-  belongs_to :container_group
+  has_one    :container_group, :through => :container_definition
   delegate   :ext_management_system, :to => :container_group
   delegate   :container_project, :to => :container_group
   belongs_to :container_definition

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -6,7 +6,8 @@ class ContainerGroup < ActiveRecord::Base
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :restart_policy, :dns_policy
 
-  has_many :containers, :dependent => :destroy
+  has_many :containers,
+           :through => :container_definitions
   has_many :container_definitions, :dependent => :destroy
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -195,7 +195,6 @@ module EmsRefresh::SaveInventoryContainer
     # The hash could be nil when the container is in transition (still downloading
     # the image, or stuck in Pending, or unable to fetch the image). Passing nil to
     # save_inventory_single is used to delete any pre-existing entity in containers,
-    hash[:container_group_id] = container_definition.container_group_id unless hash.nil?
     save_inventory_single(:container, container_definition, hash)
   end
 

--- a/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -80,6 +80,11 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
       :image         => "kubernetes/heapster_influxdb:v0.3",
       # :backing_ref   => "docker://af741769b650a408f4a65d2d27043912b6d57e5e2a721faeb7a93a1989eef0c6"
     )
+
+    # Check the relation to container group
+    @container2.container_group.should have_attributes(
+      :name => "monitoring-influx-grafana-controller-mdyqf"
+    )
   end
 
   def assert_specific_container_group
@@ -101,6 +106,12 @@ describe EmsRefresh::Refreshers::KubernetesRefresher do
     @services.first.should have_attributes(
       # :ems_ref => "49981230-e1b7-11e4-b7dc-001a4a5f4a02",
       :name    => "monitoring-heapster"
+    )
+
+    # Check the relation to containers
+    @containergroup.containers.count.should == 1
+    @services.first.should have_attributes(
+      :name => "monitoring-heapster"
     )
   end
 

--- a/spec/models/ems_refresh/refreshers/openshift_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/openshift_refresher_spec.rb
@@ -52,6 +52,11 @@ describe EmsRefresh::Refreshers::OpenshiftRefresher do
       :image         => "openshift/mysql-55-centos7",
       :backing_ref   => "docker://bb608fb1575bcc1a5326517e6c4589df5160fa804daaa4990e837f1154f1c3c9"
     )
+
+    # Check the relation to container node
+    @container.container_group.should have_attributes(
+      :ems_ref => "fc73bb4b-2870-11e5-b5bb-727174f8ab71"
+    )
   end
 
   def assert_specific_container_group
@@ -66,6 +71,12 @@ describe EmsRefresh::Refreshers::OpenshiftRefresher do
     # Check the relation to container node
     @containergroup.container_node.should have_attributes(
       :ems_ref => "248c52a3-286d-11e5-b5bb-727174f8ab71"
+    )
+
+    # Check the relation to containers
+    @containergroup.containers.count.should == 1
+    @containergroup.containers.last.should have_attributes(
+      :ems_ref => "fc73bb4b-2870-11e5-b5bb-727174f8ab71_ruby-helloworld-database_openshift/mysql-55-centos7"
     )
   end
 


### PR DESCRIPTION
Commit #1231e057 moved containers to be under container definition
instead of container group.
The above change broke the relation between container group and a single
container.
This commit fixes #3467