### PR TITLE
[api] Adding support for Dialog Queries

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -65,6 +65,7 @@ class ApiController < ApplicationController
   include_concern 'RequestTasks'
   include_concern 'Roles'
   include_concern 'ServiceCatalogs'
+  include_concern 'ServiceDialogs'
   include_concern 'ServiceRequests'
   include_concern 'Software'
   include_concern 'ServiceTemplates'

--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -1,0 +1,18 @@
+class ApiController
+  module ServiceDialogs
+    #
+    # Service Dialogs
+    #
+
+    def service_dialogs_query_resource(object)
+      object ? object.dialogs : []
+    end
+
+    def show_service_dialogs
+      if @req[:s_id] || expand?(:resources) || attribute_selection == "all"
+        @req[:additional_attributes] = %w(content)
+      end
+      show_generic(:service_dialogs)
+    end
+  end
+end

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -9,6 +9,7 @@ class Dialog < ActiveRecord::Base
   include DialogMixin
   include ReportableMixin
   has_many   :resource_actions
+  virtual_has_one :content, :class_name => "Hash"
 
   before_destroy          :reject_if_has_resource_actions
   validates_uniqueness_of :label
@@ -74,6 +75,10 @@ class Dialog < ActiveRecord::Base
 
   def field(name)
     dialog_field_hash[name.to_s]
+  end
+
+  def content
+    DialogSerializer.new.serialize(Array[self])
   end
 
   private

--- a/app/models/dialog_serializer.rb
+++ b/app/models/dialog_serializer.rb
@@ -1,0 +1,27 @@
+class DialogSerializer < Serializer
+  EXCLUDED_ATTRIBUTES = %w(created_at id updated_at)
+
+  def initialize(dialog_tab_serializer = DialogTabSerializer.new)
+    @dialog_tab_serializer = dialog_tab_serializer
+  end
+
+  def serialize(dialogs)
+    serialize_dialogs(dialogs)
+  end
+
+  private
+
+  def serialize_dialog_tabs(dialog_tabs)
+    dialog_tabs.map do |dialog_tab|
+      @dialog_tab_serializer.serialize(dialog_tab)
+    end
+  end
+
+  def serialize_dialogs(dialogs)
+    dialogs.map do |dialog|
+      serialized_dialog_tabs = serialize_dialog_tabs(dialog.dialog_tabs)
+
+      included_attributes(dialog.attributes).merge("dialog_tabs" => serialized_dialog_tabs)
+    end
+  end
+end

--- a/app/models/dialog_yaml_serializer.rb
+++ b/app/models/dialog_yaml_serializer.rb
@@ -1,27 +1,5 @@
-class DialogYamlSerializer < Serializer
-  EXCLUDED_ATTRIBUTES = ["created_at", "id", "updated_at"]
-
-  def initialize(dialog_tab_serializer = DialogTabSerializer.new)
-    @dialog_tab_serializer = dialog_tab_serializer
-  end
-
+class DialogYamlSerializer < DialogSerializer
   def serialize(dialogs)
-    serialize_dialogs(dialogs).to_yaml
-  end
-
-  private
-
-  def serialize_dialog_tabs(dialog_tabs)
-    dialog_tabs.map do |dialog_tab|
-      @dialog_tab_serializer.serialize(dialog_tab)
-    end
-  end
-
-  def serialize_dialogs(dialogs)
-    dialogs.map do |dialog|
-      serialized_dialog_tabs = serialize_dialog_tabs(dialog.dialog_tabs)
-
-      included_attributes(dialog.attributes).merge("dialog_tabs" => serialized_dialog_tabs)
-    end
+    super.to_yaml
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,6 +5,8 @@ class Service < ActiveRecord::Base
   belongs_to :service                        # Parent Service
   has_many :services, :dependent => :destroy # Child services
 
+  has_many :dialogs, -> { uniq }, :through => :service_template
+
   virtual_belongs_to :parent_service
   virtual_has_many   :direct_service_children
   virtual_has_many   :all_service_children

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -19,6 +19,8 @@ class ServiceTemplate < ActiveRecord::Base
   has_many   :custom_button_sets, :as => :owner, :dependent => :destroy
   belongs_to :service_template_catalog
 
