### PR TITLE
Changed "IP Address" label on Provider screens

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -38,7 +38,7 @@ module EmsCloudHelper::TextualSummary
 
   def textual_ipaddress
     return nil if @ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager)
-    {:label => "IP Address", :value => @ems.ipaddress}
+    {:label => "Discovered IP Address", :value => @ems.ipaddress}
   end
 
   def textual_type

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_ipaddress
-    {:label => "IP Address", :value => @ems.ipaddress}
+    {:label => "Discovered IP Address", :value => @ems.ipaddress}
   end
 
   def textual_type

--- a/product/views/ManageIQ_Providers_InfraManager.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager.yaml
@@ -58,7 +58,7 @@ col_order:
 headers:
 - Name
 - Hostname
-- IP Address
+- Discovered IP Address
 - Type
 - EVM Zone
 - Hosts


### PR DESCRIPTION
Changed label on Provider screens from "IP Address" to "Discovered IP Address"

https://bugzilla.redhat.com/show_bug.cgi?id=1248750

@dclarizio please review:

before:
![ipaddress_before_1](https://cloud.githubusercontent.com/assets/3450808/9177935/68949c56-3f62-11e5-974c-d9d65fd51e44.png)
![ipaddress_before_2](https://cloud.githubusercontent.com/assets/3450808/9177934/6893bf8e-3f62-11e5-9125-b6656d2a2c85.png)


after:
![ipaddress_after_2](https://cloud.githubusercontent.com/assets/3450808/9177915/436d44be-3f62-11e5-8c70-547a3b28d15a.png)
![ip_address_after_1](https://cloud.githubusercontent.com/assets/3450808/9177914/436bfdc0-3f62-11e5-946c-fe00524e7028.png)