### PR TITLE
Allow #ci_to_hash_struct to work with ActiveRecord Association CollectionProxy instances

### DIFF
--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -13,6 +13,9 @@ class ConfiguredSystem < ActiveRecord::Base
   belongs_to :operating_system_flavor
   has_and_belongs_to_many :configuration_tags
 
+  alias_attribute :name,    :hostname
+  alias_method    :manager, :configuration_manager
+
   delegate :name, :to => :configuration_profile,         :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_compute_profile, :prefix => true, :allow_nil => true
@@ -62,14 +65,9 @@ class ConfiguredSystem < ActiveRecord::Base
     @tag_hash ||= configuration_tags.index_by(&:class)
   end
 
-  alias_method :manager, :configuration_manager
-
   def self.common_configuration_profiles_for_selected_configured_systems(ids)
     hosts = includes(:configuration_location, :configuration_organization).where(:id => ids)
     hosts.collect(&:available_configuration_profiles).inject(:&).presence
   end
 
-  def name
-    hostname
-  end
 end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1017,12 +1017,6 @@ class MiqRequestWorkflow
     v
   end
 
-  def default_ci_to_hash_struct(ci)
-    attributes = []
-    attributes << :name if ci.respond_to?(:name)
-    build_ci_hash_struct(ci, attributes)
-  end
-
   def ems_folder_to_hash_struct(ci)
     build_ci_hash_struct(ci, [:name, :is_datacenter?])
   end
@@ -1486,5 +1480,13 @@ class MiqRequestWorkflow
       _log.error "<#{err_text}>"
       raise err_text
     end
+  end
+
+  private
+
+  def default_ci_to_hash_struct(ci)
+    attributes = []
+    attributes << :name if ci.respond_to?(:name)
+    build_ci_hash_struct(ci, attributes)
   end
 end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1000,8 +1000,8 @@ class MiqRequestWorkflow
   end
 
   def ci_to_hash_struct(ci)
-    return ci.collect { |c| ci_to_hash_struct(c) } if ci.kind_of?(Array)
     return if ci.nil?
+    return ci.collect { |c| ci_to_hash_struct(c) } if ci.respond_to?(:collect)
     method_name = "#{ci.class.base_class.name.underscore}_to_hash_struct".to_sym
     return send(method_name, ci) if respond_to?(method_name, true)
     default_ci_to_hash_struct(ci)

--- a/spec/factories/configured_system.rb
+++ b/spec/factories/configured_system.rb
@@ -1,1 +1,5 @@
-FactoryGirl.define { factory :configured_system }
+FactoryGirl.define do
+  factory :configured_system do
+    sequence(:name) { |n| "Configured_system_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -85,7 +85,7 @@ describe MiqProvisionVirtWorkflow do
                                       :host_id => @host1.id)
         workflow.instance_variable_set(:@target_resource,
                                        :host    => workflow.host_to_hash_struct(@host1),
-                                       :ems     => workflow.default_ci_to_hash_struct(@ems),
+                                       :ems     => workflow.ci_to_hash_struct(@ems),
                                        :host_id => @host1.id)
         dvs = workflow.allowed_dvs({}, nil)
         dvs.should eql(@host1_dvs_hash)
@@ -117,7 +117,7 @@ describe MiqProvisionVirtWorkflow do
                                         :placement_auto => false)
           workflow.instance_variable_set(:@target_resource,
                                          :host    => workflow.host_to_hash_struct(@host1),
-                                         :ems     => workflow.default_ci_to_hash_struct(@ems),
+                                         :ems     => workflow.ci_to_hash_struct(@ems),
                                          :host_id => @host1.id)
           dvs = workflow.allowed_dvs({}, nil)
           dvs.should eql(@host1_dvs_hash)