+  has_many   :dialogs, -> { uniq }, :through => :resource_actions
+
   virtual_has_many :custom_buttons
   virtual_column   :type_display,                 :type => :string
   virtual_column   :template_valid,               :type => :boolean

--- a/config/api.yml
+++ b/config/api.yml
@@ -416,6 +416,12 @@
         :identifier: ems_infra_protect
       - :name: unassign
         :identifier: ems_infra_protect
+  :provision_dialogs:
+    :description: Provisioning Dialogs
+    :options:
+    - :collection
+    :methods: *70174834086080
+    :klass: MiqDialog
   :provision_requests:
     :description: Provision Requests
     :options:
@@ -584,6 +590,13 @@
       :delete:
       - :name: delete
         :identifier: st_catalog_delete
+  :service_dialogs:
+    :description: Service Dialogs
+    :options:
+    - :collection
+    - :subcollection
+    :methods: *70174834086080
+    :klass: Dialog
   :service_requests:
     :description: Service Requests
     :options:
@@ -606,6 +619,7 @@
     :subcollections:
     - :tags
     - :service_requests
+    - :service_dialogs
     :collection_actions:
       :post:
       - :name: edit
@@ -658,6 +672,7 @@
     :klass: Service
     :subcollections:
     - :tags
+    - :service_dialogs
     :collection_actions:
       :post:
       - :name: edit

--- a/spec/models/dialog_serializer_spec.rb
+++ b/spec/models/dialog_serializer_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe DialogSerializer do
+  let(:dialog_tab_serializer) { auto_loaded_instance_double("DialogTabSerializer") }
+  let(:dialog_serializer) { described_class.new(dialog_tab_serializer) }
+
+  describe "#serialize" do
+    let(:buttons) { "the buttons" }
+    let(:description) { "the description" }
+    let(:dialog_tab1) { DialogTab.new }
+    let(:dialog_tab2) { DialogTab.new }
+    let(:label) { "the label" }
+
+    let(:dialog) do
+      Dialog.new(
+        :buttons     => buttons,
+        :description => description,
+        :dialog_tabs => [dialog_tab1, dialog_tab2],
+        :label       => label
+      )
+    end
+
+    let(:dialogs) { [dialog] }
+
+    let(:expected_data) do
+      [{
+        "description" => description,
+        "buttons"     => buttons,
+        "label"       => label,
+        "dialog_tabs" => %w(serialized_dialog1 serialized_dialog2)
+      }]
+    end
+
+    before do
+      dialog_tab_serializer.stub(:serialize).with(dialog_tab1).and_return("serialized_dialog1")
+      dialog_tab_serializer.stub(:serialize).with(dialog_tab2).and_return("serialized_dialog2")
+    end
+
+    it "serializes the dialog" do
+      dialog_serializer.serialize(dialogs).should == expected_data
+    end
+  end
+end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -105,6 +105,11 @@ describe ApiController do
       test_collection_query(:providers, providers_url, ExtManagementSystem, :guid)
     end
 
+    it "query Provision Dialogs" do
+      FactoryGirl.create(:miq_dialog)
+      test_collection_query(:provision_dialogs, provision_dialogs_url, MiqDialog)
+    end
+
     it "query Provision Requests" do
       FactoryGirl.create(:miq_provision_request, :source => template, :userid => api_config(:user))
       test_collection_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
@@ -151,13 +156,18 @@ describe ApiController do
     end
 
     it "query Servers" do
-      miq_server  # create resource
+      miq_server # create resource
       test_collection_query(:servers, servers_url, MiqServer, :guid)
     end
 
     it "query Service Catalogs" do
       FactoryGirl.create(:service_template_catalog)
       test_collection_query(:service_catalogs, service_catalogs_url, ServiceTemplateCatalog)
+    end
+
+    it "query Service Dialogs" do
+      FactoryGirl.create(:dialog, :label => "ServiceDialog1")
+      test_collection_query(:service_dialogs, service_dialogs_url, Dialog)
     end
 
     it "query Service Requests" do
@@ -186,7 +196,7 @@ describe ApiController do
     end
 
     it "query Templates" do
