### PR TITLE
Migrate inventory collection from REXML to Nokogiri

### DIFF
--- a/gems/pending/spec/util/xml/miq_rexml_spec.rb
+++ b/gems/pending/spec/util/xml/miq_rexml_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require 'rexml/document'
 require 'util/miq-xml'
 
-describe MIQRexml do
+describe MiqXml do
   it "attribute encoding" do
     xml = REXML::Document.new("<test/>")
     copyright_char = "\xC2\xAE"

--- a/gems/pending/spec/util/xml/miq_rexml_spec.rb
+++ b/gems/pending/spec/util/xml/miq_rexml_spec.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require "spec_helper"
+require 'rexml/document'
 require 'util/miq-xml'
 
 describe MIQRexml do

--- a/gems/pending/spec/util/xml/miq_rexml_spec.rb
+++ b/gems/pending/spec/util/xml/miq_rexml_spec.rb
@@ -16,7 +16,7 @@ describe MIQRexml do
     copyright_char = "\xC2\xAE"
     attr_string = "string #{copyright_char}"
     doc_text = "<test><element_1 attr1='#{attr_string}'/></test>"
-    xml = MiqXml.load(doc_text)
+    xml = MiqXml.load(doc_text, :rexml)
     xml.root.elements[1].attributes['attr1'].should == attr_string
   end
 
@@ -25,7 +25,7 @@ describe MIQRexml do
     utf8_bom = "\xC3\xAF\xC2\xBB\xC2\xBF"
     doc_text = "#{utf8_bom}<test><element_1 attr1='#{attr_string}'/></test>"
 
-    xml = MiqXml.load(doc_text)
+    xml = MiqXml.load(doc_text, :rexml)
     xml.root.elements[1].attributes['attr1'].should == attr_string
   end
 end

--- a/gems/pending/test/xml/tc_nokogiri.rb
+++ b/gems/pending/test/xml/tc_nokogiri.rb
@@ -9,7 +9,7 @@ class NokogiriXmlMethods < Minitest::Test
 	def setup
     @xml_klass = Nokogiri::XML
     @xml_string = self.default_test_xml() if @xml_string.nil?
-    @xml = MiqXml.load(@xml_string, @xml_klass)
+    @xml = MiqXml.load(@xml_string, :nokogiri)
 	end
 
 	def teardown

--- a/gems/pending/test/xml/tc_xml.rb
+++ b/gems/pending/test/xml/tc_xml.rb
@@ -2,47 +2,47 @@ require 'util/miq-xml'
 require 'minitest/unit'
 
 class TestBaseXmlMethods < Minitest::Test
-	def setup
-	end
-	
-	def teardown
-	end
-	
-	def test_htmlEncoding()
-		xmlType = REXML
-		test_string = "This ain't no way to do it & we don't know how"
-		encoded_string = "This ain&apos;t no way to do it &amp; we don&apos;t know how"
-		test_int = 200
+  def setup
+  end
 
-		# Create an XML document
-		xml = MiqXml.load("<test/>", xmlType)
-		assert_instance_of(REXML::Document, xml)
+  def teardown
+  end
 
-		# Load up all the data.  (Create a new elemenat with an attribute and text)
-		xml.root.add_element("test_element", {"test_attr_str"=>test_string, "test_attr_int"=>test_int}).text = test_string
-		check_element(xml.root.elements[1], test_string, encoded_string)
+  def test_htmlEncoding()
+    xmlType = :rexml
+    test_string = "This ain't no way to do it & we don't know how"
+    encoded_string = "This ain&apos;t no way to do it &amp; we don&apos;t know how"
+    test_int = 200
 
