### PR TITLE
[SCVMM] Parse CPUCount into logical_cpus

### DIFF
--- a/app/models/ems_refresh/parsers/scvmm.rb
+++ b/app/models/ems_refresh/parsers/scvmm.rb
@@ -215,7 +215,7 @@ module EmsRefresh::Parsers
         :template         => true,
         :storages         => process_vm_storages(p),
         :hardware         => {
-          :numvcpus           => p[:CPUCount],
+          :logical_cpus       => p[:CPUCount],
           :memory_cpu         => normalize_blank_property_num(p[:Memory]),
           :cpu_type           => p[:CPUType].blank? ? nil : p[:CPUType][:ToString],
           :disks              => process_disks(p),
@@ -308,7 +308,7 @@ module EmsRefresh::Parsers
       p = vm[:Properties][:Props]
 
       {
-        :numvcpus           => p[:CPUCount],
+        :logical_cpus       => p[:CPUCount],
         :guest_os           => p[:OperatingSystem][:Props][:Name],
         :guest_os_full_name => p[:OperatingSystem][:Props][:Name],
         :memory_cpu         => normalize_blank_property_num(p[:Memory]),

--- a/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
@@ -182,7 +182,7 @@ describe EmsRefresh::Refreshers::ScvmmRefresher do
       :guest_os           => "64-bit edition of Windows Server 2008 R2 Standard",
       :guest_os_full_name => "64-bit edition of Windows Server 2008 R2 Standard",
       :bios               => "67b7b7ae-34aa-474e-9050-02ed3c633f6c",
-      :numvcpus           => 1,
+      :logical_cpus       => 1,
       :annotation         => nil,
       :memory_cpu         => 512   # MB
     )


### PR DESCRIPTION
The UI (and other places) use `Vm#logical_cpus` to indicate the number of CPUs available in a VM.  Numbers like `Vm#hardware#numvcpus` and `Vm#hardware#cores_per_socket` help determine how `Vm#logical_cpus` is calculated.

However, in the case of SCVMM there is only on CPUCount value returned when collecting inventory.  So, defaulting this value to `logical_cpus` will at least show the number of CPUs the Vm has available even if the constituent parts are not known.

----

Before
![selection_011](https://cloud.githubusercontent.com/assets/14183/9284053/998b3094-42a6-11e5-8d73-20ec3030b594.png)

----

After
![selection_010](https://cloud.githubusercontent.com/assets/14183/9284049/95571632-42a6-11e5-8d78-41d954fe8226.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1210657

@Fryguy please review