### PR TITLE
containers: fix event monitor authentication

### DIFF
--- a/gems/pending/kubernetes/events/kubernetes_event_monitor.rb
+++ b/gems/pending/kubernetes/events/kubernetes_event_monitor.rb
@@ -1,15 +1,11 @@
 class KubernetesEventMonitor
-  def initialize(api_endpoint, api_version)
-    @api_endpoint = api_endpoint
-    @api_version = api_version
+  def initialize(ems)
+    @ems = ems
   end
 
   def inventory
-    require 'kubeclient'
-    @inventory ||= Kubeclient::Client.new(@api_endpoint, @api_version)
-    # TODO: support real authentication using certificates
-    @inventory.ssl_options(:verify_ssl => OpenSSL::SSL::VERIFY_NONE)
-    @inventory
+    # :service is required to handle also the case where @ems is Openshift
+    @inventory ||= @ems.connect(:service => EmsKubernetes.ems_type)
   end
 
   def watcher(version = nil)

--- a/lib/workers/mixins/event_catcher_kubernetes_mixin.rb
+++ b/lib/workers/mixins/event_catcher_kubernetes_mixin.rb
@@ -3,10 +3,7 @@ module EventCatcherKubernetesMixin
 
   def event_monitor_handle
     require 'kubernetes/events/kubernetes_event_monitor'
-    @event_monitor_handle ||= KubernetesEventMonitor.new(
-      @ems.api_endpoint,
-      @ems.api_version
-    )
+    @event_monitor_handle ||= KubernetesEventMonitor.new(@ems)
   end
 
   def reset_event_monitor_handle


### PR DESCRIPTION
Since we added support for authentication uri and api version are not enough anymore to connect to kubernetes and openshift.

This patch reuses the ems connect method (which includes authentication details, etc.) to monitor events as well.

This PR is part of the series needed to get the event worker up and running again.

cc @chessbyte @Fryguy @blomquisg @abonas @oschreib