### PR TITLE
Bring back mistakenly removed Loaded_Chart()

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -612,6 +612,15 @@ function miqPassFields(url, args) {
   return url + '?' + $.param(args);
 }
 
+// Load XML/SWF charts data (non-IE)
+// This method is called by the XML/SWF charts when a chart is loaded into the DOM
+function Loaded_Chart(chart_id) {
+  if ((ManageIQ.browser != 'Explorer') &&
+      (typeof (ManageIQ.charts.chartData) != 'undefined')) {
+    doLoadChart(chart_id, document.getElementsByName(chart_id)[0]);
+  }
+}
+
 function doLoadChart(chart_id, chart_object) {
   var id_splitted = chart_id.split('_');
   var set = id_splitted[1];

--- a/spec/javascripts/ziya_charts_spec.js
+++ b/spec/javascripts/ziya_charts_spec.js
@@ -1,0 +1,5 @@
+describe('Routines used by ziya charts', function() {
+  it('checks that Loaded_Chart() function is not undefined', function() {
+    expect(Loaded_Chart).not.toBeUndefined();
+  });
+});


### PR DESCRIPTION
This JS function is still being used by ziya charts.

Mistakenly removed in commit bffad7221f68cac34ee8a9b154640395d46a3534