### PR TITLE
Convert style1 tables to patternfly in Explorer

### DIFF
--- a/app/views/miq_ae_class/_class_form.html.haml
+++ b/app/views/miq_ae_class/_class_form.html.haml
@@ -1,28 +1,35 @@
 - url = url_for(:action => 'form_field_changed', :id => "#{@ae_class.id || 'new'}")
 - obs = {:interval => '.5', :url => url}.to_json
-%h3= _('Properties')
-%table.style1
-  %tr
-    %td.key
+%h3
+  = _('Properties')
+%form.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
       = Dictionary::gettext('fqname', :type => :column, :notfound => :titleize)
-    %td.wide
+    .col-md-8
       = @sb[:namespace_path]
-  %tr
-    %td.key= _('Name')
-    %td.wide
+  .form-group
+    %label.col-md-2.control-label
+      = _('Name')
+    .col-md-8
       = text_field_tag("name", @edit[:new][:name],
-        :maxlength         => MAX_NAME_LEN,
-        "data-miq_observe" => obs)
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => obs)
       = javascript_tag(javascript_focus('name'))
-  %tr
-    %td.key= _('Display Name')
-    %td.wide
+  .form-group
+    %label.col-md-2.control-label
+      = _('Display Name')
+    .col-md-8
       = text_field_tag("display_name", @edit[:new][:display_name],
-        :maxlength         => MAX_NAME_LEN,
-        "data-miq_observe" => obs)
-  %tr
-    %td.key= _('Description')
-    %td.wide
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => obs)
+  .form-group
+    %label.col-md-2.control-label
+      = _('Description')
+    .col-md-8
       = text_field_tag("description", @edit[:new][:description],
-       :maxlength => MAX_NAME_LEN,
-       "data-miq_observe" => obs)
+                       :maxlength => MAX_NAME_LEN,
+                       :class => "form-control",
+                       "data-miq_observe" => obs)

--- a/app/views/miq_ae_class/_copy_objects_form.html.haml
+++ b/app/views/miq_ae_class/_copy_objects_form.html.haml
@@ -3,60 +3,73 @@
 #form_div
   = hidden_div_if(!@edit[:new][:namespace], :id => "ae_tree_select_div") do
     = render(:partial => 'layouts/ae_tree_select', :locals => {:entry_point => "Namespace"})
-  %fieldset
-    %p
-    %table.style1
-      %tr
-        %td.key= _('From Domain')
-        %td.wide
+  %p
+  %form.form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('From Domain')
+      .col-md-8
+        %p.form-control-static
           = @edit[:domain_name]
-      %tr
-        %td.key= _('To Domain')
-        %td.wide
+    .form-group
+      %label.col-md-2.control-label
+        = _('To Domain')
+      .col-md-8
+        %p.form-control-static
           - if @edit[:domains].length == 1
             = @edit[:domains].first.last
           - else
             = select_tag("domain",
-              options_for_select(Array(@edit[:domains].invert).sort,
-              @edit[:new][:domain]),
-              "data-miq_observe" => {:url => url}.to_json)
-      - if @edit[:selected_items].length == 1 && @edit[:new][:domain].to_i == @edit[:domain_id]
-        %tr
-          %td.key= _('New Name')
-          %td.wider
-            = text_field_tag("new_name", @edit[:new][:new_name],
-              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                          options_for_select(Array(@edit[:domains].invert).sort,
+                          @edit[:new][:domain]),
+                          :class    => "selectpicker",
+                          "data-miq_observe" => {:url => url}.to_json)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("domain", "#{url}")
 
