### PR TITLE
timezone: fix in_time_zone typo introduced in #3793

### DIFF
--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -12,7 +12,7 @@ class ApplicationController
 
     # return timezone abbreviation
     def get_timezone_abbr(user = nil)
-      time = user ? Time.zone.now : Time.now.in_timezone(server_timezone)
+      time = user ? Time.zone.now : Time.now.in_time_zone(server_timezone)
       time.strftime("%Z")
     end
 


### PR DESCRIPTION
@kbrock @Fryguy @blomquisg I am not sure if I am right about this one but I get a `in_timezone` method unknown error at this time.