### PR TITLE
Substituted variable prefix with exact link

### DIFF
--- a/app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml
+++ b/app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml
@@ -2,27 +2,26 @@
 -# dialog      The name (symbol) of the selected dialog
 
 - current_tab = @edit && @edit[:new] ? @edit[:new][:current_tab_key] : @options[:current_tab_key]
-- pfx ||= "miq_request/"
 %br
 
 - if dialog == current_tab
   - case current_tab
   - when :requester
     - keys = [:owner_email, :owner_first_name, :owner_last_name, :owner_address, :owner_city, :owner_state, :owner_zip, :owner_country, :owner_title, :owner_company, :owner_department, :owner_office, :owner_phone, :owner_phone_mobile, :request_notes]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog       => dialog,
         :label        => _("Request Information"),
         :keys         => keys})
     - keys = [:owner_manager, :owner_manager_mail, :owner_manager_mail]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Manager"),
         :keys                       => keys})
   - when :purpose
     - keys = [:tag_ids]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Select Tags to apply"),
@@ -31,7 +30,7 @@
         :extra_table_attributes     => "cellspacing=1"})
   - when :service
     - keys = [:src_configured_system_ids, :src_configuration_profile_id]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Configured Systems"),
@@ -39,23 +38,23 @@
         :extra_table_attributes     => "width=100%"})
   - when :customize
     - keys = [:root_password]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Credentials"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
     - keys = [:hostname, :ip_addr]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("IP Address Information"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
   - when :schedule
     - has_schedule_time = (@edit && @edit[:new] && @edit[:new][:schedule_type] && @edit[:new][:schedule_type][0] == "schedule") || (@options && @options[:schedule_type] && @options[:schedule_type][0] == "schedule")
     - keys = [:schedule_type, has_schedule_time ? :schedule_time : nil, :stateless].compact
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Schedule Info"),

--- a/app/views/miq_request/_prov_host_dialog.html.haml
+++ b/app/views/miq_request/_prov_host_dialog.html.haml
@@ -2,27 +2,26 @@
 -# dialog      The name (symbol) of the selected dialog
 
 - current_tab = @edit && @edit[:new] ? @edit[:new][:current_tab_key] : @options[:current_tab_key]
-- pfx ||= "miq_request/"
 %br
 
 - if dialog == current_tab
   - case current_tab
   - when :requester
     - keys = [:owner_email, :owner_first_name, :owner_last_name, :owner_address, :owner_city, :owner_state, :owner_zip, :owner_country, :owner_title, :owner_company, :owner_department, :owner_office, :owner_phone, :owner_phone_mobile, :request_notes]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog       => dialog,
         :label        => _("Request Information"),
         :keys         => keys})
     - keys = [:owner_manager, :owner_manager_mail, :owner_manager_mail]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Manager"),
         :keys                       => keys})
   - when :purpose
     - keys = [:vm_tags]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Select Tags to apply"),
@@ -31,14 +30,14 @@
         :extra_table_attributes     => "cellspacing=1"})
   - when :service
     - keys = [:src_host_ids]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => title_for_host,
         :keys                       => keys,
         :extra_table_attributes     => "width=100%"})
     - keys = [:pxe_server_id, :pxe_image_id]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("PXE"),
@@ -50,63 +49,63 @@
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => ui_lookup(:tables => "ext_management_system"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
     - keys = [:placement_cluster_name]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => title_for_cluster,
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
     - keys = [:attached_ds]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Datastore"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
   - when :customize
     - keys = [:root_password]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Credentials"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
     - keys = [:addr_mode, :hostname, :ip_addr, :subnet_mask, :gateway]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("IP Address Information"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
     - keys = [:dns_servers, :dns_suffixes]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("DNS"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
     - keys = [:customization_template_id]
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals => {:workflow => wf,
         :dialog             => dialog,
         :label              => _("Customize Template"),
-        :prefix             => pfx,
+        :prefix             => "miq_request/",
         :keys               => keys})
     - show_customization_template_script = (@edit && @edit[:new] && @edit[:new][:customization_template_script]) || (@options && @options[:customization_template_script])
     - keys = [show_customization_template_script ? :customization_template_script : nil].compact
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Selected Template Contents"),
-        :prefix                     => pfx,
+        :prefix                     => "miq_request/",
         :keys                       => keys})
   - when :schedule
     - has_schedule_time = (@edit && @edit[:new] && @edit[:new][:schedule_type] && @edit[:new][:schedule_type][0] == "schedule") || (@options && @options[:schedule_type] && @options[:schedule_type][0] == "schedule")
     - keys = [:schedule_type, has_schedule_time ? :schedule_time : nil, :stateless].compact
