### PR TITLE
use current_user not session[:userid] in view

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -246,7 +246,7 @@ class DashboardController < ApplicationController
     widget_list = ""
     prev_type   = nil
     @available_widgets = []
-    MiqWidget.available_for_user(session[:userid]).sort_by { |a| a.content_type + a.title.downcase }.each do |w|
+    MiqWidget.available_for_user(current_user).sort_by { |a| a.content_type + a.title.downcase }.each do |w|
       @available_widgets.push(w.id)  # Keep track of widgets available to this user
       if !col_widgets.include?(w.id) && w.enabled
         image, tip = case w.content_type

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -341,7 +341,7 @@ class DashboardController < ApplicationController
 
     widget = MiqWidget.find_by_id(params[:widget].to_i)
     # Save the rr id for render_zgraph
-    @sb[:report_result_id] = widget.contents_for_user(session[:userid]).miq_report_result_id
+    @sb[:report_result_id] = widget.contents_for_user(current_user).miq_report_result_id
 
     render :update do |page|
       page.replace_html("lightbox_div", :partial => "zoomed_chart", :locals => {:widget => widget})

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::ToolbarBuilder
 
   private
 
-  delegate :request, :session, :to => :@view_context
+  delegate :request, :current_user, :to => :@view_context
 
   delegate :get_vmdb_config, :role_allows, :model_for_vm, :to => :@view_context
   delegate :x_tree_history, :x_node, :x_active_tree, :to => :@view_context
@@ -300,7 +300,7 @@ class ApplicationHelper::ToolbarBuilder
       group[:image]        = cbs.set_data[:button_image]
       group[:text_display] = cbs.set_data.has_key?(:display) ? cbs.set_data[:display] : true
 
-      available = CustomButton.available_for_user(session[:userid], cbs.name) # get all uri records for this user for specified uri set
+      available = CustomButton.available_for_user(current_user, cbs.name) # get all uri records for this user for specified uri set
       available = available.select { |b| cbs.members.include?(b) }            # making sure available_for_user uri is one of the members
       group[:buttons] = available.collect { |cb| create_raw_custom_button_hash(cb, record) }.uniq
       if cbs[:set_data][:button_order] # Show custom buttons in the order they were saved
@@ -733,15 +733,13 @@ class ApplicationHelper::ToolbarBuilder
       when "miq_request_approve", "miq_request_deny"
         return true if ["approved", "denied"].include?(@record.approval_state) || @showtype == "miq_provisions"
       when "miq_request_edit"
-        requester = User.find_by_userid(session[:userid])
-        return true if requester.name != @record.requester_name || ["approved", "denied"].include?(@record.approval_state)
+        return true if current_user.name != @record.requester_name || ["approved", "denied"].include?(@record.approval_state)
       when "miq_request_copy"
-        requester = User.find_by_userid(session[:userid])
         resource_types_for_miq_request_copy = %w(MiqProvisionRequest
                                                  MiqHostProvisionRequest
                                                  MiqProvisionConfiguredSystemRequest)
         return true if !resource_types_for_miq_request_copy.include?(@record.resource_type) ||
