### PR TITLE
Replace angularjs-rails with rails-assets-angular{,-mocks}

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "activerecord-deprecated_finders", "~>1.0.4",     :require => "active_record
 
 # Client-side dependencies
 gem "jquery-rjs", "=0.1.1", :git => 'https://github.com/amatsuda/jquery-rjs.git'
-gem 'angularjs-rails', '~>1.4.3'
 gem 'angular-ui-bootstrap-rails', '~> 0.13.0'
 gem 'momentjs-rails', '~> 2.10.3'
 gem 'jquery-rails', "~>4.0.4"
@@ -113,6 +112,8 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-c3', '~> 0.4.10'
   gem 'rails-assets-bootstrap-select', '~> 1.5.4'
   gem 'rails-assets-bootstrap-hover-dropdown', '~> 2.0.11'
+  gem 'rails-assets-angular', '~> 1.4.3'
+  gem 'rails-assets-angular-mocks', '~> 1.4.3'
 end
 
 #


### PR DESCRIPTION
This is a quick fix to enable merging #3524 with `gem 'rails-assets-kubernetes-topology-graph'`, while #3773 is being worked on.