### PR TITLE
[WIP] skip single item lists in containers ui

### DIFF
--- a/app/helpers/container_listnav_helper.rb
+++ b/app/helpers/container_listnav_helper.rb
@@ -1,0 +1,126 @@
+module ContainerListnavHelper
+  def listnav_ems
+    listnav_link_to(@record.ext_management_system, :as => EmsContainer)
+  end
+
+  def listnav_container_project
+    listnav_link_to(@record.container_project)
+  end
+
+  def listnav_container_group
+    listnav_link_to(@record.container_group)
+  end
+
+  def listnav_container_projects
+    listnav_link_to(@record.container_projects)
+  end
+
+  def listnav_container_routes
+    listnav_link_to(@record.container_routes)
+  end
+
+  def listnav_container_service
+    listnav_link_to(@record.container_service)
+  end
+
+  def listnav_container_services
+    listnav_link_to(@record.container_services)
+  end
+
+  def listnav_container_replicator
+    listnav_link_to(@record.container_replicator)
+  end
+
+  def listnav_container_replicators
+    listnav_link_to(@record.container_replicators)
+  end
+
+  def listnav_container_groups
+    listnav_link_to(@record.container_groups)
+  end
+
+  def listnav_containers
+    listnav_link_to(@record.containers, :feature => "containers") # should it be container_show_list?
+  end
+
+  def listnav_container_nodes
+    listnav_link_to(@record.container_nodes)
+  end
+
+  def listnav_container_node
+    listnav_link_to(@record.container_node)
+  end
+
+  def listnav_container_image
+    listnav_link_to(@record.container_image)
+  end
+
+  def listnav_container_images
+    listnav_link_to(@record.container_images)
+  end
+
+  def listnav_container_image_registry
+    listnav_link_to(@record.container_image_registry)
+  end
+
+  def listnav_container_image_registries
+    listnav_link_to(@record.container_image_registries)
+  end
+
+  def listnav_link_to(target, **opts, &blk)
+    case target
+      when ActiveRecord::Relation
+        listnav_collection_link(target, **opts, &blk)
+      else
+        listnav_object_link(target, **opts, &blk)
+    end
+  end
+
+  def listnav_collection_link(collection, as: nil, feature: nil)
+    klass = as || collection.klass.base_model
+    feature ||= "#{klass.name.underscore}_show_list"
+    label = ui_lookup(:models => klass.name)
+
+    if role_allows(:feature => feature)
+      count = collection.count
+      if count == 0
+        # needs to be inside li.disabled tag
+        h = link_to("#{label} (0)", "#")
+      else
+        # needs to be inside li
+        if count == 1
+          collection = collection.first
+          klass = collection.class.base_model
+          h = link_to("#{label} (#{count})",
+                      {:controller => "#{klass.name.underscore}", :action => 'show', :id => collection},
+                      :title => _("View #{label} #{collection.name}"))
+        else
+          h = link_to("#{label} (#{count})",
+                      {:action => 'show', :id => @record, :display => "#{klass}"},
+                      :title => _("Show #{label}"))
+        end
+      end
+    end
+    h
+  end
+
+  def listnav_object_link(object, as: nil, feature: nil)
+    return if object.nil?
+
+    klass = as || object.class.base_model
+    feature ||= "#{klass.name.underscore}_show"
+    label = ui_lookup(:model => klass.name)
+
+    if klass == ExtManagementSystem && role_allows(:feature => "ems_container_show")
+      h = link_to("#{label}: #{object.name}",
+                  {:controller => "ems_container", :action => 'show', :id => object.id.to_s},
+                  :title => _("Show this #{@record.class.model_name.human.downcase}'s parent #{label}"))
+    elsif role_allows(:feature => feature)
+      h = link_to("#{label}: #{object.name}",
+                  {:controller => "#{klass.name.underscore}", :action => 'show', :id => object},
+                  :title => _("View #{label} #{object.name}"))
+    end
+    #should be inside <li>
+    h
+  end
+end

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -139,17 +139,23 @@ module ContainerSummaryHelper
     h = {:label => label, :image => image, :value => count.to_s}
 
     if count > 0 && role_allows(:feature => feature)
-      if collection.respond_to?(:proxy_association)
-        h[:link] = url_for(:action  => 'show',
-                           :id      => collection.proxy_association.owner,
-                           :display => collection.proxy_association.reflection.name)
-      else
+      if collection.count == 1
         h[:link] = url_for(:controller => klass.name.underscore,
-                           :action     => 'list')
+                           :action     => 'show',
+                           :id         => collection.first)
+        h[:title]  = "Show #{collection.first.name}"
+      else
+        if collection.respond_to?(:proxy_association)
+          h[:link] = url_for(:action  => 'show',
+                             :id      => collection.proxy_association.owner,
+                             :display => collection.proxy_association.reflection.name)
+        else
+          h[:link] = url_for(:controller => klass.name.underscore,
+                             :action     => 'list')
+        end
+        h[:title] = "Show all #{label}"
       end
-      h[:title] = "Show all #{label}"
     end
-
     h
   end
 

--- a/app/helpers/ems_container_helper.rb
+++ b/app/helpers/ems_container_helper.rb
@@ -1,4 +1,5 @@
 module EmsContainerHelper
   include ContainerSummaryHelper
