### PR TITLE
Generalize MIQExtract to support Containers

### DIFF
--- a/gems/pending/MiqVm/MiqLocalVm.rb
+++ b/gems/pending/MiqVm/MiqLocalVm.rb
@@ -7,15 +7,15 @@ class MiqLocalVm < MiqVm
         
     def initialize
         @ost = OpenStruct.new
-        @vmRootTrees = [ MiqFS.new(RealFS, OpenStruct.new) ]
+        @rootTrees = [ MiqFS.new(RealFS, OpenStruct.new) ]
         @volumeManager = OpenStruct.new
         @vmConfigFile = "Local VM"
         @vmDir = ""
 		@vmConfig = OpenStruct.new
     end # def initialize
     
-    def vmRootTrees
-        return @vmRootTrees
+    def rootTrees
+        return @rootTrees
     end
     
     def volumeManager

--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -14,7 +14,7 @@ class MiqVm
         $log.debug "MiqVm::initialize: @ost = nil" if $log && !@ost
         @vmDisks = nil
         @wholeDisks = []
-        @vmRootTrees = nil
+        @rootTrees = nil
         @volumeManager = nil
         @applianceVolumeManager = nil
         @vmConfigFile = ""
@@ -144,11 +144,11 @@ class MiqVm
         return pVolumes
     end # def openDisks
     
-    def vmRootTrees
-        return @vmRootTrees if @vmRootTrees
-        @vmRootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
-        volumeManager.rootTrees = @vmRootTrees
-        return @vmRootTrees
+    def rootTrees
+        return @rootTrees if @rootTrees
+        @rootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
+        volumeManager.rootTrees = @rootTrees
+        return @rootTrees
     end
     
     def volumeManager
@@ -180,7 +180,7 @@ class MiqVm
             @volMgrPS = nil
         end
         @vimVm.release if @vimVm
-        @vmRootTrees = nil
+        @rootTrees = nil
         @vmDisks = nil
     end
 
@@ -283,8 +283,8 @@ if __FILE__ == $0
    # rfs.dirForeach("/") { |de| puts "\t\t#{de}" }
     
     puts "\n***** Detected Guest OSs:"
-    raise "No OSs detected" if vm.vmRootTrees.length == 0
-    vm.vmRootTrees.each do |rt|
+    raise "No OSs detected" if vm.rootTrees.length == 0
+    vm.rootTrees.each do |rt|
         puts "\t#{rt.guestOS}"
         if rt.guestOS == "Linux"
             puts "\n\t\t*** /etc/fstab contents:"
@@ -295,7 +295,7 @@ if __FILE__ == $0
         end
     end
     
-    vm.vmRootTrees.each do |rt|
+    vm.rootTrees.each do |rt|
         if rt.guestOS == "Linux"
             # tdirArr = [ "/", "/boot", "/var/www/miq", "/var/www/miq/vmdb/log", "/var/lib/mysql" ]
             tdirArr = [ "/", "/boot", "/etc/init.d", "/etc/rc.d/init.d", "/etc/rc.d/rc0.d" ]

--- a/gems/pending/MiqVm/test/localVm.rb
+++ b/gems/pending/MiqVm/test/localVm.rb
@@ -20,7 +20,7 @@ begin
     ost = OpenStruct.new
     vm = MiqVm.new(VMX, ost)
     
-    vm.vmRootTrees.each do | fs |
+    vm.rootTrees.each do | fs |
         puts "*** Found root tree for #{fs.guestOS}"
         puts "Listing files in #{fs.pwd} directory:"
         fs.dirEntries.each { |de| puts "\t#{de}" }

--- a/gems/pending/MiqVm/test/remoteVm.rb
+++ b/gems/pending/MiqVm/test/remoteVm.rb
@@ -41,7 +41,7 @@ begin
 
   vm = MiqVm.new(vmx, ost)
 
-  vm.vmRootTrees.each do | fs |
+  vm.rootTrees.each do | fs |
     puts "*** Found root tree for #{fs.guestOS}"
     puts "Listing files in #{fs.pwd} directory:"
     fs.dirEntries.each { |de| puts "\t#{de}" }

--- a/gems/pending/MiqVm/test/rhevmNfsTest.rb
+++ b/gems/pending/MiqVm/test/rhevmNfsTest.rb
@@ -39,10 +39,10 @@ begin
 
 	vm = MiqVm.new(hardware, ost)
 
