### PR TITLE
Stub server configuration

### DIFF
--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -3,51 +3,51 @@ require "spec_helper"
 describe VMDB::Util do
   context ".http_proxy_uri" do
     it "without config settings" do
-      VMDB::Config.any_instance.stub(:config => {})
+      stub_server_configuration({})
       described_class.http_proxy_uri.should be_nil
     end
 
     it "without a host" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {}})
+      stub_server_configuration(:http_proxy => {})
       described_class.http_proxy_uri.should be_nil
     end
 
     it "with host" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil}})
+      stub_server_configuration(:http_proxy => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "http", :host => "1.2.3.4")
     end
 
     it "with host, port" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => nil}})
+      stub_server_configuration(:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => nil})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321)
     end
 
     it "with host, port, user" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => nil}})
+      stub_server_configuration(:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => nil})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser")
     end
 
     it "with host, port, user, password" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"}})
+      stub_server_configuration(:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser:secret")
     end
 
     it "with user missing" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => "secret"}})
+      stub_server_configuration(:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => "secret"})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321)
     end
 
     it "with unescaped user value" do
       password = "secret#"
       config = {:http_proxy => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => password}}
-      VMDB::Config.any_instance.stub(:config => config)
+      stub_server_configuration(config)
       userinfo = "testuser:secret%23"
       uri_parts = {:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => userinfo}
       described_class.http_proxy_uri.should == URI::Generic.build(uri_parts)
     end
 
     it "with scheme overridden" do
