### PR TITLE
Expose all product features under Access Control parent feature

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -118,7 +118,7 @@ class OpsController < ApplicationController
       @sb[:active_tab]    ||= "settings_server"
       @built_trees << settings_build_tree
     end
-    if role_allows(:feature => "ops_rbac")
+    if role_allows(:feature => "ops_rbac", :any => true)
       @accords.push(:name => "rbac", :title => "Access Control", :container => "rbac_tree_div")
       self.x_active_accord ||= 'rbac'
       self.x_active_tree   ||= 'rbac_tree'

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -384,6 +384,7 @@ class ApplicationHelper::ToolbarBuilder
             return true
         end
       when :rbac_tree
+        return true unless role_allows(:feature => id)
         return true if %w(rbac_project_add rbac_tenant_add).include?(id) && @record.project?
         return false
       when :vmdb_tree

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -35,7 +35,13 @@
               - if !@edit
                 - if @group.miq_user_role
                   %table{:cellpadding => "0", :cellspacing => "0"}
-                    %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'ur-#{to_cid(@group.miq_user_role.id)}');", :title => _("View this Role")}
+                    - if role_allows(:feature => "rbac_role_show")
+                      - params = {:class   => "pointer",
+                                  :onclick => "miqDynatreeActivateNode('rbac_tree', 'ur-#{to_cid(@group.miq_user_role.id)}');",
+                                  :title   => _("View this Role")}
+                    - else
+                      - params = {}
+                    %tr{params}
                       %td
                         %span.product.product-role
                         = h(@group.miq_user_role.name)
@@ -54,8 +60,13 @@
                 - if @group.tenant
                   - tenant = @group.tenant
                   %table{:cellpadding => "0", :cellspacing => "0"}
-                    %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
-                                :title   => _("View this #{tenant.divisible ? "Tenant" : "Project"}")}
+                    - if role_allows(:feature => "rbac_tenant_show")
+                      - params = {:class   => "pointer",
+                                  :onclick => "miqDynatreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
+                                  :title   => _("View this #{tenant.divisible ? "Tenant" : "Project"}")}
+                    - else
+                      - params = {}
+                    %tr{params}
                       %td
                         %span.product{:class => "product-#{tenant.divisible ? "tenant" : "project"}"}
                         = h(tenant.name)
@@ -74,7 +85,13 @@
               %td
                 %table{:cellpadding => "0", :cellspacing => "0"}
                   - @group.users.sort_by { |a| a.name.downcase }.each do |u|
-                    %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'u-#{to_cid(u.id)}');", :title => _("View this User")}
+                    - if role_allows(:feature => "rbac_user_show")
+                      - params = {:class   => "pointer",
+                                  :onclick => "miqDynatreeActivateNode('rbac_tree', 'u-#{to_cid(u.id)}');",
+                                  :title   => _("View this User")}
+                    - else
+                      - params = {}
+                    %tr{params}
                       %td
                         %span.pficon.pficon-user
                         = h(u.name)

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -38,7 +38,13 @@
               %td{:style => "padding: 0px"}
                 %table{:cellpadding => "0", :cellspacing => "0"}
                   - @role.miq_groups.sort_by { |a| a.description.downcase }.each do |g|
-                    %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'g-#{to_cid(g.id)}');", :title => _("View this Group")}
+                    - if role_allows(:feature => "rbac_group_show")
+                      - params = {:class   => "pointer",
+                                  :onclick => "miqDynatreeActivateNode('rbac_tree', 'g-#{to_cid(g.id)}');",
+                                  :title   => _("View this Group")}
+                    - else
+                      - params = {}
+                    %tr{params}
                       %td.image
                         %img{:src => "/images/icons/new/miq_group.png"}/
                       %td

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -66,7 +66,11 @@
         - if !@edit
           - if @user.current_group
             %table{:cellpadding => "0", :cellspacing => "0"}
-              %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'g-#{to_cid(@user.current_group.id)}');", :title => _("View this Group")}
+              - if role_allows(:feature => "rbac_group_show")
+                - params = {:class => "pointer", :onclick => "miqDynatreeActivateNode('rbac_tree', 'g-#{to_cid(@user.current_group.id)}');", :title => _("View this Group")}
+              - else
+                - params = {}
+              %tr{params}
                 %td.image
                   %ul.icons.list-unstyled
                     %li
