### PR TITLE
Move session[:userrole] out of session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1283,7 +1283,7 @@ class ApplicationController < ActionController::Base
   end
 
   def handle_invalid_session
-    timed_out = PrivilegeCheckerService.new.user_session_timed_out?(session)
+    timed_out = PrivilegeCheckerService.new.user_session_timed_out?(session, current_user)
     reset_session
 
     session[:start_url] = if RequestRefererService.access_whitelisted?(request, controller_name, action_name)
@@ -1354,7 +1354,7 @@ class ApplicationController < ActionController::Base
   # used as a before_filter for controller actions to check that
   # the currently logged in user has rights to perform the requested action
   def check_privileges
-    unless PrivilegeCheckerService.new.valid_session?(session)
+    unless PrivilegeCheckerService.new.valid_session?(session, current_user)
       handle_invalid_session
       return
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1946,10 +1946,10 @@ class ApplicationController < ActionController::Base
     # Build the view file name
     if suffix
       viewfile = "#{VIEWS_FOLDER}/#{db}-#{suffix}.yaml"
-      viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{suffix}-#{session[:userrole]}.yaml"
+      viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{suffix}-#{current_role}.yaml"
     else
       viewfile = "#{VIEWS_FOLDER}/#{db}.yaml"
-      viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{session[:userrole]}.yaml"
+      viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{current_role}.yaml"
     end
 
     if viewfilerestricted && File.exist?(viewfilerestricted)

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -39,11 +39,10 @@ module ApplicationController::CurrentUser
   private :eligible_groups
 
   def current_role
-    @current_role ||=
-      begin
-        role = current_group.try(:miq_user_role)
-        role.try(:read_only?) ? role.name.split("-").last : ""
-      end
+    @current_role ||= begin
+      role = current_group.try(:miq_user_role)
+      role.try(:read_only?) ? role.name.split("-").last : ""
+    end
   end
   protected :current_role
 

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -4,6 +4,7 @@ module ApplicationController::CurrentUser
   included do
     helper_method :current_user,  :current_userid, :current_username
     helper_method :current_group, :current_groupid, :eligible_groups
+    helper_method :current_role, :admin_user?, :super_admin_user?
   end
 
   def clear_current_user
@@ -27,11 +28,6 @@ module ApplicationController::CurrentUser
 
   def current_group=(db_group)
     session[:group] = db_group.try(:id)
-
-    role = db_group.try(:miq_user_role)
-
-    # Build pre-sprint 69 role name if this is an EvmRole read_only role
-    session[:userrole] = role.try(:read_only?) ? role.name.split("-").last : ""
   end
   private :current_group=
 
@@ -41,6 +37,25 @@ module ApplicationController::CurrentUser
     eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
   end
   private :eligible_groups
+
+  def current_role
+    @current_role ||=
+      begin
+        role = current_group.try(:miq_user_role)
+        role.try(:read_only?) ? role.name.split("-").last : ""
+      end
+  end
+  protected :current_role
+
+  def admin_user?
+    %w(super_administrator administrator).include?(current_role)
+  end
+  protected :admin_user?
+
+  def super_admin_user?
+    current_role == "super_administrator"
+  end
+  protected :super_admin_user?
 
   def current_user
     @current_user ||= User.find_by_userid(session[:userid])

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -458,7 +458,7 @@ module ApplicationController::Explorer
       end
       return options[:count_only] ? roles.count : roles.sort_by { |a| a.name.downcase }
     when :schedules
-      if session[:userrole] == "super_administrator"  # Super admins see all report schedules
+      if super_admin_user? # Super admins see all report schedules
         objects = MiqSchedule.all(:conditions=>["towhat=?", "MiqReport"])
       else
         objects = MiqSchedule.all(:conditions=>["towhat=? AND userid=?", "MiqReport", session[:userid]])

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -189,7 +189,7 @@ module ReportController::Reports
     end
 
     if @sb[:active_tab] == "report_info"
-      if session[:userrole] == "super_administrator"  # Super admins see all report schedules
+      if super_admin_user? # Super admins see all report schedules
         schedules = MiqSchedule.all(:conditions=>["towhat=?", "MiqReport"])
       else
         schedules = MiqSchedule.all(:conditions=>["towhat=? AND userid=?", "MiqReport", session[:userid]])

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1448,7 +1448,7 @@ module ReportController::Reports::Editor
     end
 
     # Only show chargeback users choice if an admin
