### PR TITLE
Move timezone lookup out of GlobalMethods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -910,7 +910,7 @@ class ApplicationController < ActionController::Base
   # if authenticating or past login screen
   def set_user_time_zone
     user = current_user || (params[:user_name].presence && User.find_by_userid(params[:user_name]))
-    session[:user_tz] = Time.zone = get_timezone_for_userid(user)
+    session[:user_tz] = Time.zone = (user ? user.get_timezone : server_timezone)
   end
 
   # Initialize the options for server selection

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,7 @@ class ApplicationController < ActionController::Base
   include_concern 'Tags'
   include_concern 'Tenancy'
   include_concern 'Timelines'
+  include_concern 'Timezone'
   include_concern 'TreeSupport'
   include_concern 'SysprepAnswerFile'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -904,9 +904,7 @@ class ApplicationController < ActionController::Base
 
   # convert time from utc to server timezone
   def convert_time_from_utc(datetime)
-    tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
-    tz = "UTC" if tz.blank?
-    return datetime.in_time_zone(tz)
+    return datetime.in_time_zone(server_timezone)
   end
 
   # if authenticating or past login screen
@@ -1061,11 +1059,7 @@ class ApplicationController < ActionController::Base
   # Render the view data to xml for the grid view
   def view_to_xml(view, from_idx = 0, to_idx = -1, options = {})
     # Get the time zone in effect for this view
-    if view.db.downcase == 'miqschedule'
-      tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
-    else
-      tz = Time.zone
-    end
+    tz = (view.db.downcase == 'miqschedule') ? server_timezone : Time.zone
 
     xml = MiqXml.createDoc(nil, nil, 1.0, :nokogiri)
 

--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -20,7 +20,7 @@ class ApplicationController
     def get_timezone_offset(user = nil, formatted = false)
       tz = user ? user.get_timezone : server_timezone
       tz = ActiveSupport::TimeZone::MAPPING[tz]
-      ActiveSupport::TimeZone.all.each do  |a|
+      ActiveSupport::TimeZone.all.each do |a|
         if ActiveSupport::TimeZone::MAPPING[a.name] == tz
           if formatted
             return a.formatted_offset

--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -4,10 +4,10 @@ class ApplicationController
 
     included do
       helper_method :get_timezone_abbr, :get_timezone_offset
-      helper_method :get_timezone_for_userid, :server_timezone
+      helper_method :server_timezone
 
       hide_action :get_timezone_abbr, :get_timezone_offset
-      hide_action :get_timezone_for_userid, :server_timezone
+      hide_action :server_timezone
     end
 
     # return timezone abbreviation
@@ -24,7 +24,7 @@ class ApplicationController
 
     # returns utc_offset of timezone
     def get_timezone_offset(user = nil, formatted = false)
-      tz = get_timezone_for_userid(user)
+      tz = user ? user.get_timezone : server_timezone
       tz = ActiveSupport::TimeZone::MAPPING[tz]
       ActiveSupport::TimeZone.all.each do  |a|
         if ActiveSupport::TimeZone::MAPPING[a.name] == tz
@@ -35,12 +35,6 @@ class ApplicationController
           end
         end
       end
-    end
-
-    def get_timezone_for_userid(user = nil)
-      user = User.find_by_userid(user) if user.kind_of?(String)
-      tz = user && user.settings.fetch_path(:display, :timezone).presence
-      tz || server_timezone
     end
 
     def server_timezone

--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -1,0 +1,46 @@
+class ApplicationController
+  module Timezone
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :get_timezone_abbr, :get_timezone_offset
+      helper_method :get_timezone_for_userid
+
+      hide_action :get_timezone_abbr, :get_timezone_offset
+      hide_action :get_timezone_for_userid
+    end
+
+    # return timezone abbreviation
+    def get_timezone_abbr(user = nil)
+      if user.nil?
+        tz = get_timezone_for_userid(nil)
+        time = Time.now
+      else
+        tz = Time.zone
+        time = Time.zone.now
+      end
+      time.in_time_zone(tz).strftime("%Z")
+    end
+
+    # returns utc_offset of timezone
+    def get_timezone_offset(user = nil, formatted = false)
+      tz = get_timezone_for_userid(user)
+      tz = ActiveSupport::TimeZone::MAPPING[tz]
+      ActiveSupport::TimeZone.all.each do  |a|
+        if ActiveSupport::TimeZone::MAPPING[a.name] == tz
+          if formatted
+            return a.formatted_offset
+          else
+            return a.utc_offset
+          end
+        end
+      end
+    end
+
+    def get_timezone_for_userid(user = nil)
+      user = User.find_by_userid(user) if user.kind_of?(String)
+      tz = user && user.settings.fetch_path(:display, :timezone).presence
+      tz || MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+    end
+  end
+end

