### PR TITLE
Added missing 'url' key to the 'Reload' button under Saved Reports

### DIFF
--- a/product/toolbars/saved_reports_center_tb.yaml
+++ b/product/toolbars/saved_reports_center_tb.yaml
@@ -10,6 +10,7 @@
   - :button: reload
     :image: reload
     :title: 'Reload selected Reports'
+    :url: 'reload'
 - :name: saved_report_vmdb
   :items:
   - :buttonSelect: saved_report_vmdb_choice


### PR DESCRIPTION
Other areas in Reports controller have the ```'url'``` key specified appropriately in the toolbar yaml, for Reload.

In ```saved_reports_center_tb.yaml```, however, the ```'url'``` key was missing, which has now been added.

This will fix the rbac error specified in the BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=1250438
