### PR TITLE
formatters for JS charts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "jquery-hotkeys-rails"
 gem "jquery-rails",                   "~>4.0.4"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "https://github.com/amatsuda/jquery-rjs.git"
 gem "lodash-rails",                   "~>3.10.0"
-gem "momentjs-rails",                 "~>2.10.3"
 gem "patternfly-sass",                "~>2.2.0"
 gem "sass-rails"
 
@@ -121,6 +120,11 @@ source "https://rails-assets.org" do
   gem "rails-assets-bootstrap-hover-dropdown", "~>2.0.11"
   gem "rails-assets-bootstrap-select",         "~>1.7.3"
   gem "rails-assets-kubernetes-topology-graph", "=0.0.17"
+  gem "rails-assets-moment",                   "~>2.10.3"
+  gem "rails-assets-moment-strftime",          "~>0.1.4"
+  gem "rails-assets-moment-timezone",          "~>0.4.0"
+  gem "rails-assets-sprintf",                  "~>1.0.3"
+  gem "rails-assets-numeral",                  "~>1.5.3"
 end
 
 #

--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-bootstrap-select",         "~>1.7.3"
   gem "rails-assets-kubernetes-topology-graph", "=0.0.17"
   gem "rails-assets-moment",                   "~>2.10.3"
-  gem "rails-assets-moment-strftime",          "~>0.1.4"
+  gem "rails-assets-moment-strftime",          "~>0.1.5"
   gem "rails-assets-moment-timezone",          "~>0.4.0"
   gem "rails-assets-sprintf",                  "~>1.0.3"
   gem "rails-assets-numeral",                  "~>1.5.3"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,6 +5,10 @@
 //= require angular-ui-bootstrap
 //= require angular-ui-bootstrap-tpls
 //= require moment
+//= require moment-strftime
+//= require moment-timezone
+//= require sprintf
+//= require numeral
 //= require miq_angular_application
 //= require services/miq_service
 //= require services/miq_db_backup_service
@@ -76,3 +80,4 @@
 //= require spin
 //= require jquery-hotkeys
 //= require lodash
+//= require miq_formatters

