### PR TITLE
BZ1248039 - Fix being unable to import to a new Automate Domain any custom domains exist

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -90,7 +90,10 @@ class MiqAeToolsController < ApplicationController
     drop_breadcrumb( {:name=>"Import / Export", :url=>"/miq_ae_tools/import_export"} )
     @lastaction = "import_export"
     @layout = "miq_ae_export"
-    @importable_domain_options = MiqAeDomain.all_unlocked.collect { |domain| [domain.name, domain.name] }
+    @importable_domain_options = [["<Same as import from>", nil]]
+    MiqAeDomain.all_unlocked.collect do |domain|
+      @importable_domain_options << [domain.name, domain.name]
+    end
     render :action=>"show"
   end
 

--- a/app/services/automate_import_service.rb
+++ b/app/services/automate_import_service.rb
@@ -12,7 +12,7 @@ class AutomateImportService
                        namespace_or_class_list)
     File.open("automate_temporary_zip.zip", "wb") { |file| file.write(import_file_upload.binary_blob.binary) }
     import_options = {
-      "import_as" => domain_name_to_import_to,
+      "import_as" => domain_name_to_import_to.presence || domain_name_to_import_from,
       "overwrite" => true,
       "zip_file"  => "automate_temporary_zip.zip"
     }

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -20,6 +20,26 @@ describe MiqAeToolsController do
     end
   end
 
+  describe "#import_export" do
+    include_context "valid session"
+
+    let(:fake_domain) { active_record_instance_double("MiqAeDomain", :name => "test_domain") }
+
+    before do
+      bypass_rescue
+      MiqAeDomain.stub(:all_unlocked).and_return([fake_domain])
+    end
+
+    it "includes a list of importable domain options" do
+      get :import_export
+
+      expect(assigns(:importable_domain_options)).to eq([
+        ["<Same as import from>", nil],
+        %w(test_domain test_domain)
+      ])
+    end
+  end
+
   describe "#cancel_import" do
     include_context "valid session"
 

--- a/spec/services/automate_import_service_spec.rb
+++ b/spec/services/automate_import_service_spec.rb
@@ -86,6 +86,18 @@ describe AutomateImportService do
         "import stats"
       )
     end
+
+    context "when the domain name to import to is blank" do
+      it "creates a new MiqAeImport with the correct import options" do
+        expect(MiqAeImport).to receive(:new).with(
+          "carrot",
+          "import_as" => "carrot",
+          "overwrite" => true,
+          "zip_file"  => "automate_temporary_zip.zip"
+        ).and_return(miq_ae_import)
+        automate_import_service.import_datastore(import_file_upload, "carrot", "", ["starch"])
+      end
+    end
   end
 
   describe "#store_for_import" do


### PR DESCRIPTION
This fix allows the user to specify that the namespaces they've selected will be imported into a new domain with the same name as the domain they've selected from the import.

https://bugzilla.redhat.com/show_bug.cgi?id=1248039