### PR TITLE
Add MiqAeDatastore as a primordial class for seeding

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -18,12 +18,16 @@ class EvmDatabase
     VmdbDatabase
   }
 
-  EXTRA_CLASSES = %w(MiqAeDatastore)
+  RAILS_ENGINE_MODEL_CLASS_NAMES = %w(MiqAeDatastore)
 
-  def self.seedable_model_class_names
-    @seedable_model_class_names ||= begin
+  def self.find_seedable_model_class_names
+    @found_model_class_names ||= begin
       Dir.glob(Rails.root.join("app/models/*.rb")).collect { |f| File.basename(f, ".*").camelize if File.read(f).include?("self.seed") }.compact.sort
     end
+  end
+
+  def self.seedable_model_class_names
+    find_seedable_model_class_names + RAILS_ENGINE_MODEL_CLASS_NAMES
   end
 
   def self.seed_primordial
@@ -31,13 +35,13 @@ class EvmDatabase
   end
 
   def self.seed_last
-    self.seed(seedable_model_class_names + EXTRA_CLASSES - PRIMORDIAL_CLASSES)
+    self.seed(seedable_model_class_names - PRIMORDIAL_CLASSES)
   end
 
   def self.seed(classes = nil, exclude_list = [])
     _log.info("Seeding...")
 
-    classes ||= PRIMORDIAL_CLASSES + (seedable_model_class_names + EXTRA_CLASSES - PRIMORDIAL_CLASSES)
+    classes ||= PRIMORDIAL_CLASSES + (seedable_model_class_names - PRIMORDIAL_CLASSES)
     classes  -= exclude_list
 
     classes.each do |klass|

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -18,6 +18,8 @@ class EvmDatabase
     VmdbDatabase
   }
 
+  EXTRA_CLASSES = %w(MiqAeDatastore)
+
   def self.seedable_model_class_names
     @seedable_model_class_names ||= begin
       Dir.glob(Rails.root.join("app/models/*.rb")).collect { |f| File.basename(f, ".*").camelize if File.read(f).include?("self.seed") }.compact.sort
@@ -29,13 +31,13 @@ class EvmDatabase
   end
 
   def self.seed_last
-    self.seed(seedable_model_class_names - PRIMORDIAL_CLASSES)
+    self.seed(seedable_model_class_names + EXTRA_CLASSES - PRIMORDIAL_CLASSES)
   end
 
   def self.seed(classes = nil, exclude_list = [])
     _log.info("Seeding...")
 
-    classes ||= PRIMORDIAL_CLASSES + (seedable_model_class_names - PRIMORDIAL_CLASSES)
+    classes ||= PRIMORDIAL_CLASSES + (seedable_model_class_names + EXTRA_CLASSES - PRIMORDIAL_CLASSES)
     classes  -= exclude_list
 
     classes.each do |klass|


### PR DESCRIPTION
Since the MiqAeDatastore has moved to lib/miq_automation_engine/models
it fails to seed the Automate model. By adding it to the primordial list
the seeding doesn't care if the class is in app/models or
lib/miq_automation_engine/models

Fixes #3692