### PR TITLE
containers: fix default authentication type

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -61,6 +61,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def default_authentication_type
-    :token
+    :bearer
   end
 end


### PR DESCRIPTION
@blomquisg my bad I introduced this in #3830. I am sure I tested it with `:bearer` and it was failing on a missing method. I wonder if something changed meanwhile.

Anyway this should be the correct value now.