### PR TITLE
Don't break on an empty STI cache file

### DIFF
--- a/lib/extensions/as_const_missing_with_sti.rb
+++ b/lib/extensions/as_const_missing_with_sti.rb
@@ -12,7 +12,7 @@ module AsConstMissingWithSti
   end
 
   def self.cache
-    @cache ||= cache_path.exist? ? YAML.load_file(cache_path) : {}
+    @cache ||= (cache_path.exist? && YAML.load_file(cache_path)) || {}
   end
 
   def self.save_cache!


### PR DESCRIPTION
For reasons unknown, the cache file is sometimes ending up present but empty. And `YAML.load('')` is `false`, which is very much not a hash.

Fortunately, we don't really need to care about the causes -- we can just continue as if the file is absent.