### PR TITLE
Fix MiqGenericMountSession temp dir creation

### DIFF
--- a/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -5,8 +5,8 @@ describe MiqGenericMountSession do
   context "#connect" do
     before do
       MiqGenericMountSession.stub(:raw_disconnect)
-      @s1 = MiqGenericMountSession.new({:uri => '/tmp/abc'})
-      @s2 = MiqGenericMountSession.new({:uri => '/tmp/abc'})
+      @s1 = MiqGenericMountSession.new(:uri => '/tmp/abc', :mount_point => 'tmp')
+      @s2 = MiqGenericMountSession.new(:uri => '/tmp/abc', :mount_point => 'tmp')
 
       @s1.logger = Logger.new("/dev/null")
       @s2.logger = Logger.new("/dev/null")
@@ -18,9 +18,10 @@ describe MiqGenericMountSession do
     end
 
     it "is unique" do
-      MiqGenericMountSession.should_receive(:base_mount_point).twice.and_return('/tmp')
       @s1.connect
       @s2.connect
+
+      expect(@s1.mnt_point).to_not eq(@s2.mnt_point)
     end
   end
 end

--- a/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -1,31 +1,20 @@
 require "spec_helper"
-require "tmpdir"
 require "util/mount/miq_generic_mount_session"
 
 describe MiqGenericMountSession do
-  let(:prefix) { File.join(Dir.tmpdir, "miq_") }
-
   it "#connect returns a string pointing to the mount point" do
     described_class.stub(:raw_disconnect)
     s = described_class.new(:uri => '/tmp/abc')
     s.logger = Logger.new("/dev/null")
 