--- a/app/assets/javascripts/miq_formatters.js
+++ b/app/assets/javascripts/miq_formatters.js
@@ -1,0 +1,559 @@
+// Note: when changing a formatter, please consider also changing the corresponding MiqReport::Formatting#format_* method
+// TODO tests
+
+(function(window, moment, _) {
+  "use strict";
+
+  function apply_format_precision(val, precision) {
+    if (val == null || ! _.isNumber(val))
+      return val;
+
+    return sprintf("%." + (~~ precision) + "f", val);
+  };
+
+  function apply_prefix_and_suffix(val, options) {
+    options = options || {};
+    return sprintf("%s%s%s", options.prefix || "", val, options.suffix || "");
+  };
+
+  function get_time_zone(default_tz) {
+    // FIXME - like MiqReportGenerator#get_time_zone - time_profile.tz or .tz or the default
+    return default_tz;
+  };
+
+  function number_with_delimiter(val, options) {
+    options = _.extend({ delimiter: ',', separator: '.' }, options || {});
+
+    var intpart, floatpart, minus;
+    if (_.isNumber(val)) {
+      intpart = ~~ val;
+      floatpart = Math.abs(val - intpart);
+      minus = val < 0;
+      intpart = Math.abs(intpart);
+    } else {
+      minus = val[0] == '-';
+      intpart = Math.abs(~~ val);
+      floatpart = val.replace(/^.*\./, '');
+    }
+
+    var s = "";
+    while (intpart >= 1000) {
+      s = options.delimiter + sprintf("%03d", intpart % 1000) + s;
+      intpart = ~~( intpart / 1000 );
+    }
+    s = sprintf(minus ? "-%d" : "%d", intpart) + s;
+
+    if (_.isNumber(floatpart) && floatpart > 1e-12) {
+      s += options.separator;
+      s += sprintf("%f", floatpart).replace(/^.*\./, '');
+    } else if (_.isString(floatpart) && floatpart) {
+      s += options.separator + floatpart;
+    }
+
+    return s;
+  };
+
+  function number_to_currency(val, options) {
+    options = _.extend({
+      precision: 2,
+      unit: '$',
+      delimiter: ',',
+      separator: '.',
+      format: '%u%n',
+    }, options || {});
+
+    if (! ('negative_format' in options)) {
+      options.negative_format = '-' + options.format;
+    }
+
+    var numstr = val;
+    if (_.isNumber(val)) {
+      numstr = apply_format_precision(val, options.precision);
+      numstr = number_with_delimiter(numstr, options);
+    }
+
+    var fmt = (numstr[0] == '-') ? options.negative_format : options.format;
+    return fmt.replace('%u', options.unit).replace('%n', numstr);
+  };
+
+  function number_to_human_size(val, options) {
+    var fmt = "0.0";
+    if (options.precision < 2) {
+      fmt = "0";
+    } else {
+      var p = options.precision - 2;
+      while (p > 0) {
+        fmt += '0';
+      }
+    }
+
+    return numeral(val).format(fmt + ' b');
+  };
+
+  function mhz_to_human_size(val, precision) {
+    precision = _.isNumber(precision) ? precision : 1;
+    precision = "%." + precision + "f";
+
+    var s = val < 0 ? "-" : "";
+    val = Math.abs(val);
+
+    val *= 1000000; // mhz to hz
+    if (size < 1000000000) {
+      s += sprintf(precision + " MHz", val / 1000000);
+    } else if (size < 1000000000000) {
+      s += sprintf(precision + " GHz", val / 1000000000);
+    } else {
+      s += sprintf(precision + " THz", val / 1000000000000);
+    }
+
+    return s;
+  };
+
+  function ordinalize(val) {
+    return numeral(val).format('0o');
+  };
+
+  var format = {
+    /*
+      :description: Number (1,234)
+      :function:
+        :name: number_with_delimiter
+        :delimiter: ","
+
+      :description: Number (1,234.0)
+      :function:
+        :name: number_with_delimiter
+        :delimiter: ","
+
+      :description: Number, 2 Decimals (1,234.00)
+      :function:
+        :name: number_with_delimiter
+        :delimiter: ","
+
+      :description: Kilobytes per Second (10 KBps)
+      :function: 
+        :name: number_with_delimiter
+        :delimiter: ","
+        :suffix: " KBps"
+
+      :description: Percentage (99%)
+      :function: 
+        :name: number_with_delimiter
+        :delimiter: ","
+        :suffix: ! '%'
+
+      :description: Percent, 1 Decimal (99.0%)
+      :function:
+        :name: number_with_delimiter
+        :delimiter: ","
+        :suffix: ! '%'
+
+      :description: Percent, 2 Decimals (99.00%)
+      :function: 
+        :name: number_with_delimiter
+        :delimiter: ","
+        :suffix: ! '%'
+    */
+    number_with_delimiter: function(val, options) {
+      options = options || {};
+      var av_options = _.pick(options, [ 'delimiter', 'separator' ]);
+      val = apply_format_precision(val, options.precision);
+      val = number_with_delimiter(val, av_options);
+      return apply_prefix_and_suffix(val, options);
+    },
+
+    /*
+      :description: Currency, 2 Decimals ($1,234.00)
+      :function:
+        :name: currency_with_delimiter
+        :delimiter: ","
+    */
+    currency_with_delimiter: function(val, options) {
+      options = options || {};
+      var av_options = _.pick(options, [ 'delimiter', 'separator' ]);
+      val = apply_format_precision(val, options.precision);
+      val = number_to_currency(val, av_options)
+      return apply_prefix_and_suffix(val, options)
+    },
+
+    /*
+      :description: Suffixed Bytes (B, KB, MB, GB)
+      :function:
+        :name: bytes_to_human_size
+    */
+    bytes_to_human_size: function(val, options) {
+      options = options || {};
+      var av_options = { precision: options.precision || 0 };  // Precision of 0 returns the significant digits
+      val = number_to_human_size(val, av_options);
+      return apply_prefix_and_suffix(val, options);
+    },
+
+    /*
+      :description: Suffixed Kilobytes (KB, MB, GB)
+      :function:
+        :name: kbytes_to_human_size
+    */
+    kbytes_to_human_size: function(val, options) {
+      return format.bytes_to_human_size(val * 1024, options);
+    },
+
+    /*
+      :description: Suffixed Megabytes (MB, GB)
+      :function:
+        :name: mbytes_to_human_size
+    */
+    mbytes_to_human_size: function(val, options) {
+      return format.kbytes_to_human_size(val * 1024, options);
+    },
+
+    /*
+      :description: Suffixed Gigabytes (GB)
+      :function:
+        :name: gbytes_to_human_size
+    */
+    gbytes_to_human_size: function(val, options) {
+      return format.mbytes_to_human_size(val * 1024, options);
+    },
+
+    /*
+      :description: Megahertz (12 Mhz)
+      :function: 
+        :name: mhz_to_human_size
+        :delimiter: ","
+
+      :description: Megahertz Avg (12.1 Mhz)
+      :function:
+        :name: mhz_to_human_size
+        :delimiter: ","
+    */
+    mhz_to_human_size: function(val, options) {
+      options = options || {};
+      val = mhz_to_human_size(val, options.precision);
+      return apply_prefix_and_suffix(val, options);
+    },
+
+    /*
+      :description: Boolean (True/False)
+      :function:
+        :name: boolean
+
+      :description: Boolean (T/F)
+      :function:
+        :name: boolean
+        :format: t_f
+
+      :description: Boolean (Yes/No)
+      :function:
+        :name: boolean
+        :format: yes_no
+
+      :description: Boolean (Y/N)
+      :function:
+        :name: boolean
+        :format: y_n
+
+      :description: Boolean (Pass/Fail)
+      :function:
+        :name: boolean
+        :format: pass_fail
+    */
+    boolean: function(val, options) {
+      options = options || {};
+
+      if (val !== true && val !== false)
+        return _.capitalize( String(val) );
+
+      switch (options.format) {
+        case "yes_no":
+          return val ? "Yes" : "No";
+
+        case "y_n":
+          return val ? "Y" : "N";
+
+        case "t_f":
+          return val ? "T" : "F";
+
+        case "pass_fail":
+          return val ? "Pass" : "Fail";
+
+        default:
+          return val ? "True" : "False";
+      };
+    },
+
+    /*
+      :description: Date (M/D/YYYY)
+      :function:
+        :name: datetime
+        :format: "%m/%d/%Y"
+
+      :description: Date (M/D/YY)
+      :function:
+        :name: datetime
+        :format: "%m/%d/%y"
+
+      :description: Date (M/D)
+      :function:
+        :name: datetime
+        :format: "%m/%d"
+
+      :description: Time (H:M:S Z) 
+      :function:
+        :name: datetime
+        :format: "%H:%M %Z"
+
+      :description: Date/Time (M/D/Y H:M:S Z)
+      :function:
+        :name: datetime
+        :format: "%m/%d/%y %H:%M:%S %Z"
+
+      :description: Date/Hour (M/D/Y H:00 Z)
+      :function:
+        :name: datetime
+        :format: "%m/%d/%y %H:00 %Z"
+
+      :description: Date/Hour (M/D/Y H AM|PM Z)
+      :function:
+        :name: datetime
+        :format: "%m/%d/%y %I %p %Z"
+
+      :description: Hour (H:00 Z)
+      :function:
+        :name: datetime
+        :format: "%H:00 %Z"
+
+      :description: Hour (H AM|PM Z)
+      :function:
+        :name: datetime
+        :format: "%l %p %Z"
+
+      :description: Hour of Day (24)
+      :function:
+        :name: datetime
+        :format: "%k"
+
+      :description: Day Full (Monday)
+      :function:
+        :name: datetime
+        :format: "%A"
+
+      :description: Day Short (Mon)
+      :function:
+        :name: datetime
+        :format: "%a"
+
+      :description: Day of Week (1)
+      :function:
+        :name: datetime
+        :format: "%u"
+
+      :description: Day of Month (27)
+      :function:
+        :name: datetime
+        :format: "%e"
+
+      :description: Month and Year (January 2011)
+      :function:
+        :name: datetime
+        :format: "%B %Y"
+
+      :description: Month and Year Short (Jan 11)
+      :function:
+        :name: datetime
+        :format: "%b %y"
+
+      :description: Month Full (January)
+      :function:
+        :name: datetime
+        :format: "%B"
+
+      :description: Month Short (Jan)
+      :function:
+        :name: datetime
+        :format: "%b"
+
+      :description: Month of Year (12)
+      :function:
+        :name: datetime
+        :format: "%m"
+
+      :description: Week of Year (52)
+      :function:
+        :name: datetime
+        :format: "%W"
+
+      :description: Year (YYYY)
+      :function:
+        :name: datetime
+        :format: "%Y"
+    */
+    // note that we require moment-timezone so that %Z (which maps to moments z which uses zoneAbbr, which returns "UTC" or "" without moment-timezone) works
+    datetime: function(val, options) {
+      options = options || {};
+      if (!moment.isDate(val) && !moment.isMoment(val))
+        return val;
+
+      val = moment(val);
+      if (options.tz)
+        val = val.tz(options.tz);
+
+      if (! options.format)
+        return val;
+
+      return val.strftime(options.format);
+    },
+
+    /*
+      :description: Date Range (M/D/Y - M/D/Y)
+      :function:
+        :name: datetime_range
+        :format: "%m/%d/%y"
+
+      :description: Day Range (M/D - M/D)
+      :function:
+        :name: datetime_range
+        :format: "%m/%d"
+
+      :description: Day Range Start (M/D)
+      :function:
+        :name: datetime_range
+        :format: "%m/%d"
+    */
+    datetime_range: function(val, options) {
+      options = options || {};
+      if (! options.format)
+        return val;
+      if (!moment.isDate(val) && !moment.isMoment(val))
+        return val;
+
+      val = moment(val);
+
+      var col = options.column;
+      var a = String(col).split("__");
+      col = a[0];
+      var sfx = a[1]; // The suffix (month, quarter, year) defines the range
+
+      val = val.tz(get_time_zone("UTC"));
+      var stime, etime;
+      if (_.includes(['day', 'week', 'month', 'quarter', 'year'], sfx)) {
+        stime = val.clone().startOf(sfx);
+        etime = val.clone().endOf(sfx);
+      } else {
+        stime = val;
+        etime = val;
+      }
+
+      // FIXME: added for compatibility with the ruby implementation, needs fixing on both sides
+      if (_.includes(options.description || "", "Start"))
+        return stime.strftime(options.format);
+      else
+        return "(" + stime.strftime(options.format) + " - " + etime.strftime(options.format) + ")";
+    },
+
+    /*
+      :description: Comma seperated list
+      :function:
+        :name: set
+        :delimiter: ", "
+    */
+    set: function(val, options) {
+      options = options || {};
+      if (! _.isArray(val))
+        return val;
+      return val.join(options.delimiter || ", ");
+    },
+
+    /*
+      :description: Day of Month (27th)
+      :function:
+        :name: datetime_ordinal
+        :format: "%e"
+
+      :description: Week of Year (52nd)
+      :function:
+        :name: datetime_ordinal
+        :format: "%W"
+    */
+    datetime_ordinal: function(val, options) {
+      options = options || {};
+      val = format.datetime(val, options);
+      return format.number_ordinal(val, options);
+    },
+
+    // used by datetime_ordinal
+    number_ordinal: function(val, options) {
+      options = options || {};
+      return ordinalize(~~ val);
+    },
+
+    /*
+      :description: "Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"
+      :function:
+        :name: elapsed_time_human
+    */
+    elapsed_time_human: function(val, options) {
+      options = options || {};
+      val = ~~ val;
+
+      var names = ['day', 'hour', 'minute', 'second'];
+
+      var days    = ~~(val / 86400);
+      var hours   = ~~((val / 3600) - (days * 24));
+      var minutes = ~~((val / 60) - (hours * 60) - (days * 1440));
+      var seconds = ~~(val % 60);
+
+      var arr = [days, hours, minutes, seconds];
+      if (_.every(arr, 0))
+        return "";
+
+      var sidx = _.findIndex(arr, function(a) {
+        return a > 0;
+      });
+      var values = _.slice(arr, sidx, sidx + 1);
+      var result = '';
+      var sep    = '';
+      for (var i in values) {
+        var sfx = names[sidx + i];
+        if (values[i] > 1 || values[i] == 0)
+          sfx += "s";
+
+        result += sep;
+        result += values[i];
+        result += " ";
+        result += sfx;
+
+        sep = ", ";
+      }
+
+      return result;
+    },
+
+    /*
+      :description: String Truncated to 50 Characters with Elipses (...)
+      :function:
+        :name: string_truncate
+        :length: 50
+    */
+    string_truncate: function(val, options) {
+      options = options || {};
+      var result = String(val);
+      return (result.length > options.length) ? result.substr(0, options.length) + "..." : val;
+    },
+
+    /*
+      :description: Convert Numbers Larger than 1.0e+15 to Exponential Form
+      :function:
+        :name: large_number_to_exponential_form
+        :length: 50
+    */
+    large_number_to_exponential_form: function(val, options) {
+      options = options || {};
+      if (Number(val) < 1.0e+15)
+        return val;
+      return String( Number(val) );
+    },
+  };
+
+  // curryRight so that formatters.foo(options) returns a function(val)->string
+  window.ManageIQ.charts.formatters = _.mapValues(format, _.curryRight);
+})(window, moment, _);