-    if ["administrator","super_administrator"].include?(session[:userrole])
+    if admin_user?
       @edit[:cb_users] = Hash.new
       User.all.each{|u| @edit[:cb_users][u.userid] = u.name}
     else

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -38,7 +38,7 @@ module ReportController::Schedules
     @sortcol = session[:schedule_sortcol].nil? ? 0 : session[:schedule_sortcol].to_i
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
-    if session[:userrole] == "super_administrator"  # Super admins see all user's schedules
+    if super_admin_user? # Super admins see all user's schedules
       @view, @pages = get_view(MiqSchedule, :conditions=>["towhat=?", "MiqReport"]) # Get the records (into a view) and the paginator
     else
       @view, @pages = get_view(MiqSchedule, :conditions=>["towhat=? AND userid=?", "MiqReport", session[:userid]])  # Get the records (into a view) and the paginator

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -70,7 +70,7 @@ class ApplicationHelper::ToolbarChooser
         elsif @layout == "chargeback"
           return center_toolbar_filename_chargeback
         elsif @layout == "miq_ae_tools"
-          return session[:userrole] == "super_administrator" ? "miq_ae_tools_simulate_center_tb" : "blank_view_tb"
+          return super_admin_user? ? "miq_ae_tools_simulate_center_tb" : "blank_view_tb"
         elsif @layout == "miq_policy"
           return center_toolbar_filename_miq_policy
         elsif @layout == "ops"

--- a/app/services/privilege_checker_service.rb
+++ b/app/services/privilege_checker_service.rb
@@ -22,6 +22,6 @@ class PrivilegeCheckerService
   end
 
   def server_ready?(session)
-    MiqServer.my_server(true).logon_status == :ready || session[:userrole] == "super_administrator"
+    MiqServer.my_server(true).logon_status == :ready || super_admin_user?
   end
 end

--- a/app/services/privilege_checker_service.rb
+++ b/app/services/privilege_checker_service.rb
@@ -3,25 +3,25 @@ class PrivilegeCheckerService
     @vmdb_config = vmdb_config
   end
 
-  def valid_session?(session)
-    user_signed_in?(session) && session_active?(session) && server_ready?(session)
+  def valid_session?(session, current_user)
+    user_signed_in?(current_user) && session_active?(session) && server_ready?(current_user)
   end
 
-  def user_session_timed_out?(session)
-    session[:userid] && !session_active?(session)
+  def user_session_timed_out?(session, current_user)
+    user_signed_in?(current_user) && !session_active?(session)
   end
 
   private
 
-  def user_signed_in?(session)
-    !!session[:userid]
+  def user_signed_in?(current_user)
+    !!current_user
   end
 
   def session_active?(session)
     Time.current - (session[:last_trans_time] || Time.current) <= @vmdb_config[:session][:timeout]
   end
 
-  def server_ready?(session)
-    super_admin_user? || MiqServer.my_server(true).logon_status == :ready
+  def server_ready?(current_user)
+    current_user.super_admin_user? || MiqServer.my_server(true).logon_status == :ready
   end
 end

--- a/app/services/privilege_checker_service.rb
+++ b/app/services/privilege_checker_service.rb
@@ -22,6 +22,6 @@ class PrivilegeCheckerService
   end
 
   def server_ready?(session)
-    MiqServer.my_server(true).logon_status == :ready || super_admin_user?
+    super_admin_user? || MiqServer.my_server(true).logon_status == :ready
   end
 end

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -87,7 +87,7 @@ class UserValidationService
   end
 
   def user_is_super_admin?
-    session[:userrole] == 'super_administrator'
+    @controller.send(:super_admin_user?)
   end
 
   def validate_user_handle_not_ready

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -16,7 +16,7 @@
                            "data-miq_focus"   => true,
                            "data-miq_observe" => {:interval => ".5",
                                                   :url      => url}.to_json)
-      - if session[:userrole] == "super_administrator" || session[:userrole] == "administrator"
+      - if admin_user?
         %tr
           %td.key= _('Scope')
           %td
