### PR TITLE
Fixed issue where textarea adds \r\n for newline characters.

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1207,7 +1207,7 @@ function miqDomElementExists(element) {
 }
 
 function miqSerializeForm(element) {
-  return $('#' + element).find('input,select,textarea').serialize();
+  return $('#' + element).find('input,select,textarea').serialize().replace(/%0D%0A/g, '%0A');
 }
 
 function miqSerializeField(element, field_name) {

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -1,0 +1,9 @@
+describe('miq_application.js', function() {
+  beforeEach(function () {
+    var html = '<div id="form_div"><textarea name="method_data">new line added\r\n\r\n</textarea></div>'
+    setFixtures(html);
+  });
+  it('verify serialize method doesnt convert line feed value to windows line feed', function() {
+    expect(miqSerializeForm('form_div')).toEqual("method_data=new+line+added%0A%0A");
+  });
+});


### PR DESCRIPTION
- Changed 'miqSerializeForm' JS method to replace '%0D%0A' with '%0A' in the serialized form data, this is caused because 'textarea' form element adds \r\n characters in the data for the newline characters.
- Added Jasmine spec test to verify the fix

https://bugzilla.redhat.com/show_bug.cgi?id=1234465

@martinpovolny @dclarizio please review

To recreate the issue you will need to save a method in Automate explorer, then go to to Import/Export tab and export automate database, once exported go thru exported file structure to find the method you just added, open the newly added method_name.rb in vi and do :set list on it to see line endings.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/9661480/eb52f3c6-5228-11e5-9fcf-a8295d286edd.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/9661478/e89f4c1a-5228-11e5-98ee-218989230485.png)
