### PR TITLE
Fix exception when navigating to a container page with no tags

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -94,10 +94,7 @@ module ContainerSummaryHelper
     label = "#{session[:customer_name]} Tags"
     h = {:label => label}
     tags = session[:assigned_filters]
-    if tags.empty?
-      h[:image] = "smarttag"
-      h[:value] = "No #{label} have been assigned"
-    else
+    if tags.present?
       h[:value] = tags.sort_by { |category, _assigned| category.downcase }.collect do |category, assigned|
         {
           :image => "smarttag",
@@ -105,7 +102,11 @@ module ContainerSummaryHelper
           :value => assigned
         }
       end
+    else
+      h[:image] = "smarttag"
+      h[:value] = "No #{label} have been assigned"
     end
+
     h
   end
 


### PR DESCRIPTION
The exception occured when navigating to a container's ui page which had no tags due to calling empty? on a nil.

"[NoMethodError] undefined method `empty?' for nil:NilClass
/home/manageiq/app/helpers/container_summary_helper.rb:93:in `textual_tags'
/home/manageiq/app/helpers/container_helper/textual_summary.rb:16:in `block in textual_group_smart_management'"