-      %tr
-        %td.key= _('Copy to same path')
-        %td
-          = check_box_tag("override_source",
-                          value   = "1",
-                          checked = @edit[:new][:override_source],
-                          :id                         => "override_source",
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
-      - if %w(MiqAeInstance MiqAeMethod).include?(@edit[:typ].to_s)
+    - if @edit[:selected_items].length == 1 && @edit[:new][:domain].to_i == @edit[:domain_id]
+      .form-group
+        %label.col-md-2.control-label
+          = _('New Name')
+        .col-md-8
+          = text_field_tag("new_name", @edit[:new][:new_name],
+                            :class => "form-control",
+                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+
+    .form-group
+      %label.col-md-2.control-label
+        = _('Copy to same path')
+      .col-md-8
+        = check_box_tag("override_source",
+                        "1",
+                        @edit[:new][:override_source],
+                        :id                         => "override_source",
+                        "data-miq_observe_checkbox" => {:url => url}.to_json)
+    - if %w(MiqAeInstance MiqAeMethod).include?(@edit[:typ].to_s)
+      .form-group
+        %label.col-md-2.control-label
+          = _('Replace items if they already exist?')
+        .col-md-8
+          = check_box_tag("override_existing",
+                         "1",
+                         @edit[:new][:override_existing],
+                         :id                         => "override_existing",
+                         "data-miq_observe_checkbox" => {:url => url}.to_json)
+    - unless @edit[:new][:override_source]
+      .form-group
+        %label.col-md-2.control-label
+          = _('Namespace')
+        .col-md-8
+          = text_field_tag("namespace",
+                           @edit[:new][:namespace],
+                           :onFocus => 'miqShowAE_Tree("namespace");miqButtons("hide");')
+%p
+  %table.table.table-striped.table-bordered
+    %thead
+      %th #{@edit[:selected_items].count} #{n_('Item', 'Items', @edit[:selected_items].count)} #{_('selected to copy')}
+    %tbody
+      - @edit[:selected_items].values.each do |item|
         %tr
-          %td.key= _('Replace items if they already exist?')
           %td
-            = check_box_tag("override_existing",
-                           value   = "1",
-                           checked = @edit[:new][:override_existing],
-                           :id                         => "override_existing",
-                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-      - unless @edit[:new][:override_source]
-        %tr
-          %td.key= _('Namespace')
-          %td.wider
-            = text_field_tag("namespace",
-                             @edit[:new][:namespace],
-                             :onFocus => 'miqShowAE_Tree("namespace");miqButtons("hide");')
-  %p
-    %table.table.table-striped.table-bordered
-      %thead
-        %th #{@edit[:selected_items].count} #{n_('Item', 'Items', @edit[:selected_items].count)} #{_('selected to copy')}
-      %tbody
-        - @edit[:selected_items].values.each do |item|
-          %tr
-            %td
-              = item
+            = item

--- a/app/views/miq_ae_class/_instance_form.html.haml
+++ b/app/views/miq_ae_class/_instance_form.html.haml
@@ -1,34 +1,41 @@
 - url = url_for(:action => 'form_instance_field_changed', :id => "#{@ae_inst.id || "new"}")
 - obs = {:interval => '.5', :url => url}.to_json
-%h3= _('Main Info')
-%table.style1
-  %tr
-    %td.key
+%h3
+  = _('Main Info')
+%form.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
       = Dictionary::gettext('fqname', :type => :column, :notfound => :titleize)
-    %td.wide
+    .col-md-8
       = h(@sb[:namespace_path])
-  %tr
-    %td.key= _('Name')
-    %td.wide
+  .form-group
+    %label.col-md-2.control-label
+      = _('Name')
+    .col-md-8
       = text_field_tag("#{prefix}inst_name",
-        @edit[:new][:ae_inst]["name"],
-        :maxlength         => MAX_NAME_LEN,
-        "data-miq_observe" => obs)
+                        @edit[:new][:ae_inst]["name"],
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => obs)
       = javascript_tag(javascript_focus("#{prefix}inst_name"))
-  %tr
-    %td.key= _('Display Name')
-    %td.wide
+  .form-group
+    %label.col-md-2.control-label
+      = _('Display Name')
+    .col-md-8
       = text_field_tag("#{prefix}inst_display_name",
-        @edit[:new][:ae_inst]["display_name"],
-        :maxlength         => MAX_NAME_LEN,
-        "data-miq_observe" => obs)
-  %tr
-    %td.key= _('Description')
-    %td.wide
+                      @edit[:new][:ae_inst]["display_name"],
+                      :maxlength         => MAX_NAME_LEN,
+                      :class => "form-control",
+                      "data-miq_observe" => obs)
+  .form-group
+    %label.col-md-2.control-label
+      = _('Description')
+    .col-md-8
       = text_field_tag("#{prefix}inst_description",
-        @edit[:new][:ae_inst]["description"],
-        :maxlength         => MAX_NAME_LEN,
-        "data-miq_observe" => obs)
+                      @edit[:new][:ae_inst]["description"],
+                      :maxlength         => MAX_NAME_LEN,
+                      :class => "form-control",
+                      "data-miq_observe" => obs)
 %hr
 %h3= _('Fields')
 %table.table.table-striped.table-bordered

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -1,38 +1,50 @@
 - if @sb[:active_tab] == "methods"
 - url = url_for(:action => 'form_method_field_changed', :id => "#{@ae_method.id || 'new'}")
 - obs = {:interval => '.5', :url => url}.to_json