--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -12,14 +12,8 @@ class ApplicationController
 
     # return timezone abbreviation
     def get_timezone_abbr(user = nil)
-      if user.nil?
-        tz = server_timezone
-        time = Time.now
-      else
-        tz = Time.zone
-        time = Time.zone.now
-      end
-      time.in_time_zone(tz).strftime("%Z")
+      time = user ? Time.zone.now : Time.now.in_timezone(server_timezone)
+      time.strftime("%Z")
     end
 
     # returns utc_offset of timezone

--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -4,16 +4,16 @@ class ApplicationController
 
     included do
       helper_method :get_timezone_abbr, :get_timezone_offset
-      helper_method :get_timezone_for_userid
+      helper_method :get_timezone_for_userid, :server_timezone
 
       hide_action :get_timezone_abbr, :get_timezone_offset
-      hide_action :get_timezone_for_userid
+      hide_action :get_timezone_for_userid, :server_timezone
     end
 
     # return timezone abbreviation
     def get_timezone_abbr(user = nil)
       if user.nil?
-        tz = get_timezone_for_userid(nil)
+        tz = server_timezone
         time = Time.now
       else
         tz = Time.zone
@@ -40,7 +40,11 @@ class ApplicationController
     def get_timezone_for_userid(user = nil)
       user = User.find_by_userid(user) if user.kind_of?(String)
       tz = user && user.settings.fetch_path(:display, :timezone).presence
-      tz || MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+      tz || server_timezone
+    end
+
+    def server_timezone
+      MiqServer.my_server.server_timezone
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -616,7 +616,7 @@ module ApplicationHelper
 
   # Format a column in a report view for display on the screen
   def format_col_for_display(view, row, col, tz = nil)
