### PR TITLE
renamed tenant_owner_id to tenant_id

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1074,7 +1074,7 @@ module OpsController::OpsRbac
     all_projects = Tenant.all_projects
     @edit[:projects_tenants].push(["Projects", all_projects.sort_by(&:name).collect { |tenant| [tenant.name, tenant.id] }]) unless all_projects.blank?
     @edit[:projects_tenants].push(["Tenants", all_tenants.sort_by(&:name).collect { |tenant| [tenant.name, tenant.id] }]) unless all_tenants.blank?
-    @edit[:new][:group_tenant] = @group.tenant_owner_id
+    @edit[:new][:group_tenant] = @group.tenant_id
 
     @edit[:current] = copy_hash(@edit[:new])
     rbac_build_myco_tree                              # Build the MyCompanyTags tree for this user
@@ -1126,7 +1126,7 @@ module OpsController::OpsRbac
     group.sequence = groups.first.nil? ? 1 : groups.first.sequence + 1
     group.description = @edit[:new][:description]
     group.miq_user_role = role
-    group.tenant_owner = Tenant.find_by_id(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]
+    group.tenant = Tenant.find_by_id(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]
     rbac_group_set_filters(group)             # Go set the filters for the group
   end
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -24,7 +24,7 @@ class ExtManagementSystem < ActiveRecord::Base
   end
 
   belongs_to :provider
-  belongs_to :tenant_owner, :class_name => 'Tenant'
+  belongs_to :tenant
 
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate"
@@ -50,10 +50,10 @@ class ExtManagementSystem < ActiveRecord::Base
   has_many :vim_performance_states, :as => :resource  # Destroy will be handled by purger
   has_many :miq_events,             :as => :target, :dependent => :destroy
 
-  validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_owner_id]}
+  validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
   validates :hostname,
             :presence   => true,
-            :uniqueness => {:scope => [:tenant_owner_id], :case_sensitive => false},
+            :uniqueness => {:scope => [:tenant_id], :case_sensitive => false},
             :if         => :hostname_required?
 
   # TODO: Remove all callers of address

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -1,7 +1,7 @@
 class MiqGroup < ActiveRecord::Base
   default_scope { where(self.conditions_for_my_region_default_scope) }
 
-  belongs_to :tenant_owner, :class_name => "Tenant"
+  belongs_to :tenant
   belongs_to :miq_user_role
   belongs_to :resource, :polymorphic => true
   has_and_belongs_to_many :users
@@ -96,7 +96,7 @@ class MiqGroup < ActiveRecord::Base
           group.sequence      = seq
           group.filters       = ldap_to_filters[g]
           group.group_type    = "system"
-          group.tenant_owner  = root_tenant
+          group.tenant        = root_tenant
 
           mode = group.new_record? ? "Created" : "Added"
           group.save!
@@ -105,7 +105,7 @@ class MiqGroup < ActiveRecord::Base
           seq += 1
         end
       else
-        MiqGroup.where(:tenant_owner_id => nil).update_all(:tenant_owner_id => root_tenant.id)
+        MiqGroup.where(:tenant_id => nil).update_all(:tenant_id => root_tenant.id)
 
         # Migrate legacy groups to have miq_user_roles if necessary
         self.all.each do |g|

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,7 +5,7 @@ class Provider < ActiveRecord::Base
   include AsyncDeleteMixin
   include EmsRefresh::Manager
 
-  belongs_to :tenant_owner, :class_name => 'Tenant'
+  belongs_to :tenant
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -12,14 +12,14 @@ class Tenant < ActiveRecord::Base
   default_value_for :divisible,   true
   has_ancestry
 
-  has_many :owned_providers,              :foreign_key => :tenant_owner_id, :class_name => 'Provider'
-  has_many :owned_ext_management_systems, :foreign_key => :tenant_owner_id, :class_name => 'ExtManagementSystem'
-  has_many :owned_vm_or_templates,        :foreign_key => :tenant_owner_id, :class_name => 'VmOrTemplate'
-  has_many :owned_service_catalog_templates, :class_name => 'ServiceTemplateCatalog'
-  has_many :owned_service_templates, :class_name => 'ServiceTemplate'
+  has_many :providers
+  has_many :ext_management_systems
+  has_many :vm_or_templates
+  has_many :service_catalog_templates
+  has_many :service_templates
 
   has_many :tenant_quotas
-  has_many :miq_groups, :foreign_key => :tenant_owner_id
+  has_many :miq_groups
   has_many :users, :through => :miq_groups
   has_many :ae_domains, :dependent => :destroy, :class_name => 'MiqAeDomain'
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -112,7 +112,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   has_many                  :service_resources, :as => :resource
   has_many                  :direct_services, :through => :service_resources, :source => :service
-  belongs_to                :tenant_owner, :class_name => 'Tenant'
+  belongs_to                :tenant
 
   acts_as_miq_taggable
   include ReportableMixin

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -51,8 +51,8 @@
             %td.key= _("Project/Tenant")
             %td{:style => @edit ? 'padding: 0px' : ''}
               - if !@edit
-                - if @group.tenant_owner
-                  - tenant = @group.tenant_owner
+                - if @group.tenant
+                  - tenant = @group.tenant
                   %table{:cellpadding => "0", :cellspacing => "0"}
                     %tr.pointer{:onclick => "miqDynatreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
                                 :title   => _("View this #{tenant.divisible ? "Tenant" : "Project"}")}

