### PR TITLE
Small changes for running replication worker on Mac and replication worker test

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -43,8 +43,8 @@ gem "trollop",                 "~>2.0",             :require => false
 gem "psych",                   "~>2.0.12"
 gem "apipie-bindings",         "~>0.0.12",          :require => false
 
-if RUBY_PLATFORM =~ /darwin/i # This is only used on Mac
-  gem 'sys-proctable',                                :require => false
+if RbConfig::CONFIG["host_os"].include?("darwin") # This is only used on Mac
+  gem 'sys-proctable',  "~> 0.9",      :require => false
 end
 
 # Linux-only section

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -29,24 +29,21 @@ describe ReplicationWorker do
 
   context "testing child process heartbeat" do
     after do
+      Timecop.return
       File.delete(@hb_file) if File.exist?(@hb_file)
     end
 
     it "should be alive if heartbeat within threshold" do
-      Timecop.freeze(Time.current.utc)
-
       FileUtils.touch(@hb_file)
       expect(@worker.child_process_recently_active?).to be_true
     end
 
     it "should not be alive if heartbeat beyond threshold" do
-      Timecop.freeze(Time.current.utc)
-
       FileUtils.touch(@hb_file)
 
-      Timecop.freeze(301.seconds.from_now.utc)
-
-      expect(@worker.child_process_recently_active?).to be_false
+      Timecop.travel(301) do
+        expect(@worker.child_process_recently_active?).to be_false
+      end
     end
   end
 end

--- a/spec/lib/workers/replication_worker_spec.rb
+++ b/spec/lib/workers/replication_worker_spec.rb
@@ -29,7 +29,6 @@ describe ReplicationWorker do
 
   context "testing child process heartbeat" do
     after do
-      Timecop.return
       File.delete(@hb_file) if File.exist?(@hb_file)
     end
 


### PR DESCRIPTION
Used more reliable method for checkin if running Mac platform and restricted to ~>0.9 version for sys-proctable gem.

Fixed intermittent test failures caused by use of Timecop in replication worker spec.