### PR TITLE
Added missing classes to CLASSES_THAT_PARTICIPATE_IN_RBAC list

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -6,11 +6,18 @@ module Rbac
   # 3. Class contains acts_as_miq_taggable
   CLASSES_THAT_PARTICIPATE_IN_RBAC = %w{
     AvailabilityZone
+    CloudTenant
+    ConfiguredSystem
+    Container
+    ContainerGroup
+    ContainerNode
     EmsCluster
     EmsFolder
     ExtManagementSystem
+    Flavor
     Host
     MiqCimInstance
+    OrchestrationTemplate
     Repository
     ResourcePool
     SecurityGroup


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1235541

@dclarizio @jonnyfiveiq please review
Added "CloudTenant" and any other missing classes from this list, that can be tagged in UI and were included in https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_expression.rb#L6