### PR TITLE
Remove openstack_handle service_names

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -23,13 +23,9 @@ module ManageIQ::Providers
       @os_handle                  = ems.openstack_handle
       @compute_service            = @connection # for consistency
       @network_service            = @os_handle.detect_network_service
-      @network_service_name       = @os_handle.network_service_name
       @image_service              = @os_handle.detect_image_service
-      @image_service_name         = @os_handle.image_service_name
       @volume_service             = @os_handle.detect_volume_service
-      @volume_service_name        = @os_handle.volume_service_name
       @storage_service            = @os_handle.detect_storage_service
-      @storage_service_name       = @os_handle.storage_service_name
       @identity_service           = @os_handle.identity_service
       @orchestration_service      = @os_handle.detect_orchestration_service
     end
@@ -80,7 +76,7 @@ module ManageIQ::Providers
 
     def volumes
       # TODO: support volumes through :nova as well?
-      return [] unless @volume_service_name == :cinder
+      return [] unless @volume_service.name == :cinder
       @volumes ||= @volume_service.volumes_for_accessible_tenants
     end
 
@@ -109,8 +105,8 @@ module ManageIQ::Providers
 
     def get_quotas
       quotas = @compute_service.quotas_for_accessible_tenants
-      quotas.concat(@volume_service.quotas_for_accessible_tenants)  if @volume_service_name == :cinder
-      quotas.concat(@network_service.quotas_for_accessible_tenants) if @network_service_name == :neutron
+      quotas.concat(@volume_service.quotas_for_accessible_tenants)  if @volume_service.name == :cinder
+      quotas.concat(@network_service.quotas_for_accessible_tenants) if @network_service.name == :neutron
 
       process_collection(flatten_quotas(quotas), :cloud_resource_quotas) { |quota| parse_quota(quota) }
     end
@@ -133,14 +129,14 @@ module ManageIQ::Providers
     end
 
     def get_networks
-      return unless @network_service_name == :neutron
+      return unless @network_service.name == :neutron
 
       process_collection(networks, :cloud_networks) { |n| parse_network(n) }
       get_subnets
     end
 
     def get_subnets
-      return unless @network_service_name == :neutron
+      return unless @network_service.name == :neutron
 
       networks.each do |n|
         new_net = @data_index.fetch_path(:cloud_networks, n.id)
@@ -154,7 +150,7 @@ module ManageIQ::Providers
 
     def get_snapshots
       # TODO: support snapshots through :nova as well?
-      return unless @volume_service_name == :cinder
+      return unless @volume_service.name == :cinder
       process_collection(@volume_service.snapshots_for_accessible_tenants,
                          :cloud_volume_snapshots) { |snap| parse_snapshot(snap) }
     end
@@ -165,7 +161,7 @@ module ManageIQ::Providers
     end
 
     def get_floating_ips
-      ips = send("floating_ips_#{@network_service_name}")
+      ips = send("floating_ips_#{@network_service.name}")
       process_collection(ips, :floating_ips) { |ip| parse_floating_ip(ip) }
     end
 
@@ -307,7 +303,7 @@ module ManageIQ::Providers
     # TODO: Should ICMP protocol values have their own 2 columns, or
     #   should they override port and end_port like the Amazon API.
     def parse_firewall_rule(rule)
-      send("parse_firewall_rule_#{@network_service_name}", rule)
+      send("parse_firewall_rule_#{@network_service.name}", rule)
     end
 
     def parse_firewall_rule_neutron(rule)
@@ -502,7 +498,7 @@ module ManageIQ::Providers
     end
 
     def parse_floating_ip(ip)
-      send("parse_floating_ip_#{@network_service_name}", ip)
+      send("parse_floating_ip_#{@network_service.name}", ip)
     end
 
     def parse_floating_ip_neutron(ip)

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -25,13 +25,9 @@ module ManageIQ
         @os_handle                  = ems.openstack_handle
         @compute_service            = @connection # for consistency
         @baremetal_service          = @os_handle.detect_baremetal_service
-        @baremetal_service_name     = @os_handle.baremetal_service_name
         @orchestration_service      = @os_handle.detect_orchestration_service
-        @orchestration_service_name = @os_handle.orchestration_service_name
         @image_service              = @os_handle.detect_image_service
-        @image_service_name         = @os_handle.image_service_name
         @storage_service            = @os_handle.detect_storage_service
-        @storage_service_name       = @os_handle.storage_service_name
       end
 
       def ems_inv_to_hashes

--- a/app/models/manageiq/providers/openstack/refresh_parser_common/images.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/images.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Openstack
 module RefreshParserCommon
   module Images
-    
+
     def get_images
       images = @image_service.images_for_accessible_tenants
       process_collection(images, :vms) { |image| parse_image(image) }
@@ -29,7 +29,7 @@ module RefreshParserCommon
     end
 
     def parse_image_parent_id(image)
-      image_parent = @image_service_name == :glance ? image.copy_from : image.server
+      image_parent = @image_service.name == :glance ? image.copy_from : image.server
       image_parent["id"] if image_parent
     end
 

