### PR TITLE
Use Export-Clixml instead of ConvertTo-XML

### DIFF
--- a/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
+++ b/app/models/ems_refresh/parsers/ps_scripts/get_inventory.ps1
@@ -88,4 +88,7 @@ $r["clusters"] = get_clusters($c)
 $e = Get-VMMServer -ComputerName "localhost"
 $r["ems"] = $e
 
-ConvertTo-XML -InputObject $r -As string
+$file = [System.IO.Path]::GetTempFileName()
+$r | Export-CLIXML -Path $file -Encoding UTF8
+Get-Content $file -ReadCount 0
+Remove-Item -Force $file


### PR DESCRIPTION
It turns out the output of Export-Clixml and ConvertTo-XML is rather different, and it breaks our parsing. This reverts back to using a tempfile + Export-Clixml, but this time use the -ReadCount option to speed it up.

While not quite as fast because of tempfile generation, the "-ReadCount 0" option reads the file as a single block of text rather than a line-by-line approach without it.