### PR TITLE
Use sys-uname instead of Platform gem

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -60,7 +60,7 @@ class Vmware::InfraManager < InfraManager
     return false unless MiqVimBrokerWorker.has_required_role?
     cfg = VMDB::Config.new("vmdb").config[:webservices][:use_vim_broker]
     return true if cfg == "force"
-    return true if cfg && Platform::OS == :unix
+    return true if cfg && Sys::Platform::OS == :unix
     return false
   end
 

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -151,7 +151,7 @@ module MiqServer::ServerSmartProxy
     caps = {:vixDisk => false}
     begin
       # This is only available on Linux
-      if Platform::IMPL == :linux
+      if Sys::Platform::IMPL == :linux
         # We now rely on the server role to determine if we want to enable server scanning.
         # Check if we want to expose this functionality
         #        unless get_config("vmdb").config[:server][:vix_disk_enabled] == false

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -36,7 +36,7 @@ gem "kubeclient",              "=0.1.17",           :require => false
 gem "openshift_client",        "=0.0.8",            :require => false
 gem "rest-client",                                  :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
 gem "parallel",                "~>0.5.21",          :require => false
-gem "Platform",                "=0.4.0",            :require => false
+gem "sys-uname",               "~>1.0.1",           :require => false
 gem "rubyzip",                 "=0.9.5",            :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646
 gem "rufus-lru",               "~>1.0.3",           :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false

--- a/gems/pending/Verbs/implementations/MicrosoftOps.rb
+++ b/gems/pending/Verbs/implementations/MicrosoftOps.rb
@@ -1,46 +1,46 @@
 require 'util/runcmd'
 require 'metadata/MIQExtract/MIQExtract'
 require 'metadata/VmConfig/VmConfig'
-require 'platform'
+require 'sys-uname'
 require 'Verbs/implementations/SharedOps'
 
 class MicrosoftOps
     def initialize(ost)
 		extend SharedOps
-        case Platform::OS
-        when :win32
+        case Sys::Platform::OS
+        when :windows
             require 'MicrosoftOpsWin'
             extend MicrosoftOpsWin
             initializeCOM
         end
     end
-	
+
 	def GetVersion(ost)
 		return @msCom.hypervisorVersion if @msCom
 		nil
 	end
-	
+
 	def getVmFile(ost)
 		vmName = ost.args[0]
     return File.uri_to_local_path(vmName) if vmName[0,7] == "file://"
 		return vmName
 	end
-	
+
     def diskNames(vmName)
         vmDir = File.dirname(vmName)
 	    cfg = VmConfig.new(vmName).getHash
 	    dfn = cfg["scsi0:0.filename"]
 	    dfn = cfg["ide0:0.filename"] if !dfn
 	    raise "Can't determine disk file for virtual machine" if !dfn
-		
+
 	    ext = File.extname(dfn)
 	    dfBase = File.basename(dfn, ext)
-		
+
 	    diskFile = File.join(vmDir, dfBase + ext)
 	    diskFileSave = File.join(vmDir, dfBase + ".miq")
 	    bbFileSave = File.join(vmDir, dfBase + "BB.miq")
-		
+
         return diskFile, diskFileSave, bbFileSave
     end
-	
+
 end # MicrosoftOps

--- a/gems/pending/VolumeManager/MiqVolumeManager.rb
+++ b/gems/pending/VolumeManager/MiqVolumeManager.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'platform'
+require 'sys-uname'
 require 'binary_struct'
 require 'VolumeManager/MiqLvm'
 require 'VolumeManager/MiqLdm'
@@ -12,7 +12,7 @@ class MiqVolumeManager
     attr_reader :logicalVolumes, :physicalVolumes, :visibleVolumes, :hiddenVolumes, :allPhysicalVolumes, :vgHash, :lvHash, :diskFileNames
 
     def self.fromNativePvs
-    	return nil unless Platform::IMPL == :linux
+    	return nil unless Sys::Platform::IMPL == :linux
 
     	msg_pfx = "MiqVolumeManager.fromNativePvs"
 

