### PR TITLE
Simplify code that generates and loads v2_keys

### DIFF
--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -233,42 +233,38 @@ describe MiqPassword do
       expect(MiqPassword.key_root).to eq("/abc")
     end
 
-    it "clears key caches" do
-      MiqPassword.add_legacy_key("v0_key", :v0)
-      MiqPassword.add_legacy_key("v1_key")
-      MiqPassword.v2_key
+    it "clears all_keys" do
+      v0 = MiqPassword.add_legacy_key("v0_key", :v0)
+      v1 = MiqPassword.add_legacy_key("v1_key")
+      v2 = MiqPassword.v2_key
 
-      expect(MiqPassword.v0_key).to_not be_nil
-      expect(MiqPassword.v1_key).to_not be_nil
-      expect(MiqPassword.v2_key).to_not be_false
+      expect(MiqPassword.all_keys).to match_array([v2, v1, v0])
 
       MiqPassword.key_root = nil
 
-      expect(MiqPassword.v0_key).to be_nil
-      expect(MiqPassword.v1_key).to be_nil
       expect(Kernel).to receive(:warn).with(/v2_key doesn't exist/)
-      expect(MiqPassword.v2_key).to be_false
+      expect(MiqPassword.all_keys).to eq([nil])
     end
   end
 
-  it ".clear_keys" do
-    MiqPassword.add_legacy_key("v0_key", :v0)
-    MiqPassword.add_legacy_key("v1_key")
+  describe ".clear_keys" do
+    it "clears legacy_keys" do
+      v0 = MiqPassword.add_legacy_key("v0_key", :v0)
+      v1 = MiqPassword.add_legacy_key("v1_key")
 
-    expect(MiqPassword.v0_key).to_not be_nil
-    expect(MiqPassword.v1_key).to_not be_nil
+      expect(MiqPassword.legacy_keys).to match_array([v0, v1])
 
-    MiqPassword.clear_keys
+      MiqPassword.clear_keys
 
-    expect(MiqPassword.v0_key).to be_nil
-    expect(MiqPassword.v1_key).to be_nil
+      expect(MiqPassword.legacy_keys).to be_empty
+    end
   end
 
   context ".v2_key" do
     it "when missing" do
       MiqPassword.key_root = "."
       expect(Kernel).to receive(:warn).with(/v2_key doesn't exist/)
-      expect(MiqPassword.v2_key).to be_false
+      expect(MiqPassword.v2_key).not_to be
     end
 
     it "when present" do

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -122,6 +122,10 @@ class MiqPassword
     @@v2_key = @v1_key = @v0_key = nil
   end
 
+  def self.all_keys
+    [v2_key] + legacy_keys
+  end
+
   def self.v2_key
     @@v2_key ||= ez_load("v2_key") || begin
       key_file = File.expand_path("v2_key", key_root)
@@ -136,6 +140,10 @@ passwords in your database.
 EOS
       Kernel.warn msg
     end
+  end
+
+  def self.legacy_keys
+    [v1_key, v0_key].compact
   end
 
   def self.add_legacy_key(filename, type = :v1)
@@ -168,7 +176,7 @@ EOS
     return filename if filename.respond_to?(:decrypt64)
     filename = File.expand_path(filename, key_root)
     if !File.exist?(filename)
-      false
+      nil
     elsif recent
       EzCrypto::Key.load(filename)
     else

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -119,11 +119,11 @@ class MiqPassword
   end
 
   def self.clear_keys
-    @v2_key = @v1_key = @v0_key = nil
+    @@v2_key = @v1_key = @v0_key = nil
   end
 
   def self.v2_key
-    @v2_key ||= ez_load("v2_key") || begin
+    @@v2_key ||= ez_load("v2_key") || begin
       key_file = File.expand_path("v2_key", key_root)
       msg = <<-EOS
 #{key_file} doesn't exist!
@@ -150,7 +150,10 @@ EOS
   class << self
     attr_accessor :v0_key
     attr_accessor :v1_key
-    attr_writer :v2_key
+
+    def v2_key=(key)
+      @@v2_key = key
+    end
   end
 
   def self.generate_symmetric(filename = nil)

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -157,15 +157,10 @@ EOS
     attr_writer :v2_key
   end
 
-  # generate a symmetric key
-  # preferred usage is without password/salt
-  def self.generate_symmetric(filename, password = nil, salt = nil)
-    key = if password
-            EzCrypto::Key.with_password(password, salt, :algorithm => "aes-256-cbc")
-          else
-            EzCrypto::Key.generate(:algorithm => "aes-256-cbc")
-          end
-    key.store(filename)
+  def self.generate_symmetric(filename = nil)
+    EzCrypto::Key.generate(:algorithm => "aes-256-cbc").tap do |key|
+      key.store(filename) if filename
+    end
   end
 
   protected

--- a/lib/miq_automation_engine/models/miq_ae_password.rb
+++ b/lib/miq_automation_engine/models/miq_ae_password.rb
@@ -21,17 +21,4 @@ class MiqAePassword < MiqPassword
   def inspect
     "\"#{self}\""
   end
-
-  # Use the same keys for MiqPassword and MiqAePassword
-  def self.v0_key
-    MiqPassword.v0_key
-  end
-
-  def self.v1_key
-    MiqPassword.v1_key
-  end
-
-  def self.v2_key
-    MiqPassword.v2_key
-  end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
@@ -3,25 +3,7 @@ require "spec_helper"
 describe MiqAePassword do
   let(:plaintext) { "Pl$1nTeXt" }
 
-  describe ".v0_key" do
-    it "does not have v0_key" do
-      expect(described_class.v0_key).to be_false
-    end
-  end
-
-  describe ".v1_key" do
-    it "does not have v1_key" do
-      expect(described_class.v1_key).to be_false
-    end
-  end
-
-  describe ".v2_key" do
-    it "should find v2_key" do
-      expect(described_class.v2_key).not_to be_nil
-    end
-  end
-
-  describe "#v2_key" do
+  describe ".to_s" do
     subject { described_class.new(plaintext) }
 
     it "is hidden to_s" do

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -7,13 +7,13 @@ require "fix_auth/auth_config_model"
 require "fix_auth/models"
 
 describe FixAuth::AuthConfigModel do
+  let(:v1_key)  { MiqPassword.generate_symmetric }
   let(:pass)    { "password" }
   let(:enc_v1)  { MiqPassword.new.send(:encrypt_version_1, pass) }
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
 
   before do
-    MiqPassword.v0_key ||= CryptString.new(nil, "AES-128-CBC", "9999999999999999", "5555555555555555")
-    MiqPassword.v1_key ||= EzCrypto::Key.generate(:algorithm => "aes-256-cbc")
+    MiqPassword.add_legacy_key(v1_key)
   end
 
   after do

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -7,15 +7,17 @@ require "fix_auth/auth_config_model"
 require "fix_auth/models"
 
 describe FixAuth::AuthModel do
+  let(:v0_key)  { CryptString.new(nil, "AES-128-CBC", "9999999999999999", "5555555555555555") }
+  let(:v1_key)  { MiqPassword.generate_symmetric }
   let(:pass)    { "password" }
   let(:enc_v1)  { MiqPassword.new.send(:encrypt_version_1, pass) }
   let(:enc_v2)  { MiqPassword.new.send(:encrypt_version_2, pass) }
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
-  let(:enc_leg) { MiqPassword.v0_key.encrypt64(pass) }
+  let(:enc_leg) { v0_key.encrypt64(pass) }
 
   before do
-    MiqPassword.v0_key ||= CryptString.new(nil, "AES-128-CBC", "9999999999999999", "5555555555555555")
-    MiqPassword.v1_key ||= EzCrypto::Key.generate(:algorithm => "aes-256-cbc")
+    MiqPassword.add_legacy_key(v0_key, :v0)
+    MiqPassword.add_legacy_key(v1_key)
   end
 
   after do


### PR DESCRIPTION
Split out of #4091 

High level:

**Before:** Refer to keys by their version.
**After:** Refer to keys as primary key (`v2_key`) and `legacy_keys`.
**Result:** Then we will be able to `add_legacy_key("v2_key.old")` -- #4091

Low level:

- Remove unused params in `generate_symetric`. extra: tests can store keys in variables.
- Merged `ez_load` and `ez_load_v0`. extra: tests use variable based keys for `load_legacy_key`.
- ~~Changed `self.class.v2_key` to `MiqPassword.v2_key`. Before: `MiqAePassword` looked for `@v2_key` in `MiqAePassword` (ala `self.class`). After: look for keys in `MiqPassword`.~~
- Changed `@v2_key` to `@@v2_key` to use the same key for `MiqPassword` and `MiqAePassword`.
- Use `add_legacy_key`, `all_keys`, and `legacy_keys` instead of worrying about `{v1,v0}_key`.

The next pr ( #4091) removes `decrypt_version_*` and `encrypt_version_*` methods - so if you don't like them, don't worry, they're coming out soon.
