### PR TITLE
Migration auto includes

### DIFF
--- a/spec/migrations/20131107000917_expand_dialog_field_default_value_size_spec.rb
+++ b/spec/migrations/20131107000917_expand_dialog_field_default_value_size_spec.rb
@@ -1,12 +1,11 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20131107000917_expand_dialog_field_default_value_size.rb")
+require_migration
 
 describe ExpandDialogFieldDefaultValueSize do
   let(:dialog_field_stub) { migration_stub(:DialogField) }
   let(:reserve_stub)      { MigrationSpecStubs.reserved_stub }
 
   migration_context :up do
-
     it "should convert default_value to text type" do
       dialog_field_stub.columns_hash['default_value'].type.should == :string
       migrate

--- a/spec/migrations/20131118232818_encrypt_miq_database_registration_http_proxy_password_field_spec.rb
+++ b/spec/migrations/20131118232818_encrypt_miq_database_registration_http_proxy_password_field_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20131118232818_encrypt_miq_database_registration_http_proxy_password_field.rb")
+require_migration
 
 describe EncryptMiqDatabaseRegistrationHttpProxyPasswordField do
   let(:miq_database_stub) { migration_stub(:MiqDatabase) }

--- a/spec/migrations/20131121211455_change_options_in_miq_alert_spec.rb
+++ b/spec/migrations/20131121211455_change_options_in_miq_alert_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join('db/migrate/20131121211455_change_options_in_miq_alert.rb')
+require_migration
 
 describe ChangeOptionsInMiqAlert do
 

--- a/spec/migrations/20131125153220_import_provision_dialogs_spec.rb
+++ b/spec/migrations/20131125153220_import_provision_dialogs_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
-
-require Rails.root.join("db/migrate/20131125153220_import_provision_dialogs.rb")
+require_migration
 
 describe ImportProvisionDialogs do
   let(:miq_dialog_stub) { migration_stub(:MiqDialog) }

--- a/spec/migrations/20131210202928_update_log_collection_path_in_configurations_settings_spec.rb
+++ b/spec/migrations/20131210202928_update_log_collection_path_in_configurations_settings_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20131210202928_update_log_collection_path_in_configurations_settings")
+require_migration
 
 describe UpdateLogCollectionPathInConfigurationsSettings do
   let(:configuration_stub) { migration_stub(:Configuration) }

--- a/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
+++ b/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb")
+require_migration
 
 describe FixReplicationOnUpgradeFromVersionFour do
   let(:configuration_stub)  { migration_stub(:Configuration) }

--- a/spec/migrations/20140121213913_split_widget_set_name_to_three_columns_spec.rb
+++ b/spec/migrations/20140121213913_split_widget_set_name_to_three_columns_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140121213913_split_widget_set_name_to_three_columns.rb")
+require_migration
 
 describe SplitWidgetSetNameToThreeColumns do
   migration_context :up do

--- a/spec/migrations/20140201040548_add_update_repo_name_to_miq_database_spec.rb
+++ b/spec/migrations/20140201040548_add_update_repo_name_to_miq_database_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140201040548_add_update_repo_name_to_miq_database.rb")
+require_migration
 
 describe AddUpdateRepoNameToMiqDatabase do
   let(:db_stub)      { migration_stub(:MiqDatabase) }

--- a/spec/migrations/20140214191729_enhance_firewall_rules_for_neutron_networking_spec.rb
+++ b/spec/migrations/20140214191729_enhance_firewall_rules_for_neutron_networking_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140214191729_enhance_firewall_rules_for_neutron_networking.rb")
+require_migration
 
 describe EnhanceFirewallRulesForNeutronNetworking do
   let(:firewall_rule_stub) { migration_stub(:FirewallRule) }

--- a/spec/migrations/20140301034340_leverage_authentications_for_registration_http_proxy_credentials_spec.rb
+++ b/spec/migrations/20140301034340_leverage_authentications_for_registration_http_proxy_credentials_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require Rails.root.join("db/migrate/20140301034340_leverage_authentications_for_registration_http_proxy_credentials.rb")
+require_migration
 
 describe LeverageAuthenticationsForRegistrationHttpProxyCredentials do
   let(:auth_stub) { migration_stub(:Authentication) }

