### PR TITLE
Rely on env variable for manageiq-appliance repo directory

### DIFF
--- a/gems/pending/appliance_console/external_httpd_authentication.rb
+++ b/gems/pending/appliance_console/external_httpd_authentication.rb
@@ -112,7 +112,7 @@ module ApplianceConsole
 
     def configure_pam
       say("Configuring pam ...")
-      cp_template(PAM_CONFIG, TEMPLATE_BASE_DIR)
+      cp_template(PAM_CONFIG, template_directory)
     end
 
     def configure_sssd

--- a/gems/pending/appliance_console/external_httpd_configuration.rb
+++ b/gems/pending/appliance_console/external_httpd_configuration.rb
@@ -1,11 +1,11 @@
+require 'pathname'
+
 module ApplianceConsole
   class ExternalHttpdAuthentication
     module ExternalHttpdConfiguration
       #
       # External Authentication Definitions
       #
-      TEMPLATE_BASE_DIR   = "/var/www/miq/system/TEMPLATE/"
-
       IPA_COMMAND         = "/usr/bin/ipa"
       IPA_INSTALL_COMMAND = "/usr/sbin/ipa-client-install"
       IPA_GETKEYTAB       = "/usr/sbin/ipa-getkeytab"
@@ -31,6 +31,10 @@ module ApplianceConsole
         "sn"          => "REMOTE_USER_LASTNAME",
         "displayname" => "REMOTE_USER_FULLNAME"
       }
+
+      def template_directory
+        Pathname.new(ENV.fetch("APPLIANCE_TEMPLATE_DIRECTORY"))
+      end
 
       #
       # IPA Configuration Methods
@@ -68,8 +72,8 @@ module ApplianceConsole
       end
 
       def configure_httpd_application
-        cp_template(HTTP_EXTERNAL_AUTH_TEMPLATE, TEMPLATE_BASE_DIR)
-        cp_template(HTTP_REMOTE_USER, TEMPLATE_BASE_DIR)
+        cp_template(HTTP_EXTERNAL_AUTH_TEMPLATE, template_directory)
+        cp_template(HTTP_REMOTE_USER, template_directory)
       end
 
       def unconfigure_httpd_application

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -15,7 +15,7 @@ module ApplianceConsole
     end
 
     def self.postgresql_template
-      RAILS_ROOT.join("../system/TEMPLATE").join(postgres_dir)
+      PostgresAdmin.template_directory.join(postgres_dir)
     end
 
     def initialize(hash = {})

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -53,8 +53,9 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   end
 
   it ".postgresql_template" do
-    PostgresAdmin.stub(:data_directory => Pathname.new("/var/lib/pgsql/data"))
-    expect(described_class.postgresql_template.to_s).to end_with("system/TEMPLATE/var/lib/pgsql/data")
+    PostgresAdmin.stub(:data_directory     => Pathname.new("/var/lib/pgsql/data"))
+    PostgresAdmin.stub(:template_directory => Pathname.new("/opt/manageiq/manageiq-appliance/TEMPLATE"))
+    expect(described_class.postgresql_template.to_s).to end_with("TEMPLATE/var/lib/pgsql/data")
   end
 
   context "#update_fstab (private)" do

--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -12,6 +12,7 @@ describe PostgresAdmin do
      %w(service_name   APPLIANCE_PG_SERVICE      postgresql          ),
      %w(scl_name       APPLIANCE_PG_SCL_NAME     postgresql_scl      ),
      %w(package_name   APPLIANCE_PG_PACKAGE_NAME postgresql-server   ),
+     %w(template_directory APPLIANCE_TEMPLATE_DIRECTORY /some/path true),
 
     ].each do |method, var, value, pathname_required|
       it "#{method}" do

--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -7,12 +7,12 @@ describe PostgresAdmin do
       ENV.delete_if { |k, _| k.start_with?("APPLIANCE") }
     end
 
-    [%w(pg_ctl         APPLIANCE_PG_CTL          /some/path      true),
-     %w(data_directory APPLIANCE_PG_DATA         /some/path      true),
-     %w(service_name   APPLIANCE_PG_SERVICE      postgresql          ),
-     %w(scl_name       APPLIANCE_PG_SCL_NAME     postgresql_scl      ),
-     %w(package_name   APPLIANCE_PG_PACKAGE_NAME postgresql-server   ),
-     %w(template_directory APPLIANCE_TEMPLATE_DIRECTORY /some/path true),
+    [%w(pg_ctl             APPLIANCE_PG_CTL             /some/path      true),
+     %w(data_directory     APPLIANCE_PG_DATA            /some/path      true),
+     %w(service_name       APPLIANCE_PG_SERVICE         postgresql          ),
+     %w(scl_name           APPLIANCE_PG_SCL_NAME        postgresql_scl      ),
+     %w(package_name       APPLIANCE_PG_PACKAGE_NAME    postgresql-server   ),
+     %w(template_directory APPLIANCE_TEMPLATE_DIRECTORY /some/path      true),
 
     ].each do |method, var, value, pathname_required|
       it "#{method}" do

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -12,6 +12,10 @@ class PostgresAdmin
     Pathname.new(ENV.fetch("APPLIANCE_PG_DATA"))
   end
 
+  def self.template_directory
+    Pathname.new(ENV.fetch("APPLIANCE_TEMPLATE_DIRECTORY"))
+  end
+
   def self.service_name
     ENV.fetch("APPLIANCE_PG_SERVICE")
   end


### PR DESCRIPTION
ManageIQ code shouldn't know where the old system/TEMPLATE is
Use the APPLIANCE_TEMPLATE_DIRECTORY environment variable provided by manageiq-appliance PR below.

Related PRs:
* https://github.com/ManageIQ/manageiq-appliance-build/pull/33 [ clone repo in new location ] 
* https://github.com/ManageIQ/manageiq-appliance/pull/12  [set environment variable for new location]
* https://github.com/ManageIQ/manageiq/pull/4105 [use environment variable above] 