-    tz ||= ["miqschedule"].include?(view.db.downcase) ? MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC" : Time.zone
+    tz ||= ["miqschedule"].include?(view.db.downcase) ? MiqServer.my_server.server_timezone : Time.zone
     celltext = view.format(col,
                            row[col],
                            :tz=>tz

--- a/app/models/miq_report/notification.rb
+++ b/app/models/miq_report/notification.rb
@@ -29,7 +29,7 @@ module MiqReport::Notification
     subject = run_on.strftime("Your report '#{self.title}' generated on %m/%d/%Y is ready")
 
     curr_tz = Time.zone # Save current time zone setting
-    Time.zone = (user ? user.settings.fetch_path(:display, :timezone) : nil) || MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+    Time.zone = user ? user.get_timezone : MiqServer.my_server.server_timezone
 
     if self.table_has_records?
       attach_types = options.fetch_path(:email, :attach) || [:pdf] # support legacy schedules

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -179,7 +179,7 @@ class MiqReportResult < ActiveRecord::Base
 
     curr_tz = Time.zone # Save current time zone setting
     user = self.userid.include?("|") ? nil : User.find_by_userid(self.userid)
-    Time.zone = (user ? user.settings.fetch_path(:display, :timezone) : nil) || MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+    Time.zone = user ? user.get_timezone : MiqServer.my_server.server_timezone
 
     # Create the pdf header section
     html_string = generate_pdf_header(

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -685,4 +685,8 @@ class MiqServer < ActiveRecord::Base
     groups = MiqGroup.where(:resource_id => nil, :resource_type => nil).order(:sequence).to_a if groups.empty?
     groups
   end
+
+  def server_timezone
+    get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+  end
 end #class MiqServer

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -550,7 +550,7 @@ class MiqWidget < ActiveRecord::Base
     sched = self.miq_schedule
     return sched unless sched.nil?
 
-    server_tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+    server_tz = MiqServer.my_server.server_timezone
     value     = schedule_info.fetch_path(:run_at, :interval, :value)
     unit      = schedule_info.fetch_path(:run_at, :interval, :unit)
     if unit == "daily"

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -175,7 +175,7 @@ module MiqProvisionQuotaMixin
   end
 
   def quota_get_time_range(time=nil)
-    tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+    tz = MiqServer.my_server.server_timezone
     ts = time.nil? ? Time.now.in_time_zone(tz) : time.in_time_zone(tz)
     return [ts.beginning_of_day.utc, ts.end_of_day.utc]
   end

--- a/app/models/mixins/timezone_mixin.rb
+++ b/app/models/mixins/timezone_mixin.rb
@@ -19,7 +19,7 @@ module TimezoneMixin
 
   module ClassMethods
     def server_timezone
-      MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+      MiqServer.my_server.server_timezone
     end
   end
 end

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -309,6 +309,6 @@
                   - if row[col].kind_of?(Time) && row[col].nil? && row[col] != ""
                     = h(format_timezone(row[col], Time.zone, "gtl"))
                   - else
-                    - tz = view.db.downcase == "miqschedule" ? MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC" : Time.zone
+                    - tz = view.db.downcase == "miqschedule" ? server_timezone : Time.zone
                     - col_data = view.format(col, row[col], :tz => celltz || tz).gsub(/\\/, '\&')
                     = h(col_data)

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -36,39 +36,6 @@ module Vmdb
     end
 
     # Had to add timezone methods here, they are being called from models
-    # return timezone abbreviation
-    def get_timezone_abbr(user = nil)
-      if user.nil?
-        tz = get_timezone_for_userid(nil)
-        time = Time.now
-      else
-        tz = Time.zone
-        time = Time.zone.now
-      end
-      time.in_time_zone(tz).strftime("%Z")
-    end
-
-    # returns utc_offset of timezone
-    def get_timezone_offset(user = nil, formatted = false)
-      tz = get_timezone_for_userid(user)
-      tz = ActiveSupport::TimeZone::MAPPING[tz]
-      ActiveSupport::TimeZone.all.each do  |a|
-        if ActiveSupport::TimeZone::MAPPING[a.name] == tz
-          if formatted
-            return a.formatted_offset
-          else
-            return a.utc_offset
-          end
-        end
-      end
-    end
-
-    def get_timezone_for_userid(user = nil)
-      user = User.find_by_userid(user) if user.kind_of?(String)
-      tz = user && user.settings.fetch_path(:display, :timezone).presence
-      tz || MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
-    end
-
     #returns formatted time in specified timezone and format
     def format_timezone(time,timezone=Time.zone.name,ftype="view")
       timezone = timezone.name if timezone.is_a?(ActiveSupport::TimeZone)   # If a Timezone object comes in, just get the name

--- a/spec/controllers/application_controller/timezone_spec.rb
+++ b/spec/controllers/application_controller/timezone_spec.rb
@@ -59,44 +59,4 @@ describe ApplicationController, "#Timezone" do
       end
     end
   end
-
-  context "#get_timezone_for_userid" do
-    context "for a user" do
-      it "who doesn't exist" do
-        subject.get_timezone_for_userid("missing").should == "UTC"
-      end
-
-      it "who is nil with system default" do
-        stub_server_configuration(:server => {:timezone => "Eastern Time (US & Canada)"})
-        subject.get_timezone_for_userid(nil).should == "Eastern Time (US & Canada)"
-      end
-
-      it "with a timezone" do
-        user = FactoryGirl.create(:user, :settings => {:display => {:timezone => "Pacific Time (US & Canada)"}})
-        subject.get_timezone_for_userid(user).should == "Pacific Time (US & Canada)"
-      end
-
-      # currently only used in 1 place
-      it "with name lookup" do
-        user = FactoryGirl.create(:user, :settings => {:display => {:timezone => "Pacific Time (US & Canada)"}})
-        subject.get_timezone_for_userid(user.userid).should == "Pacific Time (US & Canada)"
-      end
-
-      context "without a timezone" do
-        it "with a system default" do
-          stub_server_configuration(:server => {:timezone => "Eastern Time (US & Canada)"})
-
-          user = FactoryGirl.create(:user)
-          subject.get_timezone_for_userid(user).should == "Eastern Time (US & Canada)"
-        end
-
-        it "without a system default" do
-          stub_server_configuration({})
-
-          user = FactoryGirl.create(:user)
-          subject.get_timezone_for_userid(user).should eq("UTC")
-        end
-      end
-    end
-  end
 end

--- a/spec/controllers/application_controller/timezone_spec.rb
+++ b/spec/controllers/application_controller/timezone_spec.rb
@@ -1,19 +1,9 @@
 require "spec_helper"
-require 'vmdb_helper'
 
-describe Vmdb::GlobalMethods do
+describe ApplicationController, "#Timezone" do
   before do
     _, @server, _ = EvmSpecHelper.create_guid_miq_server_zone
-    class TestClass
-      include Vmdb::GlobalMethods
-    end
   end
-
-  after do
-    Object.send(:remove_const, :TestClass)
-  end
-
-  subject { TestClass.new }
 
   context "#get_timezone_offset" do
     context "for a server" do

--- a/spec/lib/vmdb/global_methods_spec.rb
+++ b/spec/lib/vmdb/global_methods_spec.rb
@@ -33,7 +33,7 @@ describe Vmdb::GlobalMethods do
 
     context "for a user" do
       it "who doesn't exist" do
-        subject.get_timezone_offset("missing").should == 0.hours
+        subject.get_timezone_offset(nil).should == 0.hours
       end
 
       it "with a timezone" do

--- a/spec/lib/vmdb/global_methods_spec.rb
+++ b/spec/lib/vmdb/global_methods_spec.rb
@@ -109,8 +109,4 @@ describe Vmdb::GlobalMethods do
       end
     end
   end
-
-  def stub_server_configuration(config)
-    allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => config))
-  end
 end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -316,6 +316,18 @@ describe MiqServer do
           @miq_server.validate_active_messages([@worker.id])
         end
       end
