### PR TITLE
pass current_user into ResourceActionWorkflow

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -200,7 +200,7 @@ module ApplicationController::DialogRunner
     opts = {
       :target => options[:target_kls].constantize.find_by_id(options[:target_id])
     }
-    @edit[:wf] = ResourceActionWorkflow.new(@edit[:new],session[:userid],ra,opts)
+    @edit[:wf] = ResourceActionWorkflow.new(@edit[:new], current_user, ra, opts)
     @record = Dialog.find_by_id(ra.dialog_id.to_i)
     @edit[:rec_id]   = @record.id
     @edit[:key]     = "dialog_edit__#{@edit[:rec_id] || "new"}"

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -7,7 +7,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
 
   def initialize(values, requester, resource_action, options={})
     @settings        = {}
-    @requester       = User.lookup_by_identity(requester)
+    @requester       = requester
     @target          = options[:target]
     @dialog          = load_dialog(resource_action, values)
 

--- a/app/views/miq_request/_service_reconfigure_show.html.haml
+++ b/app/views/miq_request/_service_reconfigure_show.html.haml
@@ -11,4 +11,4 @@
       .row
         .col-md-12.col-lg-12
           = render :partial => "shared/dialogs/dialog_provision",
-                   :locals  => {:wf => ResourceActionWorkflow.new(values, session[:userid], ra, opts)}
+                   :locals  => {:wf => ResourceActionWorkflow.new(values, current_user, ra, opts)}

--- a/app/views/miq_request/_st_prov_show.html.haml
+++ b/app/views/miq_request/_st_prov_show.html.haml
@@ -10,4 +10,4 @@
       .row
         .col-md-12.col-lg-12
           = render :partial => "shared/dialogs/dialog_provision",
-                   :locals  => {:wf => ResourceActionWorkflow.new(values, session[:userid], ra, opts)}
+                   :locals  => {:wf => ResourceActionWorkflow.new(values, current_user, ra, opts)}

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -22,7 +22,7 @@ describe ResourceActionWorkflow do
     end
 
     it "new from resource_action" do
-      @wf = ResourceActionWorkflow.new({}, @admin.name, @resource_action)
+      @wf = ResourceActionWorkflow.new({}, @admin, @resource_action)
       values = @wf.create_values_hash
       values.fetch_path(:workflow_settings, :resource_action_id).should == @resource_action.id
       @wf.dialog.id.should == @dialog.id
@@ -30,7 +30,7 @@ describe ResourceActionWorkflow do
 
     it "new from hash" do
       nh = {:workflow_settings => {:resource_action_id => @resource_action.id}}
-      @wf = ResourceActionWorkflow.new(nh, @admin.name, nil)
+      @wf = ResourceActionWorkflow.new(nh, @admin, nil)
       values = @wf.create_values_hash
       values.fetch_path(:workflow_settings, :resource_action_id).should == @resource_action.id
       @wf.dialog.id.should == @dialog.id
@@ -38,7 +38,7 @@ describe ResourceActionWorkflow do
 
     it "load default_value" do
       @dialog_field.update_attribute(:default_value, "testing default")
-      @wf = ResourceActionWorkflow.new({}, @admin.name, @resource_action)
+      @wf = ResourceActionWorkflow.new({}, @admin, @resource_action)
       @wf.value(@dialog_field.name).should == "testing default"
       df = @wf.dialog_field(@dialog_field.name)
       df.value.should == "testing default"
@@ -53,7 +53,7 @@ describe ResourceActionWorkflow do
 
     context "with workflow" do
       before(:each) do
-        @wf = ResourceActionWorkflow.new({}, @admin.name, @resource_action)
+        @wf = ResourceActionWorkflow.new({}, @admin, @resource_action)
       end
 
       it "set_value" do
@@ -67,7 +67,7 @@ describe ResourceActionWorkflow do
     end
 
     context "#submit_request" do
-      subject { ResourceActionWorkflow.new({}, @admin.name, resource_action, :target => target) }
+      subject { ResourceActionWorkflow.new({}, @admin, resource_action, :target => target) }
       let(:resource_action) { @resource_action }
 
       context "with request class" do


### PR DESCRIPTION
Don't keep looking up the current user, but rather leverage `current_user`.
This will centralize the logic to determine current_{user,group,tenant}

- `ResourceActionWorkflow#new` was enhanced to support a user or userid.

/cc @gmcculloug 