### PR TITLE
Fix OpenstackEventMonitor specs

### DIFF
--- a/gems/pending/openstack/openstack_event_monitor.rb
+++ b/gems/pending/openstack/openstack_event_monitor.rb
@@ -2,6 +2,7 @@
 # subclass as a plugin based on the #available? class method implemented in each
 # subclass
 require 'more_core_extensions/core_ext/hash'
+require 'util/extensions/miq-module'
 
 class OpenstackEventMonitor
   DEFAULT_AMQP_PORT = 5672

--- a/gems/pending/spec/spec_helper.rb
+++ b/gems/pending/spec/spec_helper.rb
@@ -21,6 +21,10 @@ rescue LoadError
 end
 
 RSpec.configure do |config|
+  config.after(:each) do
+    Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
+  end
+
   config.backtrace_exclusion_patterns -= [%r{/lib\d*/ruby/}, %r{/gems/}]
   config.backtrace_exclusion_patterns << %r{/lib\d*/ruby/[0-9]}
   config.backtrace_exclusion_patterns << %r{/gems/[0-9][^/]+/gems/}

--- a/gems/pending/spec/util/extensions/miq-module_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-module_spec.rb
@@ -18,7 +18,7 @@ describe Module do
     end
 
     after(:each) do
-      $miq_cache_with_timeout.clear
+      Module.clear_all_cache_with_timeout
     end
 
     it 'will create the class method on that class/module only' do


### PR DESCRIPTION
`OpenstackEventMonitor` now uses `miq-module`'s `cache_with_timeout` method.  In the specs for `miq-module`, the cache used by `cache_with_timeout` was getting forcefully cleared after each `miq-module` test run.

Since no other gems in gems/pending were previously using `cache_with_timeout`, this has never caused problems before.  But, now that `OpenstackEventMonitor` is depending on the cache, the `miq-module` spec needs to be updated to use the `clear_all_cache_with_timeout` method to safely clear the cache, while leaving entries created by loading other classes available.