### PR TITLE
Added tags in container entities summary UI

### DIFF
--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -7,7 +7,6 @@ class ContainerImageController < ApplicationController
   after_action :set_session_data
 
   def show_list
-    @no_checkboxes = true
     process_show_list
   end
 

--- a/app/controllers/container_image_registry_controller.rb
+++ b/app/controllers/container_image_registry_controller.rb
@@ -6,7 +6,6 @@ class ContainerImageRegistryController < ApplicationController
   after_action :set_session_data
 
   def show_list
-    @no_checkboxes = true
     process_show_list
   end
 

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -34,6 +34,7 @@ module ContainersCommonMixin
                      :url  => "/#{controller_name}/show_list?page=#{@current_page}&refresh=y"},
                     true)
     if %w(download_pdf main summary_only).include? @display
+      get_tagdata(@record)
       drop_breadcrumb(:name => "#{record.name} (Summary)",
                       :url  => "/#{controller_name}/show/#{record.id}")
       set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -397,7 +397,8 @@ class ApplicationHelper::ToolbarChooser
       #show_list and show screens
       if !@in_a_form
         if %w(availability_zone cloud_tenant container_group container_node container_service ems_cloud ems_cluster
-              ems_container container_project container_route container_replicator ems_infra flavor host
+              ems_container container_project container_route container_replicator container_image
+              container_image_registry ems_infra flavor host
               ontap_file_share ontap_logical_disk
               ontap_storage_system orchestration_stack repository resource_pool storage storage_manager
               timeline usage security_group).include?(@layout)

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -24,6 +24,11 @@ module ContainerGroupHelper::TextualSummary
     h
   end
 
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -11,6 +11,11 @@ module ContainerHelper::TextualSummary
     %i(ems container_project container_replicator container_group container_node container_image)
   end
 
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -12,6 +12,11 @@ module ContainerImageHelper
       %i(containers container_image_registry ems)
     end
 
+    def textual_group_smart_management
+      items = %w(tags)
+      items.collect { |m| send("textual_#{m}") }.flatten.compact
+    end
+
     #
     # Items
     #

--- a/app/helpers/container_image_registry_helper/textual_summary.rb
+++ b/app/helpers/container_image_registry_helper/textual_summary.rb
@@ -12,6 +12,11 @@ module ContainerImageRegistryHelper
       %i(container_images containers ems)
     end
 
+    def textual_group_smart_management
+      items = %w(tags)
+      items.collect { |m| send("textual_#{m}") }.flatten.compact
+    end
+
     #
     # Items
     #

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -27,6 +27,11 @@ module ContainerNodeHelper::TextualSummary
     h
   end
 
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_project_helper/textual_summary.rb
+++ b/app/helpers/container_project_helper/textual_summary.rb
@@ -11,6 +11,11 @@ module ContainerProjectHelper::TextualSummary
     %i(ems container_routes container_services container_replicators container_groups)
   end
 
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_replicator_helper/textual_summary.rb
+++ b/app/helpers/container_replicator_helper/textual_summary.rb
@@ -12,6 +12,11 @@ module ContainerReplicatorHelper::TextualSummary
     %i(ems container_project container_groups container_nodes)
   end
 
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_route_helper/textual_summary.rb
+++ b/app/helpers/container_route_helper/textual_summary.rb
@@ -11,6 +11,11 @@ module ContainerRouteHelper::TextualSummary
     %i(ems container_project container_service)
   end
 
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -30,6 +30,12 @@ module ContainerServiceHelper::TextualSummary
   def textual_group_relationships
     %i(ems container_project container_routes container_groups container_nodes)
   end
+
+  def textual_group_smart_management
+    items = %w(tags)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -86,6 +86,25 @@ module ContainerSummaryHelper
     textual_link(@record.container_image_registries)
   end
 
+  def textual_tags
+    label = "#{session[:customer_name]} Tags"
+    h = {:label => label}
+    tags = session[:assigned_filters]
+    if tags.empty?
+      h[:image] = "smarttag"
+      h[:value] = "No #{label} have been assigned"
+    else
+      h[:value] = tags.sort_by { |category, _assigned| category.downcase }.collect do |category, assigned|
+        {
+          :image => "smarttag",
+          :label => category,
+          :value => assigned
+        }
+      end
+    end
+    h
+  end
+
   private
 
   def textual_key_value_group(items)

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -21,7 +21,7 @@ module EmsContainerHelper::TextualSummary
   end
 
   def textual_group_smart_management
