### PR TITLE
gitignore vmdb to prevent it from being accidentally committed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .tags
 /data/
 /productization
+/vmdb/
 BUILD
 ca/root
 coverage/


### PR DESCRIPTION
If you checkout an older branch and need to have `vmdb/.bundle/config`,
`vmdb/config/database.yml`, and other files for these older branches,
the vmdb directory will be untracked:

```
On branch master
Your branch is up-to-date with 'upstream/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

  vmdb/
```

[skip ci]
