### PR TITLE
Set seed tenant company to null

### DIFF
--- a/db/migrate/20150817213409_clear_tenant_seed.rb
+++ b/db/migrate/20150817213409_clear_tenant_seed.rb
@@ -1,0 +1,5 @@
+class ClearTenantSeed < ActiveRecord::Migration
+  def up
+    execute "update tenants set name = null"
+  end
+end


### PR DESCRIPTION
Early adopters could have a bad seed value.
Now seeding with a nil company name of null.
This will read the company name from settings

/cc @dclarizio This will fix branding on your database
/cc @gmcculloug please review