-    %i(zone)
+    %i(zone tags)
   end
 
   #

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -4,4 +4,6 @@ class ContainerImage < ActiveRecord::Base
   belongs_to :container_image_registry
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :containers
+
+  acts_as_miq_taggable
 end

--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -4,4 +4,6 @@ class ContainerImageRegistry < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :container_images, :dependent => :destroy # What about deleted registry but containers are still running
   has_many :containers, :through => :container_images
+
+  acts_as_miq_taggable
 end

--- a/app/views/container/_container_show.haml
+++ b/app/views/container/_container_show.haml
@@ -5,3 +5,5 @@
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual",
              :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual_tags",
+             :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}

--- a/app/views/container_group/_main.html.haml
+++ b/app/views/container_group/_main.html.haml
@@ -8,3 +8,5 @@
                                                                :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Conditions"),
                                                                           :items => textual_group_conditions}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
+                                                                    :items => textual_group_smart_management}

--- a/app/views/container_image/_main.html.haml
+++ b/app/views/container_image/_main.html.haml
@@ -6,3 +6,5 @@
  .col-sm-12.col-md-12.col-lg-6
   = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                              :items => textual_group_relationships}
+  = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
+                                                                  :items => textual_group_smart_management}

--- a/app/views/container_image_registry/_main.html.haml
+++ b/app/views/container_image_registry/_main.html.haml
@@ -6,3 +6,5 @@
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                                :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
+                                                                    :items => textual_group_smart_management}

--- a/app/views/container_node/_main.html.haml
+++ b/app/views/container_node/_main.html.haml
@@ -5,4 +5,5 @@
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Conditions"), :items => textual_group_conditions}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
 

--- a/app/views/container_project/_main.html.haml
+++ b/app/views/container_project/_main.html.haml
@@ -4,4 +4,5 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
 

--- a/app/views/container_replicator/_main.html.haml
+++ b/app/views/container_replicator/_main.html.haml
@@ -6,4 +6,5 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Selector"), :items => textual_group_container_selectors}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
 

--- a/app/views/container_route/_main.html.haml
+++ b/app/views/container_route/_main.html.haml
@@ -8,3 +8,6 @@
     = render :partial => "shared/summary/textual",
              :locals => {:title => _("Relationships"),
                          :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual_tags",
+             :locals => {:title => _("Smart Management"),
+                         :items => textual_group_smart_management}

--- a/app/views/container_service/_main.html.haml
+++ b/app/views/container_service/_main.html.haml
@@ -7,4 +7,5 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Selector"), :items => textual_group_container_selectors}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -425,18 +425,20 @@ Vmdb::Application.routes.draw do
     },
 
     :container_image          => {
-      :get  => %w(download_data edit index new show show_list),
+      :get  => %w(download_data edit index new show show_list tagging_edit tag_edit_form_field_changed),
       :post => %w(button create dynamic_checkbox_refresh form_field_changed listnav_search_selected panel_control
-                  quick_search save_col_widths sections_field_changed show show_list update) +
+                  quick_search save_col_widths sections_field_changed show show_list update
+                  tagging_edit tag_edit_form_field_changed) +
                adv_search_post +
                exp_post +
                save_post
     },
 
     :container_image_registry => {
-      :get  => %w(download_data edit index new show show_list),
+      :get  => %w(download_data edit index new show show_list tagging_edit tag_edit_form_field_changed),
       :post => %w(button create dynamic_checkbox_refresh form_field_changed listnav_search_selected panel_control
-                  quick_search save_col_widths sections_field_changed show show_list update) +
+                  quick_search save_col_widths sections_field_changed show show_list update
+                  tagging_edit tag_edit_form_field_changed) +
                adv_search_post +
                exp_post +
                save_post

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3759,6 +3759,15 @@
       :description: Add a Container Image
       :feature_type: admin
       :identifier: container_image_new
+  - :name: Operate
+    :description: Perform Operations on Container Images
+    :feature_type: control
+    :identifier: container_image_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Container Images
+      :feature_type: control
+      :identifier: container_image_tag
 
 # ContainerImageRegistry
 - :name: Registries
@@ -3796,6 +3805,15 @@
       :description: Add a Container Image Registry
       :feature_type: admin
       :identifier: container_image_registry_new