--- a/spec/migrations/20140402134329_change_utc_time_profile_type_to_global_spec.rb
+++ b/spec/migrations/20140402134329_change_utc_time_profile_type_to_global_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
-require Rails.root.join('db/migrate/20140402134329_change_utc_time_profile_type_to_global.rb')
+require_migration
 
 describe ChangeUtcTimeProfileTypeToGlobal do
-
   migration_context :up do
     let(:time_profile_stub) { migration_stub(:TimeProfile) }
 

--- a/spec/migrations/20140409134713_move_log_collection_depot_settings_to_file_depot_spec.rb
+++ b/spec/migrations/20140409134713_move_log_collection_depot_settings_to_file_depot_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140409134713_move_log_collection_depot_settings_to_file_depot")
+require_migration
 
 describe MoveLogCollectionDepotSettingsToFileDepot do
   let(:configuration_stub) { migration_stub(:Configuration) }

--- a/spec/migrations/20140410132430_subclass_file_depot_by_protocol_spec.rb
+++ b/spec/migrations/20140410132430_subclass_file_depot_by_protocol_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140410132430_subclass_file_depot_by_protocol")
+require_migration
 
 describe SubclassFileDepotByProtocol do
   let(:file_depot_stub) { migration_stub(:FileDepot) }

--- a/spec/migrations/20140421150958_create_miq_groups_users_join_table_spec.rb
+++ b/spec/migrations/20140421150958_create_miq_groups_users_join_table_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140421150958_create_miq_groups_users_join_table.rb")
+require_migration
 
 describe CreateMiqGroupsUsersJoinTable do
   migration_context :up do

--- a/spec/migrations/20140424173120_migrate_automate_to_customer_domain_spec.rb
+++ b/spec/migrations/20140424173120_migrate_automate_to_customer_domain_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require Rails.root.join('db/migrate/20140424173120_migrate_automate_to_customer_domain.rb')
+require_migration
 
 describe MigrateAutomateToCustomerDomain do
   let(:miq_ae_namespace_stub) { migration_stub(:MiqAeNamespace) }

--- a/spec/migrations/20140428162159_rename_miq_group_id_column_in_users_spec.rb
+++ b/spec/migrations/20140428162159_rename_miq_group_id_column_in_users_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140428162159_rename_miq_group_id_column_in_users.rb")
+require_migration
 
 describe RenameMiqGroupIdColumnInUsers do
   migration_context :up do

--- a/spec/migrations/20140519211930_add_user_current_group_to_miq_groups_spec.rb
+++ b/spec/migrations/20140519211930_add_user_current_group_to_miq_groups_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140519211930_add_user_current_group_to_miq_groups.rb")
+require_migration
 
 describe AddUserCurrentGroupToMiqGroups do
   migration_context :up do

--- a/spec/migrations/20140611194007_change_options_in_miq_alert_for_email_to_spec.rb
+++ b/spec/migrations/20140611194007_change_options_in_miq_alert_for_email_to_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
-require Rails.root.join('db/migrate/20140611194007_change_options_in_miq_alert_for_email_to.rb')
+require_migration
 
 describe ChangeOptionsInMiqAlertForEmailTo do
-
   migration_context :up do
     let(:miq_alert_stub) { migration_stub(:MiqAlert) }
 

--- a/spec/migrations/20140715200621_set_default_for_pxe_server_customization_directory_spec.rb
+++ b/spec/migrations/20140715200621_set_default_for_pxe_server_customization_directory_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140715200621_set_default_for_pxe_server_customization_directory")
+require_migration
 
 describe SetDefaultForPxeServerCustomizationDirectory do
   let(:pxe_server_stub) { migration_stub(:PxeServer) }

--- a/spec/migrations/20140905020643_update_default_registration_channel_names_spec.rb
+++ b/spec/migrations/20140905020643_update_default_registration_channel_names_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140905020643_update_default_registration_channel_names")
+require_migration
 
 describe UpdateDefaultRegistrationChannelNames do
   let(:miq_database_stub) { migration_stub(:MiqDatabase) }

--- a/spec/migrations/20140918140859_add_cloud_tenant_sti_column_spec.rb
+++ b/spec/migrations/20140918140859_add_cloud_tenant_sti_column_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140918140859_add_cloud_tenant_sti_column")
+require_migration
 
 describe AddCloudTenantStiColumn do
   let(:cloud_tenant_stub) { migration_stub(:CloudTenant) }

