### PR TITLE
Style1 tables in Optimize tab converted to Patternfly

### DIFF
--- a/app/views/miq_capacity/_bottlenecks_options.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_options.html.haml
@@ -1,26 +1,30 @@
 - url = url_for :action => 'bottleneck_tl_chooser'
 #tl_options_div
-  %h3= _('Options')
-  %table.style1
-    %tr
-      %td.key{:style => "width: 150px;"}= _('Event Groups')
-      %td
+  %h3
+    = _('Options')
+  %form.form-horizontal
+    .form-group
+      %label.control-label.col-md-2
+        = _('Event Groups')
+      .col-md-10
         = select_tag("tl_#{typ}_fl_grp1",
           options_for_select([["<#{_('ALL')}> ", ""]] + @sb[:bottlenecks][:groups].sort, @sb[:bottlenecks][:tl_options][:filter1]),
           "data-miq_sparkle_on"  => true,
           "data-miq_sparkle_off" => true,
           "data-miq_observe"     => {:url => url}.to_json)
     - unless %w(s h).include?(x_node.split("-").last.split("_").first)
-      %tr
-        %td.key{:style => "width: 150px;"}= _('Show Host Events')
-        %td
+      .form-group
+        %label.control-label.col-md-2
+          = _('Show Host Events')
+        .col-md-10
           = check_box_tag("tl_#{typ}_hosts", "1", @sb[:bottlenecks][:tl_options][:hosts],
             "data-miq_sparkle_on"       => true,
             "data-miq_sparkle_off"      => true,
             "data-miq_observe_checkbox" => {:url => url}.to_json)
-    %tr
-      %td.key{:style => "width: 150px;"}= _('Time Zone')
-      %td
+    .form-group
+      %label.control-label.col-md-2
+        = _('Time Zone')
+      .col-md-10
         = select_tag("tl_#{typ}_tz",
           options_for_select(ALL_TIMEZONES,
           @sb[:bottlenecks][:tl_options][:tz]),
@@ -29,4 +33,3 @@
           "data-miq_observe"     => {:url => url}.to_json)
   %form#hiddenForm
     %input.filter1{:type => "hidden", :name => "filter1", :value => @sb[:bottlenecks][:tl_options][:fltr1]}
-  -#= "* Dates/Times on this page are based on UTC Time."

--- a/app/views/miq_capacity/_bottlenecks_options.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_options.html.haml
@@ -9,9 +9,12 @@
       .col-md-10
         = select_tag("tl_#{typ}_fl_grp1",
           options_for_select([["<#{_('ALL')}> ", ""]] + @sb[:bottlenecks][:groups].sort, @sb[:bottlenecks][:tl_options][:filter1]),
+          "class" => "selectpicker",
           "data-miq_sparkle_on"  => true,
-          "data-miq_sparkle_off" => true,
-          "data-miq_observe"     => {:url => url}.to_json)
+          "data-miq_sparkle_off" => true)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("tl_#{typ}_fl_grp1", "#{url}");
     - unless %w(s h).include?(x_node.split("-").last.split("_").first)
       .form-group
         %label.control-label.col-md-2
@@ -28,8 +31,11 @@
         = select_tag("tl_#{typ}_tz",
           options_for_select(ALL_TIMEZONES,
           @sb[:bottlenecks][:tl_options][:tz]),
+          "class" => "selectpicker",
           "data-miq_sparkle_on"  => true,
-          "data-miq_sparkle_off" => true,
-          "data-miq_observe"     => {:url => url}.to_json)
+          "data-miq_sparkle_off" => true)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("tl_#{typ}_tz", "#{url}");
   %form#hiddenForm
     %input.filter1{:type => "hidden", :name => "filter1", :value => @sb[:bottlenecks][:tl_options][:fltr1]}

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -3,7 +3,8 @@
 #planning_options_div{:style => "width: 100%; height: 100%; overflow: auto;"}
   = render :partial => "layouts/flash_msg", :locals => {:div_num => "0"}
   %fieldset{:style => "background-color: #f0f0f0; padding: 10px;"}
-    %h3= _('Reference VM Selection')
+    %h3
+      = _('Reference VM Selection')
     - options = [["<#{_('Choose')}>"],
       [_("By %s") % ui_lookup(:table => "ems_infras"), "ems"],
       [_("By %s") % ui_lookup(:table => "ems_clusters"), "cluster"],
@@ -67,11 +68,13 @@
           "data-miq_observe"     => {:url => url}.to_json)
 
   %fieldset{:style => "background-color: #f0f0f0; padding: 10px"}
