### PR TITLE
Add token username

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -594,7 +594,10 @@ module EmsCommon
       @edit[:metrics_verify_status] = (edit_new[:metrics_password] == edit_new[:metrics_verify])
     end
 
-    if edit_new[:bearer_token].blank? || edit_new[:hostname].blank? || edit_new[:emstype].blank?
+    if edit_new[:bearer_token].blank? ||
+       edit_new[:hostname].blank? ||
+       edit_new[:emstype].blank? ||
+       edit_new[:bearer_userid].blank?
       @edit[:bearer_verify_status] = false
     else
       @edit[:bearer_verify_status] = true
@@ -739,6 +742,7 @@ module EmsCommon
     @edit[:new][:ssh_keypair_userid] = @ems.has_authentication_type?(:ssh_keypair) ? @ems.authentication_userid(:ssh_keypair).to_s : ""
     @edit[:new][:ssh_keypair_password] = @ems.has_authentication_type?(:ssh_keypair) ? @ems.authentication_key(:ssh_keypair).to_s : ""
 
+    @edit[:new][:bearer_userid] = @ems.has_authentication_type?(:bearer) ? @ems.authentication_userid(:bearer).to_s : ""
     @edit[:new][:bearer_token] = @ems.has_authentication_type?(:bearer) ? @ems.authentication_token(:bearer).to_s : ""
     @edit[:new][:bearer_verify] = @ems.has_authentication_type?(:bearer) ? @ems.authentication_token(:bearer).to_s : ""
 
@@ -805,6 +809,7 @@ module EmsCommon
     @edit[:new][:ssh_keypair_userid] = params[:ssh_keypair_userid] if params[:ssh_keypair_userid]
     @edit[:new][:ssh_keypair_password] = params[:ssh_keypair_password] if params[:ssh_keypair_password]
 
+    @edit[:new][:bearer_userid] = params[:bearer_userid] if params[:bearer_userid]
     @edit[:new][:bearer_token] = params[:bearer_token] if params[:bearer_token]
     @edit[:new][:bearer_verify] = params[:bearer_verify] if params[:bearer_verify]
 
@@ -847,8 +852,10 @@ module EmsCommon
     if ems.supports_authentication?(:ssh_keypair) && !@edit[:new][:ssh_keypair_userid].blank?
       creds[:ssh_keypair] = {:userid => @edit[:new][:ssh_keypair_userid], :auth_key => @edit[:new][:ssh_keypair_password]}
     end
-    if ems.supports_authentication?(:bearer) && !@edit[:new][:bearer_token].blank?
-      creds[:bearer] = {:auth_key => @edit[:new][:bearer_token], :userid => "_"} # Must have userid
+    if ems.supports_authentication?(:bearer) &&
+       !@edit[:new][:bearer_token].blank? &&
+       !@edit[:new][:bearer_userid].blank?
+      creds[:bearer] = {:auth_key => @edit[:new][:bearer_token], :userid => @edit[:new][:bearer_userid]}
     end
     ems.update_authentication(creds, {:save=>(mode != :validate)})
   end

--- a/app/views/layouts/_auth_bearer_token.html.haml
+++ b/app/views/layouts/_auth_bearer_token.html.haml
@@ -6,7 +6,15 @@
 - url      = url_for(:action => change_url, :id => "#{rec_id}")
 - url_json = {:interval => '.5', :url => url}.to_json
 - token_label ||= _("Token")
+- uid_label ||= _("Service Account Name")
 
+.form-group
+  %label.control-label.col-md-2
+    = uid_label
+  .col-md-8
+    = text_field_tag("#{pfx}_userid",
+                     @edit[:new]["#{pfx}_userid".to_sym],
+                     "data-miq_observe" => url_json)
 .form-group
   %label.control-label.col-md-2
     = token_label

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -143,17 +143,19 @@ describe EmsContainerController do
         set_user_privileges
         @ems = ManageIQ::Providers::Kubernetes::ContainerManager.create(:name => "k8s", :hostname => "10.10.10.1", :port => 5000)
         controller.instance_variable_set(:@edit,
-                                         :new    => {:name         => @ems.name,
-                                                     :emstype      => @ems.type,
-                                                     :hostname     => @ems.hostname,
-                                                     :port         => @ems.port,
-                                                     :bearer_token => 'valid-token'},
+                                         :new    => {:name          => @ems.name,
+                                                     :emstype       => @ems.type,
+                                                     :hostname      => @ems.hostname,
+                                                     :port          => @ems.port,
+                                                     :bearer_token  => 'valid-token',
+                                                     :bearer_userid => 'myuser'},
                                          :key    => "ems_edit__#{@ems.id}",
                                          :ems_id => @ems.id)
         session[:edit] = assigns(:edit)
         post :update, :button => "save", :id => @ems.id, :type => @ems.type
         response.status.should == 200
-        ManageIQ::Providers::Kubernetes::ContainerManager.last.authentication_token("bearer").should == "valid-token"
+        ManageIQ::Providers::Kubernetes::ContainerManager.last.authentication_token.should == "valid-token"
+        ManageIQ::Providers::Kubernetes::ContainerManager.last.authentication_userid.should == "myuser"
       end
     end
   end

--- a/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/kubernetes_refresher_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
   before(:each) do
     MiqServer.stub(:my_zone).and_return("default")
-    auth = AuthToken.new(:name => "test", :auth_key => "valid-token")
+    auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "myuser")
     @ems = FactoryGirl.create(:ems_kubernetes, :hostname => "10.35.0.169",
                               :ipaddress => "10.35.0.169", :port => 6443,
                               :authentications => [auth])
@@ -65,6 +65,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     @token = @ems.authentication_tokens.last
     @token.should have_attributes(
       :auth_key => 'valid-token'
+    )
+    @token.should have_attributes(
+      :userid => 'myuser'
     )
   end
 


### PR DESCRIPTION
In some cases, we might need to use the service account name (e.g
username) for an authentication token.
This commit adds the option to specify username for new token.