### PR TITLE
[api] Bumping up the REST API versioning from 2.0.0 to 2.1.0-pre

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -3,12 +3,12 @@
   :module: api
   :name: API
   :description: REST API
-  :version: '2.0.0'
+  :version: '2.1.0-pre'
 :version:
   :regex: !ruby/regexp /^v[0-9]+(?>\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?/
   :definitions:
-  - :name: '2.0.0'
-    :ident: 'v2.0.0'
+  - :name: '2.1.0-pre'
+    :ident: 'v2.1.0-pre'
 :method:
   :names:
   - :get

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1960,12 +1960,16 @@ Vmdb::Application.routes.draw do
 
   # Enablement for the REST API
   # OPTIONS requests for REST API pre-flight checks
-  match '/api/*path'   => 'api#handle_options_request', :via => [:options]
-  get '/api(/:version)'           => 'api#show',    :format => 'json', :version => /v\d.*/
 
-  get    '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#show',    :format => 'json', :version => /v\d.*/
-  match  '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#update',  :format => 'json', :via => [:post, :put, :patch], :version => /v\d.*/
-  delete '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#destroy', :format => 'json', :version => /v\d.*/
+  # Semantic Versioning Regex for API, i.e. vMajor.minor.patch[-pre]
+  apiver_regex = /v[\d]+(\.[\da-zA-Z]+)*(\-[\da-zA-Z]+)?/
+
+  match '/api/*path'   => 'api#handle_options_request', :via => [:options]
+  get '/api(/:version)'           => 'api#show',    :format => 'json', :version => apiver_regex
+
+  get    '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#show',    :format => 'json', :version => apiver_regex
+  match  '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#update',  :format => 'json', :via => [:post, :put, :patch], :version => apiver_regex
+  delete '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#destroy', :format => 'json', :version => apiver_regex
 
   CONTROLLER_ACTIONS.each do |controller_name, controller_actions|
 


### PR DESCRIPTION
- New backwards-compatible functionalities have been added, so bumping up the minor version, and -pre suffix.