### PR DESCRIPTION
When trying to provision VMware with a customization spec, you would receive:
```
[----] I, [2015-08-11T12:26:30.986892 #6446:3fc194f5798c]  INFO -- : Started POST "/miq_request/prov_field_changed/new" for 127.0.0.1 at 2015-08-11 12:26:30 -0400
[----] I, [2015-08-11T12:26:31.042238 #6446:3fc194f5798c]  INFO -- : Processing by MiqRequestController#prov_field_changed as JS
[----] I, [2015-08-11T12:26:31.042446 #6446:3fc194f5798c]  INFO -- :   Parameters: {"customize__sysprep_enabled"=>"fields", "id"=>"new"}
[----] F, [2015-08-11T12:26:31.095232 #6446:3fc194f5798c] FATAL -- : Error caught: [NoMethodError] undefined method `base_class' for CustomizationSpec::ActiveRecord_Associations_CollectionProxy:Class
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:1005:in `ci_to_hash_struct'
/home/bdunne/projects/redhat/manageiq/app/models/miq_provision_virt_workflow.rb:677:in `allowed_customization_specs'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:294:in `get_field'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:281:in `block in get_all_fields'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:281:in `each_key'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:281:in `get_all_fields'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:273:in `get_dialog'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:265:in `block in get_all_dialogs'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:265:in `each_key'
/home/bdunne/projects/redhat/manageiq/app/models/miq_request_workflow.rb:265:in `get_all_dialogs'
/home/bdunne/projects/redhat/manageiq/app/controllers/application_controller/miq_request_methods.rb:30:in `block in prov_field_changed'
/home/bdunne/.gem/ruby/2.2.2/bundler/gems/jquery-rjs-33e0fc1c0b25/lib/action_view/helpers/jquery_helper.rb:154:in `instance_exec'
/home/bdunne/.gem/ruby/2.2.2/bundler/gems/jquery-rjs-33e0fc1c0b25/lib/action_view/helpers/jquery_helper.rb:154:in `block in initialize'
/home/bdunne/.gem/ruby/2.2.2/gems/actionview-4.2.3/lib/action_view/helpers/capture_helper.rb:202:in `with_output_buffer'
/home/bdunne/.gem/ruby/2.2.2/bundler/gems/jquery-rjs-33e0fc1c0b25/lib/action_view/helpers/jquery_helper.rb:153:in `initialize'
/home/bdunne/.gem/ruby/2.2.2/bundler/gems/jquery-rjs-33e0fc1c0b25/lib/jquery-rjs/renderers.rb:7:in `new'
/home/bdunne/.gem/ruby/2.2.2/bundler/gems/jquery-rjs-33e0fc1c0b25/lib/jquery-rjs/renderers.rb:7:in `block in <module:Renderers>'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/renderers.rb:45:in `block in _render_to_body_with_renderer'
/home/bdunne/.rubies/ruby-2.2.2/lib/ruby/2.2.0/set.rb:283:in `each_key'
/home/bdunne/.rubies/ruby-2.2.2/lib/ruby/2.2.0/set.rb:283:in `each'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/renderers.rb:41:in `_render_to_body_with_renderer'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/renderers.rb:37:in `render_to_body'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/rendering.rb:25:in `render'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/rendering.rb:16:in `render'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
/home/bdunne/.rubies/ruby-2.2.2/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/benchmark.rb:12:in `ms'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:44:in `block in render'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/railties/controller_runtime.rb:25:in `cleanup_view_runtime'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:43:in `render'
/home/bdunne/projects/redhat/manageiq/app/controllers/application_controller/miq_request_methods.rb:28:in `prov_field_changed'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/base.rb:198:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/rendering.rb:10:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:115:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:115:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:553:in `block (2 levels) in compile'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:503:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:503:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:88:in `run_callbacks'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/callbacks.rb:19:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/rescue.rb:29:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/notifications.rb:164:in `block in instrument'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/notifications.rb:164:in `instrument'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/base.rb:137:in `process'
/home/bdunne/.gem/ruby/2.2.2/gems/actionview-4.2.3/lib/action_view/rendering.rb:30:in `process'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal.rb:196:in `dispatch'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal.rb:237:in `block in action'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:76:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:76:in `dispatch'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:45:in `serve'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/journey/router.rb:43:in `block in serve'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/journey/router.rb:30:in `each'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/journey/router.rb:30:in `serve'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:821:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/etag.rb:24:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/conditionalget.rb:38:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/params_parser.rb:27:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/flash.rb:260:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:225:in `context'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:220:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/cookies.rb:560:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/query_cache.rb:36:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:84:in `run_callbacks'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/reloader.rb:73:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/rack/logger.rb:38:in `call_app'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/rack/logger.rb:22:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/request_store-1.1.0/lib/request_store/middleware.rb:8:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/request_id.rb:21:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/methodoverride.rb:22:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/runtime.rb:18:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/lock.rb:17:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/static.rb:116:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/sendfile.rb:113:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:518:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/application.rb:165:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:86:in `block in pre_process'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:84:in `catch'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:84:in `pre_process'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:53:in `process'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:39:in `receive_data'
/home/bdunne/.gem/ruby/2.2.2/gems/eventmachine-1.0.7/lib/eventmachine.rb:187:in `run_machine'
/home/bdunne/.gem/ruby/2.2.2/gems/eventmachine-1.0.7/lib/eventmachine.rb:187:in `run'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/backends/base.rb:73:in `start'
/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/server.rb:162:in `start'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/handler/thin.rb:19:in `run'
/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/server.rb:286:in `start'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/server.rb:80:in `start'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:80:in `block in server'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:75:in `tap'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:75:in `server'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands.rb:17:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
[----] I, [2015-08-11T12:26:31.138687 #6446:3fc194f5798c]  INFO -- :   Rendered layouts/_exception_contents.html.haml (11.7ms)
[----] I, [2015-08-11T12:26:31.139307 #6446:3fc194f5798c]  INFO -- : Completed 200 OK in 97ms (Views: 42.6ms | ActiveRecord: 4.4ms)
```

An ActiveRecord::Associations::CollectionProxy instance was being passed in.  It is not a ```kind_of?(Array)```, but does ```respond_to?(:collect)```, so I updated the method accordingly.