-    = render(:partial => "#{pfx}prov_dialog_fieldset",
+    = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Schedule Info"),

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -3,141 +3,140 @@
 -# dialog      The name (symbol) of the selected dialog
 
 - current_tab = @edit && @edit[:new] ? @edit[:new][:current_tab_key] : @options[:current_tab_key]
-- prefix = "/miq_request/"
 - if dialog == current_tab
   - case current_tab
   - when :requester
     - keys = [:owner_email, :owner_first_name, :owner_last_name, :owner_address, :owner_city, :owner_state, :owner_zip, :owner_country, :owner_title, :owner_company, :owner_department, :owner_office, :owner_phone, :owner_phone_mobile, :request_notes]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Request Information"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
 
     - keys = [:owner_manager, :owner_manager_mail, :owner_manager_phone]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Manager"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :purpose
     - keys = [:vm_tags]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Select Tags to apply"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys,
         :table_class                => "tagstable",
         :extra_table_attributes     => "cellspacing=1"})
   - when :service
     - keys = wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow) ? [:src_vm_id, :provision_type, :linked_clone] : [:vm_filter, :src_vm_id, :provision_type, :linked_clone, :snapshot]
     - label = wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow) ? _("Selected VM") : _("Select")
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => label,
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys,
         :extra_table_attributes     => "width=100%"})
     - if wf.supports_pxe?
       - keys = [:pxe_server_id, :pxe_image_id, :windows_image_id]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("PXE"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})
     - if wf.supports_iso?
       - keys = [:iso_image_id]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("ISO"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})
     - keys = [:number_of_vms]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Number of Instances") : _("Number of VMs")
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => label,
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
     - keys = [:vm_name, :vm_description, :vm_prefix]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Naming"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :environment
     - keys = [:placement_auto]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Placement"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
     - if (@edit && @edit[:new] && @edit[:new][:placement_auto] && !@edit[:new][:placement_auto][0]) || (@options && !@options[:placement_auto][0])
       - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
         - keys = [:placement_dc_name]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Datacenter"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
         - keys = [:cluster_filter, :placement_cluster_name]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => title_for_cluster,
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
       - if wf.kind_of?(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow)
         - keys = [:rp_filter, :placement_rp_name]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Resource Pool"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
         - keys = [:placement_folder_name]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Folder"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
       - keys = [:host_filter, :placement_host_name]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => title_for_host,
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})
       - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
         - keys = [:ds_filter, :placement_ds_name]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Datastore"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys,
             :extra_table_attributes     => "width=100%"})
       - if wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
         - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network, :cloud_subnet, :security_groups, :floating_ip_address]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Placement - Options"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys,
             :extra_table_attributes     => "width=100%"})
   - when :hardware
@@ -145,233 +144,233 @@
               :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? "Properties" : "Hardware"
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => label,
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
     - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
       - keys = [:cpu_limit, :memory_limit]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog       => dialog,
           :label        => _("VM Limits"),
-          :prefix       => prefix,
+          :prefix       => "/miq_request/",
           :keys         => keys})
       - keys = [:cpu_reserve, :memory_reserve]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog       => dialog,
           :label        => _("VM Reservations"),
-          :prefix       => prefix,
+          :prefix       => "/miq_request/",
           :keys         => keys})
     - if wf.kind_of?(ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow)
