### PR TITLE
use public_send instead of eval

### DIFF
--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -216,19 +216,18 @@ module ActsAsTaggable
   def vtag_list(options = {})
     ns = Tag.get_namespace(options)
 
-    subject = "self"
     predicate = ns.split("/")[2..-1] # throw away /virtual
 
     # p "ns: [#{ns}]"
     # p "predicate: [#{predicate.inspect}]"
 
     begin
-      value = eval(predicate.unshift(subject).join("."))
+      predicate.inject(self) do |target, method|
+        target.public_send method
+      end
     rescue NoMethodError => err
       return ""
     end
-
-    value
   end
 end
 

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -178,7 +178,7 @@ module ActsAsTaggable
         macro = subject.class.reflect_on_association(relationship.to_sym).macro
       end
       if macro == :has_one || macro == :belongs_to
-        value = subject.instance_eval([relationship, attr].join("."))
+        value = subject.public_send(relationship).public_send(attr)
         return object.downcase == value.to_s.downcase
       else
         subject.send(relationship).any? { |o| o.send(attr).to_s == object }


### PR DESCRIPTION
I think we can just switch this to sending methods rather than evaling.
Also, I'm not sure where the tag data comes from, but we should probably
also whitelist methods.