### PR TITLE
Recovered "Smartproxy Affinity" tab in Configuration.

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -321,6 +321,15 @@ function cfmeOnClick_GenealogyTree(id) {
   }
 }
 
+// OnCheck handler for the SmartProxy Affinity tree
+function cfmeOnClick_SmartProxyAffinityCheck(node) {
+  if (node.isSelected())
+    var checked = '0';  // If node was selected, now unchecking
+  else
+    var checked = '1';
+  miqJqueryRequest(check_url + node.data.key + '?check=' + checked);
+}
+
 function cfmeGetChecked(node, treename) {
   var count = 0;
   var tree = $("#" + treename + "box").dynatree("getTree");

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -242,7 +242,7 @@ class ApplicationHelper::ToolbarChooser
         return "scan_profile_center_tb"
       elsif x_node.split('-').last == "z"
         return "zones_center_tb"
-      elsif x_node.split('-').first == "z"
+      elsif x_node.split('-').first == "z" && @sb[:active_tab] != "settings_smartproxy_affinity"
         return "zone_center_tb"
       end
     elsif x_active_tree == :diagnostics_tree

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -6,7 +6,11 @@
       %ul.nav.nav-tabs
         = miq_tab_header("settings_evm_servers", @sb[:active_tab]) do
           = _("Zone")
+        = miq_tab_header("settings_smartproxy_affinity", @sb[:active_tab]) do
+          = _("SmartProxy Affinity")
       .tab-content
+        = miq_tab_content("settings_smartproxy_affinity", @sb[:active_tab]) do
+          = render :partial => "settings_smartproxy_affinity_tab"
         = miq_tab_content("settings_evm_servers", @sb[:active_tab]) do
           = render :partial => "settings_evm_servers_tab"
     - elsif selected?(x_node, "svr")

--- a/app/views/ops/_settings_smartproxy_affinity_tab.html.haml
+++ b/app/views/ops/_settings_smartproxy_affinity_tab.html.haml
@@ -1,0 +1,3 @@
+- if @sb[:active_tab] == "settings_smartproxy_affinity"
+  = render :partial => "layouts/flash_msg"
+  = render :partial => "smartproxy_affinity"

--- a/app/views/ops/_smartproxy_affinity.html.haml
+++ b/app/views/ops/_smartproxy_affinity.html.haml
@@ -1,0 +1,19 @@
+%h3
+  Assign Hosts and Datastores to Embedded SmartProxies in Zone '#{ui_lookup(:model => "Zone")}: #{@selected_zone.description}'
+- if @smartproxy_affinity_tree.blank?
+  .alert.alert-info
+    %span.pficon.pficon-info
+    %strong
+      No Servers with the SmartProxy role are in Zone '#{ui_lookup(:model => "Zone")}: #{@selected_zone.description}'
+- else
+  - tree_id = "smartproxy_affinity_treebox"
+  %div{:id => tree_id}
+  = render(:partial => "layouts/dynatree",
+    :locals => {:tree_id         => tree_id,
+    :tree_name                   => session[:tree_name],
+    :json_tree                   => @smartproxy_affinity_tree.to_json,
+    :checkboxes                  => true,
+    :three_checks                => true,
+    :open_close_all_on_dbl_click => true,
+    :check_url                   => '/ops/smartproxy_affinity_field_changed/',
+    :oncheck                     => 'cfmeOnClick_SmartProxyAffinityCheck'})

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -1,0 +1,236 @@
+require "spec_helper"
+
+describe OpsController do
+  context "OpsController::Settings::Common" do
+    context "SmartProxy Affinity" do
+      before do
+        @zone = FactoryGirl.create(:zone, :name => 'zone1')
+
+        @storage1 = FactoryGirl.create(:storage)
+        @storage2 = FactoryGirl.create(:storage)
+
+        @host1 = FactoryGirl.create(:host, :name => 'host1', :storages => [@storage1])
+        @host2 = FactoryGirl.create(:host, :name => 'host2', :storages => [@storage2])
+
+        @ems = FactoryGirl.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @zone)
+
+        @svr1 = FactoryGirl.create(:miq_server, :name => 'svr1', :zone => @zone)
+        @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @zone)
+
+        @svr1.vm_scan_host_affinity = [@host1]
+        @svr2.vm_scan_host_affinity = [@host2]
+        @svr1.vm_scan_storage_affinity = [@storage1]
+        @svr2.vm_scan_storage_affinity = [@storage2]
+        MiqServer.any_instance.stub(:is_a_proxy? => true)
+
+        tree_hash = {
+          :trees       => {
+            :settings_tree => {
+              :active_node => "z-#{@zone.id}"
+            }
+          },
+          :active_tree => :settings_tree,
+          :active_tab  => 'settings_smartproxy_affinity'
+        }
+        controller.instance_variable_set(:@sb, tree_hash)
+        controller.instance_variable_set(:@selected_zone, @zone)
+
+        @temp = {}
+        controller.instance_variable_set(:@temp, @temp)
+
+        controller.send(:smartproxy_affinity_set_form_vars)
+        @edit = session[:edit]
+      end
+
+      context "#build_smartproxy_affinity_tree" do
+        it "should build a SmartProxy Affinity tree" do
+          tree = controller.send(:build_smartproxy_affinity_tree, @zone)
+          tree.should be == [
+            {
+              :key      => @svr1.id.to_s,
+              :icon     => "evm_server.png",
+              :title    => "Server: #{@svr1.name} [#{@svr1.id}]",
+              :expand   => true,
+              :children => [
+                {
+                  :key      => "#{@svr1.id}__host",
+                  :icon     => "host.png",
+                  :title    => "Host / Nodes",
+                  :children => [
+                    {
+                      :key    => "#{@svr1.id}__host_#{@host1.id}",
+                      :icon   => "host.png",
+                      :title  => @host1.name,
+                      :select => true
+                    },
+                    {
+                      :key    => "#{@svr1.id}__host_#{@host2.id}",
+                      :icon   => "host.png",
+                      :title  => @host2.name,
+                      :select => false
+                    }
+                  ]
+                },
+                {
+                  :key      => "#{@svr1.id}__storage",
+                  :icon     => "storage.png",
+                  :title    => "Datastores",
+                  :children => [
+                    {
+                      :key    => "#{@svr1.id}__storage_#{@storage1.id}",
+                      :icon   => "storage.png",
+                      :title  => @storage1.name,
+                      :select => true
+                    },
+                    {
+                      :key    => "#{@svr1.id}__storage_#{@storage2.id}",
+                      :icon   => "storage.png",
+                      :title  => @storage2.name,
+                      :select => false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              :key      => @svr2.id.to_s,
+              :icon     => "evm_server.png",
+              :title    => "Server: #{@svr2.name} [#{@svr2.id}]",
+              :expand   => true,
+              :children => [
+                {
+                  :key      => "#{@svr2.id}__host",
+                  :icon     => "host.png",
+                  :title    => "Host / Nodes",
+                  :children => [
+                    {
+                      :key    => "#{@svr2.id}__host_#{@host1.id}",
+                      :icon   => "host.png",
+                      :title  => @host1.name,
+                      :select => false
+                    },
+                    {
+                      :key    => "#{@svr2.id}__host_#{@host2.id}",
+                      :icon   => "host.png",
+                      :title  => @host2.name,
+                      :select => true
+                    }
+                  ]
+                },
+                {
+                  :key      => "#{@svr2.id}__storage",
+                  :icon     => "storage.png",
+                  :title    => "Datastores",
+                  :children => [
+                    {
+                      :key    => "#{@svr2.id}__storage_#{@storage1.id}",
+                      :icon   => "storage.png",
+                      :title  => @storage1.name,
+                      :select => false
+                    },
+                    {
+                      :key    => "#{@svr2.id}__storage_#{@storage2.id}",
+                      :icon   => "storage.png",
+                      :title  => @storage2.name,
+                      :select => true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        end
+      end
+
+      context "#smartproxy_affinity_field_changed" do
+        before do
+          controller.should_receive(:render)
+        end
+
+        it "should select a host when checked" do
+          controller.params = {:id => "#{@svr1.id}__host_#{@host2.id}", :check => '1'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:hosts].to_a.should include(@host2.id)
+        end
+
+        it "should deselect a host when unchecked" do
+          controller.params = {:id => "#{@svr1.id}__host_#{@host1.id}", :check => '0'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:hosts].to_a.should_not include(@host1.id)
+        end
+
+        it "should select a datastore when checked" do
+          controller.params = {:id => "#{@svr1.id}__storage_#{@storage2.id}", :check => '1'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:storages].to_a.should include(@storage2.id)
+        end
+
+        it "should deselect a datastore when unchecked" do
+          controller.params = {:id => "#{@svr1.id}__storage_#{@storage1.id}", :check => '0'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:storages].to_a.should_not include(@storage1.id)
+        end
+
+        it "should select all child hosts when checked" do
+          controller.params = {:id => "#{@svr1.id}__host", :check => '1'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:hosts].to_a.sort.should be == [@host1.id, @host2.id]
+        end
+
+        it "should deselect all child hosts when unchecked" do
+          controller.params = {:id => "#{@svr1.id}__host", :check => '0'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:hosts].to_a.should be == []
+        end
+
+        it "should select all child datastores when checked" do
+          controller.params = {:id => "#{@svr1.id}__storage", :check => '1'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:storages].to_a.sort.should be == [@storage1.id, @storage2.id]
+        end
+
+        it "should deselect all child datastores when unchecked" do
+          controller.params = {:id => "#{@svr1.id}__storage", :check => '0'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:storages].to_a.should be == []
+        end
+
+        it "should select all child hosts and datastores when checked" do
+          controller.params = {:id => "#{@svr1.id}", :check => '1'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:hosts].to_a.sort.should be == [@host1.id, @host2.id]
+          @edit[:new][:servers][@svr1.id][:storages].to_a.sort.should be == [@storage1.id, @storage2.id]
+        end
+
+        it "should deselect all child hosts and datastores when checked" do
+          controller.params = {:id => "#{@svr1.id}", :check => '0'}
+          controller.smartproxy_affinity_field_changed
+          @edit[:new][:servers][@svr1.id][:hosts].to_a.should be == []
+          @edit[:new][:servers][@svr1.id][:storages].to_a.should be == []
+        end
+      end
+
+      context "#smartproxy_affinity_update" do
+        it "updates the SmartProxy host affinities" do
+          @svr1.vm_scan_host_affinity = []
+          @svr2.vm_scan_host_affinity = []
+
+          # Commit the in-progress edit state (i.e. the initial state)
+          controller.send(:smartproxy_affinity_update)
+          @svr1.vm_scan_host_affinity.should be == [@host1]
+          @svr2.vm_scan_host_affinity.should be == [@host2]
+        end
+
+        it "updates the SmartProxy storage affinities" do
+          @svr1.vm_scan_storage_affinity = []
+          @svr2.vm_scan_storage_affinity = []
+
+          # Commit the in-progress edit state (i.e. the initial state)
+          controller.send(:smartproxy_affinity_update)
+          @svr1.vm_scan_storage_affinity.should be == [@storage1]
+          @svr2.vm_scan_storage_affinity.should be == [@storage2]
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/ops_routing_spec.rb
+++ b/spec/routing/ops_routing_spec.rb
@@ -92,6 +92,7 @@ describe "routing for OpsController" do
     settings_update
     show
     show_product_update
+    smartproxy_affinity_field_changed
     tag_edit_form_field_changed
     tl_chooser
     tree_autoload_dynatree


### PR DESCRIPTION
Recovered "Smartproxy Affinity" tab in Configuration explorer that was removed in https://github.com/ManageIQ/manageiq/pull/1531 along with all Smartproxy related code from UI in commit SHA: dd539dccd0289914df55ad81b7b977372dfcc647

https://bugzilla.redhat.com/show_bug.cgi?id=1246655

@dclarizio please review:
![smartproxy_affinity_tab](https://cloud.githubusercontent.com/assets/3450808/9182266/c427f652-3f77-11e5-83b7-c03ab10c007d.png)
