### PR TITLE
[WIP] Pass calendar parameters directly to miqBuildCalendar, instead of using globals

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -944,8 +944,8 @@ function miqBuildCalendar() {
       element.datepicker('setEndDate', ManageIQ.calendar.calDateTo);
     }
 
-    if (typeof miq_cal_skipDays != "undefined" && miq_cal_skipDays) {
-      element.datepicker('setDaysOfWeekDisabled', miq_cal_skipDays);
+    if (ManageIQ.calendar.calSkipDays) {
+      element.datepicker('setDaysOfWeekDisabled', ManageIQ.calendar.calSkipDays);
     }
 
     if (observeDateBackup != null) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -936,15 +936,15 @@ function miqBuildCalendar() {
       element.datepicker();
     }
 
-    if (typeof ManageIQ.calendar.calDateFrom != "undefined") {
+    if (ManageIQ.calendar.calDateFrom) {
       element.datepicker('setStartDate', ManageIQ.calendar.calDateFrom);
     }
 
-    if (typeof ManageIQ.calendar.calDateTo != "undefined") {
+    if (ManageIQ.calendar.calDateTo) {
       element.datepicker('setEndDate', ManageIQ.calendar.calDateTo);
     }
 
-    if (typeof miq_cal_skipDays != "undefined") {
+    if (typeof miq_cal_skipDays != "undefined" && miq_cal_skipDays) {
       element.datepicker('setDaysOfWeekDisabled', miq_cal_skipDays);
     }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -30,7 +30,7 @@ function miqOnLoad() {
     $('#compare_grid')[0].enableAutoWidth(true);
   }
 
-  miqBuildCalendar();
+  miqBuildCalendar();	// TODO remove from here
   miqLoadCharts();
 
   if (typeof miqLoadTL == "function") {
@@ -922,7 +922,7 @@ function miqDropComplete(event, ui) {
 }
 
 // Attach a calendar control to all text boxes that start with miq_date_
-function miqBuildCalendar() {
+function miqBuildCalendar(opts) {
   // Get all of the input boxes with ids starting with "miq_date_"
   var all = $('input[id^=miq_date_]');
 
@@ -936,16 +936,16 @@ function miqBuildCalendar() {
       element.datepicker();
     }
 
-    if (ManageIQ.calendar.calDateFrom) {
-      element.datepicker('setStartDate', ManageIQ.calendar.calDateFrom);
+    if (opts.dateFrom) {
+      element.datepicker('setStartDate', opts.dateFrom);
     }
 
-    if (ManageIQ.calendar.calDateTo) {
-      element.datepicker('setEndDate', ManageIQ.calendar.calDateTo);
+    if (opts.dateTo) {
+      element.datepicker('setEndDate', opts.dateTo);
     }
 
-    if (ManageIQ.calendar.calSkipDays) {
-      element.datepicker('setDaysOfWeekDisabled', ManageIQ.calendar.calSkipDays);
+    if (opts.skipDays) {
+      element.datepicker('setDaysOfWeekDisabled', opts.skipDays);
     }
 
     if (observeDateBackup != null) {

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -26,7 +26,7 @@ if (typeof(ManageIQ) === 'undefined') {
         type: null, //
       },
     },
-    calendar: { // TODO about to be removed
+    calendar: { // TODO remove in this PR
       calDateFrom: null, // to limit calendar starting
       calDateTo: null, // to limit calendar ending
       calSkipDays: null,  // to disable specific days of week

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -29,6 +29,7 @@ if (typeof(ManageIQ) === 'undefined') {
     calendar: { // TODO about to be removed
       calDateFrom: null, // to limit calendar starting
       calDateTo: null, // to limit calendar ending
+      calSkipDays: null,  // to disable specific days of week
     },
     charts: {
       chartData: null, // data for charts

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -7,9 +7,8 @@ ManageIQ.angularApplication.service('miqService', function() {
     miqButtons('hide');
   };
 
-  this.buildCalendar = function(year, month, date) {
-    ManageIQ.calendar.calDateFrom = new Date(year, month, date);
-    miqBuildCalendar(true);
+  this.buildCalendar = function(year, month, day) {
+    miqBuildCalendar({ dateFrom: new Date(year, month, day) });
   };
 
   this.miqAjaxButton = function(url, serializeFields) {

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -120,7 +120,7 @@ module ApplicationController::Filter
 
         if [:date, :datetime].include?(@edit.fetch_path(@expkey, :val1, :type)) ||
             [:date, :datetime].include?(@edit.fetch_path(@expkey, :val2, :type))
-          page << "miqBuildCalendar();"
+          page << js_build_calendar();
         end
 
         if @edit[@expkey][:exp_key] && @edit[@expkey][:exp_field]
@@ -427,7 +427,7 @@ module ApplicationController::Filter
 
           if [:date, :datetime].include?(@edit.fetch_path(@expkey, :val1, :type)) ||
               [:date, :datetime].include?(@edit.fetch_path(@expkey, :val2, :type))
-            page << "miqBuildCalendar();"
+            page << js_build_calendar();
           end
           if @edit.fetch_path(@expkey, :val1, :type)
             page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"
@@ -464,7 +464,7 @@ module ApplicationController::Filter
         page << "$('#adv_search_img').prop('src', '/images/toolbars/squashed-false.png')"
         if [:date, :datetime].include?(@edit.fetch_path(@expkey, :val1, :type)) ||
             [:date, :datetime].include?(@edit.fetch_path(@expkey, :val2, :type))
-          page << "miqBuildCalendar();"
+          page << js_build_calendar();
         end
         if @edit.fetch_path(@expkey, :val1, :type)
           page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -39,8 +39,8 @@ module ApplicationController::MiqRequestMethods
           end
         end
         if @edit.fetch_path(:new, :schedule_type, 0) == "schedule"
-          page << "ManageIQ.calendar.calDateFrom = new Date(#{@timezone_offset});"
-          page << "miqBuildCalendar();"
+          # TODO verify; new Date(@timezone_offset) was definitely wrong, but is this the intent?
+          page << "miqBuildCalendar({ dateFrom: miqCalendarDateConversion(\"#{@timezone_offset}\") });"
         end
         if changed != session[:changed]
           session[:changed] = changed

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -88,18 +88,10 @@ module ApplicationController::Performance
                   :locals => {:chart_data => @chart_data, :chart_set => "candu"})
       unless @no_util_data
         if @perf_options[:typ] == "Hourly"
-          page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate].year},#{@perf_options[:sdate].month - 1},#{@perf_options[:sdate].day});"
-          page << "ManageIQ.calendar.calDateTo   = new Date(#{@perf_options[:edate].year},#{@perf_options[:edate].month - 1},#{@perf_options[:edate].day});"
+          page << js_build_calendar(:date_from => @perf_options[:sdate], :date_to => @perf_options[:edate], :skip_days => @perf_options[:skip_days])
         else
-          page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate_daily].year},#{@perf_options[:sdate_daily].month - 1},#{@perf_options[:sdate_daily].day});"
-          page << "ManageIQ.calendar.calDateTo   = new Date(#{@perf_options[:edate_daily].year},#{@perf_options[:edate_daily].month - 1},#{@perf_options[:edate_daily].day});"
+          page << js_build_calendar(:date_from => @perf_options[:sdate_daily], :date_to => @perf_options[:edate_daily], :skip_days => @perf_options[:skip_days])
         end
-        if @perf_options[:skip_days]
-          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-        else
-          page << "miq_cal_skipDays = null;"
-        end
-        page << 'miqBuildCalendar();'
         page << Charting.js_load_statement
       end
       page << 'miqSparkle(false);'
@@ -224,7 +216,8 @@ module ApplicationController::Performance
     options[:daily_date] ||= [edate_daily.month, edate_daily.day, edate_daily.year].join("/")
 
     if options[:typ] == "Hourly" && options[:time_profile]              # If hourly and profile in effect, set hourly date to a valid day in the profile
-      options[:skip_days] = [0,1,2,3,4,5,6].delete_if{|d| options[:time_profile_days].include?(d)}.join(",")
+      options[:skip_days] = skip_days_from_time_profile(options[:time_profile_days])
+
       hdate = options[:hourly_date].to_date                             # Start at the currently set hourly date
       6.times do                                                        # Go back up to 6 days (try each weekday)
         break if options[:time_profile_days].include?(hdate.wday)       # If weekday is in the profile, use it
@@ -415,14 +408,7 @@ module ApplicationController::Performance
         end
         page.replace("perf_options_div", :partial=>"layouts/perf_options")
         page.replace("candu_charts_div", :partial=>"layouts/perf_charts", :locals=>{:chart_data=>@chart_data, :chart_set=>"candu"})
-        page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate].year},#{@perf_options[:sdate].month - 1},#{@perf_options[:sdate].day});"
-        page << "ManageIQ.calendar.calDateTo = new Date(#{@perf_options[:edate].year},#{@perf_options[:edate].month - 1},#{@perf_options[:edate].day});"
-        if @perf_options[:skip_days]
-          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-        else
-          page << "miq_cal_skipDays = null;"
-        end
-        page << 'miqBuildCalendar();'
+        page << js_build_calendar(:date_from => @perf_options[:sdate], :date_to => @perf_options[:edate], :skip_days => @perf_options[:skip_days])
         page << Charting.js_load_statement
         page << 'miqSparkle(false);'
       end
@@ -450,14 +436,7 @@ module ApplicationController::Performance
         end
         page.replace("perf_options_div", :partial=>"layouts/perf_options")
         page.replace("candu_charts_div", :partial=>"layouts/perf_charts", :locals=>{:chart_data=>@chart_data, :chart_set=>"candu"})
-        page << "ManageIQ.calendar.calDateFrom = new Date(#{@perf_options[:sdate_daily].year},#{@perf_options[:sdate_daily].month - 1},#{@perf_options[:sdate_daily].day});"
-        page << "ManageIQ.calendar.calDateTo = new Date(#{@perf_options[:edate_daily].year},#{@perf_options[:edate_daily].month - 1},#{@perf_options[:edate_daily].day});"
-        if @perf_options[:skip_days]
-          page << "miq_cal_skipDays = '#{@perf_options[:skip_days]}';"
-        else
-          page << "miq_cal_skipDays = null;"
-        end
-        page << 'miqBuildCalendar();'
+        page << js_build_calendar(:date_from => @perf_options[:sdate_daily], :date_to => @perf_options[:edate_daily], :skip_days => @perf_options[:skip_days])
         page << Charting.js_load_statement
         page << 'miqSparkle(false);'
       end

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -109,9 +109,9 @@ module ApplicationController::Timelines
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page.replace("tl_options_div", :partial=>"layouts/tl_options")
       page.replace("tl_div", :partial=>"layouts/tl_detail")
-      page << "ManageIQ.calendar.calDateFrom = new Date(#{@tl_options[:sdate]});" unless @tl_options[:sdate].nil?
-      page << "ManageIQ.calendar.calDateTo = new Date(#{@tl_options[:edate]});" unless @tl_options[:edate].nil?
-      page << 'miqBuildCalendar();'
+      # TODO probably need to fix :sdate, :edate format to fit
+      page << js_build_calendar(:date_from => @tl_options[:sdate], :date_to => @tl_options[:edate]);
+
       if @tl_options[:tl_show] == "timeline"
         page << "$('#filter1').val('#{@tl_options[:fltr1]}');"
         page << "$('#filter2').val('#{@tl_options[:fltr2]}');"

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -440,7 +440,8 @@ class MiqCapacityController < ApplicationController
     @sb[:util][:options][:chart_date] ||= [edate.month, edate.day, edate.year].join("/")
 
     if @sb[:util][:options][:time_profile]                              # If profile in effect, set date to a valid day in the profile
-      @sb[:util][:options][:skip_days] = [0,1,2,3,4,5,6].delete_if{|d| @sb[:util][:options][:time_profile_days].include?(d)}.join(",")
+      @sb[:util][:options][:skip_days] = skip_days_from_time_profile(@sb[:util][:options][:time_profile_days])
+
       cdate = @sb[:util][:options][:chart_date].to_date                 # Start at the currently set date
       6.times do                                                        # Go back up to 6 days (try each weekday)
         break if @sb[:util][:options][:time_profile_days].include?(cdate.wday)  # If weekday is in the profile, use it
@@ -492,10 +493,10 @@ class MiqCapacityController < ApplicationController
     presenter[:expand_collapse_cells][:a] = 'expand'
     presenter[:update_partials][:main_div] = r[:partial => 'utilization_tabs']
     presenter[:right_cell_text] = @right_cell_text
-    presenter[:build_calendar]  = {
-      :skip_days => @sb[:util][:options][:skip_days],
+    presenter[:build_calendar] = {
       :date_from => @sb[:util][:options][:sdate],
       :date_to   => @sb[:util][:options][:edate],
+      :skip_days => @sb[:util][:options][:skip_days],
     }
 
     # FIXME: where is curTab declared?

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -225,9 +225,7 @@ module OpsController::Diagnostics
     render :update do |page|                    # Use JS to update the display
       page.replace("flash_msg_divcu_repair", :partial=>"layouts/flash_msg", :locals=>{:div_num=>"cu_repair"})
       page.replace_html("diagnostics_cu_repair", :partial=>"diagnostics_cu_repair_tab")
-      page << "ManageIQ.calendar.calDateFrom = null;"
-      page << "ManageIQ.calendar.calDateTo = new Date();"
-      page << "miqBuildCalendar();"
+      page << js_build_calendar(:date_from => nil, :date_to => Time.zone.now);
       if @edit[:new][:start_date] == "" || @edit[:new][:end_date] == ""
         page << javascript_for_miq_button_visibility(false)
       else
@@ -257,11 +255,9 @@ module OpsController::Diagnostics
     end
 
     render :update do |page|                    # Use JS to update the display
-      page.replace("flash_msg_divcu_repair", :partial => "layouts/flash_msg", :locals=>{:div_num=>"cu_repair"})
-      page.replace_html("diagnostics_cu_repair", :partial=>"diagnostics_cu_repair_tab")
-      page << "ManageIQ.calendar.calDateFrom = null;"
-      page << "ManageIQ.calendar.calDateTo = new Date();"
-      page << "miqBuildCalendar();"
+      page.replace("flash_msg_divcu_repair", :partial => "layouts/flash_msg", :locals => {:div_num => "cu_repair"})
+      page.replace_html("diagnostics_cu_repair", :partial => "diagnostics_cu_repair_tab")
+      page << js_build_calendar(:date_from => nil, :date_to => Time.zone.now);
       page << "miqSparkle(false);"
       #disable button
       page << javascript_for_miq_button_visibility(false)

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -183,14 +183,15 @@ module ReportController::Schedules
 
       javascript_for_timer_type(params[:timer_typ]).each { |js| page << js }
 
+      # same code in widget_form_field_changed
       if params[:time_zone]
-        page << "ManageIQ.calendar.calDateFrom = new Date(#{(Time.zone.now - 1.month).in_time_zone(@edit[:tz]).strftime("%Y,%m,%d")});"
-        page << "miqBuildCalendar();"
+        page << js_build_calendar(:date_from => (Time.zone.now - 1.month).in_time_zone(@edit[:tz]));
         page << "$('#miq_date_1').val('#{@edit[:new][:start_date]}');"
         page << "$('#start_hour').val('#{@edit[:new][:start_hour].to_i}');"
         page << "$('#start_min').val('#{@edit[:new][:start_min].to_i}');"
         page.replace_html("tz_span", @timezone_abbr)
       end
+
       if @email_refresh
         page.replace("edit_email_div",
                       :partial=>"layouts/edit_email",

--- a/app/controllers/report_controller/usage.rb
+++ b/app/controllers/report_controller/usage.rb
@@ -78,7 +78,7 @@ module ReportController::Usage
       page.replace("flash_msg_div", :partial=>"layouts/flash_msg")
       page.replace("usage_options_div", :partial=>"usage_options")
       page.replace("usage_report_div", :partial=>"usage_report")
-      page << 'miqBuildCalendar();'
+      page << js_build_calendar();
       page << 'miqSparkle(false);'
     end
   end

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -160,14 +160,15 @@ module ReportController::Widgets
 
       javascript_for_timer_type(params[:timer_typ]).each { |js| page << js }
 
+      # same code in schedule_form_field_changed
       if params[:time_zone]
-        page << "ManageIQ.calendar.calDateFrom = new Date(#{(Time.zone.now - 1.month).in_time_zone(@edit[:tz]).strftime("%Y,%m,%d")});"
-        page << "miqBuildCalendar();"
+        page << js_build_calendar(:date_from => (Time.zone.now - 1.month).in_time_zone(@edit[:tz]));
         page << "$('#miq_date_1').val('#{@edit[:new][:start_date]}');"
         page << "$('#start_hour').val('#{@edit[:new][:start_hour].to_i}');"
         page << "$('#start_min').val('#{@edit[:new][:start_min].to_i}');"
         page.replace_html("tz_span", @timezone_abbr)
       end
+
       changed = (@edit[:new] != @edit[:current])
       page << javascript_for_miq_button_visibility(changed)
       page << "miqSparkle(false);"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1235,6 +1235,13 @@ module ApplicationHelper
     end
   end
 
+  def skip_days_from_time_profile(time_profile_days)
+    (1..7).to_a.delete_if do |d|
+      # time_profile_days has 0 for sunday, skip_days needs 7 for sunday
+      time_profile_days.include?(d % 7)
+    end
+  end
+
   def controller_referrer?
     controller_name == Rails.application.routes.recognize_path(request.referrer)[:controller]
   end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -115,10 +115,7 @@ module JsHelper
     skip_days = options[:skip_days].nil? ? 'undefined' : options[:skip_days].to_a.to_json
 
     <<EOD
-ManageIQ.calendar.calDateFrom = #{js_format_date(options[:date_from])};
-ManageIQ.calendar.calDateTo = #{js_format_date(options[:date_to])};
-ManageIQ.calendar.calSkipDays = #{skip_days};
-miqBuildCalendar();
+miqBuildCalendar({ dateFrom: #{js_format_date(options[:date_from])}, dateTo: #{js_format_date(options[:date_to])}, skipDays: #{skip_days} });
 EOD
   end
 

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -110,4 +110,19 @@ module JsHelper
     "if ($('##{j_str(element)}').prop('type') == 'checkbox') {$('##{j_str(element)}').prop('checked', false);}"
       .html_safe
   end
+
+  def js_build_calendar(options = {})
+    skip_days = options[:skip_days].nil? ? 'undefined' : options[:skip_days].to_a.to_json
+
+    <<EOD
+ManageIQ.calendar.calDateFrom = #{js_format_date(options[:date_from])};
+ManageIQ.calendar.calDateTo = #{js_format_date(options[:date_to])};
+miq_cal_skipDays = #{skip_days};
+miqBuildCalendar();
+EOD
+  end
+
+  def js_format_date(value)
+    value.nil? ? 'undefined' : "new Date('#{value.iso8601}')"
+  end
 end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -117,7 +117,7 @@ module JsHelper
     <<EOD
 ManageIQ.calendar.calDateFrom = #{js_format_date(options[:date_from])};
 ManageIQ.calendar.calDateTo = #{js_format_date(options[:date_to])};
-miq_cal_skipDays = #{skip_days};
+ManageIQ.calendar.calSkipDays = #{skip_days};
 miqBuildCalendar();
 EOD
   end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -13,10 +13,7 @@ class ExplorerPresenter
   #
   #   add_nodes                        -- JSON string of nodes to add to the active tree
   #   delete_node                      -- key of node to be deleted from the active tree
-  #   cal_date_from
-  #   cal_date_to
-  #   build_calendar                   -- call miqBuildCalendar, true/false or Hash with
-  #                                       compulsory key :skip_days
+  #   build_calendar                   -- call miqBuildCalendar, true/false or Hash (:date_from, :date_to, :skip_days)
   #   init_dashboard
   #   ajax_action                      -- Hash of options for AJAX action to fire
   #   cell_a_view
@@ -184,21 +181,13 @@ class ExplorerPresenter
   end
 
   def build_calendar
-    out = []
-    if Hash === @options[:build_calendar]
+    if @options[:build_calendar].kind_of? Hash
       calendar_options = @options[:build_calendar]
-      out << "ManageIQ.calendar.calDateFrom = #{format_cal_date(calendar_options[:date_from])};" if calendar_options.key?(:date_from)
-      out << "ManageIQ.calendar.calDateTo   = #{format_cal_date(calendar_options[:date_to])};"   if calendar_options.key?(:date_to)
-
-      if calendar_options.key?(:skip_days)
-        skip_days = calendar_options[:skip_days].nil? ?
-          'null' : ("'" + calendar_options[:skip_days] + "'")
-        out << "miq_cal_skipDays = #{skip_days};"
-      end
+    else
+      calendar_options = {}
     end
 
-    out << 'miqBuildCalendar();'
-    out.join("\n")
+    js_build_calendar(calendar_options)
   end
 
   # Fire an AJAX action
@@ -226,10 +215,5 @@ class ExplorerPresenter
 
   def update_partial(element, content)
     "$('##{element}').html('#{escape_javascript(content)}');"
-  end
-
-  private
-  def format_cal_date(value)
-    value.nil? ?  'undefined' : "new Date(#{value})"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1545,6 +1545,20 @@ describe ApplicationHelper do
     end
   end
 
+  context '#skip_days_from_time_profile' do
+    it 'should return empty array for whole week' do
+      skip_days_from_time_profile((0..6).to_a).should eq([])
+    end
+
+    it 'should return whole week for empty array' do
+      skip_days_from_time_profile([]).should eq((1..7).to_a)
+    end
+
+    it 'should handle Sundays' do
+      skip_days_from_time_profile((1..6).to_a).should eq([7])
+    end
+  end
+
   it 'output of remote_function should not be html_safe' do
     remote_function(:url => {:controller => 'vm_infra', :action => 'explorer'}).html_safe?.should be_false
   end

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -128,10 +128,7 @@ describe JsHelper do
   context '#js_build_calendar' do
     it 'returns JS to build calendar with no options' do
       expected = <<EOD
-ManageIQ.calendar.calDateFrom = undefined;
-ManageIQ.calendar.calDateTo = undefined;
-ManageIQ.calendar.calSkipDays = undefined;
-miqBuildCalendar();
+miqBuildCalendar({ dateFrom: undefined, dateTo: undefined, skipDays: undefined });
 EOD
 
       js_build_calendar.should eq(expected)
@@ -143,10 +140,7 @@ EOD
              :skip_days => [ 1, 2, 3 ]}
 
       expected = <<EOD
-ManageIQ.calendar.calDateFrom = new Date('1970-01-01T00:00:00Z');
-ManageIQ.calendar.calDateTo = new Date('2000-01-01T00:00:00Z');
-ManageIQ.calendar.calSkipDays = [1,2,3];
-miqBuildCalendar();
+miqBuildCalendar({ dateFrom: new Date('1970-01-01T00:00:00Z'), dateTo: new Date('2000-01-01T00:00:00Z'), skipDays: [1,2,3] });
 EOD
 
       js_build_calendar(opt).should eq(expected)

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -35,9 +35,6 @@ describe JsHelper do
     end
   end
 
-  context '#update_element' do
-  end
-
   context '#javascript_focus' do
     it 'returns js to focus on an element' do
       javascript_focus('foo').should eq("$('#foo').focus();")
@@ -125,6 +122,44 @@ describe JsHelper do
       javascript_unchecked(
         'foo'
       ).should eq("if ($('#foo').prop('type') == 'checkbox') {$('#foo').prop('checked', false);}")
+    end
+  end
+
+  context '#js_build_calendar' do
+    it 'returns JS to build calendar with no options' do
+      expected = <<EOD
+ManageIQ.calendar.calDateFrom = undefined;
+ManageIQ.calendar.calDateTo = undefined;
+miq_cal_skipDays = undefined;
+miqBuildCalendar();
+EOD
+
+      js_build_calendar.should eq(expected)
+    end
+
+    it 'returns JS to build calendar with options' do
+      opt = {:date_from => Time.at(0).utc,
+             :date_to   => Time.at(946684800).utc,
+             :skip_days => [ 1, 2, 3 ]}
+
+      expected = <<EOD
+ManageIQ.calendar.calDateFrom = new Date('1970-01-01T00:00:00Z');
+ManageIQ.calendar.calDateTo = new Date('2000-01-01T00:00:00Z');
+miq_cal_skipDays = [1,2,3];
+miqBuildCalendar();
+EOD
+
+      js_build_calendar(opt).should eq(expected)
+    end
+  end
+
+  context '#js_format_date' do
+    it 'returns undefined for nil' do
+      js_format_date(nil).should eq('undefined')
+    end
+
+    it 'returns new Date with iso string as param' do
+      js_format_date(Time.at(946684800).utc).should eq("new Date('2000-01-01T00:00:00Z')")
     end
   end
 end

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -130,7 +130,7 @@ describe JsHelper do
       expected = <<EOD
 ManageIQ.calendar.calDateFrom = undefined;
 ManageIQ.calendar.calDateTo = undefined;
-miq_cal_skipDays = undefined;
+ManageIQ.calendar.calSkipDays = undefined;
 miqBuildCalendar();
 EOD
 
@@ -145,7 +145,7 @@ EOD
       expected = <<EOD
 ManageIQ.calendar.calDateFrom = new Date('1970-01-01T00:00:00Z');
 ManageIQ.calendar.calDateTo = new Date('2000-01-01T00:00:00Z');
-miq_cal_skipDays = [1,2,3];
+ManageIQ.calendar.calSkipDays = [1,2,3];
 miqBuildCalendar();
 EOD
 

--- a/spec/presenters/explorer_presenter_spec.rb
+++ b/spec/presenters/explorer_presenter_spec.rb
@@ -48,43 +48,22 @@ describe ExplorerPresenter do
     end
 
     context "#build_calendar" do
-      it 'returns JS to build calendar with no options' do
+      it 'calls js_build_calendar' do
         @presenter[:build_calendar] = true
-        @presenter.build_calendar.should == 'miqBuildCalendar();'
+        expect(@presenter).to receive(:js_build_calendar)
+        @presenter.build_calendar
       end
 
-      it 'returns JS to build calendar with options' do
-        @presenter[:build_calendar] = {
-          :date_from => 'Fantomas',
-          :date_to   => 'was',
-          :skip_days => 'here!',
-        }
-
-        js_str = @presenter.build_calendar
-
-        expected = <<EOD
-ManageIQ.calendar.calDateFrom = new Date(Fantomas);
-ManageIQ.calendar.calDateTo   = new Date(was);
-miq_cal_skipDays = 'here!';
-miqBuildCalendar();
-EOD
-        (js_str + "\n").should == expected
-      end
-
-      it 'returns JS to undefine a date' do
-        @presenter[:build_calendar] = {
-          :date_from => 'Fantomas is gone!',
-          :date_to   => nil,
-        }
-
-        js_str = @presenter.build_calendar
-
-        expected = <<EOD
-ManageIQ.calendar.calDateFrom = new Date(Fantomas is gone!);
-ManageIQ.calendar.calDateTo   = undefined;
-miqBuildCalendar();
-EOD
-        (js_str + "\n").should == expected
+      it 'calls js_build_calendar with params' do
+        # with_indifferent_access because ExplorerPresenter#options is, and it's recursively infectious - ie. won't compare otherwise
+        obj = {
+          :date_from => Time.at(0).utc,
+          :date_to   => Time.at(946684800).utc,
+          :skip_days => [ 1, 2, 3 ],
+        }.with_indifferent_access
+        @presenter[:build_calendar] = obj
+        expect(@presenter).to receive(:js_build_calendar).with(obj)
+        @presenter.build_calendar
       end
     end
   end


### PR DESCRIPTION
This is based on #3207.

This replaces most of `miqBuildCalendar` calls with the `js_build_calendar` helper, fixed *that* to pass the parameters directlly to `miqBuildCalendar`.

There are a few places to check, a few TODOs and still needs to remove all `ManageIQ.calendar.*` mentions. And rebase when 3207 is in.

TODO merge this, somehow .. https://github.com/himdel/manageiq/pull/2