### PR TITLE
Added registry column to container images show_list

### DIFF
--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -4,4 +4,10 @@ class ContainerImageRegistry < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :container_images, :dependent => :destroy # What about deleted registry but containers are still running
   has_many :containers, :through => :container_images
+
+  virtual_column :full_name, :type => :string
+
+  def full_name
+    port.present? ? "#{host}:#{port}" : host
+  end
 end

--- a/product/views/ContainerImage.yaml
+++ b/product/views/ContainerImage.yaml
@@ -25,6 +25,9 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  container_image_registry:
+    columns:
+    - full_name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -34,12 +37,14 @@ col_order:
 - name
 - tag
 - image_ref
+- container_image_registry.full_name
 
 # Column titles, in order
 headers:
 - Name
 - Tag
 - Id
+- Image Registry
 
 # Condition(s) string for the SQL query
 conditions: 

--- a/spec/models/container_image_registry_spec.rb
+++ b/spec/models/container_image_registry_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe ContainerImageRegistry do
+  it "tests full_name" do
+    reg = ContainerImageRegistry.new(:name => "docker.io", :host =>"docker.io")
+    reg.full_name.should == "docker.io"
+
+    reg.port = "1234"
+    reg.full_name.should == "docker.io:1234"
+  end
+end


### PR DESCRIPTION

![add_registry_column](https://cloud.githubusercontent.com/assets/11256940/9466562/564391dc-4b3e-11e5-9f85-68aba2a3c5c8.png)

@abonas @simon3z

1) Is the column in the correct place(should be after ID maybe?)
2) Should the header be ```Image Registry``` instead of ```Registry```?