### PR TITLE
Cleanup domains after every test

### DIFF
--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -18,6 +18,11 @@ describe "MiqAeStateMachineRetry" do
                         :instance_name    => @root_instance,
                         :automate_message => 'create'}
     MiqServer.stub(:my_zone).and_return('default')
+    clear_domain
+  end
+
+  def clear_domain
+    MiqAeDomain.find_by_name(@domain).try(:destroy)
   end
 
   def perpetual_retry_script


### PR DESCRIPTION
Cleanup domains after every test runs. This cleanup is essential when
we move to GIT based model and doesn't hurt in the current database
model