### PR TITLE
Fix for service dialog import/export not importing all dialogs

### DIFF
--- a/app/assets/javascripts/SlickGrid-2.1/plugins/slick.checkboxselectcolumn.js
+++ b/app/assets/javascripts/SlickGrid-2.1/plugins/slick.checkboxselectcolumn.js
@@ -1,0 +1,153 @@
+(function ($) {
+  // register namespace
+  $.extend(true, window, {
+    "Slick": {
+      "CheckboxSelectColumn": CheckboxSelectColumn
+    }
+  });
+
+
+  function CheckboxSelectColumn(options) {
+    var _grid;
+    var _self = this;
+    var _handler = new Slick.EventHandler();
+    var _selectedRowsLookup = {};
+    var _defaults = {
+      columnId: "_checkbox_selector",
+      cssClass: null,
+      toolTip: "Select/Deselect All",
+      width: 30
+    };
+
+    var _options = $.extend(true, {}, _defaults, options);
+
+    function init(grid) {
+      _grid = grid;
+      _handler
+        .subscribe(_grid.onSelectedRowsChanged, handleSelectedRowsChanged)
+        .subscribe(_grid.onClick, handleClick)
+        .subscribe(_grid.onHeaderClick, handleHeaderClick)
+        .subscribe(_grid.onKeyDown, handleKeyDown);
+    }
+
+    function destroy() {
+      _handler.unsubscribeAll();
+    }
+
+    function handleSelectedRowsChanged(e, args) {
+      var selectedRows = _grid.getSelectedRows();
+      var lookup = {}, row, i;
+      for (i = 0; i < selectedRows.length; i++) {
+        row = selectedRows[i];
+        lookup[row] = true;
+        if (lookup[row] !== _selectedRowsLookup[row]) {
+          _grid.invalidateRow(row);
+          delete _selectedRowsLookup[row];
+        }
+      }
+      for (i in _selectedRowsLookup) {
+        _grid.invalidateRow(i);
+      }
+      _selectedRowsLookup = lookup;
+      _grid.render();
+
+      if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
+        _grid.updateColumnHeader(_options.columnId, "<input type='checkbox' checked='checked'>", _options.toolTip);
+      } else {
+        _grid.updateColumnHeader(_options.columnId, "<input type='checkbox'>", _options.toolTip);
+      }
+    }
+
+    function handleKeyDown(e, args) {
+      if (e.which == 32) {
+        if (_grid.getColumns()[args.cell].id === _options.columnId) {
+          // if editing, try to commit
+          if (!_grid.getEditorLock().isActive() || _grid.getEditorLock().commitCurrentEdit()) {
+            toggleRowSelection(args.row);
+          }
+          e.preventDefault();
+          e.stopImmediatePropagation();
+        }
+      }
+    }
+
+    function handleClick(e, args) {
+      // clicking on a row select checkbox
+      if (_grid.getColumns()[args.cell].id === _options.columnId && $(e.target).is(":checkbox")) {
+        // if editing, try to commit
+        if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          return;
+        }
+
+        toggleRowSelection(args.row);
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+      }
+    }
+
+    function toggleRowSelection(row) {
+      if (_selectedRowsLookup[row]) {
+        _grid.setSelectedRows($.grep(_grid.getSelectedRows(), function (n) {
+          return n != row
+        }));
+      } else {
+        _grid.setSelectedRows(_grid.getSelectedRows().concat(row));
+      }
+    }
+
+    function handleHeaderClick(e, args) {
+      if (args.column.id == _options.columnId && $(e.target).is(":checkbox")) {
+        // if editing, try to commit
+        if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          return;
+        }
+
+        if ($(e.target).is(":checked")) {
+          var rows = [];
+          for (var i = 0; i < _grid.getDataLength(); i++) {
+            rows.push(i);
+          }
+          _grid.setSelectedRows(rows);
+        } else {
+          _grid.setSelectedRows([]);
+        }
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+      }
+    }
+
+    function getColumnDefinition() {
+      return {
+        id: _options.columnId,
+        name: "<input type='checkbox'>",
+        toolTip: _options.toolTip,
+        field: "sel",
+        width: _options.width,
+        resizable: false,
+        sortable: false,
+        cssClass: _options.cssClass,
+        formatter: checkboxSelectionFormatter
+      };
+    }
+
+    function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
+      if (dataContext) {
+        return _selectedRowsLookup[row]
+            ? "<input type='checkbox' checked='checked'>"
+            : "<input type='checkbox'>";
+      }
+      return null;
+    }
+
+    $.extend(this, {
+      "init": init,
+      "destroy": destroy,
+
+      "getColumnDefinition": getColumnDefinition
+    });
+  }
+})(jQuery);

