### PR TITLE
TreeBuilder-related fixes

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -259,35 +259,35 @@ module ApplicationController::Explorer
 
     object = options[:parent]
     children_or_count = case object
-    when nil                 then x_get_tree_roots(options)
-    when AvailabilityZone    then x_get_tree_az_kids(object, options)
-    when CustomButtonSet     then x_get_tree_aset_kids(object, options)
-    when Dialog              then x_get_tree_dialog_kids(object, options)
-    when DialogTab           then x_get_tree_dialog_tab_kids(object, options)
-    when DialogGroup         then x_get_tree_dialog_group_kids(object, options)
-    when ExtManagementSystem then x_get_tree_ems_kids(object, options)
-    when EmsFolder           then object.is_datacenter ?
-                                  x_get_tree_datacenter_kids(object, options) :
-                                  x_get_tree_folder_kids(object, options)
-    when EmsCluster          then x_get_tree_cluster_kids(object, options)
-    when Host		             then x_get_tree_host_kids(object, options)
-    when LdapRegion		       then x_get_tree_lr_kids(object, options)
-    when MiqAlertSet		     then x_get_tree_ap_kids(object, options)
-    when MiqEventDefinition  then options[:tree] != :event_tree ?
-                                  x_get_tree_ev_kids(object, options) : nil
-    when MiqGroup            then options[:tree] == :db_tree ?
-                                  x_get_tree_g_kids(object, options) : nil
-    when MiqPolicySet		     then x_get_tree_pp_kids(object, options)
-    when MiqPolicy		       then x_get_tree_p_kids(object, options)
-    when MiqRegion		       then x_get_tree_region_kids(object, options)
-    when MiqReport		       then x_get_tree_r_kids(object, options)
-    when ResourcePool		     then x_get_tree_rp_kids(object, options)
-    when ServiceTemplate		 then x_get_tree_st_kids(object, options)
-    when ServiceResource		 then x_get_tree_sr_kids(object, options)
-    when VmdbTableEvm		     then x_get_tree_vmdb_table_kids(object, options)
-    when Zone		             then x_get_tree_zone_kids(object, options)
-    when Hash                then x_get_tree_custom_kids(object, options)
-    end
+                        when nil                 then x_get_tree_roots(options)
+                        when AvailabilityZone    then x_get_tree_az_kids(object, options)
+                        when CustomButtonSet     then x_get_tree_aset_kids(object, options)
+                        when Dialog              then x_get_tree_dialog_kids(object, options)
+                        when DialogTab           then x_get_tree_dialog_tab_kids(object, options)
+                        when DialogGroup         then x_get_tree_dialog_group_kids(object, options)
+                        when ExtManagementSystem then x_get_tree_ems_kids(object, options)
+                        when EmsFolder           then object.is_datacenter ?
+                                                      x_get_tree_datacenter_kids(object, options) :
+                                                      x_get_tree_folder_kids(object, options)
+                        when EmsCluster          then x_get_tree_cluster_kids(object, options)
+                        when Host                then x_get_tree_host_kids(object, options)
+                        when LdapRegion          then x_get_tree_lr_kids(object, options)
+                        when MiqAlertSet         then x_get_tree_ap_kids(object, options)
+                        when MiqEventDefinition  then options[:tree] != :event_tree ?
+                                                      x_get_tree_ev_kids(object, options) : nil
+                        when MiqGroup            then options[:tree] == :db_tree ?
+                                                      x_get_tree_g_kids(object, options) : nil
+                        when MiqPolicySet        then x_get_tree_pp_kids(object, options)
+                        when MiqPolicy           then x_get_tree_p_kids(object, options)
+                        when MiqRegion           then x_get_tree_region_kids(object, options)
+                        when MiqReport           then x_get_tree_r_kids(object, options)
+                        when ResourcePool        then x_get_tree_rp_kids(object, options)
+                        when ServiceTemplate     then x_get_tree_st_kids(object, options)
+                        when ServiceResource     then x_get_tree_sr_kids(object, options)
+                        when VmdbTableEvm        then x_get_tree_vmdb_table_kids(object, options)
+                        when Zone                then x_get_tree_zone_kids(object, options)
+                        when Hash                then x_get_tree_custom_kids(object, options)
+                        end
     children_or_count || (options[:count_only] ? 0 : [])
   end
 

--- a/app/controllers/application_controller/feature.rb
+++ b/app/controllers/application_controller/feature.rb
@@ -7,9 +7,9 @@ class ApplicationController
     end
 
     def autocomplete
-      accord_name = name.to_s unless name
-      tree_name   = "#{name}_tree".to_sym unless tree_name
-      container   = "#{accord_name}_tree_div" unless container
+      self.accord_name = name.to_s unless accord_name
+      self.tree_name   = "#{name}_tree".to_sym unless tree_name
+      self.container   = "#{accord_name}_tree_div" unless container
     end
 
     def accord_hash

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -611,7 +611,6 @@ class MiqPolicyController < ApplicationController
     presenter[:osf_node] = x_node  # Open, select, and focus on this node
 
     @changed = session[:changed] if @edit   # to get save/reset buttons to highlight when fields are moved left/right
-    edit_str = @edit ? 'editing_' : ''
 
     # Replace right side with based on selected tree node type
     case nodetype

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -165,13 +165,4 @@ module MiqPolicyController::PolicyProfiles
     instance_variable_set :"@#{name}", tree_nodes.to_json  # JSON object for tree loading
     x_node_set(tree_nodes.first[:key], name) unless x_node(name)    # Set active node to root if not set
   end
