### PR TITLE
Replace constant RAILS_VERSION with version string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 #
 
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
-gem "rails",                           RAILS_VERSION
+gem "rails",                           "~>4.2.3"
 
 # Client-side dependencies
 gem "angular-ui-bootstrap-rails",     "~>0.13.0"

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -7,11 +7,10 @@ gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
 gem "iniparse"
 
-RAILS_VERSION = "~>4.2.3"
-gem "activesupport", RAILS_VERSION
+gem "activesupport",           "~>4.2.3"
 
 # ActiveRecord is used by appliance_console
-gem "activerecord",  RAILS_VERSION
+gem "activerecord",            "~>4.2.3"
 
 # Not locally modified and not required
 gem "apipie-bindings",         "~>0.0.12",          :require => false


### PR DESCRIPTION
This allows tools like Hakiri to grok what version of Rails is being used.

[skip ci]