### PR TITLE
[wip] Tenant edit root

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -55,6 +55,12 @@ class Tenant < ActiveRecord::Base
     self.class.descendants_of(self).where(:divisible => false)
   end
 
+  # this allows us to edit this record in the ui without
+  # settings getting into the default record
+  #
+  # @return [Boolean] Read out of configurations if this is a default records?
+  attr_writer :read_settings
+
   def name
     tenant_attribute(:name, :company)
   end
@@ -144,11 +150,12 @@ class Tenant < ActiveRecord::Base
 
   # when a root tenant has an attribute with a nil value,
   #   read the value from the settings table instead
+  # this can be turned off by setting read_settings to false
   #
   # @return the attribute value
   def tenant_attribute(attr_name, setting_name)
     ret = self[attr_name]
-    if ret.nil? && root?
+    if ret.nil? && root? && (@read_settings != false)
       ret = settings.fetch_path(:server, setting_name)
       block_given? ? yield(ret) : ret
     else

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -159,6 +159,11 @@ describe Tenant do
         expect(root_tenant.name).to eq("custom")
       end
     end
+
+    it "ignores has custom name for default tenant" do
+      default_tenant.read_settings = false
+      expect(default_tenant.name).to be_nil
+    end
   end
 
   it "#parent_name" do


### PR DESCRIPTION
The root tenant's company name is read from the tenants table. When that is blank, it falls back to a value from the configurations table.

When editing the root tenant record, we don't want the fallback value to be displayed in the form. It it were displayed, that value would end up getting into the tenant table, and the configurations fallback functionality would no longer return the expected configurations value.

(this is the case with most fields in the tenant object)

/cc @gmcculloug for your review
/cc @h-kataria this is available when you need it