### PR TITLE
update all models to have tenant

### DIFF
--- a/db/migrate/20150903162623_assign_tenant.rb
+++ b/db/migrate/20150903162623_assign_tenant.rb
@@ -1,0 +1,43 @@
+class AssignTenant < ActiveRecord::Migration
+  class Tenant < ActiveRecord::Base
+    # seed and return the current root_tenant
+    def self.root_tenant
+      Tenant.where(:ancestry => nil).first || Tenant.create!(:use_config_for_attributes => true)
+    end
+  end
+
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqAeNamespace < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqGroup < ActiveRecord::Base
+  end
+
+  class Provider < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class TenantQuota < ActiveRecord::Base
+  end
+
+  class Vm < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def change
+    models = [ExtManagementSystem, MiqAeNamespace, MiqGroup,
+              Provider, TenantQuota, Vm]
+
+    # only create a root tenant if there are records in the db
+    return unless MiqGroup.exists?
+
+    root_tenant = Tenant.root_tenant
+    models.each do |model|
+      model.where(:tenant_id => nil).update_all(:tenant_id => root_tenant.id)
+    end
+  end
+end

--- a/spec/migrations/20150824130000_update_tenant_override_settings_spec.rb
+++ b/spec/migrations/20150824130000_update_tenant_override_settings_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require __FILE__.sub("spec/migrations", "db/migrate").sub("_spec.rb", ".rb")
+require_migration
 
 describe UpdateTenantOverrideSettings do
   let(:tenant_stub) { migration_stub(:Tenant) }

--- a/spec/migrations/20150903162623_assign_tenant_spec.rb
+++ b/spec/migrations/20150903162623_assign_tenant_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require_migration
+
+describe AssignTenant do
+  let(:tenant_stub)           { migration_stub(:Tenant) }
+  let(:ems_stub)              { migration_stub(:ExtManagementSystem) }
+  let(:miq_ae_namespace_stub) { migration_stub(:MiqAeNamespace) }
+  let(:miq_group_stub)        { migration_stub(:MiqGroup) }
+  let(:provider_stub)         { migration_stub(:Provider) }
+  let(:tenant_quota_stub)     { migration_stub(:TenantQuota) }
+  let(:vm_stub)               { migration_stub(:Vm) }
+
+  let(:stubs) { [ems_stub, miq_ae_namespace_stub, miq_group_stub, provider_stub, tenant_quota_stub, vm_stub] }
+
+  migration_context :up do
+    describe "#root_tenant" do
+      it "doesnt create tenant if no records exist" do
+        migrate
+
+        expect(tenant_stub.count).to eq(0)
+      end
+
+      it "creates tenant if needed" do
+        miq_group_stub.create!
+        migrate
+
+        expect(tenant_stub.count).to eq(1)
+        expect(tenant_stub.first).to be_use_config_for_attributes
+      end
+
+      it "doesnt creates additional root_tenant" do
+        tenant_stub.create!
+        miq_group_stub.create!
+
+        migrate
+
+        expect(tenant_stub.count).to eq(1)
+        # make sure tenant was not modified
+        expect(tenant_stub.first).not_to be_use_config_for_attributes
+      end
+    end
+
+    it "updates existing records" do
+      tenant_stub.root_tenant
+
+      stubs.map(&:create!)
+
+      migrate
+
+      expect(tenant_stub.count).to eq(1)
+      stubs.each do |stub|
+        expect(stub.where(:tenant_id => nil).exists?).to be_false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Update any existing models that reference tenant to assign `tenant_id` to tenant0.

If there are existing models, and no tenant, create a tenant, and then update `tenant_id` in the existing models.

Notes:

- All future migrations that need a tenant will need to create one. [this is low odds and we're writing this off]

Alternative:

- ~~always create a tenant (even in test) - and remove `seed` / primordials / `before` sections in specs that seed the tenant.~~ 2015-09-03 tenancy meeting decided to go with this option
