### PR TITLE
use current_tenant not session in controller/views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -958,8 +958,8 @@ class ApplicationController < ActionController::Base
     folders = Array.new
     user = current_user
     @sb[:grp_title] = user.admin_user? ?
-      "#{session[:customer_name]} (#{_("All %s") % ui_lookup(:models=>"MiqGroup")})" :
-      "#{session[:customer_name]} (#{_("%s") % "#{ui_lookup(:model=>"MiqGroup")}: #{user.current_group.description}"})"
+      "#{current_tenant.name} (#{_("All %s") % ui_lookup(:models => "MiqGroup")})" :
+      "#{current_tenant.name} (#{_("%s") % "#{ui_lookup(:model => "MiqGroup")}: #{user.current_group.description}"})"
     @data = Array.new
     if (!group.settings || !group.settings[:report_menus] || group.settings[:report_menus].blank?) || mode == "default"
       #array of all reports if menu not configured

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1050,7 +1050,7 @@ module ApplicationController::Compare
         @group = section[:group]
         @ci_node = TreeNodeBuilder.generic_tree_node(
           "group_#{section[:group]}",
-          section[:group] == "Categories" ? "#{session[:customer_name]} Tags" : section[:group],
+          section[:group] == "Categories" ? "#{current_tenant.name} Tags" : section[:group],
           false,
           section[:group],
           :cfmeNoClick => true,

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -177,7 +177,7 @@ module ApplicationController::Explorer
     @in_a_form = true
     session[:changed] = false
     add_flash(_("All changes have been reset"), :warning)  if params[:button] == "reset"
-    @right_cell_text = _("Editing %{model} for \"%{name}\"") % {:name=>ui_lookup(:models=>@tagging), :model=>"#{session[:customer_name]} Tags"}
+    @right_cell_text = _("Editing %{model} for \"%{name}\"") % {:name => ui_lookup(:models => @tagging), :model => "#{current_tenant.name} Tags"}
     replace_right_cell(@sb[:action])
   end
 

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -9,9 +9,9 @@ module ApplicationController::Tags
     tagging_build_screen
     area = request.parameters["controller"]
     if role_allows(:feature=>"#{area}_tag")
-      @tabs = [ ["tagging", nil], ["classifying","#{session[:customer_name]} Tags"], ["tagging", "MyTags"] ]
+      @tabs = [["tagging", nil], ["classifying", "#{current_tenant.name} Tags"], %w(tagging MyTags)]
     else
-      @tabs = [ ["tagging", nil], ["tagging", "MyTags"] ]
+      @tabs = [["tagging", nil], %w(tagging MyTags)]
     end
     render(:action=>"show")
   end
@@ -88,7 +88,7 @@ module ApplicationController::Tags
     drop_breadcrumb( {:name=>"Tag Assignment", :url=>"/#{request.parameters["controller"]}/tagging"} )
     session[:cat] = nil                 # Clear current category
     classify_build_screen
-    @tabs = [ ["classifying", nil], ["classifying","#{session[:customer_name]} Tags"], ["tagging", "MyTags"] ]
+    @tabs = [["classifying", nil], ["classifying", "#{current_tenant.name} Tags"], %w(tagging MyTags)]
     @in_a_form = true
     render :action=>"show"
   end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -393,7 +393,7 @@ class ChargebackController < ApplicationController
           self.x_node = "reports-#{rep.id}"
         else
           @sb[:rpt_menu].each_with_index do |lvl1,i|
-            if lvl1[0]  == session[:customer_name]
+            if lvl1[0] == current_tenant.name
               lvl1[1].each_with_index do |lvl2,k|
                 if lvl2[0].downcase == "custom"
                   @sb[:active_node]["report"] = "reports-#{i}-#{k}-#{lvl2[1].length-1}_#{rep.id}"

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -299,10 +299,10 @@ module MiqPolicyController::MiqActions
   def action_build_cat_tree(cats)
     r_node = Hash.new                           # Root node
     r_node = TreeNodeBuilder.generic_tree_node(
-               "r_#{session[:customer_name]}",
-               "#{session[:customer_name]} Tags",
+               "r_#{current_tenant.name}",
+               "#{current_tenant.name} Tags",
                "",
-               "#{session[:customer_name]} Tags",
+               "#{current_tenant.name} Tags",
                :style_class => "cfme-no-cursor-node",
                :expand      => true
     )

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -395,7 +395,7 @@ module OpsController::OpsRbac
     session[:changed] = false
     add_flash(_("All changes have been reset"), :warning)  if params[:button] == "reset"
     @sb[:pre_edit_node] = x_node  unless params[:button]  # Save active tree node before edit
-    @right_cell_text = _("Editing %{model} for \"%{name}\"") % {:name=>ui_lookup(:models=>@tagging), :model=>"#{session[:customer_name]} Tags"}
+    @right_cell_text = _("Editing %{model} for \"%{name}\"") % {:name => ui_lookup(:models => @tagging), :model => "#{current_tenant.name} Tags"}
     replace_right_cell("root")
   end
 

--- a/app/views/layouts/_classify_table.html.haml
+++ b/app/views/layouts/_classify_table.html.haml
@@ -11,9 +11,9 @@
           %td.narrow
           %td
             - if @tagitems.length == 1
-              = _("No %s Tags are assigned") % session[:customer_name]
+              = _("No %s Tags are assigned") % current_tenant.name
             - else
-              = _("No %s Tags are common to all of the items below") % session[:customer_name]
+              = _("No %s Tags are common to all of the items below") % current_tenant.name
           %td
       - else
         - session[:assignments].sort_by { |a| [a.parent.description, a.description] }.each do |a|

--- a/app/views/layouts/_tag_edit_assignments.html.haml
+++ b/app/views/layouts/_tag_edit_assignments.html.haml
@@ -14,9 +14,9 @@
           %td
           %td
             - if @edit[:object_ids].length == 1
-              = _("No %s Tags are assigned") % session[:customer_name]
+              = _("No %s Tags are assigned") % current_tenant.name
             - else
-              = _("No %s Tags are common to all of the items below") % session[:customer_name]
+              = _("No %s Tags are common to all of the items below") % current_tenant.name
           %td
       - else
         - @assignments.sort_by { |a| [a.parent.description, a.description] }.each do |a|

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -57,10 +57,10 @@
           = miq_tab_header("settings_cu_collection", @sb[:active_tab]) do
             = _("C & U Collection")
           = miq_tab_header("settings_co_categories", @sb[:active_tab]) do
-            = escape_javascript(session[:customer_name])
+            = escape_javascript(current_tenant.name)
             = _("Categories")
           = miq_tab_header("settings_co_tags", @sb[:active_tab]) do
-            = escape_javascript(session[:customer_name])
+            = escape_javascript(current_tenant.name)
             = _("Tags")
           = miq_tab_header("settings_import_tags", @sb[:active_tab]) do
             = _("Import Tags")

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -108,7 +108,7 @@
         #rbac_group_tabs
           %ul.nav.nav-tabs
             = miq_tab_header('customer_tags') do
-              = escape_javascript(session[:customer_name])
+              = escape_javascript(current_tenant.name)
               = _("Tags")
             = miq_tab_header('hosts_clusters') do
               = _("#{title_for_hosts} & #{title_for_clusters}")

--- a/app/views/ops/_rbac_tag_box.html.haml
+++ b/app/views/ops/_rbac_tag_box.html.haml
@@ -3,7 +3,7 @@
   .form-horizontal.static
     .form-group
       %label.col-md-2.control-label
-        = session[:customer_name]
+        = current_tenant.name
         = _("Tags")
       .col-md-10
         %table{:style => "padding: 0px; margin: 0px; border: 0px; width: 100%"}
@@ -12,7 +12,7 @@
               %td{:style => "padding: 0px; margin: 0px; border: 0px"}
                 %img{:align => "left", :height => "20", :src => "/images/icons/new/smarttag.png", :width => "20"}/
                 %div{:style => "padding-left: 2em;"}
-                  = _("No %s Tags have been assigned") % session[:customer_name]
+                  = _("No %s Tags have been assigned") % current_tenant.name
           - else
             - session[:assigned_filters].keys.sort.each do |k|
               - v = session[:assigned_filters][k]

--- a/app/views/ops/_settings_import_tags_tab.html.haml
+++ b/app/views/ops/_settings_import_tags_tab.html.haml
@@ -5,7 +5,7 @@
     = render(:partial => "layouts/flash_msg", :locals => {:click_remove => false})
     %hr/
     %h3
-      = _("Upload #{h(session[:customer_name])} Tag Assignments for VMs")
+      = _("Upload #{h(current_tenant.name)} Tag Assignments for VMs")
     %table.style1
       %tr
         %td

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -8,7 +8,7 @@
         %td.key
           = _('Show Costs by')
         %td
-          - opts = [["<#{_('Choose')}>", nil], ["#{_('Owner')}", "owner"], ["%s Tag" % session[:customer_name], "tag"]]
+          - opts = [["<#{_('Choose')}>", nil], [_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"]]
           = select_tag("cb_show_typ",
             options_for_select(opts, @edit[:new][:cb_show_typ]),
             "data-miq_sparkle_on"  => true,

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -364,6 +364,9 @@ describe CatalogController do
     end
 
     it "builds tagging screen" do
+      EvmSpecHelper.create_guid_miq_server_zone
+      controller.send(:find_tenant_by_subdomain_or_domain)
+
       controller.instance_variable_set(:@sb, :action => "ot_tags_edit")
       controller.instance_variable_set(:@_params, :miq_grid_checks => @ot.id.to_s)
       controller.send(:tags_edit, "OrchestrationTemplate")

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -51,6 +51,7 @@ module EvmSpecHelper
   end
 
   def self.remote_guid_miq_server_zone
+    Tenant.seed
     guid   = MiqUUID.new_guid
     zone   = FactoryGirl.create(:zone)
     server = FactoryGirl.create(:miq_server_master, :guid => guid, :zone => zone)


### PR DESCRIPTION
@dclarizio I want to start moving forward using the tenant object in the ui.
It is getting too much to support the session[*] variants of the tenant.

- In the view and controllers, use the `current_tenant.name`.
- In the tag views, use the `current_tenant.name`.

If this works, there are a bunch of other changes.

