### PR TITLE
use clear_current_user vs current_user=nil

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -8,26 +8,18 @@ module ApplicationController::CurrentUser
   end
 
   def clear_current_user
-    self.current_user = nil
+    User.current_userid = nil
+    session[:userid]    = nil
+    session[:group]     = nil
   end
   protected :clear_current_user
 
   def current_user=(db_user)
-    if db_user
-      User.current_userid = db_user.userid
-      session[:userid]    = db_user.userid
-    else
-      User.current_userid = nil
-      session[:userid]    = nil
-    end
-    self.current_group  = db_user.try(:current_group)
+    User.current_userid = db_user.userid
+    session[:userid]    = db_user.userid
+    session[:group]     = db_user.current_group.try(:id)
   end
   protected :current_user=
-
-  def current_group=(db_group)
-    session[:group] = db_group.try(:id)
-  end
-  private :current_group=
 
   def eligible_groups
     eligible_groups = current_user.try(:miq_groups)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -514,7 +514,7 @@ class DashboardController < ApplicationController
         page.redirect_to(validation.url)
       end
     when :fail
-      self.current_user = nil
+      clear_current_user
       add_flash(validation.flash_msg || "Error: Authentication failed", :error)
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
@@ -596,7 +596,7 @@ class DashboardController < ApplicationController
 
   def logout
     current_user.try(:logoff)
-    self.current_user = nil
+    clear_current_user
 
     session.clear
     session[:auto_login] = false

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -4,7 +4,7 @@ class UserValidationService
   end
 
   extend Forwardable
-  delegate [:session, :url_for, :initiate_wait_for_task, :session_init, :current_userid=,
+  delegate [:session, :url_for, :initiate_wait_for_task, :session_init, :clear_current_user,
             :session_reset, :get_vmdb_config, :start_url_for_user] => :@controller
 
   ValidateResult = Struct.new(:result, :flash_msg, :url)
@@ -21,7 +21,7 @@ class UserValidationService
     end
 
     unless user[:name]
-      self.current_userid = nil
+      clear_current_user
       return ValidateResult.new(:fail, @flash_msg ||= "Error: Authentication failed")
     end
 


### PR DESCRIPTION
The controller is simplified when we distinguish between setting and clearing the current user.

Currently, `session[:group]` is still getting set, but there is no reason to keep the helper method around

This is all part of tenancy and simplifying the session