### PR TITLE
Rename db from EmsEvent to EventStream in report.

### DIFF
--- a/product/reports/420_Operations - Clusters/010_Cluster - DRS migrations.yaml
+++ b/product/reports/420_Operations - Clusters/010_Cluster - DRS migrations.yaml
@@ -33,7 +33,7 @@ db_options: {}
 col_formats: 
 include: {}
 
-db: EmsEvent
+db: EventStream
 cols: 
 - ems_cluster_name
 - vm_name

--- a/product/reports/421_Operations - Events/VC Snapshot Events by User.yaml
+++ b/product/reports/421_Operations - Events/VC Snapshot Events by User.yaml
@@ -40,7 +40,7 @@ include:
   vm: 
     columns: 
     - v_total_snapshots
-db: EmsEvent
+db: EventStream
 cols: 
 - username
 - vm_name

--- a/product/reports/425_VM Sprawl - Candidates/059_Summary of VM Create and Deletes.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/059_Summary of VM Create and Deletes.yaml
@@ -56,7 +56,7 @@ include:
   ext_management_system: 
     columns: 
     - name
-db: EmsEvent
+db: EventStream
 cols: 
 - vm_name
 - host_name

--- a/product/reports/500_Events - Operations/110_vm_operational_vm_power.yaml
+++ b/product/reports/500_Events - Operations/110_vm_operational_vm_power.yaml
@@ -16,7 +16,7 @@ title: "Operations VM Power On/Off Events for Last Week"
 menu_name: "Operations VMs Powered On/Off for Last Week"
 
 # Main DB table report is based on
-db: EmsEvent
+db: EventStream
 
 # Columns to fetch from the main table
 cols:

--- a/product/reports/500_Events - Operations/120_Events_for_VM_prod_webserver.yaml
+++ b/product/reports/500_Events - Operations/120_Events_for_VM_prod_webserver.yaml
@@ -24,7 +24,7 @@ rpt_type: Custom
 filename: 
 include: {}
 
-db: EmsEvent
+db: EventStream
 cols: 
 - username
 - event_type

--- a/product/reports/500_Events - Operations/130_Reconfigure_Events_by_Department.yaml
+++ b/product/reports/500_Events - Operations/130_Reconfigure_Events_by_Department.yaml
@@ -29,7 +29,7 @@ include:
       managed: 
         columns: 
         - department
-db: EmsEvent
+db: EventStream
 cols: 
 - vm_name
 - timestamp

--- a/product/reports/500_Events - Operations/140_VC_Events_initiated_by_username_EVM.yaml
+++ b/product/reports/500_Events - Operations/140_VC_Events_initiated_by_username_EVM.yaml
@@ -24,7 +24,7 @@ rpt_type: Custom
 filename: 
 include: {}
 
-db: EmsEvent
+db: EventStream
 cols: 
 - event_type
 - vm_name

--- a/product/timelines/miq_reports/tl_events_daily.yaml
+++ b/product/timelines/miq_reports/tl_events_daily.yaml
@@ -15,7 +15,7 @@ title: "Timeline All Events"
 name: "Timeline All Events"
 
 # Main DB table report is based on
-db: EmsEvent
+db: EventStream
 
 # Columns to fetch from the main table
 cols:

--- a/product/timelines/miq_reports/tl_events_hourly.yaml
+++ b/product/timelines/miq_reports/tl_events_hourly.yaml
@@ -15,7 +15,7 @@ title: "Timeline Events Hourly"
 name: "Timeline Events Hourly"
 
 # Main DB table report is based on
-db: EmsEvent
+db: EventStream
 
 # Columns to fetch from the main table
 cols:


### PR DESCRIPTION
The DB table for EmsEvent has been renamed to EventStream in #1527.
This line db: xxx in yaml file is supposed to point to the actual DB table.