### PR TITLE
Remove unneeded column container_group_id from containers

### DIFF
--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -3,5 +3,5 @@ class ContainerDefinition < ActiveRecord::Base
   belongs_to :container_group
   has_many :container_port_configs, :dependent => :destroy
   has_many :container_env_vars,     :dependent => :destroy
-  has_one :container
+  has_one :container,               :dependent => :destroy
 end

--- a/db/migrate/20150726144643_remove_container_group_id_from_containers.rb
+++ b/db/migrate/20150726144643_remove_container_group_id_from_containers.rb
@@ -1,0 +1,5 @@
+class RemoveContainerGroupIdFromContainers < ActiveRecord::Migration
+  def change
+    remove_column :containers, :container_group_id, :bigint
+  end
+end


### PR DESCRIPTION
commit 0cf5a21ed8767d5656949e23561195d4aa0f55b9 removed the need of
container_group_id column, this patch actaully removes it.