### PR TITLE
Collect and display Containers Security Contexts

### DIFF
--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -4,7 +4,9 @@ module ContainerHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name state reason started_at finished_at exit_code signal message last_state restart_count backing_ref command)
+    %i(name state reason started_at finished_at exit_code signal message last_state restart_count backing_ref command
+       capabilities_add capabilities_drop privileged run_as_user se_linux_user se_linux_role se_linux_type
+       se_linux_level run_as_non_root)
   end
 
   def textual_group_relationships
@@ -66,5 +68,41 @@ module ContainerHelper::TextualSummary
 
   def textual_command
     {:label => "Command", :value => @record.container_definition.command} if @record.container_definition.command
+  end
+
+  def textual_capabilities_add
+    {:label => "Add Capabilities", :value => @record.container_definition.capabilities_add} unless @record.container_definition.capabilities_add.empty?
+  end
+
+  def textual_capabilities_drop
+    {:label => "Drop Capabilities", :value => @record.container_definition.capabilities_drop} unless @record.container_definition.capabilities_drop.empty?
+  end
+
+  def textual_privileged
+    {:label => "Privileged", :value => @record.container_definition.privileged} unless @record.container_definition.privileged.nil?
+  end
+
+  def textual_run_as_user
+    {:label => "Run As User", :value => @record.container_definition.run_as_user} if @record.container_definition.run_as_user
+  end
+
+  def textual_se_linux_user
+    {:label => "Se Linux User", :value => @record.security_context.se_linux_user} if @record.security_context.se_linux_user
+  end
+
+  def textual_se_linux_role
+    {:label => "Se Linux Role", :value => @record.security_context.se_linux_role} if @record.security_context.se_linux_role
+  end
+
+  def textual_se_linux_type
+    {:label => "Se Linux Type", :value => @record.security_context.se_linux_type} if @record.security_context.se_linux_type
+  end
+
+  def textual_se_linux_level
+    {:label => "Se Linux Level", :value => @record.security_context.se_linux_level} if @record.security_context.se_linux_level
+  end
+
+  def textual_run_as_non_root
+    {:label => "Run As Non Root", :value => @record.container_definition.run_as_non_root} unless @record.container_definition.run_as_non_root.nil?
   end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -11,6 +11,7 @@ class Container < ActiveRecord::Base
   belongs_to :container_definition
   belongs_to :container_image
   has_one    :container_image_registry, :through => :container_image
+  has_one    :security_context, :through => :container_definition
 
   acts_as_miq_taggable
 end

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -4,4 +4,5 @@ class ContainerDefinition < ActiveRecord::Base
   has_many :container_port_configs, :dependent => :destroy
   has_many :container_env_vars,     :dependent => :destroy
   has_one :container,               :dependent => :destroy
+  has_one :security_context,        :as => :resource, :dependent => :destroy
 end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -147,7 +147,7 @@ module EmsRefresh::SaveInventoryContainer
               end
 
     save_inventory_multi(:container_definitions, container_group, hashes, deletes,
-                         [:ems_ref], [:container_port_configs, :container_env_vars, :container])
+                         [:ems_ref], [:container_port_configs, :container_env_vars, :security_context, :container])
     store_ids_for_new_records(container_group.container_definitions, hashes, :ems_ref)
   end
 
@@ -246,6 +246,10 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(:container_conditions, container_entity, hashes, deletes, [:name])
     store_ids_for_new_records(container_entity.container_conditions, hashes, :name)
+  end
+
+  def save_security_context_inventory(container_definition, hash, _target = nil)
+    save_inventory_single(:security_context, container_definition, hash)
   end
 
   def save_labels_inventory(entity, hashes, target = nil)

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -341,7 +341,13 @@ module ManageIQ::Providers::Kubernetes
         :command           => container_def.command ? Shellwords.join(container_def.command) : nil,
         :memory            => container_def.memory,
          # https://github.com/GoogleCloudPlatform/kubernetes/blob/0b801a91b15591e2e6e156cf714bfb866807bf30/pkg/api/v1beta3/types.go#L815
-        :cpu_cores         => container_def.cpu.to_f / 1000
+        :cpu_cores         => container_def.cpu.to_f / 1000,
+        :capabilities_add  => container_def.securityContext.try(:capabilities).try(:add).to_a.join(','),
+        :capabilities_drop => container_def.securityContext.try(:capabilities).try(:drop).to_a.join(','),
+        :privileged        => container_def.securityContext.try(:privileged),
+        :run_as_user       => container_def.securityContext.try(:runAsUser),
+        :run_as_non_root   => container_def.securityContext.try(:runAsNonRoot),
+        :security_context  => parse_security_context(container_def.securityContext)
       }
       ports = container_def.ports
       new_result[:container_port_configs] = Array(ports).collect do |port_entry|
@@ -482,6 +488,16 @@ module ManageIQ::Providers::Kubernetes
           :port => parts[:port],
         },
       ]
+    end
+
+    def parse_security_context(security_context)
+      return if security_context.nil?
+      {
+        :se_linux_level => security_context.seLinuxOptions.try(:level),
+        :se_linux_user  => security_context.seLinuxOptions.try(:user),
+        :se_linux_role  => security_context.seLinuxOptions.try(:role),
+        :se_linux_type  => security_context.seLinuxOptions.try(:type)
+      }
     end
   end
 end

--- a/app/models/security_context.rb
+++ b/app/models/security_context.rb
@@ -1,0 +1,3 @@
+class SecurityContext < ActiveRecord::Base
+  belongs_to :resource, :polymorphic => true
+end

--- a/db/migrate/20150906123643_create_security_context.rb
+++ b/db/migrate/20150906123643_create_security_context.rb
@@ -1,0 +1,11 @@
+class CreateSecurityContext < ActiveRecord::Migration
+  def change
+    create_table :security_contexts do |t|
+      t.references :resource, :polymorphic => true, :type => :bigint
+      t.string     :se_linux_user
+      t.string     :se_linux_role
+      t.string     :se_linux_type
+      t.string     :se_linux_level
+    end
+  end
+end

--- a/db/migrate/20150906123956_add_container_definition_security_contexts.rb
+++ b/db/migrate/20150906123956_add_container_definition_security_contexts.rb
@@ -1,0 +1,9 @@
+class AddContainerDefinitionSecurityContexts < ActiveRecord::Migration
+  def change
+    add_column    :container_definitions, :privileged, :boolean
+    add_column    :container_definitions, :run_as_user, :bigint
+    add_column    :container_definitions, :run_as_non_root, :boolean
+    add_column    :container_definitions, :capabilities_add, :string
+    add_column    :container_definitions, :capabilities_drop, :string
+  end
+end


### PR DESCRIPTION
Persist containers security contexts and display them in the UI under containers properties. 