### PR TITLE
Fix provision workflow cluster selection

### DIFF
--- a/app/models/miq_provision_microsoft_workflow.rb
+++ b/app/models/miq_provision_microsoft_workflow.rb
@@ -31,7 +31,6 @@ class MiqProvisionMicrosoftWorkflow < MiqProvisionInfraWorkflow
   def allowed_clusters(_options = {})
     all_clusters     = EmsCluster.where(:ems_id => get_source_and_targets[:ems].id)
     filtered_targets = process_filter(:cluster_filter, EmsCluster, all_clusters)
-    filtered_ids     = filtered_targets.collect(&:id)
-    allowed_ci(:cluster, [:host], filtered_ids)
+    allowed_ci(:cluster, [:host], filtered_targets.collect(&:id))
   end
 end

--- a/app/models/miq_provision_microsoft_workflow.rb
+++ b/app/models/miq_provision_microsoft_workflow.rb
@@ -29,8 +29,9 @@ class MiqProvisionMicrosoftWorkflow < MiqProvisionInfraWorkflow
   end
 
   def allowed_clusters(_options = {})
-    filtered_targets = process_filter_all(:cluster_filter, EmsCluster)
-    filtered_ids = filtered_targets.collect(&:id)
+    all_clusters     = EmsCluster.where(:ems_id => get_source_and_targets[:ems].id)
+    filtered_targets = process_filter(:cluster_filter, EmsCluster, all_clusters)
+    filtered_ids     = filtered_targets.collect(&:id)
     allowed_ci(:cluster, [:host], filtered_ids)
   end
 end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -841,10 +841,6 @@ class MiqRequestWorkflow
   end
 
   def process_filter(filter_prop, ci_klass, targets)
-    process_filter_all(filter_prop, ci_klass, targets)
-  end
-
-  def process_filter_all(filter_prop, ci_klass, targets)
     rails_logger("process_filter - [#{ci_klass}]", 0)
     filter_id = get_value(@values[filter_prop]).to_i
     result = if filter_id.zero?

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1114,14 +1114,16 @@ class MiqRequestWorkflow
   end
 
   def allowed_clusters(_options = {})
-    filtered_targets = process_filter_all(:cluster_filter, EmsCluster)
-    filtered_ids = filtered_targets.collect(&:id)
+    all_clusters     = EmsCluster.where(:ems_id => get_source_and_targets[:ems].id)
+    filtered_targets = process_filter(:cluster_filter, EmsCluster, all_clusters)
+    filtered_ids     = filtered_targets.collect(&:id)
     allowed_ci(:cluster, [:respool, :host, :folder], filtered_ids)
   end
 
   def allowed_respools(_options = {})
-    filtered_targets = process_filter_all(:rp_filter, ResourcePool)
-    filtered_ids = filtered_targets.collect(&:id)
+    all_resource_pools = ResourcePool.where(:ems_id => get_source_and_targets[:ems].id)
+    filtered_targets   = process_filter(:rp_filter, ResourcePool, all_resource_pools)
+    filtered_ids       = filtered_targets.collect(&:id)
     allowed_ci(:respool, [:cluster, :host, :folder], filtered_ids)
   end
   alias_method :allowed_resource_pools, :allowed_respools

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1055,7 +1055,7 @@ class MiqRequestWorkflow
   end
 
   # Return empty hash if we are selecting placement automatically so we do not
-  # send time determining all the available resources
+  # spend time determining all the available resources
   def resources_for_ui
     get_source_and_targets
   end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -840,12 +840,11 @@ class MiqRequestWorkflow
     result.each_with_object({}) { |s, hash| hash[s[0]] = s[1] }
   end
 
-  def process_filter(filter_prop, ci_klass, targets = [])
-    return targets if targets.blank?
+  def process_filter(filter_prop, ci_klass, targets)
     process_filter_all(filter_prop, ci_klass, targets)
   end
 
-  def process_filter_all(filter_prop, ci_klass, targets = [])
+  def process_filter_all(filter_prop, ci_klass, targets)
     rails_logger("process_filter - [#{ci_klass}]", 0)
     filter_id = get_value(@values[filter_prop]).to_i
     result = if filter_id.zero?

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1116,15 +1116,13 @@ class MiqRequestWorkflow
   def allowed_clusters(_options = {})
     all_clusters     = EmsCluster.where(:ems_id => get_source_and_targets[:ems].id)
     filtered_targets = process_filter(:cluster_filter, EmsCluster, all_clusters)
