### PR TITLE
remove userrole from session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1928,6 +1928,9 @@ class ApplicationController < ActionController::Base
 
     db = db.gsub(/::/, '_')
 
+    current_role = current_user.try(:miq_user_role)
+    current_role = current_role.name.split("-").last if current_role.try(:read_only?)
+
     # Build the view file name
     if suffix
       viewfile = "#{VIEWS_FOLDER}/#{db}-#{suffix}.yaml"

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -4,11 +4,10 @@ module ApplicationController::CurrentUser
   included do
     helper_method :current_user,  :current_userid
     helper_method :current_group, :current_groupid, :eligible_groups
-    helper_method :current_role, :admin_user?, :super_admin_user?
+    helper_method :admin_user?, :super_admin_user?
     hide_action :clear_current_user, :current_user=
     hide_action :admin_user?, :super_admin_user?
     hide_action :current_user, :current_userid, :current_groupid
-    hide_action :current_role, :current_userrole
   end
 
   def clear_current_user
@@ -29,13 +28,6 @@ module ApplicationController::CurrentUser
     eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
   end
   private :eligible_groups
-
-  def current_role
-    @current_role ||= begin
-      role = current_user.try(:miq_user_role)
-      role.try(:read_only?) ? role.name.split("-").last : ""
-    end
-  end
 
   def admin_user?
     current_user.admin_user?
@@ -60,9 +52,5 @@ module ApplicationController::CurrentUser
 
   def current_groupid
     current_user.current_group.id
-  end
-
-  def current_userrole
-    session[:userrole]
   end
 end

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1589,7 +1589,7 @@ module ReportController::Reports::Editor
     end
 
     # Only show chargeback users choice if an admin
-    if ["administrator","super_administrator"].include?(session[:userrole])
+    if admin_user?
       @edit[:cb_users] = Hash.new
       User.all.each{|u| @edit[:cb_users][u.userid] = u.name}
     else


### PR DESCRIPTION
High level:
No need to have user identity concepts around the name of the use's roles, when all we really want is to know `admin_user?` or `super_admin_user?`,

`current_role` was used to determine the name of the report yaml name.
I just put this code in where it was needed.