### PR TITLE
Added model support to determine if Smartstate Analysis is supported.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1167,6 +1167,7 @@ class ApplicationHelper::ToolbarBuilder
               "vm_retire", "vm_retire_now"
         return "#{@record.kind_of?(ManageIQ::Providers::CloudManager::Vm) ? "Instance" : "VM"} is already retired" if @record.retired == true
       when "vm_scan", "instance_scan"
+        return @record.is_available_now_error_message(:smartstate_analysis) unless @record.is_available?(:smartstate_analysis)
         return @record.active_proxy_error_message if !@record.has_active_proxy?
       when "vm_timeline"
         return "No Timeline data has been collected for this VM" unless @record.has_events? || @record.has_events?(:policy_events)

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -55,4 +55,8 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
   def validate_migrate
     validate_supported
   end
+
+  def validate_smartstate_analysis
+    validate_unsupported("Smartstate Analysis")
+  end
 end

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -32,4 +32,8 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   def raise_created_event
     MiqEvent.raise_evm_event(self, "vm_create", :vm => self)
   end
+
+  def validate_smartstate_analysis
+    validate_supported
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -74,4 +74,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   def validate_migrate
     validate_supported
   end
+
+  def validate_smartstate_analysis
+    validate_supported
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -43,4 +43,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   def validate_migrate
     validate_unsupported("Migrate")
   end
+
+  def validate_smartstate_analysis
+    validate_supported
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -31,6 +31,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     validate_supported
   end
 
+  def validate_smartstate_analysis
+    validate_supported
+  end
+
   #
   # Show Reconfigure VM task
   def reconfigurable?

--- a/product/toolbars/x_vm_cloud_center_tb.yaml
+++ b/product/toolbars/x_vm_cloud_center_tb.yaml
@@ -19,8 +19,8 @@
     - :button: instance_scan
       :image: scan
       :text: "Perform SmartState Analysis"
-      :title: "Perform SmartState Analysis on this Image"
-      :confirm: "Perform SmartState Analysis on this Image?"
+      :title: "Perform SmartState Analysis on this Instance"
+      :confirm: "Perform SmartState Analysis on this Instance?"
     - :separator:
     - :button: instance_edit
       :image: edit

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2325,6 +2325,7 @@ describe ApplicationHelper do
       context "and id = vm_scan" do
         before do
           @id = "vm_scan"
+          @record = FactoryGirl.create(:vm_vmware, :vendor => "vmware")
           @record.stub(:has_active_proxy? => true)
         end
         it "when no active proxy" do
@@ -2332,6 +2333,16 @@ describe ApplicationHelper do
           subject.should == "No active SmartProxies found to analyze this VM"
         end
         it_behaves_like 'default case'
+      end
+
+      context "and id = instance_scan" do
+        before do
+          @id = "instance_scan"
+          @record = FactoryGirl.create(:vm_amazon, :vendor => "amazon")
+          @record.stub(:has_active_proxy? => true)
+        end
+        before { @record.stub(:is_available?).with(:smartstate_analysis).and_return(false) }
+        it_behaves_like 'record with error message', 'smartstate_analysis'
       end
 
       context "and id = vm_timeline" do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -455,6 +455,18 @@ describe VmOrTemplate do
     end
   end
 
+  context "#is_available? for Smartstate Analysis" do
+    it "returns true for VMware VM" do
+      vm =  FactoryGirl.create(:vm_vmware)
+      expect(vm.is_available?(:smartstate_analysis)).to eq(true)
+    end
+
+    it "returns false for Amazon VM" do
+      vm =  FactoryGirl.create(:vm_amazon)
+      expect(vm.is_available?(:smartstate_analysis)).to_not eq(true)
+    end
+  end
+
   context "#self.batch_operation_supported?" do
     it "when the vm_or_template supports migrate,  returns false" do
       vm1 =  FactoryGirl.create(:vm_microsoft)


### PR DESCRIPTION
Added model support to determine if Smartstate Analysis button is supported for VM/Instances, added a check in toolbar code to display a hover message when button is disabled and not supported for certain types of VM/Instance.

https://bugzilla.redhat.com/show_bug.cgi?id=1240337
https://bugzilla.redhat.com/show_bug.cgi?id=1245717

@dclarizio please review

before screenshot of an Amazon Instance:
![smartstate_analysis_button_before_fix](https://cloud.githubusercontent.com/assets/3450808/9203734/d2aa3c8a-4026-11e5-89c7-85640f8b995b.png)

after screenshot of an Amazon Instance:
![smartstate_analysis_button_after_fix](https://cloud.githubusercontent.com/assets/3450808/9203736/da519c76-4026-11e5-9186-400c08bf700d.png)
