### PR TITLE
auth: support default authentication per provider

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -18,6 +18,10 @@ module AuthenticationMixin
     %w(userid password)
   end
 
+  def default_authentication_type
+    :default
+  end
+
   def authentication_userid_passwords
     authentications.select { |a| a.kind_of?(AuthUseridPassword) }
   end
@@ -271,7 +275,7 @@ module AuthenticationMixin
 
   def authentication_best_fit(type = nil)
     # Look for the supplied type and if that is not found return the default credentials
-    authentication_type(type) || authentication_type(:default)
+    authentication_type(type) || authentication_type(default_authentication_type)
   end
 
   def authentication_component(type, method)

--- a/app/models/mixins/kubernetes_provider_mixin.rb
+++ b/app/models/mixins/kubernetes_provider_mixin.rb
@@ -59,4 +59,8 @@ module KubernetesProviderMixin
     return if authentications.present?
     update_authentication(:default => {:userid => "_", :save => false})
   end
+
+  def default_authentication_type
+    :token
+  end
 end


### PR DESCRIPTION
Some providers (e.g. kubernetes/openshift) require a different default authentication type.

This PR is part of the series needed to get the workers up and running again.

cc @chessbyte @Fryguy @blomquisg @abonas @oschreib 