### PR TITLE
Adding events and Timeline for containers, pods and projects

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1003,6 +1003,11 @@ class ApplicationHelper::ToolbarBuilder
       when "container_group_timeline"
         return "No Timeline data has been collected for this Pod" unless @record.has_events? || @record.has_events?(:policy_events)
       end
+    when "ManageIQ::Providers::Kubernetes::ContainerManager::ContainerProject"
+      case id
+      when "container_project_timeline"
+        return "No Timeline data has been collected for this Project" unless @record.has_events? || @record.has_events?(:policy_events)
+      end
     when "MiqAction"
       case id
       when "action_edit"

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -12,5 +12,19 @@ class Container < ActiveRecord::Base
   belongs_to :container_image
   has_one    :container_image_registry, :through => :container_image
 
+  include EventMixin
+
   acts_as_miq_taggable
+
+  def event_where_clause(assoc = :ems_events)
+    case assoc.to_sym
+    when :ems_events
+      # TODO: improve relationship using the id
+      ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ?", container_project.name,
+       ext_management_system.id]
+    when :policy_events
+      # TODO: implement policy events and its relationship
+      ["#{events_table_name(assoc)}.ems_id = ?", ext_management_system.id]
+    end
+  end
 end

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -36,5 +36,18 @@ class ContainerProject < ActiveRecord::Base
     container_definitions.size
   end
 
+  include EventMixin
+
   acts_as_miq_taggable
+
+  def event_where_clause(assoc = :ems_events)
+    case assoc.to_sym
+    when :ems_events
+      # TODO: improve relationship using the id
+      ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
+    when :policy_events
+      # TODO: implement policy events and its relationship
+      ["ems_id = ?", ems_id]
+    end
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -1,5 +1,9 @@
 module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
   extend ActiveSupport::Concern
+  ENABLED_EVENTS = {
+    'Node' => %w(NodeReady NodeNotReady rebooted),
+    'Pod'  => %w(scheduled failedScheduling failedValidation HostPortConflict created failed started killing)
+  }
 
   def event_monitor_handle
     require 'kubernetes/events/kubernetes_event_monitor'
@@ -44,8 +48,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       :message   => event.object.message
     }
 
-    @enabled_events ||= worker_settings[:enabled_events]
-    supported_reasons = @enabled_events[event_data[:kind]] || []
+    unless event.object.involvedObject.fieldPath.nil?
+      event_data[:fieldpath] = event.object.involvedObject.fieldPath
+    end
+
+    supported_reasons = ENABLED_EVENTS[event_data[:kind]] || []
 
     unless supported_reasons.include?(event_data[:reason])
       _log.debug "#{log_prefix} Discarding event [#{event_data}]"

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -64,8 +64,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
     when 'Node'
       event_data[:container_node_name] = event_data[:name]
     when 'Pod'
-      event_data[:container_namespace] = event_data[:namespace]
+      /^spec.containers{(?<container_name>.*)}$/ =~ event_data[:fieldpath]
+      event_data[:container_name] = container_name unless container_name.nil?
       event_data[:container_group_name] = event_data[:name]
+      event_data[:container_namespace] = event_data[:namespace]
     end
 
     _log.info "#{log_prefix} Queuing event [#{event_data}]"

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
@@ -17,6 +17,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventParserMixin
         :container_node_name  => event[:container_node_name],
         :container_group_name => event[:container_group_name],
         :container_namespace  => event[:container_namespace],
+        :container_name       => event[:container_name],
         :full_data            => event,
         :ems_id               => ems_id
       }

--- a/app/views/container_project/_main.html.haml
+++ b/app/views/container_project/_main.html.haml
@@ -1,8 +1,13 @@
-= render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
-  .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
+- if @showtype == "timeline"
+  = render(:partial => "layouts/tl_show")
+  :javascript
+          var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+- else
+  = render :partial => "layouts/flash_msg"
+  .row
+    .col-md-12.col-lg-6
+      = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
+    .col-md-12.col-lg-6
+      = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+      = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
 

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -1,4 +1,8 @@
 - if %w(container_groups container_services container_routes container_replicators).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+- elsif @showtype == "timeline"
+  = render(:partial => "layouts/tl_show")
+  :javascript
+    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/layouts/listnav/_container_project.html.haml
+++ b/app/views/layouts/listnav/_container_project.html.haml
@@ -12,6 +12,15 @@
         %li
           = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, :title => _("Show Summary"))
 
+        - if @record.has_events? || @record.has_events?(:policy_events)
+          %li
+            = link_to('Timelines',
+              {:action => 'show', :display => 'timeline', :id => @record},
+              :title => _("Show Timelines"))
+        - else
+          %li.disabled
+            = link_to(_('Timelines'), "#")
+
     = patternfly_accordion_panel(_("Relationships"), false, "container_project_rel") do
       %ul.nav.nav-pills.nav-stacked
 

