### PR TITLE
Tenant attributes

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -31,6 +31,8 @@ class Tenant < ActiveRecord::Base
   validates :subdomain, :uniqueness => true, :allow_nil => true
   validates :domain,    :uniqueness => true, :allow_nil => true
   validate  :validate_only_one_root
+  validates :name, :description, :presence => true, :unless => :root?
+  validates :name, :uniqueness => {:scope => :ancestry, :message => "should be unique per parent" }
 
   # FUTURE: allow more content_types
   validates_attachment_content_type :logo, :content_type => ['image/png']

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -5,8 +5,9 @@ class Tenant < ActiveRecord::Base
   HARDCODED_LOGIN_LOGO = "custom_login_logo.png"
   DEFAULT_URL = nil
 
-  default_value_for :name,      "My Company"
-  default_value_for :divisible, true
+  default_value_for :name,        "My Company"
+  default_value_for :description, "Tenant for My Company"
+  default_value_for :divisible,   true
   has_ancestry
 
   has_many :owned_providers,              :foreign_key => :tenant_owner_id, :class_name => 'Provider'

--- a/spec/factories/tenant.rb
+++ b/spec/factories/tenant.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :tenant do
+    sequence(:name) { |n| "Tenant #{n}" }
     sequence(:subdomain) { |n| "tenant#{n}" }
   end
 end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -107,6 +107,23 @@ describe Tenant do
       expect(tenant.name).to be_nil
     end
 
+    it "is unique per parent tenant" do
+      FactoryGirl.create(:tenant, :name => "common", :parent => root_tenant)
+      expect do
+        FactoryGirl.create(:tenant, :name => "common", :parent => root_tenant)
+      end.to raise_error
+    end
+
+    it "can be the same for different parents" do
+      parent1 = FactoryGirl.create(:tenant, :name => "parent1", :parent => root_tenant)
+      parent2 = FactoryGirl.create(:tenant, :name => "parent2", :parent => root_tenant)
+
+      FactoryGirl.create(:tenant, :name => "common", :parent => parent1)
+      expect do
+        FactoryGirl.create(:tenant, :name => "common", :parent => parent2)
+      end.not_to raise_error
+    end
+
     context "for default tenant" do
       it "reads settings" do
         expect(root_tenant[:name]).to be_nil


### PR DESCRIPTION
This adds uniqueness on name and description for a tenant

It also adds a default description for the seed tenant.

/cc @h-kataria let me know if you need a migration for the description
/cc @dclarizio hope this meets your needs