### PR TITLE
Session dashboard controller

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -168,15 +168,15 @@ class DashboardController < ApplicationController
     @dashboard = true
 
     g = current_group
-    db_order = if g.settings && g.settings[:dashboard_order]
-                 g.settings[:dashboard_order]
+    records =  if g.settings && g.settings[:dashboard_order]
+                 MiqWidgetSet.find_with_same_order(g.settings[:dashboard_order]).to_a
                else
-                 g.miq_widget_sets.sort_by { |a| a.name.downcase }.collect(&:id)
+                 g.miq_widget_sets.sort_by { |a| a.name.downcase }
                end
+    db_order = records.collect(&:id)
 
     @tabs = []
-    db_order.each_with_index do |d, i|
-      db = MiqWidgetSet.find_by_id(d)
+    records.each_with_index do |db, i|
       # load first one on intial load, or load tab from params[:tab] changed,
       # or when coming back from another screen load active tab from sandbox
       if (!params[:tab] && !@sb[:active_db_id] && i == 0) || (params[:tab] && params[:tab] == db.id.to_s) ||

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -171,16 +171,17 @@ class DashboardController < ApplicationController
     db_order = records.collect(&:id)
 
     @tabs = []
-    records.each_with_index do |db, i|
+    active_tab_id = (params[:tab] || @sb[:active_db_id]).try(:to_s)
+    active_tab = active_tab_id && records.detect { |r| r.id.to_s == active_tab_id } || records.first
       # load first one on intial load, or load tab from params[:tab] changed,
       # or when coming back from another screen load active tab from sandbox
-      if (!params[:tab] && !@sb[:active_db_id] && i == 0) || (params[:tab] && params[:tab] == db.id.to_s) ||
-         (!params[:tab] && @sb[:active_db_id] && @sb[:active_db_id].to_s == db.id.to_s) ||
-         (!db_order.include?(@sb[:active_db_id]) && !db_order.empty? && i == 0)
+      if db = active_tab
         @tabs.unshift([db.id.to_s, ""])
         @sb[:active_db]    = db.name
         @sb[:active_db_id] = db.id
       end
+
+    records.each do |db|
       @tabs.push([db.id.to_s, db.description])
       # check this only first time when user logs in comes to dashboard show
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -171,7 +171,7 @@ class DashboardController < ApplicationController
     db_order = if g.settings && g.settings[:dashboard_order]
                  g.settings[:dashboard_order]
                else
-                 MiqWidgetSet.find_all_by_owner_id(session[:group]).sort_by { |a| a.name.downcase }.collect(&:id)
+                 g.miq_widget_sets.sort_by { |a| a.name.downcase }.collect(&:id)
                end
 
     @tabs = []

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -168,18 +168,17 @@ class DashboardController < ApplicationController
     @dashboard = true
 
     records = current_group.ordered_widget_sets
-    db_order = records.collect(&:id)
 
     @tabs = []
     active_tab_id = (params[:tab] || @sb[:active_db_id]).try(:to_s)
     active_tab = active_tab_id && records.detect { |r| r.id.to_s == active_tab_id } || records.first
-      # load first one on intial load, or load tab from params[:tab] changed,
-      # or when coming back from another screen load active tab from sandbox
-      if db = active_tab
-        @tabs.unshift([db.id.to_s, ""])
-        @sb[:active_db]    = db.name
-        @sb[:active_db_id] = db.id
-      end
+    # load first one on intial load, or load tab from params[:tab] changed,
+    # or when coming back from another screen load active tab from sandbox
+    if active_tab
+      @tabs.unshift([active_tab.id.to_s, ""])
+      @sb[:active_db]    = active_tab.name
+      @sb[:active_db_id] = active_tab.id
+    end
 
     records.each do |db|
       @tabs.push([db.id.to_s, db.description])
@@ -220,7 +219,7 @@ class DashboardController < ApplicationController
     ws = create_user_dashboard(@sb[:active_db_id]) if ws.nil?
 
     # Set tabs now if user's group didnt have any dashboards using default dashboard
