### PR TITLE
Fixed parsing of docker image names issue - #3820

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -441,25 +441,21 @@ module ManageIQ::Providers::Kubernetes
     def parse_image_name(image, image_ref)
       parts = %r{
         \A
-        (?:
-          (?<host>.*?)
-          (?::(?<port>.*?))?
-          /(?=.*/)
-        )?
-        (?<name>.*?)
-        (?::(?<tag>[^:]*?))?
+          (?:(?:(?<host>[^\.:\/]+\.[^\.:\/]+)|(?:(?<host2>[^:\/]+)(?::(?<port>\d+))))\/)?
+          (?<name>(?:[^:\/@]+\/)*[^\/:@]+)
+          (?:(?::(?<tag>.+))|(?:\@(?<shatag>sha256:.+)))?
         \z
       }x.match(image)
 
       [
         {
           :name      => parts[:name],
-          :tag       => parts[:tag],
+          :tag       => parts[:tag] || parts[:shatag],
           :image_ref => image_ref,
         },
-        parts[:host] && {
-          :name => parts[:host],
-          :host => parts[:host],
+        (parts[:host] || parts[:host2]) && {
+          :name => parts[:host] || parts[:host2],
+          :host => parts[:host] || parts[:host2],
           :port => parts[:port],
         },
       ]

--- a/spec/models/ems_refresh/parsers/kubernetes_spec.rb
+++ b/spec/models/ems_refresh/parsers/kubernetes_spec.rb
@@ -21,13 +21,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                        :image      => {:name => "user/example", :tag => "tag", :image_ref => example_ref},
                        :registry   => nil},
 
-                      {:image_name => "host/subname/example",
-                       :image      => {:name => "subname/example", :tag => nil, :image_ref => example_ref},
-                       :registry   => {:name => "host", :host => "host", :port => nil}},
+                      {:image_name => "example/subname/example",
+                       :image      => {:name => "example/subname/example", :tag => nil, :image_ref => example_ref},
+                       :registry   => nil},
 
-                      {:image_name => "host/subname/example:tag",
-                       :image      => {:name => "subname/example", :tag => "tag", :image_ref => example_ref},
-                       :registry   => {:name => "host", :host => "host", :port => nil}},
+                      {:image_name => "example/subname/example:tag",
+                       :image      => {:name => "example/subname/example", :tag => "tag", :image_ref => example_ref},
+                       :registry   => nil},
 
                       {:image_name => "host:1234/subname/example",
                        :image      => {:name => "subname/example", :tag => nil, :image_ref => example_ref},
@@ -49,9 +49,25 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                        :image      => {:name => "subname/example", :tag => nil, :image_ref => example_ref},
                        :registry   => {:name => "host.com", :host => "host.com", :port => nil}},
 
+                      {:image_name => "host.com/example",
+                       :image      => {:name => "example", :tag => nil, :image_ref => example_ref},
+                       :registry   => {:name => "host.com", :host => "host.com", :port => nil}},
+
                       {:image_name => "host.com:1234/subname/more/names/example:tag",
                        :image      => {:name => "subname/more/names/example", :tag => "tag", :image_ref => example_ref},
-                       :registry   => {:name => "host.com", :host => "host.com", :port => "1234"}}]
+                       :registry   => {:name => "host.com", :host => "host.com", :port => "1234"}},
+
+                      {:image_name => "localhost:1234/name",
+                       :image      => {:name => "name", :tag => nil, :image_ref => example_ref},
+                       :registry   => {:name => "localhost", :host => "localhost", :port => "1234"}},
+
+                      {:image_name => "localhost:1234/name@sha256:1234567abcdefg",
+                       :image      => {:name => "name", :tag => "sha256:1234567abcdefg", :image_ref => example_ref},
+                       :registry   => {:name => "localhost", :host => "localhost", :port => "1234"}},
+
+                      {:image_name => "example@sha256:1234567abcdefg",
+                       :image      => {:name => "example", :tag => "sha256:1234567abcdefg", :image_ref => example_ref},
+                       :registry   => nil}]
 
     example_images.each do |ex|
       it "tests '#{ex[:image_name]}'" do


### PR DESCRIPTION
fixes #3820 

There are a few assumptions about docker image names in this fix:
1) Registries must contain with ```.``` or ```:``` i.e. ```localhost:5000```, ```site.com``` or with both: ```192.168.1.2:1234``` but not ```server``` or ```localhost``` since theres no way I could think of to differentiate between a registry and an image name. in the example ```server/image:tag``` its unknown if ```server``` is a registry or a subrepo
2) Image names in the system can be anything after registry i.e. ```aaaa/bbbb/cccc/user/example``` would be the image name from ```localhost:5000/aaaa/bbbb/cccc/user/example```

@abonas @simon3z 