### PR TITLE
Set type to storages in Red Hat provider textual summary

### DIFF
--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -125,7 +125,7 @@ module EmsInfraHelper::TextualSummary
   def textual_datastores
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
 
-    textual_link(@record.storages)
+    textual_link(@record.storages, :as => Storage)
   end
 
   def textual_vms


### PR DESCRIPTION
Fix for #3938 
@matthewd I couldn't find a way to deduce the class type of that relation.
This still might happen anywhere else an empty array can be sent to ```textual_link```.
