### PR TITLE
Bypass getting cached results for reporting classes that do not have an id column

### DIFF
--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -95,7 +95,7 @@ module MiqReport::Search
     includes = MiqExpression.merge_includes(self.get_include_for_find(self.include), self.include_for_find)
 
     self.extras ||= {}
-    return get_cached_page(limit, offset, includes, options) if self.extras[:target_ids_for_paging]
+    return get_cached_page(limit, offset, includes, options) if self.extras[:target_ids_for_paging] && self.db_class.column_names.include?('id')
 
     apply_sortby_in_search, order = get_order_info
 

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -45,4 +45,32 @@ describe MiqReport do
 
     end
   end
+
+  context "paged_view_search" do
+    it "should not call get_cached_page to load cached results if target class does not respond to id" do
+      report = MiqReport.new(
+          :name => "VmdbDatabaseSetting",
+          :title => "VmdbDatabaseSetting",
+          :db => "VmdbDatabaseSetting",
+          :cols       => ["name", "description", "value", "minimum_value", "maximum_value", "unit"],
+          :col_order  => ["name", "description", "value", "minimum_value", "maximum_value", "unit"],
+          :headers    => ["Name", "Description", "Value", "Minimum", "Maximum", "Unit"],
+          :order      => "Ascending",
+          :sortby     => ["name"],
+          :group      => "n"
+      )
+      options = {
+          :per_page    =>20,
+          :page        =>1,
+          :targets_hash=>true,
+          :userid      =>"admin"
+      }
+
+      expect(report).to_not receive(:get_cached_page)
+
+      results = attrs = nil
+      Proc.new { results, attrs = report.paged_view_search(options) }.call.should_not raise_error
+      results.length.should == 20
+    end
+  end
 end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -185,6 +185,21 @@ describe MiqReport do
           found_ids = results.data.collect { |rec| rec.data['id'] }
           found_ids.should match_array(@vms_in_silver_folder.collect(&:id))
         end
+
+        it "gets cached results" do
+          report = MiqReport.new(:db => "Vm", :sortby => "id")
+          options = {:page => 2, :per_page => 20 }
+
+          all_ids = Vm.all.order(:id).map(&:id)
+          report.extras = { :target_ids_for_paging => all_ids, :attrs_for_paging => {}}
+
+          results, attrs = report.paged_view_search(options)
+
+          results.length.should == 20
+          found_ids = results.data.collect { |rec| rec.data['id'] }
+          found_ids.should_not be_empty
+          found_ids.should == all_ids[20..39]
+        end
       end
 
       context "group has managed filters" do


### PR DESCRIPTION
Fixes error encountered while paging on database settings screen. It was failing because the VmdbDatabaseSetting class does not have an id column and the page caching caches ids.

https://github.com/ManageIQ/manageiq/issues/3945