### PR TITLE
Remove habtm to tenants

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -25,8 +25,6 @@ class ExtManagementSystem < ActiveRecord::Base
 
   belongs_to :provider
   belongs_to :tenant_owner, :class_name => 'Tenant'
-  has_many :tenant_resources, :as => :resource
-  has_many :tenants, :through => :tenant_resources
 
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate"

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,8 +8,6 @@ class Provider < ActiveRecord::Base
   belongs_to :tenant_owner, :class_name => 'Tenant'
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
-  has_many :tenant_resources, :as => :resource
-  has_many :tenants, :through => :tenant_resources
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -13,20 +13,6 @@ class Tenant < ActiveRecord::Base
   has_many :owned_vm_or_templates,        :foreign_key => :tenant_owner_id, :class_name => 'VmOrTemplate'
 
   has_many :tenant_quotas
-  has_many :tenant_resources
-  has_many :vm_or_templates,
-           :through     => :tenant_resources,
-           :source      => :resource,
-           :source_type => "VmOrTemplate"
-  has_many :ext_management_systems,
-           :through     => :tenant_resources,
-           :source      => :resource,
-           :source_type => "ExtManagementSystem"
-  has_many :providers,
-           :through     => :tenant_resources,
-           :source      => :resource,
-           :source_type => "Provider"
-
   has_many :miq_groups, :foreign_key => :tenant_owner_id
   has_many :users, :through => :miq_groups
 

--- a/app/models/tenant_resource.rb
+++ b/app/models/tenant_resource.rb
@@ -1,4 +1,0 @@
-class TenantResource < ActiveRecord::Base
-  belongs_to :tenant
-  belongs_to :resource, :polymorphic => true
-end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -114,8 +114,6 @@ class VmOrTemplate < ActiveRecord::Base
 #  has_many                  :service_templates, :through => :service_resources, :source => :service_template
   has_many                  :direct_services, :through => :service_resources, :source => :service
   belongs_to                :tenant_owner, :class_name => 'Tenant'
-  has_many                  :tenant_resources, :as => :resource
-  has_many                  :tenants, :through => :tenant_resources
 
   acts_as_miq_taggable
   include ReportableMixin

--- a/db/migrate/20150819121823_drop_tenant_resources.rb
+++ b/db/migrate/20150819121823_drop_tenant_resources.rb
@@ -1,0 +1,12 @@
+class DropTenantResources < ActiveRecord::Migration
+  def up
+    drop_table :tenant_resources
+  end
+
+  def down
+    create_table :tenant_resources do |t|
+      t.belongs_to :tenant, :type => :bigint
+      t.belongs_to :resource, :type => :bigint, :polymorphic => true
+    end
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -194,13 +194,4 @@ describe ExtManagementSystem do
       expect(tenant.owned_ext_management_systems).to include(ems)
     end
   end
-
-  context "#tenants" do
-    let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant owner" do
-      ems = FactoryGirl.create(:ext_management_system)
-      ems.tenants << tenant
-      expect(tenant.ext_management_systems).to include(ems)
-    end
-  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -55,13 +55,4 @@ describe Provider do
       expect(tenant.owned_providers).to include(provider)
     end
   end
-
-  context "#tenants" do
-    let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant owner" do
-      provider = FactoryGirl.create(:provider)
-      provider.tenants << tenant
-      expect(tenant.providers).to include(provider)
-    end
-  end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -434,15 +434,6 @@ describe VmOrTemplate do
     end
   end
 
-  context "#tenants" do
-    let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant owner" do
-      vm = FactoryGirl.create(:vm_vmware)
-      vm.tenants << tenant
-      expect(tenant.vm_or_templates).to include(vm)
-    end
-  end
-
   context "#is_available?" do
     it "returns true for SCVMM VM" do
       vm =  FactoryGirl.create(:vm_vmware)


### PR DESCRIPTION
tenant no longer needs `tenant_resources` join table.

We are using `miq_group` or `tenant_id` in the future