### PR TITLE
Remove unused MiqFtpSession

### DIFF
--- a/gems/pending/util/mount/miq_ftp_session.rb
+++ b/gems/pending/util/mount/miq_ftp_session.rb
@@ -1,6 +1,0 @@
-# FTP is not quite the same as the nfs/smb sessions in that you copy/remove files
-# via an ftp handle whereas the nfs/smb logic uses mount to mount the remote filesystem
-# and does the copy/remove directly on the mounted volume.  Will need to remove the
-# logfile logic from the LogFile _ftp methods in order to refactor it into a standalone class
-class MiqFtpSession
-end


### PR DESCRIPTION
Doesn't even inherit from MiqGenericMountSession.  All log upload via FTP
is done via the FileDepotFtp subclasses