--- a/gems/pending/VolumeManager/VolMgrPlatformSupport.rb
+++ b/gems/pending/VolumeManager/VolMgrPlatformSupport.rb
@@ -1,4 +1,4 @@
-require 'platform'
+require 'sys-uname'
 
 class VolMgrPlatformSupport
     
@@ -7,7 +7,7 @@ class VolMgrPlatformSupport
         @cfgFile = cfgFile
         @ost = ost
         
-        if Platform::OS == :win32
+        if Sys::Platform::OS == :windows
 			require "VolumeManager/VolMgrPlatformSupportWin"
 			extend VolMgrPlatformSupportWin
 		else

--- a/gems/pending/fs/MiqFS/modules/RealFS.rb
+++ b/gems/pending/fs/MiqFS/modules/RealFS.rb
@@ -3,7 +3,7 @@ module RealFS
 	attr_reader :guestOS
 	
 	def fs_init
-		case Platform::IMPL
+		case Sys::Platform::IMPL
 			when :mswin, :mingw
 				self.fsType = "NTFS"
 				@guestOS = "Windows"

--- a/gems/pending/fs/iso9660/boot_sector.rb
+++ b/gems/pending/fs/iso9660/boot_sector.rb
@@ -127,7 +127,7 @@ module Iso9660
 		end
 		
 		def getSuffix
-			if Platform::ARCH == :x86
+			if Sys::Platform::ARCH == :x86
 				@@suff = 'LE'
 			else
 				# Other architectures are bi-endian and must be determined at run time.

--- a/gems/pending/fs/iso9660/rock_ridge.rb
+++ b/gems/pending/fs/iso9660/rock_ridge.rb
@@ -1,4 +1,4 @@
-require 'platform'
+require 'sys-uname'
 
 require 'binary_struct'
 require 'util/miq-unicode'

--- a/gems/pending/fs/modules/WinMount.rb
+++ b/gems/pending/fs/modules/WinMount.rb
@@ -1,4 +1,4 @@
-require 'platform'
+require 'sys-uname'
 require 'fs/MiqFS/MiqFS'
 require 'metadata/util/win32/boot_info_win'
 
@@ -66,7 +66,7 @@ module WinMount
 	private
 
 	def normalizePath(p)
-		if Platform::OS == :unix
+		if Sys::Platform::OS == :unix
 			return p if p[1..1] == ':' # fully qualified path
 			p = p.slice(1..-1) if p[0,1] == '/'
 			# On Linux, protect the drive letter with a '/', then remove it.

--- a/gems/pending/metadata/MIQExtract/test/full_extract_test.rb
+++ b/gems/pending/metadata/MIQExtract/test/full_extract_test.rb
@@ -15,7 +15,7 @@ begin
   vmCfgFile = nil
 
   startTime = Time.now
-  vms_path  = File.join((Platform::IMPL == :macosx ? "/Volumes" : "/mnt"), "manageiq", "fleecing_test", "images", "virtual_machines")
+  vms_path  = File.join((Sys::Platform::IMPL == :macosx ? "/Volumes" : "/mnt"), "manageiq", "fleecing_test", "images", "virtual_machines")
   vmCfgFile = File.join(vms_path, "vmware", "JanusVM", "JanusVM-17-sep-2007", "JanusVM", "JanusVM.vmx")
 
   # Load VM config file

--- a/gems/pending/metadata/VMMount/VMPlatformMount.rb
+++ b/gems/pending/metadata/VMMount/VMPlatformMount.rb
@@ -1,4 +1,4 @@
-require 'platform'
+require 'sys-uname'
 
 class VMPlatformMount
     
@@ -7,7 +7,7 @@ class VMPlatformMount
         @dInfo = dInfo
         @ost = ost
         
-        if Platform::OS == :win32
+        if Sys::Platform::OS == :windows
 			require "metadata/VMMount/VMPlatformMountWin"
 			extend VMPlatformMountWin
 		else

--- a/gems/pending/metadata/VmConfig/xmlConfig.rb
+++ b/gems/pending/metadata/VmConfig/xmlConfig.rb
@@ -8,7 +8,7 @@ module XmlConfig
 
     xml_data = nil
     unless File.file?(filename)
-      if Platform::IMPL == :linux
+      if Sys::Platform::IMPL == :linux
         begin
           # First check to see if the command is available
           MiqUtil.runcmd("virsh list")

