### PR TITLE
Removed Optional. label from 'Add New Container Provider' screen

### DIFF
--- a/app/views/layouts/_container_auth.html.haml
+++ b/app/views/layouts/_container_auth.html.haml
@@ -17,7 +17,6 @@
                               :change_url   => change_url,
                               :ujs_button   => true,
                               :record       => record})
-    %span{:style => "color:black"}= _("Optional.")
 
 %hr
 :javascript


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1248547

Fixes #3634

Before:
![new_container_provider_before](https://cloud.githubusercontent.com/assets/1187051/9184094/738434cc-3fb3-11e5-8bdf-5d74bca2fa72.png)
After:
![new_container_provider](https://cloud.githubusercontent.com/assets/1187051/9184058/431b9ffa-3fb3-11e5-95ca-b8109c8b2e73.png)