+  - :name: Operate
+    :description: Perform Operations on Container Image Registries
+    :feature_type: control
+    :identifier: container_image_registry_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Container Image Registries
+      :feature_type: control
+      :identifier: container_image_registry_tag
 
 # ContainerService
 - :name: Services

--- a/product/toolbars/container_image_center_tb.yaml
+++ b/product/toolbars/container_image_center_tb.yaml
@@ -22,3 +22,14 @@
       :title: 'Remove this #{ui_lookup(:table=>"container_image")} from the VMDB'
       :url_parms: '&refresh=y'
       :confirm: 'Warning: This #{ui_lookup(:table=>"container_image")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container_image")}?'
+- :name: container_image_policy
+  :items:
+  - :buttonSelect: container_image_policy_choice
+    :image: policy
+    :title: Policy
+    :text: Policy
+    :items:
+    - :button: container_image_tag
+      :image: tag
+      :text: 'Edit Tags'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"container_image")}'

--- a/product/toolbars/container_image_registries_center_tb.yaml
+++ b/product/toolbars/container_image_registries_center_tb.yaml
@@ -29,3 +29,19 @@
       :url_parms: 'main_div'
       :confirm: 'Warning: The selected #{ui_lookup(:tables=>"container_image_registries")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"container_image_registries")}?'
       :onwhen: '1+'
+- :name: container_image_registry_policy
+  :items:
+  - :buttonSelect: container_image_registry_policy_choice
+    :image: policy
+    :title: Policy
+    :text: Policy
+    :enabled: 'false'
+    :onwhen: '1+'
+    :items:
+    - :button: container_image_registry_tag
+      :image: tag
+      :text: 'Edit Tags'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"container_image_registries")}'
+      :url_parms: 'main_div'
+      :enabled: 'false'
+      :onwhen: '1+'

--- a/product/toolbars/container_image_registry_center_tb.yaml
+++ b/product/toolbars/container_image_registry_center_tb.yaml
@@ -22,3 +22,14 @@
       :title: 'Remove this #{ui_lookup(:table=>"container_image_registry")} from the VMDB'
       :url_parms: '&refresh=y'
       :confirm: 'Warning: This #{ui_lookup(:table=>"container_image_registry")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container_image_registry")}?'
+- :name: container_image_registry_policy
+  :items:
+  - :buttonSelect: container_image_registry_policy_choice
+    :image: policy
+    :title: Policy
+    :text: Policy
+    :items:
+    - :button: container_image_registry_tag
+      :image: tag
+      :text: 'Edit Tags'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"container_image_registry")}'

--- a/product/toolbars/container_images_center_tb.yaml
+++ b/product/toolbars/container_images_center_tb.yaml
@@ -29,3 +29,19 @@
       :url_parms: 'main_div'
       :confirm: 'Warning: The selected #{ui_lookup(:tables=>"container_images")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>"container_images")}?'
       :onwhen: '1+'
+- :name: container_image_policy
+  :items:
+  - :buttonSelect: container_image_policy_choice
+    :image: policy
+    :title: Policy
+    :text: Policy
+    :enabled: 'false'
+    :onwhen: '1+'
+    :items:
+    - :button: container_image_tag
+      :image: tag
+      :text: 'Edit Tags'
+      :title: 'Edit Tags for this #{ui_lookup(:table=>"container_images")}'
+      :url_parms: 'main_div'
+      :enabled: 'false'
+      :onwhen: '1+'

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -5,14 +5,14 @@ describe MiqProductFeature do
     it "empty table" do
       MiqRegion.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(843)
+      MiqProductFeature.count.should eq(847)
     end
 
     it "run twice" do
       MiqRegion.seed
       MiqProductFeature.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(843)
+      MiqProductFeature.count.should eq(847)
     end
 
     it "with existing records" do
@@ -23,7 +23,7 @@ describe MiqProductFeature do
 
       MiqRegion.seed
       MiqProductFeature.seed
-      MiqProductFeature.count.should eq(843)
+      MiqProductFeature.count.should eq(847)
       expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
       changed.reload.name.should == "About"
       unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at


### PR DESCRIPTION
@abonas @simon3z 
![tags](https://cloud.githubusercontent.com/assets/11256940/9171121/b9a08f10-3f71-11e5-8588-71ab9d9f06b4.png)

This patch covers:
* Addition of the 'smart management' area for each of container-entitys summary pages
* Tagging feature for ```container Images``` and ```container image registries``` similar to #3548