### PR TITLE
Tenant#default_tenant now returns root_tenant

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -119,7 +119,7 @@ class Tenant < ActiveRecord::Base
 
   def self.seed
     Tenant.find_by(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL) ||
-      Tenant.create(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL).update_attributes(:name => nil)
+      Tenant.create(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL).update_attributes!(:name => nil)
   end
 
   private

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -90,7 +90,12 @@ class Tenant < ActiveRecord::Base
 
   # @return [Boolean] Is this a default tenant?
   def default?
-    subdomain == DEFAULT_URL && domain == DEFAULT_URL
+    root?
+  end
+
+  # @return [Boolean] Is this the root tenant?
+  def root?
+    !parent_id?
   end
 
   def tenant?
@@ -109,26 +114,36 @@ class Tenant < ActiveRecord::Base
     !!login_logo_file_name
   end
 
+  # The default tenant is the tenant to be used when
+  # the url does not map to a known domain or subdomain
+  #
+  # At this time, urls are not used, so the root tenant is returned
+  # @return [Tenant] default tenant
   def self.default_tenant
-    Tenant.find_by(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL)
+    root_tenant
   end
 
+  # the root tenant is also referred to as tenant0
+  # from this tenant, all tenants are positioned
+  #
+  # @return [Tenant] the root tenant
   def self.root_tenant
     roots.first
   end
 
   def self.seed
-    Tenant.find_by(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL) ||
-      Tenant.create(:subdomain => DEFAULT_URL, :domain => DEFAULT_URL).update_attributes!(:name => nil)
+    Tenant.root_tenant || Tenant.create.update_attributes!(:name => nil)
   end
 
   private
 
+  # when a root tenant has an attribute with a nil value,
+  #   read the value from the settings table instead
+  #
+  # @return the attribute value
   def tenant_attribute(attr_name, setting_name)
     ret = self[attr_name]
-    # if the attribute is nil and we are the default tenant
-    # then use settings values
-    if ret.nil? && default?
+    if ret.nil? && root?
       ret = settings.fetch_path(:server, setting_name)
       block_given? ? yield(ret) : ret
     else

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -26,7 +26,12 @@ describe Tenant do
 
   describe "#root_tenant" do
     it "has a root tenant" do
-      expect(default_tenant).to be
+      expect(root_tenant).to be
+    end
+
+    it "can update the root_tenant" do
+      root_tenant.update_attributes!(:name => 'newname')
+      expect(root_tenant.reload.name).to eq('newname')
     end
   end
 
@@ -278,14 +283,9 @@ describe Tenant do
     end
   end
 
-  context "#root_tenant" do
-    it "returns the root (not the default tenant)" do
-      Tenant.destroy_all
-      r = described_class.create(:subdomain => 'admin')
-      c = described_class.create(:parent => r)
-
-      expect(described_class.root_tenant).to eq(r)
-      expect(described_class.default_tenant).to eq(c)
+  context "#validate_only_one_root" do
+    it "allows child tenants" do
+      root_tenant.children.create!
     end
 
     it "only allows one root" do
@@ -295,11 +295,6 @@ describe Tenant do
       expect {
         described_class.create!
       }.to raise_error
-    end
-
-    it "can update the root_tenant" do
-      root_tenant.update_attributes!(:name => 'newname')
-      expect(root_tenant.reload.name).to eq('newname')
     end
   end
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -9,12 +9,23 @@ describe Tenant do
     described_class.default_tenant
   end
 
+  let(:root_tenant) do
+    Tenant.seed
+    described_class.root_tenant
+  end
+
   before do
     allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
   end
 
   describe "#default_tenant" do
     it "has a default tenant" do
+      expect(default_tenant).to be
+    end
+  end
+
+  describe "#root_tenant" do
+    it "has a root tenant" do
       expect(default_tenant).to be
     end
   end
@@ -91,14 +102,16 @@ describe Tenant do
       expect(tenant.name).to be_nil
     end
 
