### PR TITLE
For tenant, use use_settings instead of root?

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -152,12 +152,12 @@ class Tenant < ActiveRecord::Base
   private
 
   # when a root tenant has an attribute with a nil value,
-  #   read the value from the settings table instead
+  #   read the value from the configurations table instead
   #
   # @return the attribute value
   def tenant_attribute(attr_name, setting_name)
     if use_config_for_attributes?
-      ret = settings.fetch_path(:server, setting_name)
+      ret = get_vmdb_config.fetch_path(:server, setting_name)
       block_given? ? yield(ret) : ret
     else
       self[attr_name]
@@ -171,7 +171,7 @@ class Tenant < ActiveRecord::Base
     self.name = nil unless name.present?
   end
 
-  def settings
+  def get_vmdb_config
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 

--- a/db/migrate/20151435234633_add_tenant_override_settings.rb
+++ b/db/migrate/20151435234633_add_tenant_override_settings.rb
@@ -1,0 +1,5 @@
+class AddTenantOverrideSettings < ActiveRecord::Migration
+  def change
+    add_column :tenants, :use_config_for_attributes, :boolean
+  end
+end

--- a/db/migrate/20151435234634_update_tenant_override_settings.rb
+++ b/db/migrate/20151435234634_update_tenant_override_settings.rb
@@ -1,0 +1,13 @@
+require 'ancestry'
+
+class UpdateTenantOverrideSettings < ActiveRecord::Migration
+  class Tenant < ActiveRecord::Base
+    has_ancestry
+  end
+
+  def up
+    say_with_time "updating root_tenant to load from configurations" do
+      Tenant.where(:ancestry => nil).update_all(:use_config_for_attributes => true)
+    end
+  end
+end

--- a/spec/migrations/20151435234634_update_tenant_override_settings_spec.rb
+++ b/spec/migrations/20151435234634_update_tenant_override_settings_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require __FILE__.sub("spec/migrations", "db/migrate").sub("_spec.rb", ".rb")
+
+describe UpdateTenantOverrideSettings do
+  let(:tenant_stub) { migration_stub(:Tenant) }
+
+  migration_context :up do
+    it "updates root_value" do
+      root_tenant = tenant_stub.create!
+      expect(root_tenant).not_to be_use_config_for_attributes
+
+      migrate
+
+      expect(root_tenant.reload).to be_use_config_for_attributes
+    end
+
+    it "leaves other tenants alone" do
+      root_tenant = tenant_stub.create!
+      child_tenant = root_tenant.children.create!
+      expect(child_tenant).not_to be_use_config_for_attributes
+
+      migrate
+
+      expect(child_tenant).not_to be_use_config_for_attributes
+    end
+  end
+end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Tenant do
-  let(:settings) { {} }
+  let(:config) { {} }
   let(:tenant) { described_class.new(:domain => 'x.com', :parent => default_tenant) }
 
   let(:default_tenant) do
@@ -15,7 +15,7 @@ describe Tenant do
   end
 
   before do
-    stub_server_configuration(settings)
+    stub_server_configuration(config)
   end
 
   describe "#default_tenant" do
@@ -130,7 +130,7 @@ describe Tenant do
   end
 
   describe "#name" do
-    let(:settings) { {:server => {:company => "settings"}} }
+    let(:config) { {:server => {:company => "settings"}} }
 
     it "has default name" do
       expect(tenant.name).to eq("My Company")
@@ -141,7 +141,7 @@ describe Tenant do
       expect(tenant.name).to eq("custom")
     end
 
-    it "doesnt read settings for regular tenant" do
+    it "doesnt read configurations for regular tenant" do
       tenant.name = "custom"
       expect(tenant.name).to eq("custom")
     end
@@ -205,10 +205,10 @@ describe Tenant do
       expect(root_tenant.logo.url).to match(/missing/)
     end
 
-    context "with server settings" do
-      let(:settings) { {:server => {:custom_logo => true}} }
+    context "with server configurations" do
+      let(:config) { {:server => {:custom_logo => true}} }
 
-      it "uses settings value for root_tenant" do
+      it "uses configurations value for root_tenant" do
         expect(root_tenant.logo.url).to eq("/uploads/custom_logo.png")
       end
 
@@ -218,7 +218,7 @@ describe Tenant do
       end
 
       # would prefer if url was nil, but this is how paperclip works
-      it "does not use settings for regular tenant" do
+      it "does not use configurations for regular tenant" do
         tenant.save!
         expect(tenant.logo.url).to match(/missing/)
       end
@@ -249,7 +249,7 @@ describe Tenant do
       end
 
       context "#with custom_logo configuration" do
-        let(:settings) { {:server => {:custom_logo => true}} }
+        let(:config) { {:server => {:custom_logo => true}} }
 
         it "knows there is a logo from configuration" do
           expect(root_tenant).to be_logo
@@ -314,7 +314,7 @@ describe Tenant do
     end
 
     context "with custom login logo configuration" do
-      let(:settings) { {:server => {:custom_login_logo => true}} }
+      let(:config) { {:server => {:custom_login_logo => true}} }
 
       it "has custom login logo" do
         expect(root_tenant.login_logo.url).to match(/custom_login_logo.png/)


### PR DESCRIPTION
The logic to decide if we should read a tenant's attributes from configurations turns out to be tricky.
There are too many nuances.

Just adding a flag that says 'read from settings' is better documenting and simpler.

/cc @h-kataria this affects you
/cc @gtanzillo this is what we spoke about

---
A few notes:

- `defaults_value_for` fights with setting the name to nil (which is necessary to read from settings).
- saving a ui form often populates settings values into tenants table and disables the feature.
- explaining how it works and where it breaks down just takes too long. worried about supporting this.
- this will only be used by 10 customers max. But clearly documenting it removes confusion.