### PR TITLE
Rename reports mixin for api controller

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -60,7 +60,7 @@ class ApiController < ApplicationController
   include_concern 'Events'
   include_concern 'ProvisionRequests'
   include_concern "Rates"
-  include_concern "ReportResults"
+  include_concern "Reports"
   include_concern 'RequestTasks'
   include_concern 'ServiceCatalogs'
   include_concern 'ServiceRequests'

--- a/app/controllers/api_controller/reports.rb
+++ b/app/controllers/api_controller/reports.rb
@@ -1,7 +1,7 @@
 class ApiController
-  module ReportResults
+  module Reports
     #
-    # Report Results Supporting Methods
+    # Reports Supporting Methods
     #
     def results_query_resource(object)
       object.send("miq_report_results")


### PR DESCRIPTION
This started out as a collection of methods (or one method) associated
with report results (a subcollection). Since it now contains other
methods that are general to reports (the primary collection), its name
no longer reflects what's going on. This change renames it simply to
`ApiController::Reports`