### PR TITLE
Use environment variables and Rails.root to remove hardcoded PG SCL references and appliance paths

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -1,3 +1,5 @@
+require 'util/postgres_admin'
+
 class MiqDatabase < ActiveRecord::Base
   REGISTRATION_DEFAULT_VALUES = {
     :registration_type   => "sm_hosted",
@@ -23,7 +25,7 @@ class MiqDatabase < ActiveRecord::Base
   end
 
   def self.postgres_package_name
-    ENV.fetch("APPLIANCE_PG_PACKAGE_NAME", "postgresql-server")
+    PostgresAdmin.package_name
   end
 
   def self.registration_default_values

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -23,7 +23,7 @@ class MiqDatabase < ActiveRecord::Base
   end
 
   def self.postgres_package_name
-    "postgresql92-postgresql-server"
+    "rh-postgresql94-postgresql-server"
   end
 
   def self.registration_default_values

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -23,7 +23,7 @@ class MiqDatabase < ActiveRecord::Base
   end
 
   def self.postgres_package_name
-    "rh-postgresql94-postgresql-server"
+    ENV.fetch("APPLIANCE_PG_PACKAGE_NAME", "postgresql-server")
   end
 
   def self.registration_default_values

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -126,7 +126,7 @@ module MiqServer::EnvironmentManagement
         when '/'                                            then 'evm_server_system_disk_high_usage'
         when '/var/www/miq'                                 then 'evm_server_app_disk_high_usage'
         when '/var/www/miq/vmdb/log'                        then 'evm_server_log_disk_high_usage'
-        when '/opt/rh/postgresql92/root/var/lib/pgsql/data' then 'evm_server_db_disk_high_usage'
+        when '/opt/rh/rh-postgresql94/root/var/lib/pgsql/data' then 'evm_server_db_disk_high_usage'
         end
 
         next unless disk_usage_event

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -127,10 +127,10 @@ module MiqServer::EnvironmentManagement
     disks.each do |disk|
       if disk[:used_bytes_percent].to_i > threshold
         disk_usage_event = case disk[:mount_point].chomp
-        when '/'                                            then 'evm_server_system_disk_high_usage'
-        when '/var/www/miq'                                 then 'evm_server_app_disk_high_usage'
-        when '/var/www/miq/vmdb/log'                        then 'evm_server_log_disk_high_usage'
-        when /pgsql\/data/                                  then 'evm_server_db_disk_high_usage'
+        when '/'                     then 'evm_server_system_disk_high_usage'
+        when '/var/www/miq'          then 'evm_server_app_disk_high_usage'
+        when '/var/www/miq/vmdb/log' then 'evm_server_log_disk_high_usage'
+        when /pgsql\/data/           then 'evm_server_db_disk_high_usage'
         end
 
         next unless disk_usage_event

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -116,9 +116,13 @@ module MiqServer::EnvironmentManagement
     MiqApache::Control.stop(false)
   end
 
-  def check_disk_usage(disks)
+  def disk_usage_threshold
     @vmdb_config = VMDB::Config.new("vmdb")
-    threshold = @vmdb_config.config.fetch_path(:server, :events, :disk_usage_gt_percent) || 80
+    @vmdb_config.config.fetch_path(:server, :events, :disk_usage_gt_percent) || 80
+  end
+
+  def check_disk_usage(disks)
+    threshold = disk_usage_threshold
 
     disks.each do |disk|
       if disk[:used_bytes_percent].to_i > threshold
@@ -126,7 +130,7 @@ module MiqServer::EnvironmentManagement
         when '/'                                            then 'evm_server_system_disk_high_usage'
         when '/var/www/miq'                                 then 'evm_server_app_disk_high_usage'
         when '/var/www/miq/vmdb/log'                        then 'evm_server_log_disk_high_usage'
-        when '/opt/rh/rh-postgresql94/root/var/lib/pgsql/data' then 'evm_server_db_disk_high_usage'
+        when /pgsql\/data/                                  then 'evm_server_db_disk_high_usage'
         end
 
         next unless disk_usage_event

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -1,3 +1,5 @@
+require 'util/postgres_admin'
+
 module MiqServer::LogManagement
   extend ActiveSupport::Concern
 
@@ -142,7 +144,7 @@ module MiqServer::LogManagement
   end
 
   def pg_data_dir
-    ENV["APPLIANCE_PG_DATA"]
+    PostgresAdmin.data_directory
   end
 
   def pg_log_patterns

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -100,8 +100,8 @@ log:
       - log/apache/*.log
       - log/*.txt
       - config/*
-      - /opt/rh/postgresql92/root/var/lib/pgsql/data/*.conf
-      - /opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/*
+      - /opt/rh/rh-postgresql94/root/var/lib/pgsql/data/*.conf
+      - /opt/rh/rh-postgresql94/root/var/lib/pgsql/data/pg_log/*
       - /var/log/syslog*
       - /var/log/daemon.log*
       - /etc/default/ntp*

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -100,8 +100,6 @@ log:
       - log/apache/*.log
       - log/*.txt
       - config/*
-      - /opt/rh/rh-postgresql94/root/var/lib/pgsql/data/*.conf
-      - /opt/rh/rh-postgresql94/root/var/lib/pgsql/data/pg_log/*
       - /var/log/syslog*
       - /var/log/daemon.log*
       - /etc/default/ntp*

--- a/gems/pending/appliance_console/certificate_authority.rb
+++ b/gems/pending/appliance_console/certificate_authority.rb
@@ -2,6 +2,7 @@ require 'fileutils'
 require 'tempfile'
 require 'appliance_console/principal'
 require 'appliance_console/certificate'
+require 'util/postgres_admin'
 
 module ApplianceConsole
   # configure ssl certificates for postgres communication
@@ -80,7 +81,7 @@ module ApplianceConsole
         # only telling postgres to rewrite server configuration files
         # no need for username/password since not writing database.yml
         InternalDatabaseConfiguration.new(:ssl => true).configure_postgres
-        LinuxAdmin::Service.new(ApplianceConsole::POSTGRESQL_SERVICE).restart
+        LinuxAdmin::Service.new(PostgresAdmin.service_name).restart
       end
       self.pgserver = cert.status
     end

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -5,16 +5,16 @@ module ApplianceConsole
   class InternalDatabaseConfiguration < DatabaseConfiguration
     DATABASE_DISK_FILESYSTEM_TYPE = "xfs".freeze
     POSTGRES_USER                 = "postgres".freeze
-    POSTGRES_DIR                  = "opt/rh/postgresql92/root/var/lib/pgsql/data".freeze
+    POSTGRES_DIR                  = "opt/rh/rh-postgresql94/root/var/lib/pgsql/data".freeze
     DATABASE_DISK_MOUNT_POINT     = Pathname.new("/").join(POSTGRES_DIR).freeze
     VOLUME_GROUP_NAME             = "vg_data".freeze
     LOGICAL_VOLUME_NAME           = "lv_pg".freeze
     LOGICAL_VOLUME_PATH           = Pathname.new("/dev").join(VOLUME_GROUP_NAME, LOGICAL_VOLUME_NAME).freeze
-    SCL_ENABLE_PREFIX             = "scl enable postgresql92".freeze
+    SCL_ENABLE_PREFIX             = "scl enable rh-postgresql94".freeze
     CERT_LOCATION                 = Pathname.new("/var/www/miq/vmdb/certs").freeze
     POSTGRESQL_SAMPLE             = Pathname.new("/var/www/miq/system/COPY/").join(POSTGRES_DIR).freeze
     POSTGRESQL_TEMPLATE           = Pathname.new("/var/www/miq/system/TEMPLATE/").join(POSTGRES_DIR).freeze
-    POSTGRESQL_SERVICE            = "postgresql92-postgresql".freeze
+    POSTGRESQL_SERVICE            = "rh-postgresql94-postgresql".freeze
     attr_accessor :disk
     attr_accessor :ssl
 

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -197,7 +197,7 @@ module ApplianceConsole
       run_as_postgres("createdb -E utf8 -O #{username} #{database}")
     end
 
-    # some overlap with MiqPostgresAdmin
+    # some overlap with PostgresAdmin
     def run_as_postgres(cmd)
       AwesomeSpawn.run("su", :params => {"-" => nil, nil => "postgres", "-c" => "#{self.class.scl_enable_prefix} \"#{cmd}\""})
     end

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -12,11 +12,11 @@ module ApplianceConsole
     end
 
     def self.postgresql_sample
-      Pathname.new("/var/www/miq/system/COPY/").join(postgres_dir)
+      Rails.root.join("../system/COPY").join(postgres_dir)
     end
 
     def self.postgresql_template
-      Pathname.new("/var/www/miq/system/TEMPLATE/").join(postgres_dir)
+      Rails.root.join("../system/TEMPLATE").join(postgres_dir)
     end
 
     def initialize(hash = {})

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -1,6 +1,9 @@
 require "appliance_console/database_configuration"
 require "appliance_console/service_group"
+require "pathname"
 require "util/postgres_admin"
+
+RAILS_ROOT ||= Pathname.new(__dir__).join("../../../")
 
 module ApplianceConsole
   class InternalDatabaseConfiguration < DatabaseConfiguration
@@ -12,11 +15,11 @@ module ApplianceConsole
     end
 
     def self.postgresql_sample
-      Rails.root.join("../system/COPY").join(postgres_dir)
+      RAILS_ROOT.join("../system/COPY").join(postgres_dir)
     end
 
     def self.postgresql_template
-      Rails.root.join("../system/TEMPLATE").join(postgres_dir)
+      RAILS_ROOT.join("../system/TEMPLATE").join(postgres_dir)
     end
 
     def initialize(hash = {})

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -81,7 +81,7 @@ module ApplianceConsole
 
       copy_template "postgresql.conf.erb", self.class.postgresql_template
       copy_template "pg_hba.conf.erb",     self.class.postgresql_template
-      copy_template "pg_ident.conf"
+      copy_template "pg_ident.conf",       self.class.postgresql_template
     end
 
     def post_activation

--- a/gems/pending/appliance_console/service_group.rb
+++ b/gems/pending/appliance_console/service_group.rb
@@ -1,6 +1,6 @@
-module ApplianceConsole
-  POSTGRESQL_SERVICE = "rh-postgresql94-postgresql".freeze
+require "appliance_console/internal_database_configuration"
 
+module ApplianceConsole
   class ServiceGroup
     SERVICES  = %w{evminit memcached miqtop evmserverd}.freeze
 
@@ -27,14 +27,18 @@ module ApplianceConsole
       start
     end
 
+    def postgresql_service
+      InternalDatabaseConfiguration.postgresql_service
+    end
+
     def enable
       enable_miqtop
       SERVICES.each { |s| run_service(s, "enable") }
-      run_service(POSTGRESQL_SERVICE, "enable") if postgresql?
+      run_service(postgresql_service, "enable") if postgresql?
     end
 
     def disable
-      run_service(POSTGRESQL_SERVICE, "disable") unless postgresql?
+      run_service(postgresql_service, "disable") unless postgresql?
     end
 
     def start
@@ -42,7 +46,7 @@ module ApplianceConsole
     end
 
     def stop
-      run_service(POSTGRESQL_SERVICE, "stop") unless postgresql?
+      run_service(postgresql_service, "stop") unless postgresql?
     end
 
     private

--- a/gems/pending/appliance_console/service_group.rb
+++ b/gems/pending/appliance_console/service_group.rb
@@ -1,4 +1,5 @@
 require "appliance_console/internal_database_configuration"
+require "util/postgres_admin"
 
 module ApplianceConsole
   class ServiceGroup
@@ -27,18 +28,14 @@ module ApplianceConsole
       start
     end
 
-    def postgresql_service
-      InternalDatabaseConfiguration.postgresql_service
-    end
-
     def enable
       enable_miqtop
       SERVICES.each { |s| run_service(s, "enable") }
-      run_service(postgresql_service, "enable") if postgresql?
+      run_service(PostgresAdmin.service_name, "enable") if postgresql?
     end
 
     def disable
-      run_service(postgresql_service, "disable") unless postgresql?
+      run_service(PostgresAdmin.service_name, "disable") unless postgresql?
     end
 
     def start
@@ -46,7 +43,7 @@ module ApplianceConsole
     end
 
     def stop
-      run_service(postgresql_service, "stop") unless postgresql?
+      run_service(PostgresAdmin.service_name, "stop") unless postgresql?
     end
 
     private

--- a/gems/pending/appliance_console/service_group.rb
+++ b/gems/pending/appliance_console/service_group.rb
@@ -1,5 +1,5 @@
 module ApplianceConsole
-  POSTGRESQL_SERVICE = "postgresql92-postgresql".freeze
+  POSTGRESQL_SERVICE = "rh-postgresql94-postgresql".freeze
 
   class ServiceGroup
     SERVICES  = %w{evminit memcached miqtop evmserverd}.freeze

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -1,5 +1,7 @@
 #TODO: add appropriate requires instead of depending on appliance_console.rb.
 #TODO: Further refactor these unrelated methods.
+require "appliance_console/internal_database_configuration"
+
 module ApplianceConsole
   module Utilities
     def self.db_connections
@@ -42,7 +44,7 @@ module ApplianceConsole
     end
 
     def self.pg_status
-      system("service rh-postgresql94-postgresql status > /dev/null 2>&1")
+      system("service #{InternalDatabaseConfiguration.postgresql_service} status > /dev/null 2>&1")
       return $?.exitstatus == 0 ? "running" : "not running"
     end
 

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -1,6 +1,7 @@
 #TODO: add appropriate requires instead of depending on appliance_console.rb.
 #TODO: Further refactor these unrelated methods.
 require "appliance_console/internal_database_configuration"
+require "util/postgres_admin"
 
 module ApplianceConsole
   module Utilities
@@ -44,7 +45,7 @@ module ApplianceConsole
     end
 
     def self.pg_status
-      system("service #{InternalDatabaseConfiguration.postgresql_service} status > /dev/null 2>&1")
+      system("service #{PostgresAdmin.service_name} status > /dev/null 2>&1")
       return $?.exitstatus == 0 ? "running" : "not running"
     end
 

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -42,7 +42,7 @@ module ApplianceConsole
     end
 
     def self.pg_status
-      system("service postgresql92-postgresql status > /dev/null 2>&1")
+      system("service rh-postgresql94-postgresql status > /dev/null 2>&1")
       return $?.exitstatus == 0 ? "running" : "not running"
     end
 

--- a/gems/pending/spec/appliance_console/certificate_authority_spec.rb
+++ b/gems/pending/spec/appliance_console/certificate_authority_spec.rb
@@ -51,6 +51,7 @@ describe ApplianceConsole::CertificateAuthority do
 
       ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
         .and_return(double("config", :activate => true, :configure_postgres => true))
+      PostgresAdmin.stub(:service_name => "postgresql")
       LinuxAdmin::Service.should_receive(:new).and_return(double("Service", :restart => true))
       FileUtils.should_receive(:chmod).with(0644, anything)
 

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -51,6 +51,16 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
     @config.send(:create_partition_to_fill_disk).should == "fake partition"
   end
 
+  it ".postgresql_sample" do
+    PostgresAdmin.stub(:data_directory => Pathname.new("/var/lib/pgsql/data"))
+    expect(described_class.postgresql_sample.to_s).to end_with("system/COPY/var/lib/pgsql/data")
+  end
+
+  it ".postgresql_template" do
+    PostgresAdmin.stub(:data_directory => Pathname.new("/var/lib/pgsql/data"))
+    expect(described_class.postgresql_template.to_s).to end_with("system/TEMPLATE/var/lib/pgsql/data")
+  end
+
   context "#update_fstab (private)" do
     before do
       PostgresAdmin.stub(:data_directory => "/var/lib/pgsql")

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -22,6 +22,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   context "postgresql service" do
     it "#start_postgres (private)" do
       allow(LinuxAdmin::Service).to receive(:new).and_return(double(:service).as_null_object)
+      PostgresAdmin.stub(:service_name => 'postgresql')
       @config.should_receive(:block_until_postgres_accepts_connections)
       @config.send(:start_postgres)
     end
@@ -51,6 +52,10 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   end
 
   context "#update_fstab (private)" do
+    before do
+      PostgresAdmin.stub(:data_directory => "/var/lib/pgsql")
+    end
+
     it "adds database disk entry" do
       fstab = double
       fstab.stub(:entries => [])
@@ -66,7 +71,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
 
     it "skips update if mount point is in fstab" do
       fstab = double
-      fstab.stub(:entries => [double(:mount_point => described_class::DATABASE_DISK_MOUNT_POINT)])
+      fstab.stub(:entries => [double(:mount_point => PostgresAdmin.data_directory)])
       fstab.should_receive(:write!).never
       LinuxAdmin::FSTab.stub(:instance => fstab)
       fstab.entries.count.should == 1

--- a/gems/pending/spec/appliance_console/service_group_spec.rb
+++ b/gems/pending/spec/appliance_console/service_group_spec.rb
@@ -5,7 +5,7 @@ require "linux_admin"
 describe ApplianceConsole::ServiceGroup do
   let(:group)             { described_class.new }
   let(:common_services)   { %w(evminit memcached miqtop evmserverd) }
-  let(:postgres_service)  { "postgresql92-postgresql" }
+  let(:postgres_service)  { "rh-postgresql94-postgresql" }
 
   describe "#postgresql?" do
     it { expect(group).not_to be_postgresql }

--- a/gems/pending/spec/appliance_console/service_group_spec.rb
+++ b/gems/pending/spec/appliance_console/service_group_spec.rb
@@ -5,7 +5,6 @@ require "linux_admin"
 describe ApplianceConsole::ServiceGroup do
   let(:group)             { described_class.new }
   let(:common_services)   { %w(evminit memcached miqtop evmserverd) }
-  let(:postgres_service)  { "rh-postgresql94-postgresql" }
 
   describe "#postgresql?" do
     it { expect(group).not_to be_postgresql }
@@ -41,7 +40,7 @@ describe ApplianceConsole::ServiceGroup do
         common_services.each do |service|
           expect_run_service(service, "enable")
         end
-        expect_run_service(postgres_service, "enable")
+        expect_run_service(group.postgresql_service, "enable")
 
         group.enable
       end
@@ -76,7 +75,7 @@ describe ApplianceConsole::ServiceGroup do
     let(:group) { described_class.new(:internal_postgresql => false) }
 
     it "disables postgres" do
-      expect_run_service(postgres_service, "disable")
+      expect_run_service(group.postgresql_service, "disable")
 
       group.disable
     end
@@ -96,7 +95,7 @@ describe ApplianceConsole::ServiceGroup do
     let(:group) { described_class.new(:internal_postgresql => false) }
 
     it "stops postgres" do
-      expect_run_service(postgres_service, "stop")
+      expect_run_service(group.postgresql_service, "stop")
 
       group.stop
     end

--- a/gems/pending/spec/appliance_console/service_group_spec.rb
+++ b/gems/pending/spec/appliance_console/service_group_spec.rb
@@ -6,6 +6,10 @@ describe ApplianceConsole::ServiceGroup do
   let(:group)             { described_class.new }
   let(:common_services)   { %w(evminit memcached miqtop evmserverd) }
 
+  before do
+    PostgresAdmin.stub(:service_name => "postgresql")
+  end
+
   describe "#postgresql?" do
     it { expect(group).not_to be_postgresql }
 
@@ -40,7 +44,7 @@ describe ApplianceConsole::ServiceGroup do
         common_services.each do |service|
           expect_run_service(service, "enable")
         end
-        expect_run_service(group.postgresql_service, "enable")
+        expect_run_service(PostgresAdmin.service_name, "enable")
 
         group.enable
       end
@@ -75,7 +79,7 @@ describe ApplianceConsole::ServiceGroup do
     let(:group) { described_class.new(:internal_postgresql => false) }
 
     it "disables postgres" do
-      expect_run_service(group.postgresql_service, "disable")
+      expect_run_service(PostgresAdmin.service_name, "disable")
 
       group.disable
     end
@@ -95,7 +99,7 @@ describe ApplianceConsole::ServiceGroup do
     let(:group) { described_class.new(:internal_postgresql => false) }
 
     it "stops postgres" do
-      expect_run_service(group.postgresql_service, "stop")
+      expect_run_service(PostgresAdmin.service_name, "stop")
 
       group.stop
     end

--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require "util/postgres_admin"
+
+describe PostgresAdmin do
+  context "ENV dependent" do
+    after do
+      ENV.delete_if { |k, _| k.start_with?("APPLIANCE") }
+    end
+
+    [%w(pg_ctl         APPLIANCE_PG_CTL          /some/path      true),
+     %w(data_directory APPLIANCE_PG_DATA         /some/path      true),
+     %w(service_name   APPLIANCE_PG_SERVICE      postgresql          ),
+     %w(scl_name       APPLIANCE_PG_SCL_NAME     postgresql_scl      ),
+     %w(package_name   APPLIANCE_PG_PACKAGE_NAME postgresql-server   ),
+
+    ].each do |method, var, value, pathname_required|
+      it "#{method}" do
+        ENV[var] = value
+        result = described_class.public_send(method)
+        if pathname_required
+          expect(result.join("abc/def").to_s).to eql "#{value}/abc/def"
+        else
+          expect(result).to eql value
+        end
+      end
+    end
+
+    it ".scl_enable_prefix" do
+      ENV["APPLIANCE_PG_SCL_NAME"] = "postgresql92"
+      expect(described_class.scl_enable_prefix).to eql "scl enable postgresql92"
+    end
+
+    it ".start_command" do
+      ENV["APPLIANCE_PG_SERVICE"] = "postgresql"
+      expect(described_class.start_command).to eql "service postgresql start"
+    end
+
+    context ".stop_command" do
+      before do
+        ENV["APPLIANCE_PG_CTL"]  = "/ctl/path"
+        ENV["APPLIANCE_PG_DATA"] = "/pgdata/path"
+      end
+
+      it "graceful" do
+        expect(described_class.stop_command(true))
+          .to eql "su - postgres -c '/ctl/path stop -W -D /pgdata/path -s -m smart'"
+      end
+
+      it "fast" do
+        expect(described_class.stop_command(false))
+          .to eql "su - postgres -c '/ctl/path stop -W -D /pgdata/path -s -m fast'"
+      end
+    end
+  end
+end

--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -35,6 +35,10 @@ describe PostgresAdmin do
       expect(described_class.start_command).to eql "service postgresql start"
     end
 
+    it ".logical_volume_path" do
+      expect(described_class.logical_volume_path.to_s).to eql "/dev/vg_data/lv_pg"
+    end
+
     context ".stop_command" do
       before do
         ENV["APPLIANCE_PG_CTL"]  = "/ctl/path"

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -213,13 +213,20 @@ class PostgresAdmin
   end
 
   # TODO: overlaps with appliance_console/service_group.rb
-
   def self.start(opts)
-    runcmd_with_logging("service #{postgresql_service} start", opts)
+    runcmd_with_logging(start_command, opts)
+  end
+
+  def self.start_command
+    "service #{postgresql_service} start".freeze
   end
 
   def self.stop(opts)
-    mode = opts[:graceful] == true ? 'smart' : 'fast'
+    self.runcmd_with_logging(stop_command(opts[:graceful]), opts)
+  end
+
+  def self.stop_command(graceful)
+    mode = graceful == true ? 'smart' : 'fast'
     #su - postgres -c '/usr/local/pgsql/bin/pg_ctl stop -W -D /var/lib/pgsql/data -s -m smart'
     # stop postgres as postgres user
     # -W do not wait until operation completes, ie, don't block the process
@@ -227,8 +234,7 @@ class PostgresAdmin
     # -s do it silently
     # -m smart - quit after all connections have disconnected
     # -m fast  - quit directly with proper shutdown
-    cmd = "su - #{user} -c '#{pg_ctl} stop -W -D #{pg_data} -s -m #{mode}'"
-    self.runcmd_with_logging(cmd, opts)
+    "su - #{user} -c '#{pg_ctl} stop -W -D #{data_directory} -s -m #{mode}'"
   end
 
   def self.runcmd(cmd_str, opts, args)

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -1,7 +1,5 @@
 require 'awesome_spawn'
 class PostgresAdmin
-  include Vmdb::Logging
-
   # Who to run the postmaster as, usually "postgres".  (NOT "root")
   PGUSER='postgres'
 
@@ -152,11 +150,11 @@ class PostgresAdmin
     options = (options[:aggressive] ? GC_AGGRESSIVE_DEFAULTS : GC_DEFAULTS).merge(options)
 
     result = self.vacuum(options)
-    _log.info("Output... #{result}") if result.to_s.length > 0
+    $log.info("MIQ(#{self.name}.#{__method__}) Output... #{result}") if result.to_s.length > 0
 
     if options[:reindex]
       result = self.reindex(options)
-      _log.info("Output... #{result}") if result.to_s.length > 0
+      $log.info("MIQ(#{self.name}.#{__method__}) Output... #{result}") if result.to_s.length > 0
     end
   end
 
@@ -208,7 +206,7 @@ class PostgresAdmin
   end
 
   def self.runcmd_with_logging(cmd_str, opts, params = {})
-    _log.info("Running command... #{AwesomeSpawn.build_command_line(cmd_str, params)}")
+    $log.info("MIQ(#{self.name}.#{__method__}) Running command... #{AwesomeSpawn.build_command_line(cmd_str, params)}")
     with_pgpass_file(opts) do
       AwesomeSpawn.run!(cmd_str, :params => params).output
     end

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -50,7 +50,7 @@ class PostgresAdmin
   end
 
   def self.logical_volume_path
-    Pathname.new("/dev").join(VOLUME_GROUP_NAME, LOGICAL_VOLUME_NAME)
+    Pathname.new("/dev").join(volume_group_name, logical_volume_name)
   end
 
   def self.database_size(opts)

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -1,6 +1,8 @@
 require 'awesome_spawn'
 require 'pathname'
 
+RAILS_ROOT ||= Pathname.new(__dir__).join("../../../")
+
 class PostgresAdmin
   def self.pg_ctl
     Pathname.new(ENV.fetch("APPLIANCE_PG_CTL"))
@@ -32,7 +34,7 @@ class PostgresAdmin
   end
 
   def self.certificate_location
-    Rails.root.join("certs")
+    RAILS_ROOT.join("certs")
   end
 
   def self.logical_volume_name

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -188,11 +188,11 @@ class PostgresAdmin
     options = (options[:aggressive] ? GC_AGGRESSIVE_DEFAULTS : GC_DEFAULTS).merge(options)
 
     result = self.vacuum(options)
-    $log.info("MIQ(#{self.name}.#{__method__}) Output... #{result}") if result.to_s.length > 0
+    $log.info("MIQ(#{name}.#{__method__}) Output... #{result}") if result.to_s.length > 0
 
     if options[:reindex]
       result = self.reindex(options)
-      $log.info("MIQ(#{self.name}.#{__method__}) Output... #{result}") if result.to_s.length > 0
+      $log.info("MIQ(#{name}.#{__method__}) Output... #{result}") if result.to_s.length > 0
     end
   end
 

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -32,7 +32,7 @@ class PostgresAdmin
   end
 
   def self.certificate_location
-    Pathname.new("/var/www/miq/vmdb/certs")
+    Rails.root.join("certs")
   end
 
   def self.logical_volume_name

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -3,7 +3,7 @@ require 'pathname'
 
 class PostgresAdmin
   def self.pg_ctl
-    ENV.fetch("APPLIANCE_PG_CTL")
+    Pathname.new(ENV.fetch("APPLIANCE_PG_CTL"))
   end
 
   def self.data_directory
@@ -218,7 +218,7 @@ class PostgresAdmin
   end
 
   def self.start_command
-    "service #{postgresql_service} start".freeze
+    "service #{service_name} start".freeze
   end
 
   def self.stop(opts)

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -1,18 +1,54 @@
 require 'awesome_spawn'
-class PostgresAdmin
-  # Who to run the postmaster as, usually "postgres".  (NOT "root")
-  PGUSER='postgres'
+require 'pathname'
 
-  def self.appliance_pg_ctl
+class PostgresAdmin
+  def self.pg_ctl
     ENV.fetch("APPLIANCE_PG_CTL")
   end
 
-  def self.appliance_pg_data
+  def self.data_directory
     Pathname.new(ENV.fetch("APPLIANCE_PG_DATA"))
   end
 
-  def self.postgresql_service
-    ENV.fetch("APPLIANCE_PG_SERVICE", "postgresql")
+  def self.service_name
+    ENV.fetch("APPLIANCE_PG_SERVICE")
+  end
+
+  def self.scl_name
+    ENV.fetch('APPLIANCE_PG_SCL_NAME')
+  end
+
+  def self.scl_enable_prefix
+    "scl enable #{scl_name}"
+  end
+
+  def self.package_name
+    ENV.fetch('APPLIANCE_PG_PACKAGE_NAME')
+  end
+
+  # Unprivileged user to run postgresql
+  def self.user
+    "postgres".freeze
+  end
+
+  def self.certificate_location
+    Pathname.new("/var/www/miq/vmdb/certs")
+  end
+
+  def self.logical_volume_name
+    "lv_pg".freeze
+  end
+
+  def self.volume_group_name
+    "vg_data".freeze
+  end
+
+  def self.database_disk_filesystem
+    "xfs".freeze
+  end
+
+  def self.logical_volume_path
+    Pathname.new("/dev").join(VOLUME_GROUP_NAME, LOGICAL_VOLUME_NAME)
   end
 
   def self.database_size(opts)
@@ -191,7 +227,7 @@ class PostgresAdmin
     # -s do it silently
     # -m smart - quit after all connections have disconnected
     # -m fast  - quit directly with proper shutdown
-    cmd = "su - #{PGUSER} -c '#{appliance_pg_ctl} stop -W -D #{appliance_pg_data} -s -m #{mode}'"
+    cmd = "su - #{user} -c '#{pg_ctl} stop -W -D #{pg_data} -s -m #{mode}'"
     self.runcmd_with_logging(cmd, opts)
   end
 

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -1,5 +1,5 @@
 require 'awesome_spawn'
-class MiqPostgresAdmin
+class PostgresAdmin
   include Vmdb::Logging
 
   # Who to run the postmaster as, usually "postgres".  (NOT "root")

--- a/lib/db_administration/miq_postgres_admin.rb
+++ b/lib/db_administration/miq_postgres_admin.rb
@@ -4,10 +4,10 @@ class MiqPostgresAdmin
 
   # From /etc/init.d/postgresql script
   # Installation prefix
-  PREFIX='/opt/rh/postgresql92/root/usr'
+  PREFIX='/opt/rh/rh-postgresql94/root/usr'
 
   # Data directory
-  PGDATA="/opt/rh/postgresql92/root/var/lib/pgsql/data"
+  PGDATA="/opt/rh/rh-postgresql94/root/var/lib/pgsql/data"
 
   # Who to run the postmaster as, usually "postgres".  (NOT "root")
   PGUSER='postgres'
@@ -15,7 +15,7 @@ class MiqPostgresAdmin
   # What to use to shut down the postmaster
   PGCTL="#{PREFIX}/bin/pg_ctl"
 
-  PGSERVICE = "postgresql92-postgresql".freeze
+  PGSERVICE = "rh-postgresql94-postgresql".freeze
 
   def self.database_size(opts)
     result = runcmd("psql", opts, :command => "SELECT pg_database_size('#{opts[:dbname]}');")

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -1,7 +1,7 @@
 require 'vmdb-logger'
 
 $LOAD_PATH << File.expand_path(__dir__)
-require 'db_administration/miq_postgres_admin'
+require 'util/postgres_admin'
 
 $LOAD_PATH << File.join(GEMS_PENDING_ROOT, "util/mount")
 require 'miq_generic_mount_session'
@@ -30,7 +30,7 @@ class EvmDatabaseOps
   end
 
   def self.database_size(opts)
-    MiqPostgresAdmin.database_size(opts)
+    PostgresAdmin.database_size(opts)
   end
 
   def self.backup(db_opts, connect_opts = {})
@@ -67,7 +67,7 @@ class EvmDatabaseOps
         MiqEvent.raise_evm_event_queue(MiqServer.my_server, "evm_server_db_backup_low_space", :event_details => msg)
         raise MiqException::MiqDatabaseBackupInsufficientSpace, msg
       end
-      backup = MiqPostgresAdmin.backup(db_opts)
+      backup = PostgresAdmin.backup(db_opts)
     ensure
       session.disconnect if session
     end
@@ -98,7 +98,7 @@ class EvmDatabaseOps
         db_opts[:local_file] = session.uri_to_local_path(uri)
       end
 
-      backup = MiqPostgresAdmin.restore(db_opts)
+      backup = PostgresAdmin.restore(db_opts)
     ensure
       session.disconnect if session
     end
@@ -109,7 +109,7 @@ class EvmDatabaseOps
   end
 
   def self.gc(options = {})
-    MiqPostgresAdmin.gc(options)
+    PostgresAdmin.gc(options)
   end
 
   def self.database_connections(database = nil, type = :all)
@@ -120,12 +120,12 @@ class EvmDatabaseOps
 
   def self.stop
     _log.info("Stopping internal database")
-    MiqPostgresAdmin.stop(DEFAULT_OPTS.merge(:graceful => true))
+    PostgresAdmin.stop(DEFAULT_OPTS.merge(:graceful => true))
   end
 
   def self.start
     _log.info("Starting internal database")
-    MiqPostgresAdmin.start(DEFAULT_OPTS)
+    PostgresAdmin.start(DEFAULT_OPTS)
   end
 
   private

--- a/lib/tasks/evm_dbsync.rake
+++ b/lib/tasks/evm_dbsync.rake
@@ -206,7 +206,7 @@ namespace :evm do
         .sort
     end
 
-    # TODO: possible overlap with MiqPostgresAdmin
+    # TODO: possible overlap with PostgresAdmin
     def do_pg_copy(direction, tables, database, username, password, host, port)
       dir = File.join(Rails.root, "tmp", "sync")
       FileUtils.mkdir_p(dir)

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -8,7 +8,7 @@ describe EvmDatabaseOps do
       MiqSmbSession.stub(:runcmd)
       MiqSmbSession.stub(:base_mount_point).and_return(Rails.root.join("/tmp"))
       MiqUtil.stub(:runcmd)
-      MiqPostgresAdmin.stub(:runcmd_with_logging)
+      PostgresAdmin.stub(:runcmd_with_logging)
       EvmDatabaseOps.stub(:backup_destination_free_space).and_return(200.megabytes)
       EvmDatabaseOps.stub(:database_size).and_return(100.megabytes)
     end
@@ -55,7 +55,7 @@ describe EvmDatabaseOps do
       MiqSmbSession.stub(:runcmd)
       MiqSmbSession.stub(:raw_disconnect)
       MiqSmbSession.stub(:base_mount_point).and_return(Rails.root.join("/tmp"))
-      MiqPostgresAdmin.stub(:runcmd_with_logging)
+      PostgresAdmin.stub(:runcmd_with_logging)
     end
 
     it "from local backup" do

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -102,7 +102,7 @@ describe VMDB::Util do
     assert_zip_entry_from_path("ROOT/www/var/vmdb/miq/log/something.log", "/www/var/vmdb/miq/log/something.log")
     assert_zip_entry_from_path("log/apache/ssl_access.log", "/var/www/miq/vmdb/log/apache/ssl_access.log")
     assert_zip_entry_from_path("config/database.yml", "/var/www/miq/vmdb/config/database.yml")
-    assert_zip_entry_from_path("ROOT/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf", "/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_hba.conf")
+    assert_zip_entry_from_path("ROOT/opt/rh/rh-postgresql94/root/var/lib/pgsql/data/pg_hba.conf", "/opt/rh/rh-postgresql94/root/var/lib/pgsql/data/pg_hba.conf")
     assert_zip_entry_from_path("GUID", "/var/www/miq/vmdb/GUID")
   end
 

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -102,7 +102,6 @@ describe VMDB::Util do
     assert_zip_entry_from_path("ROOT/www/var/vmdb/miq/log/something.log", "/www/var/vmdb/miq/log/something.log")
     assert_zip_entry_from_path("log/apache/ssl_access.log", "/var/www/miq/vmdb/log/apache/ssl_access.log")
     assert_zip_entry_from_path("config/database.yml", "/var/www/miq/vmdb/config/database.yml")
-    assert_zip_entry_from_path("ROOT/opt/rh/rh-postgresql94/root/var/lib/pgsql/data/pg_hba.conf", "/opt/rh/rh-postgresql94/root/var/lib/pgsql/data/pg_hba.conf")
     assert_zip_entry_from_path("GUID", "/var/www/miq/vmdb/GUID")
   end
 

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -195,6 +195,7 @@ describe MiqServer do
   it "#check_updates" do
     yum.should_receive(:updates_available?).twice.and_return(true)
     yum.should_receive(:version_available).with("cfme-appliance").once.and_return({"cfme-appliance" => "3.1"})
+    MiqDatabase.stub(:postgres_package_name => "postgresql-server")
 
     @server.check_updates
 
@@ -202,6 +203,10 @@ describe MiqServer do
   end
 
   context "#apply_updates" do
+    before do
+      MiqDatabase.stub(:postgres_package_name => "postgresql-server")
+    end
+
     it "will apply cfme updates only with local database" do
       yum.should_receive(:updates_available?).twice.and_return(true)
       yum.should_receive(:version_available).once.and_return({})
@@ -228,6 +233,7 @@ describe MiqServer do
     it "does not have updates to apply" do
       yum.should_receive(:updates_available?).twice.and_return(false)
       yum.should_receive(:version_available).once.and_return({})
+      MiqDatabase.stub(:postgres_package_name => "postgresql-server")
 
       @server.apply_updates
     end


### PR DESCRIPTION
https://trello.com/c/aLn9eAj1

Related PRs:
- [ ] https://github.com/ManageIQ/manageiq-appliance/pull/9
- [ ] https://github.com/ManageIQ/manageiq-appliance-build/pull/19

This pull request does the following:
- [x] Externalize the service name and one or more of the paths to a single place PostgresAdmin, which reads the environment variables from https://github.com/ManageIQ/manageiq-appliance/pull/9
- [x] No longer modifies an existing migration
- [x] The configurations table should not reference RPM installation paths, the log collection code should retrieve this from the ENV (in this PR or another) 
- [x] Move/rename MiqPostgresAdmin out of the rails app as PostgresAdmin.