### PR TITLE
[api] Use request helper syntax

### DIFF
--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_delete rates_url(chargeback_rate_detail.id)
       end.to change(ChargebackRateDetail, :count).by(-1)
-      expect(last_response.status).to eq(204)
+      expect_request_success_with_no_content
     end
 
     it "can delete a chargeback rate detail through POST" do


### PR DESCRIPTION
Updates this spec to utilize a helper method for this request
expectation.

Addresses https://github.com/ManageIQ/manageiq/pull/3846#discussion_r37579979