### PR TITLE
Remove caching of EmsEvent configuration items.

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -41,19 +41,19 @@ class EmsEvent < ActiveRecord::Base
   end
 
   def self.task_final_events
-    @task_final_events ||= VMDB::Config.new('event_handling').config[:task_final_events]
+    VMDB::Config.new('event_handling').config[:task_final_events]
   end
 
   def self.event_groups
-    @event_groups ||= VMDB::Config.new('event_handling').config[:event_groups]
+    VMDB::Config.new('event_handling').config[:event_groups]
   end
 
   def self.bottleneck_event_groups
-    @bottleneck_event_groups ||= VMDB::Config.new('event_handling').config[:bottleneck_event_groups]
+    VMDB::Config.new('event_handling').config[:bottleneck_event_groups]
   end
 
   def self.filtered_events
-    @filtered_events ||= VMDB::Config.new('event_handling').config[:filtered_events]
+    VMDB::Config.new('event_handling').config[:filtered_events]
   end
 
   def self.group_and_level(event_type)


### PR DESCRIPTION
@kbrock @gmcculloug Please review.

This caching was added as part of #3520 , probably because some of them were put into constants.  VMDB::Config has it's own caching, which expires after a while, allow for users to make changes, and those changes will eventually get picked up by the system.  Prior to this PR, the caching at the class layer prevents the changes from being made.

We *may* want to keep the caching on event_groups and bottleneck_event_groups, since those were the only two that were originally cached, but @gmcculloug mentioned that even those as unchanging constants were problematic.