### PR TITLE
Changed delegates to has_one through relationship

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -3,12 +3,12 @@ class Container < ActiveRecord::Base
   include NewWithTypeStiMixin
 
   has_one    :container_group, :through => :container_definition
-  delegate   :ext_management_system, :to => :container_group
+  has_one    :ext_management_system, :through => :container_group
   has_one    :container_replicator, :through => :container_group
-  delegate   :container_project, :to => :container_group
+  has_one    :container_project, :through => :container_group
   belongs_to :container_definition
   belongs_to :container_image
-  delegate   :container_image_registry, :to => :container_image
+  has_one    :container_image_registry, :through => :container_image
 
   acts_as_miq_taggable
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/container.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::Container < ::Container
-  has_one :pod_uid, through: :container_group
+  delegate :pod_uid, :to => :container_group
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/container.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::Container < ::Container
-  delegate :pod_uid, :to => :container_group
+  has_one :pod_uid, through: :container_group
 end


### PR DESCRIPTION
Delegate entries has been converted to has_one through relationships in the following files:
app/models/container.rb
app/models/manageiq/providers/kubernetes/container_manager/container.rb
