### PR TITLE
Websocket proxy execution ignored configured key and cert.

### DIFF
--- a/lib/ws_proxy.rb
+++ b/lib/ws_proxy.rb
@@ -46,10 +46,7 @@ class WsProxy
 
   def file_or_default(config_path, default)
     file_requested = vmdb_config.fetch_path(:server, *config_path)
-    if file_requested.present?
-      file_requested = File.join(Rails.root, cert_file_requested)
-      return file_requested if File.file?(file_requested)
-    end
+    return file_requested if file_requested.present? && File.file?(file_requested)
     default
   end
 
@@ -63,8 +60,8 @@ class WsProxy
       run_options[:'ssl-target'] = nil if ssl_target
 
       if encrypt
-        run_options[:cert] = file_or_default([:server, :websocket, :cert], DEFAULT_CERT_FILE)
-        run_options[:key]  = file_or_default([:server, :websocket, :key],  DEFAULT_KEY_FILE)
+        run_options[:cert] = file_or_default([:websocket, :cert], DEFAULT_CERT_FILE)
+        run_options[:key]  = file_or_default([:websocket, :key],  DEFAULT_KEY_FILE)
       end
 
       run_options
@@ -81,7 +78,7 @@ class WsProxy
   end
 
   def ws_proxy
-    "#{Rails.root}/extras/noVNC/websockify/websocketproxy.py"
+    File.join(Rails.root, 'extras/noVNC/websockify/websocketproxy.py')
   end
 
   def defaults

--- a/spec/lib/ws_proxy_spec.rb
+++ b/spec/lib/ws_proxy_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe WsProxy do
+
+  before(:each) do
+    config = {
+      :server => {
+        :websocket => {
+          :cert => 'non-existent-foo-bar',
+          :key  => 'REGION' # file existing under Rails root
+        }
+      }
+    }
+    vmdb_config = double('vmdb_config')
+    vmdb_config.stub(:config => config)
+    VMDB::Config.stub(:new).with("vmdb").and_return(vmdb_config)
+  end
+
+  context '#try_run_proxy' do
+    it "runs proxy by calling AwesomeSpawn with correct params" do
+      port = 5900
+      ws_proxy = WsProxy.new(:encrypt => true)
+
+      expect(AwesomeSpawn).to receive(:run).with(
+        ws_proxy.send(:ws_proxy),
+        {
+          :params => {
+            :daemon        => nil,
+            :idle_timeout= => 120,
+            :timeout=      => 120,
+            :cert          => WsProxy::DEFAULT_CERT_FILE,
+            :key           => 'REGION', 
+            nil            => [port, "0.0.0.0:5900"],
+          }
+        }
+      )
+
+      ws_proxy.send(:try_run_proxy, port)
+    end
+  end
+end


### PR DESCRIPTION
When running websocket proxy, we ignored key and cert values configured
under :server/:websocket/{:cert,:key} and where using the default values
instead.