### PR TITLE
Support migrating from old v2_key to a new one

### DIFF
--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -169,7 +169,7 @@ describe MiqPassword do
     end
 
     it "should fail on recrypt bad password" do
-      expect { MiqPassword.new.recrypt("v2:{55555}") }.to raise_error
+      expect { MiqPassword.new.recrypt("v2:{55555}") }.to raise_error(MiqPassword::MiqPasswordError)
     end
 
     it "should decrypt passwords with newlines" do
@@ -181,7 +181,9 @@ describe MiqPassword do
 
   context "with missing v1_key" do
     it "should report decent error when decryption with missing an encryption key" do
-      expect { described_class.decrypt("v1:{KSOqhNiOWJbR0lz7v6PTJg==}") }.to raise_error("no encryption key v1_key")
+      expect {
+        described_class.decrypt("v1:{KSOqhNiOWJbR0lz7v6PTJg==}")
+      }.to raise_error(MiqPassword::MiqPasswordError, /can not decrypt.*v1_key/)
     end
   end
 

--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -300,6 +300,16 @@ describe MiqPassword do
       expect(MiqPassword.all_keys.size).to eq(2)
     end
 
+    it "supports relative path" do
+      with_key do |dir, filename|
+        Dir.chdir dir do
+          expect(MiqPassword.all_keys.size).to eq(1)
+          MiqPassword.add_legacy_key(filename)
+          expect(MiqPassword.all_keys.size).to eq(2)
+        end
+      end
+    end
+
     it "supports root_key path (also warns if v2 key not found)" do
       with_key do |dir, filename|
         MiqPassword.key_root = dir

--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require 'util/miq-password'
+require 'tempfile'
 
 describe MiqPassword do
   before do
