### PR TITLE
Added EmsEvent table name to ExtManagementSystem#event_where_clause

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -353,7 +353,7 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   def event_where_clause(assoc)
-    ["ems_id = ?", self.id]
+    ["#{EmsEvent.table_name}.ems_id = ?", self.id]
   end
 
   def total_vms_and_templates


### PR DESCRIPTION
Prevents ambiguity when selecting from multiple tables with an ems_id column.

Fixes #3829
https://bugzilla.redhat.com/show_bug.cgi?id=1253126