-		# Make sure we were able to set an integer and get it back
-		# Everything in xml is a string, so test base value and converted to_i value.
-		assert_equal(xml.root.elements[1].attributes["test_attr_int"], test_int.to_s)
-		assert_equal(xml.root.elements[1].attributes["test_attr_int"].to_i, test_int)
-		
-		# This is where the enocoding was messed up.  If we write the data out (to a string or file)
-		# it would not encode the attributes and the encoded elements would get doubled up
-		# when asking for the attribute back.
-		1.upto(5) do |i|
-			data = ""
-			xml.write(data,0)
-			xml = MiqXml.load(data, xmlType)
-			assert_instance_of(REXML::Document, xml)
-			check_element(xml.root.elements[1], test_string, encoded_string)
-		end
-	end
-	
-	def check_element(e, value, encoded_value)
-		assert_equal(e.attributes["test_attr_str"], value)
-		x = e.attributes.get_attribute("test_attr_str")
-		assert_equal(x.to_s, encoded_value)
-		assert_equal(x.value, value)
+    # Create an XML document
+    xml = MiqXml.load("<test/>", xmlType)
+    assert_instance_of(REXML::Document, xml)
+
+    # Load up all the data.  (Create a new elemenat with an attribute and text)
+    xml.root.add_element("test_element", {"test_attr_str"=>test_string, "test_attr_int"=>test_int}).text = test_string
+    check_element(xml.root.elements[1], test_string, encoded_string)
+
+    # Make sure we were able to set an integer and get it back
+    # Everything in xml is a string, so test base value and converted to_i value.
+    assert_equal(xml.root.elements[1].attributes["test_attr_int"], test_int.to_s)
+    assert_equal(xml.root.elements[1].attributes["test_attr_int"].to_i, test_int)
+
+    # This is where the enocoding was messed up.  If we write the data out (to a string or file)
+    # it would not encode the attributes and the encoded elements would get doubled up
+    # when asking for the attribute back.
+    1.upto(5) do |i|
+      data = ""
+      xml.write(data,0)
+      xml = MiqXml.load(data, xmlType)
+      assert_instance_of(REXML::Document, xml)
+      check_element(xml.root.elements[1], test_string, encoded_string)
+    end
+  end
+
+  def check_element(e, value, encoded_value)
+    assert_equal(e.attributes["test_attr_str"], value)
+    x = e.attributes.get_attribute("test_attr_str")
+    assert_equal(x.to_s, encoded_value)
+    assert_equal(x.value, value)
   end
 end

--- a/gems/pending/util/miq-xml.rb
+++ b/gems/pending/util/miq-xml.rb
@@ -13,28 +13,28 @@ class MiqXml
   @rexml_parser = false
 
   def self.loadFile(filename, xmlClass = DefaultXmlType)
-    self.xml_document(xmlClass).loadFile(filename)
+    xml_document(xmlClass).loadFile(filename)
   end
 
   def self.load(data, xmlClass = DefaultXmlType)
-    self.xml_document(xmlClass).load(data)
+    xml_document(xmlClass).load(data)
   end
 
   def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = DefaultXmlType)
-    self.xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
+    xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
   end
 
   def self.newDoc(xmlClass = DefaultXmlType)
-    self.xml_document(xmlClass).newDoc()
+    xml_document(xmlClass).newDoc()
   end
 
   def self.decode(encodedText, xmlClass = DefaultXmlType)
-    return self.xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
-    self.newDoc()
+    return xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
+    newDoc()
   end
 
   def self.newNode(data=nil, xmlClass = DefaultXmlType)
-    self.xml_document(xmlClass).newNode(data)
+    xml_document(xmlClass).newNode(data)
   end
 
   def self.xml_document(xmlClass)
@@ -59,19 +59,19 @@ class MiqXml
 
   def self.isXmlElement?(handle)
     return true if handle.kind_of?(Nokogiri::XML::Node)
-    return true if rexml_parser? && handle.is_a?(REXML::Element) || handle.is_a?(XmlHash::Element)
+    return true if rexml_parser? && handle.kind_of?(REXML::Element) || handle.kind_of?(XmlHash::Element)
     false
   end
 
   def self.isXmlDoc?(handle)
-    return true if handle.is_a?(Nokogiri::XML::Document)
-    return true if rexml_parser? && handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Document)
+    return true if handle.kind_of?(Nokogiri::XML::Document)
+    return true if rexml_parser? && handle.kind_of?(REXML::Document) || handle.kind_of?(XmlHash::Document)
     false
   end
 
   def self.isXml?(handle)
-    return true if (handle.is_a?(Nokogiri::XML::Element) || handle.is_a?(Nokogiri::XML::Document))
-    return true if rexml_parser? && handle.is_a?(REXML::Element) || handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Element) || handle.is_a?(XmlHash::Document)
+    return true if (handle.kind_of?(Nokogiri::XML::Element) || handle.kind_of?(Nokogiri::XML::Document))
+    return true if rexml_parser? && handle.kind_of?(REXML::Element) || handle.kind_of?(REXML::Document) || handle.kind_of?(XmlHash::Element) || handle.kind_of?(XmlHash::Document)
     false
   end
 

--- a/gems/pending/util/miq-xml.rb
+++ b/gems/pending/util/miq-xml.rb
@@ -6,35 +6,34 @@ require 'util/xml/xml_diff'
 require 'util/xml/xml_patch'
 
 class MiqXml
-  MIQ_XML_VERSION = 2.0 # Changed sub-xmls, added namespaces
+  MIQ_XML_VERSION = 3.0 # Use Nokogiri by default
 
