### PR TITLE
Fix legend selection to be remembered after topology refresh

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -11,12 +11,16 @@ angular.module('topologyApp', ['kubernetesUI'])
         else {
             id = '/'+ (/container_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
         }
-
+        var currentSelectedKinds = $scope.kinds;
         var url = '/container_topology/data'+id;
         $http.get(url).success(function(data) {
             $scope.items = data.data.items;
             $scope.relations = data.data.relations;
             $scope.kinds = data.data.kinds;
+            if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !=  Object.keys($scope.kinds).length)) {
+                $scope.kinds = currentSelectedKinds;
+            }
+
         });
 
     };


### PR DESCRIPTION
The topology legend allows show/hide the entities on the graph by pressing the legend icons.
So far, the refresh action would "forget" if any entity was unselected and would show it after refresh in the legend and the graph.
This fix is keeping the legend selection remembered after refresh, so if any entity was unselected/hidden before refresh, it remains so after the refresh as well.