### PR TITLE
reuse textual_tags

### DIFF
--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -32,20 +32,4 @@ module AvailabilityZoneHelper::TextualSummary
     end
     h
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.blank?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
-
-
 end

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -50,19 +50,6 @@ module CloudTenantHelper::TextualSummary
     h
   end
 
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.blank?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned} }
-    end
-    h
-  end
-
   def textual_quotas(quota)
     label = quota_label(quota.service_name, quota.name)
     num   = quota.value.to_i

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -132,18 +132,4 @@ module EmsCloudHelper::TextualSummary
   def textual_zone
     {:label => "Managed by Zone", :image => "zone", :value => @ems.zone.name}
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
 end

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -224,19 +224,6 @@ module EmsClusterHelper::TextualSummary
     h
   end
 
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
   def textual_ha_enabled
     value = @record.ha_enabled
     return nil if value.nil?

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -189,19 +189,6 @@ module EmsInfraHelper::TextualSummary
     {:label => "Managed by Zone", :image => "zone", :value => @ems.zone.name}
   end
 
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
   def textual_host_default_vnc_port_range
     return nil unless @ems.is_a?(ManageIQ::Providers::Vmware::InfraManager)
     value = @ems.host_default_vnc_port_start.blank? ?

--- a/app/helpers/flavor_helper/textual_summary.rb
+++ b/app/helpers/flavor_helper/textual_summary.rb
@@ -88,17 +88,4 @@ module FlavorHelper::TextualSummary
     end
     h
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.blank?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -318,19 +318,6 @@ module HostHelper::TextualSummary
     textual_link(@record.miq_templates)
   end
 
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
   def textual_storage_systems
     num = @record.storage_systems_size
     label = ui_lookup(:tables => "ontap_storage_system")

--- a/app/helpers/ontap_file_share_helper/textual_summary.rb
+++ b/app/helpers/ontap_file_share_helper/textual_summary.rb
@@ -122,17 +122,4 @@ module OntapFileShareHelper::TextualSummary
   def textual_vms
     textual_link(@record.vms)
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/ontap_logical_disk_helper/textual_summary.rb
+++ b/app/helpers/ontap_logical_disk_helper/textual_summary.rb
@@ -250,17 +250,4 @@ module OntapLogicalDiskHelper::TextualSummary
   def textual_vms
     textual_link(@record.vms)
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/ontap_storage_system_helper/textual_summary.rb
+++ b/app/helpers/ontap_storage_system_helper/textual_summary.rb
@@ -136,17 +136,4 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_vms
     textual_link(@record.vms)
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/ontap_storage_volume_helper/textual_summary.rb
+++ b/app/helpers/ontap_storage_volume_helper/textual_summary.rb
@@ -151,17 +151,4 @@ module OntapStorageVolumeHelper::TextualSummary
   def textual_vms
     textual_link(@record.vms)
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -116,17 +116,4 @@ module OrchestrationStackHelper::TextualSummary
     end
     h
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.blank?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, _| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned} }
-    end
-    h
-  end
 end

--- a/app/helpers/provider_foreman_helper.rb
+++ b/app/helpers/provider_foreman_helper.rb
@@ -54,20 +54,6 @@ module ProviderForemanHelper
     [textual_tags].flatten.compact
   end
 
-  def textual_tags
-    label = _("%s Tags") % session[:customer_name]
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] =
-        tags.sort_by { |category, _assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned} }
-    end
-    h
-  end
-
   def textual_group_environment
     [textual_configuration_environment_name,
      textual_configuration_domain_name,

--- a/app/helpers/repository_helper/textual_summary.rb
+++ b/app/helpers/repository_helper/textual_summary.rb
@@ -33,17 +33,4 @@ module RepositoryHelper::TextualSummary
   def textual_miq_templates
     textual_link(@record.miq_templates)
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/resource_pool_helper/textual_summary.rb
+++ b/app/helpers/resource_pool_helper/textual_summary.rb
@@ -175,17 +175,4 @@ module ResourcePoolHelper::TextualSummary
     return nil if value.nil?
     {:label => "CPU Shares Level", :value => value}
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -63,22 +63,4 @@ module SecurityGroupHelper::TextualSummary
   def textual_orchestration_stack
     textual_link(@record.orchestration_stack)
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.blank?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, _assigned| category.downcase }
-                  .collect do |category, assigned|
-                    {:image => "smarttag",
-                     :label => category,
-                     :value => assigned}
-                  end
-    end
-    h
-  end
 end

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -121,19 +121,6 @@ module ServiceHelper::TextualSummary
     {:label => "Created On", :value => format_timezone(@record.created_at)}
   end
 
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
   def textual_miq_custom_attributes
     attrs = @record.miq_custom_attributes
     return nil if attrs.blank?

--- a/app/helpers/storage_helper/textual_summary.rb
+++ b/app/helpers/storage_helper/textual_summary.rb
@@ -234,18 +234,4 @@ module StorageHelper::TextualSummary
     end
     h
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h     = {:label => label}
-    tags  = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
 end

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -8,6 +8,24 @@ module TextualSummaryHelper
     end
   end
 
+def textual_tags
+    label = "#{session[:customer_name]} Tags"
+    h = {:label => label}
+    tags = session[:assigned_filters]
+    if tags.blank?
+      h[:image] = "smarttag"
+      h[:value] = "No #{label} have been assigned"
+    else
+      h[:value] = tags.sort_by { |category, _assigned| category.downcase }
+                  .collect do |category, assigned|
+                    {:image => "smarttag",
+                     :label => category,
+                     :value => assigned}
+                  end
+    end
+    h
+  end
+
   private
 
   def textual_object_link(object, as: nil, controller: nil, feature: nil)

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -513,19 +513,6 @@ module VmCloudHelper::TextualSummary
     {:label => "State Changed On", :value => (date.nil? ? "N/A" : format_timezone(date))}
   end
 
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
-
   def textual_security_groups
     label = ui_lookup(:tables => "security_group")
     num   = @record.number_of(:security_groups)

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -815,17 +815,4 @@ module VmHelper::TextualSummary
     end
     h
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end

--- a/app/helpers/vm_infra_helper/textual_summary.rb
+++ b/app/helpers/vm_infra_helper/textual_summary.rb
@@ -712,17 +712,4 @@ module VmCloudHelper::TextualSummary
     end
     h
   end
-
-  def textual_tags
-    label = "#{session[:customer_name]} Tags"
-    h = {:label => label}
-    tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
-      h[:value] = tags.sort_by { |category, assigned| category.downcase }.collect { |category, assigned| {:image => "smarttag", :label => category, :value => assigned } }
-    end
-    h
-  end
 end


### PR DESCRIPTION
method `textual_tags` is copied 21 times.
converge to one instance.

This will make it easier for us to swap in `current_tenant.name` in the future.