### PR TITLE
Fixed positioning of whitelabeled class

### DIFF
--- a/app/views/stylesheets/_template50.html.haml
+++ b/app/views/stylesheets/_template50.html.haml
@@ -1,6 +1,6 @@
 :css
   #searchbox              {top: #{@explorer ? 138 : 63}px;}
-  #searchbox.whitelabeled {top: 40px;}
+  #searchbox.whitelabeled {top: 150px;}
 
 - if big_iframe
   - padding_top = session[:custom_logo] ? 83 : 70


### PR DESCRIPTION
Fixed positioning of whitelabeled class that is used when user has a custom logo in place, this was causing search box to not appear in right place.

https://bugzilla.redhat.com/show_bug.cgi?id=1237091

@dclarizio @epwinchell  please review

before:
![before](https://cloud.githubusercontent.com/assets/3450808/9311722/2f0e75cc-44e6-11e5-8df4-61dc9389b9ea.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/9311701/f74f2924-44e5-11e5-96a3-8cfe01dc2b14.png)
