### PR TITLE
Add trollop to cfme client gemfile

### DIFF
--- a/gems/pending/cfme_client/Gemfile
+++ b/gems/pending/cfme_client/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem "rack"
 gem "faraday"
 gem "faraday_middleware"
+gem "trollop"
 gem "activesupport", "~>3.2.17"
 gem "more_core_extensions", "~>1.2.0"
 


### PR DESCRIPTION
This is a project dependency but was missing from the gemfile.

...Unless I'm mistaken. cc/ @abellotti 