-      = render(:partial => "#{prefix}prov_dialog_cloud_quota",
+      = render(:partial => "/miq_request/prov_dialog_cloud_quota",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
   - when :network
     - keys = [:vlan, :mac_address]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Network Adapter Information"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :customize
     - if wf.kind_of?(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow) && !wf.supports_pxe? && !wf.supports_iso?
       - keys = [:sysprep_enabled]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("Basic Options"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
       - if (@edit && @edit[:new] && @edit[:new][:sysprep_enabled] && @edit[:new][:sysprep_enabled][0] == "fields") || (@options && @options[:sysprep_enabled] && @options[:sysprep_enabled][0] == "fields")
         - keys = [:sysprep_custom_spec, :sysprep_spec_override]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Custom Specification"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys,
             :extra_table_attributes     => "width=100%"})
         - if @sb[:vm_os] == "windows"
           - keys = [:sysprep_timezone, :sysprep_auto_logon, :sysprep_auto_logon_count, :sysprep_password]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("Unattended GUI"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
           - keys = [:sysprep_identification]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("Identification"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
           - if (@edit && @edit[:new] && @edit[:new][:sysprep_identification][0] == "domain") || (@options && @options[:sysprep_identification][0] == "domain")
             - keys = [:sysprep_domain_name, @ldap_ous_tree ? :ldap_ous : nil, :sysprep_domain_admin, :sysprep_domain_password].compact
-            = render(:partial => "#{prefix}prov_dialog_fieldset",
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
               :locals         => {:workflow => wf,
                 :dialog                     => dialog,
                 :label                      => _("Domain Information"),
-                :prefix                     => prefix,
+                :prefix                     => "/miq_request/",
                 :keys                       => keys})
           - else
             - keys = [:sysprep_workgroup_name]
-            = render(:partial => "#{prefix}prov_dialog_fieldset",
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
               :locals         => {:workflow => wf,
                 :dialog                     => dialog,
                 :label                      => _("Workgroup Information"),
-                :prefix                     => prefix,
+                :prefix                     => "/miq_request/",
                 :keys                       => keys})
           - keys = [:sysprep_full_name, :sysprep_organization, :sysprep_product_id, :sysprep_computer_name]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("User Data"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
           - keys = [:sysprep_change_sid, :sysprep_delete_accounts]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("Windows Options"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
           - keys = [:sysprep_server_license_mode, :sysprep_per_server_max_connections]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("Server License"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
         - elsif @sb[:vm_os] == "linux"
           - keys = [:linux_host_name, :linux_domain_name]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("Naming"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
       - elsif (@edit && @edit[:new] && @edit[:new][:sysprep_enabled] && @edit[:new][:sysprep_enabled][0] == "file") || (@options && @options[:sysprep_enabled] && @options[:sysprep_enabled][0] == "file")
         - keys = [:sysprep_custom_spec, :sysprep_spec_override]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Custom Specification"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
         - keys = [:sysprep_change_sid, :sysprep_delete_accounts]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Windows Options"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
         - if @edit && @edit[:new]
           - keys = [:sysprep_upload_file]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("Upload File"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
         - if (@edit && @edit[:new] && @edit[:new][:sysprep_upload_text]) || (@options && @options[:sysprep_upload_text])
           - file_name = (@edit && @edit[:new]) ? @edit[:new][:sysprep_upload_file] : @options[:sysprep_upload_file]
           - label = _("Uploaded File '%s'") % file_name
           - keys = [:sysprep_upload_text]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => label,
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
       - elsif (@edit && @edit[:new] && @edit[:new][:sysprep_enabled] && @edit[:new][:sysprep_enabled][0] == "customspec") || (@options && @options[:sysprep_enabled] && @options[:sysprep_enabled][0] == "customspec")
         - keys = [:sysprep_custom_spec]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("Custom Specification"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
       - if (!@options && @edit && @edit[:new] && @edit[:new][:sysprep_enabled] && @edit[:new][:sysprep_enabled][0] && @edit[:new][:sysprep_enabled][0] != "disabled") || (!@edit && @options && @options[:sysprep_enabled] && @options[:sysprep_enabled][0] && @options[:sysprep_enabled][0] != "disabled")
         - keys = [:addr_mode, :ip_addr, :subnet_mask, :gateway]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("IP Address Information"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
         - keys = [:dns_servers, :dns_suffixes]
-        = render(:partial => "#{prefix}prov_dialog_fieldset",
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
             :label                      => _("DNS"),
-            :prefix                     => prefix,
+            :prefix                     => "/miq_request/",
             :keys                       => keys})
         - if @sb[:vm_os] == "windows"
           - keys = [:wins_servers]
-          = render(:partial => "#{prefix}prov_dialog_fieldset",
+          = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
               :label                      => _("WINS Server"),
-              :prefix                     => prefix,
+              :prefix                     => "/miq_request/",
               :keys                       => keys})
     - else
       - keys = [:root_password]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("Credentials"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
       - keys = [:addr_mode, :hostname, :ip_addr, :subnet_mask, :gateway]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("IP Address Information"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
       - keys = [:dns_servers, :dns_suffixes]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("DNS"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
       - keys = [:customization_template_id]
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("Customize Template"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
       - show_customization_template_script = (@edit && @edit[:new] && @edit[:new][:customization_template_script]) || (@options && @options[:customization_template_script])
       - keys = [show_customization_template_script ? :customization_template_script : nil].compact
-      = render(:partial => "#{prefix}prov_dialog_fieldset",
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,
           :label                      => _("Selected Template Contents"),
-          :prefix                     => prefix,
+          :prefix                     => "/miq_request/",
           :keys                       => keys})
   - when :schedule
     - has_schedule_time = (@edit && @edit[:new] && @edit[:new][:schedule_type] && @edit[:new][:schedule_type][0] == "schedule") || (@options && @options[:schedule_type] && @options[:schedule_type][0] == "schedule")
     - keys = [:schedule_type, has_schedule_time ? :schedule_time : nil, :stateless].compact
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Schedule Info"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})
     - keys = [:vm_auto_start, :retirement, :retirement_warn]
-    = render(:partial => "#{prefix}prov_dialog_fieldset",
+    = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Lifespan"),
-        :prefix                     => prefix,
+        :prefix                     => "/miq_request/",
         :keys                       => keys})


### PR DESCRIPTION
I've changed variable prefix with exact link since there isn't another same-named partial in other folder.
It makes situation harder to me, when I need to search for another potential place from where partial could be called.

Also I changed conditional assignment with standard assignment in partials because I haven't found any situation where partial would be called with another prefix

@martinpovolny can you review please?