### PR TITLE
Added image relationship for container UI

### DIFF
--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -4,22 +4,18 @@ module ContainerHelper::TextualSummary
   #
 
   def textual_group_properties
-    items = %w(image name state restart_count backing_ref image_ref)
+    items = %w(name state restart_count backing_ref)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
   def textual_group_relationships
-    items = %w(ems container_replicator container_group container_project)
+    items = %w(ems container_project container_replicator container_group container_image)
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
   #
   # Items
   #
-
-  def textual_image
-    {:label => "Image", :value => @record.container_image.name}
-  end
 
   def textual_name
     {:label => "Name", :value => @record.name}
@@ -35,9 +31,5 @@ module ContainerHelper::TextualSummary
 
   def textual_backing_ref
     {:label => "Backing Ref (Container ID)", :value => @record.backing_ref}
-  end
-
-  def textual_image_ref
-    {:label => "Image Ref (Image ID)", :value => @record.container_image.image_ref}
   end
 end

--- a/product/views/Container.yaml
+++ b/product/views/Container.yaml
@@ -20,23 +20,26 @@ db: Container
 # Columns to fetch from the main table
 cols:
 - name
-- image
 
 # Included tables (joined, has_one, has_many) and columns
 include:
   container_group:
     columns:
     - name
+  container_image:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
   :container_group: {}
+  :container_image: {}
 
 # Order of columns (from all tables)
 col_order: 
 - name
 - container_group.name
-- image
+- container_image.name
 
 # Column titles, in order
 headers:
@@ -54,7 +57,7 @@ order: Ascending
 sortby:
 - name
 - container_group.name
-- image
+- container_image.name
 
 # Group rows (y=yes,n=no,c=count)
 group: n


### PR DESCRIPTION

![continer_image_relationship](https://cloud.githubusercontent.com/assets/11256940/9193529/c88d2302-401c-11e5-8665-b11f2cbe3ac4.png)
![container_image_missing_field](https://cloud.githubusercontent.com/assets/11256940/9195886/eb6d10a0-402e-11e5-8e41-ce813ea727e8.png)

![container_image_missing_field](https://cloud.githubusercontent.com/assets/11256940/9193555/f73f1c14-401c-11e5-8f9f-2913ceb35562.png)

* Removed 'image' and 'image_ref' from container UI and added container_image relationship
* Fixed missing image field in 'All containers' table


@abonas @simon3z Please review