-	raise "No filesystems detected." if vm.vmRootTrees.empty?
+	raise "No filesystems detected." if vm.rootTrees.empty?
 
 	puts "\nChecking for file systems..."
-	vm.vmRootTrees.each do | fs |
+	vm.rootTrees.each do | fs |
 	    puts "*** Found root tree for #{fs.guestOS}"
 	    puts "Listing files in #{fs.pwd} directory:"
 	    fs.dirEntries.each { |de| puts "\t#{de}" }

--- a/gems/pending/MiqVm/test/rhevmTest.rb
+++ b/gems/pending/MiqVm/test/rhevmTest.rb
@@ -47,7 +47,7 @@ begin
   vm = MiqVm.new(rvm.api_endpoint, ost)
 
   puts "\nChecking for file systems..."
-  vm.vmRootTrees.each do | fs |
+  vm.rootTrees.each do | fs |
       puts "*** Found root tree for #{fs.guestOS}"
       puts "Listing files in #{fs.pwd} directory:"
       fs.dirEntries.each { |de| puts "\t#{de}" }

--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
@@ -4,7 +4,7 @@ require_relative '../../MiqVm/MiqVm'
 class MiqOpenStackImage
   attr_reader :vmConfigFile
 
-  SUPPORTED_METHODS = [ :vmRootTrees, :extract, :diskInitErrors ]
+  SUPPORTED_METHODS = [ :rootTrees, :extract, :diskInitErrors ]
 
 	def initialize(image_id, args)
     @image_id     = image_id

--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -9,7 +9,7 @@ require_relative '../../MiqVm/MiqVm'
 class MiqOpenStackInstance
   attr_reader :vmConfigFile
   
-  SUPPORTED_METHODS = [:vmRootTrees, :extract, :diskInitErrors]
+  SUPPORTED_METHODS = [:rootTrees, :extract, :diskInitErrors]
 
   def initialize(instance_id, openstack_handle)
     @instance_id      = instance_id

--- a/gems/pending/VolumeManager/test/ldm.rb
+++ b/gems/pending/VolumeManager/test/ldm.rb
@@ -44,7 +44,7 @@ begin
 	# xml.write($stdout, 4)
 	# puts
 	
-	rta = vm.vmRootTrees
+	rta = vm.rootTrees
 	raise "No root filesystems detected for: #{vmCfg}" if rta.empty?
 	rt = rta.first
 	puts "**** Filesystem information:"

--- a/gems/pending/metadata/MIQExtract/MIQExtract.rb
+++ b/gems/pending/metadata/MIQExtract/MIQExtract.rb
@@ -33,7 +33,7 @@ class MIQExtract
 
     # TODO: Should all be subclasses of MiqVm.
     #       Going forward, we should only pass in an MiqVm - so the "else" will be removed.
-		if filename.respond_to?(:vmRootTrees)
+		if filename.respond_to?(:rootTrees)
 			@externalMount = true
 			@target = filename
 			@configFile = filename.respond_to?(:vmConfigFile) ? @target.vmConfigFile : nil
@@ -56,7 +56,7 @@ class MIQExtract
 		begin
       st = Time.now
       $log.info "Loading disk files for VM [#{@configFile}]"
-			@systemFs = @target.vmRootTrees[0]
+			@systemFs = @target.rootTrees[0]
 			if @systemFs.nil?
 				raise MiqException::MiqVmMountError, "No root filesystem found." if @target.diskInitErrors.empty?
 

--- a/gems/pending/metadata/ScanProfile/modules/VmScanItemFile.rb
+++ b/gems/pending/metadata/ScanProfile/modules/VmScanItemFile.rb
@@ -29,7 +29,7 @@ module VmScanItemFile
         begin
           # Skip if we already have data for this element
           options = {'contents'=>d['content']}
-          d["data"] = MD5deep.scan_glob(vm.vmRootTrees[0], d["target"], options) if d["data"].nil?
+          d["data"] = MD5deep.scan_glob(vm.rootTrees[0], d["target"], options) if d["data"].nil?
         rescue
         end
       end

--- a/gems/pending/metadata/ScanProfile/modules/VmScanItemNteventlog.rb
+++ b/gems/pending/metadata/ScanProfile/modules/VmScanItemNteventlog.rb
@@ -11,12 +11,12 @@ module VmScanItemNteventlog
     if data.nil?
       d = self.scan_definition
       if d[:data].nil?
