### PR TITLE
Change access into session browser information

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -26,7 +26,7 @@ module ApplicationController::Automate
     c_buttons, c_xml = build_toolbar_buttons_and_xml(center_toolbar_filename)
     render :update do |page|
       # IE7 doesn't redraw the tree until the screen is clicked, so redirect back to this method for a refresh
-      if is_browser_ie? && browser_info("version") == "7"
+      if is_browser_ie? && browser_info(:version) == "7"
         page.redirect_to :action => 'resolve'
       else
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -225,7 +225,7 @@ module ApplicationController::Timelines
         add_flash(_("No records found for this timeline"), :warning)
       else
         @timeline = true
-        @report.extras[:browser_name] = browser_info("name").downcase
+        @report.extras[:browser_name] = browser_info(:name)
         if is_browser_ie?
           blob = BinaryBlob.new(:name => "timeline_results")
           blob.binary=(@report.to_timeline)
@@ -480,7 +480,7 @@ module ApplicationController::Timelines
         if @report.table.data.length == 0
           add_flash(_("No records found for this timeline"), :warning)
         else
-          @report.extras[:browser_name] = browser_info("name").downcase
+          @report.extras[:browser_name] = browser_info(:name)
           if is_browser_ie?
             blob = BinaryBlob.new(:name => "timeline_results")
             blob.binary=(@report.to_timeline)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -696,9 +696,15 @@ class DashboardController < ApplicationController
 
     session[:user_TZO] = params[:user_TZO] ? params[:user_TZO].to_i : nil     # Grab the timezone (future use)
     session[:browser] ||= Hash.new("Unknown")
-    session[:browser][:name] = params[:browser_name] if params[:browser_name]
+    if params[:browser_name]
+      session[:browser][:name] = params[:browser_name].to_s.downcase
+      session[:browser][:name_ui] = params[:browser_name]
+    end
     session[:browser][:version] = params[:browser_version] if params[:browser_version]
-    session[:browser][:os] = params[:browser_os] if params[:browser_os]
+    if params[:browser_os]
+      session[:browser][:os] = params[:browser_os].to_s.downcase
+      session[:browser][:os_ui] = params[:browser_os]
+    end
   end
 
   # Create a user's dashboard, pass in dashboard id if that is used to copy else use default dashboard

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -767,7 +767,7 @@ class DashboardController < ApplicationController
       return
     end
 
-    @report.extras[:browser_name] = browser_info("name").downcase
+    @report.extras[:browser_name] = browser_info(:name)
     if is_browser_ie?
       blob = BinaryBlob.new(:name => "timeline_results")
       blob.binary = @report.to_timeline

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -730,7 +730,7 @@ class MiqCapacityController < ApplicationController
       add_flash(_("No records found for this timeline"), :warning)
     else
       tz = @sb[:bottlenecks][:report].tz ? @sb[:bottlenecks][:report].tz : Time.zone
-      @sb[:bottlenecks][:report].extras[:browser_name] = browser_info("name").downcase
+      @sb[:bottlenecks][:report].extras[:browser_name] = browser_info(:name)
       if is_browser_ie?
         blob = BinaryBlob.new(:name => "timeline_results")
         blob.binary=(@sb[:bottlenecks][:report].to_timeline)

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -55,7 +55,7 @@ module ReportController::Reports
 
       if rpt.timeline                   # If timeline present
         @timeline                 = true
-        rpt.extras[:browser_name] = browser_info("name").downcase
+        rpt.extras[:browser_name] = browser_info(:name)
         #flag to force formatter to build timeline in xml for preview screen
         rpt.extras[:tl_preview] = true
         @edit[:tl_xml]            = rpt.to_timeline

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -111,7 +111,7 @@ module VmCommon
                   :vmid        => @record.ems_ref,
                   :ticket      => @sb[:vmrc],
                   :api_version => @record.ext_management_system.api_version.to_s,
-                  :os          => browser_info(:os).downcase,
+                  :os          => browser_info(:os),
                   :name        => @record.name
                 }
               end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -404,7 +404,7 @@ module ApplicationHelper
   end
 
   def is_browser_ie?
-    browser_info(:name).downcase == "explorer"
+    browser_info(:name) == "explorer"
   end
 
   def is_browser_ie7?
@@ -412,17 +412,18 @@ module ApplicationHelper
   end
 
   def is_browser?(name)
-    browser_name = browser_info(:name).downcase
+    browser_name = browser_info(:name)
     name.kind_of?(Array) ? name.include?(browser_name) : (browser_name == name)
   end
 
   def is_browser_os?(os)
-    browser_os = browser_info(:os).downcase
+    browser_os = browser_info(:os)
     os.kind_of?(Array) ? os.include?(browser_os) : (browser_os == os)
   end
 
-  def browser_info(typ = :name)
-    session.fetch_path(:browser, typ.to_sym).to_s
+  def browser_info(typ, downcase = true)
+    value = session.fetch_path(:browser, typ).to_s
+    downcase ? value.downcase : value
   end
 
   ############# Following methods generate JS lines for render page blocks

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -421,9 +421,8 @@ module ApplicationHelper
     os.kind_of?(Array) ? os.include?(browser_os) : (browser_os == os)
   end
 
-  def browser_info(typ, downcase = true)
-    value = session.fetch_path(:browser, typ).to_s
-    downcase ? value.downcase : value
+  def browser_info(typ)
+    session.fetch_path(:browser, typ).to_s
   end
 
   ############# Following methods generate JS lines for render page blocks

