### PR TITLE
Style1 table in Configure -> Tasks converted to patternfly

### DIFF
--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -1,96 +1,110 @@
 - url = url_for(:action => 'tasks_change_options')
 #tasks_options_div
-  %h3= _("Filter By")
-  %table.style1
-    %tbody
-      - if %w(my_tasks all_tasks).include?(@layout)
-        %tr
-          %td.key= _("Zone:")
-          %td
-            - my_zone = MiqServer.my_server(true).my_zone
-            - opts = [["<#{_('All Zones')}>", "<all>"]] + @tasks_options[:zones].sort.collect { |a| [a == my_zone ? a + " (current)" : a, a] }
-            = select_tag("chosen_zone",
-              options_for_select(opts, @tasks_options[@tabform][:zone]),
-              "data-miq_observe" => {:url => url}.to_json)
-      - if @lastaction == "all_jobs" || @lastaction == "all_ui_jobs"
-        %tr
-          %td.key= _("User:")
-          %td
-            = select_tag("user_choice",
-              options_for_select([["#{_('All Users')}", "all"]] + @user_names.sort, @tasks_options[@tabform][:user_choice]),
-              "data-miq_observe" => {:url => url}.to_json)
-      %tr
-        %td.key= _("24 Hour Time Period:")
-        %td
-          = select_tag("time_period",
-            options_for_select(Array(TASK_TIME_PERIODS.invert).sort_by(&:last), @tasks_options[@tabform][:time_period]),
-            "data-miq_observe" => {:url => url}.to_json)
-      %tr
-        %td.key= _("Task Status:")
-        %td
-          = check_box_tag("queued", "1", @tasks_options[@tabform][:queued], "data-miq_observe_checkbox" => {:url => url}.to_json)
-          &nbsp;
-          %img{:src => "/images/icons/16/job-queued.png", :valign => "middle", :title => "Queued"}= _("Queued")
-          &nbsp;
-          = check_box_tag("running", "1", @tasks_options[@tabform][:running], "data-miq_observe_checkbox" => {:url => url}.to_json)
-          &nbsp;
-          %img{:src => "/images/icons/16/job-running.png", :valign => "middle", :title => "Warn"}= _("Running")
-          &nbsp;
-          = check_box_tag("ok", "1", @tasks_options[@tabform][:ok], "data-miq_observe_checkbox" => {:url => url}.to_json)
-          &nbsp;
-          %img{:src => "/images/icons/new/checkmark.png", :valign => "middle", :title => "Ok"}= _("Ok")
-          &nbsp;
-          = check_box_tag("error", "1", @tasks_options[@tabform][:error], "data-miq_observe_checkbox" => {:url => url}.to_json)
-          &nbsp;
-          %img{:src => "/images/icons/new/x.png", :valign => "middle", :title => "Error"}= _("Error")
-          &nbsp;
-          = check_box_tag("warn", "1", @tasks_options[@tabform][:warn], "data-miq_observe_checkbox" => {:url => url}.to_json)
-          &nbsp;
-          %img{:src => "/images/icons/16/warning.png", :valign => "middle", :title => "Warn"}= _("Warn")
-      %tr
-        %td.key= _("Task State:")
-        %td
-          = select_tag("state_choice",
-            options_for_select([["#{_('All')}", "all"]] + @tasks_options[@tabform][:states].sort, @tasks_options[@tabform][:state_choice]),
-            "data-miq_observe" => {:url => url}.to_json)
-      %tr
-        %td
-        %td{:align => "right"}
-          #buttons_off
-            = button_tag(_("Apply"), :class => "btn btn-primary btn-disabled")
-            = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
-            = link_to(_('Default'),
-              {:action => "tasks_button", :button => "default"},
-              :class                 => "btn btn-default",
-              :alt                   => (t = _("Set filters to default")),
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              :title                 => t)
-          #buttons_on{:style => "display:none"}
-            = link_to(_('Apply'),
-              {:action => "tasks_button", :button => "apply"},
-              :class                 => "btn btn-primary",
-              :alt                   => (t = _("Apply the selected filters")),
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              :title                 => t)
-            = link_to(_('Reset'),
-              {:action => "tasks_button", :button => "reset"},
-              :class                 => "btn btn-default",
-              :alt                   => (t = _("Reset filter changes")),
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              :title                 => t)
-            = link_to(_('Default'),
-              {:action => "tasks_button", :button => "default"},
-              :class                 => "btn btn-default",
-              :alt                   => (t = _("Set filters to default")),
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              :title                 => t)
+  %h3
+    = _("Filter By")
+  .form-horizontal
+    - if %w(my_tasks all_tasks).include?(@layout)
+      .form-group
+        %label.control-label.col-md-2
+          = _("Zone")
+        .col-md-8
+          - my_zone = MiqServer.my_server(true).my_zone
+          - opts = [["<#{_('All Zones')}>", "<all>"]] + @tasks_options[:zones].sort.collect { |a| [a == my_zone ? a + " (current)" : a, a] }
+          = select_tag("chosen_zone",
+            options_for_select(opts, @tasks_options[@tabform][:zone]),
+            :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("chosen_zone", "#{url}");
+    - if @lastaction == "all_jobs" || @lastaction == "all_ui_jobs"
+      .form-group
+        %label.control-label.col-md-2
+          = _("User")
+        .col-md-8
+          = select_tag("user_choice",
+            options_for_select([["#{_('All Users')}", "all"]] + @user_names.sort, @tasks_options[@tabform][:user_choice]),
+            :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("user_choice", "#{url}");
+    .form-group
+      %label.control-label.col-md-2
+        = _("24 Hour Time Period")
+      .col-md-8
+        = select_tag("time_period",
+          options_for_select(Array(TASK_TIME_PERIODS.invert).sort_by(&:last), @tasks_options[@tabform][:time_period]),
+          :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("time_period", "#{url}");
+    .form-group
+      %label.control-label.col-md-2
+        = _("Task Status")
+      .col-md-8
+        = check_box_tag("queued", "1", @tasks_options[@tabform][:queued], "data-miq_observe_checkbox" => {:url => url}.to_json)
+        &nbsp;
+        %img{:src => "/images/icons/16/job-queued.png", :valign => "middle", :title => _("Queued")}= _("Queued")
+        &nbsp;
+        = check_box_tag("running", "1", @tasks_options[@tabform][:running], "data-miq_observe_checkbox" => {:url => url}.to_json)
+        &nbsp;
+        %img{:src => "/images/icons/16/job-running.png", :valign => "middle", :title => _("Warn")}= _("Running")
+        &nbsp;
+        = check_box_tag("ok", "1", @tasks_options[@tabform][:ok], "data-miq_observe_checkbox" => {:url => url}.to_json)
+        &nbsp;
+        %img{:src => "/images/icons/new/checkmark.png", :valign => "middle", :title => _("Ok"), :style => "height: 16px;"}= _("Ok")
+        &nbsp;
+        = check_box_tag("error", "1", @tasks_options[@tabform][:error], "data-miq_observe_checkbox" => {:url => url}.to_json)
+        &nbsp;
+        %img{:src => "/images/icons/new/x.png", :valign => "middle", :title => _("Error"), :style => "height: 16px;"}= _("Error")
+        &nbsp;
+        = check_box_tag("warn", "1", @tasks_options[@tabform][:warn], "data-miq_observe_checkbox" => {:url => url}.to_json)
+        &nbsp;
+        %img{:src => "/images/icons/16/warning.png", :valign => "middle", :title => _("Warn")}= _("Warn")
+    .form-group
+      %label.control-label.col-md-2
+        = _("Task State")
+      .col-md-8
+        = select_tag("state_choice",
+          options_for_select([["#{_('All')}", "all"]] + @tasks_options[@tabform][:states].sort, @tasks_options[@tabform][:state_choice]),
+          :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("state_choice", "#{url}");
+    #form_buttons_div.clearfix{:style => "padding-right: 10px"}
+      #buttons_off.pull-right
+        = button_tag(_("Apply"), :class => "btn btn-primary btn-disabled")
+        = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+        = link_to(_('Default'),
+          {:action => "tasks_button", :button => "default"},
+          :class                 => "btn btn-default",
+          :alt                   => (t = _("Set filters to default")),
+          "data-miq_sparkle_on"  => true,
+          "data-miq_sparkle_off" => true,
+          :remote                => true,
+          :title                 => t)
+      #buttons_on.pull-right{:style => "display:none"}
+        = link_to(_('Apply'),
+          {:action => "tasks_button", :button => "apply"},
+          :class                 => "btn btn-primary",
+          :alt                   => (t = _("Apply the selected filters")),
+          "data-miq_sparkle_on"  => true,
+          "data-miq_sparkle_off" => true,
+          :remote                => true,
+          :title                 => t)
+        = link_to(_('Reset'),
+          {:action => "tasks_button", :button => "reset"},
+          :class                 => "btn btn-default",
+          :alt                   => (t = _("Reset filter changes")),
+          "data-miq_sparkle_on"  => true,
+          "data-miq_sparkle_off" => true,
+          :remote                => true,
+          :title                 => t)
+        = link_to(_('Default'),
+          {:action => "tasks_button", :button => "default"},
+          :class                 => "btn btn-default",
+          :alt                   => (t = _("Set filters to default")),
+          "data-miq_sparkle_on"  => true,
+          "data-miq_sparkle_off" => true,
+          :remote                => true,
+          :title                 => t)
   %hr
-


### PR DESCRIPTION
Parent issue: #3139

Before:
![screencapture-localhost-3000-miq_task-change_tab-1441370214416](https://cloud.githubusercontent.com/assets/1187051/9683998/05e426e6-5315-11e5-9e4c-355f0265194b.png)
After:
![screencapture-localhost-3000-miq_task-index-1441630007197](https://cloud.githubusercontent.com/assets/1187051/9717009/4ebaa6b8-556f-11e5-9201-cbeef95fce1f.png)

@epwinchell @skateman after conversion some images were larger, fixed by adding `:style => "height: 16px;"` attribute. Please review.