### PR TITLE
Set datepicker date format to month/day/year

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -244,7 +244,7 @@ module ApplicationController::CiProcessing
     end
     obj = kls.find_by_id(params[:id])
     render :json => {
-      :retirement_date    => obj.retires_on,
+      :retirement_date    => obj.retires_on.strftime('%m/%d/%Y'),
       :retirement_warning => obj.retirement_warn
     }
   end

--- a/app/helpers/application_helper/form_tags.rb
+++ b/app/helpers/application_helper/form_tags.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
       datepicker_options = {
         "data-provide"         => "datepicker",
         "data-date-autoclose"  => "true",
-        "data-date-format"     => "yyyy-mm-dd",
+        "data-date-format"     => "mm/dd/yyyy",
         "data-date-language"   => FastGettext.locale,
         "data-date-week-start" => 0
       }

--- a/spec/javascripts/controllers/retirement/retirement_form_controller_spec.js
+++ b/spec/javascripts/controllers/retirement/retirement_form_controller_spec.js
@@ -21,7 +21,7 @@ describe('retirementFormController', function() {
 
   beforeEach(inject(function(_$controller_) {
     var retirementFormResponse = {
-      retirement_date: '2015-12-31',
+      retirement_date: '12/31/2015',
       retirement_warning: '0'
     };
     $httpBackend.whenGET('retirement_info/1000000000001').respond(retirementFormResponse);
@@ -35,7 +35,7 @@ describe('retirementFormController', function() {
 
   describe('initialization', function() {
     it('sets the retirementDate to the value returned with http request', function() {
-      expect($scope.retirementInfo.retirementDate).toEqual('2015-12-31');
+      expect($scope.retirementInfo.retirementDate).toEqual('12/31/2015');
     });
 
     it('sets the retirementWarning to the value returned with http request', function() {


### PR DESCRIPTION
Currently, our application assumes mm/dd/yyyy date format in many
places, so the datepicker needs to honor that.

Setting datepicker to iso format (yyyy-mm-dd) and at the same time
setting the element value with a date in mm/dd/yyyy format would
break datepicker functionality.