### PR TITLE
EmsContainer display name in the UI fixed back to Containers Provider

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -65,7 +65,7 @@ module ContainerSummaryHelper
 
     feature ||= "#{klass.name.underscore}_show"
 
-    label = ui_lookup(:table => klass.name)
+    label = ui_lookup(:model => klass.name)
     image = textual_object_icon(object)
     value = if block_given?
               yield object
@@ -90,7 +90,7 @@ module ContainerSummaryHelper
 
     feature ||= "#{klass.name.underscore}_show_list"
 
-    label = ui_lookup(:tables => klass.name)
+    label = ui_lookup(:models => klass.name)
     image = textual_collection_icon(collection)
     count = collection.count
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -838,7 +838,7 @@ en:
       #EmsCloud:                 Cloud Provider
       EmsCluster:               Cluster / Deployment Role
       EmsClusterPerformance:    Performance - Cluster
-      EmsContainer:             Container Provider
+      EmsContainer:             Containers Provider
       EmsEvent:                 Management Event
       EmsFolder:                Folder
       #EmsInfra:                 Infrastructure Provider


### PR DESCRIPTION
Before:
![container_provider](https://cloud.githubusercontent.com/assets/11256940/9026105/ec833d26-392a-11e5-9ec8-2e36c5307185.png)
After:
![container_provider_ever_after](https://cloud.githubusercontent.com/assets/11256940/9026162/7265b61a-392d-11e5-9f4f-6b4a5ae4dc19.png)

Since #3402 the parameter for ```ui_lookup```(from containers ui) is a class name and not a table name so the translation for ```EmsContainer``` wasn't in en.yml under 'table' or rather it was for ```ems_container```.

@simon3z @abonas 
