### PR TITLE
Make RHEVm Provider report suspended power_state

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -32,9 +32,10 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
 
   def self.calculate_power_state(raw_power_state)
     case raw_power_state
-    when 'up'   then 'on'
-    when 'down' then 'off'
-    else             super
+    when 'up'        then 'on'
+    when 'down'      then 'off'
+    when 'suspended' then 'suspended'
+    else                  super
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_provider/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/vm_spec.rb
@@ -56,4 +56,18 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       expect(vm_redhat.cloneable?).to eq(true)
     end
   end
+
+  context "#calculate_power_state" do
+    it "returns suspended when suspended" do
+      expect(described_class.calculate_power_state('suspended')).to eq('suspended')
+    end
+
+    it "returns on when up" do
+      expect(described_class.calculate_power_state('up')).to eq('on')
+    end
+
+    it "returns down when off" do
+      expect(described_class.calculate_power_state('down')).to eq('off')
+    end
+  end
 end


### PR DESCRIPTION
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1174858

Added support to properly handle suspended raw_power_state and
3 new spec tests to exercise the 3 special cased handled in
ManageIQ::Providers::Redhat::InfraManager::Vm#calculate_power_state