### PR TITLE
Added missing case statement introduced during HAML conversion.

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -103,6 +103,7 @@
             "data-miq_sparkle_off" => true,
             "data-miq_observe"     => {:url => url}.to_json)
           = _("going back")
+        - case @edit[:new][:cb_interval]
         - when "daily"
           - opts = (1..6).map { |i| [n_('%s Day', '%s Days', i) % i, i] } + (1..4).map { |i| [n_('%s Week', '%s Weeks', i) % i, i] }
           = select_tag("cb_interval_size",


### PR DESCRIPTION
This was preventing Going back pull down to not show up in Chargeback reports editor UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1230262

@dclarizio please review, this was introduced in commit sha: 631c9021:

before:
![going_back_pulldown_missing](https://cloud.githubusercontent.com/assets/3450808/9185408/a216b852-3f89-11e5-9f5b-dbcda4f20f37.png)

after:
![going_back_pulldown_after](https://cloud.githubusercontent.com/assets/3450808/9185412/a9efdae0-3f89-11e5-8a60-a2c9ab12a95d.png)