### PR TITLE
Add specs around Marshal dump and load

### DIFF
--- a/gems/pending/spec/util/miq-hash_struct_spec.rb
+++ b/gems/pending/spec/util/miq-hash_struct_spec.rb
@@ -122,4 +122,11 @@ describe MiqHashStruct do
       expect(hs.to_hash[:abc]).to eq(123)
     end
   end
+
+  context "dump and load" do
+    let (:orig) { described_class.new("a" => 1, "b" => 2) }
+
+    it("Marshal") { expect(Marshal.load(Marshal.dump(orig))).to eq(orig) }
+    it("YAML")    { expect(YAML.load(YAML.dump(orig))).to       eq(orig) }
+  end
 end

--- a/gems/pending/util/miq-hash_struct.rb
+++ b/gems/pending/util/miq-hash_struct.rb
@@ -55,7 +55,8 @@ class MiqHashStruct
 
   private
 
-  def respond_to_missing?(*)
-    true
+  def respond_to_missing?(sym, *)
+    # Methods for Marshal and YAML dumping and loading shouldn't #respond_to_missing?
+    !sym.in?([:encode_with, :init_with, :yaml_initialize, :marshal_dump, :_dump])
   end
 end


### PR DESCRIPTION
Marshal.dump appears to dump the object without ```@hash``` or ```@key_type```.  When it is re-loaded you wind up with ```@hash``` being nil.

```
[----] E, [2015-08-18T09:55:13.469312 #7426:3fb157137994] ERROR -- : Unexpected exception during Dalli request: NoMethodError: undefined method `[]' for nil:NilClass
[----] E, [2015-08-18T09:55:13.469463 #7426:3fb157137994] ERROR -- : /home/bdunne/projects/redhat/manageiq/gems/pending/util/miq-hash_struct.rb:52:in `method_missing'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/marshal.rb:6:in `load'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/marshal.rb:6:in `load_with_autoloading'
	/home/bdunne/projects/redhat/manageiq/config/initializers/marshal_autoloader.rb:3:in `load_with_autoload_missing_constants'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/server.rb:430:in `deserialize'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/server.rb:494:in `generic_response'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/server.rb:261:in `get'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/server.rb:63:in `request'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/options.rb:18:in `block in request'
	/home/bdunne/.rubies/ruby-2.2.2/lib/ruby/2.2.0/monitor.rb:211:in `mon_synchronize'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/options.rb:17:in `request'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/client.rb:333:in `perform'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/dalli/client.rb:56:in `get'
	/home/bdunne/.gem/ruby/2.2.2/gems/dalli-2.7.4/lib/action_dispatch/middleware/session/dalli_store.rb:37:in `get_session'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:266:in `load_session'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/session/abstract_store.rb:43:in `block in load_session'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/session/abstract_store.rb:51:in `stale_session_check!'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/session/abstract_store.rb:43:in `load_session'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/request/session.rb:180:in `load!'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/request/session.rb:172:in `load_for_read!'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/request/session.rb:89:in `[]'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/request_forgery_protection.rb:316:in `real_csrf_token'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/request_forgery_protection.rb:312:in `compare_with_real_token'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/request_forgery_protection.rb:304:in `valid_authenticity_token?'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/request_forgery_protection.rb:255:in `verified_request?'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/request_forgery_protection.rb:200:in `verify_authenticity_token'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:430:in `block in make_lambda'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:143:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:143:in `block in halting_and_conditional'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:502:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:502:in `block in call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:502:in `each'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:502:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:88:in `run_callbacks'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/callbacks.rb:19:in `process_action'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/rescue.rb:29:in `process_action'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/notifications.rb:164:in `block in instrument'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/notifications.rb:164:in `instrument'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
	/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/abstract_controller/base.rb:137:in `process'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionview-4.2.3/lib/action_view/rendering.rb:30:in `process'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal.rb:196:in `dispatch'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_controller/metal.rb:237:in `block in action'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:76:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:76:in `dispatch'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:45:in `serve'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/journey/router.rb:43:in `block in serve'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/journey/router.rb:30:in `each'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/journey/router.rb:30:in `serve'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/routing/route_set.rb:821:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/etag.rb:24:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/conditionalget.rb:38:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/params_parser.rb:27:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/flash.rb:260:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:225:in `context'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:220:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/cookies.rb:560:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/query_cache.rb:36:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:84:in `run_callbacks'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/reloader.rb:73:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/rack/logger.rb:38:in `call_app'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/rack/logger.rb:22:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/request_store-1.1.0/lib/request_store/middleware.rb:8:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/request_id.rb:21:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/methodoverride.rb:22:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/runtime.rb:18:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/lock.rb:17:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/middleware/static.rb:116:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/sendfile.rb:113:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:518:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/application.rb:165:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:86:in `block in pre_process'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:84:in `catch'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:84:in `pre_process'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:53:in `process'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/connection.rb:39:in `receive_data'
	/home/bdunne/.gem/ruby/2.2.2/gems/eventmachine-1.0.7/lib/eventmachine.rb:187:in `run_machine'
	/home/bdunne/.gem/ruby/2.2.2/gems/eventmachine-1.0.7/lib/eventmachine.rb:187:in `run'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/backends/base.rb:73:in `start'
	/home/bdunne/.gem/ruby/2.2.2/gems/thin-1.6.3/lib/thin/server.rb:162:in `start'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/handler/thin.rb:19:in `run'
	/home/bdunne/.gem/ruby/2.2.2/gems/rack-1.6.4/lib/rack/server.rb:286:in `start'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/server.rb:80:in `start'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:80:in `block in server'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:75:in `tap'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:75:in `server'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	/home/bdunne/.gem/ruby/2.2.2/gems/railties-4.2.3/lib/rails/commands.rb:17:in `<top (required)>'
	bin/rails:4:in `require'
	bin/rails:4:in `<main>'
```