### PR TITLE
Use Ovirt logger

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -35,6 +35,8 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
   def self.raw_connect(server, port, username, password, service = "Service")
     require 'ovirt'
+    Ovirt.logger = $rhevm_log
+
     params = {
       :server     => server,
       :port       => port.presence && port.to_i,

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -30,7 +30,7 @@ gem "memoist",                 "~>0.11.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>1.2.0",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
-gem "ovirt",                   "~>0.5.0",           :require => false
+gem "ovirt",                   "~>0.6.0",           :require => false
 gem "kubeclient",              "=0.1.17",           :require => false
 gem "openshift_client",        "=0.0.8",            :require => false
 gem "rest-client",                                  :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"

--- a/gems/pending/MiqVm/test/rhevmTest.rb
+++ b/gems/pending/MiqVm/test/rhevmTest.rb
@@ -3,6 +3,7 @@ require 'log4r'
 require 'ostruct'
 require 'MiqVm/MiqVm'
 require 'ovirt'
+Ovirt.logger = $rhevm_log if $rhevm_log
 
 RHEVM_SERVER        = raise "please define RHEVM_SERVER"
 RHEVM_PORT          = 443

--- a/gems/pending/discovery/modules/RedHatRhevmProbe.rb
+++ b/gems/pending/discovery/modules/RedHatRhevmProbe.rb
@@ -11,6 +11,8 @@ class RedHatRhevmProbe
     $log.debug "#{log_header}: probing ip = #{ost.ipaddr}" if $log
 
     require 'ovirt'
+    Ovirt.logger = $rhevm_log if $rhevm_log
+
     if PortScanner.portOpen(ost, Ovirt::Service::DEFAULT_PORT)
       if Ovirt::Service.ovirt?(:server => ost.ipaddr, :verify_ssl => false)
         ost.hypervisor << :rhevm

--- a/gems/pending/metadata/MIQExtract/MIQExtract.rb
+++ b/gems/pending/metadata/MIQExtract/MIQExtract.rb
@@ -430,6 +430,8 @@ class MIQExtract
 
       begin
         require 'ovirt'
+        Ovirt.logger = $rhevm_log if $rhevm_log
+
         ems_opt = {
           :server     => miqVimHost[:address],
           :username   => miqVimHost[:username],

--- a/gems/pending/ovirt_provider/events/ovirt_event_monitor.rb
+++ b/gems/pending/ovirt_provider/events/ovirt_event_monitor.rb
@@ -5,6 +5,8 @@ class OvirtEventMonitor
 
   def inventory
     require 'ovirt'
+    Ovirt.logger = $rhevm_log if $rhevm_log
+
     @inventory ||= Ovirt::Inventory.new(@options)
   end
 


### PR DESCRIPTION
In order to remove $rhevm_log from the ovirt gem, a logger was added.  Use that logger in MIQ code base.