-    expect(s.connect).to match(%r(\A#{prefix}\d{8}-\d{5}-\w+\z))
+    result = s.connect
+    expect(result).to     be_kind_of(String)
+    expect(result).to_not be_blank
 
     s.disconnect
   end
 
-  context "#mount_share" do
-    it "without :mount_point uses default temp directory as a base" do
-      expect(described_class.new(:uri => '/tmp/abc').mount_share).to match(%r(\A#{prefix}\d{8}-\d{5}-\w+\z))
-    end
-
-    it "with :mount_point uses specified directory as a base" do
-      expect(described_class.new(:uri => '/tmp/abc', :mount_point => "xyz").mount_share).to match(%r(\Axyz/miq_\d{8}-\d{5}-\w+\z))
-    end
-
-    it "is unique" do
-      expect(described_class.new(:uri => '/tmp/abc').mount_share).to_not eq(described_class.new(:uri => '/tmp/abc').mount_share)
-    end
+  it "#mount_share is unique" do
+    expect(described_class.new(:uri => '/tmp/abc').mount_share).to_not eq(described_class.new(:uri => '/tmp/abc').mount_share)
   end
 end

--- a/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -2,26 +2,27 @@ require "spec_helper"
 require 'util/mount/miq_generic_mount_session'
 
 describe MiqGenericMountSession do
-  context "#connect" do
-    before do
-      MiqGenericMountSession.stub(:raw_disconnect)
-      @s1 = MiqGenericMountSession.new(:uri => '/tmp/abc', :mount_point => 'tmp')
-      @s2 = MiqGenericMountSession.new(:uri => '/tmp/abc', :mount_point => 'tmp')
+  it "#connect returns a string pointing to the mount point" do
+    described_class.stub(:raw_disconnect)
+    s = described_class.new(:uri => '/tmp/abc')
+    s.logger = Logger.new("/dev/null")
 
-      @s1.logger = Logger.new("/dev/null")
-      @s2.logger = Logger.new("/dev/null")
+    expect(s.connect).to match(/\A\/tmp\/miq_\d{8}-\d{5}-\w+\z/)
+
+    s.disconnect
+  end
+
+  context "#mount_share" do
+    it "without :mount_point uses default temp directory as a base" do
+      expect(described_class.new(:uri => '/tmp/abc').mount_share).to match(/\A\/tmp\/miq_\d{8}-\d{5}-\w+\z/)
     end
 
-    after do
-      @s1.disconnect
-      @s2.disconnect
+    it "with :mount_point uses specified directory as a base" do
+      expect(described_class.new(:uri => '/tmp/abc', :mount_point => "abc").mount_share).to match(/\Aabc\/miq_\d{8}-\d{5}-\w+\z/)
     end
 
     it "is unique" do
-      @s1.connect
-      @s2.connect
-
-      expect(@s1.mnt_point).to_not eq(@s2.mnt_point)
+      expect(described_class.new(:uri => '/tmp/abc').mount_share).to_not eq(described_class.new(:uri => '/tmp/abc').mount_share)
     end
   end
 end

--- a/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -2,23 +2,25 @@ require "spec_helper"
 require 'util/mount/miq_generic_mount_session'
 
 describe MiqGenericMountSession do
+  let(:prefix) { File.join(Dir.tmpdir, "miq_") }
+
   it "#connect returns a string pointing to the mount point" do
     described_class.stub(:raw_disconnect)
     s = described_class.new(:uri => '/tmp/abc')
     s.logger = Logger.new("/dev/null")
 
-    expect(s.connect).to match(/\A\/tmp\/miq_\d{8}-\d{5}-\w+\z/)
+    expect(s.connect).to match(%r(\A#{prefix}\d{8}-\d{5}-\w+\z))
 
     s.disconnect
   end
 
   context "#mount_share" do
     it "without :mount_point uses default temp directory as a base" do
-      expect(described_class.new(:uri => '/tmp/abc').mount_share).to match(/\A\/tmp\/miq_\d{8}-\d{5}-\w+\z/)
+      expect(described_class.new(:uri => '/tmp/abc').mount_share).to match(%r(\A#{prefix}\d{8}-\d{5}-\w+\z))
     end
 
     it "with :mount_point uses specified directory as a base" do
-      expect(described_class.new(:uri => '/tmp/abc', :mount_point => "abc").mount_share).to match(/\Aabc\/miq_\d{8}-\d{5}-\w+\z/)
+      expect(described_class.new(:uri => '/tmp/abc', :mount_point => "xyz").mount_share).to match(%r(\Axyz/miq_\d{8}-\d{5}-\w+\z))
     end
 
     it "is unique" do

--- a/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
-require 'util/mount/miq_generic_mount_session'
+require "tmpdir"
+require "util/mount/miq_generic_mount_session"
 
 describe MiqGenericMountSession do
   let(:prefix) { File.join(Dir.tmpdir, "miq_") }

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -63,7 +63,7 @@ class MiqGenericMountSession
   end
 
   def mount_share
-    @mnt_point = settings_mount_point || Dir.mktmpdir
+    @mnt_point = Dir.mktmpdir("miq_", settings_mount_point)
   end
 
   def get_ping_depot_options
@@ -456,10 +456,6 @@ class MiqGenericMountSession
 
   def settings_mount_point
     return if @settings[:mount_point].blank? # Check if settings contains the mount_point to use
-    mount_point = File.join(@settings[:mount_point], "miq_#{MiqUUID.new_guid}")
-    raise MiqException::MountPointAlreadyExists, "#{@mnt_point} directory already exists!!!" if File.exist?(mount_point)
-    dir = FileUtils.mkdir_p(mount_point).first
-    raise MiqException::MiqLogFileMountPointMissing, "mount point: [#{@mnt_point}] failed to be created" unless File.directory?(dir)
-    dir
+    FileUtils.mkdir_p(@settings[:mount_point]).first
   end
 end

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -14,8 +14,8 @@ class MiqGenericMountSession
   attr_accessor :settings, :mnt_point, :logger
 
   def initialize(log_settings)
-    @settings = log_settings.dup
-    raise "URI missing" if @settings[:uri].nil?
+    raise "URI missing" unless log_settings.key?(:uri)
+    @settings  = log_settings.dup
     @mnt_point = nil
   end
 

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -63,6 +63,7 @@ class MiqGenericMountSession
   end
 
   def mount_share
+    require 'tmpdir'
     @mnt_point = Dir.mktmpdir("miq_", settings_mount_point)
   end
 

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -30,9 +30,7 @@ describe EvmDatabaseOps do
       EvmDatabaseOps.stub(:backup_destination_free_space).and_return(100.megabytes)
       EvmDatabaseOps.stub(:database_size).and_return(200.megabytes)
       lambda { EvmDatabaseOps.backup(@db_opts, @connect_opts)}.should raise_error(MiqException::MiqDatabaseBackupInsufficientSpace)
-      msg = MiqQueue.first
-      msg.class_name.should == "MiqEvent"
-      msg.method_name.should == "raise_evm_event"
+      expect(MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event").count).to eq(1)
     end
 
     it "remotely" do

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -6,7 +6,7 @@ describe EvmDatabaseOps do
       @connect_opts = {:username => 'blah', :password => 'blahblah', :uri => "smb://myserver.com/share"}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
       MiqSmbSession.stub(:runcmd)
-      MiqSmbSession.stub(:base_mount_point).and_return(Rails.root.join("/tmp"))
+      allow_any_instance_of(MiqSmbSession).to receive(:settings_mount_point).and_return(Rails.root.join("tmp"))
       MiqUtil.stub(:runcmd)
       PostgresAdmin.stub(:runcmd_with_logging)
       EvmDatabaseOps.stub(:backup_destination_free_space).and_return(200.megabytes)
@@ -54,7 +54,7 @@ describe EvmDatabaseOps do
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
       MiqSmbSession.stub(:runcmd)
       MiqSmbSession.stub(:raw_disconnect)
-      MiqSmbSession.stub(:base_mount_point).and_return(Rails.root.join("/tmp"))
+      allow_any_instance_of(MiqSmbSession).to receive(:settings_mount_point).and_return(Rails.root.join("tmp"))
       PostgresAdmin.stub(:runcmd_with_logging)
     end
 


### PR DESCRIPTION
Fails to create a temp dir on linux when run as non-root user.  Instead, let Ruby choose the tempdir location somewhere that it has permission.