### PR TITLE
brakeman likes j

### DIFF
--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,0 +1,4 @@
+---
+:safe_methods:
+- :j
+- :escape_javascript


### PR DESCRIPTION
When we put `j` in our haml views, it properly escapes them.
but brakeman gets confused and complains.

This config file will help brakeman understand the wisdom of it's way.

/cc @skateman @matthewd I locally verified that this will fix #4016 (ran both before and after the change)