### PR TITLE
Check if LD_LIBRARY_PATH is nil before manipulating

### DIFF
--- a/gems/pending/VixDiskLib/VixDiskLib.rb
+++ b/gems/pending/VixDiskLib/VixDiskLib.rb
@@ -96,7 +96,8 @@ class VixDiskLib
     vars_to_clear.each do |key|
       my_env.delete(key)
     end
-    my_env["LD_LIBRARY_PATH"] = my_env["LD_LIBRARY_PATH"] + ":" + VIXDISKLIB_PATH
+
+    my_env["LD_LIBRARY_PATH"] = (my_env["LD_LIBRARY_PATH"].to_s.split(':') << VIXDISKLIB_PATH).compact.join(":")
     my_env
   end
 


### PR DESCRIPTION
If LD_LIBRARY_PATH is not set, the app errors out.

See http://talk.manageiq.org/t/where-to-run-the-smart-proxy/836/14