@@ -245,20 +246,22 @@ describe MiqPassword do
       MiqPassword.key_root = nil
 
       expect(Kernel).to receive(:warn).with(/v2_key doesn't exist/)
-      expect(MiqPassword.all_keys).to eq([nil])
+      expect(MiqPassword.all_keys).to be_empty
     end
   end
 
   describe ".clear_keys" do
-    it "clears legacy_keys" do
+    it "removes legacy keys from all_keys" do
       v0 = MiqPassword.add_legacy_key("v0_key", :v0)
       v1 = MiqPassword.add_legacy_key("v1_key")
+      v2 = MiqPassword.v2_key
 
-      expect(MiqPassword.legacy_keys).to match_array([v0, v1])
+      expect(MiqPassword.all_keys).to match_array([v2, v1, v0])
 
       MiqPassword.clear_keys
 
-      expect(MiqPassword.legacy_keys).to be_empty
+      v2 = MiqPassword.v2_key
+      expect(MiqPassword.all_keys).to match_array([v2])
     end
   end
 
@@ -271,6 +274,50 @@ describe MiqPassword do
 
     it "when present" do
       expect(MiqPassword.v2_key.to_s).to eq "5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g="
+    end
+  end
+
+  describe ".add_legacy_key" do
+    let(:v0_key)  { CryptString.new(nil, "AES-128-CBC", "9999999999999999", "5555555555555555") }
+    let(:v1_key)  { MiqPassword.generate_symmetric }
+
+    it "ignores bad key filename" do
+      expect(MiqPassword.all_keys.size).to eq(1)
+      MiqPassword.add_legacy_key("some_bogus_name")
+      expect(MiqPassword.all_keys.size).to eq(1)
+    end
+
+    it "supports raw key" do
+      expect(MiqPassword.all_keys.size).to eq(1)
+      MiqPassword.add_legacy_key(v1_key)
+      expect(MiqPassword.all_keys.size).to eq(2)
+    end
+
+    it "supports absolute path" do
+      with_key do |dir, filename|
+        MiqPassword.add_legacy_key("#{dir}/#{filename}")
+      end
+      expect(MiqPassword.all_keys.size).to eq(2)
+    end
+
+    it "supports root_key path (also warns if v2 key not found)" do
+      with_key do |dir, filename|
+        MiqPassword.key_root = dir
+        # NOTE: no v2_key in this key_root
+        expect(Kernel).to receive(:warn).with(/doesn't exist/)
+        expect(MiqPassword.all_keys.size).to eq(0)
+        MiqPassword.add_legacy_key(filename)
+        expect(MiqPassword.all_keys.size).to eq(1)
+      end
+    end
+  end
+
+  private
+
+  def with_key
+    Dir.mktmpdir('test-key-root') do |d|
+      MiqPassword.generate_symmetric.store("#{d}/my-key")
+      yield d, "my-key"
     end
   end
 

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -18,8 +18,9 @@ class MiqPassword
     @encStr = encrypt(str)
   end
 
-  def encrypt(str)
-    encrypt_version_2(str)
+  def encrypt(str, ver = "v2", key = self.class.v2_key)
+    value = key.encrypt64(str).delete("\n") unless str.nil? || str.empty?
+    "#{ver}:{#{value}}"
   end
 
   def decrypt(str)
@@ -195,16 +196,6 @@ EOS
       params = YAML.load_file(filename)
       CryptString.new(nil, params[:algorithm], params[:key], params[:iv])
     end
-  end
-
-  def encrypt_version_2(str)
-    return "v2:{}" if str.nil? || str.empty?
-    "v2:{#{self.class.v2_key.encrypt64(str).chomp.gsub("\n", "")}}"
-  end
-
-  def encrypt_version_1(str)
-    return "v1:{}" if str.nil? || str.empty?
-    "v1:{#{self.class.v1_key.encrypt64(str).chomp}}"
   end
 
   def self.extract_erb_encrypted_value(value)

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -183,7 +183,10 @@ EOS
 
   def self.ez_load(filename, recent = true)
     return filename if filename.respond_to?(:decrypt64)
-    filename = File.expand_path(filename, key_root)
+
+    # if it is an absolute path, or relative to pwd, leave as is
+    # otherwise, look in key root for it
+    filename = File.expand_path(filename, key_root) unless File.exist?(filename)
     if !File.exist?(filename)
       nil
     elsif recent

--- a/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
@@ -21,7 +21,7 @@ describe MiqAePassword do
     end
 
     it "throws understandable error" do
-      expect { described_class.decrypt("v1:{something}") }.to raise_error("no encryption key v1_key")
+      expect { described_class.decrypt("v1:{something}") }.to raise_error(MiqAePassword::MiqPasswordError)
     end
   end
 

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -60,7 +60,7 @@ describe FixAuth::AuthConfigModel do
     end
 
     it "should fail on bad passwords" do
-      expect { subject.fix_passwords(config_with_bad_password) }.to raise_error
+      expect { subject.fix_passwords(config_with_bad_password) }.to raise_error(MiqPassword::MiqPasswordError)
     end
 
     it "should replace bad passwords" do

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -9,7 +9,7 @@ require "fix_auth/models"
 describe FixAuth::AuthConfigModel do
   let(:v1_key)  { MiqPassword.generate_symmetric }
   let(:pass)    { "password" }
-  let(:enc_v1)  { MiqPassword.new.send(:encrypt_version_1, pass) }
+  let(:enc_v1)  { MiqPassword.new.encrypt(pass, "v1", v1_key) }
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
 
   before do

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -100,7 +100,7 @@ describe FixAuth::AuthModel do
       end
 
       it "should raise exception for bad encryption" do
-        expect { subject.fix_passwords(badv2) }.to raise_error("not decryptable string")
+        expect { subject.fix_passwords(badv2) }.to raise_error(MiqPassword::MiqPasswordError)
       end
 
       it "should replace for bad encryption" do

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -10,8 +10,8 @@ describe FixAuth::AuthModel do
   let(:v0_key)  { CryptString.new(nil, "AES-128-CBC", "9999999999999999", "5555555555555555") }
   let(:v1_key)  { MiqPassword.generate_symmetric }
   let(:pass)    { "password" }
-  let(:enc_v1)  { MiqPassword.new.send(:encrypt_version_1, pass) }
-  let(:enc_v2)  { MiqPassword.new.send(:encrypt_version_2, pass) }
+  let(:enc_v1)  { MiqPassword.new.encrypt(pass, "v1", v1_key) }
+  let(:enc_v2)  { MiqPassword.new.encrypt(pass) }
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
   let(:enc_leg) { v0_key.encrypt64(pass) }
 

--- a/spec/tools/fix_auth/cli_spec.rb
+++ b/spec/tools/fix_auth/cli_spec.rb
@@ -65,6 +65,18 @@ describe FixAuth::Cli do
       expect(opts).to eq(:db => true, :databaseyml => true, :key => true)
     end
 
+    it "parses legacy_keys" do
+      opts = described_class.new.parse(%w(--legacy-key v2.bak -K v2.bakbak))
+             .options.slice(:legacy_key)
+      expect(opts).to eq(:legacy_key => %w(v2.bak v2.bakbak))
+    end
+
+    it "parses without legacy_keys specified" do
+      opts = described_class.new.parse(%w())
+             .options.slice(:legacy_key)
+      expect(opts[:legacy_key] || []).to eq([])
+    end
+
     describe "v2" do
       it "exists" do
         expect { described_class.new.parse(%w(--v2)) }.not_to raise_error

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -23,6 +23,7 @@ module FixAuth
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w{.. ..})))
         opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false
         opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
+        opt :legacy_key, "Legacy Key",      :type => :string, :short => "K", :multi => true
       end
 
       options[:databases] = args.presence || %w(vmdb_production)

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -79,6 +79,11 @@ module FixAuth
       MiqPassword.key_root = cert_dir if cert_dir
       MiqPassword.add_legacy_key("v0_key", :v0)
       MiqPassword.add_legacy_key("v1_key", :v1)
+      (options[:legacy_key] || []).each do |k|
+        unless MiqPassword.add_legacy_key(k)
+          puts "WARNING: key #{k} not found"
+        end
+      end
     end
 
     def run


### PR DESCRIPTION
This allows us to migrate from one v2_key to another

1. external classes and specs no longer rely upon a key's version number.
2. allow any number of legacy keys to be present
3. GOAL: fix auth can migrate a database from one v2_key to another. (see bz)

/cc @jrafanie 

https://bugzilla.redhat.com/show_bug.cgi?id=1159009