--- a/app/assets/javascripts/miq_formatters.js
+++ b/app/assets/javascripts/miq_formatters.js
@@ -33,7 +33,7 @@
     } else {
       minus = val[0] == '-';
       intpart = Math.abs(~~ val);
-      floatpart = val.replace(/^.*\./, '');
+      floatpart = (val.indexOf('.') < 0) ? '' : val.replace(/^.*\./, '');
     }
 
     var s = "";
@@ -69,8 +69,8 @@
     var numstr = val;
     if (_.isNumber(val)) {
       numstr = apply_format_precision(val, options.precision);
-      numstr = number_with_delimiter(numstr, options);
     }
+    numstr = number_with_delimiter(numstr, options);
 
     var fmt = (numstr[0] == '-') ? options.negative_format : options.format;
     return fmt.replace('%u', options.unit).replace('%n', numstr);
@@ -98,9 +98,9 @@
     val = Math.abs(val);
 
     val *= 1000000; // mhz to hz
-    if (size < 1000000000) {
+    if (val < 1000000000) {
       s += sprintf(precision + " MHz", val / 1000000);
-    } else if (size < 1000000000000) {
+    } else if (val < 1000000000000) {
       s += sprintf(precision + " GHz", val / 1000000000);
     } else {
       s += sprintf(precision + " THz", val / 1000000000000);
@@ -114,46 +114,6 @@
   };
 
   var format = {
-    /*
-      :description: Number (1,234)
-      :function:
-        :name: number_with_delimiter
-        :delimiter: ","
-
-      :description: Number (1,234.0)
-      :function:
-        :name: number_with_delimiter
-        :delimiter: ","
-
-      :description: Number, 2 Decimals (1,234.00)
-      :function:
-        :name: number_with_delimiter
-        :delimiter: ","
-
-      :description: Kilobytes per Second (10 KBps)
-      :function: 
-        :name: number_with_delimiter
-        :delimiter: ","
-        :suffix: " KBps"
-
-      :description: Percentage (99%)
-      :function: 
-        :name: number_with_delimiter
-        :delimiter: ","
-        :suffix: ! '%'
-
-      :description: Percent, 1 Decimal (99.0%)
-      :function:
-        :name: number_with_delimiter
-        :delimiter: ","
-        :suffix: ! '%'
-
-      :description: Percent, 2 Decimals (99.00%)
-      :function: 
-        :name: number_with_delimiter
-        :delimiter: ","
-        :suffix: ! '%'
-    */
     number_with_delimiter: function(val, options) {
       options = options || {};
       var av_options = _.pick(options, [ 'delimiter', 'separator' ]);
@@ -162,12 +122,6 @@
       return apply_prefix_and_suffix(val, options);
     },
 
-    /*
-      :description: Currency, 2 Decimals ($1,234.00)
-      :function:
-        :name: currency_with_delimiter
-        :delimiter: ","
-    */
     currency_with_delimiter: function(val, options) {
       options = options || {};
       var av_options = _.pick(options, [ 'delimiter', 'separator' ]);
@@ -176,11 +130,6 @@
       return apply_prefix_and_suffix(val, options)
     },
 
-    /*
-      :description: Suffixed Bytes (B, KB, MB, GB)
-      :function:
-        :name: bytes_to_human_size
-    */
     bytes_to_human_size: function(val, options) {
       options = options || {};
       var av_options = { precision: options.precision || 0 };  // Precision of 0 returns the significant digits
@@ -188,75 +137,24 @@
       return apply_prefix_and_suffix(val, options);
     },
 
-    /*
-      :description: Suffixed Kilobytes (KB, MB, GB)
-      :function:
-        :name: kbytes_to_human_size
-    */
     kbytes_to_human_size: function(val, options) {
       return format.bytes_to_human_size(val * 1024, options);
     },
 
-    /*
-      :description: Suffixed Megabytes (MB, GB)
-      :function:
-        :name: mbytes_to_human_size
-    */
     mbytes_to_human_size: function(val, options) {
       return format.kbytes_to_human_size(val * 1024, options);
     },
 
-    /*
-      :description: Suffixed Gigabytes (GB)
-      :function:
-        :name: gbytes_to_human_size
-    */
     gbytes_to_human_size: function(val, options) {
       return format.mbytes_to_human_size(val * 1024, options);
     },
 
-    /*
-      :description: Megahertz (12 Mhz)
-      :function: 
-        :name: mhz_to_human_size
-        :delimiter: ","
-
-      :description: Megahertz Avg (12.1 Mhz)
-      :function:
-        :name: mhz_to_human_size
-        :delimiter: ","
-    */
     mhz_to_human_size: function(val, options) {
       options = options || {};
       val = mhz_to_human_size(val, options.precision);
       return apply_prefix_and_suffix(val, options);
     },
 
-    /*
-      :description: Boolean (True/False)
-      :function:
-        :name: boolean
-
-      :description: Boolean (T/F)
-      :function:
-        :name: boolean
-        :format: t_f
-
-      :description: Boolean (Yes/No)
-      :function:
-        :name: boolean
-        :format: yes_no
-
-      :description: Boolean (Y/N)
-      :function:
-        :name: boolean
-        :format: y_n
-
-      :description: Boolean (Pass/Fail)
-      :function:
-        :name: boolean
-        :format: pass_fail
-    */
     boolean: function(val, options) {
       options = options || {};
 
@@ -281,112 +179,6 @@
       };
     },
 
-    /*
-      :description: Date (M/D/YYYY)
-      :function:
-        :name: datetime
-        :format: "%m/%d/%Y"
-
-      :description: Date (M/D/YY)
-      :function:
-        :name: datetime
-        :format: "%m/%d/%y"
-
-      :description: Date (M/D)
-      :function:
-        :name: datetime
-        :format: "%m/%d"
-
-      :description: Time (H:M:S Z) 
-      :function:
-        :name: datetime
-        :format: "%H:%M %Z"
-
-      :description: Date/Time (M/D/Y H:M:S Z)
-      :function:
-        :name: datetime
-        :format: "%m/%d/%y %H:%M:%S %Z"
-
-      :description: Date/Hour (M/D/Y H:00 Z)
-      :function:
-        :name: datetime
-        :format: "%m/%d/%y %H:00 %Z"
-
-      :description: Date/Hour (M/D/Y H AM|PM Z)
-      :function:
-        :name: datetime
-        :format: "%m/%d/%y %I %p %Z"
-
-      :description: Hour (H:00 Z)
-      :function:
-        :name: datetime
-        :format: "%H:00 %Z"
-
-      :description: Hour (H AM|PM Z)
-      :function:
-        :name: datetime
-        :format: "%l %p %Z"
-
-      :description: Hour of Day (24)
-      :function:
-        :name: datetime
-        :format: "%k"
-
-      :description: Day Full (Monday)
-      :function:
-        :name: datetime
-        :format: "%A"
-
-      :description: Day Short (Mon)
-      :function:
-        :name: datetime
-        :format: "%a"
-
-      :description: Day of Week (1)
-      :function:
-        :name: datetime
-        :format: "%u"
-
-      :description: Day of Month (27)
-      :function:
-        :name: datetime
-        :format: "%e"
-
-      :description: Month and Year (January 2011)
-      :function:
-        :name: datetime
-        :format: "%B %Y"
-
-      :description: Month and Year Short (Jan 11)
-      :function:
-        :name: datetime
-        :format: "%b %y"
-
-      :description: Month Full (January)
-      :function:
-        :name: datetime
-        :format: "%B"
-
-      :description: Month Short (Jan)
-      :function:
-        :name: datetime
-        :format: "%b"
-
-      :description: Month of Year (12)
-      :function:
-        :name: datetime
-        :format: "%m"
-
-      :description: Week of Year (52)
-      :function:
-        :name: datetime
-        :format: "%W"
-
-      :description: Year (YYYY)
-      :function:
-        :name: datetime
-        :format: "%Y"
-    */
     // note that we require moment-timezone so that %Z (which maps to moments z which uses zoneAbbr, which returns "UTC" or "" without moment-timezone) works
     datetime: function(val, options) {
       options = options || {};
@@ -403,22 +195,6 @@
       return val.strftime(options.format);
     },
 
-    /*
-      :description: Date Range (M/D/Y - M/D/Y)
-      :function:
-        :name: datetime_range
-        :format: "%m/%d/%y"
-
-      :description: Day Range (M/D - M/D)
-      :function:
-        :name: datetime_range
-        :format: "%m/%d"
-
-      :description: Day Range Start (M/D)
-      :function:
-        :name: datetime_range
-        :format: "%m/%d"
-    */
     datetime_range: function(val, options) {
       options = options || {};
       if (! options.format)
@@ -450,12 +226,6 @@
         return "(" + stime.strftime(options.format) + " - " + etime.strftime(options.format) + ")";
     },
 
-    /*
-      :description: Comma seperated list
-      :function:
-        :name: set
-        :delimiter: ", "
-    */
     set: function(val, options) {
       options = options || {};
       if (! _.isArray(val))
@@ -463,17 +233,6 @@
       return val.join(options.delimiter || ", ");
     },
 
-    /*
-      :description: Day of Month (27th)
-      :function:
-        :name: datetime_ordinal
-        :format: "%e"
-
-      :description: Week of Year (52nd)
-      :function:
-        :name: datetime_ordinal
-        :format: "%W"
-    */
     datetime_ordinal: function(val, options) {
       options = options || {};
       val = format.datetime(val, options);
@@ -486,16 +245,11 @@
       return ordinalize(~~ val);
     },
 
-    /*
-      :description: "Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"
-      :function:
-        :name: elapsed_time_human
-    */
     elapsed_time_human: function(val, options) {
       options = options || {};
       val = ~~ val;
 
-      var names = ['day', 'hour', 'minute', 'second'];
+      var names = ['Day', 'Hour', 'Minute', 'Second'];
 
       var days    = ~~(val / 86400);
       var hours   = ~~((val / 3600) - (days * 24));
@@ -509,12 +263,12 @@
       var sidx = _.findIndex(arr, function(a) {
         return a > 0;
       });
-      var values = _.slice(arr, sidx, sidx + 1);
+      var values = _.slice(arr, sidx, sidx + 2);
       var result = '';
       var sep    = '';
-      for (var i in values) {
+      values.forEach(function(val, i) {
         var sfx = names[sidx + i];
-        if (values[i] > 1 || values[i] == 0)
+        if (val > 1 || val == 0)
           sfx += "s";
 
         result += sep;
@@ -523,34 +277,22 @@
         result += sfx;
 
         sep = ", ";
-      }
+      });
 
       return result;
     },
 
-    /*
-      :description: String Truncated to 50 Characters with Elipses (...)
-      :function:
-        :name: string_truncate
-        :length: 50
-    */
     string_truncate: function(val, options) {
       options = options || {};
       var result = String(val);
       return (result.length > options.length) ? result.substr(0, options.length) + "..." : val;
     },
 
-    /*
-      :description: Convert Numbers Larger than 1.0e+15 to Exponential Form
-      :function:
-        :name: large_number_to_exponential_form
-        :length: 50
-    */
     large_number_to_exponential_form: function(val, options) {
       options = options || {};
       if (Number(val) < 1.0e+15)
         return val;
-      return String( Number(val) );
+      return Number(val).toPrecision(2);
     },
   };
 

