### PR TITLE
remove `@tz` variable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -911,7 +911,7 @@ class ApplicationController < ActionController::Base
   # if authenticating or past login screen
   def set_user_time_zone
     user = current_user || (params[:user_name].presence && User.find_by_userid(params[:user_name]))
-    session[:user_tz] = Time.zone = @tz = get_timezone_for_userid(user)
+    session[:user_tz] = Time.zone = get_timezone_for_userid(user)
   end
 
   # Initialize the options for server selection

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1639,7 +1639,7 @@ module VmCommon
         locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids][0] if @sb[:action] == "tag"
         unless @sb[:action] == 'ownership'
           presenter[:build_calendar] = {
-            :date_from => Time.now.in_time_zone(@tz).to_i * 1000,
+            :date_from => Time.zone.now.to_i * 1000,
             :date_to   => nil,
           }
         end

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -51,7 +51,6 @@ module Vmdb
     # returns utc_offset of timezone
     def get_timezone_offset(user = nil, formatted = false)
       tz = get_timezone_for_userid(user)
-      @tz = tz if user && tz.present?
       tz = ActiveSupport::TimeZone::MAPPING[tz]
       ActiveSupport::TimeZone.all.each do  |a|
         if ActiveSupport::TimeZone::MAPPING[a.name] == tz


### PR DESCRIPTION
The User's timezone is stored in `session[:user_timezone]` and `Time.zone`.
No need to also store it in `@tz`