### PR TITLE
[WIP] Keep a long-running partner process to fork AE work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "rails-i18n",                                                     :git => "g
 # Not vendored and not required
 gem "ancestry",                       "~>2.1.0",   :require => false
 gem "aws-sdk",                        "~>1.56.0",  :require => false
+gem "connection_pool",                "~>2.2.0",   :require => false
 gem "dalli",                          "~>2.7.4",   :require => false
 gem "elif",                           "=0.1.0",    :require => false
 gem "hamlit",                         "~>1.7.2",   :require => false

--- a/lib/miq_automation_engine/engine/miq_ae_executor.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_executor.rb
@@ -1,0 +1,125 @@
+require 'monitor'
+
+module MiqAeEngine
+  class MiqAeExecutor
+    class InternalError < RuntimeError
+    end
+
+    class UsageError < RuntimeError
+    end
+
+    include MonitorMixin
+
+    def initialize
+      super
+
+      launch
+
+      rc, _stdout, _stderr = run_ruby('nil')
+      raise InternalError, "Ready failure" unless rc == 0
+    end
+
+    #--
+    # We're not using #synchronize, because that would block; an
+    # attempted double-usage is an error
+    def exclusively
+      raise UsageError, "Executor in use" unless mon_try_enter
+
+      begin
+        yield
+      ensure
+        mon_exit
+      end
+    end
+
+    def run_ruby(ruby_code, miq_uri = 'NONE', service_id = -1)
+      exclusively do
+        @command.puts miq_uri
+        @command.puts service_id
+        @command.puts ruby_code.bytesize
+        @command.write ruby_code
+        @command.puts
+        @command.puts '<EOF>'
+        raise InternalError, "Sync failure [00]" unless @complete.gets == "running\n"
+        rc = @complete.gets.to_i
+
+        format_result(rc)
+      end
+    end
+
+    def format_result(rc)
+      [rc, @out_buffer.slice, @err_buffer.slice]
+    end
+
+    def stop
+      Process.kill 'TERM', @pid
+      Process.wait @pid
+
+      @out_buffer.join
+      @err_buffer.join
+    end
+
+    private
+
+    def setup_io_redirections
+      command_in, @command = IO.pipe
+      @complete, complete_out = IO.pipe
+
+      @command.sync = true
+      @complete.sync = true
+
+      @out_buffer = LineBuffer.new { |msg| $miq_ae_logger.info  "Method STDOUT: #{msg}" }
+      @err_buffer = LineBuffer.new { |msg| $miq_ae_logger.error "Method STDERR: #{msg}" }
+
+      {
+        :out => @out_buffer.pipe,
+        :err => @err_buffer.pipe,
+        4    => command_in,
+        5    => complete_out,
+      }
+    end
+
+    def launch
+      fds = setup_io_redirections
+
+      Bundler.with_clean_env do
+        @pid = spawn(
+          Gem.ruby,
+          "-I", File.join(Gem.loaded_specs['activesupport'].full_gem_path, 'lib'),
+          File.expand_path('../miq_ae_executor_body.rb', __FILE__),
+
+          fds.merge(:in => :close)
+        )
+
+        fds.values.each(&:close)
+      end
+
+      raise InternalError, "Boot failure" unless @complete.gets == "booted\n"
+    end
+
+    class LineBuffer
+      attr_reader :pipe
+      def initialize
+        @buffer = ''
+
+        input, @pipe = IO.pipe
+
+        @thread = Thread.new do
+          while (s = input.gets)
+            @buffer << s
+            yield s
+          end
+        end
+      end
+
+      def slice
+        previous, @buffer = @buffer, ''
+        previous
+      end
+
+      def join
+        @thread.join
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_executor_body.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_executor_body.rb
@@ -1,0 +1,135 @@
+class AutomateMethodException < StandardError
+end
+
+begin
+  require 'date'
+  require 'rubygems'
+  require 'active_support/all'
+  require 'socket'
+  Socket.do_not_reverse_lookup = true  # turn off reverse DNS resolution
+
+  require 'drb'
+  require 'yaml'
+
+  Time.zone = 'UTC'
+
+  MIQ_OK    = 0
+  MIQ_WARN  = 4
+  MIQ_ERROR = 8
+  MIQ_STOP  = 8
+  MIQ_ABORT = 16
+
+  DRbObject.send(:undef_method, :inspect)
+  DRbObject.send(:undef_method, :id) if DRbObject.respond_to?(:id)
+
+rescue Exception => err
+  STDERR.puts('The following error occurred during inline method preamble evaluation:')
+  STDERR.puts("  #{err.class}: #{err.message}")
+  STDERR.puts("  #{err.backtrace.join("\n")}") unless err.kind_of?(AutomateMethodException)
+  raise
+end
+
+class Exception
+  def backtrace_with_evm
+    value = backtrace_without_evm
+    $evm && value ? $evm.backtrace(value) : value
+  end
+
+  alias backtrace_without_evm backtrace
+  alias backtrace backtrace_with_evm
+end
+
+class AutomateScriptRunner
+  def initialize(root_binding)
+    @root_binding = root_binding
+
+    @command_pipe = IO.for_fd(4, "r")
+    @status_pipe = IO.for_fd(5, "w")
+
+    @status_pipe.sync = true
+    @command_pipe.sync = true
+  end
+
+  def activate_service(miq_uri, miq_id)
+    return if miq_uri == 'NONE'
+    ::Object.const_set :MIQ_URI, miq_uri
+
+    DRb.start_service("druby://127.0.0.1:0")
+    $evmdrb = DRbObject.new(nil, miq_uri)
+    raise AutomateMethodException,"Cannot create DRbObject for uri=#{miq_uri}" if $evmdrb.nil?
+
+    return if miq_id == -1
+
+    $evm = $evmdrb.find(miq_id)
+    raise AutomateMethodException, "Cannot find Service for id=#{miq_id} and uri=#{miq_uri}" if $evm.nil?
+    ::Object.const_set :MIQ_ARGS, $evm.inputs
+  rescue Exception => err
+    STDERR.puts('The following error occurred during service activation:')
+    STDERR.puts("  #{err.class}: #{err.message}")
+    STDERR.puts("  #{err.backtrace.join("\n")}") unless err.kind_of?(AutomateMethodException)
+    raise
+  end
+
+  def execute_incoming_scripts
+    @status_pipe.puts "booted"
+
+    loop do
+      first_line = @command_pipe.gets
+      return if first_line.nil? # EOF
+      miq_uri = first_line.chomp
+
+      service_id = @command_pipe.gets.to_i
+      raise "Sync failure [01]" if service_id == 0
+
+      data_length = @command_pipe.gets.to_i
+      raise "Sync failure [02]" unless data_length > 0
+
+      data = @command_pipe.read(data_length)
+      raise "Sync failure [03]" unless data.size == data_length
+
+      tag = @command_pipe.gets + @command_pipe.gets
+      raise "Sync failure [04]" unless tag == "\n<EOF>\n"
+
+      @status_pipe.puts "running"
+
+      status = execute_script(miq_uri, service_id, data)
+
+      @status_pipe.puts status.exitstatus
+    end
+  end
+
+  def clear_child_environment
+    @command_pipe.close
+    @status_pipe.close
+
+    ::Object.send :remove_const, :AutomateScriptRunner
+  end
+
+  def execute_script(miq_uri, service_id, data)
+    pid = fork do
+      activate_service miq_uri, service_id
+      clear_child_environment
+
+      begin
+        @root_binding.eval(data, "<ae-method>", 1)
+      rescue SystemExit
+        raise
+      rescue Exception => err
+        if $evm
+          $evm.log('error', 'The following error occurred during method evaluation:')
+          $evm.log('error', "  #{err.class}: #{err.message}")
+          $evm.log('error', "  #{err.backtrace[0..-2].join("\n")}")
+        end
+        raise
+      ensure
+        $evm.disconnect_sql if $evm
+      end
+    end
+
+    _, status = Process.waitpid2(pid)
+
+    status
+  end
+end
+
+AutomateScriptRunner.new(binding).execute_incoming_scripts


### PR DESCRIPTION
We still fork a clean process for every Method call... but this way, we don't waste time loading ruby etc.

As a bonus, we no longer have a large chunk of code living in a string.

Also, it seems to make the tests a bit faster.
