### PR TITLE
Better caching for Openstack Event Monitors

### DIFF
--- a/gems/pending/openstack/amqp/openstack_null_event_monitor.rb
+++ b/gems/pending/openstack/amqp/openstack_null_event_monitor.rb
@@ -11,23 +11,20 @@ class OpenstackNullEventMonitor < OpenstackEventMonitor
   end
 
   def initialize(options = {})
+    $log.warn("MIQ(#{self.class.name}##{__method__}) There was an problem establishing a connection to the AMQP service on #{options[:hostname]}.
+               Check the evm.log for more details.")
     @options = options
   end
 
   def start
-    raise NotImplementedError, error_message
   end
 
   def stop
-    raise NotImplementedError, error_message
   end
 
   def each_batch
-    raise NotImplementedError, error_message
-  end
-
-  private
-  def error_message
-    @error_message ||= "Openstack Event Monitoring is not available for #{@options[:hostname]}.  Check logs for more details."
+    # yield empty array to enter the each_batch block and trigger sleep
+    # to avoid smashing the CPU with a tight loop
+    yield []
   end
 end

--- a/lib/workers/mixins/event_catcher_openstack_mixin.rb
+++ b/lib/workers/mixins/event_catcher_openstack_mixin.rb
@@ -40,8 +40,10 @@ module EventCatcherOpenstackMixin
     begin
       event_monitor_handle.start
       event_monitor_handle.each_batch do |events|
-        _log.debug("#{self.log_prefix} Received events #{events.collect { |e| e.payload["event_type"] }}") if _log.debug?
-        @queue.enq events
+        if events && !events.empty?
+          _log.debug("#{self.log_prefix} Received events #{events.collect { |e| e.payload["event_type"] }}") if _log.debug?
+          @queue.enq events
+        end
         sleep_poll_normal
       end
     ensure


### PR DESCRIPTION
`OpenstackEventMonitor` implementation classes were cached to be sure that we didn't do expensive connection tests each time events were gathered for an openstack provider.  However, the cache was a permanent cache and was only cleared when the appliance was restarted.  The new cache will invalidate every 5 minutes.

This cache invalidation will allow the `OpenstackEventMonitor` to recover from communication failures with the AMQP service.

Additionally, the `OpenstackNullEventMonitor` served the purpose of a [Null Object pattern](https://en.wikipedia.org/wiki/Null_Object_pattern) for an Openstack Event Monitor.  Specifically, it was supposed to do nothing when used as the fallback event monitor.  However, it didn't do nothing, it raised exceptions; which all happened to be swallowed by the `EventCatcherWorker` thread.  The EventCatcherWorker thread would then die and immediately restart.

By implementing these methods to return nothing, it avoids having the `OpenstackNullEventMonitor` perpetually kill the `EventCatcherWorker`.

The combination of these two fixes will allow Openstack providers to recover from network communication errors when establishing an AMQP connection, as well as be a little less petulant with the `OpenstackNullEventMonitor`.

https://bugzilla.redhat.com/show_bug.cgi?id=1247200