-                       ((requester.name != @record.requester_name ||
+                       ((current_user.name != @record.requester_name ||
                          !@record.request_pending_approval?) &&
                         @showtype == "miq_provisions")
       end
@@ -1036,7 +1034,7 @@ class ApplicationHelper::ToolbarBuilder
     when "MiqRequest"
       case id
       when "miq_request_delete"
-        requester = User.find_by_userid(session[:userid])
+        requester = current_user
         return false if requester.admin_user?
         return _("Users are only allowed to delete their own requests") if requester.name != @record.requester_name
         return _("%s requests cannot be deleted" % @record.approval_state.titleize) if %w(approved denied).include?(@record.approval_state)

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -11,7 +11,7 @@ class WidgetPresenter
   end
 
   extend Forwardable
-  delegate [:session, :url_for, :initiate_wait_for_task, :session_init,
+  delegate [:current_user, :url_for, :initiate_wait_for_task, :session_init,
             :session_reset, :get_vmdb_config, :start_url_for_user] => :@controller
 
   attr_reader :widget
@@ -26,7 +26,7 @@ class WidgetPresenter
       @view.link_to("",
                     {:action => "report_only",
                      :type   => "hybrid",
-                     :rr_id  => @widget.contents_for_user(session[:userid]).miq_report_result_id},
+                     :rr_id  => @widget.contents_for_user(current_user).miq_report_result_id},
                     :id                => "w_#{@widget.id}_fullscreen",
                     :class             => "fullscreenbox",
                     :title             => _("Open the chart and full report in a new window"),
@@ -37,7 +37,7 @@ class WidgetPresenter
       @view.link_to("",
                     {:action => "report_only",
                      :type   => "tabular",
-                     :rr_id  => @widget.contents_for_user(session[:userid]).miq_report_result_id},
+                     :rr_id  => @widget.contents_for_user(current_user).miq_report_result_id},
                     :id                => "w_#{@widget.id}_fullscreen",
                     :class             => "fullscreenbox",
                     :title             => _("Open the full report in a new window"),
@@ -79,7 +79,7 @@ class WidgetPresenter
     if PdfGenerator.available? && %w(report chart).include?(@widget.content_type)
       @view.link_to("",
                     {:action => "widget_to_pdf",
-                     :rr_id  => @widget.contents_for_user(session[:userid]).miq_report_result_id},
+                     :rr_id  => @widget.contents_for_user(current_user).miq_report_result_id},
                     :id    => "w_#{@widget.id}_pdf",
                     :class => "pdfbox",
                     :title => _("Download the full report (all rows) as a PDF file"))

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -7,7 +7,7 @@
       - if role_allows(:feature => "dashboard_add")
         = presenter.button_close
       = presenter.button_minmax
-      - if presenter.widget.contents_for_user(session[:userid]).present?
+      - if presenter.widget.contents_for_user(current_user).present?
         - if %(report chart).include?(presenter.widget.content_type)
           = presenter.button_fullscreen
           = presenter.button_pdf
@@ -17,7 +17,7 @@
         %span.modtitle_text= h(presenter.widget.title)
     - if presenter.widget.content_type == "menu"
       = render :partial => 'widget_menu', :locals => {:widget => presenter.widget}
-    - elsif presenter.widget.contents_for_user(session[:userid]).blank?
+    - elsif presenter.widget.contents_for_user(current_user).blank?
       = render :partial => 'widget_blank', :locals => {:widget => presenter.widget}
     - elsif %(report chart rss).include?(presenter.widget.content_type)
       = render :partial => "widget_#{presenter.widget.content_type}", :locals => {:widget => presenter.widget}

--- a/app/views/dashboard/_widget_chart.html.haml
+++ b/app/views/dashboard/_widget_chart.html.haml
@@ -7,15 +7,15 @@
   .mc{:id => "dd_w#{widget.id}_box",
     :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display:none' : ''}
 
-    - if widget.contents_for_user(session[:userid]).contents.blank?
+    - if widget.contents_for_user(current_user).contents.blank?
       = _('No chart data found')
       \. . .
-    - datum = widget.contents_for_user(session[:userid]).contents
+    - datum = widget.contents_for_user(current_user).contents
     - if Charting.data_ok?(datum)
       -# we need to count all charts to be able to display multiple
       -# charts on a dashboard screen
 
-      - datum = widget.contents_for_user(session[:userid]).contents
+      - datum = widget.contents_for_user(current_user).contents
       - WidgetPresenter.chart_data.push(:xml => datum)
       - chart_index = WidgetPresenter.chart_data.length - 1
       - chart_data = YAML.load(datum) if Charting.backend == :jqplot

--- a/app/views/dashboard/_widget_footer.html.haml
+++ b/app/views/dashboard/_widget_footer.html.haml
@@ -3,7 +3,7 @@
     widget -- MiqWidget object
 .modboxfooter
   = _('Updated')
-  - last_run_on = widget.last_run_on_for_user(session[:userid])
+  - last_run_on = widget.last_run_on_for_user(current_user)
   - if last_run_on
     = format_timezone(last_run_on, session[:user_tz], "widget_footer")
   - else

--- a/app/views/dashboard/_widget_report.html.haml
+++ b/app/views/dashboard/_widget_report.html.haml
@@ -4,8 +4,8 @@
 .modboxin.report_widget
   .mc{:id => "dd_w#{widget.id}_box",
     :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display: none;' : ''}
-    - if widget.contents_for_user(session[:userid]).contents.blank?
+    - if widget.contents_for_user(current_user).contents.blank?
       = _('No Report data found')
       \. . .
     - else
-      = widget.contents_for_user(session[:userid]).contents.html_safe
+      = widget.contents_for_user(current_user).contents.html_safe

--- a/app/views/dashboard/_widget_rss.html.haml
+++ b/app/views/dashboard/_widget_rss.html.haml
@@ -3,9 +3,9 @@
     widget: MiqWidget object
 .modboxin.rss_widget
   = hidden_div_if(@sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id), :id => "dd_w#{widget.id}_box") do
-    - if widget.contents_for_user(session[:userid]).contents.blank?
+    - if widget.contents_for_user(current_user).contents.blank?
       = _('No RSS Feed data found')
       \. . .
     - else
-      = widget.contents_for_user(session[:userid]).contents.gsub("https://localhost:3000",
+      = widget.contents_for_user(current_user).contents.gsub("https://localhost:3000",
           "#{request.protocol}#{request.host}:#{request.port}").html_safe

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -1,4 +1,4 @@
-- if session[:userid]
+- if current_user
   %li.dropdown
     %a{:href => "#", :class => "dropdown-toggle", "data-toggle" => "dropdown"}
       %span.pficon.pficon-user

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -3,7 +3,12 @@ require "spec_helper"
 describe ApplicationHelper do
   before do
     controller.send(:extend, ApplicationHelper)
+    controller.send(:extend, ApplicationController::CurrentUser)
     self.class.send(:include, ApplicationHelper)
+    self.class.send(:include, ApplicationController::CurrentUser)
+  end
+
+  def self.hide_action(*args)
   end
 
   def method_missing(sym, *args)


### PR DESCRIPTION
High level:
Don't keep looking up the current user, but rather leverage `current_user`.
This will centralize the logic to determine `current_{user,group,tenant}`

Specifics:

- `contents_for_user` calls `get_user` so it already supports a user or userid.
- `last_run_on_for_user` just calls into `contents_for_user`, and `get_user`.
- `available_for_user` calls `get_user` so it already supports a user or userid.

/cc @dclarizio @gmcculloug 

**EDIT:** for clarification

- updated helpers so they knew how to lookup the `current_user` - instead of delegating `session` to the controller, they're delegating the actual `current_usesr` call.