### PR TITLE
Bootstrap datepicker fixes

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -918,6 +918,13 @@ function miqBuildCalendar() {
   all.each(function () {
     var element = $(this);
 
+    if (! element.data('datepicker')) {
+      var observeDateBackup = ManageIQ.observeDate;
+      ManageIQ.observeDate = function() {};
+      element.datepicker();
+      ManageIQ.observeDate = observeDateBackup;
+    }
+
     if (typeof ManageIQ.calendar.calDateFrom != "undefined") {
       element.datepicker('setStartDate', ManageIQ.calendar.calDateFrom);
     }

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -919,15 +919,15 @@ function miqBuildCalendar() {
     var element = $(this);
 
     if (typeof ManageIQ.calendar.calDateFrom != "undefined") {
-      element.datepicker({startDate: ManageIQ.calendar.calDateFrom});
+      element.datepicker('setStartDate', ManageIQ.calendar.calDateFrom);
     }
 
     if (typeof ManageIQ.calendar.calDateTo != "undefined") {
-      element.datepicker({endDate: ManageIQ.calendar.calDateTo});
+      element.datepicker('setEndDate', ManageIQ.calendar.calDateTo);
     }
 
     if (typeof miq_cal_skipDays != "undefined") {
-      element.datepicker({daysOfWeekDisabled: miq_cal_skipDays});
+      element.datepicker('setDaysOfWeekDisabled', miq_cal_skipDays);
     }
   });
 }

--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -104,8 +104,12 @@ $(document).ready(function () {
     miqJqueryRequest(url, options);
   });
 
+  ManageIQ.observeDate = function(el) {
+    miqSendDateRequest(el);
+  };
+
   $(document).on('changeDate clearDate', '[data-miq_observe_date]', function() {
-    miqSendDateRequest($(this));
+    ManageIQ.observeDate($(this));
   });
 
   // Run this last to be sure all other UJS bindings have been run in case the focus field is observed


### PR DESCRIPTION
This PR addresses the following:
* Correctly sets start / end date & skip days.
We need to use 'setStartDate', 'setEndDate' and 'setDaysOfWeekDisabled'
rather than initialization options to correctly set parameters for datepicker.

* Correctly initializes the datepicker object, if it's not initialized.
We need to explicitly initialize the datepicker here if it's
not initialized and suppress the date observer callback during
the initialization.
Calling startDate / endDate on an unitialized datepicker would
trigger 'changeDate' event, upon which miqSendDateRequest() call
would be executed.