@@ -40,7 +40,7 @@
                        "data-miq_sparkle_on"  => true,
                        "data-miq_sparkle_off" => true,
                        "data-miq_observe"     => {:url => url}.to_json)
-      - if %w(super_administrator administrator).include?(session[:userrole])
+      - if admin_user?
         %tr#rollup_daily_tr{:style => ("display:none;" unless @edit[:new][:profile][:tz])}
           %td.key= _('Roll Up Daily Performance')
           %td

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -73,7 +73,7 @@
                                    :style             => "width: 250px",
                                    "data-miq_focus"   => true,
                                    "data-miq_observe" => {:interval => ".5", :url => url2}.to_json)
-            - if session[:userrole] == "super_administrator" || session[:userrole] == "administrator"
+            - if admin_user?
               %tr
                 %td.key
                   = _("Global search:")

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -33,7 +33,7 @@
                 :remote                => true,
                 :title                 => t)
     - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
-      - if (session[:userrole] == "super_administrator" || session[:userrole] == "administrator") || (session[:userrole] != "super_administrator" && session[:userrole] != "administrator" && @edit[@expkey][:selected][:typ] == "user")
+      - if admin_user? || @edit[@expkey][:selected][:typ] == "user"
         = link_to(_("Delete"),
                   {:action => "adv_search_button",
                    :button => "delete" },

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -148,17 +148,17 @@
       %ul.nav.nav-tabs
         = miq_tab_header("diagnostics_zones", @sb[:active_tab]) do
           = ui_lookup(:models => 'Zone')
-        - if session[:userrole] == "super_administrator"
+        - if super_admin_user?
           = miq_tab_header("diagnostics_roles_servers", @sb[:active_tab]) do
             = _("Roles by Servers")
           = miq_tab_header("diagnostics_servers_roles", @sb[:active_tab]) do
             = _("Servers by Roles")
         = miq_tab_header("diagnostics_server_list", @sb[:active_tab]) do
           = _("Servers")
-        - if !MiqEnterprise.is_enterprise? && session[:userrole] == "super_administrator"
+        - if !MiqEnterprise.is_enterprise? && super_admin_user?
           = miq_tab_header("diagnostics_replication", @sb[:active_tab]) do
             = _("Replication")
-        - if session[:userrole] == "super_administrator"
+        - if super_admin_user?
           = miq_tab_header("diagnostics_database", @sb[:active_tab]) do
             = _("Database")
           = miq_tab_header("diagnostics_orphaned_data", @sb[:active_tab]) do
@@ -166,17 +166,17 @@
       .tab-content
         = miq_tab_content("diagnostics_zones", @sb[:active_tab]) do
           = render :partial => "diagnostics_zones_tab"
-        - if session[:userrole] == "super_administrator"
+        - if super_admin_user?
           = miq_tab_content("diagnostics_roles_servers", @sb[:active_tab]) do
             = render :partial => "diagnostics_roles_servers_tab"
           = miq_tab_content("diagnostics_servers_roles", @sb[:active_tab]) do
             = render :partial => "diagnostics_servers_roles_tab"
         = miq_tab_content("diagnostics_server_list", @sb[:active_tab]) do
           = render :partial => "diagnostics_server_list_tab"
-        - if !MiqEnterprise.is_enterprise? && session[:userrole] == "super_administrator"
+        - if !MiqEnterprise.is_enterprise? && super_admin_user?
           = miq_tab_content("diagnostics_replication", @sb[:active_tab]) do
             = render :partial => "diagnostics_replication_tab"
-        - if session[:userrole] == "super_administrator"
+        - if super_admin_user?
           = miq_tab_content("diagnostics_database", @sb[:active_tab]) do
             - if @sb[:active_tab] == "diagnostics_database"
               = render :partial => "diagnostics_database_tab"

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_details"
-  - if session[:userrole] == "super_administrator"
+  - if super_admin_user?
     = render :partial => "layouts/flash_msg"
     - region = MiqRegion.my_region
     - if @edit

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -66,7 +66,7 @@
           = _('Last Run Time')
         %th
           = _('Next Run Time')
-        - if session[:userrole] == "super_administrator"
+        - if super_admin_user?
           %th
             = _('Username')
         %th
@@ -97,7 +97,7 @@
               - unless s.next_run_on.blank?
                 %center
                   = h(format_timezone(s.next_run_on, tz, "gtl"))
-            - if session[:userrole] == "super_administrator"
+            - if super_admin_user?
               %td
                 = s.userid
             %td

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -23,12 +23,11 @@
       - desc = get_vmdb_config[:server][:custom_support_url_description]
       - url  = get_vmdb_config[:server][:custom_support_url]
       - cond_url      = desc.present? && url.present?
-      - cond_userrole = %w(super_administrator administrator).include?(session[:userrole])
-      - if cond_userrole || cond_url
+      - if admin_user? || cond_url
         .col-md-12.col-lg-6
           %fieldset
             %h3= _('Product Assistance')
-            - if cond_userrole
+            - if admin_user?
               - @pdf_documents.each do |filename, title|
                 - docfile_path = "/doc/#{filename}.pdf"
                 %br

--- a/spec/services/privilege_checker_service_spec.rb
+++ b/spec/services/privilege_checker_service_spec.rb
@@ -7,27 +7,25 @@ describe PrivilegeCheckerService do
   describe "#valid_session?" do
     shared_examples_for "PrivilegeCheckerService#valid_session? that returns false" do
       it "returns false" do
-        privilege_checker.valid_session?(session).should be_false
+        privilege_checker.valid_session?(session, user).should be_false
       end
     end
 
     let(:session) do
       {
-        :userid          => userid,
-        :last_trans_time => last_trans_time,
-        :userrole        => "non super administrator"
+        :last_trans_time => last_trans_time
       }
     end
 
     context "when the user is signed out" do
-      let(:userid) { nil }
+      let(:user) { nil }
       let(:last_trans_time) { nil }
 
       it_behaves_like "PrivilegeCheckerService#valid_session? that returns false"
     end
 
     context "when the user is signed in" do
-      let(:userid) { 123 }
+      let(:user) { FactoryGirl.create(:user) }
 
       context "when the session is timed out" do
         let(:last_trans_time) { 2.hours.ago }
@@ -53,7 +51,7 @@ describe PrivilegeCheckerService do
           let(:logon_status) { :ready }
 
           it "returns true" do
-            privilege_checker.valid_session?(session).should be_true
+            privilege_checker.valid_session?(session, user).should be_true
           end
         end
       end
@@ -63,19 +61,18 @@ describe PrivilegeCheckerService do
   describe "#user_session_timed_out?" do
     let(:session) do
       {
-        :userid          => userid,
         :last_trans_time => last_trans_time
       }
     end
 
-    context "when a userid exists" do
-      let(:userid) { 123 }
+    context "when a user exists" do
+      let(:user) { FactoryGirl.create(:user) }
 
       context "when the session is timed out" do
         let(:last_trans_time) { 2.hours.ago }
 
         it "returns true" do
-          privilege_checker.user_session_timed_out?(session).should be_true
+          privilege_checker.user_session_timed_out?(session, user).should be_true
         end
       end
 
@@ -83,17 +80,17 @@ describe PrivilegeCheckerService do
         let(:last_trans_time) { Time.current }
 
         it "returns false" do
-          privilege_checker.user_session_timed_out?(session).should be_false
+          privilege_checker.user_session_timed_out?(session, user).should be_false
         end
       end
     end
 
-    context "when a userid does not exist" do
-      let(:userid) { nil }
+    context "when a user does not exist" do
+      let(:user) { nil }
       let(:last_trans_time) { nil }
 
       it "returns false" do
-        privilege_checker.user_session_timed_out?(session).should be_false
+        privilege_checker.user_session_timed_out?(session, user).should be_false
       end
     end
   end


### PR DESCRIPTION
part of #3519 - no ui change

lazily access `userrole` based upon `current_group`.

Also replace string comparisons with `admin_user?` / `super_admin_user?`

please note: (a || !a && b) === (a || b)

These will be replaced with `current_user.admin_user?` as soon as we are sure that session's `current_group` is the same as `current_user.current_group`.

/cc @dclarizio @gmcculloug 