### PR TITLE
remove appliance_name from tenant

### DIFF
--- a/app/controllers/application_controller/tenancy.rb
+++ b/app/controllers/application_controller/tenancy.rb
@@ -19,7 +19,6 @@ module ApplicationController::Tenancy
   # NOTE: remove when these session vars are removed
   def set_session_tenant(tenant = current_tenant)
     session[:customer_name] = tenant.try(:name)
-    session[:vmdb_name]     = tenant.try(:appliance_name)
     session[:custom_logo]   = tenant.try(:logo?)
     tenant
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1381,4 +1381,8 @@ module ApplicationHelper
   end
 
   attr_reader :big_iframe
+
+  def appliance_name
+    MiqServer.my_server.name
+  end
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -54,10 +54,6 @@ class Tenant < ActiveRecord::Base
     tenant_attribute(:name, :company)
   end
 
-  def appliance_name
-    tenant_attribute(:appliance_name, :name)
-  end
-
   def login_text
     tenant_attribute(:login_text, :custom_login_text)
   end
@@ -133,7 +129,6 @@ class Tenant < ActiveRecord::Base
     self.domain = nil unless domain.present?
 
     self.name = nil unless name.present?
-    self.appliance_name = nil unless appliance_name.present?
   end
 
   def settings

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -142,8 +142,9 @@ class Tenant < ActiveRecord::Base
 
   # validates that there is only one tree
   def validate_only_one_root
-    if !(parent_id || parent) && self.class.roots.exists?
-      errors.add(:parent, "required")
+    if !(parent_id || parent)
+      root = self.class.root_tenant
+      errors.add(:parent, "required") if root && root != self
     end
   end
 end

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -2,12 +2,12 @@
   %li.dropdown
     %a{:href => "#", :class => "dropdown-toggle", "data-toggle" => "dropdown"}
       %span.pficon.pficon-user
-      = "#{current_user.name} | #{current_tenant.appliance_name}"
+      = "#{current_user.name} | #{appliance_name}"
       %b.caret
     %ul.dropdown-menu
       %li.disabled
         %a{:href => "#"}
-          = _('Server: %s') % current_tenant.appliance_name
+          = _('Server: %s') % appliance_name
 
       - if eligible_groups.length > 1
         %li.dropdown-submenu
@@ -30,4 +30,4 @@
 
 - else
   = _('Logging into')
-  = current_tenant.appliance_name
+  = appliance_name

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -6,7 +6,7 @@
         %fieldset
           %h3= _('Session Information')
           .form-horizontal.static
-            - [[_("Server Name"),     h(current_tenant.appliance_name)],
+            - [[_("Server Name"),     h(appliance_name)],
                [_("Version"),         h(@vmdb[:version] + "." + @vmdb[:build])],
                [_("User Name"),       h(current_user.name)],
                [_("User Role"),       h(@user_role)],

--- a/db/migrate/20150819154348_drop_tenant_appliance_name.rb
+++ b/db/migrate/20150819154348_drop_tenant_appliance_name.rb
@@ -1,0 +1,9 @@
+class DropTenantApplianceName < ActiveRecord::Migration
+  def up
+    remove_column :tenants, :appliance_name
+  end
+
+  def down
+    add_column :tenants, :appliance_name, :string
+  end
+end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -41,10 +41,6 @@ describe Tenant do
       expect(tenant.name).to eq("custom")
     end
 
-    it "reads settings for default tenant" do
-      expect(default_tenant.name).to eq("settings")
-    end
-
     it "doesnt read settings for regular tenant" do
       tenant.name = nil
       expect(tenant.name).to be_nil
@@ -55,7 +51,8 @@ describe Tenant do
       expect(default_tenant.name).to eq("custom")
     end
 
-    it "has custom name for default tenant" do
+    it "reads settings for default tenant" do
+      expect(default_tenant[:name]).to be_nil
       expect(default_tenant.name).to eq("settings")
     end
   end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -215,8 +215,8 @@ describe Tenant do
   context "#root_tenant" do
     it "returns the root (not the default tenant)" do
       Tenant.destroy_all
-      r = described_class.create(:appliance_name => 'a', :subdomain => 'admin')
-      c = described_class.create(:appliance_name => 'b', :parent => r)
+      r = described_class.create(:subdomain => 'admin')
+      c = described_class.create(:parent => r)
 
       expect(described_class.root_tenant).to eq(r)
       expect(described_class.default_tenant).to eq(c)


### PR DESCRIPTION
`appliance_name` is only used by legacy appliances. New installations will not use and there is no reason to have in `Tenant`.

In the short term, we are going to use the settings value.
Once tenancy has authentication at every level, the need for this completely goes away and we can remove from settings.
