### PR TITLE
TreeBuilder: remove anoying log message.

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -11,7 +11,6 @@ module Sandbox
   end
 
   def x_tree_init(name, type, leaf, values = {})
-    Rails.logger.error("x_tree_init called for type #{type}")
     return if @sb.has_key_path?(:trees, name)
 
     values = values.reverse_merge(


### PR DESCRIPTION
I thought we will get the remaining trees converted quickly and move on to further cleanups so I left this in, but it's anoying people. 