### PR TITLE
PG 9.4 compatibility: 9.4 dropped pg_class.reltoastidxid in favor of pg_index.indexrelid.

### DIFF
--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -507,7 +507,7 @@ module ActiveRecord
            INNER JOIN pg_class i ON d.indexrelid = i.oid
            WHERE i.relkind = 'i'
              AND t.relkind = 't'
-             AND i.oid = t.reltoastidxid
+             AND i.oid = #{postgresql_version >= 90400 ? 'd.indexrelid' : 't.reltoastidxid'}
              AND t.relname = '#{table_name}'
              AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = 'pg_toast' )
           ORDER BY i.relname


### PR DESCRIPTION
https://trello.com/c/Mk4DhnCW

Fixes #1616
Fixes #3550
Fixes #3598

http://www.postgresql.org/message-id/E1UuRj8-0001au-F9@gemulon.postgresql.org
http://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=2ef085d0e6960f5087c97266a7211d37ddaa9f68
http://www.postgresql.org/docs/9.4/static/release-9-4.html

"Treat TOAST index just the same as normal one and get the OID
of TOAST index from pg_index but not pg_class.reltoastidxid.
This change allows us to handle multiple TOAST indexes, and
which is required infrastructure for upcoming
REINDEX CONCURRENTLY feature.

Patch by Michael Paquier, reviewed by Andres Freund and me."


**I've verified this on both PostgreSQL 9.3 and 9.4 and that our existing tests blow up on 9.4 before this change**