-  %h3= _('Main Info')
-  %table.style1
-    %tr
-      %td.key
+  %h3
+    = _('Main Info')
+  %form.form-horizontal
+    .form-group
+      %label.col-md-2.control-label
         = Dictionary::gettext('fqname', :type => :column, :notfound => :titleize)
-      %td.wide
-        = h(@sb[:namespace_path])
-    %tr
-      %td.key= _('Name')
-      %td.wide
+      .col-md-8
+        %p.form-control-static
+          = h(@sb[:namespace_path])
+    .form-group
+      %label.col-md-2.control-label
+        = _('Name')
+      .col-md-8
         = text_field_tag("#{prefix}method_name",
-          @edit[:new][:name],
-          :maxlength         => MAX_NAME_LEN,
-          "data-miq_observe" => obs)
-    %tr
-      %td.key= _('Display Name')
-      %td.wide
+                        @edit[:new][:name],
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => obs)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Display Name')
+      .col-md-8
         = text_field_tag("#{prefix}method_display_name",
-          @edit[:new][:display_name],
-          :maxlength         => MAX_NAME_LEN,
-          "data-miq_observe" => obs)
-    %tr
-      %td.key= _('Location')
-      %td.wide
+                        @edit[:new][:display_name],
+                        :maxlength         => MAX_NAME_LEN,
+                        :class => "form-control",
+                        "data-miq_observe" => obs)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Location')
+      .col-md-8
         = select_tag("#{prefix}method_location",
-          options_for_select(@edit[:new][:available_locations].sort,
-          @edit[:new][:location]),
-          "data-miq_observe" => {:url => url}.to_json)
+                      options_for_select(@edit[:new][:available_locations].sort,
+                      @edit[:new][:location]),
+                      :class    => "selectpicker",
+                      "data-miq_observe" => {:url => url}.to_json)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("#{prefix}method_location", "#{url}")
     - if @ae_method.created_on
-      %tr
-        %td.key= _("Created On")
-        %td.wide
+      .form-group
+        %label.col-md-2.control-label
+          = _("Created On")
+        .col-md-8
           = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
   %hr
   %h3= _("Data")

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -1,32 +1,39 @@
 #method_inputs_div
   - if !@in_a_form && @ae_method
     = render :partial => "layouts/flash_msg", :locals => {:div_num => "_method_inputs"}
-    %h3= _('Main Info')
-    %table.style1
-      %tr
-        %td.key
+    %h3
+      = _('Main Info')
+    %form.form-horizontal.static
+      .form-group
+        %label.col-md-2.control-label
           = Dictionary::gettext('fqname', :type => :column, :notfound => :titleize)