--- a/app/assets/javascripts/SlickGrid-2.1/plugins/slick.rowselectionmodel.js
+++ b/app/assets/javascripts/SlickGrid-2.1/plugins/slick.rowselectionmodel.js
@@ -1,0 +1,187 @@
+(function ($) {
+  // register namespace
+  $.extend(true, window, {
+    "Slick": {
+      "RowSelectionModel": RowSelectionModel
+    }
+  });
+
+  function RowSelectionModel(options) {
+    var _grid;
+    var _ranges = [];
+    var _self = this;
+    var _handler = new Slick.EventHandler();
+    var _inHandler;
+    var _options;
+    var _defaults = {
+      selectActiveRow: true
+    };
+
+    function init(grid) {
+      _options = $.extend(true, {}, _defaults, options);
+      _grid = grid;
+      _handler.subscribe(_grid.onActiveCellChanged,
+          wrapHandler(handleActiveCellChange));
+      _handler.subscribe(_grid.onKeyDown,
+          wrapHandler(handleKeyDown));
+      _handler.subscribe(_grid.onClick,
+          wrapHandler(handleClick));
+    }
+
+    function destroy() {
+      _handler.unsubscribeAll();
+    }
+
+    function wrapHandler(handler) {
+      return function () {
+        if (!_inHandler) {
+          _inHandler = true;
+          handler.apply(this, arguments);
+          _inHandler = false;
+        }
+      };
+    }
+
+    function rangesToRows(ranges) {
+      var rows = [];
+      for (var i = 0; i < ranges.length; i++) {
+        for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
+          rows.push(j);
+        }
+      }
+      return rows;
+    }
+
+    function rowsToRanges(rows) {
+      var ranges = [];
+      var lastCell = _grid.getColumns().length - 1;
+      for (var i = 0; i < rows.length; i++) {
+        ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
+      }
+      return ranges;
+    }
+
+    function getRowsRange(from, to) {
+      var i, rows = [];
+      for (i = from; i <= to; i++) {
+        rows.push(i);
+      }
+      for (i = to; i < from; i++) {
+        rows.push(i);
+      }
+      return rows;
+    }
+
+    function getSelectedRows() {
+      return rangesToRows(_ranges);
+    }
+
+    function setSelectedRows(rows) {
+      setSelectedRanges(rowsToRanges(rows));
+    }
+
+    function setSelectedRanges(ranges) {
+      _ranges = ranges;
+      _self.onSelectedRangesChanged.notify(_ranges);
+    }
+
+    function getSelectedRanges() {
+      return _ranges;
+    }
+
+    function handleActiveCellChange(e, data) {
+      if (_options.selectActiveRow && data.row != null) {
+        setSelectedRanges([new Slick.Range(data.row, 0, data.row, _grid.getColumns().length - 1)]);
+      }
+    }
+
+    function handleKeyDown(e) {
+      var activeRow = _grid.getActiveCell();
+      if (activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.which == 38 || e.which == 40)) {
+        var selectedRows = getSelectedRows();
+        selectedRows.sort(function (x, y) {
+          return x - y
+        });
+
+        if (!selectedRows.length) {
+          selectedRows = [activeRow.row];
+        }
+
+        var top = selectedRows[0];
+        var bottom = selectedRows[selectedRows.length - 1];
+        var active;
+
+        if (e.which == 40) {
+          active = activeRow.row < bottom || top == bottom ? ++bottom : ++top;
+        } else {
+          active = activeRow.row < bottom ? --bottom : --top;
+        }
+
+        if (active >= 0 && active < _grid.getDataLength()) {
+          _grid.scrollRowIntoView(active);
+          _ranges = rowsToRanges(getRowsRange(top, bottom));
+          setSelectedRanges(_ranges);
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+
+    function handleClick(e) {
+      var cell = _grid.getCellFromEvent(e);
+      if (!cell || !_grid.canCellBeActive(cell.row, cell.cell)) {
+        return false;
+      }
+
+      if (!_grid.getOptions().multiSelect || (
+          !e.ctrlKey && !e.shiftKey && !e.metaKey)) {
+        return false;
+      }
+
+      var selection = rangesToRows(_ranges);
+      var idx = $.inArray(cell.row, selection);
+
+      if (idx === -1 && (e.ctrlKey || e.metaKey)) {
+        selection.push(cell.row);
+        _grid.setActiveCell(cell.row, cell.cell);
+      } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
+        selection = $.grep(selection, function (o, i) {
+          return (o !== cell.row);
+        });
+        _grid.setActiveCell(cell.row, cell.cell);
+      } else if (selection.length && e.shiftKey) {
+        var last = selection.pop();
+        var from = Math.min(cell.row, last);
+        var to = Math.max(cell.row, last);
+        selection = [];
+        for (var i = from; i <= to; i++) {
+          if (i !== last) {
+            selection.push(i);
+          }
+        }
+        selection.push(last);
+        _grid.setActiveCell(cell.row, cell.cell);
+      }
+
+      _ranges = rowsToRanges(selection);
+      setSelectedRanges(_ranges);
+      e.stopImmediatePropagation();
+
+      return true;
+    }
+
+    $.extend(this, {
+      "getSelectedRows": getSelectedRows,
+      "setSelectedRows": setSelectedRows,
+
+      "getSelectedRanges": getSelectedRanges,
+      "setSelectedRanges": setSelectedRanges,
+
+      "init": init,
+      "destroy": destroy,
+
+      "onSelectedRangesChanged": new Slick.Event()
+    });
+  }
+})(jQuery);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -77,6 +77,8 @@
 //= require SlickGrid-2.1/slick.grid
 //= require SlickGrid-2.1/slick.dataview
 //= require SlickGrid-2.1/plugins/slick.autotooltips
