### PR TITLE
containers: fix timeline displaying errors

### DIFF
--- a/app/views/ems_container/show.html.haml
+++ b/app/views/ems_container/show.html.haml
@@ -1,5 +1,1 @@
-- if %w(containers container_groups container_services container_routes container_replicators container_nodes container_projects container_images container_image_registries).include?(@display)
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-- else
-  = render :partial => @showtype
-
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -13,4 +13,4 @@
   - elsif @showtype == "dialog_provision"
     = render :partial => "shared/dialogs/dialog_provision"
   - else
-    = render :partial => "shared/views/ems_common/#{@showtype}"
+    = render :partial => @showtype

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -527,19 +527,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "335bc3c5f388ecc8a0322d73850c3857343b661e7a582054f80eb39a93735c2e",
+      "fingerprint": "e95f7b494233d0543110961a8058f9fa42e06813db3579e54afa8adc9fbe62a7",
       "message": "Render path contains parameter value",
       "file": "app/views/shared/views/ems_common/_show.html.haml",
       "line": 16,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(partial => \"shared/views/ems_common/#{((((\"config\" or (params[:display] or \"main\")) or \"timeline\") or \"config\") or \"main\")}\", {})",
+      "code": "render(partial => ((((\"config\" or (params[:display] or \"main\")) or \"timeline\") or \"config\") or \"main\"), {})",
       "render_path": ["EmsCloudController#show","Template:ems_cloud/show"],
       "location": {
         "type": "template",
         "template": "shared/views/ems_common/_show (Template:ems_cloud/show)"
       },
       "user_input": "params[:display]",
-      "confidence": "Medium",
+      "confidence": "High",
       "note": ""
     },
     {
@@ -595,8 +595,29 @@
       "user_input": null,
       "confidence": "Weak",
       "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "335bc3c5f388ecc8a0322d73850c3857343b661e7a582054f80eb39a93735c2e",
+      "message": "Render path contains parameter value",
+      "file": "app/views/shared/views/ems_common/_show.html.haml",
+      "line": 16,
+      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(partial => \"shared/views/ems_common/#{((((\"config\" or (params[:display] or \"main\")) or \"timeline\") or \"config\") or \"main\")}\", {})",
+      "render_path": [
+        "EmsCloudController#show",
+        "Template:ems_cloud/show"
+      ],
+      "location": {
+        "type": "template",
+        "template": "shared/views/ems_common/_show (Template:ems_cloud/show)"
+      },
+      "user_input": "params[:display]",
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2015-09-08 09:54:37 +0200",
+  "updated": "2015-09-07 19:29:17 -0400",
   "brakeman_version": "3.0.5"
 }

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -1,27 +1,18 @@
 require "spec_helper"
 
 describe EmsContainerController do
-  describe "#create" do
-    before do
-      EvmSpecHelper.seed_specific_product_features("ems_container_new")
-      feature = MiqProductFeature.find_all_by_identifier(["ems_container_new"])
-      test_user_role  = FactoryGirl.create(:miq_user_role,
-                                           :name                 => "test_user_role",
-                                           :miq_product_features => feature)
-      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+  before(:each) do
+    set_user_privileges
+  end
 
-      allow(user).to receive(:server_timezone).and_return("UTC")
-      described_class.any_instance.stub(:set_user_time_zone)
-      controller.stub(:check_privileges).and_return(true)
-      login_as user
-    end
+  it "#new" do
+    controller.instance_variable_set(:@breadcrumbs, [])
+    get :new
 
-    it "adds a new provider" do
-      controller.instance_variable_set(:@breadcrumbs, [])
-      get :new
-      expect(response.status).to eq(200)
-      expect(controller.stub(:edit)).to_not be_nil
-    end
+    expect(response.status).to eq(200)
+    expect(controller.stub(:edit)).to_not be_nil
+  end
+
+
   end
 end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe EmsContainerController do
   before(:each) do
+    session[:settings] = {:views => {}}
     set_user_privileges
   end
 
@@ -13,6 +14,11 @@ describe EmsContainerController do
     expect(controller.stub(:edit)).to_not be_nil
   end
 
+  it "#show" do
+    ems = FactoryGirl.create(:ems_kubernetes)
+    get :show, :id => ems.id
 
+    expect(response.status).to eq(200)
+    expect(response).to render_template('ems_container/show')
   end
 end


### PR DESCRIPTION
The addition of the topology widget has introduced a regression in displaying the timeline:

    FATAL -- : Error caught: [ActionView::MissingTemplate] Missing partial ems_container/_timeline,
    application/_timeline with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:erb,
    :builder, :raw, :ruby, :haml, :jbuilder, :rjs]}. Searched in:
    * "/home/simon/manageiq/app/views"

This patch attempts to restore the correct beahvior of the timeline (maintaining the topology functionalities).