### PR TITLE
dashboard/login haml - replace link_to with block with link_to with name

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -46,18 +46,18 @@
         .form-group
           .col-xs-8.col-md-offset-3.col-md-6
             - if auth_mode == "database"
-              #back_button{:style => "display:none"}
-                = link_to({:action => "authenticate", 
-                           :button => "back", 
-                           :method => :post},
+              #back_button{:style => "display: none"}
+                = link_to(_("Back"), {:action => "authenticate",
+                                      :button => "back",
+                                      :method => :post},
                           :remote => true,
-                          :title => _("Back")) { _("Back")}
+                          :title => _("Back"))
               #more_button
-                = link_to({:action => "authenticate", 
-                           :button => "more", 
-                           :method => :post},
-                :remote => true,
-                :title => _("Update Password")) { _("Update password") }
+                = link_to(_("Update password"), {:action => "authenticate",
+                                                 :button => "more",
+                                                 :method => :post},
+                          :remote => true,
+                          :title => _("Update Password"))
 
           .col-xs-4.col-md-3.submit
             = link_to("Login",


### PR DESCRIPTION
Cosmetic change replacing the more esoteric `link_to(params) { name }` with `link_to(name, params)`.

Relevant `link_to` documentation can be found [here](http://apidock.com/rails/ActionView/Helpers/UrlHelper/link_to)