--- a/spec/migrations/20140918154013_add_provider_region_to_ext_management_systems_spec.rb
+++ b/spec/migrations/20140918154013_add_provider_region_to_ext_management_systems_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20140918154013_add_provider_region_to_ext_management_systems")
+require_migration
 
 describe AddProviderRegionToExtManagementSystems do
   let(:ems_stub) { migration_stub(:ExtManagementSystem) }

--- a/spec/migrations/20141015170920_remove_vdi_tab_from_miq_dialogs_spec.rb
+++ b/spec/migrations/20141015170920_remove_vdi_tab_from_miq_dialogs_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20141015170920_remove_vdi_tab_from_miq_dialogs")
+require_migration
 
 describe RemoveVdiTabFromMiqDialogs do
   let(:miq_dialog_stub) { migration_stub(:MiqDialog) }

--- a/spec/migrations/20141021103820_remove_miq_search_vdi_instances_spec.rb
+++ b/spec/migrations/20141021103820_remove_miq_search_vdi_instances_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20141021103820_remove_miq_search_vdi_instances.rb")
+require_migration
 
 describe RemoveMiqSearchVdiInstances do
   let(:miq_search_stub) { migration_stub(:MiqSearch) }

--- a/spec/migrations/20141126161823_convert_show_refresh_button_and_load_values_on_init_to_real_columns_for_dialog_fields_spec.rb
+++ b/spec/migrations/20141126161823_convert_show_refresh_button_and_load_values_on_init_to_real_columns_for_dialog_fields_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20141126161823_convert_show_refresh_button_and_load_values_on_init_to_real_columns_for_dialog_fields.rb")
+require_migration
 
 describe ConvertShowRefreshButtonAndLoadValuesOnInitToRealColumnsForDialogFields do
   let(:dialog_field_stub) { migration_stub(:DialogField) }

--- a/spec/migrations/20141219222843_remove_miq_worker_rows_without_model_spec.rb
+++ b/spec/migrations/20141219222843_remove_miq_worker_rows_without_model_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20141219222843_remove_miq_worker_rows_without_model.rb")
+require_migration
 
 describe RemoveMiqWorkerRowsWithoutModel do
   migration_context :up do

--- a/spec/migrations/20150109142457_namespace_ems_classes_spec.rb
+++ b/spec/migrations/20150109142457_namespace_ems_classes_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150109142457_namespace_ems_classes")
+require_migration
 
 describe NamespaceEmsClasses do
   class NamespaceEmsClasses::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb
+++ b/spec/migrations/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb")
+require_migration
 
 describe MigrateMiqDatabaseRegistrationOrganizationDisplayNameOutOfReserves do
   let(:db_stub)      { migration_stub(:MiqDatabase) }

--- a/spec/migrations/20150224164512_add_loopback_to_memcache_server_opts_in_configuration_spec.rb
+++ b/spec/migrations/20150224164512_add_loopback_to_memcache_server_opts_in_configuration_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration")
+require_migration
 
 describe AddLoopbackToMemcacheServerOptsInConfiguration do
   let(:configuration_stub) { migration_stub(:Configuration) }

--- a/spec/migrations/20150224192716_migrate_configuration_manager_to_ems_spec.rb
+++ b/spec/migrations/20150224192716_migrate_configuration_manager_to_ems_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150224192716_migrate_configuration_manager_to_ems")
+require_migration
 
 describe MigrateConfigurationManagerToEms do
   let(:config_manager_stub) { migration_stub(:ConfigurationManager) }

--- a/spec/migrations/20150224192816_migrate_provisioning_manager_to_ems_spec.rb
+++ b/spec/migrations/20150224192816_migrate_provisioning_manager_to_ems_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150224192816_migrate_provisioning_manager_to_ems")
+require_migration
 
 describe MigrateProvisioningManagerToEms do
   let(:prov_manager_stub) { migration_stub(:ProvisioningManager) }

--- a/spec/migrations/20150316175916_update_miq_database_default_update_repo_name_spec.rb
+++ b/spec/migrations/20150316175916_update_miq_database_default_update_repo_name_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150316175916_update_miq_database_default_update_repo_name")
+require_migration
 
 describe UpdateMiqDatabaseDefaultUpdateRepoName do
   let(:db_stub) { migration_stub(:MiqDatabase) }

