### PR TITLE
SCVMM provisioning - manipulation of the datastore name.

### DIFF
--- a/app/models/miq_provision_microsoft/cloning.rb
+++ b/app/models/miq_provision_microsoft/cloning.rb
@@ -1,5 +1,5 @@
 module MiqProvisionMicrosoft::Cloning
-  DRIVE_LETTER     = /[a-z][:]/i
+  MT_POINT_REGEX = %r{file://.*/([A-Z][:].*)}i
 
   def log_clone_options(clone_options)
     _log.info("Provisioning [#{source.name}] to [#{clone_options[:name]}]")
@@ -35,7 +35,8 @@ module MiqProvisionMicrosoft::Cloning
   end
 
   def dest_mount_point
-    dest_datastore.name.scan(DRIVE_LETTER).last.to_s
+    name = dest_datastore.name.scan(MT_POINT_REGEX).flatten.pop
+    URI.decode(name.to_s).gsub('/', '\\')
   end
 
   def dest_virtual_network

--- a/spec/models/miq_provision_microsoft_spec.rb
+++ b/spec/models/miq_provision_microsoft_spec.rb
@@ -63,12 +63,13 @@ describe MiqProvisionMicrosoft do
 
     context "#parse mount point" do
       before do
-        @datastore = FactoryGirl.create(:storage, :name => "C:\\directoryname\\test_datastore")
+        ds_name = "file://server.local/C:/ClusterStorage/CLUSP04%20Prod%20Volume%203-1"
+        @datastore = FactoryGirl.create(:storage, :name => ds_name)
         vm_prov.stub(:dest_datastore).and_return(@datastore)
       end
 
       it "valid drive" do
-        vm_prov.dest_mount_point.should == "C:"
+        vm_prov.dest_mount_point.should == "C:\\ClusterStorage\\CLUSP04 Prod Volume 3-1"
       end
     end
 


### PR DESCRIPTION
Involves:
 - URI decoding (note, we encode the datastore path in the SCVMM parser;  as I understand it, this is a requirement for SSA )
-  processing more complex datastore paths
- spec test was improved to reflect a real life datastore path

https://bugzilla.redhat.com/show_bug.cgi?id=1234990