### PR TITLE
Fixed code to not rebuild trees on each transaction in reports explorer

### DIFF
--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -215,7 +215,6 @@ module ReportController::Menus
       get_tree_data
       #set menu_default flag to true
       @sb[:menu_default] = true
-      @sb[:rep_tree_build_time] = Time.now.utc
       replace_right_cell(:menu_edit_action => "menu_default")
     elsif params[:button] == "save"
       @menu_lastaction = "save"

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -31,7 +31,6 @@ module ReportController::Reports
     @right_cell_div  = "report_list"
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name=>r.name, :model=>"Saved Report"}
     add_flash(_("%{model} \"%{name}\" was saved") % {:model=>ui_lookup(:model=>"MiqReport"), :name=>r.name})
-    @sb[:rep_tree_build_time] = Time.now.utc
     replace_right_cell(:replace_trees => [:reports,:savedreports])
   end
 
@@ -108,7 +107,6 @@ module ReportController::Reports
         add_flash(_("%{model} \"%{name}\": Delete successful") % {:model=>ui_lookup(:model=>"MiqReport"), :name=>rpt_name})
       end
       params[:id] = nil
-      @sb[:rep_tree_build_time] = Time.now.utc
       nodes = x_node.split('_')
       self.x_node = "#{nodes[0]}_#{nodes[1]}"
       replace_right_cell(:replace_trees => [:reports])

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -67,7 +67,6 @@ module ReportController::Reports::Editor
             setnode_for_customreport
           end
           @edit = session[:edit] = nil # clean out the saved info
-          @sb[:rep_tree_build_time] = Time.now.utc
           if role_allows(:feature=>"miq_report_widget_editor")
             # all widgets for this report
             get_all_widgets("report",from_cid(x_node.split('_').last))

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -105,7 +105,6 @@ module ReportController::SavedReports
     end
     self.x_node = "xx-#{to_cid(@sb[:miq_report_id])}" if x_active_tree == :savedreports_tree &&
         x_node.split('-').first == "rr"
-    @sb[:rep_tree_build_time] = Time.now.utc
     replace_right_cell(:replace_trees => [:reports,:savedreports])
   end
 


### PR DESCRIPTION
- Fixed code that was rebuilding reports trees on every transaction after user pressed Queue report to run button once in UI, code was not setting rep_tree_build_time correctly in some of the places, removed setting of rep_tree_build_time from other places in code and moved it into rebuild_trees method.
- added spec tests around rebuild_trees method and replace_right_cell method to verify changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1258927
https://bugzilla.redhat.com/show_bug.cgi?id=1258933

@dclarizio please review/test