### PR TITLE
Renamed leftover usages of miqEditor to ManageIQ.editor

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1004,8 +1004,8 @@ function miq_tabs_init(id, url) {
   });
   $(id + ' > ul.nav-tabs a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
     // Refresh CodeMirror when its tab is toggled
-    if ($($(e.target).attr('href')).hasClass('cm-tab') && typeof(miqEditor) != 'undefined') {
-      miqEditor.refresh();
+    if ($($(e.target).attr('href')).hasClass('cm-tab') && typeof(ManageIQ.editor) != 'undefined') {
+      ManageIQ.editor.refresh();
     }
     // Show buttons according to the show/hide-buttons class
     if ($($(e.target).attr('href')).hasClass('show-buttons')) {

--- a/app/views/layouts/_my_code_mirror.html.haml
+++ b/app/views/layouts/_my_code_mirror.html.haml
@@ -32,7 +32,7 @@
   }
   );
   ManageIQ.editor.on("change", function(cm, change) {miqSendOneTrans('#{url}')}),
-  ManageIQ.editor.on("blur", function(cm) {miqEditor.save()}),
+  ManageIQ.editor.on("blur", function(cm) {ManageIQ.editor.save()}),
   $('.CodeMirror-scroll')[0].style.height = '#{height}px';
   $('.CodeMirror-scroll')[0].style.width = '#{width}px';
   - unless no_focus


### PR DESCRIPTION
This issue was introduced in https://github.com/ManageIQ/manageiq/pull/3254, Commit SHA: a7966b2b
changed leftover occurrences of miqEditor to use ManageIQ.editor

fixes #3624 

@mkanoor @dclarizio please review/test.