-    if db_order.empty?
+    if records.empty?
       db = MiqWidgetSet.find_by_id(@sb[:active_db_id])
       @tabs.unshift([ws.id.to_s, ""])
       @tabs.push([ws.id.to_s, db.description])

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -167,12 +167,7 @@ class DashboardController < ApplicationController
     @layout    = "dashboard"
     @dashboard = true
 
-    g = current_group
-    records =  if g.settings && g.settings[:dashboard_order]
-                 MiqWidgetSet.find_with_same_order(g.settings[:dashboard_order]).to_a
-               else
-                 g.miq_widget_sets.sort_by { |a| a.name.downcase }
-               end
+    records = current_group.ordered_widget_sets
     db_order = records.collect(&:id)
 
     @tabs = []

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -201,4 +201,12 @@ class MiqGroup < ActiveRecord::Base
   def description=(val)
     super(val.to_s.strip)
   end
+
+  def ordered_widget_sets
+    if settings && settings[:dashboard_order]
+      MiqWidgetSet.find_with_same_order(settings[:dashboard_order]).to_a
+    else
+      miq_widget_sets.sort_by { |a| a.name.downcase }
+    end
+  end
 end

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -73,4 +73,9 @@ class MiqWidgetSet < ActiveRecord::Base
       self.sync_from_dir
     end
   end
+
+  def self.find_with_same_order(ids)
+    recs = where(:id => ids).index_by(&:id)
+    ids.map { |id| recs[id.to_i] }
+  end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -275,4 +275,23 @@ describe MiqGroup do
       expect(group_without_tenant.reload.tenant_owner).to eq(root_tenant)
     end
   end
+
+  context "#ordered_widget_sets" do
+    let(:group) { FactoryGirl.create(:miq_group) }
+    it "uses dashboard_order if present" do
+      ws1 = FactoryGirl.create(:miq_widget_set, :name => 'A1', :owner => group)
+      ws2 = FactoryGirl.create(:miq_widget_set, :name => 'C3', :owner => group)
+      ws3 = FactoryGirl.create(:miq_widget_set, :name => 'B2', :owner => group)
+      group.update_attributes(:settings => {:dashboard_order => [ws3.id.to_s, ws1.id.to_s]})
+
+      expect(group.ordered_widget_sets).to eq([ws3, ws1])
+    end
+
+    it "uses all owned widgets" do
+      ws1 = FactoryGirl.create(:miq_widget_set, :name => 'A1', :owner => group)
+      ws2 = FactoryGirl.create(:miq_widget_set, :name => 'C3', :owner => group)
+      ws3 = FactoryGirl.create(:miq_widget_set, :name => 'B2', :owner => group)
+      expect(group.ordered_widget_sets).to eq([ws1, ws3, ws2])
+    end
+  end
 end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -76,4 +76,18 @@ describe MiqWidgetSet do
       expect(described_class.with_users).to eq([ws_1])
     end
   end
+
+  context ".find_with_same_order" do
+    it "returns in index order" do
+      g1 = FactoryGirl.create(:miq_widget_set)
+      g2 = FactoryGirl.create(:miq_widget_set)
+      expect(MiqWidgetSet.find_with_same_order([g1.id.to_s, g2.id.to_s])).to eq([g1, g2])
+    end
+
+    it "returns in non index order" do
+      g1 = FactoryGirl.create(:miq_widget_set)
+      g2 = FactoryGirl.create(:miq_widget_set)
+      expect(MiqWidgetSet.find_with_same_order([g2.id.to_s, g1.id.to_s])).to eq([g2, g1])
+    end
+  end
 end


### PR DESCRIPTION
Goal: pull out `session[:group]`. no ui change.

1. Remove `session[:group]` from the dashboard_controller.
2. Remove n+1 query on `WorkSpaceSet`. Added specs after the fact.
3. Removed current active tab logic from loop to simplify it. @matthewd coached me here and it feels like a good change.

To be honest, I only need the `session[:group]` fix.
But felt I needed to clean up the code around that fix. I can throw that away if you want.
I did remove one N+1 query, but there are a few more in there.

/cc @dclarizio @martinpovolny Let me know if there is a better way to refactor this / share it.