### PR TITLE
Use `size` instead of `count` or `count(:all)`

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -326,7 +326,7 @@ class TreeBuilder
 
   def count_only_or_objects(count_only, objects, sort_by)
     if count_only
-      objects.count
+      objects.count(:all)
     elsif sort_by
       objects.sort_by { |o| Array(sort_by).collect { |sb| o.deep_send(sb).to_s.downcase } }
     else

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -326,7 +326,7 @@ class TreeBuilder
 
   def count_only_or_objects(count_only, objects, sort_by)
     if count_only
-      objects.count(:all)
+      objects.size
     elsif sort_by
       objects.sort_by { |o| Array(sort_by).collect { |sb| o.deep_send(sb).to_s.downcase } }
     else

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -42,7 +42,7 @@ class TreeBuilderChargebackReports  < TreeBuilder
     objects = MiqReportResult.auto_generated.where(
       :miq_report_id => from_cid(object[:id].split('-').first),
       :userid        => User.current_user.userid
-    ).order("created_on DESC").select(options[:count_only] ? "*" : "id, miq_report_id, name, last_run_on")
+    ).order("created_on DESC").select("id, miq_report_id, name, last_run_on")
 
     count_only_or_objects(options[:count_only], objects, "name")
   end


### PR DESCRIPTION
`count_only_or_objects` choking on a relation with a `select` clause set is a bug.

Our first attempt to fix that properly (using `count(:all)`) tripped over the fact that it also needs to work for plain arrays.. where `count(:all)` works, but means a very different thing.

Happily, there's actually a different method that we really should've been using in the first place: `size`.

(see #3635, #3675)