### PR TITLE
remove miq_group v4 data migration

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -104,23 +104,6 @@ class MiqGroup < ActiveRecord::Base
 
           seq += 1
         end
-      else
-        MiqGroup.where(:tenant_id => nil).update_all(:tenant_id => root_tenant.id)
-
-        # Migrate legacy groups to have miq_user_roles if necessary
-        self.all.each do |g|
-          next unless g.group_type == "ldap"
-          role_name = "EvmRole-#{g.description.split("-").last}"
-          role = MiqUserRole.find_by_name(role_name)
-          if role.nil? && g.role
-            role_name = "EvmRole-#{g.role.name}"
-            role = MiqUserRole.find_by_name(role_name)
-          end
-          g.update_attributes(
-            :group_type    => "system",
-            :miq_user_role => role
-          )
-        end
       end
     end
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -263,17 +263,6 @@ describe MiqGroup do
       [MiqRegion, Tenant, MiqUserRole, MiqGroup].each(&:seed)
       expect(MiqGroup.where(:tenant => root_tenant).count).to eq(MiqGroup.count)
     end
-
-    it "has tenant for legacy records" do
-      [MiqRegion, Tenant, MiqUserRole].each(&:seed)
-      new_tenant           = root_tenant.children.create!
-      group_with_tenant    = FactoryGirl.create(:miq_group, :tenant => new_tenant)
-      group_without_tenant = FactoryGirl.create(:miq_group, :tenant => nil)
-      MiqGroup.seed
-
-      expect(group_with_tenant.reload.tenant).to    eq(new_tenant)
-      expect(group_without_tenant.reload.tenant).to eq(root_tenant)
-    end
   end
 
   context "#ordered_widget_sets" do


### PR DESCRIPTION
1. Since #4204 sets the tenant, `MiqGroup.seed` does not need to set `MiqGroup#tenant`.
2. Since we no longer support migrating a v4.0 database, `MiqGroup.seed` does not need to migrate pre 4.0 `MiqGroup#miq_user_role` values.

**NOTE:** merget this OR #4255
/cc @gmcculloug this is what we discussed