### PR TITLE
Use current_user.username instead of session

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -2,7 +2,7 @@ module ApplicationController::CurrentUser
   extend ActiveSupport::Concern
 
   included do
-    helper_method :current_user,  :current_userid, :current_username
+    helper_method :current_user,  :current_userid
     helper_method :current_group, :current_groupid, :eligible_groups
     helper_method :current_role, :admin_user?, :super_admin_user?
   end
@@ -16,11 +16,9 @@ module ApplicationController::CurrentUser
     if db_user
       User.current_userid = db_user.userid
       session[:userid]    = db_user.userid
-      session[:username]  = db_user.name
     else
       User.current_userid = nil
       session[:userid]    = nil
-      session[:username]  = nil
     end
     self.current_group  = db_user.try(:current_group)
   end
@@ -66,12 +64,6 @@ module ApplicationController::CurrentUser
     session[:userid]
   end
   protected :current_userid
-
-  # current_user.username
-  def current_username
-    session[:username]
-  end
-  protected :current_username
 
   def current_group
     @current_group ||= MiqGroup.find_by_id(session[:group])

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -260,7 +260,7 @@ class ConfigurationController < ApplicationController
           @css.merge!(@settings[:display])
           @css.merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
           set_user_time_zone
-          add_flash(_("User Interface settings saved for User %s") %  session[:username])
+          add_flash(_("User Interface settings saved for User %s") % db_user.name)
         else
           add_flash(_("User Interface settings saved for this session"))
         end
@@ -286,7 +286,7 @@ class ConfigurationController < ApplicationController
           db_user.settings[:display].delete(:vm_summary_cool)     # :vm_summary_cool moved to :views hash
           db_user.settings[:views].delete(:vm_summary_cool)       # :views/:vm_summary_cool changed to :dashboards
           db_user.save
-          add_flash(_("User Interface settings saved for User %s") %  session[:username])
+          add_flash(_("User Interface settings saved for User %s") % db_user.name)
         else
           add_flash(_("User Interface settings saved for this session"))
         end

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -485,7 +485,7 @@ class MiqRequestController < ApplicationController
     end
 
     unless is_approver
-      username = session[:username]
+      username = current_user.name
       opts[:users] = opts[:users].value?(username) ? {opts[:users].key(username) => username} : {}
     end
     opts[:applied_states] = opts[:states].collect { |s| s[0] }

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -61,7 +61,7 @@ class MiqTaskController < ApplicationController
   # Show job list for the current user
   def jobs
     build_jobs_tab
-    @title = "Tasks for #{session[:username]}"
+    @title = "Tasks for #{current_user.name}"
     @breadcrumbs = []
     @lastaction = "jobs"
 

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -110,7 +110,13 @@ module ReportController::Schedules
     end
     MiqSchedule.find_all_by_id(scheds, :order => "lower(name)").each do |sched|
       MiqSchedule.queue_scheduled_work(sched.id, nil, Time.now.utc.to_i, nil)
-      audit = {:event=>"queue_scheduled_work", :message=>"Schedule [#{sched.name}] queued to run from the UI by user #{session[:username]}", :target_id=>sched.id, :target_class=>"MiqSchedule", :userid => session[:userid]}
+      audit = {
+        :event        => "queue_scheduled_work",
+        :message      => "Schedule [#{sched.name}] queued to run from the UI by user #{current_user.name}",
+        :target_id    => sched.id,
+        :target_class => "MiqSchedule",
+        :userid       => session[:userid]
+      }
       AuditEvent.success(audit)
     end
     unless flash_errors?

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -2,7 +2,7 @@
   %li.dropdown
     %a{:href => "#", :class => "dropdown-toggle", "data-toggle" => "dropdown"}
       %span.pficon.pficon-user
-      = "#{session[:username]} | #{session[:vmdb_name]}"
+      = "#{current_user.name} | #{session[:vmdb_name]}"
       %b.caret
     %ul.dropdown-menu
       %li.disabled

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -8,7 +8,7 @@
           .form-horizontal.static
             - [[_("Server Name"),     h(session[:vmdb_name])],
                [_("Version"),         h(@vmdb[:version] + "." + @vmdb[:build])],
-               [_("User Name"),       h(session[:username])],
+               [_("User Name"),       h(current_user.name)],
                [_("User Role"),       h(@user_role)],
                [_("Browser"),         h(browser_info("name"))],
                [_("Browser Version"), h(browser_info("version"))],

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -7,7 +7,6 @@ module AuthHelper
     User.stub(:current_user => user)
     User.stub(:current_userid => user.userid)
     session[:userid]   = user.userid
-    session[:username] = user.name
     session[:group]    = user.current_group.try(:id)
   end
 end


### PR DESCRIPTION
Some places already loaded `current_user` into local variable `db_user`
In those cases, we just use `db_user`.

This has no visible ui change

This is part of #3170 - Consolidating sources of identity will make knowing the current tenant / group easier.

/cc @dclarizio @gmcculloug 