-      VMDB::Config.any_instance.stub(:config => {:http_proxy => {:scheme => "https", :host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"}})
+      stub_server_configuration(:http_proxy => {:scheme => "https", :host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"})
       described_class.http_proxy_uri.should == URI::Generic.build(:scheme => "https", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser:secret")
     end
   end

--- a/spec/lib/workers/schedule_worker_spec.rb
+++ b/spec/lib/workers/schedule_worker_spec.rb
@@ -276,7 +276,7 @@ describe ScheduleWorker do
 
         context "LDAP synchronization role" do
           before(:each) do
-            VMDB::Config.any_instance.stub(:config).and_return(Hash.new(5.minutes))
+            stub_server_configuration(Hash.new(5.minutes))
             @schedule_worker.stub(:heartbeat)
 
             # Initialize active_roles
@@ -290,10 +290,7 @@ describe ScheduleWorker do
             @ldap_synchronization_collection = { :ldap_synchronization_schedule => "0 2 * * *" }
             config                           = { :ldap_synchronization => @ldap_synchronization_collection }
 
-            vmdb_config = double("vmdb_config")
-            vmdb_config.stub(:config => config)
-            vmdb_config.stub(:merge_from_template_if_missing)
-            VMDB::Config.stub(:new).with("vmdb").and_return(vmdb_config)
+            stub_server_configuration(config)
           end
 
           context "#schedules_for_ldap_synchronization_role" do
@@ -343,7 +340,7 @@ describe ScheduleWorker do
 
         context "Database operations role" do
           before(:each) do
-            VMDB::Config.any_instance.stub(:config).and_return(Hash.new(5.minutes))
+            stub_server_configuration(Hash.new(5.minutes))
             @schedule_worker.stub(:heartbeat)
 
             MiqRegion.seed
@@ -354,11 +351,7 @@ describe ScheduleWorker do
             @metrics_collection = { :collection_schedule => "1 * * * *", :daily_rollup_schedule => "23 0 * * *" }
             @metrics_history    = { :purge_schedule => "50 * * * *" }
             database_config     = { :metrics_collection => @metrics_collection, :metrics_history => @metrics_history }
-            config              = { :database => database_config }
-            vmdb_config = double("vmdb_config")
-            vmdb_config.stub(:config => config)
-            vmdb_config.stub(:merge_from_template_if_missing)
-            VMDB::Config.stub(:new).with("vmdb").and_return(vmdb_config)
+            stub_server_configuration(:database => database_config)
           end
 
           context "with database_owner in region" do
@@ -485,7 +478,7 @@ describe ScheduleWorker do
         context "end-to-end schedules modified to run every 5 minutes" do
           before(:each) do
             @schedule_worker.stub(:worker_settings).and_return(Hash.new(5.minutes))
-            VMDB::Config.any_instance.stub(:config).and_return(Hash.new(5.minutes))
+            stub_server_configuration(Hash.new(5.minutes))
             @schedule_worker.stub(:heartbeat)
 
             # Initialize active_roles
@@ -617,7 +610,7 @@ describe ScheduleWorker do
     it "#schedule_settings_for_ems_refresh (private)" do
       _ = ManageIQ::Providers::Microsoft::InfraManager # FIXME: Loader
 
-      VMDB::Config.any_instance.stub(:config).and_return(
+      stub_server_configuration(
         :ems_refresh => {
           :refresh_interval => 24.hours,
           :scvmm            => {:refresh_interval => 15.minutes}

--- a/spec/lib/ws_proxy_spec.rb
+++ b/spec/lib/ws_proxy_spec.rb
@@ -3,17 +3,14 @@ require "spec_helper"
 describe WsProxy do
 
   before(:each) do
-    config = {
+    stub_server_configuration(
       :server => {
         :websocket => {
           :cert => 'non-existent-foo-bar',
           :key  => 'REGION' # file existing under Rails root
         }
       }
-    }
-    vmdb_config = double('vmdb_config')
-    vmdb_config.stub(:config => config)
-    VMDB::Config.stub(:new).with("vmdb").and_return(vmdb_config)
+    )
   end
 
   context '#try_run_proxy' do

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -84,9 +84,7 @@ describe GenericMailer do
   end
 
   it "call deliver for generic_notification without a 'from' address" do
-    config = VMDB::Config.new("vmdb")
-    config.config[:smtp][:from] = "test@123.com"
-    VMDB::Config.stub(:new).with("vmdb").and_return(config)
+    stub_server_configuration(:smtp => {:from => "test@123.com"} )
     new_args = @args.dup
     new_args.delete(:from)
     msg = GenericMailer.deliver(:generic_notification, new_args)

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -13,7 +13,7 @@ describe DriftState do
           }
         }
       }
-      VMDB::Config.any_instance.stub(:config).and_return(@vmdb_config)
+      stub_server_configuration(@vmdb_config)
 
       @rr1 = [
         FactoryGirl.create(:drift_state, :resource_type => 'VmOrTemplate', :resource_id => 1, :timestamp => (6.months + 1.days).to_i.seconds.ago.utc),

--- a/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
+++ b/spec/models/ems_refresh/refreshers/openstack_refresher_rhos_havana_spec.rb
@@ -52,7 +52,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
 
   context "when configured with skips" do
     before(:each) do
-      VMDB::Config.any_instance.stub(:config).and_return(
+      stub_server_configuration(
         :ems_refresh => {:openstack => {:inventory_ignore => [:cloud_volumes, :cloud_volume_snapshots]}}
       )
     end

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -10,7 +10,7 @@ describe Metric::Capture do
                      :capture_threshold_with_alerts => {:vm => @capture_rt, :host => @capture_rt}
                     }
                   }
-      VMDB::Config.any_instance.stub(:config).and_return(settings)
+      stub_server_configuration(settings)
       @time = Time.utc(2013, 4, 22, 8, 31)
     end
 

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -35,7 +35,7 @@ describe Metric::Purging do
             }
           }
         }
-        VMDB::Config.any_instance.stub(:config).and_return(@vmdb_config)
+        stub_server_configuration(@vmdb_config)
 
         @metrics1 = [
           FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => 1, :timestamp => (6.months + 1.days).ago.utc),

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -63,7 +63,7 @@ describe Metric do
 
       context "executing perf_capture_timer" do
         before(:each) do
-          VMDB::Config.any_instance.stub(:config).and_return({:performance => {:history => {:initial_capture_days => 7}}})
+          stub_server_configuration(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
 
@@ -478,7 +478,7 @@ describe Metric do
 
       context "executing perf_capture_now?" do
         before(:each) do
-          VMDB::Config.any_instance.stub(:config).and_return({:performance => {:capture_threshold => {:vm => 10}, :capture_threshold_with_alerts => {:vm => 2}}})
+          stub_server_configuration(:performance => {:capture_threshold => {:vm => 10}, :capture_threshold_with_alerts => {:vm => 2}})
         end
 
         it "without alerts assigned" do
@@ -1206,7 +1206,7 @@ describe Metric do
 
       context "executing perf_capture_timer" do
         before(:each) do
-          VMDB::Config.any_instance.stub(:config).and_return({:performance => {:history => {:initial_capture_days => 7}}})
+          stub_server_configuration(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -99,10 +99,7 @@ describe MiqGroup do
 
     it "should return LDAP groups by user name" do
       auth_config = { :group_memberships_max_depth => 1 }
-      config = { :authentication =>  auth_config }
-      vmdb_config = double('vmdb_config')
-      vmdb_config.stub(:config => config)
-      VMDB::Config.stub(:new).with('vmdb').and_return(vmdb_config)
+      stub_server_configuration(:authentication =>  auth_config)
 
       miq_ldap = double('miq_ldap')
       miq_ldap.stub(:fqusername => 'fred')
@@ -118,10 +115,7 @@ describe MiqGroup do
 
     it "should issue an error message when user name could not be bound to LDAP" do
       auth_config = { :group_memberships_max_depth => 1 }
-      config = { :authentication =>  auth_config }
-      vmdb_config = double('vmdb_config')
-      vmdb_config.stub(:config => config)
-      VMDB::Config.stub(:new).with('vmdb').and_return(vmdb_config)
+      stub_server_configuration(:authentication =>  auth_config)
 
       miq_ldap = double('miq_ldap')
       miq_ldap.stub(:fqusername => 'fred')
@@ -142,10 +136,7 @@ describe MiqGroup do
 
     it "should issue an error message when user name does not exist in LDAP directory" do
       auth_config = { :group_memberships_max_depth => 1 }
-      config = { :authentication =>  auth_config }
-      vmdb_config = double('vmdb_config')
-      vmdb_config.stub(:config => config)
-      VMDB::Config.stub(:new).with('vmdb').and_return(vmdb_config)
+      stub_server_configuration(:authentication => auth_config)
 
       miq_ldap = double('miq_ldap')
       miq_ldap.stub(:fqusername => 'fred')

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -11,7 +11,7 @@ describe MiqReportResult do
           }
         }
       }
-      VMDB::Config.any_instance.stub(:config).and_return(@vmdb_config)
+      stub_server_configuration(@vmdb_config)
 
       @rr1 = [
         FactoryGirl.create(:miq_report_result, :miq_report_id => 1, :created_on => (6.months + 1.days).to_i.seconds.ago.utc),

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -416,7 +416,7 @@ describe MiqWidget do
     end
 
     it "with report_sync" do
-      VMDB::Config.any_instance.stub(:config).and_return({:product => {:report_sync => true}})
+      stub_server_configuration(:product => {:report_sync => true})
 
       user_est =  FactoryGirl.create(:user, :userid => 'user_est', :miq_groups => [@group2], :settings => {:display => {:timezone => "Eastern Time (US & Canada)"}})
       user_est.get_timezone.should == "Eastern Time (US & Canada)"

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -44,9 +44,7 @@ describe Storage do
 
   it "#vmdb_storage_config" do
     config = { :foo => 1, :bar => 2 }
-    vmdb_storage_config = double('vmdb_storage_config')
-    vmdb_storage_config.stub(:config => config)
-    VMDB::Config.stub(:new).with('storage').and_return(vmdb_storage_config)
+    stub_server_configuration(config, "storage")
     Storage.vmdb_storage_config.should == config
   end
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -15,7 +15,7 @@ describe Tenant do
   end
 
   before do
-    allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => settings))
+    stub_server_configuration(settings)
   end
 
   describe "#default_tenant" do

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -117,9 +117,7 @@ describe Authenticator::Ldap do
   end
 
   def setup_vmdb_config
-    vmdb_config = double("vmdb_config")
-    vmdb_config.stub(:config => @auth_config)
-    VMDB::Config.stub(:new).with("vmdb").and_return(vmdb_config)
+    stub_server_configuration(@auth_config)
   end
 
   def setup_to_create_user(group)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -245,9 +245,7 @@ describe User do
               :ldaphost=>["192.168.254.15"]
             }
           }
