### PR TITLE
events: fix ambiguous reference to ems_id in where clause

### DIFF
--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -41,11 +41,6 @@ class AvailabilityZone < ActiveRecord::Base
   end
 
   def event_where_clause(assoc=:ems_events)
-    case assoc.to_sym
-    when :ems_events
-      ["availability_zone_id = ?", self.id]
-    when :policy_events
-      ["availability_zone_id = ?", self.id]
-    end
+    ["#{events_table_name(assoc)}.availability_zone_id = ?", id]
   end
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -38,11 +38,11 @@ class ContainerGroup < ActiveRecord::Base
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_namespace = ? AND container_group_name = ? AND ems_id = ?",
+      ["container_namespace = ? AND container_group_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
        container_project.name, name, ems_id]
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["ems_id = ?", ems_id]
+      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
     end
   end
 end

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -40,10 +40,10 @@ class ContainerNode < ActiveRecord::Base
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_node_name = ? AND ems_id = ?", name, ems_id]
+      ["container_node_name = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["ems_id = ?", ems_id]
+      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
     end
   end
 end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -352,8 +352,8 @@ class ExtManagementSystem < ActiveRecord::Base
     end
   end
 
-  def event_where_clause(assoc)
-    ["ems_id = ?", self.id]
+  def event_where_clause(assoc = :ems_events)
+    ["#{events_table_name(assoc)}.ems_id = ?", id]
   end
 
   def total_vms_and_templates

--- a/app/models/mixins/event_mixin.rb
+++ b/app/models/mixins/event_mixin.rb
@@ -15,27 +15,26 @@ module EventMixin
   end
 
   def has_events?(assoc=:ems_events)
+    # TODO: homemade caching is probably harfmul as it's not expected.
+    # It should be considered for removal.
     @has_events ||= {}
     return @has_events[assoc] if @has_events.has_key?(assoc)
+    @has_events[assoc] = events_assoc_class(assoc).where(event_where_clause(assoc)).exists?
+  end
 
-    klass = assoc.to_s.singularize.camelize.constantize
-    @has_events[assoc] = klass.where(event_where_clause(assoc)).exists?
+  def events_assoc_class(assoc)
+    assoc.to_s.classify.constantize
+  end
+
+  def events_table_name(assoc)
+    events_assoc_class(assoc).table_name
   end
 
   private
 
   def find_one_event(assoc, order)
-    ewc = self.event_where_clause(assoc)
-    return nil if ewc.blank?
-
-    klass = if assoc == :ems_events
-      EmsEvent
-    elsif assoc == :policy_events
-      PolicyEvent
-    end
-    return nil if klass.blank?
-
-    klass.where(ewc).order(order).first
+    ewc = event_where_clause(assoc)
+    events_assoc_class(assoc).where(ewc).order(order).first unless ewc.blank?
   end
 
 end

--- a/spec/models/availability_zone_spec.rb
+++ b/spec/models/availability_zone_spec.rb
@@ -9,4 +9,10 @@ describe AvailabilityZone do
     described_class.available.length.should == 2
     described_class.available.each { |az| az.class.should_not == ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull }
   end
+
+  it ".event_where_clause" do
+    zone = FactoryGirl.create(:availability_zone_amazon)
+    zone.event_where_clause.should_not be nil
+    EmsEvent.where(zone.event_where_clause).length.should be == 0
+  end
 end

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -7,7 +7,7 @@ describe EventMixin do
         include EventMixin
 
         def event_where_clause(assoc)
-          ["ems_id = ?", 1]
+          ["#{events_table_name(assoc)}.ems_id = ?", 1]
         end
       end
 
@@ -49,7 +49,7 @@ describe EventMixin do
         include EventMixin
 
         def event_where_clause(assoc)
-          ["ems_id = ?", nil]
+          ["#{events_table_name(assoc)}.ems_id = ?", nil]
         end
       end
     end


### PR DESCRIPTION
Before this patch the generation of the timeline was broken by:

    PG::AmbiguousColumn: ERROR: column reference "ems_id" is ambiguous

Fixes #3829