### PR TITLE
Fix for #2595 - Provider hostname field shortened

### DIFF
--- a/app/views/ems_container/_form_fields.html.haml
+++ b/app/views/ems_container/_form_fields.html.haml
@@ -1,11 +1,12 @@
 - unless @edit[:new][:emstype].blank?
   %tr
-    %td.key= _('Hostname (or IPv4 or IPv6 address)')
+    %td.key= _('Hostname or IP address')
     %td.wide
       = text_field_tag("hostname",
         @edit[:new][:hostname],
         :maxlength => MAX_HOSTNAME_LEN,
-        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+        "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+        :title => 'Hostname or IPv4/IPv6 address')
   %tr
     %td.key= _('Port')
     %td.wide


### PR DESCRIPTION
Before: (two line label)
![89981264-e12c-11e4-844a-3a1e4e2f1ef7](https://cloud.githubusercontent.com/assets/11256940/9361991/c5d72596-46a6-11e5-91f3-67210ab52c34.png)
After (Focused into tooltip):
![provider_short_hostname_label](https://cloud.githubusercontent.com/assets/11256940/9361863/28119c6a-46a6-11e5-9324-cd041f5f0a8a.png)

The options for dealing with this were:
> 1. take the part in brackets to a new line
2. instead of a "double or", do something like "or Ipv4 / Ipv6 address" (with one "or" and a slash)
3. in a tooltip then document away the problem.

I'll make the change for other providers once we agree on the solution.

@abonas @dclarizio @Fryguy Please review

