### PR TITLE
take session from tenant.name

### DIFF
--- a/app/controllers/application_controller/tenancy.rb
+++ b/app/controllers/application_controller/tenancy.rb
@@ -7,7 +7,7 @@ module ApplicationController::Tenancy
 
   # NOTE: remove when these session vars are removed
   def set_session_tenant(tenant = current_tenant)
-    session[:customer_name] = tenant.try(:company_name)
+    session[:customer_name] = tenant.try(:name)
     session[:vmdb_name]     = tenant.try(:appliance_name)
     session[:custom_logo]   = tenant.try(:logo?)
     tenant


### PR DESCRIPTION
`tenant#company_name` was renamed to `tenant#name`.

This one slipped through the crack

/cc @dclarizio @gmcculloug this field has been renamed, so the tenant name is not going to get set