### PR TITLE
Remove selective hiding of container filters

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -742,7 +742,6 @@ class ConfigurationController < ApplicationController
       }
     when 'ui_3'
       current = MiqSearch.where(:search_type => "default")
-                         .select  { |s| allowed_filter_db?(s.db) }
                          .sort_by { |s| [NAV_TAB_PATH[s.db.downcase.to_sym], s.description.downcase] }
       @edit = {
         :key         => 'config_edit__ui3',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1213,11 +1213,6 @@ module ApplicationHelper
     role_allows(:feature => start_page, :any => true)
   end
 
-  def allowed_filter_db?(db)
-    return false if db.start_with?('Container') && !get_vmdb_config[:product][:containers]
-    true
-  end
-
   def miq_tab_header(id, active = nil, options = {}, &block)
     content_tag(:li,
                 :class     => "#{options[:class]} #{active == id ? 'active' : ''}",


### PR DESCRIPTION
Since commit 10760c80345cfff8ec27cc38097385f2b850e6cb
enabled containers UI by default,
hiding container related filters is no longer needed.