### PR TITLE
blackbox: fix writeData mkdir permissions

### DIFF
--- a/gems/pending/blackbox/VmBlackBox.rb
+++ b/gems/pending/blackbox/VmBlackBox.rb
@@ -88,7 +88,7 @@ module Manageiq
     end
 
     def writeData(filename, data)
-      Dir.mkdir(@localDataDir, 755) unless File.exist?(@localDataDir)
+      Dir.mkdir(@localDataDir, 0755) unless File.exist?(@localDataDir)
       filename2 = filename.gsub("/", "_")
       fullpath = File.join(@localDataDir, filename2)
       f = File.open(fullpath, "w")


### PR DESCRIPTION
It's clear that the intent of this mkdir was to use permissions 0755 (drwxr-xr-x.) and not 755 (d-wxrw---t).
