### PR TITLE
don't def controller_name since rails provides it

### DIFF
--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -12,10 +12,6 @@ class ContainerGroupController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_group"
-  end
-
   def display_name
     "Pods"
   end

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -12,10 +12,6 @@ class ContainerImageController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_image"
-  end
-
   def display_name
     "Container Images"
   end

--- a/app/controllers/container_image_registry_controller.rb
+++ b/app/controllers/container_image_registry_controller.rb
@@ -11,10 +11,6 @@ class ContainerImageRegistryController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_image_registry"
-  end
-
   def display_name
     "Container Image Registry"
   end

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -12,10 +12,6 @@ class ContainerNodeController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_node"
-  end
-
   def display_name
     "Container Nodes"
   end

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -12,10 +12,6 @@ class ContainerProjectController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_project"
-  end
-
   def display_name
     "Container Projects"
   end

--- a/app/controllers/container_replicator_controller.rb
+++ b/app/controllers/container_replicator_controller.rb
@@ -12,10 +12,6 @@ class ContainerReplicatorController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_replicator"
-  end
-
   def display_name
     "Container Replicators"
   end

--- a/app/controllers/container_route_controller.rb
+++ b/app/controllers/container_route_controller.rb
@@ -12,10 +12,6 @@ class ContainerRouteController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_route"
-  end
-
   def display_name
     "Container Routes"
   end

--- a/app/controllers/container_service_controller.rb
+++ b/app/controllers/container_service_controller.rb
@@ -12,10 +12,6 @@ class ContainerServiceController < ApplicationController
 
   private ############################
 
-  def controller_name
-    "container_service"
-  end
-
   def display_name
     "Container Services"
   end


### PR DESCRIPTION
no need to define `controller_name` since it is built into rails

These definitions caused issues for #4203 (which was trying to get rid of using `params[:controller]` to appease brakeman