--- a/app/assets/javascripts/miq_formatters.js
+++ b/app/assets/javascripts/miq_formatters.js
@@ -1,5 +1,4 @@
 // Note: when changing a formatter, please consider also changing the corresponding MiqReport::Formatting#format_* method
-// TODO tests
 
 (function(window, moment, _) {
   "use strict";
@@ -296,6 +295,16 @@
     },
   };
 
-  // curryRight so that formatters.foo(options) returns a function(val)->string
-  window.ManageIQ.charts.formatters = _.mapValues(format, _.curryRight);
+  // .foo(val, opt) or .foo.c3(opt)(val) or .foo.jqplot(opt)(_, val)
+  window.ManageIQ.charts.formatters = _.mapValues(format, function(fn) {
+    fn.c3 = _.curryRight(fn);
+
+    fn.jqplot = function(opt) {
+      return function(_fmt, val) {
+        return fn(val, opt);
+      };
+    };
+
+    return fn;
+  });
 })(window, moment, _);

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -33,6 +33,7 @@ if (typeof(ManageIQ) === 'undefined') {
     charts: {
       chartData: null, // data for charts
       charts: {}, // object with registered charts used in jqplot_register_chart
+      formatters: {}, // functions corresponding to MiqReport::Formatting
     },
     grids: {
       grids: null, // stored grids on the screen

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -1,3 +1,5 @@
+# Note: when changing a formatter, please consider also changing the corresponding entry in miq_formatters.js
+
 module MiqReport::Formatting
   extend ActiveSupport::Concern
 

--- a/spec/javascripts/miq_formatters_spec.js
+++ b/spec/javascripts/miq_formatters_spec.js
@@ -1,0 +1,590 @@
+describe('ManageIQ.charts.formatters', function() {
+  describe('.number_with_delimiter', function() {
+    it('Number (1,234)', function() {
+      var options = {
+        description: 'Number (1,234)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        precision: 0,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(1234)).toEqual('1,234');
+    });
+
+    it('Number (1,234.0)', function() {
+      var options = {
+        description: 'Number (1,234.0)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(1234)).toEqual('1,234.0');
+    });
+
+    it('Number, 2 Decimals (1,234.00)', function() {
+      var options = {
+        description: 'Number, 2 Decimals (1,234.00)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(1234)).toEqual('1,234.00');
+    });
+
+    it('Kilobytes per Second (10 KBps)', function() {
+      var options = {
+        description: 'Kilobytes per Second (10 KBps)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        suffix: " KBps",
+        precision: 0,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(10)).toEqual('10 KBps');
+    });
+
+    it('Percentage (99%)', function() {
+      var options = {
+        description: 'Percentage (99%)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        suffix: '%',
+        precision: 0,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(99)).toEqual('99%');
+    });
+
+    it('Percent, 1 Decimal (99.0%)', function() {
+      var options = {
+        description: 'Percent, 1 Decimal (99.0%)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        suffix: '%',
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(99)).toEqual('99.0%');
+    });
+
+    it('Percent, 2 Decimals (99.00%)', function() {
+      var options = {
+        description: 'Percent, 2 Decimals (99.00%)',
+        name: 'number_with_delimiter',
+        delimiter: ",",
+        suffix: '%',
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(99)).toEqual('99.00%');
+    });
+  });
+
+  describe('.currency_with_delimiter', function() {
+    it('Currency, 2 Decimals ($1,234.00)', function() {
+      var options = {
+        description: 'Currency, 2 Decimals ($1,234.00)',
+        name: 'currency_with_delimiter',
+        delimiter: ",",
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(1234)).toEqual('$1,234.00');
+    });
+  });
+
+  describe('.bytes_to_human_size', function() {
+    it('Suffixed Bytes (B, KB, MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Bytes (B, KB, MB, GB)',
+        name: 'bytes_to_human_size',
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(1234)).toEqual('1.2 KB');
+    });
+  });
+
+  describe('.kbytes_to_human_size', function() {
+    it('Suffixed Kilobytes (KB, MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Kilobytes (KB, MB, GB)',
+        name: 'kbytes_to_human_size',
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(234)).toEqual('234 KB');
+    });
+  });
+
+  describe('.mbytes_to_human_size', function() {
+    it('Suffixed Megabytes (MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Megabytes (MB, GB)',
+        name: 'mbytes_to_human_size',
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(2)).toEqual('2 MB');
+    });
+  });
+
+  describe('.gbytes_to_human_size', function() {
+    it('Suffixed Gigabytes (GB)', function() {
+      var options = {
+        description: 'Suffixed Gigabytes (GB)',
+        name: 'gbytes_to_human_size',
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(0.1)).toEqual('102 MB');
+    });
+  });
+
+  describe('.mhz_to_human_size', function() {
+    it('Megahertz (12 Mhz)', function() {
+      var options = {
+        description: 'Megahertz (12 Mhz)',
+        name: 'mhz_to_human_size',
+        delimiter: ",",
+        precision: 0,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(12.1)).toEqual('12 MHz');
+    });
+
+    it('Megahertz Avg (12.1 Mhz)', function() {
+      var options = {
+        description: 'Megahertz Avg (12.1 Mhz)',
+        name: 'mhz_to_human_size',
+        delimiter: ",",
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(12.1)).toEqual('12.1 MHz');
+    });
+  });
+
+  describe('.boolean', function() {
+    it('Boolean (True/False)', function() {
+      var options = {
+        description: 'Boolean (True/False)',
+        name: 'boolean',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(true)).toEqual('True');
+      expect(fn(false)).toEqual('False');
+    });
+
+    it('Boolean (T/F)', function() {
+      var options = {
+        description: 'Boolean (T/F)',
+        name: 'boolean',
+        format: 't_f',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(true)).toEqual('T');
+      expect(fn(false)).toEqual('F');
+    });
+
+    it('Boolean (Yes/No)', function() {
+      var options = {
+        description: 'Boolean (Yes/No)',
+        name: 'boolean',
+        format: 'yes_no',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(true)).toEqual('Yes');
+      expect(fn(false)).toEqual('No');
+    });
+
+    it('Boolean (Y/N)', function() {
+      var options = {
+        description: 'Boolean (Y/N)',
+        name: 'boolean',
+        format: 'y_n',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(true)).toEqual('Y');
+      expect(fn(false)).toEqual('N');
+    });
+
+    it('Boolean (Pass/Fail)', function() {
+      var options = {
+        description: 'Boolean (Pass/Fail)',
+        name: 'boolean',
+        format: 'pass_fail',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(true)).toEqual('Pass');
+      expect(fn(false)).toEqual('Fail');
+    });
+  });
+
+  describe('.datetime', function() {
+    it('Date (M/D/YYYY)', function() {
+      var options = {
+        description: 'Date (M/D/YYYY)',
+        name: 'datetime',
+        format: "%m/%d/%Y",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03/14/2015');
+    });
+
+    it('Date (M/D/YY)', function() {
+      var options = {
+        description: 'Date (M/D/YY)',
+        name: 'datetime',
+        format: "%m/%d/%y",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03/14/15');
+    });
+
+    it('Date (M/D)', function() {
+      var options = {
+        description: 'Date (M/D)',
+        name: 'datetime',
+        format: "%m/%d",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03/14');
+    });
+
+    it('Time (HM:S Z)', function() {
+      var options = {
+        description: 'Time (H:M:S Z) ',
+        name: 'datetime',
+        format: "%H:%M %Z",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('11:22 UTC');
+    });
+
+    it('Date/Time (M/D/Y HM:S Z)', function() {
+      var options = {
+        description: 'Date/Time (M/D/Y H:M:S Z)',
+        name: 'datetime',
+        format: "%m/%d/%y %H:%M:%S %Z",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('03/14/15 11:22:05 UTC');
+    });
+
+    it('Date/Hour (M/D/Y H:00 Z)', function() {
+      var options = {
+        description: 'Date/Hour (M/D/Y H:00 Z)',
+        name: 'datetime',
+        format: "%m/%d/%y %H:00 %Z",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('03/14/15 11:00 UTC');
+    });
+
+    it('Date/Hour (M/D/Y H AM|PM Z)', function() {
+      var options = {
+        description: 'Date/Hour (M/D/Y H AM|PM Z)',
+        name: 'datetime',
+        format: "%m/%d/%y %I %p %Z",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('03/14/15 11 AM UTC');
+    });
+
+    it('Hour (H:00 Z)', function() {
+      var options = {
+        description: 'Hour (H:00 Z)',
+        name: 'datetime',
+        format: "%H:00 %Z",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('11:00 UTC');
+    });
+
+    it('Hour (H AM|PM Z)', function() {
+      var options = {
+        description: 'Hour (H AM|PM Z)',
+        name: 'datetime',
+        format: "%l %p %Z",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('11 AM UTC');
+    });
+
+    it('Hour of Day (24)', function() {
+      var options = {
+        description: 'Hour of Day (24)',
+        name: 'datetime',
+        format: "%k",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('11');
+    });
+
+    it('Day Full (Monday)', function() {
+      var options = {
+        description: 'Day Full (Monday)',
+        name: 'datetime',
+        format: "%A",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Saturday');
+    });
+
+    it('Day Short (Mon)', function() {
+      var options = {
+        description: 'Day Short (Mon)',
+        name: 'datetime',
+        format: "%a",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Sat');
+    });
+
+    it('Day of Week (1)', function() {
+      var options = {
+        description: 'Day of Week (1)',
+        name: 'datetime',
+        format: "%u",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('6');
+    });
+
+    it('Day of Month (27)', function() {
+      var options = {
+        description: 'Day of Month (27)',
+        name: 'datetime',
+        format: "%e",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('14');
+    });
+
+    it('Month and Year (January 2011)', function() {
+      var options = {
+        description: 'Month and Year (January 2011)',
+        name: 'datetime',
+        format: "%B %Y",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('March 2015');
+    });
+
+    it('Month and Year Short (Jan 11)', function() {
+      var options = {
+        description: 'Month and Year Short (Jan 11)',
+        name: 'datetime',
+        format: "%b %y",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Mar 15');
+    });
+
+    it('Month Full (January)', function() {
+      var options = {
+        description: 'Month Full (January)',
+        name: 'datetime',
+        format: "%B",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('March');
+    });
+
+    it('Month Short (Jan)', function() {
+      var options = {
+        description: 'Month Short (Jan)',
+        name: 'datetime',
+        format: "%b",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Mar');
+    });
+
+    it('Month of Year (12)', function() {
+      var options = {
+        description: 'Month of Year (12)',
+        name: 'datetime',
+        format: "%m",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03');
+    });
+
+    it('Week of Year (52)', function() {
+      var options = {
+        description: 'Week of Year (52)',
+        name: 'datetime',
+        format: "%W",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('11');
+    });
+
+    it('Year (YYYY)', function() {
+      var options = {
+        description: 'Year (YYYY)',
+        name: 'datetime',
+        format: "%Y",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('2015');
+    });
+  });
+
+  describe('.datetime_range', function() {
+    it('Date Range (M/D/Y - M/D/Y)', function() {
+      var options = {
+        description: 'Date Range (M/D/Y - M/D/Y)',
+        name: 'datetime_range',
+        format: "%m/%d/%y",
+        column: 'foo__month',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('(03/01/15 - 03/31/15)');
+    });
+
+    it('Day Range (M/D - M/D)', function() {
+      var options = {
+        description: 'Day Range (M/D - M/D)',
+        name: 'datetime_range',
+        format: "%m/%d",
+        column: 'foo__week',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('(03/08 - 03/14)');
+    });
+
+    it('Day Range Start (M/D)', function() {
+      var options = {
+        description: 'Day Range Start (M/D)',
+        name: 'datetime_range',
+        format: "%m/%d",
+        column: 'foo__year',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('01/01');
+    });
+  });
+
+  describe('.set', function() {
+    it('Comma seperated list', function() {
+      var options = {
+        description: 'Comma seperated list',
+        name: 'set',
+        delimiter: ", ",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(['foo', 'bar', 'quux'])).toEqual('foo, bar, quux');
+    });
+  });
+
+  describe('.datetime_ordinal', function() {
+    it('Day of Month (27th)', function() {
+      var options = {
+        description: 'Day of Month (27th)',
+        name: 'datetime_ordinal',
+        format: "%e",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-07-27T00:00:00Z'))).toEqual('27th');
+    });
+
+    it('Week of Year (52nd)', function() {
+      var options = {
+        description: 'Week of Year (52nd)',
+        name: 'datetime_ordinal',
+        format: "%W",
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(new Date('2015-12-21T00:00:00Z'))).toEqual('52nd');
+    });
+  });
+
+  describe('.elapsed_time_human', function() {
+    it('"Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"', function() {
+      var options = {
+        description: '"Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"',
+        name: 'elapsed_time_human',
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(864104)).toEqual('10 Days, 0 Hours');
+    });
+  });
+
+  describe('.string_truncate', function() {
+    it('String Truncated to 50 Characters with Elipses (...)', function() {
+      var options = {
+        description: 'String Truncated to 50 Characters with Elipses (...)',
+        name: 'string_truncate',
+        length: 50,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed.')).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing...');
+    });
+  });
+
+  describe('.large_number_to_exponential_form', function() {
+    it('Convert Numbers Larger than 1.0e+15 to Exponential Form', function() {
+      var options = {
+        description: 'Convert Numbers Larger than 1.0e+15 to Exponential Form',
+        name: 'large_number_to_exponential_form',
+        length: 50,
+      };
+      var fn = ManageIQ.charts.formatters[options.name](options);
+
+      expect(fn(1000000000000123)).toEqual('1.0e+15');
+    });
+  });
+});

--- a/spec/javascripts/miq_formatters_spec.js
+++ b/spec/javascripts/miq_formatters_spec.js
@@ -1,4 +1,28 @@
 describe('ManageIQ.charts.formatters', function() {
+  describe('curried/uncurried', function() {
+    var options = {
+      description: 'Number (1,234)',
+      name: 'number_with_delimiter',
+      delimiter: ",",
+      precision: 0,
+    };
+
+    it('foo(val, opt)', function() {
+      var fn = ManageIQ.charts.formatters[options.name];
+      expect(fn(1234, options)).toEqual('1,234');
+    });
+
+    it('foo.c3(opt)(val)', function() {
+      var fn = ManageIQ.charts.formatters[options.name].c3(options);
+      expect(fn(1234)).toEqual('1,234');
+    });
+
+    it('foo.jqplot(opt)(_, val)', function() {
+      var fn = ManageIQ.charts.formatters[options.name].jqplot(options);
+      expect(fn(null, 1234)).toEqual('1,234');
+    });
+  });
+
   describe('.number_with_delimiter', function() {
     it('Number (1,234)', function() {
       var options = {
@@ -7,9 +31,9 @@ describe('ManageIQ.charts.formatters', function() {
         delimiter: ",",
         precision: 0,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234)).toEqual('1,234');
+      expect(fn(1234, options)).toEqual('1,234');
     });
 
     it('Number (1,234.0)', function() {
@@ -19,9 +43,9 @@ describe('ManageIQ.charts.formatters', function() {
         delimiter: ",",
         precision: 1,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234)).toEqual('1,234.0');
+      expect(fn(1234, options)).toEqual('1,234.0');
     });
 
     it('Number, 2 Decimals (1,234.00)', function() {
@@ -31,9 +55,9 @@ describe('ManageIQ.charts.formatters', function() {
         delimiter: ",",
         precision: 2,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234)).toEqual('1,234.00');
+      expect(fn(1234, options)).toEqual('1,234.00');
     });
 
     it('Kilobytes per Second (10 KBps)', function() {
@@ -44,9 +68,9 @@ describe('ManageIQ.charts.formatters', function() {
         suffix: " KBps",
         precision: 0,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(10)).toEqual('10 KBps');
+      expect(fn(10, options)).toEqual('10 KBps');
     });
 
     it('Percentage (99%)', function() {
@@ -57,9 +81,9 @@ describe('ManageIQ.charts.formatters', function() {
         suffix: '%',
         precision: 0,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(99)).toEqual('99%');
+      expect(fn(99, options)).toEqual('99%');
     });
 
     it('Percent, 1 Decimal (99.0%)', function() {
@@ -70,9 +94,9 @@ describe('ManageIQ.charts.formatters', function() {
         suffix: '%',
         precision: 1,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(99)).toEqual('99.0%');
+      expect(fn(99, options)).toEqual('99.0%');
     });
 
     it('Percent, 2 Decimals (99.00%)', function() {
@@ -83,9 +107,9 @@ describe('ManageIQ.charts.formatters', function() {
         suffix: '%',
         precision: 2,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(99)).toEqual('99.00%');
+      expect(fn(99, options)).toEqual('99.00%');
     });
   });
 
@@ -97,9 +121,9 @@ describe('ManageIQ.charts.formatters', function() {
         delimiter: ",",
         precision: 2,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234)).toEqual('$1,234.00');
+      expect(fn(1234, options)).toEqual('$1,234.00');
     });
   });
 
@@ -110,9 +134,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'bytes_to_human_size',
         precision: 2,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234)).toEqual('1.2 KB');
+      expect(fn(1234, options)).toEqual('1.2 KB');
     });
   });
 
@@ -123,9 +147,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'kbytes_to_human_size',
         precision: 1,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(234)).toEqual('234 KB');
+      expect(fn(234, options)).toEqual('234 KB');
     });
   });
 
@@ -136,9 +160,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'mbytes_to_human_size',
         precision: 1,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(2)).toEqual('2 MB');
+      expect(fn(2, options)).toEqual('2 MB');
     });
   });
 
@@ -149,9 +173,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'gbytes_to_human_size',
         precision: 1,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(0.1)).toEqual('102 MB');
+      expect(fn(0.1, options)).toEqual('102 MB');
     });
   });
 
@@ -163,9 +187,9 @@ describe('ManageIQ.charts.formatters', function() {
         delimiter: ",",
         precision: 0,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(12.1)).toEqual('12 MHz');
+      expect(fn(12.1, options)).toEqual('12 MHz');
     });
 
     it('Megahertz Avg (12.1 Mhz)', function() {
@@ -175,9 +199,9 @@ describe('ManageIQ.charts.formatters', function() {
         delimiter: ",",
         precision: 1,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(12.1)).toEqual('12.1 MHz');
+      expect(fn(12.1, options)).toEqual('12.1 MHz');
     });
   });
 
@@ -187,10 +211,10 @@ describe('ManageIQ.charts.formatters', function() {
         description: 'Boolean (True/False)',
         name: 'boolean',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(true)).toEqual('True');
-      expect(fn(false)).toEqual('False');
+      expect(fn(true, options)).toEqual('True');
+      expect(fn(false, options)).toEqual('False');
     });
 
     it('Boolean (T/F)', function() {
@@ -199,10 +223,10 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'boolean',
         format: 't_f',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(true)).toEqual('T');
-      expect(fn(false)).toEqual('F');
+      expect(fn(true, options)).toEqual('T');
+      expect(fn(false, options)).toEqual('F');
     });
 
     it('Boolean (Yes/No)', function() {
@@ -211,10 +235,10 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'boolean',
         format: 'yes_no',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(true)).toEqual('Yes');
-      expect(fn(false)).toEqual('No');
+      expect(fn(true, options)).toEqual('Yes');
+      expect(fn(false, options)).toEqual('No');
     });
 
     it('Boolean (Y/N)', function() {
@@ -223,10 +247,10 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'boolean',
         format: 'y_n',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(true)).toEqual('Y');
-      expect(fn(false)).toEqual('N');
+      expect(fn(true, options)).toEqual('Y');
+      expect(fn(false, options)).toEqual('N');
     });
 
     it('Boolean (Pass/Fail)', function() {
@@ -235,10 +259,10 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'boolean',
         format: 'pass_fail',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(true)).toEqual('Pass');
-      expect(fn(false)).toEqual('Fail');
+      expect(fn(true, options)).toEqual('Pass');
+      expect(fn(false, options)).toEqual('Fail');
     });
   });
 
