### PR TITLE
Fix Fog deprecation warnings

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -64,7 +64,7 @@ module ManageIQ
         # TODO(lsmola) loading this from already obtained nested stack hierarchy will be more effective. This is one
         # extra API call. But we will need to change order of loading, so we have all resources first.
         # Nested depth 50 just for sure, although nobody should nest templates that much
-        @orchestration_service.list_resources(stack, :nested_depth => 50).body['resources']
+        @orchestration_service.list_resources(:stack => stack, :nested_depth => 50).body['resources']
       end
 
       def servers

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -107,7 +107,7 @@ module ManageIQ
       end
 
       def hosts_ports
-        @hosts_ports ||= @baremetal_service.ports.details
+        @hosts_ports ||= @baremetal_service.ports.all
       end
 
       def load_hosts

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -72,7 +72,7 @@ module ManageIQ
       end
 
       def hosts
-        @hosts ||= @baremetal_service.nodes.details
+        @hosts ||= @baremetal_service.nodes.all
       end
 
       def clouds

--- a/gems/pending/openstack/openstack_handle/image_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/image_delegate.rb
@@ -11,13 +11,13 @@ module OpenstackHandle
     end
 
     def images_with_pagination_loop
-      all_images = images.details
+      all_images = images.all
       last_image = all_images.last
 
       # There is always default pagination in Glance, so we obtain all
       # the images in loop, using last image of each page as marker.
       if last_image
-        while (images = self.images.details('marker', last_image.id)).count > 0
+        while (images = self.images.all(:marker => last_image.id)).count > 0
           last_image = images.last
           all_images.concat(images)
         end


### PR DESCRIPTION
Fix several Fog deprecation warnings:

* Calling OpenStack[:orchestration].list_resources(stack, options) is deprecated, call .list_resources(:stack => stack) or .list_resources(:stack_name => value, :stack_id => value) instead
* Calling OpenStack[:baremetal].nodes.details will be removed, call .nodes.all for detailed list.
* Calling OpenStack[:baremetal].ports.details will be removed, call .ports.all for detailed list.
* Calling OpenStack[:glance].images.details will be removed, call .images.all for detailed list.

There are only 3 left, but those three *really* hit us hard.  Unfortunately, they're the result of Fog code calling deprecated Fog methds.  I submitted a couple PRs to Fog to handle those:

* https://github.com/fog/fog/pull/3678
* https://github.com/fog/fog/pull/3677