### PR TITLE
Start out Access Control tree in OPS as collapsed on initial load.

### DIFF
--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -3,8 +3,9 @@ class TreeBuilderOpsRbac < TreeBuilder
 
   def tree_init_options(tree_name)
     {
-      :open_all   => true,
-      :leaf       => "Access Control"
+      :open_all => true,
+      :leaf     => "Access Control",
+      :expand   => false
      }
   end
 
@@ -18,6 +19,7 @@ class TreeBuilderOpsRbac < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(options)
+    options.merge!(:expand => false)
     [
       {:id => "u",  :text => "Users",   :image => "user",          :tip => "Users"},
       {:id => "g",  :text => "Groups",  :image => "group",         :tip => "Groups"},
@@ -38,6 +40,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   end
 
   def x_get_tree_tenant_kids(object, options)
+    options.merge!(:expand => false)
     count_only_or_objects(options[:count_only], object.children, "name")
   end
 end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -152,7 +152,8 @@ class TreeNodeBuilder
       :title => text,
       :icon  => image
     }
-    @node[:expand] = true if options[:open_all]  # Start with all nodes open
+    # Start with all nodes open unless expand is explicitly set to false
+    @node[:expand] = true if options[:open_all] && options[:expand] != false
     tooltip(tip)
   end
 
@@ -171,7 +172,8 @@ class TreeNodeBuilder
       :icon  => "#{object[:image] || text}.png",
       :title => ERB::Util.html_escape(text),
     }
-    @node[:expand] = true if options[:open_all] # Start with all nodes open
+    # Start with all nodes open unless expand is explicitly set to false
+    @node[:expand] = true if options[:open_all] && options[:expand] != false
     @node[:cfmeNoClick] = object[:cfmeNoClick] if object.key?(:cfmeNoClick)
 
     # FIXME: check the following

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -319,5 +319,23 @@ describe TreeNodeBuilder do
       node = TreeNodeBuilder.build(zone, nil, {})
       node.should_not be_nil
     end
+
+    it "expand attribute of node should be set to true when open_all is true and expand is nil in options" do
+      tenant = FactoryGirl.build(:tenant)
+      node = TreeNodeBuilder.build(tenant, "root", :expand => nil, :open_all => true)
+      node[:expand].should eq(true)
+    end
+
+    it "expand attribute of node should be set to nil when open_all is true and expand is set to false in options" do
+      tenant = FactoryGirl.build(:tenant)
+      node = TreeNodeBuilder.build(tenant, "root", :expand => false, :open_all => true)
+      node[:expand].should eq(nil)
+    end
+
+    it "expand attribute of node should be set to true when open_all and expand are true in options" do
+      tenant = FactoryGirl.build(:tenant)
+      node = TreeNodeBuilder.build(tenant, "root", :expand => true, :open_all => true)
+      node[:expand].should eq(true)
+    end
   end
 end


### PR DESCRIPTION
@dclarizio please review/test

before:
![before](https://cloud.githubusercontent.com/assets/3450808/9694916/de5e3196-532a-11e5-894b-cdacd24f7d27.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/9694894/b775d4bc-532a-11e5-87f2-b71478184142.png)
