### PR TITLE
Flash message displayed twice after resetting changes for chargeback rates

### DIFF
--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,5 +1,4 @@
 - url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
-= render :partial => "layouts/flash_msg"
 #form_div
   %h3= _('Basic Info')
   %form.form-horizontal.static


### PR DESCRIPTION

 Flash message div duplicate in the rate edit layout.

 https://bugzilla.redhat.com/show_bug.cgi?id=1224425

@dclarizio - this is WIP because it cannot be tested until https://github.com/ManageIQ/manageiq/issues/3620 is fixed