### PR TITLE
Improve EmsRefresh performance by implementing bulk connection creation

### DIFF
--- a/app/models/ems_refresh/link_inventory.rb
+++ b/app/models/ems_refresh/link_inventory.rb
@@ -117,7 +117,7 @@ module EmsRefresh::LinkInventory
     self.update_relats_by_ids(prev_ids, new_ids,
       do_disconnect ? Proc.new { |s| object.send(accessor).delete(model.find_by_id(s)) } : nil, # Disconnect proc
       Proc.new { |s| object.send(accessor) << model.find_by_id(s) },                            # Connect proc
-      Proc.new { |vs| object.send(accessor) << model.where(id: vs).to_a }                       # Bulk connect proc
+      Proc.new { |ss| object.send(accessor) << model.where(id: ss).to_a }                       # Bulk connect proc
     )
   end
 

--- a/app/models/ems_refresh/link_inventory.rb
+++ b/app/models/ems_refresh/link_inventory.rb
@@ -165,7 +165,7 @@ module EmsRefresh::LinkInventory
           bulk_connect.call(new_ids)
         rescue => err
           _log.error "EMS: [#{@ems.name}], id: [#{@ems.id}] An error occurred while connecting ids [#{new_ids.join(',')}]: #{err}"
-            _log.log_backtrace(err)
+          _log.log_backtrace(err)
         end
       elsif connect_proc
         new_ids.each do |n|

--- a/app/models/ems_refresh/refreshers/refresher_relats_mixin.rb
+++ b/app/models/ems_refresh/refreshers/refresher_relats_mixin.rb
@@ -358,7 +358,7 @@ module EmsRefresh::Refreshers::RefresherRelatsMixin
       do_relat_compare(:folders_to_folders, prev_relats, new_relats) do |f|
         folder = EmsFolder.find(f)
         [ do_disconnect ? Proc.new { |f2| folder.remove_folder(EmsFolder.find(f2)) } : nil, # Disconnect proc
-          Proc.new { |f2| folder.add_folder(EmsFolder.find_by_id(f2)) },                    # Connect proc
+          Proc.new { |f2| folder.add_folder(EmsFolder.find(f2)) },                    # Connect proc
           Proc.new { |f2s| folder.add_folder(EmsFolder.where(id: f2s).to_a) } ]             # Bulk connect proc
       end
 
@@ -366,7 +366,7 @@ module EmsRefresh::Refreshers::RefresherRelatsMixin
       do_relat_compare(:folders_to_clusters, prev_relats, new_relats) do |f|
         folder = EmsFolder.find(f)
         [ do_disconnect ? Proc.new { |c| folder.remove_cluster(EmsCluster.find(c)) } : nil, # Disconnect proc
-          Proc.new { |c| folder.add_cluster(EmsCluster.find_by_id(c)) },                    # Connect proc
+          Proc.new { |c| folder.add_cluster(EmsCluster.find(c)) },                    # Connect proc
           Proc.new { |cs| folder.add_cluster(EmsCluster.where(id: cs).to_a) } ]             # Bulk connect proc
       end
 

--- a/app/models/ems_refresh/refreshers/refresher_relats_mixin.rb
+++ b/app/models/ems_refresh/refreshers/refresher_relats_mixin.rb
@@ -358,16 +358,16 @@ module EmsRefresh::Refreshers::RefresherRelatsMixin
       do_relat_compare(:folders_to_folders, prev_relats, new_relats) do |f|
         folder = EmsFolder.find(f)
         [ do_disconnect ? Proc.new { |f2| folder.remove_folder(EmsFolder.find(f2)) } : nil, # Disconnect proc
-        Proc.new { |f2| folder.add_folder(EmsFolder.find_by_id(f2)) },                      # Connect proc
-        Proc.new { |f2s| folder.add_folder(EmsFolder.where(id: f2s).to_a) } ]               # Bulk connect proc
+          Proc.new { |f2| folder.add_folder(EmsFolder.find_by_id(f2)) },                    # Connect proc
+          Proc.new { |f2s| folder.add_folder(EmsFolder.where(id: f2s).to_a) } ]             # Bulk connect proc
       end
 
       # Do the Folders to Clusters relationships
       do_relat_compare(:folders_to_clusters, prev_relats, new_relats) do |f|
         folder = EmsFolder.find(f)
         [ do_disconnect ? Proc.new { |c| folder.remove_cluster(EmsCluster.find(c)) } : nil, # Disconnect proc
-        Proc.new { |c| folder.add_cluster(EmsCluster.find_by_id(c)) },                      # Connect proc
-        Proc.new { |cs| folder.add_cluster(EmsCluster.where(id: cs).to_a) } ]               # Bulk connect proc
+          Proc.new { |c| folder.add_cluster(EmsCluster.find_by_id(c)) },                    # Connect proc
+          Proc.new { |cs| folder.add_cluster(EmsCluster.where(id: cs).to_a) } ]             # Bulk connect proc
       end
 
       # Do the Folders to Hosts relationships


### PR DESCRIPTION
In EmsRefresh::LinkInventory, implemented "bulk connect" when creating connections between objects by passing the array of object id's to the add methods (add_folder, add_clusted, etc.) rather than multiple calls with one id per call. Initial large environment testing by the performance team showed a 75% performance increase on the initial inventory refresh.

https://bugzilla.redhat.com/show_bug.cgi?id=1243938