-  @@defaultXmlType = :rexml  # REXML is always available so default it here.
+  DefaultXmlType = :nokogiri
 
-  # Set to true if nokogiri is set as parser.
-  @@nokogiri_loaded = false
+  @rexml_parser = false
 
-  def self.loadFile(filename, xmlClass = @@defaultXmlType)
+  def self.loadFile(filename, xmlClass = DefaultXmlType)
     self.xml_document(xmlClass).loadFile(filename)
   end
 
-  def self.load(data, xmlClass = @@defaultXmlType)
+  def self.load(data, xmlClass = DefaultXmlType)
     self.xml_document(xmlClass).load(data)
   end
 
-  def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = @@defaultXmlType)
+  def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = DefaultXmlType)
     self.xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
   end
 
-  def self.newDoc(xmlClass = @@defaultXmlType)
+  def self.newDoc(xmlClass = DefaultXmlType)
     self.xml_document(xmlClass).newDoc()
   end
 
-  def self.decode(encodedText, xmlClass = @@defaultXmlType)
+  def self.decode(encodedText, xmlClass = DefaultXmlType)
     return self.xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
     self.newDoc()
   end
 
-  def self.newNode(data=nil, xmlClass = @@defaultXmlType)
+  def self.newNode(data=nil, xmlClass = DefaultXmlType)
     self.xml_document(xmlClass).newNode(data)
   end
 
@@ -43,12 +42,12 @@ class MiqXml
     begin
       case xmlClass
       when :rexml
+        @rexml_parser = true
         REXML::Document
       when :xmlhash
         XmlHash::Document
       when :nokogiri
         require 'util/xml/miq_nokogiri'
-        @@nokogiri_loaded = true
         Nokogiri::XML::Document
       else
         REXML::Document
@@ -59,24 +58,24 @@ class MiqXml
   end
 
   def self.isXmlElement?(handle)
-    return true if handle.is_a?(REXML::Element) || handle.is_a?(XmlHash::Element)
-    return true if @@nokogiri_loaded && handle.kind_of?(Nokogiri::XML::Node)
+    return true if handle.kind_of?(Nokogiri::XML::Node)
+    return true if rexml_parser? && handle.is_a?(REXML::Element) || handle.is_a?(XmlHash::Element)
     false
   end
 
   def self.isXmlDoc?(handle)
-    return true if handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Document)
-    return true if @@nokogiri_loaded && handle.is_a?(Nokogiri::XML::Document)
+    return true if handle.is_a?(Nokogiri::XML::Document)
+    return true if rexml_parser? && handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Document)
     false
   end
 
   def self.isXml?(handle)
-    return true if handle.is_a?(REXML::Element) || handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Element) || handle.is_a?(XmlHash::Document)
-    return true if @@nokogiri_loaded && (handle.is_a?(Nokogiri::XML::Element) || handle.is_a?(Nokogiri::XML::Document))
+    return true if (handle.is_a?(Nokogiri::XML::Element) || handle.is_a?(Nokogiri::XML::Document))
+    return true if rexml_parser? && handle.is_a?(REXML::Element) || handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Element) || handle.is_a?(XmlHash::Document)
     false
   end
 
-  def self.is_nokogiri_loaded?
-    @@nokogiri_loaded
+  def self.rexml_parser?
+    @rexml_parser
   end
 end

--- a/gems/pending/util/miq-xml.rb
+++ b/gems/pending/util/miq-xml.rb
@@ -1,5 +1,4 @@
 require 'time'
-require 'util/xml/miq_rexml'
 require 'util/xml/xml_hash'
 require 'util/miq-encode'
 require 'util/xml/xml_diff'
@@ -38,10 +37,15 @@ class MiqXml
   end
 
   def self.xml_document(xmlClass)
-    return xmlClass::Document if xmlClass.kind_of?(Module)
+    if xmlClass.kind_of?(Module)
+      require 'util/xml/miq_nokogiri'
+      return xmlClass::Document
+    end
+
     begin
       case xmlClass
       when :rexml
+        require 'util/xml/miq_rexml'
         @rexml_parser = true
         REXML::Document
       when :xmlhash
@@ -50,10 +54,12 @@ class MiqXml
         require 'util/xml/miq_nokogiri'
         Nokogiri::XML::Document
       else
+        require 'util/xml/miq_rexml'
         @rexml_parser = true
         REXML::Document
       end
     rescue
+      require 'util/xml/miq_rexml'
       @rexml_parser = true
       REXML::Document
     end

