### PR TITLE
Openstack add shelve related actions

### DIFF
--- a/app/controllers/api_controller/vms.rb
+++ b/app/controllers/api_controller/vms.rb
@@ -52,6 +52,32 @@ class ApiController
       end
     end
 
+    def shelve_resource_vms(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for shelving a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        vm = resource_search(id, type, klass)
+        api_log_info("Shelving #{vm_ident(vm)}")
+
+        result = validate_vm_for_action(vm, "shelve")
+        result = shelve_vm(vm) if result[:success]
+        result
+      end
+    end
+
+    def shelve_offload_resource_vms(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for shelve-offloading a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        vm = resource_search(id, type, klass)
+        api_log_info("Shelve-offloading #{vm_ident(vm)}")
+
+        result = validate_vm_for_action(vm, "shelve_offload")
+        result = shelve_offload_vm(vm) if result[:success]
+        result
+      end
+    end
+
     def delete_resource_vms(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
 
@@ -152,6 +178,22 @@ class ApiController
     def pause_vm(vm)
       desc = "#{vm_ident(vm)} pausing"
       task_id = queue_object_action(vm, desc, :method_name => "pause", :role => "ems_operations")
+      action_result(true, desc, :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def shelve_vm(vm)
+      desc = "#{vm_ident(vm)} shelving"
+      task_id = queue_object_action(vm, desc, :method_name => "shelve", :role => "ems_operations")
+      action_result(true, desc, :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def shelve_offload_vm(vm)
+      desc = "#{vm_ident(vm)} shelve-offloading"
+      task_id = queue_object_action(vm, desc, :method_name => "shelve_offload", :role => "ems_operations")
       action_result(true, desc, :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1346,6 +1346,22 @@ module ApplicationController::CiProcessing
   alias instance_stop stopvms
   alias vm_stop stopvms
 
+  # Shelve all selected or single displayed vm(s)
+  def shelvevms
+    assert_privileges(params[:pressed])
+    vm_button_operation('shelve', 'shelve')
+  end
+  alias instance_shelve shelvevms
+  alias vm_shelve shelvevms
+
+  # Shelve all selected or single displayed vm(s)
+  def shelveoffloadvms
+    assert_privileges(params[:pressed])
+    vm_button_operation('shelve_offload', 'shelve_offload')
+  end
+  alias instance_shelve_offload shelveoffloadvms
+  alias vm_shelve_offload shelveoffloadvms
+
   # Reset all selected or single displayed vm(s)
   def resetvms
     assert_privileges(params[:pressed])
@@ -1880,6 +1896,9 @@ module ApplicationController::CiProcessing
     when "#{pfx}_start"                     then startvms
     when "#{pfx}_stop"                      then stopvms
     when "#{pfx}_suspend"                   then suspendvms
+    when "#{pfx}_pause"                     then pausevms
+    when "#{pfx}_shelve"                    then shelvevms
+    when "#{pfx}_shelveoffloadvms"          then shelveoffloadvms
     when "#{pfx}_reset"                     then resetvms
     when "#{pfx}_check_compliance"          then check_compliance_vms
     when "#{pfx}_reconfigure"               then reconfigurevms

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -60,6 +60,7 @@ module ApplicationController::Explorer
     'guest_restart'    => :s1, 'retire_now'                => :s1, 'snapshot_revert'     => :s1,
     'start'            => :s1, 'stop'                      => :s1, 'suspend'             => :s1,
     'reset'            => :s1, 'terminate'                 => :s1, 'pause'               => :s1,
+    'shelve'           => :s1, 'shelve_offload'            => :s1,
 
     # group 2
     'clone'     => :s2, 'compare'          => :s2, 'drift'           => :s2,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -792,6 +792,10 @@ class ApplicationHelper::ToolbarBuilder
         return true if !@record.is_available?(:reset)
       when "vm_suspend", "instance_suspend"
         return true if !@record.is_available?(:suspend)
+      when "instance_shelve"
+        return true if !@record.is_available?(:shelve)
+      when "instance_shelve_offload"
+        return true if !@record.is_available?(:shelve_offload)
       when "instance_pause"
         return true if !@record.is_available?(:pause)
       when "vm_policy_sim", "vm_protect"

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -76,6 +76,18 @@ class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
+  def vm_shelve(vm, options = {})
+    vm.shelve
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
+  def vm_shelve_offload(vm, options = {})
+    vm.shelve_offload
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
   def vm_destroy(vm, options = {})
     vm.vm_destroy
   rescue => err

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -52,55 +52,55 @@ class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
   # Operations
   #
 
-  def vm_start(vm, options = {})
+  def vm_start(vm, _options = {})
     vm.start
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_stop(vm, options = {})
+  def vm_stop(vm, _options = {})
     vm.stop
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_pause(vm, options = {})
+  def vm_pause(vm, _options = {})
     vm.pause
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_suspend(vm, options = {})
+  def vm_suspend(vm, _options = {})
     vm.suspend
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_shelve(vm, options = {})
+  def vm_shelve(vm, _options = {})
     vm.shelve
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_shelve_offload(vm, options = {})
+  def vm_shelve_offload(vm, _options = {})
     vm.shelve_offload
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_destroy(vm, options = {})
+  def vm_destroy(vm, _options = {})
     vm.vm_destroy
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_reboot_guest(vm, options = {})
+  def vm_reboot_guest(vm, _options = {})
     vm.reboot_guest
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_reset(vm, options = {})
+  def vm_reset(vm, _options = {})
     vm.reset
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -15,6 +15,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
     when "SHUTOFF"               then "off"
     when "SUSPENDED"             then "suspended"
     when "PAUSED"                then "paused"
+    when "SHELVED"               then "shelved"
+    when "SHELVED_OFFLOADED"     then "shelved_offloaded"
     when "REBOOT", "HARD_REBOOT" then "reboot_in_progress"
     when "ERROR"                 then "non_operational"
     when "BUILD", "REBUILD"      then "wait_for_launch"

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/power.rb
@@ -1,10 +1,19 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Power
+  def validate_shelve
+    validate_vm_control_shelve_action
+  end
+
+  def validate_shelve_offload
+    validate_vm_control_shelve_offload_action
+  end
+
   def raw_start
     with_provider_connection do |connection|
       case raw_power_state
-      when "PAUSED"             then connection.unpause_server(ems_ref)
-      when "SUSPENDED"          then connection.resume_server(ems_ref)
-      when "SHUTOFF"            then connection.start_server(ems_ref)
+      when "PAUSED"                       then connection.unpause_server(ems_ref)
+      when "SUSPENDED"                    then connection.resume_server(ems_ref)
+      when "SHUTOFF"                      then connection.start_server(ems_ref)
+      when "SHELVED", "SHELVED_OFFLOADED" then connection.unshelve_server(ems_ref)
       end
     end
   end
@@ -25,5 +34,17 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Power
     with_provider_connection { |connection| connection.suspend_server(self.ems_ref) }
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "SUSPENDED")
+  end
+
+  def raw_shelve
+    with_provider_connection { |connection| connection.shelve_server(self.ems_ref) }
+    # Temporarily update state for quick UI response until refresh comes along
+    self.update_attributes!(:raw_power_state => "SHELVED")
+  end
+
+  def raw_shelve_offload
+    with_provider_connection { |connection| connection.shelve_offload_server(self.ems_ref) }
+    # Temporarily update state for quick UI response until refresh comes along
+    self.update_attributes!(:raw_power_state => "SHELVED_OFFLOADED")
   end
 end

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -14,4 +14,12 @@ module Vm::Operations::Power
   def validate_pause
     validate_vm_control_powered_on
   end
+
+  def validate_shelve
+    validate_unsupported("Shelve Operation")
+  end
+
+  def validate_shelve_offload
+    validate_unsupported("Shelve Offload Operation")
+  end
 end

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -64,6 +64,20 @@ module VmOrTemplate::Operations
   # UI button validation methods
   #
 
+  def validate_vm_control_shelve_action
+    msg = validate_vm_control
+    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    return {:available => true,   :message => nil}  if %w(on off suspended paused).include?(self.current_state)
+    return {:available => false,  :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused"}
+  end
+
+  def validate_vm_control_shelve_offload_action
+    msg = validate_vm_control
+    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    return {:available => true,   :message => nil}  if %w(shelved).include?(self.current_state)
+    return {:available => false,  :message => "The VM can't be shelved offload, current state has to be shelved"}
+  end
+
   def validate_vm_control
     # Check the basic require to interact with a VM.
     return [false, 'The VM is retired'] if self.retired?

--- a/app/models/vm_or_template/operations/power.rb
+++ b/app/models/vm_or_template/operations/power.rb
@@ -24,6 +24,24 @@ module VmOrTemplate::Operations::Power
     raw_suspend unless policy_prevented?(:request_vm_suspend)
   end
 
+  # All associated data and resources are kept but anything still in memory is not retained.
+  def raw_shelve
+    run_command_via_parent(:vm_shelve)
+  end
+
+  def shelve
+    raw_shelve unless policy_prevented?(:request_vm_shelve)
+  end
+
+  # Has to be in shelved state first. Data and resource associations are deleted.
+  def raw_shelve_offload
+    run_command_via_parent(:vm_shelve_offload)
+  end
+
+  def shelve_offload
+    raw_shelve_offload unless policy_prevented?(:request_vm_shelve_offload)
+  end
+
   # Pause keeps the VM in memory but does not give it CPU cycles.
   # Not supported in VMware, so it is the same as suspend
   def raw_pause

--- a/config/api.yml
+++ b/config/api.yml
@@ -806,6 +806,10 @@
         :identifier: vm_stop
       - :name: suspend
         :identifier: vm_suspend
+      - :name: shelve
+        :identifier: vm_shelve
+      - :name: shelve_offload
+        :identifier: vm_shelve_offload
       - :name: pause
         :identifier: vm_pause
       - :name: reset
@@ -844,6 +848,10 @@
         :identifier: vm_stop
       - :name: suspend
         :identifier: vm_suspend
+      - :name: shelve
+        :identifier: vm_shelve
+      - :name: shelve_offload
+        :identifier: vm_shelve_offload
       - :name: pause
         :identifier: vm_pause
       - :name: reset

--- a/config/event_handling.tmpl.yml
+++ b/config/event_handling.tmpl.yml
@@ -522,6 +522,11 @@ event_groups:
     - compute.instance.reboot.end
     - compute.instance.suspend
     - compute.instance.resume
+    - compute.instance.pause.end
+    - compute.instance.unpause.end
+    - compute.instance.shelve.end
+    - compute.instance.unshelve.end
+    - compute.instance.shelve_offload.end
     - NODE_REBOOT
     - POD_SCHEDULED
     :detail:
@@ -1310,6 +1315,27 @@ event_handling:
   - policy:
     - src_vm
     - vm_poweroff
+  compute.instance.suspend:
+  - refresh:
+    - ems
+  compute.instance.resume:
+  - refresh:
+    - ems
+  compute.instance.pause.end:
+  - refresh:
+    - ems
+  compute.instance.unpause.end:
+  - refresh:
+    - ems
+  compute.instance.shelve.end:
+  - refresh:
+    - ems
+  compute.instance.unshelve.end:
+  - refresh:
+    - ems
+  compute.instance.shelve_offload.end:
+  - refresh:
+    - ems
   image.update:
   - refresh:
     - ems
@@ -1332,6 +1358,9 @@ event_handling:
   - refresh:
     - ems
   orchestration.stack.suspend.end:
+  - refresh:
+    - ems
+  orchestration.stack.pause.end:
   - refresh:
     - ems
   orchestration.stack.resume.end:

--- a/db/fixtures/miq_actions.csv
+++ b/db/fixtures/miq_actions.csv
@@ -12,6 +12,8 @@ prevent,Prevent current event from proceeding
 vm_start,Start Virtual Machine
 vm_stop,Stop Virtual Machine
 vm_suspend,Suspend Virtual Machine
+vm_shelve,Shelve Virtual Machine
+vm_shelve_offload,Shelve Offload Virtual Machine
 vm_pause,Pause Virtual Machine
 vm_shutdown_guest,Shutdown Virtual Machine Guest OS
 vm_standby_guest,Put Virtual Machine Guest OS in Standby

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -493,6 +493,14 @@
         :description: Suspend Instance
         :feature_type: control
         :identifier: instance_suspend
+      - :name: Shelve
+        :description: Shelve Instance
+        :feature_type: control
+        :identifier: instance_shelve
+      - :name: Shelve Offload
+        :description: Shelve Offload Instance
+        :feature_type: control
+        :identifier: instance_shelve_offload
       - :name: Reset
         :description: Reset Instance
         :feature_type: control

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -316,6 +316,8 @@
   - vm_stop
   - vm_suspend
   - vm_pause
+  - vm_shelve
+  - vm_shelve_offload
   - vm_timeline
 
 - :name: EvmRole-operator
@@ -454,6 +456,8 @@
   - vm_stop
   - vm_suspend
   - vm_pause
+  - vm_shelve
+  - vm_shelve_offload
   - vm_sync
   - vm_tag
   - vm_timeline
@@ -769,6 +773,8 @@
   - vm_stop
   - vm_suspend
   - vm_pause
+  - vm_shelve
+  - vm_shelve_offload
   - vm_tag
 
 - :name: EvmRole-user_self_service
@@ -818,6 +824,8 @@
   - vm_stop
   - vm_suspend
   - vm_pause
+  - vm_shelve
+  - vm_shelve_offload
   - vm_sync
   - vm_tag
   - vm_timeline
@@ -872,6 +880,8 @@
   - vm_stop
   - vm_suspend
   - vm_pause
+  - vm_shelve
+  - vm_shelve_offload
   - vm_sync
   - vm_tag
   - vm_timeline

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -21,7 +21,7 @@ gem "ezcrypto",                "=0.7",              :require => false
 gem "facade",                  "~>1.0.5",           :require => false  # Used by util/pathname2.rb
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.1",           :require => false  # used by lib/VixDiskLib
-gem "fog",                     "~>1.30.0",          :require => false
+gem "fog",                     "~>1.33.0",          :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "linux_admin",             ">=0.10.1", "<1",    :require => false

--- a/gems/pending/openstack/openstack_handle/identity_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/identity_delegate.rb
@@ -25,7 +25,7 @@ module OpenstackHandle
         )
       end
       body = Fog::JSON.decode(response.body)
-      vtenants = Fog::Identity::OpenStack::Tenants.new
+      vtenants = Fog::Identity::OpenStack::V2::Tenants.new
       vtenants.load(body['tenants'])
       vtenants
     end

--- a/product/timelines/icons/vm_event.csv
+++ b/product/timelines/icons/vm_event.csv
@@ -14,6 +14,10 @@ compute.instance.power_on.end,vm_power_on
 compute.instance.soft_delete.end,vm_disconnected
 compute.instance.reboot.end,vm_rebooted
 compute.instance.suspend,vm_suspended
+compute.instance.pause,vm_paused
+compute.instance.shelve.end,vm_shelved
+compute.instance.unshelve.end,vm_unshelved
+compute.instance.shelve_offload.end,vm_shelved_offloaded
 compute.instance.resume,vm_resuming
 createsnapshot_task,vm_snapshot_create
 createvm_task,vm_being_created

--- a/product/toolbars/x_vm_cloud_center_tb.yaml
+++ b/product/toolbars/x_vm_cloud_center_tb.yaml
@@ -125,6 +125,16 @@
       :text: "Suspend"
       :title: "Suspend this Instance"
       :confirm: "Suspend this Instance?"
+    - :button: instance_shelve
+      :image: shelve
+      :text: "Shelve"
+      :title: "Shelve this Instance"
+      :confirm: "Shelve this Instance?"
+    - :button: instance_shelve_offload
+      :image: shelve_offload
+      :text: "Shelve Offload"
+      :title: "Shelve Offload this Instance"
+      :confirm: "Shelve Offload this Instance?"
     - :button: instance_resume
       :image: power_resume
       :text: "Resume"

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -5,14 +5,14 @@ describe MiqProductFeature do
     it "empty table" do
       MiqRegion.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(836)
+      MiqProductFeature.count.should eq(838)
     end
 
     it "run twice" do
       MiqRegion.seed
       MiqProductFeature.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(836)
+      MiqProductFeature.count.should eq(838)
     end
 
     it "with existing records" do
@@ -23,7 +23,7 @@ describe MiqProductFeature do
 
       MiqRegion.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(836)
+      MiqProductFeature.count.should eq(838)
       expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
       changed.reload.name.should == "About"
       unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at


### PR DESCRIPTION
OpenStack add shelve related actions

OpenStack add shelve related actions. Adding actions shelve,
unshelve and shelve_off_load

Note: Shelve offload state can be reached automatically
depending on settings in shelved_offload_time in nova.conf.

BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1202884