-    it "has custom name for default tenant" do
-      default_tenant.name = "custom"
-      expect(default_tenant.name).to eq("custom")
-    end
+    context "for default tenant" do
+      it "reads settings" do
+        expect(default_tenant[:name]).to be_nil
+        expect(default_tenant.name).to eq("settings")
+      end
 
-    it "reads settings for default tenant" do
-      expect(default_tenant[:name]).to be_nil
-      expect(default_tenant.name).to eq("settings")
+      it "has custom name" do
+        default_tenant.name = "custom"
+        expect(default_tenant.name).to eq("custom")
+      end
     end
   end
 
@@ -273,6 +286,20 @@ describe Tenant do
 
       expect(described_class.root_tenant).to eq(r)
       expect(described_class.default_tenant).to eq(c)
+    end
+
+    it "only allows one root" do
+      described_class.destroy_all
+      described_class.seed
+
+      expect {
+        described_class.create!
+      }.to raise_error
+    end
+
+    it "can update the root_tenant" do
+      root_tenant.update_attributes!(:name => 'newname')
+      expect(root_tenant.reload.name).to eq('newname')
     end
   end
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -56,22 +56,22 @@ describe Tenant do
   end
 
   it ".all_tenants" do
-    FactoryGirl.create(:tenant, :parent => default_tenant)
-    FactoryGirl.create(:tenant, :parent => default_tenant, :divisible => false)
+    FactoryGirl.create(:tenant, :parent => root_tenant)
+    FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
 
     expect(Tenant.all_tenants.count).to eql 2 # The one we created + the default tenant
   end
 
   it ".all_projects" do
-    FactoryGirl.create(:tenant, :parent => default_tenant, :divisible => false)
-    FactoryGirl.create(:tenant, :parent => default_tenant, :divisible => false)
+    FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
+    FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
 
     expect(Tenant.all_projects.count).to eql 2 # Should not return the default tenant
   end
 
   context "subtenants and subprojects" do
     before do
-      @t1  = FactoryGirl.create(:tenant, :parent => default_tenant, :name => "T1")
+      @t1  = FactoryGirl.create(:tenant, :parent => root_tenant, :name => "T1")
       @t2  = FactoryGirl.create(:tenant, :parent => @t1, :name => "T2")
       @t2p = FactoryGirl.create(:tenant, :parent => @t1, :name => "T2 Project", :divisible => false)
       @t3  = FactoryGirl.create(:tenant, :parent => @t2, :name => "T3")
@@ -109,19 +109,19 @@ describe Tenant do
 
     context "for default tenant" do
       it "reads settings" do
-        expect(default_tenant[:name]).to be_nil
-        expect(default_tenant.name).to eq("settings")
+        expect(root_tenant[:name]).to be_nil
+        expect(root_tenant.name).to eq("settings")
       end
 
       it "has custom name" do
-        default_tenant.name = "custom"
-        expect(default_tenant.name).to eq("custom")
+        root_tenant.name = "custom"
+        expect(root_tenant.name).to eq("custom")
       end
     end
   end
 
   it "#parent_name" do
-    t1 = FactoryGirl.create(:tenant, :name => "T1", :parent => default_tenant)
+    t1 = FactoryGirl.create(:tenant, :name => "T1", :parent => root_tenant)
     t2 = FactoryGirl.create(:tenant, :name => "T2", :parent => t1, :divisible => false)
 
     expect(t2.parent_name).to eql "T1"
@@ -146,20 +146,20 @@ describe Tenant do
       expect(tenant.logo.path).to eq(Rails.root.join("public/uploads/custom_logo.png").to_s)
     end
 
-    it "has no logo for default_tenant" do
-      expect(default_tenant.logo.url).to match(/missing/)
+    it "has no logo for root_tenant" do
+      expect(root_tenant.logo.url).to match(/missing/)
     end
 
     context "with server settings" do
       let(:settings) { {:server => {:custom_logo => true}} }
 
-      it "uses settings value for default tenant" do
-        expect(default_tenant.logo.url).to eq("/uploads/custom_logo.png")
+      it "uses settings value for root_tenant" do
+        expect(root_tenant.logo.url).to eq("/uploads/custom_logo.png")
       end
 
       it "overrides settings for default tenant" do
