### PR TITLE
Update rest-client to 2.0.0.rc1

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -35,7 +35,7 @@ gem "openshift_client",        "=0.0.8",            :require => false
 gem "ovirt",                   "~>0.6.0",           :require => false
 gem "parallel",                "~>0.5.21",          :require => false
 gem "psych",                   "~>2.0.12"
-gem "rest-client",                                  :require => false, :git => "git://github.com/rest-client/rest-client.git", :ref => "08480eb86aef1e"
+gem "rest-client",             "=2.0.0.rc1"
 gem "rubyzip",                 "=0.9.5",            :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646
 gem "rufus-lru",               "~>1.0.3",           :require => false
 gem "sys-uname",               "~>1.0.1",           :require => false


### PR DESCRIPTION
Here's the list of breaking changes introduced by version 2 (quoted from
the repository's changelog) with any impact on this project explained:

- Drop support for Ruby 1.9.2

Not an issue

- Respect Content-Type charset header provided by server. Previously,
  rest-client would not override the string encoding chosen by Net::HTTP. Now
  responses that specify a charset will yield a body string in that encoding.
  For example, `Content-Type: text/plain; charset=EUC-JP` will return a String
  encoded with `Encoding::EUC_JP`.

I don't *believe* this is an issue

- Change exceptions raised on request timeout. Instead of
  RestClient::RequestTimeout (which is still used for HTTP 408), network
  timeouts will now raise either RestClient::Exceptions::ReadTimeout or
  RestClient::Exceptions::OpenTimeout, both of which inherit from
  RestClient::Exceptions::Timeout. This class also makes the original
  wrapped exception available as `#original_exception`.

We don't appear to be referencing RestClient::RequestTimeout anywhere

- Rename `:timeout` to `:read_timeout`. When `:timeout` is passed, now
  set both `:read_timeout` and `:open_timeout`.

- Change default HTTP Accept header to `*/*`

- Use a more descriptive User-Agent header by default

- Drop RC4-MD5 from default cipher list

- Only prepend http:// to URIs without a scheme

- Fix some support for using IPv6 addresses in URLs (still affected by
  Ruby 2.0+ bug https://bugs.ruby-lang.org/issues/9129, with the fix
  expected to be backported to 2.0 and 2.1)

That's a revision @jrafanie introduced, and the one that we were
previously referencing in the gemfile so this should be good

- `Response` objects are now a subclass of `String` rather than a
  `String` that mixes in the response functionality. Most of the methods
  remain unchanged, but this makes it much easier to understand what is
  happening when you look at a RestClient response object. There are a
  few additional changes:

  - Response objects now implement `.inspect` to make this distinction
    clearer.

  - `Response#to_i` will now behave like `String#to_i` instead of
    returning the HTTP response code, which was very surprising behavior.

  - `Response#body` and `#to_s` will now return a true `String` object
    rather than self. Previously there was no easy way to get the true
    `String` response instead of the Frankenstein response string object
    with AbstractResponse mixed in.

Since ApipieBindings::API wraps these responses, this shouldn't be a concern.

- Handle multiple HTTP response headers with the same name (except for
  Set-Cookie, which is special) by joining the values with a comma space,
  compliant with RFC 7230

- Don't set basic auth header if explicit `Authorization` header is
  specified

- Add `:proxy` option to requests, which can be used for thread-safe
  per-request proxy configuration, overriding `RestClient.proxy`

- Allow overriding `ENV['http_proxy']` to disable proxies by setting
  `RestClient.proxy` to a falsey value. Previously there was no way in
  Ruby 2.x to turn off a proxy specified in the environment without
  changing `ENV`.

- Add actual support for streaming request payloads. Previously
  rest-client would call `.to_s` even on RestClient::Payload::Streamed
  objects. Instead, treat any object that responds to `.read` as a
  streaming payload and pass it through to `.body_stream=` on the
  Net:HTTP object. This massively reduces the memory required for large
  file uploads.

- Remove `RestClient::MaxRedirectsReached` in favor of the normal
  `ExceptionWithResponse` subclasses. This makes the response accessible
  on the exception object as `.response`, making it possible for callers
  to tell what has actually happened when the redirect limit is reached.

- When following HTTP redirection, store a list of each previous
  response on the response object as `.history`. This makes it possible
  to access the original response headers and body before the
  redirection was followed.

- Add `:before_execution_proc` option to `RestClient::Request`. This
  makes it possible to add procs like
  `RestClient.add_before_execution_proc` to a single request without
  global state.

Anything above that I have not commented on is either not applicable or
the concern of apipie-bindings which is the library that requires
rest-client (we do a couple of things to handle rest-client's
exceptions, but that's pretty much it). It's worth noting that
apipie-bindings added support for rest-client v 1.8 in
https://github.com/Apipie/apipie-bindings/commit/da7ea84725f1a75f17e88cdf663131425b01a5fb
but as it stands nothing has been done with regard to changes introduced
in 2.0.0.rc1. Having said that, I did run the tests for apipie-bindings
locally using rest-client 2.0.0.rc1 and everything passed.

Resolves https://github.com/ManageIQ/manageiq/issues/3969