### PR TITLE
Fixed introduced during bootstrap tab conversion

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -307,7 +307,10 @@ class MiqRequestController < ApplicationController
     #only build host grid if that field is visible/exists in dialog
     build_host_grid(@options[:wf].allowed_hosts, @options[:host_sortdir], @options[:host_sortcol]) if !@options[:wf].get_field(:src_host_ids,:service).blank? || !@options[:wf].get_field(:placement_host_name,:environment).blank?
     render :update do |page|                    # Use JS to update the display
-      page.replace_html("#{@options[:current_tab_key]}_div", :partial => dialog_partial_for_workflow, :locals => {:wf => @options[:wf], :dialog => @options[:current_tab_key]})
+      page.replace_html(@options[:current_tab_key],
+                        :partial => dialog_partial_for_workflow,
+                        :locals  => {:wf => @options[:wf], :dialog => @options[:current_tab_key]}
+                       )
       # page << javascript_show("hider_#{@options[:current_tab_key].to_s}_div")
       page << "miqSparkle(false);"
     end


### PR DESCRIPTION
Needed to fix div name in page.replace_html call to load contents on Request details screen when tab is changed.

@dclarizio please review/test. This is a fallout of changes in commit SHA 5dd5f46aecfa71408fa3dbaf3a4790d8f2d39309

before:
![before](https://cloud.githubusercontent.com/assets/3450808/9689545/c5a4ce7e-5304-11e5-92da-9aa3bcfdcc4f.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/9689546/cafc9faa-5304-11e5-9b4d-b644e7eeeaf4.png)
