### PR TITLE
Fix [NameError]: undefined local variable `log_header' 

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
@@ -25,7 +25,7 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
   # :name: USER_INITIATED_SHUTDOWN_VM
 
   def self.event_to_hash(event, ems_id = nil)
-    log_header << "ems_id: [#{ems_id}] " unless ems_id.nil?
+    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
 
     _log.debug { "#{log_header}event: [#{event.inspect}]" }
 


### PR DESCRIPTION
Fix undefined local variable  `log_header' for  ManageIQ::Providers::Redhat::InfraManager::EventParser:Module.

```
[----] E, [2015-08-12T17:02:40.830831 #83010:3fea74c601f8] ERROR -- : [NameError]: undefined local variable or method `log_header' for ManageIQ::Providers::Redhat::InfraManager::EventParser:Module  Method:[rescue in deliver]
[----] E, [2015-08-12T17:02:40.830893 #83010:3fea74c601f8] ERROR -- : /Users/lfu/code/miq/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb:28:in `event_to_hash'
/Users/lfu/code/miq/app/models/ems_event.rb:74:in `add_rhevm'
/Users/lfu/code/miq/app/models/miq_queue.rb:343:in `block in deliver'
```