-      template  # create resource
+      template # create resource
       test_collection_query(:templates, templates_url, MiqTemplate, :guid)
     end
 

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -1,0 +1,87 @@
+#
+# REST API Request Tests - Service Dialogs specs
+#
+require 'spec_helper'
+
+describe ApiController do
+  include Rack::Test::Methods
+
+  let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
+  let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
+  let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
+  let(:host)       { FactoryGirl.create(:host) }
+
+  let(:dialog1)    { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
+  let(:dialog2)    { FactoryGirl.create(:dialog, :label => "ServiceDialog2") }
+
+  let(:ra1)        { FactoryGirl.create(:resource_action, :dialog => dialog1) }
+  let(:ra2)        { FactoryGirl.create(:resource_action, :dialog => dialog2) }
+
+  let(:template)   { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
+  let(:service)    { FactoryGirl.create(:service, :name => "Service1") }
+
+  before(:each) do
+    init_api_spec_env
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  context "Service Dialogs collection" do
+    before do
+      template.resource_actions = [ra1, ra2]
+      api_basic_authorize
+    end
+
+    it "query only returns href" do
+      run_get service_dialogs_url
+
+      expect_query_result(:service_dialogs, Dialog.count, Dialog.count)
+      expect_result_resources_to_have_only_keys("resources", %w(href))
+    end
+
+    it "query with expanded resources to include content" do
+      run_get service_dialogs_url, :expand => "resources"
+
+      expect_query_result(:service_dialogs, Dialog.count, Dialog.count)
+      expect_result_resources_to_include_keys("resources", %w(id href label content))
+    end
+
+    it "query single dialog to include content" do
+      run_get service_dialogs_url(dialog1.id)
+
+      expect_single_resource_query(
+        "id"    => dialog1.id,
+        "href"  => service_dialogs_url(dialog1.id),
+        "label" => dialog1.label
+      )
+      expect_result_to_have_keys(%w(content))
+    end
+  end
+
+  context "Service Dialogs subcollection" do
+    before do
+      template.resource_actions = [ra1, ra2]
+      api_basic_authorize
+    end
+
+    it "query all service dialogs of a Service Template" do
+      run_get "#{service_templates_url(template.id)}/service_dialogs", :expand => "resources"
+
+      dialogs = template.dialogs
+      expect_query_result(:service_dialogs, dialogs.count, dialogs.count)
+      expect_result_resources_to_include_data("resources", "label" => dialogs.pluck(:label))
+    end
+
+    it "query all service dialogs of a Service" do
+      service.update_attributes!(:service_template_id => template.id)
+
+      run_get "#{services_url(service.id)}/service_dialogs", :expand => "resources"
+
+      dialogs = service.dialogs
+      expect_query_result(:service_dialogs, dialogs.count, dialogs.count)
+      expect_result_resources_to_include_data("resources", "label" => dialogs.pluck(:label))
+    end
+  end
+end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -99,12 +99,12 @@ module ApiSpecHelper
     Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
     @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
-    collections  = %w(automation_requests availability_zones chargebacks clusters conditions
-                      data_stores events features flavors groups hosts policies policy_actions
-                      policy_profiles providers provision_requests rates reports request_tasks
-                      requests resource_pools results roles security_groups servers service_catalogs
-                      service_requests service_templates services tags tasks templates users
-                      vms zones)
+    collections = %w(automation_requests availability_zones chargebacks clusters conditions
+                     data_stores events features flavors groups hosts policies policy_actions
+                     policy_profiles providers provision_dialogs provision_requests rates
+                     reports request_tasks requests resource_pools results roles security_groups
+                     servers service_dialogs service_catalogs service_requests service_templates
+                     services tags tasks templates users vms zones)
 
     define_entrypoint_url_methods
     define_url_methods(collections)


### PR DESCRIPTION
- Primary /api/service_dialogs collection queries
- Primary /api/provision_dialogs collection queries
- Making DialogYamlSerializer a generic DialogSerializer
- Updating DialogYamlSerializer to subclass DialogSerializer
- Adding content virtual attribute to Dialog to mimic provision dialogs
- Adding virtual reflection :dialogs to service_template and service
- Adding service_dialogs.rb to fetch the dialog content when expanding resource
- Subcollection /api/service_templates/:id/service_dialogs
- Subcollection /api/services/:id/service_dialogs

https://trello.com/c/88TGJWqP