### PR TITLE
persist and show containerService type and portConfigs.nodePort

### DIFF
--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -15,14 +15,15 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_group_port_configs
-    labels = [_("Name"), _("Protocol"), _("Port"), _("Target Port")]
+    labels = [_("Name"), _("Protocol"), _("Port"), _("Target Port"), _("Node Port")]
     h = {:labels => labels}
     h[:values] = @record.container_service_port_configs.collect do |config|
       [
         config.name || _("<Unnamed>"),
         config.protocol,
         config.port,
-        config.target_port
+        config.target_port,
+        config.node_port
       ]
     end
     h

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -9,6 +9,7 @@ module ContainerServiceHelper::TextualSummary
       creation_timestamp
       resource_version
       session_affinity
+      service_type
       portal_ip
     )
   end
@@ -54,6 +55,10 @@ module ContainerServiceHelper::TextualSummary
 
   def textual_session_affinity
     @record.session_affinity
+  end
+
+  def textual_service_type
+    {:label => "Type", :value => @record.service_type}
   end
 
   def textual_portal_ip

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -15,14 +15,14 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_group_port_configs
-    labels = [_("Name"), _("Port"), _("Target Port"), _("Protocol")]
+    labels = [_("Name"), _("Protocol"), _("Port"), _("Target Port")]
     h = {:labels => labels}
     h[:values] = @record.container_service_port_configs.collect do |config|
       [
         config.name || _("<Unnamed>"),
+        config.protocol,
         config.port,
-        config.target_port,
-        config.protocol
+        config.target_port
       ]
     end
     h

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -440,9 +440,9 @@ module ManageIQ::Providers::Kubernetes
       {
         :ems_ref     => "#{service_id}_#{port_config.port}_#{port_config.targetPort}",
         :name        => port_config.name,
+        :protocol    => port_config.protocol,
         :port        => port_config.port,
-        :target_port => port_config.targetPort,
-        :protocol    => port_config.protocol
+        :target_port => port_config.targetPort
       }
     end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -175,6 +175,7 @@ module ManageIQ::Providers::Kubernetes
         # TODO: We might want to change portal_ip to clusterIP
         :portal_ip        => service.spec.clusterIP,
         :session_affinity => service.spec.sessionAffinity,
+        :service_type     => service.spec.type,
 
         :labels           => parse_labels(service),
         :selector_parts   => parse_selector_parts(service),

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -442,7 +442,8 @@ module ManageIQ::Providers::Kubernetes
         :name        => port_config.name,
         :protocol    => port_config.protocol,
         :port        => port_config.port,
-        :target_port => port_config.targetPort
+        :target_port => port_config.targetPort,
+        :node_port   => port_config.nodePort,
       }
     end
 

--- a/db/migrate/20150906234626_add_service_type.rb
+++ b/db/migrate/20150906234626_add_service_type.rb
@@ -1,0 +1,5 @@
+class AddServiceType < ActiveRecord::Migration
+  def change
+    add_column :container_services, :service_type, :string
+  end
+end

--- a/db/migrate/20150906234635_add_node_port.rb
+++ b/db/migrate/20150906234635_add_node_port.rb
@@ -1,0 +1,5 @@
+class AddNodePort < ActiveRecord::Migration
+  def change
+    add_column :container_service_port_configs, :node_port, :integer
+  end
+end

--- a/product/views/ContainerService.yaml
+++ b/product/views/ContainerService.yaml
@@ -20,6 +20,7 @@ db: ContainerService
 # Columns to fetch from the main table
 cols:
 - name
+- service_type
 - portal_ip
 - session_affinity
 
@@ -40,6 +41,7 @@ col_order:
 - name
 - ext_management_system.name
 - container_project.name
+- service_type
 - portal_ip
 - session_affinity
 
@@ -48,6 +50,7 @@ headers:
 - Name
 - Provider
 - Project Name
+- Type
 - Portal IP
 - Session Affinity
 

--- a/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -136,7 +136,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     @services.count.should == 1
     @services.first.should have_attributes(
       # :ems_ref => "49981230-e1b7-11e4-b7dc-001a4a5f4a02",
-      :name    => "monitoring-heapster"
+      :name         => "monitoring-heapster",
+      :service_type => "ClusterIP"
     )
 
     # Check the relation to containers

--- a/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -221,7 +221,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :name        => nil,
       :protocol    => "TCP",
       :port        => 443,
-      :target_port => "443"
+      :target_port => "443",
+      :node_port   => 0
     )
 
     # Check group relation

--- a/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -219,9 +219,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     @confs = @confs.first
     @confs.should have_attributes(
       :name        => nil,
+      :protocol    => "TCP",
       :port        => 443,
-      :target_port => "443",
-      :protocol    => "TCP"
+      :target_port => "443"
     )
 
     # Check group relation


### PR DESCRIPTION
serviceSpec.type from k8s. Since rails uses the 'type'
columns for inheritance it is named 'service_type' internally.
Possible values in k8s: clusterIp, nodePort, loadBalancer.

display in container service views, both at item and explorer.

kubernetes: persist service port condig nodePort

display in container service item view in port config table.

reorder columns to match k8b v1 types.go order.