### PR TITLE
containers: fix event lookup for container_group

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -28,7 +28,7 @@ class ContainerGroup < ActiveRecord::Base
     when :ems_events
       # TODO: improve relationship using the id
       ["container_namespace = ? AND container_group_name = ? AND ems_id = ?",
-       namespace, name, ems_id]
+       container_project.name, name, ems_id]
     when :policy_events
       # TODO: implement policy events and its relationship
       ["ems_id = ?", ems_id]

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -15,7 +15,10 @@ describe ContainerGroupController do
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
     ems = FactoryGirl.create(:ems_kubernetes)
-    container_group = ContainerGroup.create(:ext_management_system => ems, :name => "Test Group")
+    container_project = ContainerProject.create(:ext_management_system => ems)
+    container_group = ContainerGroup.create(:ext_management_system => ems,
+                                            :container_project => container_project,
+                                            :name => "Test Group")
     get :show, :id => container_group.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty


### PR DESCRIPTION
The attribute namespace has been moved to be a relationship to project.