### PR TITLE
MiqGroup seeding assigns group to root tenant if not already assigned

### DIFF
--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -264,4 +264,24 @@ describe MiqGroup do
       MiqGroup.count.should eq 2
     end
   end
+
+  context "#seed" do
+    let(:root_tenant) { Tenant.root_tenant }
+
+    it "has tenant_owner for new records" do
+      [MiqRegion, Tenant, MiqUserRole, MiqGroup].each(&:seed)
+      expect(MiqGroup.where(:tenant_owner_id => root_tenant.id).count).to eq(MiqGroup.count)
+    end
+
+    it "has tenant_owner for legacy records" do
+      [MiqRegion, Tenant, MiqUserRole].each(&:seed)
+      new_tenant           = root_tenant.children.create!
+      group_with_tenant    = FactoryGirl.create(:miq_group, :tenant_owner => new_tenant)
+      group_without_tenant = FactoryGirl.create(:miq_group, :tenant_owner => nil)
+      MiqGroup.seed
+
+      expect(group_with_tenant.reload.tenant_owner).to    eq(new_tenant)
+      expect(group_without_tenant.reload.tenant_owner).to eq(root_tenant)
+    end
+  end
 end


### PR DESCRIPTION
Ensure all MiqGroup records are associated with a tenant.
If the association does not exist assign to the root tenant.

Trello https://trello.com/c/AjdWIkmv