### PR TITLE
scanning: add MIQExtract requirement in the mixin

### DIFF
--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -5,6 +5,7 @@ $LOAD_PATH << File.join(GEMS_PENDING_ROOT, "util/xml")
 require 'xml_utils'
 
 require 'blackbox/VmBlackBox'
+require 'metadata/MIQExtract/MIQExtract'
 require 'scanning_operations_mixin'
 
 module ScanningMixin


### PR DESCRIPTION
MIQExtract is used in `scanning_mixin.rb` but the relevant requirement was missing.