### PR TITLE
Freeze puma revision.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 gem "american_date"
 gem "default_value_for",              "~>3.0.1"
 gem "thin",                           "~>1.3.1"  # Used by rails server through rack
-gem "puma",                                                              :git => "git://github.com/puma/puma.git", :branch => "master"
+gem "puma",                                                              :git => "git://github.com/puma/puma.git", :ref => "7e5b78861097be62912245f93d0187bb975f7753"
 gem "bcrypt",                         "3.1.10"
 gem 'outfielding-jqplot-rails',       "= 1.0.8"
 gem "responders",                     "~> 2.0"


### PR DESCRIPTION
This change locks the version of puma to be installed to the revision
where @matthewd's bugfix was merged upstream. This should help avoid any
unexpected changes that are introduced in master before an official
release is cut.