### PR TITLE
Bugfix: safe call of truncate

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/cloud_manager/refresh_parser.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::CloudManager::RefreshParser
       :type        => self.class.security_group_type,
       :ems_ref     => uid,
       :name        => sg.name,
-      :description => sg.description.truncate(255)
+      :description => sg.description.try(:truncate, 255)
     }
 
     return uid, new_result


### PR DESCRIPTION
Calling truncate safely on non mandatory attribute.
It is causing exception mentioned here
http://talk.manageiq.org/t/solved-problem-with-new-ems-cloud/806/18