### PR TITLE
MiqPolicy#action_result_for_event - fail when called with wrong ids

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -131,8 +131,8 @@ class MiqPolicy < ActiveRecord::Base
   end
 
   def action_result_for_event(action, event)
-    pe = miq_policy_contents.where(:miq_action_id => action.id, :miq_event_definition_id => event.id)
-    pe.first.present? && pe.first.qualifier == "success"
+    pe = miq_policy_contents.find_by(:miq_action_id => action.id, :miq_event_definition_id => event.id)
+    pe.qualifier == "success"
   end
 
   def delete_event(event)


### PR DESCRIPTION
This partially reverts edd0ba3, keeping the fixed argument order but
raising when no db entry found.

The original change was meant to address a bug where miq_action_node was
called with a nonsensical action_id + miq_event_definition_id
combination, which was triggered by a bug in Policy trees'
x_get_tree_po_kids and is not present either in master or in #3530.