### PR TITLE
Added tenant and quota to automate service models

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_tenant.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_tenant.rb
@@ -1,0 +1,17 @@
+module MiqAeMethodService
+  class MiqAeServiceTenant < MiqAeServiceModelBase
+    expose :id
+    expose :domain
+    expose :subdomain
+    expose :name
+    expose :login_text
+    expose :logo_file_name
+    expose :logo_content_type
+    expose :logo_file_size
+    expose :login_logo_file_name
+    expose :login_logo_content_type
+    expose :login_logo_file_size
+    expose :ancestry
+    expose :description
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_tenant_quota.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_tenant_quota.rb
@@ -1,0 +1,8 @@
+module MiqAeMethodService
+  class MiqAeServiceTenantQuota < MiqAeServiceModelBase
+    expose :tenant,  :association => true
+    expose :name
+    expose :unit
+    expose :value
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_quota_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_quota_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+module MiqAeServiceTenantQuotaSpec
+  describe MiqAeMethodService::MiqAeServiceTenantQuota do
+    let(:settings) { {} }
+    let(:tenant) { Tenant.create(:name => 'fred', :domain => 'a.b', :parent => default_tenant) }
+    let(:cpu_quota) { TenantQuota.create(:name => "max_cpu", :unit => "int", :value => 2, :tenant_id => tenant.id) }
+    let(:storage_quota) { TenantQuota.create(:name => "stor", :unit => "GB", :value => 160, :tenant_id => tenant.id) }
+
+    let(:default_tenant) do
+      Tenant.seed
+      Tenant.default_tenant
+    end
+
+    let(:st_cpu_quota) { MiqAeMethodService::MiqAeServiceTenantQuota.find(cpu_quota.id) }
+    let(:st_storage_quota) { MiqAeMethodService::MiqAeServiceTenantQuota.find(storage_quota.id) }
+
+    before do
+      allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
+    end
+
+    it "check max_cpu quota" do
+      expect(st_cpu_quota.name).to eq('max_cpu')
+      expect(st_cpu_quota.unit).to eq('int')
+      expect(st_cpu_quota.value.to_i).to eq(2)
+    end
+
+    it "check storage quota" do
+      expect(st_storage_quota.name).to eq('stor')
+      expect(st_storage_quota.unit).to eq('GB')
+      expect(st_storage_quota.value.to_i).to eq(160)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_quota_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_quota_spec.rb
@@ -16,7 +16,7 @@ module MiqAeServiceTenantQuotaSpec
     let(:st_storage_quota) { MiqAeMethodService::MiqAeServiceTenantQuota.find(storage_quota.id) }
 
     before do
-      allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
+      stub_server_configuration(settings)
     end
 
     it "check max_cpu quota" do
@@ -29,6 +29,10 @@ module MiqAeServiceTenantQuotaSpec
       expect(st_storage_quota.name).to eq('stor')
       expect(st_storage_quota.unit).to eq('GB')
       expect(st_storage_quota.value.to_i).to eq(160)
+    end
+
+    it "check tenant from quota" do
+      expect(st_storage_quota.tenant.name).to eq('fred')
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_spec.rb
@@ -13,7 +13,7 @@ module MiqAeServiceTenantSpec
     let(:service_tenant) { MiqAeMethodService::MiqAeServiceTenant.find(tenant.id) }
 
     before do
-      allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
+      stub_server_configuration(settings)
     end
 
     it "#name" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+module MiqAeServiceTenantSpec
+  describe MiqAeMethodService::MiqAeServiceTenant do
+    let(:settings) { {} }
+    let(:tenant) { Tenant.create(:name => 'fred', :domain => 'a.b', :parent => def_tenant, :description => "Krueger") }
+
+    let(:def_tenant) do
+      Tenant.seed
+      Tenant.default_tenant
+    end
+
+    let(:service_tenant) { MiqAeMethodService::MiqAeServiceTenant.find(tenant.id) }
+
+    before do
+      allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
+    end
+
+    it "#name" do
+      expect(service_tenant.name).to eq('fred')
+    end
+
+    it "#domain" do
+      expect(service_tenant.domain).to eq('a.b')
+    end
+
+    it "#description" do
+      expect(service_tenant.description).to eq('Krueger')
+    end
+  end
+end


### PR DESCRIPTION
The Automate Service models expose the Tenant and Tenant_Quote models so that automate methods can access the tenant and quota information.