--- a/app/models/manageiq/providers/openstack/refresh_parser_common/objects.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/objects.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers
     module RefreshParserCommon
       module Objects
         def get_object_store
-          return unless @storage_service_name == :swift
+          return unless @storage_service.name == :swift
           @os_handle.service_for_each_accessible_tenant('Storage') do |svc, tenant|
             svc.directories.each do |dir|
               result = process_collection_item(dir, :cloud_object_store_containers) { |c| parse_container(c, tenant) }

--- a/gems/pending/openstack/openstack_handle/baremetal_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/baremetal_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class BaremetalDelegate < DelegateClass(Fog::Baremetal::OpenStack)
     SERVICE_NAME = "Baremetal"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
   end
 end

--- a/gems/pending/openstack/openstack_handle/compute_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/compute_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class ComputeDelegate < DelegateClass(Fog::Compute::OpenStack)
     SERVICE_NAME = "Compute"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     def servers_with_pagination_loop

--- a/gems/pending/openstack/openstack_handle/identity_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/identity_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class IdentityDelegate < DelegateClass(Fog::Identity::OpenStack)
     SERVICE_NAME = "Identity"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     #

--- a/gems/pending/openstack/openstack_handle/image_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/image_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class ImageDelegate < DelegateClass(Fog::Image::OpenStack)
     SERVICE_NAME = "Image"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     def images_with_pagination_loop

--- a/gems/pending/openstack/openstack_handle/metering_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/metering_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class MeteringDelegate < DelegateClass(Fog::Metering::OpenStack)
     SERVICE_NAME = "Metering"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
   end
 end

--- a/gems/pending/openstack/openstack_handle/network_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/network_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class NetworkDelegate < DelegateClass(Fog::Network::OpenStack)
     SERVICE_NAME = "Network"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     def security_groups_for_accessible_tenants

--- a/gems/pending/openstack/openstack_handle/orchestration_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/orchestration_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class OrchestrationDelegate < DelegateClass(Fog::Orchestration::OpenStack)
     SERVICE_NAME = "Orchestration"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     def stacks_for_accessible_tenants(opts = {})

--- a/gems/pending/openstack/openstack_handle/storage_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/storage_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class StorageDelegate < DelegateClass(Fog::Storage::OpenStack)
     SERVICE_NAME = "Storage"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     def directories_for_accessible_tenants

--- a/gems/pending/openstack/openstack_handle/volume_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/volume_delegate.rb
@@ -2,9 +2,12 @@ module OpenstackHandle
   class VolumeDelegate < DelegateClass(Fog::Volume::OpenStack)
     SERVICE_NAME = "Volume"
 
-    def initialize(dobj, os_handle)
+    attr_reader :name
+
+    def initialize(dobj, os_handle, name)
       super(dobj)
       @os_handle = os_handle
+      @name      = name
     end
 
     def volumes_for_accessible_tenants

--- a/gems/pending/openstack/test/image_openstack_handle_example.rb
+++ b/gems/pending/openstack/test/image_openstack_handle_example.rb
@@ -14,7 +14,7 @@ begin
     puts "\t#{t.name}\t(#{t.id})"
   end
 
-  unless os_handle.image_service_name == :glance
+  unless os_handle.image_service.name == :glance
     puts "Image service glance is not available, exiting."
     exit
   end

--- a/gems/pending/openstack/test/storage_openstack_handle_example.rb
+++ b/gems/pending/openstack/test/storage_openstack_handle_example.rb
@@ -16,7 +16,7 @@ begin
     puts "\t#{t.name}\t(#{t.id})"
   end
 
-  unless os_handle.storage_service_name == :swift
+  unless os_handle.storage_service.name == :swift
     puts "Storeage service swift is not available, exiting."
     exit
   end

--- a/gems/pending/openstack/test/tenant_openstack_handle_example.rb
+++ b/gems/pending/openstack/test/tenant_openstack_handle_example.rb
@@ -62,7 +62,7 @@ begin
       puts
       puts "\t#{service}##{method}:"
 
-      if req_name && os_handle.service_name(service) != req_name
+      if req_name && os_handle.detect_service(service).name != req_name
         puts "\t\tSkipping, required service: #{req_name}, not available."
         next
       end

--- a/gems/pending/openstack/test/volume_openstack_handle_example.rb
+++ b/gems/pending/openstack/test/volume_openstack_handle_example.rb
@@ -14,7 +14,7 @@ begin
     puts "\t#{t.name}\t(#{t.id})"
   end
 
-  unless os_handle.volume_service_name == :cinder
+  unless os_handle.volume_service.name == :cinder
     puts "Volume service cinder is not available, exiting."
     exit
   end


### PR DESCRIPTION
Originally, the openstack refreshers had to look up each service, and separately lookup each service_name to see if the service was the appropriate service they wanted.

Now the openstack refreshers can rely on the returned service object to have contain the name of
the service directly.  This eliminates the need for the openstack refreshers to carry around instance vars for both the services as well as the service names.