### PR TITLE
truncate user message to 255 characters 

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -79,4 +79,4 @@ if $evm.state_var_exist?('provider_last_refresh')
 else
   check_deployed(service)
 end
-task.miq_request.user_message = $evm.root['ae_reason'] unless $evm.root['ae_reason'].blank?
+task.miq_request.user_message = $evm.root['ae_reason'].truncate(255) unless $evm.root['ae_reason'].blank?

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -13,6 +13,6 @@ begin
 rescue => err
   $evm.root['ae_result'] = 'error'
   $evm.root['ae_reason'] = err.message
-  task.miq_request.user_message = err.message
+  task.miq_request.user_message = err.message.truncate(255)
   $evm.log("error", "Stack #{service.stack_name} creation failed. Reason: #{err.message}")
 end

--- a/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
@@ -22,6 +22,15 @@ describe "Orchestration check_provisioned Method Validation" do
     ServiceOrchestration.any_instance.stub(:orchestration_stack_status) { ['CREATE_FAILED', failure_msg] }
     ws.root['ae_result'].should == 'error'
     ws.root['ae_reason'].should == failure_msg
+    request.reload.message.should == failure_msg
+  end
+
+  it "truncates the error message that exceeds 255 characters" do
+    long_error = 't' * 300
+    ServiceOrchestration.any_instance.stub(:orchestration_stack_status) { ['CREATE_FAILED', long_error] }
+    ws.root['ae_result'].should == 'error'
+    ws.root['ae_reason'].should == long_error
+    request.reload.message.should == 't' * 252 + '...'
   end
 
   it "considers rollback as provision error" do

--- a/spec/automation/unit/method_validation/orchestration_provision_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_provision_spec.rb
@@ -16,5 +16,14 @@ describe "Orchestration provision Method Validation" do
     ServiceOrchestration.any_instance.stub(:deploy_orchestration_stack) { raise "test failure" }
     ws.root['ae_result'].should == "error"
     ws.root['ae_reason'].should == "test failure"
+    request.reload.message.should == "test failure"
+  end
+
+  it "truncates the error message exceeding 255 character limits" do
+    long_error = 't' * 300
+    ServiceOrchestration.any_instance.stub(:deploy_orchestration_stack) { raise long_error }
+    ws.root['ae_result'].should == "error"
+    ws.root['ae_reason'].should == long_error
+    request.reload.message.should == 't' * 252 + '...'
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1252849

This bug complains a failed provisioning still shows progress in pending. The log already showed the provisioning encountered error. When the worker updated the service status the user message exceeded 255 character limit. 

The fix is to truncate the error message up to 255 characters so that the provisioning status can be updated successfully. On the UI screen the user may not be able to see the complete error message, but it is fully recorded in the log.