### PR TITLE
Openstack wrongly filled cloud_tenant type

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -265,6 +265,7 @@ module ManageIQ::Providers
       uid = tenant.id
 
       new_result = {
+        :type        => "ManageIQ::Providers::Openstack::CloudManager::CloudTenant",
         :name        => tenant.name,
         :description => tenant.description,
         :enabled     => tenant.enabled,


### PR DESCRIPTION
Causing vm.cloud_tenant to return nil