+
+      context "#server_timezone" do
+        it "utc with no system default" do
+          stub_server_configuration(:server => {:timezone => nil})
+          expect(@miq_server.server_timezone).to eq("UTC")
+        end
+
+        it "uses system default" do
+          stub_server_configuration(:server => {:timezone => "Eastern Time (US & Canada)"})
+          expect(@miq_server.server_timezone).to eq("Eastern Time (US & Canada)")
+        end
+      end
     end
 
     context "with server roles" do

--- a/spec/models/mixins/timezone_mixin_spec.rb
+++ b/spec/models/mixins/timezone_mixin_spec.rb
@@ -21,13 +21,8 @@ describe TimezoneMixin do
   end
 
   context ".server_timezone" do
-    it "default" do
-      Hash.any_instance.stub(:fetch_path).and_return(nil)
-      TestClass.server_timezone.should == "UTC"
-    end
-
     it "server default" do
-      Hash.any_instance.stub(:fetch_path).and_return("Eastern Time (US & Canada)")
+      expect(MiqServer).to receive(:my_server).and_return(double(:server_timezone => "Eastern Time (US & Canada)"))
       TestClass.server_timezone.should == "Eastern Time (US & Canada)"
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   config.include AuthHelper,  :type => :helper
   config.include AuthRequestHelper, :type => :request
   config.include UiConstants, :type => :view
+  config.include ConfigurationHelper
 
   config.include AutomationSpecHelper, :type => :automation
   config.include PresenterSpecHelper, :type => :presenter, :example_group => {

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -1,0 +1,5 @@
+module ConfigurationHelper
+  def stub_server_configuration(config)
+    allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => config))
+  end
+end


### PR DESCRIPTION
There is no reason to put these timezone methods into the global namespace, since:

a) they are only used by controllers
b) the old form was not usable by models.

They have been moved into the controllers.

This is the last in a series of changes to remove access to `session[:userid]` from the timezone lookups.

Before:

- `global_methods.rb` had `timezone` lookup helpers.
- They were only used in controllers
- timezone for the `current_user` was looked up from multiple locations in multiple ways

After:

- move timezone lookup helpers from global_methods to `application_controller/timezone`.
- consistent lookup for current user and server's timezone.

Punt:

- convert `format_in_timezone` to rails's mechanism.
- Make 'current user timezone' just use `Time.zone`.
- remove a bunch of formatters that could just call `time.to_s(:format)`
- fix parser to not change Time.zone temporarily.