### PR TITLE
Allow MiqHashStruct to properly respond to :try

### DIFF
--- a/gems/pending/spec/util/miq-hash_struct_spec.rb
+++ b/gems/pending/spec/util/miq-hash_struct_spec.rb
@@ -109,4 +109,17 @@ describe MiqHashStruct do
       test_struct.should_not == "string"
     end
   end
+
+  context "#try" do
+    let(:hs) { MiqHashStruct.new(:id => 1) }
+
+    it("with existing key") { expect(hs.try(:id)).to        eq(1) }
+    it("with missing key")  { expect(hs.try(:abc)).to       be_nil }
+    it("with :object_id")   { expect(hs.try(:object_id)).to be_kind_of(Integer) }
+
+    it "storing data" do
+      hs.try(:abc=, 123)
+      expect(hs.to_hash[:abc]).to eq(123)
+    end
+  end
 end

--- a/gems/pending/util/miq-hash_struct.rb
+++ b/gems/pending/util/miq-hash_struct.rb
@@ -52,4 +52,10 @@ class MiqHashStruct
       @hash[m]
     end
   end
+
+  private
+
+  def respond_to_missing?(*)
+    true
+  end
 end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -191,7 +191,7 @@ describe MiqRequestWorkflow do
 
       it "with valid sources" do
         FactoryGirl.create(:resource_pool)
-        allow(workflow).to receive(:get_source_and_targets).and_return(:ems => ems)
+        allow(workflow).to receive(:get_source_and_targets).and_return(:ems => workflow.ci_to_hash_struct(ems))
 
         expect(workflow).to receive(:allowed_ci).with(:respool, [:cluster, :host, :folder], [resource_pool.id])
 


### PR DESCRIPTION
Before:
```
irb(main):001:0> require './gems/pending/util/miq-hash_struct'
=> true
irb(main):002:0> hs = MiqHashStruct.new(:id => 1)
=> #<MiqHashStruct:0x007f8a52c41088 @hash={:id=>1}, @key_type=Symbol>
irb(main):003:0> hs.try(:id)
=> nil
irb(main):004:0> hs.id
=> 1
irb(main):005:0> hs.abc
=> nil
```

After:
```
irb(main):001:0> require './gems/pending/util/miq-hash_struct'
=> true
irb(main):002:0> hs = MiqHashStruct.new(:id => 1)
=> #<MiqHashStruct:0x007f049534d2a8 @hash={:id=>1}, @key_type=Symbol>
irb(main):003:0> hs.try(:id)
=> 1
irb(main):004:0> hs.id
=> 1
irb(main):005:0> hs.abc
=> nil
```
https://bugzilla.redhat.com/show_bug.cgi?id=1250087