### PR TITLE
For MiqWidgetSet, use current_user instead of session[:userid]

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -412,7 +412,7 @@ module ApplicationController::Explorer
       return count_only ? objects.length : objects
     when :db
       objects = Array.new
-      @default_ws = MiqWidgetSet.where_unique_on("default", nil, nil).where(:read_only => true).first
+      @default_ws = MiqWidgetSet.where_unique_on("default").where(:read_only => true).first
       text = "#{@default_ws.description} (#{@default_ws.name})"
       objects.push(:id=>to_cid(@default_ws.id),:text=>text, :image=>"dashboard", :tip=>text )
       objects.push({:id=>"g", :text=>"All Groups", :image=>"folder", :tip=>"All Groups"})

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -13,7 +13,7 @@ module ReportController::Dashboards
       err = false
       dashboard_order = Array.new
       @edit[:new][:dashboard_order].each do |n|
-        dashboard_order.push(MiqWidgetSet.where_unique_on(n, nil, nil).first.id)
+        dashboard_order.push(MiqWidgetSet.where_unique_on(n).first.id)
       end
         g = MiqGroup.find(from_cid(@sb[:nodes][2]))
         g.settings ||= Hash.new
@@ -81,7 +81,7 @@ module ReportController::Dashboards
           AuditEvent.success(build_saved_audit(@db, @edit))
           add_flash(_("%{model} \"%{name}\" was saved") % {:model=>"Dashboard", :name=>@db.name})
           if params[:button] == "add"
-            widgetset = MiqWidgetSet.where_unique_on(@edit[:new][:name], nil, nil).first
+            widgetset = MiqWidgetSet.where_unique_on(@edit[:new][:name]).first
             settings = g.settings ? g.settings : Hash.new
             settings[:dashboard_order] = settings[:dashboard_order] ? settings[:dashboard_order] : Array.new
             settings[:dashboard_order].push(widgetset.id) if !settings[:dashboard_order].include?(widgetset.id)
@@ -213,7 +213,7 @@ module ReportController::Dashboards
   def db_get_node_info
     @sb[:nodes] = x_node.split('-')
     if @sb[:nodes].length == 1
-      @default_ws = MiqWidgetSet.where_unique_on("default", nil, nil).where(:read_only => true).first
+      @default_ws = MiqWidgetSet.where_unique_on("default").where(:read_only => true).first
       @right_cell_text = _("All %s") % "Dashboards"
       @right_cell_div  = "db_list"
       @db_nodes = Hash.new

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -8,7 +8,7 @@ class MiqWidgetSet < ActiveRecord::Base
   WIDGET_DIR =  File.expand_path(File.join(Rails.root, "product/dashboard/dashboards"))
 
   def self.with_users
-    where(arel_table[:userid].not_eq(nil))
+    where.not(:userid => nil)
   end
 
   def destroy_user_versions

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -20,7 +20,9 @@ class MiqWidgetSet < ActiveRecord::Base
     MiqWidgetSet.with_users.where(:name => name, :group_id => owner_id).destroy_all
   end
 
-  def self.where_unique_on(name, group_id, userid)
+  def self.where_unique_on(name, user = nil)
+    userid = user.try(:userid)
+    group_id = user.try(:current_group_id)
     # a unique record is defined by name, group_id and userid
     where(:name => name, :group_id => group_id, :userid => userid)
   end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
 describe MiqWidgetSet do
+  let(:group) { FactoryGirl.create(:miq_group, :description => 'dev group') }
+  let(:user)  { FactoryGirl.create(:user, :name => 'cloud', :userid => 'cloud', :miq_groups => [group]) }
   before do
-    @group = FactoryGirl.create(:miq_group, :description => 'dev group')
-    @user  = FactoryGirl.create(:user, :name => 'cloud', :userid => 'cloud', :miq_groups => [@group])
-    @ws_group = FactoryGirl.create(:miq_widget_set, :name => 'Home', :owner => @group)
+    @ws_group = FactoryGirl.create(:miq_widget_set, :name => 'Home', :owner => group)
   end
 
   it "when a group dashboard is deleted" do
@@ -16,15 +16,15 @@ describe MiqWidgetSet do
   context "with a group" do
     it "being deleted" do
       expect(MiqWidgetSet.count).to eq(1)
-      @user.miq_groups = []
-      @group.destroy
+      user.miq_groups = []
+      group.destroy
       expect(MiqWidgetSet.count).to eq(0)
     end
   end
 
   context "with a user" do
     before do
-      FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => @user.userid, :group_id => @group.id)
+      FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => user.userid, :group_id => group.id)
     end
 
     it "initial state" do
@@ -32,17 +32,17 @@ describe MiqWidgetSet do
     end
 
     it "no longer belonging to a group" do
-      @user.destroy_widget_sets_for_group(@group.id)
+      user.destroy_widget_sets_for_group(group.id)
       expect(MiqWidgetSet.count).to eq(1)
     end
 
     it "the belong to group is being deleted" do
-      expect { @group.destroy }.to raise_error
+      expect { group.destroy }.to raise_error
       expect(MiqWidgetSet.count).to eq(2)
     end
 
     it "being deleted" do
-      @user.destroy
+      user.destroy
       expect(MiqWidgetSet.count).to eq(1)
     end
   end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -46,4 +46,27 @@ describe MiqWidgetSet do
       expect(MiqWidgetSet.count).to eq(1)
     end
   end
+
+  describe "#where_unique_on" do
+    let(:group2) { FactoryGirl.create(:miq_group, :description => 'dev group2') }
+    let(:ws_1)   { FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => user.userid, :group_id => group.id) }
+
+     before do
+      user.miq_groups << group2
+      ws_1
+      FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => user.userid, :group_id => group2.id )
+    end
+
+    it "initial state" do
+      expect(MiqWidgetSet.count).to eq(3)
+    end
+
+    it "brings back all group records" do
+      expect(MiqWidgetSet.where_unique_on('Home', nil, nil)).to eq([@ws_group])
+    end
+
+    it "brings back records for a user with a group" do
+      expect(MiqWidgetSet.where_unique_on('Home', group.id, user.userid)).to eq([ws_1])
+    end
+  end
 end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -69,4 +69,11 @@ describe MiqWidgetSet do
       expect(MiqWidgetSet.where_unique_on('Home', user)).to eq([ws_1])
     end
   end
+
+  describe "#with_users" do
+    it "brings back records with users" do
+      ws_1 = FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => user.userid, :group_id => group.id)
+      expect(described_class.with_users).to eq([ws_1])
+    end
+  end
 end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -62,11 +62,11 @@ describe MiqWidgetSet do
     end
 
     it "brings back all group records" do
-      expect(MiqWidgetSet.where_unique_on('Home', nil, nil)).to eq([@ws_group])
+      expect(MiqWidgetSet.where_unique_on('Home')).to eq([@ws_group])
     end
 
     it "brings back records for a user with a group" do
-      expect(MiqWidgetSet.where_unique_on('Home', group.id, user.userid)).to eq([ws_1])
+      expect(MiqWidgetSet.where_unique_on('Home', user)).to eq([ws_1])
     end
   end
 end


### PR DESCRIPTION
This is a user identity/tenancy play.

The goal is to use `current_user` in our code instead of `session[:userid]` and `session[:group]`
Also, goal of removing `session[:group]`, especially since it is just `current_user.current_group`.

I added tests before introducing these changes, to reduce the chance of a regression.