### PR TITLE
Show RHN organization name when display name is not populated.

### DIFF
--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -99,7 +99,7 @@ module OpsController::Settings::RHN
       :registration_type => db.registration_type,
       :user_name         => username,
       :server            => db.registration_server,
-      :company_name      => db.registration_organization_display_name,
+      :company_name      => db.registration_organization_name,
       :subscription      => rhn_subscription_map[db.registration_type] || 'None',
       :update_repo_name  => db.update_repo_name,
       :version_available => db.cfme_version_available

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -85,6 +85,10 @@ class MiqDatabase < ActiveRecord::Base
     MiqTask.wait_for_taskid(RegistrationSystem.verify_credentials_queue).task_results if auth_type == :registration
   end
 
+  def registration_organization_name
+    registration_organization_display_name || registration_organization
+  end
+
   private
 
   def registration_server_url_is_valid

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -109,4 +109,18 @@ describe MiqDatabase do
       end
     end
   end
+
+  context "#registration_organization_name" do
+    it "returns registration_organization when registration_organization_display_name is not available" do
+      db = FactoryGirl.create(:miq_database, :registration_organization => "foo")
+      expect(db.registration_organization_name).to eq("foo")
+    end
+
+    it "returns registration_organization_display_name when available" do
+      db = FactoryGirl.create(:miq_database,
+                              :registration_organization              => "foo",
+                              :registration_organization_display_name => "FOO")
+      expect(db.registration_organization_name).to eq("FOO")
+    end
+  end
 end


### PR DESCRIPTION
Show RHN organization name value when display name is not populated in the table.

https://bugzilla.redhat.com/show_bug.cgi?id=1221060

@brandondunne @dclarizio please review

before:
![rhn_screen_before_fix](https://cloud.githubusercontent.com/assets/3450808/8937038/f041f7be-3523-11e5-9f03-1646b478175e.png)

after:
![rhn_screen_after_fix](https://cloud.githubusercontent.com/assets/3450808/8937041/f4f41aa8-3523-11e5-9104-0b9f245f3658.png)
