### PR TITLE
[WIP] Add password_digest to authentications

### DIFF
--- a/app/models/auth_internal_userid_password.rb
+++ b/app/models/auth_internal_userid_password.rb
@@ -1,0 +1,8 @@
+require 'bcrypt'
+class AuthInternalUseridPassword < AuthUseridPassword
+  before_save :set_password_digest
+
+  def set_password_digest
+    self.password_digest = BCrypt::Password.create(password)
+  end
+end

--- a/db/migrate/20150813111111_add_password_digest_to_authentications.rb
+++ b/db/migrate/20150813111111_add_password_digest_to_authentications.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToAuthentications < ActiveRecord::Migration
+  def change
+    add_column :authentications, :password_digest, :string
+  end
+end

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -29,4 +29,8 @@ FactoryGirl.define do
     auth_key    nil
     status      "SomeMockedStatus"
   end
+
+  factory :authentication_internal, :parent => :authentication, :class => AuthInternalUseridPassword do
+    type        "AuthInternalUseridPassword"
+  end
 end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -30,6 +30,17 @@ describe Authentication do
     it "should store encrypted password" do
       expect(Authentication.where(:password => pwd_plain).count).to eq(0)
       expect(auth.reload.password).to eq(pwd_plain)
+      expect(auth.password_digest).to be_nil
+    end
+  end
+
+  context "internal user password" do
+    let(:pwd_plain) { "smartvm" }
+    let(:pwd_encrypt) { MiqPassword.encrypt(pwd_plain) }
+    let(:auth) { FactoryGirl.create(:authentication_internal, :password => pwd_plain) }
+
+    it "should store the bcrypt hash in password digest" do
+      expect(BCrypt::Password.new(auth.password_digest)).to eq(pwd_plain)
     end
   end
 end


### PR DESCRIPTION
This was added to allow Apache to validate the password digest stored in
Postgres Database. This way we dont have to expose our encryption keys
to Apache.