### PR TITLE
Update name of OpenStack Infrastructure

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   end
 
   def self.description
-    @description ||= "OpenStack Infrastructure".freeze
+    @description ||= "OpenStack Platform Director".freeze
   end
 
   def supports_port?

--- a/spec/models/ems_openstack_infra_spec.rb
+++ b/spec/models/ems_openstack_infra_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::Openstack::InfraManager do
   end
 
   it ".description" do
-    described_class.description.should == 'OpenStack Infrastructure'
+    described_class.description.should == 'OpenStack Platform Director'
   end
 
   context "validation" do


### PR DESCRIPTION
Change OpenStack infrastructure to "OpenStack Platform Director" in an attempt to call attention to the fact that a very specific type of OpenStack Infrastructure is supported.

https://bugzilla.redhat.com/show_bug.cgi?id=1249692
https://bugzilla.redhat.com/show_bug.cgi?id=1251139