### PR TITLE
[WIP] ensure default_tenant exists in tests

### DIFF
--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -5,6 +5,7 @@ describe "Login process" do
     Vmdb::Application.config.secret_token = 'x' * 40
     EvmSpecHelper.seed_admin_user_and_friends
 
+    EvmSpecHelper.local_guid_miq_server_zone
     ApplicationController.any_instance.stub(:set_user_time_zone)
     MiqEnvironment::Process.stub(:is_web_server_worker?).and_return(true)
   end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -51,7 +51,7 @@ module EvmSpecHelper
   end
 
   def self.remote_guid_miq_server_zone
-    Tenant.seed
+    ActsAsTenant.default_tenant ||= Tenant.seed
     guid   = MiqUUID.new_guid
     zone   = FactoryGirl.create(:zone)
     server = FactoryGirl.create(:miq_server_master, :guid => guid, :zone => zone)


### PR DESCRIPTION
Tests were failing because the views now assume there exists a tenant

The tenant is loaded from the default tenant.