--- a/gems/pending/util/miq-xml.rb
+++ b/gems/pending/util/miq-xml.rb
@@ -8,32 +8,32 @@ require 'util/xml/xml_patch'
 class MiqXml
   MIQ_XML_VERSION = 3.0 # Use Nokogiri by default
 
-  DefaultXmlType = :nokogiri
+  DEFAULT_XML_TYPE = :nokogiri
 
   @rexml_parser = false
 
-  def self.loadFile(filename, xmlClass = DefaultXmlType)
+  def self.loadFile(filename, xmlClass = DEFAULT_XML_TYPE)
     xml_document(xmlClass).loadFile(filename)
   end
 
-  def self.load(data, xmlClass = DefaultXmlType)
+  def self.load(data, xmlClass = DEFAULT_XML_TYPE)
     xml_document(xmlClass).load(data)
   end
 
-  def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = DefaultXmlType)
+  def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = DEFAULT_XML_TYPE)
     xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
   end
 
-  def self.newDoc(xmlClass = DefaultXmlType)
-    xml_document(xmlClass).newDoc()
+  def self.newDoc(xmlClass = DEFAULT_XML_TYPE)
+    xml_document(xmlClass).newDoc
   end
 
-  def self.decode(encodedText, xmlClass = DefaultXmlType)
+  def self.decode(encodedText, xmlClass = DEFAULT_XML_TYPE)
     return xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
-    newDoc()
+    newDoc
   end
 
-  def self.newNode(data=nil, xmlClass = DefaultXmlType)
+  def self.newNode(data = nil, xmlClass = DEFAULT_XML_TYPE)
     xml_document(xmlClass).newNode(data)
   end
 
@@ -50,9 +50,11 @@ class MiqXml
         require 'util/xml/miq_nokogiri'
         Nokogiri::XML::Document
       else
+        @rexml_parser = true
         REXML::Document
       end
     rescue
+      @rexml_parser = true
       REXML::Document
     end
   end

--- a/gems/pending/util/miq-xml.rb
+++ b/gems/pending/util/miq-xml.rb
@@ -5,43 +5,34 @@ require 'util/miq-encode'
 require 'util/xml/xml_diff'
 require 'util/xml/xml_patch'
 
-class MiqXml  
-	#MIQ_XML_VERSION = 1.0
-	#MIQ_XML_VERSION = 1.1	# Added create_time to root in seconds for easier time conversions
-	MIQ_XML_VERSION = 2.0	# Changed sub-xmls, added namespaces
+class MiqXml
+  MIQ_XML_VERSION = 2.0 # Changed sub-xmls, added namespaces
 
-	@@defaultXmlType = :rexml  # REXML is always available so default it here.
+  @@defaultXmlType = :rexml  # REXML is always available so default it here.
 
-  # Now test to see if nokogiri is available
+  # Set to true if nokogiri is set as parser.
   @@nokogiri_loaded = false
-	begin
-    require 'util/xml/miq_nokogiri'
-  	Nokogiri::XML::Document.new
-    #@@defaultXmlType = :nokogiri
-		@@nokogiri_loaded = true
-  rescue
+
+  def self.loadFile(filename, xmlClass = @@defaultXmlType)
+    self.xml_document(xmlClass).loadFile(filename)
   end
 
-	def self.loadFile(filename, xmlClass = @@defaultXmlType)
-		self.xml_document(xmlClass).loadFile(filename)
-	end
+  def self.load(data, xmlClass = @@defaultXmlType)
+    self.xml_document(xmlClass).load(data)
+  end
 
-	def self.load(data, xmlClass = @@defaultXmlType)
-		self.xml_document(xmlClass).load(data)
-	end
-
-	def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = @@defaultXmlType)
-		self.xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
-	end
+  def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = @@defaultXmlType)
+    self.xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
+  end
 
   def self.newDoc(xmlClass = @@defaultXmlType)
     self.xml_document(xmlClass).newDoc()
   end
 
-	def self.decode(encodedText, xmlClass = @@defaultXmlType)
-		return self.xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
-		self.newDoc()
-	end
+  def self.decode(encodedText, xmlClass = @@defaultXmlType)
+    return self.xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
+    self.newDoc()
+  end
 
   def self.newNode(data=nil, xmlClass = @@defaultXmlType)
     self.xml_document(xmlClass).newNode(data)
@@ -51,10 +42,16 @@ class MiqXml
     return xmlClass::Document if xmlClass.kind_of?(Module)
     begin
       case xmlClass