-        vmdb_config = double("vmdb_config")
-        vmdb_config.stub(:config => @auth_config)
-        VMDB::Config.stub(:new).with("vmdb").and_return(vmdb_config)
+        stub_server_configuration(@auth_config)
         @miq_ldap = double('miq_ldap')
         @miq_ldap.stub(:bind => false)
       end

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -1,5 +1,5 @@
 module ConfigurationHelper
-  def stub_server_configuration(config)
-    allow(VMDB::Config).to receive(:new).with("vmdb").and_return(double(:config => config))
+  def stub_server_configuration(config, config_name = "vmdb")
+    allow(VMDB::Config).to receive(:new).with(config_name).and_return(double(:config => config))
   end
 end

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -1,5 +1,6 @@
 module ConfigurationHelper
   def stub_server_configuration(config, config_name = "vmdb")
-    allow(VMDB::Config).to receive(:new).with(config_name).and_return(double(:config => config))
+    configuration = double(:config => config, :merge_from_template_if_missing => nil)
+    allow(VMDB::Config).to receive(:new).with(config_name).and_return(configuration)
   end
 end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -16,8 +16,8 @@ module EvmSpecHelper
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
 
     clear_instance_variables(MiqEnvironment::Command)
-    clear_instance_variable(MiqProductFeature, :@feature_cache)
-    clear_instance_variable(BottleneckEvent, :@event_definitions)
+    clear_instance_variable(MiqProductFeature, :@feature_cache) if defined?(MiqProductFeature)
+    clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
 
     # Clear the thread local variable to prevent test contamination
     User.current_userid = nil if defined?(User) && User.respond_to?(:current_userid=)


### PR DESCRIPTION
We have a number of ways to stub out server configuration.
This attempts to consolidate them into `stub_server_configuration`

Enhanced that method to support non `"vmdb`"` configurations, and to support `merge_from_template`

/cc @fryguy we briefly mentioned this last week