### PR TITLE
Fix bug where attr_writer was overriding the key_root= method.

### DIFF
--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -223,7 +223,7 @@ describe MiqPassword do
     expect(x).to eq("some :password: ******** and another :password: ********")
   end
 
-  context ".key_root" do
+  context ".key_root / .key_root=" do
     it "defaults key_root" do
       expect(ENV).to receive(:[]).with("KEY_ROOT").and_return("/certs")
       MiqPassword.key_root = nil
@@ -234,6 +234,22 @@ describe MiqPassword do
       expect(ENV).not_to receive(:[])
       MiqPassword.key_root = "/abc"
       expect(MiqPassword.key_root).to eq("/abc")
+    end
+
+    it "clears key caches" do
+      MiqPassword.add_legacy_key("v0_key", :v0)
+      MiqPassword.add_legacy_key("v1_key")
+      MiqPassword.v2_key
+
+      expect(MiqPassword.v0_key).to_not be_nil
+      expect(MiqPassword.v1_key).to_not be_nil
+      expect(MiqPassword.v2_key).to_not be_false
+
+      MiqPassword.key_root = nil
+
+      expect(MiqPassword.v0_key).to be_nil
+      expect(MiqPassword.v1_key).to be_nil
+      expect(MiqPassword.v2_key).to be_false
     end
   end
 

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -109,6 +109,10 @@ class MiqPassword
     end
   end
 
+  def self.key_root
+    @key_root ||= ENV["KEY_ROOT"]
+  end
+
   def self.key_root=(key_root)
     @v2_key = @v1_key = @v0_key = nil
     @key_root = key_root
@@ -177,13 +181,6 @@ class MiqPassword
 
   def decrypt_version_0(str)
     self.class.v0_key.decrypt64(str)
-  end
-
-  class << self
-    attr_writer :key_root
-    def key_root
-      @key_root ||= ENV["KEY_ROOT"]
-    end
   end
 
   def self.extract_erb_encrypted_value(value)


### PR DESCRIPTION
Extracted from #4082 

@kbrock please review...@fryguy and I fixed an issue where the `key_root=` class method was being 

:v: whacked :v: 

by the `attr_writer`, causing the v*_key caches to not be reset via `key_root=`, particularly during tests.

I ran into this "bug" locally for seemingly unrelated tests and couldn't track it down previously:
`bin/rspec gems/pending/spec/util/miq-password_spec.rb spec/models/miq_server/rhn_mirror_spec.rb --seed 46323`

It's weird to run gems/pending tests with models but I was doing it for changes that affected all of miq_server and util.

This test would run the miq-password spec first, reset the `key_root`, not clear out the v*_key, and subsequent tests that run `MiqDatabase.seed` such as rhn_mirror_spec.rb would fail with seemingly cryptic errors like: 

```
     Failure/Error: it("#decrypt")        { expect(MiqPassword.new.decrypt(enc_v2)).to           be_decrypted(pass) }
     OpenSSL::Cipher::CipherError:
       bad decrypt
```

Or 
```
     Failure/Error: it("#recrypt legacy") { expect(MiqPassword.new.recrypt(enc_v0)).to eq(enc_v2) }

       expected: "v2:{27X41c6xqCCdVcw4LlQ1Qg==}"
            got: "v2:{kGuPkrN8fYq0cJPTjytisw==}"
```

These tests now don't randomly fail with this PR.