--- a/app/views/layouts/_global_header.html.haml
+++ b/app/views/layouts/_global_header.html.haml
@@ -25,7 +25,7 @@
         = javascript_include_tag '/javascripts/timeline/api/scripts/miq_painters.js'
 
     :javascript
-      ManageIQ.browser = "#{j browser_info(:name, false)}";
+      ManageIQ.browser = "#{j browser_info(:name_ui)}";
       ManageIQ.controller = "#{j controller_name}";
 
     %style html, body{width:100%; height:100%; margin:0px; padding:0px; overflow:hidden;}

--- a/app/views/layouts/_global_header.html.haml
+++ b/app/views/layouts/_global_header.html.haml
@@ -25,7 +25,7 @@
         = javascript_include_tag '/javascripts/timeline/api/scripts/miq_painters.js'
 
     :javascript
-      ManageIQ.browser = "#{j browser_info(:name)}";
+      ManageIQ.browser = "#{j browser_info(:name, false)}";
       ManageIQ.controller = "#{j controller_name}";
 
     %style html, body{width:100%; height:100%; margin:0px; padding:0px; overflow:hidden;}

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -10,9 +10,9 @@
                [_("Version"),         h(@vmdb[:version] + "." + @vmdb[:build])],
                [_("User Name"),       h(current_user.name)],
                [_("User Role"),       h(@user_role)],
-               [_("Browser"),         h(browser_info(:name, false))],
+               [_("Browser"),         h(browser_info(:name_ui))],
                [_("Browser Version"), h(browser_info(:version))],
-               [_("Browser OS"),      h(browser_info(:os, false))]].each do |session_info|
+               [_("Browser OS"),      h(browser_info(:os_ui))]].each do |session_info|
               .form-group
                 %label.col-md-3.control-label
                   = session_info[0]

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -10,9 +10,9 @@
                [_("Version"),         h(@vmdb[:version] + "." + @vmdb[:build])],
                [_("User Name"),       h(current_user.name)],
                [_("User Role"),       h(@user_role)],
-               [_("Browser"),         h(browser_info("name"))],
-               [_("Browser Version"), h(browser_info("version"))],
-               [_("Browser OS"),      h(browser_info("os"))]].each do |session_info|
+               [_("Browser"),         h(browser_info(:name, false))],
+               [_("Browser Version"), h(browser_info(:version))],
+               [_("Browser OS"),      h(browser_info(:os, false))]].each do |session_info|
               .form-group
                 %label.col-md-3.control-label
                   = session_info[0]

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -1,7 +1,7 @@
 !!! Strict
 %html
   %head
-    - if %w(5.1 5.5).include?(api_version) && is_browser_ie? && browser_info("version").to_i > 9
+    - if %w(5.1 5.5).include?(api_version) && is_browser_ie? && browser_info(:version).to_i > 9
       %meta{:content => "IE=8", "http-equiv" => "X-UA-Compatible"}
     %meta{:content => "text/html; charset=ISO-8859-1", "http-equiv" => "Content-Type"}
     = stylesheet_link_tag "vmrc"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -677,15 +677,16 @@ describe ApplicationHelper do
   end
 
   context "#browser_info" do
-    it "checks by name when called with NO argument" do
-      ActionController::TestSession.any_instance.stub(:fetch_path).with(:browser, :name).and_return('checked_by_name')
-      browser_info( ).should == 'checked_by_name'
+    it "downcases by default" do
+      type = :a_type
+      ActionController::TestSession.any_instance.stub(:fetch_path).with(:browser, type).and_return('checked_by_A_TYPE')
+      browser_info(type).should == 'checked_by_a_type'
     end
 
-    it "checks by 'a_type' when called with 'a_type'" do
+    it "can provide full case" do
       type = :a_type
-      ActionController::TestSession.any_instance.stub(:fetch_path).with(:browser, type).and_return('checked_by_a_type')
-      browser_info(type).should == 'checked_by_a_type'
+      ActionController::TestSession.any_instance.stub(:fetch_path).with(:browser, type).and_return('checked_by_A_TYPE')
+      browser_info(type, false).should == 'checked_by_A_TYPE'
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -677,16 +677,10 @@ describe ApplicationHelper do
   end
 
   context "#browser_info" do
-    it "downcases by default" do
+    it "preserves the case" do
       type = :a_type
       ActionController::TestSession.any_instance.stub(:fetch_path).with(:browser, type).and_return('checked_by_A_TYPE')
-      browser_info(type).should == 'checked_by_a_type'
-    end
-
-    it "can provide full case" do
-      type = :a_type
-      ActionController::TestSession.any_instance.stub(:fetch_path).with(:browser, type).and_return('checked_by_A_TYPE')
-      browser_info(type, false).should == 'checked_by_A_TYPE'
+      browser_info(type).should == 'checked_by_A_TYPE'
     end
   end
 


### PR DESCRIPTION
I was working through the session and stumbled upon this.

- Since we store `typ` as a symbol, access it with a symbol. No reason to `.to_sym` it.
- Since we `downcase` in all by 3 examples, `downcase` by default
- No need to default `typ` to name, that feature is not used anywhere.

@martinpovolny  questions:

- can we just `downcase` all browser values? Storing the value in `downcase` in the first place would be simplest. Only ManageIQ.browser (javascript) and display use regular case.

**FOLLOWUP:**

This resolves [hakiri](https://hakiri.io/github/ManageIQ/manageiq/master/6192c97baa710ffb7d40c06893219a6e94106e4d/warnings?name=Cross-Site+Scripting) / brakeman, so if we don't want to do this, I'll resolve those errors in another PR.