-    %h3= _('VM Options')
-    %table.style1
-      %tr
-        %td.key{:style => "width: 120px;"}= _('Source')
-        %td
+    %h3
+      = _('VM Options')
+    %form.form-horizontal
+      .form-group
+        %label.control-label.col-md-4
+          = _('Source')
+        .col-md-8
           = select_tag("vm_mode",
             options_for_select(PLANNING_VM_MODES.invert.sort, @sb[:planning][:options][:vm_mode]),
             "data-miq_sparkle_on"  => true,
@@ -79,9 +82,10 @@
             "data-miq_observe"     => {:url => url}.to_json)
       - vm_opts = VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])
       - if vm_opts[:cpu]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('CPU Speed')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('CPU Speed')
+          .col-md-8
             = check_box_tag("trend_cpu", "1", @sb[:planning][:options][:trend_cpu],
               "data-miq_sparkle_on"       => true,
               "data-miq_sparkle_off"      => true,
@@ -96,9 +100,10 @@
               = @sb[:planning][:options][:values][:cpu]
             = _('MHz')
       - if vm_opts[:vcpus]
-        %tr
-          %td.key{:style => "width: 120px;"}vCPU Count</td>
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('vCPU Count')
+          .col-md-8
             = check_box_tag("trend_vcpus", "1", @sb[:planning][:options][:trend_vcpus],
             "data-miq_sparkle_on"       => true,
             "data-miq_sparkle_off"      => true,
@@ -112,9 +117,10 @@
             - else
               = @sb[:planning][:options][:values][:vcpus]
       - if vm_opts[:memory]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('Memory Size')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('Memory Size')
+          .col-md-8
             = check_box_tag("trend_memory", "1", @sb[:planning][:options][:trend_memory],
               "data-miq_sparkle_on"       => true,
               "data-miq_sparkle_off"      => true,
@@ -129,9 +135,10 @@
               = @sb[:planning][:options][:values][:memory]
             = _('MB')
       - if vm_opts[:storage]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('Disk Space')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('Disk Space')
+          .col-md-8
             = check_box_tag("trend_storage", "1", @sb[:planning][:options][:trend_storage],
               "data-miq_sparkle_on"       => true,
               "data-miq_sparkle_off"      => true,
@@ -147,20 +154,23 @@
             = _('GB')
 
   %fieldset{:style => "background-color: #f0f0f0; padding: 10px;"}
-    %h3= _('Target Options / Limits')
-    %table.style1
-      %tr
-        %td.key{:style => "width: 120px;"}= _('Show')
-        %td
+    %h3
+      = _('Target Options / Limits')
+    %form.form-horizontal
+      .form-group
+        %label.control-label.col-md-4
+          = _('Show')
+        .col-md-8
           = select_tag("target_typ",
             options_for_select(TARGET_TYPE_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:target_typ]),
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             "data-miq_observe"     => {:url => url}.to_json)
       - unless @sb[:planning][:options][:target_filters].blank?
-        %tr
-          %td.key{:style => "width: 120px;"}= _('Filter')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('Filter')
+          .col-md-8
             - options = [["<#{_('All')}>", nil]] + Array(@sb[:planning][:options][:target_filters].invert).sort_by { |a| a.first.downcase }
             = select_tag("target_filter",
               options_for_select(options, @sb[:planning][:options][:target_filter]),
@@ -168,9 +178,10 @@
               "data-miq_sparkle_off" => true,
               "data-miq_observe"     => {:url => url}.to_json)
       - if vm_opts[:cpu]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('CPU Speed')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('CPU Speed')
+          .col-md-8
             = select_tag("limit_cpu",
               options_for_select(TREND_LIMIT_PERCENTS.invert.sort_by(&:last).reverse, @sb[:planning][:options][:limit_cpu]),
               :disabled              => @sb[:planning][:options][:trend_cpu] ? false : true,
@@ -178,9 +189,10 @@
               "data-miq_sparkle_off" => true,
               "data-miq_observe"     => {:url => url}.to_json)
       - if vm_opts[:vcpus]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('vCPUs per Core')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('vCPUs per Core')
+          .col-md-8
             = select_tag("limit_vcpus",
               options_for_select((1..25).to_a.reverse, @sb[:planning][:options][:limit_vcpus]),
               :disabled => @sb[:planning][:options][:trend_vcpus] ? false : true,
@@ -188,9 +200,10 @@
               "data-miq_sparkle_off" => true,
               "data-miq_observe"     => {:url => url}.to_json)
       - if vm_opts[:memory]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('Memory Size')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('Memory Size')
+          .col-md-8
             = select_tag("limit_memory",
               options_for_select(TREND_LIMIT_PERCENTS.invert.sort_by(&:last).reverse, @sb[:planning][:options][:limit_memory]),
               :disabled              => @sb[:planning][:options][:trend_memory] ? false : true,
@@ -198,9 +211,10 @@
               "data-miq_sparkle_off" => true,
               "data-miq_observe"     => {:url => url}.to_json)
       - if vm_opts[:storage]
-        %tr
-          %td.key{:style => "width: 120px;"}= _('Datastore Space')
-          %td
+        .form-group
+          %label.control-label.col-md-4
+            = _('Datastore Space')
+          .col-md-8
             = select_tag("limit_storage",
               options_for_select(TREND_LIMIT_PERCENTS.invert.sort_by(&:last).reverse, @sb[:planning][:options][:limit_storage]),
               :disabled => @sb[:planning][:options][:trend_storage] ? false : true,
@@ -209,19 +223,22 @@
               "data-miq_observe"     => {:url => url}.to_json)
 
   %fieldset{:style => "background-color: #f0f0f0; padding: 10px"}
-    %h3= _('Trend Options')
-    %table.style1
-      %tr
-        %td.key{:style => "width: 120px;"}= _('Trends for past')
-        %td
+    %h3
+      = _('Trend Options')
+    %form.form-horizontal
+      .form-group
+        %label.control-label.col-md-4
+          = _('Trends for past')
+        .col-md-8
           = select_tag("trend_days",
             options_for_select(WEEK_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:days].to_i),
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             "data-miq_observe"     => {:url => url}.to_json)
-      %tr
-        %td.key{:style => "width: 120px;"}= _('Time Profile')
-        %td.wide{:style => "padding-right: 5px;", :valign => "top"}
+      .form-group
+        %label.control-label.col-md-4
+          = _('Time Profile')
+        .col-md-8
           - if session[:time_profiles].blank?
             = _('No Time Profiles found')
           - elsif session[:time_profiles].length == 1

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -14,15 +14,19 @@
     = select_tag("filter_typ",
       options_for_select(options, @sb[:planning][:options][:filter_typ]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
+        "class"                => "selectpicker",
         "data-miq_sparkle_on"  => true,
-        "data-miq_sparkle_off" => true,
-        "data-miq_observe"     => {:url => url}.to_json)
+        "data-miq_sparkle_off" => true)
+    :javascript
+      miqInitSelectPicker();
+      miqSelectPickerEvent("filter_typ", "#{url}");
     - if @sb[:planning][:options][:filter_typ] == "host"
       %br
       - options = [["<#{_('Choose a %s') % title_for_host}>", "<Choose>"]] + Array(@sb[:planning][:hosts].invert).sort_by { |a| a.first.downcase }
       = select_tag("filter_value",
         options_for_select(options, @sb[:planning][:options][:filter_value]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
+        "class"                => "selectpicker",
         "data-miq_sparkle_on"  => true,
         "data-miq_sparkle_off" => true,
         "data-miq_observe"     => {:url => url}.to_json)
@@ -32,6 +36,7 @@
       = select_tag("filter_value",
         options_for_select(options, @sb[:planning][:options][:filter_value]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
+        "class"                => "selectpicker",
         "data-miq_sparkle_on"  => true,
         "data-miq_sparkle_off" => true,
         "data-miq_observe"     => {:url => url}.to_json)
@@ -41,6 +46,7 @@
       = select_tag("filter_value",
         options_for_select(options, @sb[:planning][:options][:filter_value]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
+        "class"                => "selectpicker",
         "data-miq_sparkle_on"  => true,
         "data-miq_sparkle_off" => true,
         "data-miq_observe"     => {:url => url}.to_json)
@@ -50,9 +56,12 @@
       = select_tag("filter_value",
         options_for_select(options, @sb[:planning][:options][:filter_value]),
         :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
+        "class"                => "selectpicker",
         "data-miq_sparkle_on"  => true,
-        "data-miq_sparkle_off" => true,
-        "data-miq_observe"     => {:url => url}.to_json)
+        "data-miq_sparkle_off" => true)
+    :javascript
+      miqInitSelectPicker();
+      miqSelectPickerEvent("filter_value", "#{url}");
     - if @sb[:planning][:vms]
       %br
       - if @sb[:planning][:vms].empty?
@@ -63,9 +72,12 @@
         = select_tag("chosen_vm",
           options_for_select(options, @sb[:planning][:options][:chosen_vm]),
           :disabled              => @sb[:planning][:options][:vm_mode] != :manual ? false : true,
+          "class"                => "selectpicker",
           "data-miq_sparkle_on"  => true,
-          "data-miq_sparkle_off" => true,
-          "data-miq_observe"     => {:url => url}.to_json)
+          "data-miq_sparkle_off" => true)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("chosen_vm", "#{url}");
 
   %fieldset{:style => "background-color: #f0f0f0; padding: 10px"}
     %h3
@@ -77,9 +89,12 @@
         .col-md-8
           = select_tag("vm_mode",
             options_for_select(PLANNING_VM_MODES.invert.sort, @sb[:planning][:options][:vm_mode]),
+            "class"                => "selectpicker",
             "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            "data-miq_observe"     => {:url => url}.to_json)
+            "data-miq_sparkle_off" => true)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("vm_mode", "#{url}");
       - vm_opts = VimPerformancePlanning.vm_default_options(@sb[:planning][:options][:vm_mode])
       - if vm_opts[:cpu]
         .form-group
@@ -163,9 +178,12 @@
         .col-md-8
           = select_tag("target_typ",
             options_for_select(TARGET_TYPE_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:target_typ]),
+            "class"                => "selectpicker",
             "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            "data-miq_observe"     => {:url => url}.to_json)
+            "data-miq_sparkle_off" => true)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("target_typ", "#{url}");
       - unless @sb[:planning][:options][:target_filters].blank?
         .form-group
           %label.control-label.col-md-4
@@ -174,9 +192,12 @@
             - options = [["<#{_('All')}>", nil]] + Array(@sb[:planning][:options][:target_filters].invert).sort_by { |a| a.first.downcase }
             = select_tag("target_filter",
               options_for_select(options, @sb[:planning][:options][:target_filter]),
+              "class"                => "selectpicker",
               "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-miq_observe"     => {:url => url}.to_json)
+              "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("target_filter", "#{url}");
       - if vm_opts[:cpu]
         .form-group
           %label.control-label.col-md-4
@@ -185,9 +206,12 @@
             = select_tag("limit_cpu",
               options_for_select(TREND_LIMIT_PERCENTS.invert.sort_by(&:last).reverse, @sb[:planning][:options][:limit_cpu]),
               :disabled              => @sb[:planning][:options][:trend_cpu] ? false : true,
+              "class"                => "selectpicker",
               "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-miq_observe"     => {:url => url}.to_json)
+              "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("limit_cpu", "#{url}");
       - if vm_opts[:vcpus]
         .form-group
           %label.control-label.col-md-4
@@ -196,9 +220,12 @@
             = select_tag("limit_vcpus",
               options_for_select((1..25).to_a.reverse, @sb[:planning][:options][:limit_vcpus]),
               :disabled => @sb[:planning][:options][:trend_vcpus] ? false : true,
+              "class"                => "selectpicker",
               "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-miq_observe"     => {:url => url}.to_json)
+              "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("limit_vcpus", "#{url}");
       - if vm_opts[:memory]
         .form-group
           %label.control-label.col-md-4
@@ -207,9 +234,12 @@
             = select_tag("limit_memory",
               options_for_select(TREND_LIMIT_PERCENTS.invert.sort_by(&:last).reverse, @sb[:planning][:options][:limit_memory]),
               :disabled              => @sb[:planning][:options][:trend_memory] ? false : true,
+              "class"                => "selectpicker",
               "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-miq_observe"     => {:url => url}.to_json)
+              "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("limit_memory", "#{url}");
       - if vm_opts[:storage]
         .form-group
           %label.control-label.col-md-4
@@ -218,9 +248,12 @@
             = select_tag("limit_storage",
               options_for_select(TREND_LIMIT_PERCENTS.invert.sort_by(&:last).reverse, @sb[:planning][:options][:limit_storage]),
               :disabled => @sb[:planning][:options][:trend_storage] ? false : true,
+              "class"                => "selectpicker",
               "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-miq_observe"     => {:url => url}.to_json)
+              "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("limit_storage", "#{url}");
 
   %fieldset{:style => "background-color: #f0f0f0; padding: 10px"}
     %h3
@@ -232,9 +265,12 @@
         .col-md-8
           = select_tag("trend_days",
             options_for_select(WEEK_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:days].to_i),
+            "class"                => "selectpicker",
             "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            "data-miq_observe"     => {:url => url}.to_json)
+            "data-miq_sparkle_off" => true)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("trend_days", "#{url}");
       .form-group
         %label.control-label.col-md-4
           = _('Time Profile')
@@ -247,6 +283,9 @@
           - else
             = select_tag("time_profile",
               options_for_select(session[:time_profiles].invert.sort_by(&:first), @sb[:planning][:options][:time_profile]),
+              "class"                => "selectpicker",
               "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              "data-miq_observe"     => {:url => url}.to_json)
+              "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("time_profile", "#{url}");

--- a/app/views/miq_capacity/_utilization_options.html.haml
+++ b/app/views/miq_capacity/_utilization_options.html.haml
@@ -10,8 +10,11 @@
       .col-md-10
         = select_tag("#{cap_type}_days",
           options_for_select(WEEK_CHOICES.invert.sort_by(&:last), @sb[:util][:options][:days].to_i),
-          "data-miq_sparkle_on" => true,
-          "data-miq_observe"    => {:url => url}.to_json)
+          "class"               => "selectpicker",
+          "data-miq_sparkle_on" => true)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("#{cap_type}_days", "#{url}");
 
   %form.form-horizontal
     .form-group
@@ -21,8 +24,11 @@
         - options = [["<#{_('None')}>", "<None>"]] + (@sb[:util][:tags] ? @sb[:util][:tags].invert.sort : [])
         = select_tag("#{cap_type}_tag",
           options_for_select(options, @sb[:util][:options][:tag]),
-          "data-miq_sparkle_on" => true,
-          "data-miq_observe"    => {:url => url}.to_json)
+          "class"               => "selectpicker",
+          "data-miq_sparkle_on" => true)
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("#{cap_type}_tag", "#{url}");
 
   %form.form-horizontal
     .form-group