+//= require SlickGrid-2.1/plugins/slick.rowselectionmodel
+//= require SlickGrid-2.1/plugins/slick.checkboxselectcolumn
 //= require miq_slickgrid
 //= require codemirror
 //= require codemirror/modes/yaml

--- a/app/assets/javascripts/dialog_import_export.js
+++ b/app/assets/javascripts/dialog_import_export.js
@@ -21,67 +21,71 @@ var listenForDialogPostMessages = function() {
   });
 };
 
+var renderServiceDialogJson = function(rows_json, importFileUploadId) {
+  var statusFormatter = function(row, cell, value, columnDef, dataContext) {
+    var status_img = "<img src=/images/icons/16/" + dataContext.status_icon + ".png >";
+
+    return status_img + dataContext.status;
+  };
+
+  var dataview = new Slick.Data.DataView({inlineFilters: true});
+
+  var checkboxSelector = new Slick.CheckboxSelectColumn({
+    cssClass: "import-checkbox",
+  });
+
+  var columns = [
+    checkboxSelector.getColumnDefinition(),
+    {
+      id: "name",
+      name: "Service Dialog Name",
+      field: "name",
+      width: 300
+    }, {
+      id: "status",
+      name: "Status",
+      field: "status",
+      width: 300,
+      formatter: statusFormatter
+    }
+  ];
+
+  dataview.beginUpdate();
+  dataview.setItems(rows_json);
+  dataview.endUpdate();
+
+  var grid = new Slick.Grid("#import-grid", dataview, columns, {enableColumnReorder: false});
+
+  grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
+  grid.registerPlugin(checkboxSelector);
+
+  $('#import_file_upload_id').val(importFileUploadId);
+  $('.import-data').show();
+  $('.import-or-export').hide();
+
+  var rowsToSelect = [];
+  $.each(grid.getData().getItems(), function(index, item) {
+    if (item.status_icon === 'equal-green') {
+      rowsToSelect.push(item.id);
+    }
+  });
+
+  grid.setSelectedRows(rowsToSelect);
+  grid.invalidate();
+  grid.render();
+
+  setUpImportClickHandlers('import_service_dialogs', grid, function() {
+    $.get('dialog_accordion_json', function(data) {
+      ManageIQ.dynatreeReplacement.replace(data.locals_for_render);
+    });
+  });
+};
+
 var getAndRenderServiceDialogJson = function(importFileUploadId, message) {
   $('.hidden-import-file-upload-id').val(importFileUploadId);
 
-  $.getJSON("service_dialog_json?import_file_upload_id=" + importFileUploadId, function(rows_json) {
-    var statusFormatter = function(row, cell, value, columnDef, dataContext) {
-      var status_img = "<img src=/images/icons/16/" + dataContext.status_icon + ".png >";
-
-      return status_img + dataContext.status;
-    };
-
-    var dataview = new Slick.Data.DataView({inlineFilters: true});
-
-    var checkboxSelector = new Slick.CheckboxSelectColumn({
-      cssClass: "import-checkbox",
-    });
-
-    var columns = [
-      checkboxSelector.getColumnDefinition(),
-      {
-        id: "name",
-        name: "Service Dialog Name",
-        field: "name",
-        width: 300
-      }, {
-        id: "status",
-        name: "Status",
-        field: "status",
-        width: 300,
-        formatter: statusFormatter
-      }
-    ];
-
-    dataview.beginUpdate();
-    dataview.setItems(rows_json);
-    dataview.endUpdate();
-
-    var grid = new Slick.Grid("#import-grid", dataview, columns, {enableColumnReorder: false});
-
-    grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
-    grid.registerPlugin(checkboxSelector);
-
-    $('#import_file_upload_id').val(importFileUploadId);
-    $('.import-data').show();
-    $('.import-or-export').hide();
-
-    var rowsToSelect = [];
-    $.each(grid.getData().getItems(), function(index, item) {
-      if (item.status_icon === 'equal-green') {
-        rowsToSelect.push(item.id);
-      }
-    });
-
-    grid.setSelectedRows(rowsToSelect);
-    grid.invalidate();
-    grid.render();
-
-    setUpImportClickHandlers('import_service_dialogs', grid, function() {
-      $.get('dialog_accordion_json', function(data) {
-        ManageIQ.dynatreeReplacement.replace(data.locals_for_render);
-      });
-    });
+  $.getJSON("service_dialog_json?import_file_upload_id=" + importFileUploadId).done(function(rows_json) {
+    renderServiceDialogJson(rows_json, importFileUploadId);
   });
 
   showSuccessMessage(JSON.parse(message).message);

--- a/app/assets/javascripts/import.js
+++ b/app/assets/javascripts/import.js
@@ -1,11 +1,18 @@
 //= require_directory ./SlickGrid-2.1/
 
-var setUpImportClickHandlers = function(url, importCallback) {
+var setUpImportClickHandlers = function(url, grid, importCallback) {
   $('.import-commit').click(function() {
     miqSparkleOn();
     clearMessages();
 
-    $.post(url, $('#import-form').serialize(), function(data) {
+    var serializedDialogs = '';
+    $.each(grid.getData().getItems(), function(index, item) {
+      if ($.inArray(item.id, grid.getSelectedRows()) !== -1) {
+        serializedDialogs += '&dialogs_to_import[]=' + item.name;
+      }
+    });
+
+    $.post(url, $('#import-form').serialize() + serializedDialogs, function(data) {
       var flashMessage = data[0];
       if (flashMessage.level == 'error') {
         showErrorMessage(flashMessage.message);
@@ -36,10 +43,6 @@ var setUpImportClickHandlers = function(url, importCallback) {
       $('.import-data').hide();
       miqSparkleOff();
     }, 'json');
-  });
-
-  $('#toggle-all').click(function() {
-    $('.import-checkbox').prop('checked', this.checked);
   });
 };
 

--- a/app/views/layouts/_listnav.html.haml
+++ b/app/views/layouts/_listnav.html.haml
@@ -2,5 +2,5 @@
   - filename = render_listnav_filename
   - locals = {:truncate_length => 23}
   - locals.merge!(:size => 72) if @compare
-  = render :partial => "layouts/listnav/#{filename}", :locals => locals
+  = render :partial => "layouts/listnav/#{filename}", :locals => locals if filename
 

--- a/app/views/miq_ae_customization/_dialog_import_export.haml
+++ b/app/views/miq_ae_customization/_dialog_import_export.haml
@@ -28,9 +28,6 @@
   %form#import-form
     %h3= _('Import Service Dialogs')
 
-    %label{:for => 'toggle-all'}= _('All')
-    %input#toggle-all{:type => 'checkbox'}
-
     #import-grid{:style => "width: #{@winW - 50}px; height: #{center_div_height + 5}px; cursor: hand; overflow-x: auto; overflow-y: auto;"}
 
     %table{:width => "100%"}
@@ -50,12 +47,4 @@
     });
 
     listenForDialogPostMessages();
-
-    var importCallback = function() {
-      $.get('dialog_accordion_json', function(data) {
-        ManageIQ.dynatreeReplacement.replace(data.locals_for_render);
-      });
-    };
-
-    setUpImportClickHandlers('import_service_dialogs', importCallback);
   });

--- a/app/views/miq_ae_customization/review_import.haml
+++ b/app/views/miq_ae_customization/review_import.haml
@@ -1,7 +1,7 @@
 :javascript
   var postMessageData = {
     import_file_upload_id: '#{@import_file_upload_id}',
-    message: '#{@message}'
+    message: '#{@message.html_safe}'
   };
 
   $(function() {

--- a/spec/javascripts/dialog_import_export_spec.js
+++ b/spec/javascripts/dialog_import_export_spec.js
@@ -1,0 +1,113 @@
+describe('dialog_import_export.js', function() {
+  describe('#getAndRenderServiceDialogJson', function() {
+    var data;
+
+    beforeEach(function() {
+      data = 'the data';
+
+      spyOn($, 'getJSON').and.callFake(function() {
+        var d = $.Deferred();
+        d.resolve(data);
+        return d.promise();
+      });
+
+      spyOn(window, 'renderServiceDialogJson');
+      spyOn(window, 'showSuccessMessage');
+    });
+
+    it('renders the service dialogs via the json', function() {
+      getAndRenderServiceDialogJson(123, '{"message": "the message"}');
+      expect(window.renderServiceDialogJson).toHaveBeenCalledWith(data, 123);
+    });
+
+    it('shows the success messages', function() {
+      getAndRenderServiceDialogJson(123, '{"message": "the message"}');
+      expect(window.showSuccessMessage).toHaveBeenCalledWith('the message');
+    });
+  });
+
+  describe('#renderServiceDialogJson', function() {
+    var checkboxSelector, grid, data, dataView, importFileUploadId;
+
+    beforeEach(function() {
+      var html = '';
+      html += '<div id="import-grid">';
+      html += '</div>';
+      setFixtures(html);
+
+      importFileUploadId = 123;
+      data = {
+        'responseJSON': [{
+          id: 321,
+          status_icon: 'equal-green'
+        }, {
+          id: 322,
+          status_icon: 'not-equal-green'
+        }],
+        'status': 200
+      };
+
+      var gridConstructor = Slick.Grid;
+      var dataViewConstructor = Slick.Data.DataView;
+      var checkboxSelectColumnConstructor = Slick.CheckboxSelectColumn;
+
+      spyOn(window.Slick, 'Grid').and.callFake(function() {
+        var fakeDataView = new dataViewConstructor();
+        grid = new gridConstructor('#import-grid', fakeDataView, []);
+        spyOn(grid, 'setSelectionModel');
+        spyOn(grid, 'registerPlugin');
+        spyOn(grid.getData(), 'getItems').and.callFake(function() {
+          return [{id: 321, status_icon: 'equal-green'}, {id: 322, status_icon: 'not-equal-green'}];
+        });
+        spyOn(grid, 'setSelectedRows');
+        spyOn(grid, 'invalidate');
+        spyOn(grid, 'render');
+        return grid;
+      });
+
+      spyOn(window.Slick, 'CheckboxSelectColumn').and.callFake(function() {
+        checkboxSelector = new checkboxSelectColumnConstructor();
+        spyOn(checkboxSelector, 'getColumnDefinition');
+        return checkboxSelector;
+      });
+
+      spyOn(window.Slick.Data, 'DataView').and.callFake(function() {
+        dataView = new dataViewConstructor();
+        spyOn(dataView, 'beginUpdate');
+        spyOn(dataView, 'setItems');
+        spyOn(dataView, 'endUpdate');
+        return dataView;
+      });
+    });
+
+    it('sets up the slick data view', function() {
+      renderServiceDialogJson(data, importFileUploadId);
+      expect(window.Slick.Data.DataView).toHaveBeenCalledWith({inlineFilters: true});
+    });
+
+    it('sets up the slick checkbox select column', function() {
+      renderServiceDialogJson(data, importFileUploadId);
+      expect(window.Slick.CheckboxSelectColumn).toHaveBeenCalledWith({cssClass: "import-checkbox"});
+    });
+
+    it('updates the data view', function() {
+      renderServiceDialogJson(data, importFileUploadId);
+      expect(dataView.beginUpdate).toHaveBeenCalled();
+    });
+
+    it('sets the items in the data view', function() {
+      renderServiceDialogJson(data, importFileUploadId);
+      expect(dataView.setItems).toHaveBeenCalledWith(data);
+    });
+
+    it('ends the update of the data view', function() {
+      renderServiceDialogJson(data, importFileUploadId);
+      expect(dataView.endUpdate).toHaveBeenCalled();
+    });
+
+    it('sets up the slick grid with the selected rows', function() {
+      renderServiceDialogJson(data, importFileUploadId);
+      expect(grid.setSelectedRows).toHaveBeenCalledWith([321]);
+    });
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -30,6 +30,7 @@ src_files:
   - javascripts/controllers/repository/repository_form_controller.js
   - javascripts/controllers/retirement/retirement_form_controller.js
   - javascripts/controllers/buttons/button_group_controller.js
+  - javascripts/SlickGrid-2.1/**/*.js
   - javascripts/directives/autofocus.js
   - javascripts/directives/repository/valid_unc_path.js
   - javascripts/directives/checkchange.js
@@ -39,6 +40,7 @@ src_files:
   - javascripts/directives/scheduler/updateDropdownForFilter.js
   - javascripts/directives/scheduler/updateDropdownForTimer.js
   - javascripts/import.js
+  - javascripts/dialog_import_export.js
 
 # stylesheets
 #


### PR DESCRIPTION
SlickGrid uses an auto-adaptive display, where if the screen is too small or if the dataset is too large, it actually removes/re-adds rows to the table as you scroll. This was causing the issue where some of the items in the table weren't being selected to import.

The fix was to use SlickGrid's built in plugins for handling row selection, and then serializing the data from the grid itself instead of from the form.

https://bugzilla.redhat.com/show_bug.cgi?id=1252976