+  include ContainerListnavHelper
   include_concern 'TextualSummary'
 end

--- a/app/views/layouts/listnav/_ems_container.html.haml
+++ b/app/views/layouts/listnav/_ems_container.html.haml
@@ -23,95 +23,13 @@
     = patternfly_accordion_panel(_("Relationships"), false, "ems_container_rel") do
       %ul.nav.nav-pills.nav-stacked
 
-        - if role_allows(:feature => "container_node_show_list")
-          - num_nodes = @record.number_of(:container_nodes)
-          - if num_nodes == 0
-            %li.disabled
-              = link_to(_('Container Nodes (0)'), "#")
-          - else
-            %li
-              = link_to(_("Container Nodes (%s)") % num_nodes,
-                  {:action  => 'show', :id => @record, :display => 'container_nodes'},
-                  :title => _("Show Container Nodes"))
-
-        - if role_allows(:feature => "container_service_show_list")
-          - num_services = @record.number_of(:container_services)
-          - if num_services == 0
-            %li.disabled
-              = link_to(_('Container Services (0)'), "#")
-          - else
-            %li
-              = link_to(_("Container Services (%s)") % num_services,
-                  {:action  => 'show', :id => @record, :display => 'container_services'},
-                  :title => _("Show Container Services"))
-
-        - if role_allows(:feature => "container_group_show_list")
-          - num_groups = @record.number_of(:container_groups)
-          - if num_groups == 0
-            %li.disabled
-              = link_to(_('Pods (0)'), "#")
-          - else
-            %li
-              = link_to(_("Pods (%s)") % num_groups,
-                  {:action  => 'show', :id => @record, :display => 'container_groups'},
-                  :title => _("Show Pods"))
-        - if role_allows(:feature => "container_route_show_list") && @record.kind_of?(EmsOpenshift)
-          - num_groups = @record.number_of(:container_routes)
-          - if num_groups == 0
-            %li.disabled
-              = link_to(_('Container Routes (0)'), "#")
-          - else
-            %li
-              = link_to(_("Container Routes (%s)") % num_groups,
-                  {:action  => 'show', :id => @record, :display => 'container_routes'},
-                  :title => _("Show Container Routes"))
-        - if role_allows(:feature => "container_project_show_list") && @record.kind_of?(EmsOpenshift)
-          - num_groups = @record.number_of(:container_projects)
-          - if num_groups == 0
-            %li.disabled
-              = link_to(_('Container Projects (0)'), "#")
-          - else
-            %li
-              = link_to(_("Container Projects (%s)") % num_groups,
-                  {:action  => 'show', :id => @record, :display => 'container_projects'},
-                  :title => _("Show Container Projects"))
-        - if role_allows(:feature => "container_replicator_show_list")
-          - num_replicators = @record.number_of(:container_replicators)
-          - if num_replicators == 0
-            %li.disabled
-              = link_to(_('Replicators (0)'), "#")
-          - else
-            %li
-              = link_to(_("Replicators (%s)") % num_replicators,
-                  {:action  => 'show', :id => @record, :display => 'container_replicators'},
-                  :title => _("Show Replicators"))
-        - if role_allows(:feature => "containers")
-          - num_containers = @record.number_of(:containers)
-          - if num_containers == 0
-            %li.disabled
-              = link_to(_('Containers (0)'), "#")
-          - else
-            %li
-              = link_to(_("Containers (%s)") % num_containers,
-                  {:action  => 'show', :id => @record,
-                  :display => 'containers'}, :title => _("Show Containers"))
-        - if role_allows(:feature => "container_image_registry_show_list")
-          - num_registries = @record.number_of(:container_image_registries)
-          - if num_registries == 0
-            %li.disabled
-              = link_to(_('Image Registries (0)'), "#")
-          - else
-            %li
-              = link_to(_("Image Registries (%s)") % num_registries,
-                  {:action  => 'show', :id => @record, :display => 'container_image_registries'},
-                  :title => _("Show Image Registries"))
-        - if role_allows(:feature => "container_image_show_list")
-          - num_images = @record.number_of(:container_images)
-          - if num_images == 0
-            %li.disabled
-              = link_to(_('Images (0)'), "#")
-          - else
-            %li
-              = link_to(_("Images (%s)") % num_images,
-                  {:action  => 'show', :id => @record, :display => 'container_images'},
-                  :title => _("Show Images"))
+        = listnav_container_nodes
+        = listnav_container_services
+        = listnav_container_groups
+        - if @record.kind_of?(EmsOpenshift)
+          = listnav_container_routes
+        = listnav_container_projects
+        = listnav_container_replicators
+        = listnav_containers
+        = listnav_container_image_registries
+        = listnav_container_images


### PR DESCRIPTION
Skips single item lists and navigates directly to the item.
Clicking here:
![clicking_here](https://cloud.githubusercontent.com/assets/11256940/9060490/1dc8b666-3abd-11e5-840c-ab1820711fd4.png)
Leads directly to here:
![leads_to](https://cloud.githubusercontent.com/assets/11256940/9060514/50825990-3abd-11e5-9ef9-511caab43209.png)
And skips:
![skips](https://cloud.githubusercontent.com/assets/11256940/9060551/994ca9aa-3abd-11e5-8644-8dee466fc691.png)

@dclarizio @abonas Please review


