### PR TITLE
process_objects should set the objs in option as an array of VM ids

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1169,13 +1169,13 @@ module ApplicationController::CiProcessing
     begin
       case get_rec_cls.to_s
       when "OrchestrationStack"
-        objs = filter_ids_in_region(objs, "OrchestrationStack")
+        objs, _objs_out_reg = filter_ids_in_region(objs, "OrchestrationStack")
         klass = OrchestrationStack
       when "Service"
-        objs = filter_ids_in_region(objs, "Service")
+        objs, _objs_out_reg = filter_ids_in_region(objs, "Service")
         klass = Service
       when "VmOrTemplate"
-        objs = filter_ids_in_region(objs, "VM") unless VmOrTemplate::POWER_OPS.include?(task)
+        objs, _objs_out_reg = filter_ids_in_region(objs, "VM") unless VmOrTemplate::POWER_OPS.include?(task)
         klass = Vm
       end
 

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -228,4 +228,17 @@ describe HostController do
       expect(controller.send(:breadcrumb_name, nil)).to eq("Hosts")
     end
   end
+
+  context "#process_objects" do
+    it "returns array of object ids " do
+      vm1 = FactoryGirl.create(:vm_vmware)
+      vm2 = FactoryGirl.create(:vm_vmware)
+      vm3 = FactoryGirl.create(:vm_vmware)
+      vms=[vm1.id, vm2.id, vm3.id]
+      controller.send(:process_objects, vms, 'refresh_ems')
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include "Refresh Ems initiated for #{vms.length} VMs"
+    end
+  end
 end
+


### PR DESCRIPTION
 https://github.com/ManageIQ/manageiq/issues/3983
 https://github.com/ManageIQ/manageiq/issues/4022