--- a/spec/migrations/20150330214408_add_file_depot_id_to_miq_schedule_spec.rb
+++ b/spec/migrations/20150330214408_add_file_depot_id_to_miq_schedule_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150330214408_add_file_depot_id_to_miq_schedule")
+require_migration
 
 describe AddFileDepotIdToMiqSchedule do
   let(:depot_stub)    { migration_stub(:FileDepot) }

--- a/spec/migrations/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag_spec.rb
+++ b/spec/migrations/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag.rb")
+require_migration
 
 describe ChangeDialogFieldDynamicListsToDialogFieldDropDownListWithDynamicFlag do
   let(:dialog_field_stub) { migration_stub(:DialogField) }

--- a/spec/migrations/20150405141637_remove_port_config_from_container_service_spec.rb
+++ b/spec/migrations/20150405141637_remove_port_config_from_container_service_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150405141637_remove_port_config_from_container_service.rb")
+require_migration
 
 describe RemovePortConfigFromContainerService do
   let(:container_service_stub)             { migration_stub(:ContainerService) }

--- a/spec/migrations/20150407144345_add_kerberos_to_ext_management_system_spec.rb
+++ b/spec/migrations/20150407144345_add_kerberos_to_ext_management_system_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150407144345_add_kerberos_to_ext_management_system.rb")
+require_migration
 
 describe AddKerberosToExtManagementSystem do
   let(:reserve_stub) { MigrationSpecStubs.reserved_stub }

--- a/spec/migrations/20150501193927_default_provider_verify_ssl_spec.rb
+++ b/spec/migrations/20150501193927_default_provider_verify_ssl_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150501193927_default_provider_verify_ssl")
+require_migration
 
 describe DefaultProviderVerifySsl do
   migration_context :up do

--- a/spec/migrations/20150522161336_add_container_entities_type_spec.rb
+++ b/spec/migrations/20150522161336_add_container_entities_type_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150522161336_add_container_entities_type")
+require_migration
 
 describe AddContainerEntitiesType do
   let(:container_node_stub)  { migration_stub(:ContainerNode) }

--- a/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
+++ b/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb")
+require_migration
 
 describe FixSerializedReportsForRailsFour do
   let(:report_result_stub)  { migration_stub(:MiqReportResult) }

--- a/spec/migrations/20150630100251_namespace_ems_amazon_spec.rb
+++ b/spec/migrations/20150630100251_namespace_ems_amazon_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150630100251_namespace_ems_amazon")
+require_migration
 
 describe NamespaceEmsAmazon do
   class NamespaceEmsAmazon::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150714053019_namespace_ems_redhat_spec.rb
+++ b/spec/migrations/20150714053019_namespace_ems_redhat_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150714053019_namespace_ems_redhat")
+require_migration
 
 describe NamespaceEmsRedhat do
   class NamespaceEmsRedhat::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150714143821_remove_ui_tasks_and_ui_task_sets_spec.rb
+++ b/spec/migrations/20150714143821_remove_ui_tasks_and_ui_task_sets_spec.rb
@@ -1,5 +1,5 @@
-require_relative '../spec_helper'
-require Rails.root.join("db/migrate/20150714143821_remove_ui_tasks_and_ui_task_sets")
+require "spec_helper"
+require_migration
 
 describe RemoveUiTasksAndUiTaskSets do
   let(:miq_set_stub)      { migration_stub(:MiqSet) }

--- a/spec/migrations/20150716021334_fix_redhat_namespace_spec.rb
+++ b/spec/migrations/20150716021334_fix_redhat_namespace_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150716021334_fix_redhat_namespace")
+require_migration
 
 describe FixRedhatNamespace do
   class FixRedhatNamespace::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150724030353_namespace_ems_foreman_spec.rb
+++ b/spec/migrations/20150724030353_namespace_ems_foreman_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150724030353_namespace_ems_foreman")
+require_migration
 
 describe NamespaceEmsForeman do
   class NamespaceEmsForeman::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150731025210_namespace_ems_openstack_spec.rb