@@ -38,24 +44,18 @@
           = select_tag("#{cap_type}_time_profile",
             options_for_select(Array(session[:time_profiles].invert).sort_by(&:first),
             @sb[:util][:options][:time_profile]),
-            "data-miq_sparkle_on" => true,
-            "data-miq_observe"    => {:url => url}.to_json)
-    - if ["summ"].include?(cap_type)
+            "class"               => "selectpicker",
+            "data-miq_sparkle_on" => true)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("#{cap_type}_time_profile", "#{url}");
+    - if %w(summ report).include?(cap_type)
+      - date_id = cap_type == "summ" ? "1" : "2"
       .form-group
         %label.control-label.col-md-2
           = _('Selected Day')
         .col-md-10
-          = datepicker_input_tag("miq_date_1",
-            @sb[:util][:options][:chart_date],
-            :readonly               => "true",
-            "data-miq_sparkle_on"   => true,
-            "data-miq_observe_date" => {:url => url}.to_json)
-    - elsif ["report"].include?(cap_type)
-      .form-group
-        %label.control-label.col-md-2
-          = _('Selected Day')
-        .col-md-10
-          = datepicker_input_tag("miq_date_2",
+          = datepicker_input_tag("miq_date_#{date_id}",
             @sb[:util][:options][:chart_date],
             :readonly               => "true",
             "data-miq_sparkle_on"   => true,

--- a/app/views/miq_capacity/_utilization_options.html.haml
+++ b/app/views/miq_capacity/_utilization_options.html.haml
@@ -1,30 +1,34 @@
 - cap_type ||= "details"
 - url = url_for(:action => 'util_chart_chooser', :id => @record.id)
 %div{:id => "capacity_#{cap_type}_options_div", :onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
-  %h3= _('Options')
-  %table.style1
-    %tr
-      %td.key{:style => "width: 120px;"}= _('Trends for past')
-      %td.wide{:style => "padding-right: 5px;"}
+  %h3
+    = _('Options')
+  %form.form-horizontal
+    .form-group
+      %label.control-label.col-md-2
+        = _('Trends for past')
+      .col-md-10
         = select_tag("#{cap_type}_days",
           options_for_select(WEEK_CHOICES.invert.sort_by(&:last), @sb[:util][:options][:days].to_i),
           "data-miq_sparkle_on" => true,
           "data-miq_observe"    => {:url => url}.to_json)
 
-  %table.style1
-    %tr
-      %td.key{:style => "width: 120px;"}= _('Classification')
-      %td.wide{:style => "padding-right: 5px;"}
+  %form.form-horizontal
+    .form-group
+      %label.control-label.col-md-2
+        = _('Classification')
+      .col-md-10
         - options = [["<#{_('None')}>", "<None>"]] + (@sb[:util][:tags] ? @sb[:util][:tags].invert.sort : [])
         = select_tag("#{cap_type}_tag",
           options_for_select(options, @sb[:util][:options][:tag]),
           "data-miq_sparkle_on" => true,
           "data-miq_observe"    => {:url => url}.to_json)
 
-  %table.style1
-    %tr
-      %td.key{:style => "width: 120px;"}= _('Time Profile')
-      %td.wide{:style => "padding-right: 5px;", :valign => "top"}
+  %form.form-horizontal
+    .form-group
+      %label.control-label.col-md-2
+        = _('Time Profile')
+      .col-md-10
         - if session[:time_profiles].blank?
           = _('No Time Profiles found')
         - elsif session[:time_profiles].length == 1
@@ -37,18 +41,20 @@
             "data-miq_sparkle_on" => true,
             "data-miq_observe"    => {:url => url}.to_json)
     - if ["summ"].include?(cap_type)
-      %tr
-        %td.key{:style => "width: 120px;"}= _('Selected Day')
-        %td.wide{:style => "padding-right: 5px;"}
+      .form-group
+        %label.control-label.col-md-2
+          = _('Selected Day')
+        .col-md-10
           = datepicker_input_tag("miq_date_1",
             @sb[:util][:options][:chart_date],
             :readonly               => "true",
             "data-miq_sparkle_on"   => true,
             "data-miq_observe_date" => {:url => url}.to_json)
     - elsif ["report"].include?(cap_type)
-      %tr
-        %td.key{:style => "width: 120px;"}= _('Selected Day')
-        %td.wide{:style => "padding-right: 5px;"}
+      .form-group
+        %label.control-label.col-md-2
+          = _('Selected Day')
+        .col-md-10
           = datepicker_input_tag("miq_date_2",
             @sb[:util][:options][:chart_date],
             :readonly               => "true",

--- a/spec/views/miq_capacity/_utilization_options.html.haml_spec.rb
+++ b/spec/views/miq_capacity/_utilization_options.html.haml_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+include ApplicationHelper
+
+describe "miq_capacity/_utilization_options.html.haml" do
+  before :each do
+    set_controller_for_view("miq_capacity")
+    assign(:record, Struct.new("Record", :id).new(2))
+    assign(:sb, {:util => {:options => {:days         => 2,
+                                        :time_profile => "1",
+                                        :chart_date   => "asdf"
+                                       },
+                           :tags    => {:asdf => "fdsa"}
+                          }
+                }
+          )
+  end
+  it "check if correct fields are being displayed if cap_type is not set" do
+    # render with default cap_type variable value
+    render :partial => "miq_capacity/utilization_options",
+           :locals  => {:cap_type => nil}
+  end
+  it "check if correct fields are being displayed if cap_type is set" do
+    response.should_not have_selector('label', :text => 'Selected Day')
+    # render with cap_type variable set
+    render :partial => "miq_capacity/utilization_options",
+           :locals  => {:cap_type => "summ"}
+    response.should have_selector('label', :text => 'Selected Day')
+  end
+end


### PR DESCRIPTION

Parent issue: #3139

Before:
![before](https://cloud.githubusercontent.com/assets/1187051/9334632/fe5cc9f2-45cf-11e5-8107-a4a827d5e83d.png)
After:
![plan_after](https://cloud.githubusercontent.com/assets/1187051/9474942/d9d0c356-4b63-11e5-93b3-419eb686c3ac.png)


Before:
![bott_before](https://cloud.githubusercontent.com/assets/1187051/9474946/dfaea572-4b63-11e5-88e4-48e7b673d840.png)
After:
![bott_after](https://cloud.githubusercontent.com/assets/1187051/9474950/e488fd54-4b63-11e5-81fc-c2ff38de98a9.png)

