### PR TITLE
Chargeback report time zone not saved

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1227,6 +1227,7 @@ module ReportController::Reports::Editor
       rpt.col_options = Chargeback.report_col_options
       rpt.order = "Ascending"
       rpt.group = "y"
+      rpt.tz = @edit[:new][:tz]
     end
 
     # Remove when we support user sorting of trend reports

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -20,6 +20,55 @@ describe ReportController do
         new_hash.should have_key(:cb_owner_id)
         new_hash[:cb_owner_id].should == user.userid
       end
+
+      it "should save the selected time zone with a chargeback report" do
+        user = FactoryGirl.create(:user)
+        login_as user
+        rep = FactoryGirl.create(
+            :miq_report,
+            :db         => "Chargeback",
+            :name       => 'name',
+            :title      => 'title',
+            :db_options => {:options => {:owner => user.userid}},
+            :col_order  => ["name"],
+            :headers    => ["Name"],
+            :tz         => nil
+        )
+
+        edit = {
+            :rpt_id  => rep.id,
+            :new     => {
+                :model  => "Chargeback",
+                :name   => 'name',
+                :title  => 'title',
+                :tz     => "Eastern Time (US & Canada)",
+                :fields => []
+            },
+            :current => {}
+        }
+        controller.instance_variable_set(:@edit, edit)
+        session[:edit] = assigns(:edit)
+
+        allow(User).to receive(:server_timezone).and_return("UTC")
+
+        login_as user
+        User.any_instance.stub(:role_allows?).and_return(true)
+
+        controller.stub(:check_privileges).and_return(true)
+        controller.stub(:load_edit).and_return(true)
+        controller.stub(:valid_report?).and_return(true)
+        controller.stub(:x_node).and_return("")
+        controller.stub(:gfv_sort)
+        controller.stub(:build_edit_screen)
+        controller.stub(:get_all_widgets)
+        controller.stub(:replace_right_cell)
+
+        post :miq_report_edit, :id => rep.id, :button => 'save'
+
+        rep.reload
+
+        rep.tz.should == "Eastern Time (US & Canada)"
+      end
     end
   end
 end


### PR DESCRIPTION
Fixed bug where time zone selected in report editor was not getting saved with report.

https://bugzilla.redhat.com/show_bug.cgi?id=1243695