+++ b/spec/migrations/20150731025210_namespace_ems_openstack_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150731025210_namespace_ems_openstack")
+require_migration
 
 describe NamespaceEmsOpenstack do
   class NamespaceEmsOpenstack::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150806190149_rename_miq_event_table_to_miq_event_definition_spec.rb
+++ b/spec/migrations/20150806190149_rename_miq_event_table_to_miq_event_definition_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require Rails.root.join('db/migrate/20150806190149_rename_miq_event_table_to_miq_event_definition')
+require_migration
 
 describe RenameMiqEventTableToMiqEventDefinition do
   migration_context :up do

--- a/spec/migrations/20150806194147_migrate_filtered_events_to_blacklisted_events_spec.rb
+++ b/spec/migrations/20150806194147_migrate_filtered_events_to_blacklisted_events_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require Rails.root.join('db/migrate/20150806194147_migrate_filtered_events_to_blacklisted_events.rb')
+require_migration
 
 describe MigrateFilteredEventsToBlacklistedEvents do
   let(:configuration_stub)     { migration_stub(:Configuration) }

--- a/spec/migrations/20150806211453_rename_ems_event_table_to_event_stream_spec.rb
+++ b/spec/migrations/20150806211453_rename_ems_event_table_to_event_stream_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require Rails.root.join('db/migrate/20150806211453_rename_ems_event_table_to_event_stream')
+require_migration
 
 describe RenameEmsEventTableToEventStream do
   let(:ems_event_stub)      { migration_stub(:EmsEvent) }

--- a/spec/migrations/20150807165254_namespace_ems_container_spec.rb
+++ b/spec/migrations/20150807165254_namespace_ems_container_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150807165254_namespace_ems_container")
+require_migration
 
 describe NamespaceEmsContainer do
   class NamespaceEmsContainer::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150815051916_namespace_ems_microsoft_spec.rb
+++ b/spec/migrations/20150815051916_namespace_ems_microsoft_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150815051916_namespace_ems_microsoft")
+require_migration
 
 describe NamespaceEmsMicrosoft do
   class NamespaceEmsMicrosoft::ExtManagementSystem < ActiveRecord::Base

--- a/spec/migrations/20150815052719_fix_foreman_provider_type_spec.rb
+++ b/spec/migrations/20150815052719_fix_foreman_provider_type_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150815052719_fix_foreman_provider_type")
+require_migration
 
 describe FixForemanProviderType do
   class FixForemanProviderType::Provider < ActiveRecord::Base

--- a/spec/migrations/20150817213409_clear_tenant_seed_spec.rb
+++ b/spec/migrations/20150817213409_clear_tenant_seed_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150817213409_clear_tenant_seed")
+require_migration
 
 describe ClearTenantSeed do
   migration_context :up do

--- a/spec/migrations/20150818181427_update_tenant_divisible_on_existing_rows_spec.rb
+++ b/spec/migrations/20150818181427_update_tenant_divisible_on_existing_rows_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require Rails.root.join("db/migrate/20150818181427_update_tenant_divisible_on_existing_rows.rb")
+require_migration
 
 describe UpdateTenantDivisibleOnExistingRows do
   let(:tenant_stub)  { migration_stub(:Tenant) }

--- a/spec/support/migration_name_helper.rb
+++ b/spec/support/migration_name_helper.rb
@@ -1,0 +1,6 @@
+def require_migration
+  spec_name = caller_locations.first.path
+  migration_name = spec_name.sub("spec/migrations", "db/migrate").sub("_spec.rb", ".rb")
+
+  require migration_name
+end


### PR DESCRIPTION
One of the hardest things for me when writing migration tests is copy and pasting the full path to the migration.

Today I had to rename 5 migrations. No idea why we had that many conflicts.
But it occurred to me that if there had been specs for those migrations, then that would have be a pain to copy the new paths back into those files.

Before:

```ruby
require "spec_helper"
require Rails.root.join("db/migrate/20140214191729_enhance_firewall_rules_for_neutron_networking.rb")
describe EnhanceFirewallRulesForNeutronNetworking do
  # ...
end
```

After:

```ruby
require "spec_helper"
require_migration
describe EnhanceFirewallRulesForNeutronNetworking do
  # ...
end
```

/cc @Fryguy @matthewd @jrafanie Food for thought 