### PR TITLE
SCVMM: Handles provisioning from a template with spaces in name

### DIFF
--- a/app/models/miq_provision_microsoft/cloning.rb
+++ b/app/models/miq_provision_microsoft/cloning.rb
@@ -95,7 +95,7 @@ module MiqProvisionMicrosoft::Cloning
   end
 
   def template_ps_script
-    "(Get-SCVMTemplate -Name #{source.name})"
+    "(Get-SCVMTemplate -Name '#{source.name}')"
   end
 
   def logical_network_ps_script


### PR DESCRIPTION
Insert single quote marks around template name to handle names that contain spaces.

https://bugzilla.redhat.com/show_bug.cgi?id=1234894