### PR TITLE
remove warning: specify blacklisted_events timestamp nil

### DIFF
--- a/db/migrate/20150804194147_create_blacklisted_events.rb
+++ b/db/migrate/20150804194147_create_blacklisted_events.rb
@@ -6,7 +6,7 @@ class CreateBlacklistedEvents < ActiveRecord::Migration
       t.bigint  :ems_id
       t.boolean :system
       t.boolean :enabled
-      t.timestamps
+      t.timestamps :null => true
     end
   end
 end


### PR DESCRIPTION
remove warning:

```
DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing. (called from block in change at db/migrate/20150804194147_create_blacklisted_events.rb:9)
```

/cc @matthewd @Fryguy @jrafanie this is low hanging fruit