### PR TITLE
memory parameter should be false if missing

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
@@ -12,5 +12,26 @@ module MiqAeMethodService
     def add_disk(disk_name, disk_size_mb, options = {})
       sync_or_async_ems_operation(options[:sync], "add_disk", [disk_name, disk_size_mb])
     end
+
+    def create_snapshot(name, desc = nil)
+      snapshot_operation(:create_snapshot, {:name=>name, :description => desc})
+    end
+
+    def remove_all_snapshots
+      snapshot_operation(:remove_all_snapshots)
+    end
+
+    def remove_snapshot(snapshot_id)
+      snapshot_operation(:remove_snapshot, {:snap_selected => snapshot_id})
+    end
+
+    def revert_to_snapshot(snapshot_id)
+      snapshot_operation(:revert_to_snapshot, {:snap_selected => snapshot_id})
+    end
+
+    def snapshot_operation(task, options = {})
+      options.merge!(:ids=>[self.id], :task=>task.to_s)
+      Vm.process_tasks(options)
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
@@ -13,8 +13,8 @@ module MiqAeMethodService
       sync_or_async_ems_operation(options[:sync], "add_disk", [disk_name, disk_size_mb])
     end
 
-    def create_snapshot(name, desc = nil)
-      snapshot_operation(:create_snapshot, {:name=>name, :description => desc})
+    def create_snapshot(name, desc = nil, memory = false)
+      snapshot_operation(:create_snapshot, {:name=>name, :description => desc, :memory => !!memory})
     end
 
     def remove_all_snapshots

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
@@ -14,7 +14,7 @@ module MiqAeMethodService
     end
 
     def create_snapshot(name, desc = nil, memory = false)
-      snapshot_operation(:create_snapshot, {:name=>name, :description => desc, :memory => !!memory})
+      snapshot_operation(:create_snapshot, :name => name, :description => desc, :memory => !!memory)
     end
 
     def remove_all_snapshots
@@ -22,15 +22,15 @@ module MiqAeMethodService
     end
 
     def remove_snapshot(snapshot_id)
-      snapshot_operation(:remove_snapshot, {:snap_selected => snapshot_id})
+      snapshot_operation(:remove_snapshot, :snap_selected => snapshot_id)
     end
 
     def revert_to_snapshot(snapshot_id)
-      snapshot_operation(:revert_to_snapshot, {:snap_selected => snapshot_id})
+      snapshot_operation(:revert_to_snapshot, :snap_selected => snapshot_id)
     end
 
     def snapshot_operation(task, options = {})
-      options.merge!(:ids=>[self.id], :task=>task.to_s)
+      options.merge!(:ids => [id], :task => task.to_s)
       Vm.process_tasks(options)
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -161,27 +161,6 @@ module MiqAeMethodService
       end
     end
 
-    def create_snapshot(name, desc = nil)
-      snapshot_operation(:create_snapshot, {:name=>name, :description => desc})
-    end
-
-    def remove_all_snapshots
-      snapshot_operation(:remove_all_snapshots)
-    end
-
-    def remove_snapshot(snapshot_id)
-      snapshot_operation(:remove_snapshot, {:snap_selected => snapshot_id})
-    end
-
-    def revert_to_snapshot(snapshot_id)
-      snapshot_operation(:revert_to_snapshot, {:snap_selected => snapshot_id})
-    end
-
-    def snapshot_operation(task, options = {})
-      options.merge!(:ids=>[self.id], :task=>task.to_s)
-      Vm.process_tasks(options)
-    end
-
     def remove_from_disk(sync = true)
       sync_or_async_ems_operation(sync, "vm_destroy", [])
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -7,6 +7,7 @@ module MiqAeServiceVmVmwareSpec
 
     before do
       Vm.any_instance.stub(:my_zone).and_return('default')
+      MiqServer.stub(:my_zone).and_return('default')
       @base_queue_options = {
         :class_name  => vm.class.name,
         :instance_id => vm.id,
@@ -59,6 +60,28 @@ module MiqAeServiceVmVmwareSpec
         @base_queue_options.merge(
           :method_name => 'vm_destroy',
           :args        => [])
+      )
+    end
+
+    it "#create_snapshot without memory" do
+      service_vm.create_snapshot('snap', 'crackle & pop')
+
+      MiqQueue.first.args.first.should have_attributes(
+        :task        => 'create_snapshot',
+        :memory      => false,
+        :name        => 'snap',
+        :description => 'crackle & pop'
+      )
+    end
+
+    it "#create_snapshot with memory" do
+      service_vm.create_snapshot('snap', 'crackle & pop', true)
+
+      MiqQueue.first.args.first.should have_attributes(
+        :task        => 'create_snapshot',
+        :memory      => true,
+        :name        => 'snap',
+        :description => 'crackle & pop'
       )
     end
   end


### PR DESCRIPTION
The VMWare snapshot API takes 3 parameters name, description and memory.
memory cannot be nil if not specified, it should be false for the VIM api to work properly.
The Automate Service model now exposes the memory parameter and defaults it to false if not
specified. 

https://bugzilla.redhat.com/show_bug.cgi?id=1247664