### PR TITLE
Make Rates a primary collection.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -420,6 +420,7 @@
   :rates:
     :description: Chargeback Rates
     :options:
+    - :collection
     - :subcollection
     :methods: *70174834086080
     :klass: ChargebackRateDetail

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -105,6 +105,11 @@ describe ApiController do
       test_collection_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
     end
 
+    example "query Rates" do
+      FactoryGirl.create(:chargeback_rate_detail)
+      test_collection_query(:rates, rates_url, ChargebackRateDetail)
+    end
+
     example "query Reports" do
       FactoryGirl.create(:miq_report)
       test_collection_query(:reports, reports_url, MiqReport)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -101,7 +101,7 @@ module ApiSpecHelper
 
     collections  = %w(automation_requests availability_zones chargebacks clusters conditions
                       data_stores events flavors groups hosts policies policy_actions
-                      policy_profiles providers provision_requests reports request_tasks
+                      policy_profiles providers provision_requests rates reports request_tasks
                       requests resource_pools roles security_groups servers service_catalogs
                       service_requests service_templates services tags tasks templates users
                       vms zones)


### PR DESCRIPTION
Enables all rates to be queried through the API.

/cc @abellotti 