### PR TITLE
Ensure tenant is created in a region

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -173,7 +173,9 @@ class Tenant < ActiveRecord::Base
   end
 
   def self.seed
-    Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => true)
+    MiqRegion.my_region.lock do
+      Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => true)
+    end
   end
 
   private

--- a/spec/controllers/application_controller/tenancy_spec.rb
+++ b/spec/controllers/application_controller/tenancy_spec.rb
@@ -7,9 +7,8 @@ describe DashboardController do
 
   context "#with unknown subdomain or domain" do
     before do
-      # acts_as_tenant initializer
+      MiqRegion.seed
       Tenant.seed
-      # end of acts_as_tenant_initializer
       @request.host = "www.example.com"
     end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -6,6 +6,7 @@ describe OpsController do
 
   context "::Tenants" do
     before do
+      MiqRegion.seed
       Tenant.seed
       set_user_privileges
     end
@@ -32,7 +33,7 @@ describe OpsController do
 
     context "#rbac_tenant_get_details" do
       it "sets @tenant record" do
-        t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant, :subdomain => "foo", :domain => "bar")
+        t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant, :subdomain => "foo")
         controller.send(:rbac_tenant_get_details, t.id)
         assigns(:tenant).should eq(t)
       end
@@ -74,7 +75,6 @@ describe OpsController do
         @tenant = FactoryGirl.create(:tenant,
                                      :name      => "Foo",
                                      :parent    => Tenant.root_tenant,
-                                     :domain    => "test",
                                      :subdomain => "test")
         sb_hash = {
           :trees       => {:rbac_tree => {:active_node => "tn-#{controller.to_cid(@tenant.id)}"}},

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_quota_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_quota_spec.rb
@@ -3,13 +3,14 @@ require "spec_helper"
 module MiqAeServiceTenantQuotaSpec
   describe MiqAeMethodService::MiqAeServiceTenantQuota do
     let(:settings) { {} }
-    let(:tenant) { Tenant.create(:name => 'fred', :domain => 'a.b', :parent => default_tenant) }
+    let(:tenant) { Tenant.create(:name => 'fred', :domain => 'a.b', :parent => root_tenant) }
     let(:cpu_quota) { TenantQuota.create(:name => "cpu_allocated", :unit => "int", :value => 2, :tenant_id => tenant.id) }
     let(:storage_quota) { TenantQuota.create(:name => "storage_allocated", :unit => "GB", :value => 160, :tenant_id => tenant.id) }
 
-    let(:default_tenant) do
+    let(:root_tenant) do
+      MiqRegion.seed
       Tenant.seed
-      Tenant.default_tenant
+      Tenant.root_tenant
     end
 
     let(:st_cpu_quota) { MiqAeMethodService::MiqAeServiceTenantQuota.find(cpu_quota.id) }

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_tenant_spec.rb
@@ -3,11 +3,12 @@ require "spec_helper"
 module MiqAeServiceTenantSpec
   describe MiqAeMethodService::MiqAeServiceTenant do
     let(:settings) { {} }
-    let(:tenant) { Tenant.create(:name => 'fred', :domain => 'a.b', :parent => def_tenant, :description => "Krueger") }
+    let(:tenant) { Tenant.create(:name => 'fred', :domain => 'a.b', :parent => root_tenant, :description => "Krueger") }
 
-    let(:def_tenant) do
+    let(:root_tenant) do
+      MiqRegion.seed
       Tenant.seed
-      Tenant.default_tenant
+      Tenant.root_tenant
     end
 
     let(:service_tenant) { MiqAeMethodService::MiqAeServiceTenant.find(tenant.id) }

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe ServiceTemplateCatalog do
   let(:root_tenant) do
+    MiqRegion.seed
     Tenant.seed
     Tenant.root_tenant
   end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -5,11 +5,12 @@ describe Tenant do
   let(:tenant) { described_class.new(:domain => 'x.com', :parent => default_tenant) }
 
   let(:default_tenant) do
-    Tenant.seed
+    root_tenant
     described_class.default_tenant
   end
 
   let(:root_tenant) do
+    MiqRegion.seed
     Tenant.seed
     described_class.root_tenant
   end
@@ -334,11 +335,11 @@ describe Tenant do
 
   describe "#nil_blanks" do
     it "nulls out blank domain" do
-      expect(described_class.create(:domain => "  ").domain).to be_nil
+      expect(described_class.create!(:domain => "  ", :parent => root_tenant).domain).to be_nil
     end
 
     it "nulls out blank subdomain" do
-      expect(described_class.create(:subdomain => "  ").domain).to be_nil
+      expect(described_class.create!(:subdomain => "  ", :parent => root_tenant).domain).to be_nil
     end
   end
 
@@ -349,7 +350,7 @@ describe Tenant do
 
     it "only allows one root" do
       described_class.destroy_all
-      described_class.seed
+      root_tenant # create a root tenant
 
       expect {
         described_class.create!

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -51,6 +51,7 @@ module EvmSpecHelper
   end
 
   def self.remote_guid_miq_server_zone
+    MiqRegion.seed
     Tenant.seed
     guid   = MiqUUID.new_guid
     zone   = FactoryGirl.create(:zone)


### PR DESCRIPTION
All seeds (except for the tenant model) lock on region.

This requires that a `MiqRegion` be created.

ASIDE: When I write data migrations in the database for tenants, I may be able to remove this

/cc @Fryguy 