### PR TITLE
Session timezone offset

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -561,7 +561,7 @@ module OpsController::Diagnostics
   end
 
   def cu_repair_set_form_vars
-    @timezone_offset = get_timezone_offset("server")
+    @timezone_offset = get_timezone_offset
     @in_a_form = true
     @edit ||= Hash.new
     @edit[:new] ||= Hash.new

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -120,7 +120,7 @@ class ReportController < ApplicationController
     @report          = nil
     @edit            = nil
     @timeline        = true
-    @timezone_abbr   = get_timezone_abbr("server")
+    @timezone_abbr   = get_timezone_abbr
     @timezone_offset = get_timezone_offset
     @sb[:select_node] = false
     @sb[:open_tree_nodes] ||= Array.new

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -121,7 +121,7 @@ class ReportController < ApplicationController
     @edit            = nil
     @timeline        = true
     @timezone_abbr   = get_timezone_abbr("server")
-    @timezone_offset = get_timezone_offset("server")
+    @timezone_offset = get_timezone_offset
     @sb[:select_node] = false
     @sb[:open_tree_nodes] ||= Array.new
     @trees = Array.new

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -352,7 +352,7 @@ module ReportController::Dashboards
   end
 
   def db_set_form_vars
-    @timezone_abbr = get_timezone_abbr("server")
+    @timezone_abbr = get_timezone_abbr
     @edit = Hash.new
     @edit[:db_id] = @db.id
     @edit[:read_only] = @db.read_only ? true : false

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -309,7 +309,7 @@ module ReportController::Schedules
 
   # Set form variables for edit
   def schedule_set_form_vars
-    @timezone_abbr = get_timezone_abbr("server")
+    @timezone_abbr = get_timezone_abbr
     @edit = Hash.new
     @folders = Array.new
 

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -309,7 +309,7 @@ module ReportController::Widgets
   end
 
   def widget_set_form_vars
-    @timezone_abbr = get_timezone_abbr("server")
+    @timezone_abbr = get_timezone_abbr
     @edit = Hash.new
     @edit[:widget_id] = @widget.id
     @edit[:read_only] = @widget.read_only ? true : false

--- a/app/views/layouts/_timeline.html.haml
+++ b/app/views/layouts/_timeline.html.haml
@@ -127,5 +127,5 @@
 
 
 -# START of TIMELINE TIMEZONE Code
--# "* Times displayed are in #{get_timezone_offset(current_user, true)} #{get_timezone_abbr("user")} time"
+-# "* Times displayed are in #{get_timezone_offset(current_user, true)} #{get_timezone_abbr(current_user)} time"
 -# END of TIMELINE TIMEZONE Code

--- a/app/views/layouts/_timeline.html.haml
+++ b/app/views/layouts/_timeline.html.haml
@@ -127,5 +127,5 @@
 
 
 -# START of TIMELINE TIMEZONE Code
--# "* Times displayed are in #{get_timezone_offset("user",true)} #{get_timezone_abbr("user")} time"
+-# "* Times displayed are in #{get_timezone_offset(current_user, true)} #{get_timezone_abbr("user")} time"
 -# END of TIMELINE TIMEZONE Code

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -465,7 +465,7 @@
             = options[:start_date]
         </tr><tr>
         %td.key
-          = _("Starting Time (%s)") % get_timezone_abbr("user")
+          = _("Starting Time (%s)") % get_timezone_abbr(current_user)
         %td
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -51,16 +51,11 @@ module Vmdb
       return abbr
     end
 
+    # returns utc_offset of timezone
     def get_timezone_offset(user = nil, formatted = false)
-      # returns utc_offset of timezone
-      if user.nil?
-        tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
-        tz = ActiveSupport::TimeZone::MAPPING[tz.blank? ? "UTC" : tz]
-      else
-        tz = get_timezone_for_userid(user)
-        @tz = tz unless tz.blank?
-        tz = ActiveSupport::TimeZone::MAPPING[@tz]
-      end
+      tz = get_timezone_for_userid(user)
+      @tz = tz if user && tz.present?
+      tz = ActiveSupport::TimeZone::MAPPING[tz]
       ActiveSupport::TimeZone.all.each do  |a|
         if ActiveSupport::TimeZone::MAPPING[a.name] == tz
           if formatted

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -36,9 +36,9 @@ module Vmdb
     end
 
     # Had to add timezone methods here, they are being called from models
-    def get_timezone_abbr(typ="server")
+    def get_timezone_abbr(user = nil)
       # return timezone abbreviation
-      if typ == "server"
+      if user.nil?
         tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
         tz = ActiveSupport::TimeZone::MAPPING[tz.blank? ? "UTC" : tz]
         time = Time.now

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -51,13 +51,13 @@ module Vmdb
       return abbr
     end
 
-    def get_timezone_offset(typ="server",formatted=false)
+    def get_timezone_offset(user = nil, formatted = false)
       # returns utc_offset of timezone
-      if typ == "server"
+      if user.nil?
         tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
         tz = ActiveSupport::TimeZone::MAPPING[tz.blank? ? "UTC" : tz]
       else
-        tz = get_timezone_for_userid(session[:userid])
+        tz = get_timezone_for_userid(user)
         @tz = tz unless tz.blank?
         tz = ActiveSupport::TimeZone::MAPPING[@tz]
       end

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -36,19 +36,16 @@ module Vmdb
     end
 
     # Had to add timezone methods here, they are being called from models
+    # return timezone abbreviation
     def get_timezone_abbr(user = nil)
-      # return timezone abbreviation
       if user.nil?
-        tz = MiqServer.my_server.get_config("vmdb").config.fetch_path(:server, :timezone)
-        tz = ActiveSupport::TimeZone::MAPPING[tz.blank? ? "UTC" : tz]
+        tz = get_timezone_for_userid(nil)
         time = Time.now
       else
         tz = Time.zone
         time = Time.zone.now
       end
-      new_time = time.in_time_zone(tz)
-      abbr = new_time.strftime("%Z")
-      return abbr
+      time.in_time_zone(tz).strftime("%Z")
     end
 
     # returns utc_offset of timezone


### PR DESCRIPTION
**Issue:**

The timezone methods are added to `Object`.
One currently accesses `session[:userid]`, which is only available in a few Objects, namely Controllers.

**Solution:**

Removes the access to `session[:userid]` from `Object`. Make the methods look consistent.

1. simplify `get_timezone_offset`
2. get_timezone_offset no longer uses `session[:userid]`
2. simplify `session_timezone_abbr`. The changes are similar and relatively minor.

**Solved later:**

1. move these methods out of object and put into controller mixin.
2. remove `@tz` variable
3. remove `session[:user_tz]`

