### PR TITLE
Eliminate all logging in CI environments.

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -86,19 +86,25 @@ module Vmdb
       path     = config[:path] || DEFAULT_LOG_PATH
       path_dir = File.dirname(path)
 
-      $log           = VMDBLogger.new(File.join(path_dir, "evm.log"))
-      $rails_log     = VMDBLogger.new(path)
-      $audit_log     = AuditLogger.new(File.join(path_dir, "audit.log"))
-      $fog_log       = FogLogger.new(File.join(path_dir, "fog.log"))
-      $policy_log    = MirroredLogger.new(File.join(path_dir, "policy.log"),     "<PolicyEngine> ")
-      $vim_log       = MirroredLogger.new(File.join(path_dir, "vim.log"),        "<VIM> ")
-      $rhevm_log     = MirroredLogger.new(File.join(path_dir, "rhevm.log"),      "<RHEVM> ")
-      $aws_log       = MirroredLogger.new(File.join(path_dir, "aws.log"),        "<AWS> ")
-      $kube_log      = MirroredLogger.new(File.join(path_dir, "kubernetes.log"), "<KUBERNETES> ")
-      $scvmm_log     = MirroredLogger.new(File.join(path_dir, "scvmm.log"),      "<SCVMM> ")
-      $api_log       = MirroredLogger.new(File.join(path_dir, "api.log"),        "<API> ")
-      $miq_ae_logger = MirroredLogger.new(File.join(path_dir, "automation.log"), "<AutomationEngine> ")
-      $miq_ae_logger.mirror_level = VMDBLogger::INFO
+      if ENV.key?("CI")
+        $log = $rails_log = $audit_log = $fog_log = $policy_log = $vim_log =
+          $rhevm_log = $aws_log = $kube_log = $scvmm_log = $api_log =
+          $miq_ae_logger = LogProxy.null_logger
+      else
+        $log           = VMDBLogger.new(File.join(path_dir, "evm.log"))
+        $rails_log     = VMDBLogger.new(path)
+        $audit_log     = AuditLogger.new(File.join(path_dir, "audit.log"))
+        $fog_log       = FogLogger.new(File.join(path_dir, "fog.log"))
+        $policy_log    = MirroredLogger.new(File.join(path_dir, "policy.log"),     "<PolicyEngine> ")
+        $vim_log       = MirroredLogger.new(File.join(path_dir, "vim.log"),        "<VIM> ")
+        $rhevm_log     = MirroredLogger.new(File.join(path_dir, "rhevm.log"),      "<RHEVM> ")
+        $aws_log       = MirroredLogger.new(File.join(path_dir, "aws.log"),        "<AWS> ")
+        $kube_log      = MirroredLogger.new(File.join(path_dir, "kubernetes.log"), "<KUBERNETES> ")
+        $scvmm_log     = MirroredLogger.new(File.join(path_dir, "scvmm.log"),      "<SCVMM> ")
+        $api_log       = MirroredLogger.new(File.join(path_dir, "api.log"),        "<API> ")
+        $miq_ae_logger = MirroredLogger.new(File.join(path_dir, "automation.log"), "<AutomationEngine> ")
+        $miq_ae_logger.mirror_level = VMDBLogger::INFO
+      end
 
       configure_external_loggers
     end
@@ -110,6 +116,7 @@ module Vmdb
     private_class_method :configure_external_loggers
 
     def self.apply_config_value(config, logger, key, mirror_key = nil)
+      return if logger == LogProxy.null_logger
       apply_config_value_logged(config, logger, :level, key)
       apply_config_value_logged(config, logger, :mirror_level, mirror_key) if mirror_key
     end

--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -1,7 +1,20 @@
 module Vmdb
   class LogProxy < Struct.new(:klass, :separator)
+    class NullLogger < Logger
+      def initialize(*)
+        super('/dev/null')
+        self.level = Logger::UNKNOWN
+      end
+
+      def filename(*); end
+      def log_backtrace(*); end
+      def log_hashes(*); end
+      def success(*); end
+      def failure(*); end
+    end
+
     def self.null_logger
-      @null_logger ||= Logger.new('/dev/null').tap { |o| o.level = Logger::UNKNOWN }
+      @null_logger ||= NullLogger.new
     end
 
     LEVELS = [:debug, :info, :warn, :error]

--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -11,6 +11,9 @@ module Vmdb
       def log_hashes(*); end
       def success(*); end
       def failure(*); end
+      def instrument(*)
+        yield if block_given?
+      end
     end
 
     def self.null_logger


### PR DESCRIPTION
We only ever use STDOUT/STDERR in travis so any logging is completely useless.

Let's see if this makes any difference.  Travis is very unreliable in terms of timing but it seems to be at most a few minutes faster overall.