### PR TITLE
Fix rufus undefined method error.

### DIFF
--- a/lib/workers/schedule_worker/jobs.rb
+++ b/lib/workers/schedule_worker/jobs.rb
@@ -174,7 +174,7 @@ class ScheduleWorker < WorkerBase
     end
 
     def miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
-      MiqSchedule.queue_scheduled_work(schedule_id, rufus_job.job_id, rufus_job.at, rufus_job.params)
+      MiqSchedule.queue_scheduled_work(schedule_id, rufus_job.job_id, rufus_job.next_time, rufus_job.opts)
     end
 
     def ldap_server_sync_data_from_timer

--- a/spec/lib/workers/jobs/jobs_spec.rb
+++ b/spec/lib/workers/jobs/jobs_spec.rb
@@ -29,13 +29,12 @@ describe ScheduleWorker::Jobs do
     require "rufus-scheduler"
 
     it "delegates the queueing to MiqSchedule" do
-      miq_schedule = stub_const("MiqSchedule", double("MiqSchedule"))
       schedule_id = 123
       scheduler = Rufus::Scheduler.new
       block = -> { "some work" }
       rufus_job = Rufus::Scheduler::EveryJob.new(scheduler, 1.hour, {}, block)
 
-      expect(miq_schedule).to receive(:queue_scheduled_work).with(schedule_id, rufus_job.job_id, rufus_job.next_time, {})
+      expect(MiqSchedule).to receive(:queue_scheduled_work).with(schedule_id, rufus_job.job_id, rufus_job.next_time, {})
 
       described_class.new.miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
     end

--- a/spec/lib/workers/jobs/jobs_spec.rb
+++ b/spec/lib/workers/jobs/jobs_spec.rb
@@ -24,4 +24,20 @@ describe ScheduleWorker::Jobs do
       )
     end
   end
+
+  describe "#miq_schedule_queue_scheduled_work" do
+    require "rufus-scheduler"
+
+    it "delegates the queueing to MiqSchedule" do
+      miq_schedule = stub_const("MiqSchedule", double("MiqSchedule"))
+      schedule_id = 123
+      scheduler = Rufus::Scheduler.new
+      block = -> { "some work" }
+      rufus_job = Rufus::Scheduler::EveryJob.new(scheduler, 1.hour, {}, block)
+
+      expect(miq_schedule).to receive(:queue_scheduled_work).with(schedule_id, rufus_job.job_id, rufus_job.next_time, {})
+
+      described_class.new.miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
+    end
+  end
 end


### PR DESCRIPTION
Adds a test for the previously uncovered
ScheduleWorker::Jobs#miq_schedule_queue_scheduled_work and replaces the
deprecated #at with #next_time and #params with #opts.

This is probably not a great test since it doesn't do much, and it is testing the implementation rather than behavior, but it does enable me to prove that there was a bug and that the changes below should work. Any suggestions on improving this are welcome!