### PR TITLE
Fix exception when computing textual_rps_size for EmsCluster

### DIFF
--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -160,7 +160,9 @@ module EmsClusterHelper::TextualSummary
   def textual_rps_size
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::EmsCluster)
 
-    textual_link(@record.resource_pools)
+    textual_link(@record.resource_pools,
+                 :as => EmsCluster,
+                 :link => url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'resource_pools'))
   end
 
   def textual_states_size


### PR DESCRIPTION
Showing an EmsCluster in current master throws 

```
Error caught: [ArgumentError] :as and :link are both required when linking to an array
/home/himdel/manageiq/app/helpers/ems_cluster_helper/textual_summary.rb:163:in `textual_rps_size'
/home/himdel/manageiq/app/views/shared/summary/_textual.html.haml:1:in `_app_views_shared_summary__textual_html_haml___3706561883468147294_47108304720640'
```

The `@record` in `textual_rps_size` is an `EmsCluster`, it's `#resource_pools` returns an empty Array, which triggers that exception. This fixes that.

Introduced in 8451d637, @matthewd please review..?