### PR TITLE
Fix for issue #2854 - default :port value in container manageers re-directed to DEFAULT_PORT class constant 

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -779,9 +779,9 @@ module EmsCommon
       if ["openstack", "openstack_infra"].include?(params[:server_emstype])
         @edit[:new][:port] = @ems.port ? @ems.port : 5000
       elsif params[:server_emstype] == ManageIQ::Providers::Kubernetes::ContainerManager.ems_type
-        @edit[:new][:port] = @ems.port ?  @ems.port : ManageIQ::Providers::Kubernetes::ContainerManager.new.port
+        @edit[:new][:port] = @ems.port ? @ems.port : ManageIQ::Providers::Kubernetes::ContainerManager::DEFAULT_PORT
       elsif params[:server_emstype] == ManageIQ::Providers::Openshift::ContainerManager.ems_type
-        @edit[:new][:port] = @ems.port ?  @ems.port : ManageIQ::Providers::Openshift::ContainerManager.new.port
+        @edit[:new][:port] = @ems.port ? @ems.port : ManageIQ::Providers::Openshift::ContainerManager::DEFAULT_PORT
       else
         @edit[:new][:port] = nil
       end

--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -12,7 +12,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
 
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
-  default_value_for :port, 6443
+  DEFAULT_PORT = 6443
+  default_value_for :port, DEFAULT_PORT
 
   # This is the API version that we use and support throughout the entire code
   # (parsers, events, etc.). It should be explicitly selected here and not

--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -10,7 +10,8 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   has_many :container_routes,                      :foreign_key => :ems_id, :dependent => :destroy
   has_many :container_projects,                    :foreign_key => :ems_id, :dependent => :destroy
 
-  default_value_for :port, 8443
+  DEFAULT_PORT = 8443
+  default_value_for :port, DEFAULT_PORT
 
   # This is the API version that we use and support throughout the entire code
   # (parsers, events, etc.). It should be explicitly selected here and not


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/2854

```:port``` re-factored to ```DEFAULT_PORT``` class constant 

@abonas @simon3z I couldn't find any other references to ```:default_port``` other than the ones in this patch. Please see if I missed anything.
