### PR TITLE
Move restoration of date observer callback after datepicker initialization

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -922,12 +922,12 @@ function miqBuildCalendar() {
 
   all.each(function () {
     var element = $(this);
+    var observeDateBackup = null;
 
     if (! element.data('datepicker')) {
-      var observeDateBackup = ManageIQ.observeDate;
+      observeDateBackup = ManageIQ.observeDate;
       ManageIQ.observeDate = function() {};
       element.datepicker();
-      ManageIQ.observeDate = observeDateBackup;
     }
 
     if (typeof ManageIQ.calendar.calDateFrom != "undefined") {
@@ -940,6 +940,10 @@ function miqBuildCalendar() {
 
     if (typeof miq_cal_skipDays != "undefined") {
       element.datepicker('setDaysOfWeekDisabled', miq_cal_skipDays);
+    }
+
+    if (observeDateBackup != null) {
+      ManageIQ.observeDate = observeDateBackup;
     }
   });
 }


### PR DESCRIPTION
We need to disable callback to 'changeDate' and 'clearDate' events
thrown by datepicker during the datepicker initialization (start date,
end date, disabled days). Bootstrap datepicker may throw one of these
events during initialization / configuration in certain corner case
situations.

Fixes: #3845