### PR TITLE
Dispense with temp file generation in inventory collection on Windows

### DIFF
--- a/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -71,7 +71,6 @@ function get_clusters {
  return $results
 }
 
-$file = [System.IO.Path]::GetTempFileName()
 $r = @{}
 $v = Get-SCVirtualMachine -VMMServer "localhost"
 $r["vms"] = get_vms($v)
@@ -89,6 +88,4 @@ $r["clusters"] = get_clusters($c)
 $e = Get-VMMServer -ComputerName "localhost"
 $r["ems"] = $e
 
-$r | Export-CLIXML -path $file -encoding UTF8
-get-content $file
-Remove-Item -Force $file
+ConvertTo-XML -InputObject $r -As string


### PR DESCRIPTION
This change modifies the powershell inventory collection script so that it's no longer writing XML to a temp file, but instead just writes directly to stdout. The WinRM library is just gathering stdout information, so writing to a temp file was not only not necessary, but reading it back out was time consuming.

With this change I saw a 30-40% speed improvement.