-        default_tenant.update_attributes(:logo_file_name => "different.png")
-        expect(default_tenant.logo.url).to eq("/uploads/different.png")
+        root_tenant.update_attributes(:logo_file_name => "different.png")
+        expect(root_tenant.logo.url).to eq("/uploads/different.png")
       end
 
       # would prefer if url was nil, but this is how paperclip works
@@ -182,13 +182,13 @@ describe Tenant do
       expect(tenant).not_to be_logo
     end
 
-    it "knows there is no logo from configuration for default tenant" do
-      expect(default_tenant).not_to be_logo
+    it "knows there is no logo from configuration for root_tenant" do
+      expect(root_tenant).not_to be_logo
     end
 
-    it "knows there is a logo overriding configuration for default tenant" do
-      default_tenant.logo_file_name = "custom_logo.png"
-      expect(default_tenant).to be_logo
+    it "knows there is a logo overriding configuration for root_tenant" do
+      root_tenant.logo_file_name = "custom_logo.png"
+      expect(root_tenant).to be_logo
     end
 
     context "#with custom_logo configuration" do
@@ -198,8 +198,8 @@ describe Tenant do
         expect(tenant).not_to be_logo
       end
 
-      it "knows there is a logo from configuration for default tenant" do
-        expect(default_tenant).to be_logo
+      it "knows there is a logo from configuration for root_tenant" do
+        expect(root_tenant).to be_logo
       end
 
       # don't know how to override custom_logo configuration for default tenant
@@ -224,15 +224,15 @@ describe Tenant do
       expect(tenant.logo_content_type).to be_nil
     end
 
-    it "has custom content_type for default tenant" do
-      expect(default_tenant.logo_content_type).to eq("image/png")
+    it "has custom content_type for root_tenant" do
+      expect(root_tenant.logo_content_type).to eq("image/png")
     end
 
     context "#with custom logo configuration" do
       let(:settings) { {:server => {:custom_logo => true}} }
 
-      it "has custom content_type for default tenant" do
-        expect(default_tenant.logo_content_type).to eq("image/png")
+      it "has custom content_type for root_tenant" do
+        expect(root_tenant.logo_content_type).to eq("image/png")
       end
     end
   end
@@ -245,8 +245,8 @@ describe Tenant do
       expect(tenant.login_logo.url).to match(/login-screen-logo.png/)
     end
 
-    it "has a default login image for default tenant" do
-      expect(default_tenant.login_logo.url).to match(/login-screen-logo.png/)
+    it "has a default login image for root_tenant" do
+      expect(root_tenant.login_logo.url).to match(/login-screen-logo.png/)
     end
 
     it "has custom login logo" do
@@ -258,7 +258,7 @@ describe Tenant do
       let(:settings) { {:server => {:custom_login_logo => true}} }
 
       it "has custom login logo" do
-        expect(default_tenant.login_logo.url).to match(/custom_login_logo.png/)
+        expect(root_tenant.login_logo.url).to match(/custom_login_logo.png/)
       end
     end
   end


### PR DESCRIPTION
TL;DR:

Before: `Tenant#default_tenant` returns any tenant.
After: `Tenant#default_tenant` returns tenant 0.

look at commits 1 and 2 - those have meat
commit 3 is just a bunch of renames

---
full version

We intermix the terms "default tenant", "root tenant", and "tenant0".
Most of the time we mean "tenant0", which is the "root tenant".

A "default tenant" is the tenant we choose when we don't know what tenant we should use. This used to mean what tenant we would choose when the url did not match. It is more of a ui concern.

### Before:

The root tenant is the one at the top of the tree.
The default tenant is the tenant with a nil domain or subdomain url (the wild card url).

Since we populate all tenants with a nil url, this means all tenants are the default tenant.  oops

After:

Have the default tenant just return the root tenant. It may not be perfect, but at least it is deterministic.

1. de-emphasize urls.
2. have `default_tenant` return the `root_tenant`.

/cc @gtanzillo @Fryguy need this to get in other tenant changes