### PR TITLE
remove session[:user_tz] from Time.now calls

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -240,7 +240,7 @@ module ApplicationController::DialogRunner
         # if user didnt choose the date and goes with default shown in the textbox,
         # need to set that value in wf before adding hour/min
         if @edit[:wf].value(field_name).nil?
-          t = Time.now.in_time_zone(session[:user_tz]) + 1.day
+          t = Time.zone.now + 1.day
           date_val = ["#{t.month}/#{t.day}/#{t.year}"]
           @edit[:wf].set_value(field_name, date_val)
         else

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1894,7 +1894,7 @@ class CatalogController < ApplicationController
         @record.dialog_fields.each do |field|
           if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
             presenter[:build_calendar]  = {
-              :date_from => field.show_past_dates ? nil : Time.now.in_time_zone(session[:user_tz]).to_i * 1000
+              :date_from => field.show_past_dates ? nil : Time.zone.now.to_i * 1000
             }
           end
         end

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -40,7 +40,7 @@ module MiqAeCustomizationController::Dialogs
           if params[:field_past_dates] == "1"
             page << "ManageIQ.calendar.calDateFrom = undefined ;"
           else
-            date_tz = Time.now.in_time_zone(session[:user_tz]).strftime("%Y,%m,%d")
+            date_tz = Time.zone.now.strftime("%Y,%m,%d")
             page << "ManageIQ.calendar.calDateFrom = new Date('#{date_tz}');"
           end
         end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -409,7 +409,7 @@ module OpsController::Settings::Schedules
 
     build_schedule_options_for_select
 
-    one_month_ago = (Time.now - 1.month).in_time_zone(session[:user_tz])
+    one_month_ago = Time.zone.now - 1.month
     @one_month_ago = {
       :year  => one_month_ago.year,
       :month => one_month_ago.month - 1, # Javascript counts months 0-11

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -423,7 +423,7 @@ class ServiceController < ApplicationController
       @record.dialog_fields.each do |field|
         if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
           presenter[:build_calendar]  = {
-            :date_from => field.show_past_dates ? nil : Time.now.in_time_zone(session[:user_tz]).to_i * 1000
+            :date_from => field.show_past_dates ? nil : Time.zone.now.to_i * 1000
           }
         end
       end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1628,7 +1628,7 @@ module VmCommon
         @record.dialog_fields.each do |field|
           if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
             presenter[:build_calendar]  = {
-              :date_from => field.show_past_dates ? nil : Time.now.in_time_zone(session[:user_tz]).to_i * 1000
+              :date_from => field.show_past_dates ? nil : Time.zone.now.to_i * 1000
             }
           end
         end

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -38,8 +38,8 @@
                             ManageIQ.calendar.calDateFrom = undefined;
                         - else
                           :javascript
-                            ManageIQ.calendar.calDateFrom = new Date("#{Time.now.in_time_zone(session[:user_tz]).strftime("%Y, %m, %d")}");
-                        - t = Time.now.in_time_zone(session[:user_tz]) + 1.day
+                            ManageIQ.calendar.calDateFrom = new Date("#{Time.zone.now.strftime("%Y, %m, %d")}");
+                        - t = Time.zone.now + 1.day
                         - date_val = field.value ? field.value.split(" ") : ["#{t.month}/#{t.day}/#{t.year}"]
                         = datepicker_input_tag("miq_date_1", h(date_val[0]),
                           :class    => "css1",


### PR DESCRIPTION
The goal is to remove extra user information from session.

```ruby
  # given
  def set_user_time_zone
    session[:user_tz] = Time.zone = @tz = get_timezone_for_userid(user)
  end

  #old:
  Time.now.in_time_zone(session[:user_tz])

  #new:
  Time.zone.now
```

/cc @matthewd can you verify?