### PR TITLE
[Provider Namespacing] Ensure that workers require runners

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/refresh_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker < MiqEmsRefreshWorker
+  require_dependency 'manageiq/providers/foreman/configuration_manager/refresh_worker/runner'
+
   def self.ems_class
     parent
   end

--- a/app/models/manageiq/providers/foreman/provisioning_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/foreman/provisioning_manager/refresh_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Foreman::ProvisioningManager::RefreshWorker < MiqEmsRefreshWorker
+  require_dependency 'manageiq/providers/foreman/provisioning_manager/refresh_worker/runner'
+
   def self.ems_class
     parent
   end

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::CloudManager::EventCatcher < ::MiqEventCatcher
+  require_dependency 'manageiq/providers/openstack/cloud_manager/event_catcher/runner'
+
   def self.ems_class
     ManageIQ::Providers::Openstack::CloudManager
   end

--- a/app/models/manageiq/providers/openstack/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/metrics_collector_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
+  require_dependency 'manageiq/providers/openstack/cloud_manager/metrics_collector_worker/runner'
+
   self.default_queue_name = "openstack"
 
   def friendly_name

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::CloudManager::RefreshWorker < ::MiqEmsRefreshWorker
+  require_dependency 'manageiq/providers/openstack/cloud_manager/refresh_worker/runner'
+
   def self.ems_class
     ManageIQ::Providers::Openstack::CloudManager
   end

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::Openstack::CloudManager::EventCatcherMixin
+module ManageIQ::Providers::Openstack::EventCatcherMixin
   # seems like most of this class could be boilerplate when compared against EventCatcherRhevm
   def event_monitor_handle
     require 'openstack/openstack_event_monitor'

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ::MiqEventCatcher
+  require_dependency 'manageiq/providers/openstack/infra_manager/event_catcher/runner'
+
   def self.ems_class
     ManageIQ::Providers::Openstack::InfraManager
   end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+class ManageIQ::Providers::Openstack::InfraManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
   def add_openstack_queue(event_hash)

--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_collector_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::InfraManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
+  require_dependency 'manageiq/providers/openstack/infra_manager/metrics_collector_worker/runner'
+
   self.default_queue_name = "openstack_infra"
 
   def friendly_name

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::InfraManager::RefreshWorker < ::MiqEmsRefreshWorker
+  require_dependency 'manageiq/providers/openstack/infra_manager/refresh_worker/runner'
+
   def self.ems_class
     ManageIQ::Providers::Openstack::InfraManager
   end

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -1,6 +1,36 @@
 require "spec_helper"
 
 describe MiqWorker do
+  context ".corresponding_runner" do
+
+    def all_workers
+      MiqWorker.descendants.select { |c| c.subclasses.empty? }
+    end
+
+    it "finds the correct corresponding runner for workers" do
+      namespaced, legacy = all_workers.partition { |c| c.name =~ /::/ }
+
+      namespaced.each do |worker|
+        # namespaced workers are spelled:
+        # ManageIQ::Providers::ProviderName::ManagerType::WorkerType
+        # namespaced runners are spelled:
+        # ManageIQ::Providers::ProviderName::ManagerType::WorkerType::Runner
+        worker.corresponding_runner.should end_with("Runner")
+      end
+
+      legacy.each do |worker|
+        # Legacy workers look like:
+        # MiqWorkerName
+        # Legacy runners look like:
+        # WorkerName
+        #
+        # Strip the "Miq" to get the runner name
+        runner_name = worker.name.slice(3..-1)
+        worker.corresponding_runner.should eq runner_name
+      end
+    end
+  end
+
   context ".sync_workers" do
     it "stops extra workers, returning deleted pids" do
       described_class.any_instance.should_receive(:stop)


### PR DESCRIPTION
If workers do not `require_dependency` their runners, the `const_defined?(:Runner, false)` call in `corresponding_runner` will fail to find the appropriate runner class when starting up the worker.
    
This results in finding the "legacy" runner.  For example, after the namespacing of OpenStack CloudManager, the event catcher worker is `ManageIQ::Providers::Openstack::CloudManager::EventCatcher` and the corresponding runner is `ManageIQ::Providers::Openstack::CloudManager::EventCatcher::Runner`.  However, the legacy `MiqEventCatcherOpenstack`, the corresponding runner used to be 'workers/event_catcher_openstack'.

When `corresponding_runner` fails to find the appropriately namespaced runner class, it throws errors like:
    
> (LoadError) cannot load such file -- workers/event_catcher_openstack on adding
> openstack provider

Additionally, Openstack's `EventCatcherMixin` had the wrong module name.  Even though the class was located at `manageiq/providers/openstack/event_catcher_mixin.rb`, the full class and module name was `ManageIQ::Providers::Openstack::CloudManager::EventCatcherMixin`.  Removed the `CloudManager` so the class could be loaded correctly.
    
(Upstream only)
https://bugzilla.redhat.com/show_bug.cgi?id=1253134