### PR TITLE
Use Nokogiri for powershell inventory collection instead of REXML

### DIFF
--- a/gems/pending/test/xml/tc_nokogiri.rb
+++ b/gems/pending/test/xml/tc_nokogiri.rb
@@ -9,7 +9,7 @@ class NokogiriXmlMethods < Minitest::Test
 	def setup
     @xml_klass = Nokogiri::XML
     @xml_string = self.default_test_xml() if @xml_string.nil?
-    @xml = MiqXml.load(@xml_string, @xml_klass)
+    @xml = MiqXml.load(@xml_string, :nokogiri)
 	end
 
 	def teardown

--- a/gems/pending/util/miq-xml.rb
+++ b/gems/pending/util/miq-xml.rb
@@ -5,56 +5,52 @@ require 'util/miq-encode'
 require 'util/xml/xml_diff'
 require 'util/xml/xml_patch'
 
-class MiqXml  
-	#MIQ_XML_VERSION = 1.0
-	#MIQ_XML_VERSION = 1.1	# Added create_time to root in seconds for easier time conversions
-	MIQ_XML_VERSION = 2.0	# Changed sub-xmls, added namespaces
+class MiqXml
+  MIQ_XML_VERSION = 2.1 # Refactor Nokogiri handling
 
-	@@defaultXmlType = :rexml  # REXML is always available so default it here.
+  DEFAULT_XML_TYPE = :rexml # REXML is always available so default it here.
 
-  # Now test to see if nokogiri is available
-  @@nokogiri_loaded = false
-	begin
-    require 'util/xml/miq_nokogiri'
-  	Nokogiri::XML::Document.new
-    #@@defaultXmlType = :nokogiri
-		@@nokogiri_loaded = true
-  rescue
+  @nokogiri = false
+
+  def self.loadFile(filename, xmlClass = DEFAULT_XML_TYPE)
+    xml_document(xmlClass).loadFile(filename)
   end
 
-	def self.loadFile(filename, xmlClass = @@defaultXmlType)
-		self.xml_document(xmlClass).loadFile(filename)
-	end
-
-	def self.load(data, xmlClass = @@defaultXmlType)
-		self.xml_document(xmlClass).load(data)
-	end
-
-	def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = @@defaultXmlType)
-		self.xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
-	end
-
-  def self.newDoc(xmlClass = @@defaultXmlType)
-    self.xml_document(xmlClass).newDoc()
+  def self.load(data, xmlClass = DEFAULT_XML_TYPE)
+    xml_document(xmlClass).load(data)
   end
 
-	def self.decode(encodedText, xmlClass = @@defaultXmlType)
-		return self.xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
-		self.newDoc()
-	end
+  def self.createDoc(rootName, rootAttrs = nil, version = MIQ_XML_VERSION, xmlClass = DEFAULT_XML_TYPE)
+    xml_document(xmlClass).createDoc(rootName, rootAttrs, version)
+  end
 
-  def self.newNode(data=nil, xmlClass = @@defaultXmlType)
-    self.xml_document(xmlClass).newNode(data)
+  def self.newDoc(xmlClass = DEFAULT_XML_TYPE)
+    xml_document(xmlClass).newDoc
+  end
+
+  def self.decode(encodedText, xmlClass = DEFAULT_XML_TYPE)
+    return xml_document(xmlClass).load(MIQEncode.decode(encodedText)) if encodedText
+    newDoc
+  end
+
+  def self.newNode(data=nil, xmlClass = DEFAULT_XML_TYPE)
+    xml_document(xmlClass).newNode(data)
   end
 
   def self.xml_document(xmlClass)
     return xmlClass::Document if xmlClass.kind_of?(Module)
     begin
       case xmlClass
-      when :rexml then REXML::Document
-      when :xmlhash then XmlHash::Document
-      when :nokogiri then Nokogiri::XML::Document
-      else REXML::Document
+      when :rexml
+        REXML::Document
+      when :xmlhash
+        XmlHash::Document
+      when :nokogiri
+        require 'util/xml/miq_nokogiri'
+        @nokogiri = true
+        Nokogiri::XML::Document
+      else
+        REXML::Document
       end
     rescue
       REXML::Document
@@ -62,24 +58,24 @@ class MiqXml
   end
 
   def self.isXmlElement?(handle)
-    return true if handle.is_a?(REXML::Element) || handle.is_a?(XmlHash::Element)
-    return true if @@nokogiri_loaded && handle.kind_of?(Nokogiri::XML::Node)
+    return true if handle.kind_of?(REXML::Element) || handle.kind_of?(XmlHash::Element)
+    return true if nokogiri? && handle.kind_of?(Nokogiri::XML::Node)
     false
   end
 
   def self.isXmlDoc?(handle)
-    return true if handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Document)
-    return true if @@nokogiri_loaded && handle.is_a?(Nokogiri::XML::Document)
+    return true if handle.kind_of?(REXML::Document) || handle.kind_of?(XmlHash::Document)
+    return true if nokogiri? && handle.kind_of?(Nokogiri::XML::Document)
     false
   end
 
   def self.isXml?(handle)
-    return true if handle.is_a?(REXML::Element) || handle.is_a?(REXML::Document) || handle.is_a?(XmlHash::Element) || handle.is_a?(XmlHash::Document)
-    return true if @@nokogiri_loaded && (handle.is_a?(Nokogiri::XML::Element) || handle.is_a?(Nokogiri::XML::Document))
+    return true if handle.kind_of?(REXML::Element) || handle.kind_of?(REXML::Document) || handle.kind_of?(XmlHash::Element) || handle.kind_of?(XmlHash::Document)
+    return true if nokogiri? && (handle.kind_of?(Nokogiri::XML::Element) || handle.kind_of?(Nokogiri::XML::Document))
     false
   end
 
-  def self.is_nokogiri_loaded?
-    @@nokogiri_loaded
+  def self.nokogiri?
+    @nokogiri
   end
 end

--- a/gems/pending/util/xml/miq_nokogiri.rb
+++ b/gems/pending/util/xml/miq_nokogiri.rb
@@ -7,6 +7,15 @@ begin
   # Add class methods to nokogiri to have it behave more like REXML for easy replacement
   module Nokogiri
     module XML
+      class Attr
+        # REXML::Attributes are typically accessed so that it returns the value of an
+        # attribute, whereas Nokogiri returns an object with a "value" reader method.
+        # Our approach essentially forwards the call to the value.
+        def method_missing(*args, &block)
+          self.value.send(*args, &block)
+        end
+      end
+
       class Node
         def add_attribute(key, value)
           self[key.to_s] = value.to_s unless value.nil?
@@ -124,9 +133,9 @@ begin
 
         def self.loadFile(filename)
           begin
-            Nokogiri::XML::Document.file(filename)
+            Nokogiri::XML::Document.new(filename)
           rescue => err
-            $log.warn "Unabled to load XML document with Nokogiri, retrying with REXML" if $log
+            $log.warn "Unable to load XML document with Nokogiri, retrying with REXML" if $log
             self.from_xml(filename, true)
           end
         end


### PR DESCRIPTION
Third time's the charm?

After falling into a rat-hole of issues when I tried to make Nokogiri the default parser, this PR focuses only on the changes needed to use Nokogiri for the powershell inventory collection.

For now we will have to let REXML be the default parser for other libs under gems/pending, because they parse XML using the REXML API internally, and cannot easily be changed. Updating those files (over 20 of them) should be split into separate PR's.