### PR TITLE
Set priority in factories if not specified for domains

### DIFF
--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :miq_ae_domain_enabled, :parent => :miq_ae_namespace do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
     enabled true
+    priority 1
   end
 
   factory :miq_ae_domain_disabled, :parent => :miq_ae_namespace do
@@ -9,6 +10,7 @@ FactoryGirl.define do
   end
 
   factory :miq_ae_domain, :parent => :miq_ae_namespace do
+    priority 1
     trait :with_methods do
       transient do
         ae_methods do {'method1' => {:scope => 'instance', :location => 'inline',


### PR DESCRIPTION
If the priority for domain is not defined by the caller
it gets set to nil.