### PR TITLE
remove Build warnings

### DIFF
--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -25,7 +25,7 @@ module MiqReport::Search
       offset ||= 0
       ids      = ids[offset..offset + limit - 1]
     end
-    data         = self.db_class.find_all_by_id(ids, :include => includes)
+    data         = db_class.where(:id => ids).includes(includes).to_a
     targets_hash = data.index_by(&:id) if options[:targets_hash]
     self.build_table(data, self.db, options)
     return self.table, self.extras[:attrs_for_paging].merge(:paged_read_from_cache => true, :targets_hash => targets_hash)

--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -34,7 +34,7 @@ module MiqReport::Seeding
         cond = ["rpt_type = 'Default' and template_type = ?", typ]
       end
 
-      self.find(:all, :conditions => cond).each do |f|
+      where(cond).each do |f|
         next unless f.filename
         unless File.exist?(File.join(dir, f.filename))
           $log.info("#{typ.titleize}: file [#{f.filename}] has been deleted from disk, deleting from model")

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -68,9 +68,8 @@ describe MiqReport do
 
       expect(report).to_not receive(:get_cached_page)
 
-      results = attrs = nil
-      Proc.new { results, attrs = report.paged_view_search(options) }.call.should_not raise_error
-      results.length.should == 20
+      results, attrs = report.paged_view_search(options)
+      expect(results.length).to eq(20)
     end
   end
 end


### PR DESCRIPTION
/cc @matthewd I know you like to keep these down.

one outstanding: `raise_error called with non-proc object`