@@ -89,7 +93,11 @@
         %td{:style => "padding: 0px"}
           - if @user.current_group && @user.current_group.miq_user_role
             %table{:cellpadding => "0", :cellspacing => "0"}
-              %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'ur-#{to_cid(@user.current_group.miq_user_role.id)}');", :title => _("View this Role")}
+              - if role_allows(:feature => "rbac_user_show")
+                - params = {:class => "pointer", :onclick => "miqDynatreeActivateNode('rbac_tree', 'ur-#{to_cid(@user.current_group.miq_user_role.id)}');", :title => _("View this Role")}
+              - else
+                - params = {}
+              %tr{params}
                 %td.image
                   %ul.icons.list-unstyled
                     %li

--- a/app/views/ops/explorer.html.haml
+++ b/app/views/ops/explorer.html.haml
@@ -10,7 +10,7 @@
                         :active_accord          => @sb[:active_accord],
                         :accord_select_function => "miqAccordOpsSelect"})
 #main_div.main_div
-  - if role_allows(:feature => "ops_settings") || role_allows(:feature => "ops_rbac") || role_allows(:feature => "ops_diagnostics") || role_allows(:feature => "ops_db")
+  - if role_allows(:feature => "ops_settings") || role_allows(:feature => "ops_rbac", :any => true) || role_allows(:feature => "ops_diagnostics") || role_allows(:feature => "ops_db")
     #tab_all_tabs_div= render :partial => "all_tabs"
   %br/
   %br/
@@ -36,7 +36,7 @@
   = javascript_dim("settings_tree_div", false) if role_allows(:feature => "ops_settings")
   = javascript_dim("diagnostics_tree_div", false) if role_allows(:feature => "ops_diagnostics")
   = javascript_dim("vmdb_tree_div", false) if role_allows(:feature => "ops_db")
-  = javascript_dim("rbac_tree_div", false) if role_allows(:feature => "ops_rbac")
+  = javascript_dim("rbac_tree_div", false) if role_allows(:feature => "ops_rbac", :any => true)
   = javascript_dim("analytics_tree_div", false) if get_vmdb_config[:product][:analytics]
   - if @sb[:active_tab] == "db_utilization"
     miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2685,147 +2685,199 @@
     - :name: Users
       :description: Users
       :feature_type: node
-      :hidden: true
+      :hidden: false
       :identifier: rbac_user
       :children:
+      - :name: View
+        :description: View Users
+        :feature_type: view
+        :identifier: rbac_user_view
+        :children:
+        - :name: List
+          :description: Display Lists of Users
+          :feature_type: view
+          :identifier: rbac_user_show_list
+        - :name: Show
+          :description: Display Individual Users
+          :feature_type: view
+          :identifier: rbac_user_show
       - :name: Modify
         :description: Modify User
         :feature_type: admin
         :identifier: rbac_user_admin
-        :hidden: true
+        :hidden: false
         :children:
         - :name: Add
           :description: Add a User
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_user_add
         - :name: Edit
           :description: Edit a User
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_user_edit
         - :name: Copy
           :description: Copy a User
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_user_copy
         - :name: Delete
           :description: Delete a User
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_user_delete
       - :name: Operate
         :description: Operate User
         :feature_type: control
         :identifier: rbac_user_operate
-        :hidden: true
+        :hidden: false
         :children:
         - :name: Edit Tags
           :description: Edit Tags
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_user_tags_edit
     - :name: Groups
       :description: Groups
       :feature_type: node
-      :hidden: true
+      :hidden: false
       :identifier: rbac_group
       :children:
+      - :name: View
+        :description: View Groups
+        :feature_type: view
+        :identifier: rbac_group_view
+        :children:
+        - :name: List
+          :description: Display Lists of Groups
+          :feature_type: view
+          :identifier: rbac_group_show_list
+        - :name: Show
+          :description: Display Individual Groups
+          :feature_type: view
+          :identifier: rbac_group_show
       - :name: Modify
-        :description: Modify User
+        :description: Modify Group
         :feature_type: admin
         :identifier: rbac_group_admin
-        :hidden: true
+        :hidden: false
         :children:
         - :name: Add
           :description: Add a Group
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_group_add
         - :name: Edit
           :description: Edit a Group
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_group_edit
         - :name: Edit Sequence
           :description: Edit Sequence of User Groups for LDAP Look Up
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_group_seq_edit
         - :name: Delete
           :description: Delete a Group
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_group_delete
       - :name: Operate
         :description: Operate Group
         :feature_type: control
         :identifier: rbac_group_operate