-    filtered_ids     = filtered_targets.collect(&:id)
-    allowed_ci(:cluster, [:respool, :host, :folder], filtered_ids)
+    allowed_ci(:cluster, [:respool, :host, :folder], filtered_targets.collect(&:id))
   end
 
   def allowed_respools(_options = {})
     all_resource_pools = ResourcePool.where(:ems_id => get_source_and_targets[:ems].id)
     filtered_targets   = process_filter(:rp_filter, ResourcePool, all_resource_pools)
-    filtered_ids       = filtered_targets.collect(&:id)
-    allowed_ci(:respool, [:cluster, :host, :folder], filtered_ids)
+    allowed_ci(:respool, [:cluster, :host, :folder], filtered_targets.collect(&:id))
   end
   alias_method :allowed_resource_pools, :allowed_respools
 

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -151,4 +151,30 @@ describe MiqRequestWorkflow do
       expect(workflow.provisioning_tab_list).to eq([{:name => "test3", :description => "test description 3"}])
     end
   end
+
+  context "'allowed_*' methods" do
+    let(:cluster)       { FactoryGirl.create(:ems_cluster, :ems_id => ems.id) }
+    let(:ems)           { FactoryGirl.create(:ext_management_system) }
+    let(:resource_pool) { FactoryGirl.create(:resource_pool, :ems_id => ems.id) }
+
+    it "#allowed_clusters" do
+      FactoryGirl.create(:ems_cluster)
+      allow_any_instance_of(User).to receive(:get_timezone).and_return("UTC")
+      allow(workflow).to receive(:get_source_and_targets).and_return(:ems => ems)
+
+      expect(workflow).to receive(:allowed_ci).with(:cluster, [:respool, :host, :folder], [cluster.id])
+
+      workflow.allowed_clusters
+    end
+
+    it "#allowed_resource_pools" do
+      FactoryGirl.create(:resource_pool)
+      allow_any_instance_of(User).to receive(:get_timezone).and_return("UTC")
+      allow(workflow).to receive(:get_source_and_targets).and_return(:ems => ems)
+
+      expect(workflow).to receive(:allowed_ci).with(:respool, [:cluster, :host, :folder], [resource_pool.id])
+
+      workflow.allowed_resource_pools
+    end
+  end
 end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -157,7 +157,7 @@ describe MiqRequestWorkflow do
     let(:ems)           { FactoryGirl.create(:ext_management_system) }
     let(:resource_pool) { FactoryGirl.create(:resource_pool, :ems_id => ems.id) }
 
-    it "#allowed_clusters" do
+    it "#allowed_clusters calls allowed_ci with the correct set of cluster ids" do
       FactoryGirl.create(:ems_cluster)
       allow_any_instance_of(User).to receive(:get_timezone).and_return("UTC")
       allow(workflow).to receive(:get_source_and_targets).and_return(:ems => ems)
@@ -167,7 +167,7 @@ describe MiqRequestWorkflow do
       workflow.allowed_clusters
     end
 
-    it "#allowed_resource_pools" do
+    it "#allowed_resource_pools calls allowed_ci with the correct set of resource_pool ids" do
       FactoryGirl.create(:resource_pool)
       allow_any_instance_of(User).to receive(:get_timezone).and_return("UTC")
       allow(workflow).to receive(:get_source_and_targets).and_return(:ems => ems)

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -1,9 +1,10 @@
 require "spec_helper"
 
 describe MiqRequestWorkflow do
+  let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
+
   context "#validate" do
     let(:dialog)   { workflow.instance_variable_get(:@dialogs) }
-    let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
 
     context "validation_method" do
       it "skips validation if no validation_method is defined" do
@@ -50,7 +51,6 @@ describe MiqRequestWorkflow do
 
   describe "#init_from_dialog" do
     let(:dialogs) { workflow.instance_variable_get(:@dialogs) }
-    let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
     let(:init_values) { {} }
 
     context "when the initial values already have a value for the field name" do
@@ -139,7 +139,6 @@ describe MiqRequestWorkflow do
 
   describe "#provisioning_tab_list" do
     let(:dialogs) { workflow.instance_variable_get(:@dialogs) }
-    let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
 
     before do
       dialogs[:dialog_order] = [:test, :test2, :test3]


### PR DESCRIPTION
Cluster drop-down had no items due to ```Rbac.filtered``` returning an empty array since cluster wasn't passing along a collection to filter.  Resource Pool drop-down had the same problem.  ```Rbac.search``` was changed to ```Rbac.filtered``` [here](https://github.com/ManageIQ/manageiq/pull/3202/files#diff-caa6b129c7d141508e92beac40dcb232R832)

https://bugzilla.redhat.com/show_bug.cgi?id=1250087