-      when :rexml then REXML::Document
-      when :xmlhash then XmlHash::Document
-      when :nokogiri then Nokogiri::XML::Document
-      else REXML::Document
+      when :rexml
+        REXML::Document
+      when :xmlhash
+        XmlHash::Document
+      when :nokogiri
+        require 'util/xml/miq_nokogiri'
+        @@nokogiri_loaded = true
+        Nokogiri::XML::Document
+      else
+        REXML::Document
       end
     rescue
       REXML::Document

--- a/gems/pending/util/win32/miq-powershell.rb
+++ b/gems/pending/util/win32/miq-powershell.rb
@@ -245,11 +245,8 @@ module MiqPowerShell
     def process_named_elements(node)
       hsh = {}
       node.each_element do |e|
-        if e.attributes['N'].respond_to?(:value)
-          name = e.attributes['N'].value
-        else
-          name = e.attributes['N']
-        end
+        name = e.attributes['N']
+        name = name.value if name.respond_to?(:value)
 
         name = e.name if name.nil?
         name = name.to_sym
@@ -268,8 +265,8 @@ module MiqPowerShell
     end
 
     def process_obj(node)
-      lst = node.elements.find{ |e| e.name == 'LST' }
-      dct = node.elements.find{ |e| e.name == 'DCT' }
+      lst = node.elements.find { |e| e.name == 'LST' }
+      dct = node.elements.find { |e| e.name == 'DCT' }
 
       refId = node.attributes['RefId'].to_i
 
@@ -301,7 +298,7 @@ module MiqPowerShell
       when :U16, :U32, :I32, :U64, :I64, :D, :By then c.text.to_i
       when :Db then c.text.to_f
       when :B then c.text.downcase == 'true'
-      when :S, :Version, :G, :Ref then c.text.chomp unless (c.text.nil? || c.text.empty?)
+      when :S, :Version, :G, :Ref then c.text.chomp unless c.text.nil? || c.text.empty?
       when :DT
         c_text = c.text
         if /\d+-\d+-\d+T\d+:\d+:\d+.\d+(.*)/ =~ c_text

--- a/gems/pending/util/win32/miq-powershell.rb
+++ b/gems/pending/util/win32/miq-powershell.rb
@@ -83,10 +83,10 @@ module MiqPowerShell
   end
 
   def self.is_error_object?(xml)
-    if MiqXml.is_nokogiri_loaded?
-      object_type = xml.root.elements[0].attributes['Type'].value rescue ""
-    else
+    if MiqXml.rexml_parser?
       object_type = xml.root.elements[1].attributes['Type'] rescue ""
+    else
+      object_type = xml.root.elements[0].attributes['Type'].value rescue ""
     end
     return true if !object_type.nil? && object_type.split('.').last == 'ErrorRecord'
     return false
@@ -226,8 +226,8 @@ module MiqPowerShell
       hsh = {}
       node.each_element do |e|
         # REXML starts its elements indexing at 1, Nokogiri at 0.
-        index1 = MiqXml.is_nokogiri_loaded? ? 0 : 1
-        index2 = MiqXml.is_nokogiri_loaded? ? 1 : 2
+        index1 = MiqXml.rexml_parser? ? 1 : 0
+        index2 = MiqXml.rexml_parser? ? 2 : 1
 
         name = convert_type(e.elements[index1])
         name = name.to_sym if name.is_a?(String)

--- a/gems/pending/util/xml/miq_nokogiri.rb
+++ b/gems/pending/util/xml/miq_nokogiri.rb
@@ -130,9 +130,9 @@ begin
 
         def self.loadFile(filename)
           begin
-            Nokogiri::XML::Document.file(filename)
+            Nokogiri::XML::Document.new(filename)
           rescue => err
-            $log.warn "Unabled to load XML document with Nokogiri, retrying with REXML" if $log
+            $log.warn "Unable to load XML document with Nokogiri, retrying with REXML" if $log
             self.from_xml(filename, true)
           end
         end

--- a/gems/pending/util/xml/miq_nokogiri.rb
+++ b/gems/pending/util/xml/miq_nokogiri.rb
@@ -7,6 +7,12 @@ begin
   # Add class methods to nokogiri to have it behave more like REXML for easy replacement
   module Nokogiri
     module XML
+      class Attr
+        def to_i
+          self.value.to_i
+        end
+      end
+
       class Node
         def add_attribute(key, value)
           self[key.to_s] = value.to_s unless value.nil?


### PR DESCRIPTION
Alright, let's try again, with some of those commits squished down a bit...

As per the discussion at https://github.com/ManageIQ/manageiq/issues/241

This switches the SCVMM inventory collection from REXML to Nokogiri. The changes were largely to account for some remaining differences between those two libraries. There were also some minor formatting tweaks.

The benefits include a major reduction in memory usage and a minor speed boost.