### PR TITLE
Small optimizations in ConfigurationEncoder

### DIFF
--- a/lib/vmdb/configuration_encoder.rb
+++ b/lib/vmdb/configuration_encoder.rb
@@ -62,7 +62,7 @@ module Vmdb
 
     def self.encrypt_password_fields!(hash)
       walk_nested_hashes(hash) do |k, v, h|
-        h[k] = MiqPassword.try_encrypt(v) if k.to_s.in?(PASSWORD_FIELDS) && v.present?
+        h[k] = MiqPassword.try_encrypt(v) if PASSWORD_FIELDS.include?(k.to_s) && v.present?
       end
     end
 
@@ -72,7 +72,7 @@ module Vmdb
 
     def self.decrypt_password_fields!(hash)
       walk_nested_hashes(hash) do |k, v, h|
-        h[k] = MiqPassword.try_decrypt(v) if k.to_s.in?(PASSWORD_FIELDS) && v.present?
+        h[k] = MiqPassword.try_decrypt(v) if PASSWORD_FIELDS.include?(k.to_s) && v.present?
       end
     end
 

--- a/lib/vmdb/configuration_encoder.rb
+++ b/lib/vmdb/configuration_encoder.rb
@@ -53,8 +53,7 @@ module Vmdb
     end
 
     def self.walk_nested_hashes(hash, &block)
-      hash.keys.each do |k|
-        v = hash[k]
+      hash.each do |k, v|
         yield k, v, hash
         walk_nested_hashes(v, &block) if v.kind_of?(Hash)
       end


### PR DESCRIPTION
I noticed this area of code was called many, many times in our test suite, some lines 1.2 million times:

![image](https://cloud.githubusercontent.com/assets/19339/9676520/0feb8d8e-529b-11e5-9ceb-34c17588e7b6.png)

https://coveralls.io/builds/3482459/source?filename=lib%2Fvmdb%2Fconfiguration_encoder.rb

This won't make a big dent but they seemed like small wins to me.
Not running VMDB::Config.new so many times in test is probably a better idea but much harder.

See each commit for micro benchmarks against ruby 2.2.3.