### PR TITLE
fix HAML conversion - layouts/_item

### DIFF
--- a/app/views/layouts/_item.html.haml
+++ b/app/views/layouts/_item.html.haml
@@ -1,40 +1,41 @@
 = render :partial => "layouts/flash_msg"
 %table.style1
-  - if @item.kind_of?(CimStorageExtent)
-    - cols = [%w(Name               evm_display_name),
-              %w(Vendor             vendor),
-              %w(Zone               zone_name),
-              %w(Description        description),
-              %w(Operational Status operational_status_str),
-              %w(Health State       health_state_str),
-              %w(Enabled            enabled_state),
-              %w(System             system_name),
-              %w(Number of Blocks   number_of_blocks),
-              %w(Block Size         block_size),
-              %w(Consumable Blocks  consumable_blocks),
-              %w(Device ID          device_id),
-              %w(Extent Status      extent_status),
-              %w(Primordial         primordial?),
-              %w(Last Update Status last_update_status_str)]
-  - elsif @item.kind_of?(SniaLocalFileSystem)
-    - cols = [%w(Name                       evm_display_name),
-              %w(Caption                    caption),
-              %w(Zone                       zone_name),
-              %w(Operational Status         operational_status_str),
-              %w(Root                       root),
-              %w(CS Name                    cs_name),
-              %w(File System Type           file_system_type),
-              %w(Path Name Separator String path_name_separator_string),
-              %w(Resize Increment           resize_increment),
-              %w(Cluster Size               cluster_size),
-              %w(Block Size                 block_size),
-              %w(File System Size           file_system_size),
-              %w(Available Space            available_space),
-              %w(Max File Name Length       max_file_name_length),
-              %w(Read Only                  read_only?),
-              %w(Case Sensitive             case_sensitive?),
-              %w(Case Preserved             case_preserved?),
-              %w(Last Update Status         last_update_status_str)]
+  - if @item.kind_of?(CimStorageExtent) || @item.kind_of?(SniaLocalFileSystem)
+    - if @item.kind_of?(CimStorageExtent)
+      - cols = [%w(Name               evm_display_name),
+                %w(Vendor             vendor),
+                %w(Zone               zone_name),
+                %w(Description        description),
+                %w(Operational Status operational_status_str),
+                %w(Health State       health_state_str),
+                %w(Enabled            enabled_state),
+                %w(System             system_name),
+                %w(Number of Blocks   number_of_blocks),
+                %w(Block Size         block_size),
+                %w(Consumable Blocks  consumable_blocks),
+                %w(Device ID          device_id),
+                %w(Extent Status      extent_status),
+                %w(Primordial         primordial?),
+                %w(Last Update Status last_update_status_str)]
+    - elsif @item.kind_of?(SniaLocalFileSystem)
+      - cols = [%w(Name                       evm_display_name),
+                %w(Caption                    caption),
+                %w(Zone                       zone_name),
+                %w(Operational Status         operational_status_str),
+                %w(Root                       root),
+                %w(CS Name                    cs_name),
+                %w(File System Type           file_system_type),
+                %w(Path Name Separator String path_name_separator_string),
+                %w(Resize Increment           resize_increment),
+                %w(Cluster Size               cluster_size),
+                %w(Block Size                 block_size),
+                %w(File System Size           file_system_size),
+                %w(Available Space            available_space),
+                %w(Max File Name Length       max_file_name_length),
+                %w(Read Only                  read_only?),
+                %w(Case Sensitive             case_sensitive?),
+                %w(Case Preserved             case_preserved?),
+                %w(Last Update Status         last_update_status_str)]
 
     - cols.each do |title, val|
       %tr{:class => "#{cycle('row0', 'row1')}"}


### PR DESCRIPTION
this was introduced in a82effc,  the `cols.each` needs to happen for both types, only the outer else should be separate