### PR TITLE
[auth] Lookup LDAP Groups does not work with IDM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem "jbuilder",                       "~>2.3.1"
 gem "paperclip",                      "~>4.3.0"
 gem "rails-i18n",                                                     :git => "git://github.com/svenfuchs/rails-i18n.git", :branch => "master"
 
+# Needed by External Auth
+gem "ruby-dbus"
+
 # Not vendored and not required
 gem "ancestry",                       "~>2.1.0",   :require => false
 gem "aws-sdk",                        "~>1.56.0",  :require => false

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -109,7 +109,29 @@
             %h3
               = _("LDAP Group Look Up")
             .form-horizontal
-              .form-group
+              .form-group#user_id_ext_auth_form_group
+                %label.col-md-2.control-label
+                  = _("User to Look Up")
+                .col-md-8
+                  = text_field_tag("user",
+                                   @edit[:new][:user],
+                                   :maxlength         => 255,
+                                   :class => "form-control",
+                                   "data-miq_observe" => {:interval => '.5',
+                                                          :url      => url}.to_json)
+                .col-md-12{:align => "right", :valign => "bottom"}
+                  = link_to("Retrieve",
+                            {:action => "rbac_group_user_lookup",
+                             :button => "submit",
+                             :id     => "#{@edit[:group_id] || "new"}"},
+                             :class => "btn btn-primary",
+                             :alt   => _("LDAP Group Lookup"),
+                             "data-miq_sparkle_on"  => true,
+                             "data-miq_sparkle_off" => true,
+                             :remote                => true,
+                             :title                 => _("LDAP Group Lookup"))
+
+              .form-group#user_id_form_group
                 %label.col-md-2.control-label
                   = _("User to Look Up")
                 .col-md-8
@@ -120,7 +142,7 @@
                                    "data-miq_observe" => {:interval => '.5',
                                                           :url      => url}.to_json)
 
-              .form-group
+              .form-group#user_name_form_group
                 %label.col-md-2.control-label
                   = _("Username")
                 .col-md-8
@@ -131,7 +153,7 @@
                                    "data-miq_observe" => {:interval => '.5',
                                                           :url      => url}.to_json)
 
-              .form-group
+              .form-group#user_password_form_group
                 %label.col-md-2.control-label
                   = _("Password")
                 .col-md-8
@@ -216,3 +238,14 @@
                                     :checkboxes     => true})
 :javascript
   miq_tabs_init('#rbac_group_tabs');
+%script{:type => "text/javascript"}
+  - if get_vmdb_config[:authentication][:mode] == "httpd"
+    $('#user_id_ext_auth_form_group').show();
+    $('#user_id_form_group').hide();
+    $('#user_name_form_group').hide();
+    $('#user_password_form_group').hide();
+  - else
+    $('#user_id_ext_auth_form_group').hide();
+    $('#user_id_form_group').show();
+    $('#user_name_form_group').show();
+    $('#user_password_form_group').show();


### PR DESCRIPTION
- Adding ruby to sssd interface (via dbus)
- Added Support Getting User Groups for External Auth, should work with all ext auth, IdM, AD, Ldap.
- Updated UI to not prompt for bind DN/password when ext auth enabled
- Updated controller to call new get_httpd_groups_by_user method in model.

Depends on: https://github.com/ManageIQ/manageiq-appliance/pull/24

https://bugzilla.redhat.com/show_bug.cgi?id=1158421