### PR TITLE
Fix for 3891 - added project relationship to kubernetes provider UI

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -10,7 +10,8 @@ module EmsContainerHelper::TextualSummary
   def textual_group_relationships
     # Order of items should be from parent to child
     items = []
-    items.concat(%i(container_projects container_routes)) if @ems.kind_of?(ManageIQ::Providers::Openshift::ContainerManager)
+    items.concat(%i(container_projects))
+    items.concat(%i(container_routes)) if @ems.kind_of?(ManageIQ::Providers::Openshift::ContainerManager)
     items.concat(%i(container_services container_replicators container_groups container_nodes containers
                     container_image_registries container_images))
     items

--- a/app/views/layouts/listnav/_ems_container.html.haml
+++ b/app/views/layouts/listnav/_ems_container.html.haml
@@ -65,7 +65,7 @@
               = link_to(_("Container Routes (%s)") % num_groups,
                   {:action  => 'show', :id => @record, :display => 'container_routes'},
                   :title => _("Show Container Routes"))
-        - if role_allows(:feature => "container_project_show_list") && @record.kind_of?(ManageIQ::Providers::Openshift::ContainerManager)
+        - if role_allows(:feature => "container_project_show_list")
           - num_groups = @record.number_of(:container_projects)
           - if num_groups == 0
             %li.disabled


### PR DESCRIPTION
Fixes #3891 
![add_project_relationship_to_provider](https://cloud.githubusercontent.com/assets/11256940/9470132/3f76d436-4b53-11e5-8ae3-5fbcf62e1e87.png)

@simon3z @abonas 
Its a little awkward since kubernetes has namespaces and not projects so I'm a little unsure about this change.