### PR TITLE
Session group

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -58,12 +58,11 @@ module ApplicationController::CurrentUser
   protected :current_userid
 
   def current_group
-    @current_group ||= MiqGroup.find_by_id(session[:group])
+    current_user.current_group
   end
 
-  # current_group.id
   def current_groupid
-    session[:group]
+    current_user.current_group.id
   end
   protected :current_groupid
 

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -30,19 +30,19 @@ module ApplicationController::CurrentUser
 
   def current_role
     @current_role ||= begin
-      role = current_group.try(:miq_user_role)
+      role = current_user.try(:miq_user_role)
       role.try(:read_only?) ? role.name.split("-").last : ""
     end
   end
   protected :current_role
 
   def admin_user?
-    %w(super_administrator administrator).include?(current_role)
+    current_user.admin_user?
   end
   protected :admin_user?
 
   def super_admin_user?
-    current_role == "super_administrator"
+    current_user.super_admin_user?
   end
   protected :super_admin_user?
 

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -454,7 +454,7 @@ module ApplicationController::Explorer
       if user.super_admin_user?
         roles = MiqGroup.all
       else
-        roles = [MiqGroup.find_by_id(user.current_group_id)]
+        roles = [user.current_group]
       end
       return options[:count_only] ? roles.count : roles.sort_by { |a| a.name.downcase }
     when :schedules


### PR DESCRIPTION
reducing the number of methods available on the controllers.

Mostly focus on using `current_user.current_group` rather than `session[:group]`, which was set from `current_user.current_group` at login.

