### PR TITLE
Corrected Ruby interpretation in Service Catalogs partial

### DIFF
--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -25,14 +25,14 @@
             %label.col-md-2.control-label
               = _('Name')
             .col-md-8
-              @record.name
+              = @record.name
           .form-group
             %label.col-md-2.control-label
               = _('Description')
             .col-md-8
-              @record.description
+              = @record.description
           .form-group
             %label.col-md-2.control-label
               = _('Long Description')
             .col-md-8
-              @record.long_description.to_s.html_safe
+              = @record.long_description.to_s.html_safe


### PR DESCRIPTION
introduced by changes in #3446.

Before:

![screenshot-localhost 3000 2015-08-11 11-54-53](https://cloud.githubusercontent.com/assets/1187051/9195019/0112a4ce-4020-11e5-91e4-409cb4289bc2.png)
After:

![screenshot-localhost 3000 2015-08-11 11-53-36](https://cloud.githubusercontent.com/assets/1187051/9195020/0222c272-4020-11e5-8860-09aa13e9e4c9.png)

@PanSpagetka can you review?