### PR TITLE
Retain breadcrumb path after Cancel is pressed on a VM Action (like, 'Set Ownership')

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1478,7 +1478,7 @@ module VmCommon
         get_node_info("root")
         return
       else
-        if params[:id].nil?
+        unless controller_referrer?
           @breadcrumbs.clear
           drop_breadcrumb({:name => breadcrumb_name(model), :url => "/#{controller_name}/explorer"}, false)
         end


### PR DESCRIPTION
While the breadcrumb path should be retained after Cancel is pressed on a VM Action (like, 'Set Ownership'), the path should be cleared when the controllers are switched, say, from ```vm_infra``` to ```vm_cloud``` and updated with the new controller's explorer path.

https://bugzilla.redhat.com/show_bug.cgi?id=1121759