-
-  def profile_get_all
-    @profiles = MiqPolicySet.all.sort_by { |ps| ps.description.downcase }
-    set_search_text
-    @profiles = apply_search_filter(@search_text, @profiles) if !@search_text.blank?
-    @right_cell_text = _("All %s") % ui_lookup(:models=>"MiqPolicySet")
-    @right_cell_div = "profile_list"
-  end
-
 end

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -130,9 +130,9 @@ class MiqPolicy < ActiveRecord::Base
     end.compact
   end
 
-  def action_result_for_event(action,event)
-    pe = miq_policy_contents.find_by_miq_action_id_and_miq_event_definition_id(event.id, action.id)
-    return pe.qualifier == "success"
+  def action_result_for_event(action, event)
+    pe = miq_policy_contents.where(:miq_action_id => action.id, :miq_event_definition_id => event.id)
+    pe.first.present? && pe.first.qualifier == "success"
   end
 
   def delete_event(event)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -272,7 +272,7 @@ class TreeBuilder
                         when Service             then x_get_tree_service_kids(parent, options)
                         when ServiceTemplateCatalog
                                                  then x_get_tree_stc_kids(parent, options)
-                        when ServiceTemplate		 then x_get_tree_st_kids(parent, options)
+                        when ServiceTemplate     then x_get_tree_st_kids(parent, options)
                         when Tenant              then x_get_tree_tenant_kids(parent, options)
                         when VmdbTableEvm        then x_get_tree_vmdb_table_kids(parent, options)
                         when Zone                then x_get_tree_zone_kids(parent, options)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -19,7 +19,11 @@ class TreeBuilder
     end
   end
 
-  # FIXME: need to move this to a subclass
+  def root_options
+    TreeBuilder.root_options(@name)
+  end
+
+  # FIXME: need to move this to a subclass (#root_options)
   def self.root_options(tree_name)
     #returns title, tooltip, root icon
     case tree_name
@@ -181,7 +185,7 @@ class TreeBuilder
 
   def add_root_node(nodes)
     root = nodes.first
-    root[:title], root[:tooltip], icon = TreeBuilder.root_options(@name)
+    root[:title], root[:tooltip], icon = root_options
     root[:icon] = "#{icon || 'folder'}.png"
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -87,7 +87,7 @@ class TreeBuilder
     @locals_for_render  = {}
     @name               = name.to_sym                     # includes _tree
     @options            = tree_init_options(name.to_sym)
-    @tree_nodes         = {}
+    @tree_nodes         = {}.to_json
     # FIXME: remove @name or @tree, unify
     @type               = type.to_sym                     # *usually* same as @name but w/o _tree
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -328,6 +328,8 @@ class TreeBuilder
   def count_only_or_objects(count_only, objects, sort_by)
     if count_only
       objects.size
+    elsif sort_by.kind_of?(Proc)
+      objects.sort_by(&sort_by)
     elsif sort_by
       objects.sort_by { |o| Array(sort_by).collect { |sb| o.deep_send(sb).to_s.downcase } }
     else

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -2,7 +2,7 @@ class TreeBuilderAeCustomization  < TreeBuilder
   private
 
   def tree_init_options(tree_name)
-    {:open_all => true }
+    {:open_all => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -266,7 +266,7 @@ class TreeNodeBuilder
       end
       p  = MiqPolicy.find_by_id(ActiveRecord::Base.uncompress_id(policy_id))
       ev = MiqEventDefinition.find_by_id(ActiveRecord::Base.uncompress_id(event_id))
-      image = p.action_result_for_event(ev, object) ? "check" : "x"
+      image = p.action_result_for_event(object, ev) ? "check" : "x"
     else
       image = object.action_type == "default" ? "miq_action" : "miq_action_#{object.action_type}"
     end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -127,23 +127,6 @@ describe VmInfraController do
         objects.first[:id].should_not == ems_cloud.id
         objects.first[:id].should == ems_infra.id
       end
-
-      it "Return Zones only in My Region" do
-        my_region_zone = FactoryGirl.create(:zone)
-        controller.instance_variable_set(:@sb, {:trees =>
-                                                    {:settings_tree => {:active_node => "root"}},
-                                                :active_tree => :utilization_tree})
-        options = {
-            :tree => :settings_tree,
-            :type => :settings,
-            :parent => @region
-        }
-        object = {:id => "z"}
-        objects = controller.send(:x_get_tree_custom_kids, object , options)
-        objects.each do |o|
-          o.miq_region.id.should == @region.id
-        end
-      end
     end
 
     context "#x_settings_changed" do

--- a/spec/controllers/application_controller/feature.rb
+++ b/spec/controllers/application_controller/feature.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require File.expand_path("../app/controllers/application_controller/", "feature.rb")
+
+describe ApplicationController do
+  context "Feature" do
+    Feature = ApplicationController.const_get('Feature')
+
+    it "#new_with_hash creates a Struct" do
+      Feature.new_with_hash(:name => "whatever").should be_a_kind_of(Struct)
+    end
+
+    it "#autocomplete doesn't replace stuff" do
+      feature = Feature.new_with_hash(:name => "foo", :accord_name => "bar", :tree_name => "quux", :container => "frob")
+      feature.accord_name.should eq("bar")
+      feature.tree_name.should eq("quux")
+      feature.container.should eq("frob")
+    end
+
+    it "#autocomplete does set missing stuff" do
+      feature = Feature.new_with_hash(:name => "foo")
+      feature.accord_name.should eq("foo")
+      feature.tree_name.should eq(:foo_tree)
+      feature.container.should eq("foo_tree_div")
+    end
+  end
+end


### PR DESCRIPTION
This splits a bunch of commits from #3530 that are unrelated to Policy trees specifically. All the changes here are either cleanup, or introduce new features relied on by #3530. 

@martinpovolny please review