### PR TITLE
containers: trigger auth check on provider addition

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,2 +1,6 @@
 class AuthToken < Authentication
+  def auth_key=(val)
+    @auth_changed = true if val != auth_key
+    super val
+  end
 end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -139,6 +139,7 @@ describe EmsContainerController do
   context "::EmsCommon" do
     context "#update" do
       it "updates provider with new token" do
+        MiqServer.stub(:my_zone).and_return("default")
         set_user_privileges
         @ems = ManageIQ::Providers::Kubernetes::ContainerManager.create(:name => "k8s", :hostname => "10.10.10.1", :port => 5000)
         controller.instance_variable_set(:@edit,

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -103,6 +103,30 @@ describe AuthenticationMixin do
     end
   end
 
+  context "authorization event and check for container providers" do
+    before(:each) do
+      MiqServer.stub(:my_zone).and_return("default")
+    end
+
+    it "should be triggered for kubernetes" do
+      auth = AuthToken.new(:name => "bearer", :auth_key => "valid-token")
+      FactoryGirl.create(:ems_kubernetes, :authentications => [auth])
+
+      MiqQueue.count.should be == 2
+      MiqQueue.find_by(:method_name => 'raise_evm_event').should_not be_nil
+      MiqQueue.find_by(:method_name => 'authentication_check_types').should_not be_nil
+    end
+
+    it "should be triggered for openshift" do
+      auth = AuthToken.new(:name => "bearer", :auth_key => "valid-token")
+      FactoryGirl.create(:ems_openshift, :authentications => [auth])
+
+      MiqQueue.count.should be == 2
+      MiqQueue.find_by(:method_name => 'raise_evm_event').should_not be_nil
+      MiqQueue.find_by(:method_name => 'authentication_check_types').should_not be_nil
+    end
+  end
+
   context "with server and zone" do
     before(:each) do
       @guid = MiqUUID.new_guid


### PR DESCRIPTION
In order to trigger the provider authentication check on provider addition (after_authentication_changed) the new AuthToken type must update the @auth_changed flag when the auth_key is created/updated.

Fixes #3832

cc @oschreib @blomquisg @abonas 