@@ -249,9 +273,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m/%d/%Y",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03/14/2015');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('03/14/2015');
     });
 
     it('Date (M/D/YY)', function() {
@@ -260,9 +284,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m/%d/%y",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03/14/15');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15');
     });
 
     it('Date (M/D)', function() {
@@ -271,9 +295,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m/%d",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03/14');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('03/14');
     });
 
     it('Time (HM:S Z)', function() {
@@ -282,9 +306,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%H:%M %Z",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('11:22 UTC');
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('11:22 UTC');
     });
 
     it('Date/Time (M/D/Y HM:S Z)', function() {
@@ -293,9 +317,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m/%d/%y %H:%M:%S %Z",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('03/14/15 11:22:05 UTC');
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15 11:22:05 UTC');
     });
 
     it('Date/Hour (M/D/Y H:00 Z)', function() {
@@ -304,9 +328,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m/%d/%y %H:00 %Z",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('03/14/15 11:00 UTC');
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15 11:00 UTC');
     });
 
     it('Date/Hour (M/D/Y H AM|PM Z)', function() {
@@ -315,9 +339,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m/%d/%y %I %p %Z",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('03/14/15 11 AM UTC');
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15 11 AM UTC');
     });
 
     it('Hour (H:00 Z)', function() {
@@ -326,9 +350,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%H:00 %Z",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('11:00 UTC');
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('11:00 UTC');
     });
 
     it('Hour (H AM|PM Z)', function() {
@@ -337,9 +361,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%l %p %Z",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(moment.utc('2015-03-14T11:22:05Z'))).toEqual('11 AM UTC');
+      expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('11 AM UTC');
     });
 
     it('Hour of Day (24)', function() {
@@ -348,9 +372,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%k",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('11');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('11');
     });
 
     it('Day Full (Monday)', function() {
@@ -359,9 +383,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%A",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Saturday');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('Saturday');
     });
 
     it('Day Short (Mon)', function() {
@@ -370,9 +394,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%a",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Sat');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('Sat');
     });
 
     it('Day of Week (1)', function() {
@@ -381,9 +405,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%u",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('6');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('6');
     });
 
     it('Day of Month (27)', function() {
@@ -392,9 +416,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%e",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('14');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('14');
     });
 
     it('Month and Year (January 2011)', function() {
@@ -403,9 +427,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%B %Y",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('March 2015');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('March 2015');
     });
 
     it('Month and Year Short (Jan 11)', function() {
@@ -414,9 +438,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%b %y",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Mar 15');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('Mar 15');
     });
 
     it('Month Full (January)', function() {
@@ -425,9 +449,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%B",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('March');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('March');
     });
 
     it('Month Short (Jan)', function() {
@@ -436,9 +460,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%b",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('Mar');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('Mar');
     });
 
     it('Month of Year (12)', function() {
@@ -447,9 +471,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%m",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('03');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('03');
     });
 
     it('Week of Year (52)', function() {
@@ -458,9 +482,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%W",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('11');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('11');
     });
 
     it('Year (YYYY)', function() {
@@ -469,9 +493,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime',
         format: "%Y",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('2015');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('2015');
     });
   });
 
