### PR TITLE
remove eligible_groups: use miq_groups instead

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -3,7 +3,7 @@ module ApplicationController::CurrentUser
 
   included do
     helper_method :current_user,  :current_userid
-    helper_method :current_group, :current_groupid, :eligible_groups
+    helper_method :current_group, :current_groupid
     helper_method :admin_user?, :super_admin_user?
     hide_action :clear_current_user, :current_user=
     hide_action :admin_user?, :super_admin_user?
@@ -21,13 +21,6 @@ module ApplicationController::CurrentUser
     session[:userid]    = db_user.userid
     session[:group]     = db_user.current_group.try(:id)
   end
-
-  def eligible_groups
-    eligible_groups = current_user.try(:miq_groups)
-    eligible_groups = eligible_groups ? eligible_groups.sort_by { |g| g.description.downcase } : []
-    eligible_groups.length < 2 ? [] : eligible_groups.collect { |g| [g.description, g.id] }
-  end
-  private :eligible_groups
 
   def admin_user?
     current_user.admin_user?

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -209,4 +209,8 @@ class MiqGroup < ActiveRecord::Base
       miq_widget_sets.sort_by { |a| a.name.downcase }
     end
   end
+
+  def self.sort_by_desc
+    all.sort_by { |g| g.description.downcase }
+  end
 end

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -9,16 +9,17 @@
         %a{:href => "#"}
           = _('Server: %s') % appliance_name
 
-      - if eligible_groups.length > 1
+      - if current_user.miq_groups.length > 1
         %li.dropdown-submenu
           %a{:href => "#"}
             = _('Change Group:')
             %ul.dropdown-menu
-              - eligible_groups.each do |group, id|
+              - current_user.miq_groups.sort_by_desc.each do |group|
                 %li
                   %a{:title => _("Select to change to another Group"), :href => "#",
-                        :onclick => "miqSparkle(true);miqToggleUserOptions(#{id})"}
-                    = id == current_groupid ? "#{group} (#{_('Current Group')})" : group
+                        :onclick => "miqSparkle(true);miqToggleUserOptions(#{group.id})"}
+                    = group.description
+                    = "(#{_('Current Group')})" if group == current_group
       - else
         %li.disabled
           %a{:href => "#"}

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -180,32 +180,6 @@ describe DashboardController do
     end
   end
 
-  describe "#eligible_groups" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-    let(:role1)  { FactoryGirl.create(:miq_user_role, :name => 'test_role1') }
-    let(:group1) { FactoryGirl.create(:miq_group, :description => 'test_group1', :miq_user_role => role1) }
-    let(:role2)  { FactoryGirl.create(:miq_user_role, :name => 'test_role2') }
-    let(:group2) { FactoryGirl.create(:miq_group, :description => 'test_group2', :miq_user_role => role2) }
-
-    it "has no eligible groups for single group users" do
-      user = FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group1])
-      skip_data_checks
-      post :authenticate, :user_name => user.userid, :user_password => 'dummy'
-      expect(controller.send(:current_user)).to eq(user)
-      expect(controller.send(:eligible_groups)).to eq([])
-    end
-
-    it "has eligible groups" do
-      user = FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group1, group2])
-      skip_data_checks
-      post :authenticate, :user_name => user.userid, :user_password => 'dummy'
-      expect(controller.send(:current_user)).to eq(user)
-      expect(controller.send(:eligible_groups)).to eq([group1, group2].map {|g| [g.description, g.id] })
-    end
-  end
-
   def skip_data_checks(url = '/')
     UserValidationService.any_instance.stub(:data_ready?).and_return(true)
     UserValidationService.any_instance.stub(:server_ready?).and_return(true)

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -294,4 +294,16 @@ describe MiqGroup do
       expect(group.ordered_widget_sets).to eq([ws1, ws3, ws2])
     end
   end
+
+  context ".sort_by_desc" do
+    it "sorts by description" do
+      tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+      gc = FactoryGirl.create(:miq_group, :description => 'C', :tenant => tenant)
+      ga = FactoryGirl.create(:miq_group, :description => 'a', :tenant => tenant)
+      gb = FactoryGirl.create(:miq_group, :description => 'B', :tenant => tenant)
+      FactoryGirl.create(:miq_group, :description => 'X')
+
+      expect(tenant.miq_groups.sort_by_desc).to eq([ga, gb, gc])
+    end
+  end
 end


### PR DESCRIPTION
Background: removing `session[:group]` from everywhere.
If possible, removing access to the user's id, or group ids, and using real objects instead.

In this case, the logic in the method was overkill.

1. the user is logged in.
2. the method was only called if the count was > 1.
3. the method only pulled out the id and description.
