### PR TITLE
Remove rails deprecation warnings for Model.all(:condition)

### DIFF
--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -44,7 +44,7 @@ class TreeBuilderChargebackRates < TreeBuilder
   # Handle custom tree nodes (object is a Hash)
   def x_get_tree_custom_kids(object, options)
     count_only = options[:count_only]
-    objects = ChargebackRate.all(:conditions => ["rate_type = ?",object[:id]])
+    objects = ChargebackRate.where(:rate_type => object[:id]).to_a
     count_only_or_objects(options[:count_only], objects, "description")
   end
 end

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -35,9 +35,9 @@ class TreeBuilderOpsSettings < TreeBuilderOps
       count_only_or_objects(options[:count_only], LdapRegion.all, "name.to_s")
     when "msc"
       objects = []
-      MiqSchedule.all(:conditions=>"prod_default != 'system' or prod_default is null").sort{
+      MiqSchedule.where("prod_default != 'system' or prod_default is null").to_a.sort{
           |a,b| a.name.downcase <=> b.name.downcase}.each do |z|
-        objects.push(z) if z.adhoc.nil? && (z.towhat != "DatabaseBackup" || (z.towhat == "DatabaseBackup" && DatabaseBackup.backup_supported?))
+        objects.push(z) if z.adhoc.nil? && (z.towhat != "DatabaseBackup" || DatabaseBackup.backup_supported?)
       end
       count_only_or_objects(options[:count_only], objects, nil)
     when "sis"


### PR DESCRIPTION
This resolves:

```
DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you
can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of
records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`).
(called from x_get_tree_custom_kids at
/home/travis/build/ManageIQ/manageiq/app/presenters/tree_builder_ops_settings.rb:38)

DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you
can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of
records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`).
(called from x_get_tree_custom_kids at
/home/travis/build/ManageIQ/manageiq/app/presenters/tree_builder_chargeback_rates.rb:47)
```