-        :hidden: true
+        :hidden: false
         :children:
         - :name: Edit Tags
           :description: Edit Tags
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_group_tags_edit
     - :name: Roles
       :description: Roles
       :feature_type: node
-      :hidden: true
+      :hidden: false
       :identifier: rbac_role
       :children:
+      - :name: View
+        :description: View Roles
+        :feature_type: view
+        :identifier: rbac_role_view
+        :children:
+        - :name: List
+          :description: Display Lists of Roles
+          :feature_type: view
+          :identifier: rbac_role_show_list
+        - :name: Show
+          :description: Display Individual Roles
+          :feature_type: view
+          :identifier: rbac_role_show
       - :name: Modify
         :description: Modify Role
         :feature_type: admin
         :identifier: rbac_role_admin
-        :hidden: true
+        :hidden: false
         :children:
         - :name: Add
           :description: Add a Role
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_role_add
         - :name: Edit
           :description: Edit a Role
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_role_edit
         - :name: Copy
           :description: Copy a Role
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_role_copy
         - :name: Delete
           :description: Delete a Role
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_role_delete
     - :name: Tenants
       :description: Tenants
       :feature_type: node
-      :hidden: true
+      :hidden: false
       :identifier: rbac_tenant
       :children:
+      - :name: View
+        :description: View Tenants
+        :feature_type: view
+        :identifier: rbac_tenant_view
+        :children:
+        - :name: List
+          :description: Display Lists of Tenants
+          :feature_type: view
+          :identifier: rbac_tenant_show_list
+        - :name: Show
+          :description: Display Individual Tenants
+          :feature_type: view
+          :identifier: rbac_tenant_show
       - :name: Modify
         :description: Modify Tenant/Project
         :feature_type: admin
         :identifier: rbac_tenant_admin
-        :hidden: true
+        :hidden: false
         :children:
         - :name: Add
           :description: Add a Tenant/Project
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_tenant_add
         - :name: Edit
           :description: Edit a Tenant/Project
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_tenant_edit
         - :name: Delete
           :description: Delete a Tenant/Project
           :feature_type: admin
-          :hidden: true
+          :hidden: false
           :identifier: rbac_tenant_delete
   - :name: Diagnostics
     :description: Diagnostics Accordion

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2534,6 +2534,41 @@ describe ApplicationHelper do
     end
   end #end of disable button
 
+  describe "#build_toolbar_hide_button_ops" do
+    subject { build_toolbar_hide_button_ops(@id) }
+    before do
+      @user = FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred')
+      @record = double("record")
+      login_as @user
+      EvmSpecHelper.seed_specific_product_features("ops_rbac", "rbac_group_add", "rbac_tenant_delete")
+      feature = MiqProductFeature.find_all_by_identifier(%w(ops_rbac rbac_group_add rbac_tenant_delete))
+      test_user_role = FactoryGirl.create(:miq_user_role,
+                                          :name                 => "test_user_role",
+                                          :miq_product_features => feature)
+      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
+      login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+      @sb = {:active_tree => :rbac_tree}
+    end
+
+    %w(rbac_group_add rbac_tenant_delete).each do |id|
+      context "when with #{id} button should be visible" do
+        before { @id = id }
+        it "and record_id" do
+          subject.should be_false
+        end
+      end
+    end
+
+    %w(rbac_group_edit rbac_role_edit).each do |id|
+      context "when with #{id} button should not be visible as user does not have access to these features" do
+        before { @id = id }
+        it "and record_id" do
+          subject.should be_true
+        end
+      end
+    end
+  end
+
   describe "#get_record_cls"  do
     subject { get_record_cls(record) }
     context "when record not exist" do

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe MiqProductFeature do
   before do
-    @expected_feature_count = 846
+    @expected_feature_count = 858
   end
 
   context ".seed" do


### PR DESCRIPTION
- Added any missing features such as show/show_list for users/groups/roles/tenants under Access Control tree
- Added role_allows call for features under RBAC tree and around the links on summary screens.
- Added spec test to verify that buttons that are allowed to user are displayed and others are hidden.

@dclarizio please review

before:
![before](https://cloud.githubusercontent.com/assets/3450808/9580571/4dbdc71a-4fc8-11e5-9e5f-031225da7263.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/9580576/532ef4e4-4fc8-11e5-81a6-dd5fb725e12c.png)
