### PR TITLE
Fix success flash messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1229,7 +1229,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Add a msg to the @flash_array
-  def add_flash(msg, level = :info, reset = false)
+  def add_flash(msg, level = :success, reset = false)
     @flash_array = [] if reset
     @flash_array ||= []
     @flash_array.push({:message => msg, :level => level})

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -373,7 +373,7 @@ describe MiqAeClassController do
       flash_messages.first[:message].should include("cannot be deleted")
       flash_messages.first[:level].should == :error
       flash_messages.last[:message].should include("Delete successful")
-      flash_messages.last[:level].should == :info
+      flash_messages.last[:level].should == :success
     end
   end
 

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -109,7 +109,7 @@ describe OpsController do
 
       flash_message = assigns(:flash_array).first
       flash_message[:message].should include("Delete successful")
-      flash_message[:level].should be(:info)
+      flash_message[:level].should be(:success)
     end
 
     context "#logs_collect" do

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -54,7 +54,7 @@ describe OpsController do
 
         flash_message = assigns(:flash_array).first
         flash_message[:message].should include("Delete successful")
-        flash_message[:level].should be(:info)
+        flash_message[:level].should be(:success)
       end
     end
 
@@ -100,7 +100,7 @@ describe OpsController do
         controller.send(:rbac_tenant_edit)
         flash_message = assigns(:flash_array).first
         flash_message[:message].should include("Edit of Tenant \"#{@tenant.name}\" was cancelled by the user")
-        flash_message[:level].should be(:info)
+        flash_message[:level].should be(:success)
       end
 
       it "saves tenant record changes" do
@@ -115,7 +115,7 @@ describe OpsController do
         controller.send(:rbac_tenant_edit)
         flash_message = assigns(:flash_array).first
         flash_message[:message].should include("Tenant \"Foo_Bar\" was saved")
-        flash_message[:level].should be(:info)
+        flash_message[:level].should be(:success)
       end
     end
   end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -80,7 +80,7 @@ describe StorageController do
         controller.button
         flash_messages = assigns(:flash_array)
         flash_messages.first[:message].should include("successfully initiated")
-        flash_messages.first[:level].should == :info
+        flash_messages.first[:level].should == :success
       end
     end
   end


### PR DESCRIPTION
Fixed issue caused by #3526.
Flash messages without specified flag were defaultly marked as `info` messages.
After change, if flag is not set, default class is `success`