--- a/gems/pending/spec/util/miq-system_spec.rb
+++ b/gems/pending/spec/util/miq-system_spec.rb
@@ -137,7 +137,7 @@ EOF
         }
       ]
 
-      stub_const("Platform::IMPL", :linux)
+      stub_const("Sys::Platform::IMPL", :linux)
       AwesomeSpawn.should_receive(:launch).with("df -T -P -l", {}).and_return([linux_df_output_bytes, "", 0])
       AwesomeSpawn.should_receive(:launch).with("df -T -P -i -l", {}).and_return([linux_df_output_inodes, "", 0])
 
@@ -204,7 +204,7 @@ EOF
         # }
       ]
 
-      stub_const("Platform::IMPL", :macosx)
+      stub_const("Sys::Platform::IMPL", :macosx)
       AwesomeSpawn.should_receive(:launch).and_return([mac_df_output, "", 0])
 
       expect(described_class.disk_usage).to eq(expected)

--- a/gems/pending/test/DiskTestCommon/tc_MiqDisk.rb
+++ b/gems/pending/test/DiskTestCommon/tc_MiqDisk.rb
@@ -5,7 +5,7 @@ require 'minitest/unit'
 
 module DiskTestCommon
   class TestMiqDisk < Minitest::Test
-    FILE_PATH = (Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
+    FILE_PATH = (Sys::Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
 
     FILE_DESC_4GB    = FILE_PATH + "disks/DiskTestCommon_MiqDisk_Flat4GB.vmdk"
     FILE_FLAT_4GB    = FILE_PATH + "disks/DiskTestCommon_MiqDisk_Flat4GB-flat.vmdk"

--- a/gems/pending/test/DiskTestCommon/tc_MiqLargeFile.rb
+++ b/gems/pending/test/DiskTestCommon/tc_MiqLargeFile.rb
@@ -6,7 +6,7 @@ require 'tmpdir'
 
 module DiskTestCommon
   class TestMiqLargeFile < Minitest::Test
-    FILE_PATH = (Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
+    FILE_PATH = (Sys::Platform::IMPL == :macosx ? "/Volumes" : "/mnt") + "/manageiq/fleecing_test/images/"
 
     FILE_1MB = FILE_PATH + "containers/raw/DiskTestCommon_MiqLargeFile_1MB"
     FILE_1GB = FILE_PATH + "containers/raw/DiskTestCommon_MiqLargeFile_1GB"

--- a/gems/pending/test/VmsFromYaml.rb
+++ b/gems/pending/test/VmsFromYaml.rb
@@ -1,13 +1,13 @@
 require 'yaml'
-require 'platform'
+require 'sys-uname'
 
 class VmsFromYaml
   @vms = {} 
   def initialize(file)
       raise "Missing file" unless File.file?(file)
       @vms = File.open(file)  { |yf| YAML::load( yf ) }
-      if Platform::OS == :unix
-        root_dir = (Platform::IMPL == :macosx) ? '/Volumes' : '/mnt'
+      if Sys::Platform::OS == :unix
+        root_dir = (Sys::Platform::IMPL == :macosx) ? '/Volumes' : '/mnt'
         @vms.each do |vm, options|
           options["location"].gsub!('\\\\miq-websvr1', root_dir)
           options["location"].gsub!('\\', '/')

--- a/gems/pending/test/extract/tc_registry.rb
+++ b/gems/pending/test/extract/tc_registry.rb
@@ -4,7 +4,7 @@ require 'util/miq-xml'
 require 'digest/md5'
 require 'minitest/unit'
 
-$qaShare = File.join((Platform::IMPL == :macosx ? "/Volumes" : "/mnt"), "manageiq", "fleecing_test", "images", "virtual_machines")
+$qaShare = File.join((Sys::Platform::IMPL == :macosx ? "/Volumes" : "/mnt"), "manageiq", "fleecing_test", "images", "virtual_machines")
 
 module Extract
   class TestRegistry < Minitest::Test

--- a/gems/pending/test/ts_mdfs.rb
+++ b/gems/pending/test/ts_mdfs.rb
@@ -1,6 +1,6 @@
 require_relative './test_helper'
 
-require 'platform'
+require 'sys-uname'
 
 # This test runs all disk & file system tests on all VMs.
 # Each test case is responsible for pulling it's own VMs

--- a/gems/pending/util/extensions/miq-file.rb
+++ b/gems/pending/util/extensions/miq-file.rb
@@ -1,5 +1,5 @@
-require 'platform'
-require "Win32API" if Platform::OS == :win32
+require 'sys-uname'
+require 'Win32API' if Sys::Platform::OS == :windows
 require 'disk/modules/MiqLargeFile'
 require 'util/runcmd'
 require 'uri'
@@ -7,7 +7,7 @@ require 'util/MiqSockUtil'
 
 class File
   def self.paths_equal?(f1, f2)
-    if Platform::OS == :win32
+    if Sys::Platform::OS == :windows
       # Note: The file needs to exist and be accessable for getShortFileName to work.
       f1 = File.getShortFileName(f1).downcase
       f2 = File.getShortFileName(f2).downcase
@@ -17,22 +17,22 @@ class File
   end
 
   def self.getShortFileName(longName)
-    if Platform::OS == :win32
+    if Sys::Platform::OS == :windows
       size = 255
       buffer = " " * 255
       returnSize = Win32API.new("kernel32" , "GetShortPathNameA" , 'ppl'  , 'L').Call(longName ,  buffer , size )
       a = ""
-      a = a + buffer[0...returnSize]        
+      a = a + buffer[0...returnSize]
       return a
     else
       return longName
     end
   end
-  
+
   def self.normalize(path)
     File.expand_path(path.gsub(/\\/,"/"))
   end
-  
+
   def self.splitpath(path)
     ext = File.extname(path)
     return File.dirname(path), File.basename(path, ext), ext
@@ -40,7 +40,7 @@ class File
 
   # Extended File.size method to handle files over 2GB
   def self.sizeEx(path)
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :linux
       MiqUtil.runcmd("ls -lQ \"#{path}\"").split(" ")[4].to_i
     when :mswin, :mingw

--- a/gems/pending/util/miq-logger.rb
+++ b/gems/pending/util/miq-logger.rb
@@ -6,7 +6,7 @@ if $log.nil?
   require 'log4r'
   require 'log4r/configurator'
   require 'time'
-  require 'platform'
+  require 'sys-uname'
   require 'util/MiqSockUtil'
 
   #Define custom logging level to insert the "Summary" level
@@ -70,7 +70,7 @@ if $log.nil?
         log.level = eval('Log4r::' + logSettings[:level].upcase)
 
         # Logger header here which might product duplicates if running from the scripts
-        log.miqLogHeader #unless Platform::OS == :win32
+        log.miqLogHeader #unless Sys::Platform::OS == :windows
       end
       return log
     end
@@ -139,7 +139,7 @@ if $log.nil?
         # Log an opening message framed in "*" chars
         @miqFileName = fileName if fileName
         if logData == true && @miqFileName.nil? == false
-          init_msg = "* [#{File.basename(@miqFileName, ".*")}] [#{Platform::IMPL}] started on [#{Time.now}] *"
+          init_msg = "* [#{File.basename(@miqFileName, ".*")}] [#{Sys::Platform::IMPL}] started on [#{Time.now}] *"
           border = "*" * init_msg.length; 
           self.summary border
           self.summary init_msg 

--- a/gems/pending/util/miq-syntax-checker.rb
+++ b/gems/pending/util/miq-syntax-checker.rb
@@ -1,9 +1,9 @@
-require 'platform'
+require 'sys-uname'
 require "open3"
 
 class MiqSyntaxChecker
   def self.check(ruby)
-    return MiqSyntaxCheckResult.new("Syntax OK\n") if Platform::OS == :win32
+    return MiqSyntaxCheckResult.new("Syntax OK\n") if Sys::Platform::OS == :windows
 
     Open3.popen3 "ruby -wc" do |stdin, stdout, stderr|
       stdin.write ruby

--- a/gems/pending/util/miq-system.rb
+++ b/gems/pending/util/miq-system.rb
@@ -1,7 +1,7 @@
 require 'util/extensions/miq-blank'
 require 'awesome_spawn'
-require 'platform'
-if Platform::OS == :win32
+require 'sys-uname'
+if Sys::Platform::OS == :windows
   require 'util/win32/miq-wmi'
 end
 
@@ -11,7 +11,7 @@ class MiqSystem
   @@cpu_usage_computed_value      = nil
 
   def self.cpu_usage
-    if Platform::IMPL == :linux
+    if Sys::Platform::IMPL == :linux
       filename = "/var/www/miq/vmdb/log/vmstat_output.log"
 
       begin
@@ -47,7 +47,7 @@ class MiqSystem
   end
 
   def self.num_cpus
-    if Platform::IMPL == :linux
+    if Sys::Platform::IMPL == :linux
       @num_cpus ||= begin
         filename = "/proc/cpuinfo"
         count = 0
@@ -109,7 +109,7 @@ class MiqSystem
 
   def self.memory
     result = Hash.new
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :mswin, :mingw
       # raise "MiqSystem.memory: Windows Not Supported"
     when :linux
@@ -142,7 +142,7 @@ class MiqSystem
   def self.status
     result = Hash.new
 
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :mswin, :mingw
       # raise "MiqSystem.status: Windows Not Supported"
     when :linux
@@ -284,7 +284,7 @@ class MiqSystem
   def self.disk_usage(file=nil)
     file = normalize_df_file_argument(file)
 
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :linux
       # Collect bytes
       result = AwesomeSpawn.run!("df", :params => ["-T", "-P", file]).output.lines.each_with_object([]) do |line, array|
@@ -478,8 +478,8 @@ class MiqSystem
   #   GNU coreutils 6.10                                             April 2008                                                          DU(1)
   ##############################################################################################################################
   def self.arch
-    arch = Platform::ARCH
-    case Platform::OS
+    arch = Sys::Platform::ARCH
+    case Sys::Platform::OS
     when :unix
       if arch == :unknown
         p = Gem::Platform.local
@@ -494,7 +494,7 @@ class MiqSystem
     return nil unless File.file?(filename)
 
     lines = nil
-    if Platform::OS == :unix
+    if Sys::Platform::OS == :unix
       tail  = `tail -n #{last} #{filename}` rescue nil
       tail.force_encoding("BINARY") if tail.respond_to?(:force_encoding)
       lines = tail.nil? ? [] : tail.split("\n")
@@ -525,7 +525,7 @@ class MiqSystem
 
   def self.open_browser(url)
     require 'shellwords'
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :macosx        then `open #{url.shellescape}`
     when :linux         then `xdg-open #{url.shellescape}`
     when :mingw, :mswin then `start "#{url.gsub('"', '""')}"`

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext/object/blank'
 require 'fileutils'
 require 'logger'
-require 'platform'
+require 'sys-uname'
 require 'uri'
 
 require 'util/miq-exception'
@@ -447,7 +447,7 @@ class MiqGenericMountSession
   end
 
   def self.raw_disconnect(mnt_point)
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :macosx
       self.runcmd("sudo umount #{mnt_point}")
     when :linux
@@ -458,7 +458,7 @@ class MiqGenericMountSession
   end
 
   def self.base_mount_point
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :macosx
       "/Volumes"
     when :linux

--- a/gems/pending/util/mount/miq_nfs_session.rb
+++ b/gems/pending/util/mount/miq_nfs_session.rb
@@ -21,7 +21,7 @@ class MiqNfsSession < MiqGenericMountSession
     # mount 192.168.252.139:/exported/miq /mnt/miq
 
     # Quote the host:exported directory since the directory can have spaces in it
-    case Platform::IMPL
+    case Sys::Platform::IMPL
     when :macosx
       self.runcmd("sudo mount -t nfs -o resvport '#{@host}:#{@mount_path}' #{@mnt_point}")
     when :linux

--- a/gems/pending/util/ntp/miq-ntp.rb
+++ b/gems/pending/util/ntp/miq-ntp.rb
@@ -5,7 +5,7 @@ class MiqNtp
 
   class << self
     def sync_settings(ntp_settings)
-      return unless Platform::IMPL == :linux && File.exist?(SCRIPT)
+      return unless Sys::Platform::IMPL == :linux && File.exist?(SCRIPT)
       update_ntp_conf(ntp_settings[:server])
 
       sync_to_ntpd if use_ntpd?

--- a/gems/pending/util/win32/miq-powershell-daemon.rb
+++ b/gems/pending/util/win32/miq-powershell-daemon.rb
@@ -198,7 +198,7 @@ module MiqPowerShell
     end
 
     def self.get_log_dir
-      return nil unless Platform::OS == :win32
+      return nil unless Sys::Platform::OS == :windows
       ps_log_dir = $miqHostCfg ? $miqHostCfg.miqLogs : nil
       unless ps_log_dir.blank?
         ps_log_dir = File.join(ps_log_dir, "ps_log")

--- a/gems/pending/util/win32/miq-powershell.rb
+++ b/gems/pending/util/win32/miq-powershell.rb
@@ -5,7 +5,7 @@ require 'io/wait'
 require 'open-uri'
 require 'util/miq-encode'
 require 'util/miq-unicode'
-require 'win32/registry' if Platform::OS == :win32
+require 'win32/registry' if Sys::Platform::OS == :windows
 
 module MiqPowerShell
   @@default_port = 9121

--- a/gems/pending/util/win32/miq-wmi.rb
+++ b/gems/pending/util/win32/miq-wmi.rb
@@ -1,9 +1,9 @@
-require 'platform'
+require 'sys-uname'
 
 class WMIHelper
   WMI_ROOT_NAMESPACE = "root\\cimv2" unless defined?(WMI_ROOT_NAMESPACE)
 
-  platform = Platform::IMPL
+  platform = Sys::Platform::IMPL
   unless platform == :macosx
     platform = :mswin if platform == :mingw
     require "util/win32/miq-wmi-#{platform}"

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -1,4 +1,4 @@
-require 'platform'
+require 'sys-uname'
 
 module MiqEnvironment
   class Process
@@ -97,7 +97,7 @@ module MiqEnvironment
 
     def self.is_linux?
       return @is_linux unless @is_linux.nil?
-      return @is_linux = (Platform::IMPL == :linux)
+      return @is_linux = (Sys::Platform::IMPL == :linux)
     end
 
     def self.rake_command
@@ -129,11 +129,11 @@ module MiqEnvironment
     end
 
     def self.which
-      case Platform::IMPL
+      case Sys::Platform::IMPL
       when :linux
         "which"
       else
-        raise "Not yet supported platform: #{Platform::IMPL}"
+        raise "Not yet supported platform: #{Sys::Platform::IMPL}"
       end
     end
   end

--- a/lib/vmdb_helper.rb
+++ b/lib/vmdb_helper.rb
@@ -5,7 +5,7 @@ require 'ostruct'
 require 'fileutils'
 require 'erb'
 require 'sync'
-require 'platform'
+require 'sys-uname'
 
 # Need to push the workers path here, since __FILE__ doesn't work
 #   correctly in the workers when run as a separate process

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -3,12 +3,12 @@ require "spec_helper"
 describe MiqEnvironment do
   context "with linux platform" do
     before(:each) do
-      @old_impl = Platform::IMPL
-      silence_warnings { Platform::IMPL = :linux }
+      @old_impl = Sys::Platform::IMPL
+      silence_warnings { Sys::Platform::IMPL = :linux }
     end
 
     after(:each) do
-      silence_warnings { Platform::IMPL = @old_impl } if @old_impl
+      silence_warnings { Sys::Platform::IMPL = @old_impl } if @old_impl
     end
 
     context "Command" do


### PR DESCRIPTION
This PR replaces the Platform gem with the sys-uname gem. This mainly consists of replacing "Platform" with "Sys::Platform", and updating require statements, throughout the code base. I did also have to change :win32 to :windows for Platform::OS checks where used.

Using sys-uname has a few advantages over the Platform gem:

* It's current and maintained.
* It's an actual interface to the uname function (on Unixy systems), so it's not static information, unlike various Ruby internal bits that Platform uses.
* It works properly with JRuby.
* It doesn't conflict with other gems with the same name (Platform vs platform).