--- a/db/migrate/20150831123700_rename_tenant_owner_id.rb
+++ b/db/migrate/20150831123700_rename_tenant_owner_id.rb
@@ -1,0 +1,8 @@
+class RenameTenantOwnerId < ActiveRecord::Migration
+  def change
+    rename_column :ext_management_systems, :tenant_owner_id, :tenant_id
+    rename_column :miq_groups, :tenant_owner_id, :tenant_id
+    rename_column :providers, :tenant_owner_id, :tenant_id
+    rename_column :vms, :tenant_owner_id, :tenant_id
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -172,26 +172,26 @@ describe ExtManagementSystem do
         tenant = FactoryGirl.create(:tenant)
         expect do
           FactoryGirl.create(:ems_vmware,
-                             :name         => @ems.name,
-                             :hostname     => @different_host_name,
-                             :tenant_owner => tenant)
+                             :name     => @ems.name,
+                             :hostname => @different_host_name,
+                             :tenant   => tenant)
         end.not_to raise_error
       end
 
       it "allows duplicate hostname across tenants" do
         tenant = FactoryGirl.create(:tenant)
         expect do
-          FactoryGirl.create(:ems_vmware, :hostname => @same_host_name, :tenant_owner => tenant)
+          FactoryGirl.create(:ems_vmware, :hostname => @same_host_name, :tenant => tenant)
         end.not_to raise_error
       end
     end
   end
 
-  context "#tenant_owner" do
+  context "#tenant" do
     let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant owner" do
-      ems = FactoryGirl.create(:ext_management_system, :tenant_owner => tenant)
-      expect(tenant.owned_ext_management_systems).to include(ems)
+    it "has a tenant" do
+      ems = FactoryGirl.create(:ext_management_system, :tenant => tenant)
+      expect(tenant.ext_management_systems).to include(ems)
     end
   end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -259,20 +259,20 @@ describe MiqGroup do
   context "#seed" do
     let(:root_tenant) { Tenant.root_tenant }
 
-    it "has tenant_owner for new records" do
+    it "has tenant for new records" do
       [MiqRegion, Tenant, MiqUserRole, MiqGroup].each(&:seed)
-      expect(MiqGroup.where(:tenant_owner_id => root_tenant.id).count).to eq(MiqGroup.count)
+      expect(MiqGroup.where(:tenant => root_tenant).count).to eq(MiqGroup.count)
     end
 
-    it "has tenant_owner for legacy records" do
+    it "has tenant for legacy records" do
       [MiqRegion, Tenant, MiqUserRole].each(&:seed)
       new_tenant           = root_tenant.children.create!
-      group_with_tenant    = FactoryGirl.create(:miq_group, :tenant_owner => new_tenant)
-      group_without_tenant = FactoryGirl.create(:miq_group, :tenant_owner => nil)
+      group_with_tenant    = FactoryGirl.create(:miq_group, :tenant => new_tenant)
+      group_without_tenant = FactoryGirl.create(:miq_group, :tenant => nil)
       MiqGroup.seed
 
-      expect(group_with_tenant.reload.tenant_owner).to    eq(new_tenant)
-      expect(group_without_tenant.reload.tenant_owner).to eq(root_tenant)
+      expect(group_with_tenant.reload.tenant).to    eq(new_tenant)
+      expect(group_without_tenant.reload.tenant).to eq(root_tenant)
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -48,11 +48,11 @@ describe Provider do
     end
   end
 
-  context "#tenant_owner" do
+  context "#tenant" do
     let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant owner" do
-      provider = FactoryGirl.create(:provider, :tenant_owner => tenant)
-      expect(tenant.owned_providers).to include(provider)
+    it "has a tenant" do
+      provider = FactoryGirl.create(:provider, :tenant => tenant)
+      expect(tenant.providers).to include(provider)
     end
   end
 end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -384,12 +384,12 @@ describe Tenant do
     let(:tenant1_admins) do
       FactoryGirl.create(:miq_group,
                          :miq_user_role => admin_with_brand,
-                         :tenant_owner  => tenant1
+                         :tenant        => tenant1
                          )
     end
     let(:tenant1_users) do
       FactoryGirl.create(:miq_group,
-                         :tenant_owner  => tenant1,
+                         :tenant        => tenant1,
                          :miq_user_role => self_service_role)
     end
     let(:admin) { FactoryGirl.create(:user, :userid => 'admin', :miq_groups => [tenant1_users, tenant1_admins]) }

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -426,11 +426,11 @@ describe VmOrTemplate do
     end
   end
 
-  context "#tenant_owner" do
+  context "#tenant" do
     let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant owner" do
-      vm = FactoryGirl.create(:vm_vmware, :tenant_owner => tenant)
-      expect(tenant.owned_vm_or_templates).to include(vm)
+    it "has a tenant" do
+      vm = FactoryGirl.create(:vm_vmware, :tenant => tenant)
+      expect(tenant.vm_or_templates).to include(vm)
     end
   end
 


### PR DESCRIPTION
We are only storing ownership in tables for tenant data.
The `owner`/`owned` nomenclature was redundant and went agains rails conventions.

Removing this will simplify the models and be closer to the conventions

/cc @h-kataria @gtanzillo 