-        if vm.vmRootTrees[0].guestOS == "Windows"
+        if vm.rootTrees[0].guestOS == "Windows"
           begin
             st = Time.now
             $log.info "Scanning [Profile-EventLogs] information."
             yield({:msg=>'Scanning Profile-EventLogs'}) if block_given?
-            ntevent = Win32EventLog.new(vm.vmRootTrees[0])
+            ntevent = Win32EventLog.new(vm.rootTrees[0])
             ntevent.readAllLogs(d['content'])
           rescue MiqException::NtEventLogFormat
             $log.warn "#{$!}"

--- a/gems/pending/metadata/VmConfig/VmConfig.rb
+++ b/gems/pending/metadata/VmConfig/VmConfig.rb
@@ -180,7 +180,7 @@ class VmConfig
     unless miqvm.nil?
       # Make sure we have the volume manager and loaded
       begin
-        miqvm.vmRootTrees[0]
+        miqvm.rootTrees[0]
         @vol_mgr_loaded = true
       rescue LoadError
         $log.warn "add_disk_stats [#{$!.class}]-[#{$!}]"
@@ -567,7 +567,7 @@ class VmConfig
       free_space = 0; disk_capacity = 0
       if miqvm && @vol_mgr_loaded
         # Make sure we have the volume manager loaded
-        vmRoot = miqvm.vmRootTrees[0]
+        vmRoot = miqvm.rootTrees[0]
         if vmRoot
           miqvm.wholeDisks.each {|d| disk_capacity += d.size}
           rootAdded = false

--- a/gems/pending/metadata/linux/LinuxUsers.rb
+++ b/gems/pending/metadata/linux/LinuxUsers.rb
@@ -280,8 +280,8 @@ if __FILE__ == $0
 	puts "VM config file: #{vmCfg}"
     
 	vm = MiqVm.new(vmCfg)
-	raise "No OSs detected" if vm.vmRootTrees.length == 0
-	rt = vm.vmRootTrees[0]
+	raise "No OSs detected" if vm.rootTrees.length == 0
+	rt = vm.rootTrees[0]
 	u = MiqLinux::Users.new(rt)
 	puts "**** USERS:"
 	u.usersToXml.write($stdout, 4)

--- a/gems/pending/metadata/util/md5deep.rb
+++ b/gems/pending/metadata/util/md5deep.rb
@@ -254,7 +254,7 @@ if __FILE__ == $0 then
   begin
     @vm = MiqVm.new(vmHDImage, nil)
 
-    @systemFs = @vm.vmRootTrees[0]
+    @systemFs = @vm.rootTrees[0]
     if @systemFs
       #Note: SHA22 is not valid.  It is here for testing of bad parms
       #md5 = MD5deep.new(@systemFs, {"digest"=>%w(SHA1)}) #, %w(MD5 RMD160 SHA1 SHA256 SHA384 SHA512 SHA22))

--- a/gems/pending/test/extract/tc_registry.rb
+++ b/gems/pending/test/extract/tc_registry.rb
@@ -43,7 +43,7 @@ module Extract
       # Load VM object
       @vm = MiqVm.new(fileName)
       # Set the system fs handle
-      @systemFs = @vm.vmRootTrees[0]
+      @systemFs = @vm.rootTrees[0]
       assert_instance_of(MiqMountManager, @systemFs)
       assert_instance_of(String, @systemFs.pwd)
 

--- a/gems/pending/util/MiqVmFsUtil.rb
+++ b/gems/pending/util/MiqVmFsUtil.rb
@@ -107,9 +107,9 @@ if __FILE__ == $0
     # vmfsu = MiqVmFsUtil.new(fs)
     
     vm = MiqVm.new(vmCfg)
-    raise "No OSs detected" if vm.vmRootTrees.length == 0
+    raise "No OSs detected" if vm.rootTrees.length == 0
     
-    vmfsu = MiqVmFsUtil.new(vm.vmRootTrees[0])
+    vmfsu = MiqVmFsUtil.new(vm.rootTrees[0])
     # vmfsu.flatDirCopyOut("/var/lib/rpm", "rpm_test_dir")
     vmfsu.fs.chdir("/var/lib")
     vmfsu.findEach(".") { |f| puts f }


### PR DESCRIPTION
cc @roliveri 

In this pull request:

- detection of the object in `MIQExtract.initialize` is done with duck typing `respond_to?(:rootTrees)`
- `@vm` is renamed to `@target`
- `@vmRootTrees` is renamed to `@rootTrees`