### PR TITLE
[auth] Fix for External Auth authenticator

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -21,10 +21,9 @@ module Authenticator
       false
     end
 
-    def _authenticate(username, _password, request)
+    def _authenticate(_username, _password, request)
       request.present? &&
-        request.headers['X-REMOTE-USER'].present? &&
-        request.headers['X-REMOTE-USER'] == username
+        request.headers['X-REMOTE-USER'].present?
     end
 
     def failure_reason(_username, request)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -127,8 +127,8 @@ describe Authenticator::Httpd do
       end
     end
 
-    context "with mismatched username" do
-      let(:headers) { super().merge('X-Remote-User' => 'eve') }
+    context "with invalid user" do
+      let(:headers) { super().except('X-Remote-User') }
 
       it "fails" do
         expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")


### PR DESCRIPTION
For External Authentication, we trust the X-REMOTE-USER coming to us if defined.
It is the source for defining username and does not always equal the
username value for cases like Kerberos ticket principal and such.

https://trello.com/c/kky5CB6r