@@ -483,9 +507,9 @@ describe('ManageIQ.charts.formatters', function() {
         format: "%m/%d/%y",
         column: 'foo__month',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('(03/01/15 - 03/31/15)');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('(03/01/15 - 03/31/15)');
     });
 
     it('Day Range (M/D - M/D)', function() {
@@ -495,9 +519,9 @@ describe('ManageIQ.charts.formatters', function() {
         format: "%m/%d",
         column: 'foo__week',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('(03/08 - 03/14)');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('(03/08 - 03/14)');
     });
 
     it('Day Range Start (M/D)', function() {
@@ -507,9 +531,9 @@ describe('ManageIQ.charts.formatters', function() {
         format: "%m/%d",
         column: 'foo__year',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-03-14T11:22:05Z'))).toEqual('01/01');
+      expect(fn(new Date('2015-03-14T11:22:05Z'), options)).toEqual('01/01');
     });
   });
 
@@ -520,9 +544,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'set',
         delimiter: ", ",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(['foo', 'bar', 'quux'])).toEqual('foo, bar, quux');
+      expect(fn(['foo', 'bar', 'quux'], options)).toEqual('foo, bar, quux');
     });
   });
 
@@ -533,9 +557,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime_ordinal',
         format: "%e",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-07-27T00:00:00Z'))).toEqual('27th');
