### PR TITLE
Labels and Selector parts removal when entity is destroyed

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -10,7 +10,7 @@ class ContainerGroup < ActiveRecord::Base
            :through => :container_definitions
   has_many :container_definitions, :dependent => :destroy
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
-  has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource
+  has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
   has_many :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
   belongs_to :container_node
   has_and_belongs_to_many :container_services, :join_table => :container_groups_container_services

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -8,7 +8,7 @@ class ContainerProject < ActiveRecord::Base
   has_many :container_services
   has_many :container_definitions, :through => :container_groups
 
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource
+  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
 
   virtual_column :groups_count,      :type => :integer
   virtual_column :services_count,    :type => :integer

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -5,8 +5,8 @@ class ContainerReplicator < ActiveRecord::Base
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :container_groups
   belongs_to :container_project
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource
-  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource
+  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
   has_many :container_nodes, -> { distinct }, :through => :container_groups
 
   acts_as_miq_taggable

--- a/app/models/container_route.rb
+++ b/app/models/container_route.rb
@@ -5,7 +5,7 @@ class ContainerRoute < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
   belongs_to :container_service
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource
+  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
 
   acts_as_miq_taggable
 end

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -9,8 +9,8 @@ class ContainerService < ActiveRecord::Base
   has_many :container_routes
   has_many :container_service_port_configs, :dependent => :destroy
   belongs_to :container_project
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource
-  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource
+  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
   has_many :container_nodes, -> { distinct }, :through => :container_groups
 
   acts_as_miq_taggable


### PR DESCRIPTION
Custom attributes aren't removed when the entity they're associated with is gone.
I added :dependent => :destroy to the relevant models to fix it.

fixes #3937