### PR TITLE
Prefer String#%, not Kernel#format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,8 @@ GlobalVars:
   - $vim_log
   # In Automate methods
   - $evm
+FormatString:
+  EnforcedStyle: percent
 HashSyntax:
   EnforcedStyle: hash_rockets
 LineLength:


### PR DESCRIPTION
Yet another instance where "The Ruby Style Guide" seems to stray far away from what people actually do in the real world. :confused: