### PR TITLE
Fixes issue where password are logged with Audit events.

### DIFF
--- a/spec/controllers/application_controller/build_audit_spec.rb
+++ b/spec/controllers/application_controller/build_audit_spec.rb
@@ -14,6 +14,15 @@ describe ApplicationController do
                    :message => "VMDB config updated (changing_value:[test] to [test2], password:[*] to [*])"}
     end
 
+    it "tests build_config_audit password filtering" do
+      edit = {:current => {:user_proxies => [{:ldapport => "389", :bind_pwd => "secret"}]},
+              :new     => {:user_proxies => [{:ldapport => "636", :bind_pwd => "super_secret"}]}}
+      controller.send(:build_config_audit, edit[:new], edit[:current])
+        .should == {:event   => "vmdb_config_update",
+                    :userid  => nil,
+                    :message => 'VMDB config updated (user_proxies:[[{:ldapport=>"389", :bind_pwd=>"[FILTERED]"}]] to [[{:ldapport=>"636", :bind_pwd=>"[FILTERED]"}]])'}
+    end
+
     it "tests build_created_audit" do
       category = FactoryGirl.create(:classification, :name => 'environment', :description => 'Environment')
       edit = {:new     => {:name => "the-name", :changing_value=>"test2", :static_value=>"same",


### PR DESCRIPTION
When updating Trusted forest, the bind_pwd gets logged in clear text.
The faulty logic was in build_audit_msg, where config data of array
type wasn't being traversed.  Leveraging the Rails ParameterFilter
to do the magic for us.

https://bugzilla.redhat.com/show_bug.cgi?id=1174458