### PR TITLE
miq_password: normalize loading and clearing keys

### DIFF
--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -8,12 +8,13 @@ require "appliance_console/logging"
 
 describe ApplianceConsole::DatabaseConfiguration do
   before do
+    @old_key_root = MiqPassword.key_root
     MiqPassword.key_root = File.join(GEMS_PENDING_ROOT, "spec/support")
     @config = described_class.new
   end
 
   after do
-    MiqPassword.key_root = nil
+    MiqPassword.key_root = @old_key_root
   end
 
   context ".initialize" do

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -3,12 +3,13 @@ require "appliance_console/internal_database_configuration"
 
 describe ApplianceConsole::InternalDatabaseConfiguration do
   before do
+    @old_key_root = MiqPassword.key_root
     MiqPassword.key_root = File.join(GEMS_PENDING_ROOT, "spec/support")
     @config = described_class.new
   end
 
   after do
-    MiqPassword.key_root = nil
+    MiqPassword.key_root = @old_key_root
   end
 
   context ".new" do

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -114,8 +114,12 @@ class MiqPassword
   end
 
   def self.key_root=(key_root)
-    @v2_key = @v1_key = @v0_key = nil
+    clear_keys
     @key_root = key_root
+  end
+
+  def self.clear_keys
+    @v2_key = @v1_key = @v0_key = nil
   end
 
   def self.v2_key

--- a/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
@@ -3,11 +3,6 @@ require "spec_helper"
 describe MiqAePassword do
   let(:plaintext) { "Pl$1nTeXt" }
 
-  before do
-    # clear out cached key files
-    MiqPassword.key_root = Rails.root.join("certs")
-  end
-
   describe ".v0_key" do
     it "does not have v0_key" do
       expect(described_class.v0_key).to be_false

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -9,9 +9,7 @@ require "fix_auth/models"
 describe FixAuth::AuthConfigModel do
   let(:pass)    { "password" }
   let(:enc_v1)  { MiqPassword.new.send(:encrypt_version_1, pass) }
-  let(:enc_v2)  { MiqPassword.new.send(:encrypt_version_2, pass) }
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
-  let(:enc_leg) { MiqPassword.v0_key.encrypt64(pass) }
 
   before do
     MiqPassword.v0_key ||= CryptString.new(nil, "AES-128-CBC", "9999999999999999", "5555555555555555")
@@ -19,8 +17,7 @@ describe FixAuth::AuthConfigModel do
   end
 
   after do
-    MiqPassword.v0_key = nil
-    MiqPassword.v1_key = nil
+    MiqPassword.clear_keys
   end
 
   context "#configurations" do

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -19,8 +19,7 @@ describe FixAuth::AuthModel do
   end
 
   after do
-    MiqPassword.v0_key = nil
-    MiqPassword.v1_key = nil
+    MiqPassword.clear_keys
   end
 
   context "#authentications" do


### PR DESCRIPTION
This is to remove sporadic tests

ensure all tests leave the environment with a good `key_root` / `v2_key`

Pulls out test stabilization from #4091 

/cc @jrafanie this will let you run with specs pending gems AND models in 1 swoop. I know, don't do that... but both you and I were doing this today. just sayin'