+      expect(fn(new Date('2015-07-27T00:00:00Z'), options)).toEqual('27th');
     });
 
     it('Week of Year (52nd)', function() {
@@ -544,9 +568,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'datetime_ordinal',
         format: "%W",
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date('2015-12-21T00:00:00Z'))).toEqual('52nd');
+      expect(fn(new Date('2015-12-21T00:00:00Z'), options)).toEqual('52nd');
     });
   });
 
@@ -556,9 +580,9 @@ describe('ManageIQ.charts.formatters', function() {
         description: '"Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"',
         name: 'elapsed_time_human',
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(864104)).toEqual('10 Days, 0 Hours');
+      expect(fn(864104, options)).toEqual('10 Days, 0 Hours');
     });
   });
 
@@ -569,9 +593,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'string_truncate',
         length: 50,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed.')).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing...');
+      expect(fn('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed.', options)).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing...');
     });
   });
 
@@ -582,9 +606,9 @@ describe('ManageIQ.charts.formatters', function() {
         name: 'large_number_to_exponential_form',
         length: 50,
       };
-      var fn = ManageIQ.charts.formatters[options.name](options);
+      var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1000000000000123)).toEqual('1.0e+15');
+      expect(fn(1000000000000123, options)).toEqual('1.0e+15');
     });
   });
 });


### PR DESCRIPTION
JS implementation of `MiqReport::Formatting#format_*`, meant to be used by code from #3894.

Curried so that we can say things like `axis.x.tick.formatter = ManageIQ.charts.formatters.boolean({ format: 't_f' });`. (`ManageIQ.charts.formatters.number_with_delimiter({ precision: 3, separator: '!', delimiter: '@' })(123456.7891)` yields `"123@456!789"`).

TODO:

* [x] remove the included yml fragments
* [x] write tests
* [x] fix test failures

Will do a separate PR addressing these issues later:
* ruby tests
* non-UTC time zone handling
* datetime_range should not look at description and probably not column suffix either
* test that we have the same functions in JS and Ruby

EDIT:
The date-related test failures will be gone after benjaminoakes/moment-strftime#15 .