### PR TITLE
Style1 to patternfly conversion in chargebacks

### DIFF
--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -2,27 +2,37 @@
 - url = url_for(:action => 'cb_assign_field_changed', :id => "#{x_node}")
 #cb_assignment_div{:style => "width: 100%; height: 100%; overflow: auto;"}
   = render :partial => "layouts/flash_msg", :locals => {:top_pad => 10}
-  %h3= _('Basic Info')
-  %table.style1
-    %tr
-      %td.key= _('Assign To')
-      %td
+  %h3
+    = _('Basic Info')
+  %form.form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Assign To')
+      .col-md-8
         - options = ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].invert.sort
         = select_tag("cbshow_typ", options_for_select([[nothing, "nil"]] + options, @edit[:new][:cbshow_typ]),
-          "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, "data-miq_observe" => {:url => url}.to_json)
+                    "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent("cbshow_typ", "#{url}")
 
     - if !@edit[:new][:cbshow_typ].blank? && @edit[:new][:cbshow_typ].ends_with?("-tags")
-      %tr
-        %td.key= _('Tag Category')
-        %td
+      .form-group
+        %label.col-md-2.control-label
+          = _('Tag Category')
+        .col-md-8
           - options = Array(@edit[:cb_assign][:cats].invert).sort_by { |a| a.first.downcase }
           = select_tag("cbtag_cat", options_for_select([["<#{_('Choose a Category')}>", ""]] + options, @edit[:new][:cbtag_cat].to_s),
-            "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, "data-miq_observe" => {:url => url}.to_json)
+                      "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("cbtag_cat", "#{url}")
 
   - unless @edit[:new][:cbshow_typ].nil? || @edit[:new][:cbshow_typ] == "nil"
     - if !@edit[:new][:cbshow_typ].ends_with?("-tags") || (@edit[:new][:cbshow_typ].ends_with?("-tags") && !@edit[:new][:cbtag_cat].blank?)
       %hr
-      %h3= _('Selections')
+      %h3
+        = _('Selections')
       %table.table.table-bordered.table-striped
         %thead
           %tr
@@ -37,8 +47,11 @@
                 %td
                   - options = @edit[:cb_rates].invert.sort
                   = select_tag("#{@edit[:new][:cbshow_typ]}__#{id}",
-                    options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
-                    "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, "data-miq_observe" => {:url => url}.to_json)
+                              options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
+                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
+                :javascript
+                  miqInitSelectPicker();
+                  miqSelectPickerEvent("#{@edit[:new][:cbshow_typ]}__#{id}", "#{url}")
           - else
             - @edit[:cb_assign][:cis].invert.sort_by { |a| a.first.downcase }.each do |ci, id|
               %tr#new_tr
@@ -47,6 +60,8 @@
                 %td
                   - options = @edit[:cb_rates].invert.sort
                   = select_tag("#{@edit[:new][:cbshow_typ]}__#{id}",
-                    options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
-                    "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, "data-miq_observe" => {:url => url}.to_json)
-
+                              options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
+                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
+                :javascript
+                  miqInitSelectPicker();
+                  miqSelectPickerEvent("#{@edit[:new][:cbshow_typ]}__#{id}", "#{url}")


### PR DESCRIPTION
Parent issue: #3139

1.
Before:
![chargebackscomputeassignmentsbefore](https://cloud.githubusercontent.com/assets/9535558/9440871/e22f7660-4a72-11e5-8183-bbe345046a5e.png)

After:
![chargebackscomputeassignmentsafter](https://cloud.githubusercontent.com/assets/9535558/9440876/e874fffe-4a72-11e5-8b9b-159ae3fad84a.png)

@epwinchell Please review 