### PR TITLE
Corrected fields in Control Action editor

### DIFF
--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -3,12 +3,12 @@
 - ae_custom_button  ||= false
 - rec_id = @edit && @edit[:action_id].present? ? @edit[:action_id] : "new"
 - url    = url_for(:action => field_changed_url, :id => rec_id)
-%hr
-%h3= _("Object Details")
-%table.style1
-  - if form_action == "ae_resolve"
+- if form_action == "ae_resolve"
+  %hr
+  %h3= _("Object Details")
+  %table.style1
     %tr
-      %td.key= _("System/Process/")
+      %td.key= _("System/Process")
       %td
         = select_tag('instance_name',
                      options_for_select(resolve[:instance_names].sort_by(&:downcase),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1229420

It seems to me that field `Object Details` should be visible only in `Automate → Simulation` tab, so I moved title under the condition.


Before:


![screenshot-localhost 3000 2015-08-11 14-46-06](https://cloud.githubusercontent.com/assets/1187051/9197808/caa0dcea-4037-11e5-8162-a02a09a17461.png)


After:


![screenshot-localhost 3000 2015-08-11 14-45-31](https://cloud.githubusercontent.com/assets/1187051/9197806/c99ba532-4037-11e5-9d39-43f4adc06af6.png)

@h-kataria please review