-        %td.wide
-          = h(@sb[:namespace_path])
-      %tr
-        %td.key= _('Name')
-        %td.wide
-          = @ae_method.name
-      </tr>
-      %tr
-        %td.key= _('Display Name')
-        %td.wide
-          = @ae_method.display_name
-      </tr>
-      %tr
-        %td.key= _('Location')
-        %td.wide
-          = @ae_method.location
-      </tr>
-      %tr
-        %td.key= _('Created On')
-        %td.wide
-          = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
+        .col-md-8
+          %p.form-control-static
+            = h(@sb[:namespace_path])
+      .form-group
+        %label.col-md-2.control-label
+          = _('Name')
+        .col-md-8
+          %p.form-control-static
+            = @ae_method.name
+      .form-group
+        %label.col-md-2.control-label
+          = _('Display Name')
+        .col-md-8
+          %p.form-control-static
+            = @ae_method.display_name
+      .form-group
+        %label.col-md-2.control-label
+          = _('Location')
+        .col-md-8
+          %p.form-control-static
+            = @ae_method.location
+      .form-group
+        %label.col-md-2.control-label
+          = _('Created On')
+        .col-md-8
+          %p.form-control-static
+            = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
     = render :partial => "domain_overrides", :locals => {:node_prefix => "aem", :model => "Method"}
     %h3= _('Data')
     - if @ae_method.location == "inline"

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -17,37 +17,42 @@
         :div_in_js                          => true}}
   - else
     - url = url_for(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
-    - obs = {:interval => '.5', :url => url}.to_json
     = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
     #form_ns_div
-      %h3= _('Info')
-      %table.style1
+      %h3
+      = _('Info')
+      %form.form-horizontal
         - unless @ae_ns.domain?
-          %tr
-            %td.key
+          .form-group
+            %label.col-md-2.control-label
               = Dictionary::gettext('fqname', :type => :column, :notfound => :titleize)
-            %td.wide
+            .col-md-8
               = h(@sb[:namespace_path])
-        %tr
-          %td.key= _('Name')
-          %td.wide
+        .form-group
+          %label.col-md-2.control-label
+            = _('Name')
+          .col-md-8
             = text_field_tag("ns_name",
-              @edit[:new][:ns_name],
-              :maxlength         => MAX_NAME_LEN,
-              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                              @edit[:new][:ns_name],
+                              :maxlength         => MAX_NAME_LEN,
+                              :class => "form-control",
+                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             = javascript_tag(javascript_focus('ns_name'))
-        %tr
-          %td.key= _('Description')
-          %td.wide
+        .form-group
+          %label.col-md-2.control-label
+            = _('Description')
+          .col-md-8
             = text_field_tag("ns_description",
-              @edit[:new][:ns_description],
-              :maxlength         => MAX_NAME_LEN,
-              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                              @edit[:new][:ns_description],
+                              :maxlength         => MAX_NAME_LEN,
+                              :class => "form-control",
+                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         - if @ae_ns.domain?
-          %tr
-            %td.key= _('Enabled')
-            %td
+          .form-group
+            %label.col-md-2.control-label
+              = _('Enabled')
+            .col-md-8
               = check_box_tag("ns_enabled",
-                value   = "1",
-                checked = @edit[:new][:enabled],
-                "data-miq_observe_checkbox" => {:url => url}.to_json)
+                              "1",
+                              @edit[:new][:enabled],
+                              "data-miq_observe_checkbox" => {:url => url}.to_json)


### PR DESCRIPTION
Parent issue: #3139
Convert style1 tables to patternfly in Explorer

1.
Before:
![automatemethodshowbefore](https://cloud.githubusercontent.com/assets/9535558/8958536/b8dd434a-3605-11e5-87ea-a9e3bb999ccb.png)

After:
![automatemethodshowafter](https://cloud.githubusercontent.com/assets/9535558/8958540/bb288650-3605-11e5-8125-19aedb6a82d4.png)



2.
Before:
![copyautomateinstancebefore](https://cloud.githubusercontent.com/assets/9535558/8958543/c0762d06-3605-11e5-85d2-8f09f4328709.png)

After:
![copyautomateinstanceafter](https://cloud.githubusercontent.com/assets/9535558/8958546/c30cca84-3605-11e5-96e8-d2c6fb006770.png)


3.
Before:
![editautomatedomainbefore](https://cloud.githubusercontent.com/assets/9535558/8958559/de824654-3605-11e5-9e10-f13d64430230.png)


After:
![editautomatedomainafter](https://cloud.githubusercontent.com/assets/9535558/8958561/e02b94b0-3605-11e5-96db-57bbfc5ae7c5.png)


4.
Before:
![editautomateinstancebefore](https://cloud.githubusercontent.com/assets/9535558/8958563/e2f3f16a-3605-11e5-88a1-09a91b42fc72.png)

After:
![editautomateinstanceafter](https://cloud.githubusercontent.com/assets/9535558/8958564/e68d42ae-3605-11e5-88c9-b330e63447be.png)


5.
Before:
![editautomatemethodbefore](https://cloud.githubusercontent.com/assets/9535558/8958568/ea4b477e-3605-11e5-8fcf-530d7104f605.png)

After:
![editautomatemethodafter](https://cloud.githubusercontent.com/assets/9535558/8958569/ed321724-3605-11e5-8f46-4cb22c32eb17.png)


6.
Before:
![editclassbefore](https://cloud.githubusercontent.com/assets/9535558/8958573/f09c2c06-3605-11e5-806f-df79053c7358.png)

After:
![editclassafter](https://cloud.githubusercontent.com/assets/9535558/8958575/f2946e38-3605-11e5-93af-1e82e852ece3.png)


@epwinchell @dclarizio  Please review 
