### PR TITLE
Fix non-deterministic coverage.. maybe

### DIFF
--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe "Server Environment Management" do
   context ".spartan_mode" do
     before(:each) { MiqServer.class_eval {instance_variable_set :@spartan_mode, nil } }
+    after(:each) { MiqServer.class_eval {instance_variable_set :@spartan_mode, nil } }
 
     it "when ENV['MIQ_SPARTAN'] is not set" do
       ENV.stub(:[]).with('MIQ_SPARTAN').and_return(nil)
@@ -47,6 +48,7 @@ describe "Server Environment Management" do
 
   context ".minimal_env_options" do
     before(:each) { MiqServer.class_eval {instance_variable_set :@minimal_env_options, nil } }
+    after(:each) { MiqServer.class_eval {instance_variable_set :@minimal_env_options, nil } }
 
     it "when spartan_mode is 'minimal'" do
       MiqServer.stub(:spartan_mode).and_return("minimal")


### PR DESCRIPTION
AFAICS, whichever of these tests runs last would leave its value cached in `@spartan_mode` -- which can then affect [seemingly unrelated code](https://github.com/ManageIQ/manageiq/blob/ca5964cd1fff0ca661d2272c1ccec10662bd5a26/app/models/miq_worker.rb#L53).

I haven't really proven it's the source of the problem, but it sure sounds plausible. ¯\\\_(ツ)_/¯ 