--- a/config/event_handling.tmpl.yml
+++ b/config/event_handling.tmpl.yml
@@ -445,6 +445,7 @@ event_groups:
     - network.floating_ip.deallocate
     - network.floating_ip.associate
     - network.floating_ip.disassociate
+    - POD_HOSTPORTCONFLICT
     :detail: []
     :name: Network
   power:
@@ -529,6 +530,10 @@ event_groups:
     - compute.instance.shelve_offload.end
     - NODE_REBOOT
     - POD_SCHEDULED
+    - POD_FAILEDSCHEDULING
+    - CONTAINER_CREATED
+    - CONTAINER_KILLING
+    - CONTAINER_STARTED
     :detail:
     - PowerOffVM_Task
     - PowerOffVM_Task_Complete
@@ -608,6 +613,7 @@ event_groups:
     - VmConfigMissingEvent
     - NODE_NODEREADY
     - NODE_NODENOTREADY
+    - POD_FAILEDVALIDATION
     :detail:
     - DatacenterRenamedEvent
     - GeneralUserEvent
@@ -1439,6 +1445,27 @@ event_handling:
   - refresh:
     - ems
   POD_SCHEDULED:
+  - refresh:
+    - ems
+  POD_FAILEDSCHEDULING:
+  - refresh:
+    - ems
+  POD_FAILEDVALIDATION:
+  - refresh:
+    - ems
+  POD_HOSTPORTCONFLICT:
+  - refresh:
+    - ems
+  CONTAINER_CREATED:
+  - refresh:
+    - ems
+  CONTAINER_FAILED:
+  - refresh:
+    - ems
+  CONTAINER_STARTED:
+  - refresh:
+    - ems
+  CONTAINER_KILLING:
   - refresh:
     - ems
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -499,7 +499,9 @@ Vmdb::Application.routes.draw do
         sections_field_changed
         show
         show_list
+        tl_chooser
         update
+        wait_for_task
         tagging_edit
         tag_edit_form_field_changed
       ) + adv_search_post + exp_post + save_post

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -314,22 +314,8 @@ workers:
         :poll: 15.seconds
       :event_catcher_kubernetes:
         :poll: 1.seconds
-        :enabled_events:
-          Node:
-            - NodeReady
-            - NodeNotReady
-            - rebooted
-          Pod:
-            - scheduled
       :event_catcher_openshift:
         :poll: 1.seconds
-        :enabled_events:
-          Node:
-            - NodeReady
-            - NodeNotReady
-            - rebooted
-          Pod:
-            - scheduled
     :queue_worker_base:
       :defaults:
         :cpu_usage_threshold: 100.percent

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3896,6 +3896,10 @@
       :description: Display Individual Container Routes
       :feature_type: view
       :identifier: container_project_show
+    - :name: Timeline
+      :description: Display Timelines for container Projects
+      :feature_type: view
+      :identifier: container_project_timeline
   - :name: Operate
     :description: Perform Operations on Container Projects
     :feature_type: control

--- a/db/migrate/20150819144149_add_container_entity_events.rb
+++ b/db/migrate/20150819144149_add_container_entity_events.rb
@@ -1,0 +1,6 @@
+class AddContainerEntityEvents < ActiveRecord::Migration
+  def change
+    add_column  :event_streams, :container_id, :bigint
+    add_column  :event_streams, :container_name, :string
+  end
+end

--- a/product/toolbars/container_project_center_tb.yaml
+++ b/product/toolbars/container_project_center_tb.yaml
@@ -22,6 +22,19 @@
       :title: 'Remove this #{ui_lookup(:table=>"container_project")} from the VMDB'
       :url_parms: '&refresh=y'
       :confirm: 'Warning: This #{ui_lookup(:table=>"container_project")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>"container_project")}?'
+- :name: container_project_monitoring
+  :items:
+  - :buttonSelect: container_project_monitoring_choice
+    :image: monitoring
+    :title: Monitoring
+    :text: Monitoring
+    :items:
+    - :button: container_project_timeline
+      :image: timeline
+      :text: "Timelines"
+      :title: "Show Timelines for this Project"
+      :url: '/show'
+      :url_parms: '?display=timeline'
 - :name: container_project_policy
   :items:
   - :buttonSelect: container_project_policy_choice

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe MiqProductFeature do
   before do
-    @expected_feature_count = 846
+    @expected_feature_count = 847
   end
 
   context ".seed" do


### PR DESCRIPTION
This PR consists of 3 commits related to events and timeline:
1. Moving container enabled events from config to event catcher
2. Adding events and Timeline for containers and adding more events for container groups
3. Add Project events and timeline