### PR TITLE
Refactor session timezone for userid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -908,17 +908,10 @@ class ApplicationController < ActionController::Base
     return datetime.in_time_zone(tz)
   end
 
+  # if authenticating or past login screen
   def set_user_time_zone
-    # if authenticating or past login screen
-    @tz = if session[:userid].present? || params[:user_name].present?
-            get_timezone_for_userid(session[:userid] || params[:user_name])
-          else
-            MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
-          end
-
-    @tz ||= 'UTC'
-
-    session[:user_tz] = Time.zone = @tz
+    user = current_user || (params[:user_name].presence && User.find_by_userid(params[:user_name]))
+    session[:user_tz] = Time.zone = @tz = get_timezone_for_userid(user)
   end
 
   # Initialize the options for server selection

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -72,19 +72,10 @@ module Vmdb
       end
     end
 
-    def get_timezone_for_userid(userid)
-      db_user = User.find_by_userid(userid)
-      if !db_user.blank?
-        if db_user.settings && db_user.settings[:display] && !db_user.settings[:display][:timezone].blank?
-          tz = db_user.settings[:display][:timezone]
-        else
-          tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
-        end
-      else    # if userid is not valid
-        tz = "UTC"
-      end
-
-      tz
+    def get_timezone_for_userid(user = nil)
+      user = User.find_by_userid(user) if user.kind_of?(String)
+      tz = user && user.settings.fetch_path(:display, :timezone).presence
+      tz || MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
     end
 
     #returns formatted time in specified timezone and format

--- a/spec/lib/vmdb/global_methods_spec.rb
+++ b/spec/lib/vmdb/global_methods_spec.rb
@@ -3,6 +3,7 @@ require 'vmdb_helper'
 
 describe Vmdb::GlobalMethods do
   before do
+    _, @server, _ = EvmSpecHelper.create_guid_miq_server_zone
     class TestClass
       include Vmdb::GlobalMethods
     end
@@ -15,10 +16,6 @@ describe Vmdb::GlobalMethods do
   subject { TestClass.new }
 
   context "#get_timezone_offset" do
-    before do
-      _, @server, _ = EvmSpecHelper.create_guid_miq_server_zone
-    end
-
     context "for a server" do
       it "with a system default" do
         stub_server_configuration(:server => {:timezone => "Eastern Time (US & Canada)"})
@@ -67,23 +64,25 @@ describe Vmdb::GlobalMethods do
         it "without a system default" do
           stub_server_configuration({})
 
-          subject.get_timezone_offset("user").should == ActiveSupport::TimeZone.all # TODO: This is most definitely wrong.  Should be 0.hours?
+          subject.get_timezone_offset("user").should == 0.hours
         end
       end
     end
   end
 
   context "#get_timezone_for_userid" do
-    before do
-      _, @server, _ = EvmSpecHelper.create_guid_miq_server_zone
-    end
-
     context "for a user" do
       it "who doesn't exist" do
         subject.get_timezone_for_userid("missing").should == "UTC"
       end
 
       it "with a timezone" do
+        user = FactoryGirl.create(:user, :settings => {:display => {:timezone => "Pacific Time (US & Canada)"}})
+        subject.get_timezone_for_userid(user).should == "Pacific Time (US & Canada)"
+      end
+
+      # currently only used in 1 place
+      it "with name lookup" do
         user = FactoryGirl.create(:user, :settings => {:display => {:timezone => "Pacific Time (US & Canada)"}})
         subject.get_timezone_for_userid(user.userid).should == "Pacific Time (US & Canada)"
       end
@@ -93,21 +92,20 @@ describe Vmdb::GlobalMethods do
           stub_server_configuration(:server => {:timezone => "Eastern Time (US & Canada)"})
 
           user = FactoryGirl.create(:user)
-          subject.get_timezone_for_userid(user.userid).should == "Eastern Time (US & Canada)"
+          subject.get_timezone_for_userid(user).should == "Eastern Time (US & Canada)"
         end
 
         it "without a system default" do
           stub_server_configuration({})
 
           user = FactoryGirl.create(:user)
-          subject.get_timezone_for_userid(user.userid).should be_nil # TODO: Is this correct? Should it be "UTC"?
+          subject.get_timezone_for_userid(user).should eq("UTC")
         end
       end
     end
   end
 
   def stub_server_configuration(config)
-    VMDB::Config.any_instance.stub(:config => config)
-    @server.stub(:get_config => VMDB::Config.new("vmdb"))
+    allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => config))
   end
 end


### PR DESCRIPTION
pulled out of #3793

- simplify `get_timezone_for_userid`
- fix bug where timezone of `"UTC"` came back instead of system default
- fix bug where bogus timezone_offset returned instead of 0.
- set_user_timezone now calls `get_timezone_for_userid` with `current_user`

/cc @chessbyte 
/cc thanks @matthewd 