### PR TITLE
remove db_user=current_user from application_controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -318,14 +318,14 @@ class ApplicationController < ActionController::Base
   end
 
   # Save column widths
+  # skip processing when session[:view] is nil. Possible causes:
+  #   - user used back button
+  #   - user has multiple tabs to access the list view screen
   def save_col_widths
     @view = session[:view]
-    #don't do anything if @view is nil, incase user used back button or multiple tabs to access list view screen
+    cws = (params[:col_widths] || "").split(",")[2..-1]
     if @view
-#   cols_key = @view.scoped_association.nil? ? @view.db.to_sym : (@view.db + "-" + @view.scoped_association).to_sym
     cols_key = create_cols_key(@view)
-      if params[:col_widths]
-        cws = params[:col_widths].split(",")[2..-1]
         if cws.length > 0
           if (db_user = current_user)
             db_user.settings[:col_widths] ||= Hash.new                        # Create the col widths hash, if not there
@@ -339,7 +339,6 @@ class ApplicationController < ActionController::Base
             db_user.save
           end
         end
-      end
     end
     render :nothing => true                                 # No response needed
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -324,21 +324,21 @@ class ApplicationController < ActionController::Base
   def save_col_widths
     @view = session[:view]
     cws = (params[:col_widths] || "").split(",")[2..-1]
-    if @view
-    cols_key = create_cols_key(@view)
-        if cws.length > 0
-          if (db_user = current_user)
-            db_user.settings[:col_widths] ||= {}
-            db_user.settings[:col_widths][cols_key] ||= {}
-            @settings[:col_widths] ||= {}
-            @settings[:col_widths][cols_key] ||= {}
-            cws.each_with_index do |cw, i|
-              @settings[:col_widths][cols_key][@view.col_order[i]] = cw.to_i
-            end
-            db_user.settings[:col_widths][cols_key] = @settings[:col_widths][cols_key]
-            db_user.save
-          end
+    if @view && cws.length > 0
+      cols_key = create_cols_key(@view)
+      @settings[:col_widths] ||= {}
+      @settings[:col_widths][cols_key] ||= {}
+      cws.each_with_index do |cw, i|
+        @settings[:col_widths][cols_key][@view.col_order[i]] = cw.to_i
+      end
+
+        if (db_user = current_user)
+          db_user.settings[:col_widths] ||= {}
+          db_user.settings[:col_widths][cols_key] ||= {}
+          db_user.settings[:col_widths][cols_key] = @settings[:col_widths][cols_key]
+          db_user.save
         end
+      end
     end
     render :nothing => true                                 # No response needed
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -328,12 +328,12 @@ class ApplicationController < ActionController::Base
     cols_key = create_cols_key(@view)
         if cws.length > 0
           if (db_user = current_user)
-            db_user.settings[:col_widths] ||= Hash.new                        # Create the col widths hash, if not there
-            db_user.settings[:col_widths][cols_key] ||= Hash.new        # Create hash for the view db
-            @settings[:col_widths] ||= Hash.new                               # Create the col widths hash, if not there
-            @settings[:col_widths][cols_key] ||= Hash.new             # Create hash for the view db
+            db_user.settings[:col_widths] ||= {}
+            db_user.settings[:col_widths][cols_key] ||= {}
+            @settings[:col_widths] ||= {}
+            @settings[:col_widths][cols_key] ||= {}
             cws.each_with_index do |cw, i|
-              @settings[:col_widths][cols_key][@view.col_order[i]] = cw.to_i  # Save each cols width
+              @settings[:col_widths][cols_key][@view.col_order[i]] = cw.to_i
             end
             db_user.settings[:col_widths][cols_key] = @settings[:col_widths][cols_key]
             db_user.save

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -332,12 +332,11 @@ class ApplicationController < ActionController::Base
         @settings[:col_widths][cols_key][@view.col_order[i]] = cw.to_i
       end
 
-        if (db_user = current_user)
-          db_user.settings[:col_widths] ||= {}
-          db_user.settings[:col_widths][cols_key] ||= {}
-          db_user.settings[:col_widths][cols_key] = @settings[:col_widths][cols_key]
-          db_user.save
-        end
+      if current_user
+        user_settings = current_user.settings || {}
+        user_settings[:col_widths] ||= {}
+        user_settings[:col_widths][cols_key] = @settings[:col_widths][cols_key]
+        current_user.update_attributes(:settings => user_settings)
       end
     end
     render :nothing => true                                 # No response needed


### PR DESCRIPTION
It was confusing to keep `db_user` and `current_user` straight. This removed `db_user` local variable.

This changes `application_controller.rb` so the settings are extracted, manipulated and updated in the current_user.

I grouped the `@settings` and the `user_settings` changes to show how the 2 different hashes are updated. This is to make it more consistent with a number of controllers that set `@settings`.

I did split up into 4 commits, let me know if they are still not clear and I'll try again.

/cc @chessbyte and thus it begins.