### PR TITLE
Incorrect check of automate result.

### DIFF
--- a/app/models/service_template/filter.rb
+++ b/app/models/service_template/filter.rb
@@ -12,7 +12,7 @@ module ServiceTemplate::Filter
 
     def automate_result_include_service_template?(uri, name)
       ws  = MiqAeEngine.resolve_automation_object(uri)
-      result = ws.root('include_service').presence || true
+      result = ws.root['include_service'].nil? ? true : ws.root['include_service']
       _log.info("Include Service Template <#{name}> : <#{result}>")
       result
     end

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -50,8 +50,8 @@ describe "Service Filter" do
   end
 
   context "#automate_result_include_service_template?" do
-    before do
-      TestClass = Class.new do
+    let(:test_class) do
+      Class.new do
         include ServiceTemplate::Filter
         def initialize(workspace)
           @workspace = workspace
@@ -59,18 +59,13 @@ describe "Service Filter" do
       end
     end
 
-    after do
-      Object.send(:remove_const, :TestClass)
-    end
-
     let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspace", :root => options) }
-    let(:test_class) { TestClass.new(workspace) }
 
     context "allow" do
       let(:options) { {'include_service' => true} }
       it "check true value" do
         MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
-        expect(TestClass.automate_result_include_service_template?('a', 'b')).to be_true
+        expect(test_class.automate_result_include_service_template?('a', 'b')).to be_true
       end
     end
 
@@ -78,7 +73,7 @@ describe "Service Filter" do
       let(:options) { {'include_service' => false} }
       it "check false value" do
         MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
-        expect(TestClass.automate_result_include_service_template?('a', 'b')).to be_false
+        expect(test_class.automate_result_include_service_template?('a', 'b')).to be_false
       end
     end
 
@@ -86,7 +81,7 @@ describe "Service Filter" do
       let(:options) { {} }
       it "check nil value" do
         MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
-        expect(TestClass.automate_result_include_service_template?('a', 'b')).to be_true
+        expect(test_class.automate_result_include_service_template?('a', 'b')).to be_true
       end
     end
   end

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -48,4 +48,46 @@ describe "Service Filter" do
       @request.miq_request_tasks.count.should eql(1)
     end
   end
+
+  context "#automate_result_include_service_template?" do
+    before do
+      TestClass = Class.new do
+        include ServiceTemplate::Filter
+        def initialize(workspace)
+          @workspace = workspace
+        end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :TestClass)
+    end
+
+    let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspace", :root => options) }
+    let(:test_class) { TestClass.new(workspace) }
+
+    context "allow" do
+      let(:options) { {'include_service' => true} }
+      it "check true value" do
+        MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
+        expect(TestClass.automate_result_include_service_template?('a', 'b')).to be_true
+      end
+    end
+
+    context "dont allow" do
+      let(:options) { {'include_service' => false} }
+      it "check false value" do
+        MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
+        expect(TestClass.automate_result_include_service_template?('a', 'b')).to be_false
+      end
+    end
+
+    context "not present" do
+      let(:options) { {} }
+      it "check nil value" do
+        MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
+        expect(TestClass.automate_result_include_service_template?('a', 'b')).to be_true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #4047

The code has a protection for when the automate method doesn't set the
include_service. If the include_service has not been defined in the root
object, the service should get include to stay backward compatible.