### PR TITLE
Upgrade thin to latest.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "default_value_for",              "~>3.0.1"
-gem "thin",                           "~>1.3.1"  # Used by rails server through rack
+gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 gem "puma",                                                              :git => "git://github.com/puma/puma.git", :ref => "7e5b78861097be62912245f93d0187bb975f7753"
 gem "bcrypt",                         "3.1.10"
 gem 'outfielding-jqplot-rails',       "= 1.0.8"


### PR DESCRIPTION
At the time of writing this is 1.6.3. This change should guarantee that
the latest 1.6.x release is installed.

Resolves https://github.com/ManageIQ/manageiq/issues/3533