### PR TITLE
Factories miq server

### DIFF
--- a/spec/automation/unit/method_validation/inspect_me_spec.rb
+++ b/spec/automation/unit/method_validation/inspect_me_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "InspectMe Automate Method" do
   before do
-    @miq_server = FactoryGirl.create(:miq_server, :my_server)
+    @miq_server = EvmSpecHelper.local_miq_server
   end
 
   def run_automate_method

--- a/spec/automation/unit/method_validation/inspect_me_spec.rb
+++ b/spec/automation/unit/method_validation/inspect_me_spec.rb
@@ -2,10 +2,7 @@ require "spec_helper"
 
 describe "InspectMe Automate Method" do
   before do
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-    @zone       = FactoryGirl.create(:zone)
-    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
+    @miq_server = FactoryGirl.create(:miq_server, :my_server)
   end
 
   def run_automate_method

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -242,7 +242,7 @@ end
 
 describe OpsController do
   before do
-    FactoryGirl.create(:miq_server, :my_server)
+    EvmSpecHelper.local_miq_server
     EvmSpecHelper.seed_specific_product_features("ops_rbac")
     feature = MiqProductFeature.find_all_by_identifier("ops_rbac")
     @test_user_role  = FactoryGirl.create(:miq_user_role,

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -242,10 +242,7 @@ end
 
 describe OpsController do
   before do
-    MiqRegion.seed
-    zone       = FactoryGirl.create(:zone)
-    MiqRegion.my_region.stub(:zones).and_return([zone])
-    server = FactoryGirl.create(:miq_server, :guid => 'guid', :zone => zone)
+    FactoryGirl.create(:miq_server, :my_server)
     EvmSpecHelper.seed_specific_product_features("ops_rbac")
     feature = MiqProductFeature.find_all_by_identifier("ops_rbac")
     @test_user_role  = FactoryGirl.create(:miq_user_role,
@@ -253,7 +250,6 @@ describe OpsController do
                                           :miq_product_features => feature)
     test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => @test_user_role)
     login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-    MiqServer.stub(:my_server).and_return(server)
     controller.stub(:get_vmdb_config).and_return(:product => {})
   end
 

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -137,7 +137,7 @@ describe OpsController do
 
   context "replace_right_cell" do
     before do
-      miq_server = FactoryGirl.create(:miq_server, :my_server)
+      miq_server = EvmSpecHelper.local_miq_server
       MiqRegion.seed
       expect(MiqRegion.my_region.zones).to eq([miq_server.zone])
     end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -137,11 +137,9 @@ describe OpsController do
 
   context "replace_right_cell" do
     before do
+      miq_server = FactoryGirl.create(:miq_server, :my_server)
       MiqRegion.seed
-      zone       = FactoryGirl.create(:zone)
-      MiqRegion.my_region.stub(:zones).and_return([zone])
-      miq_server = FactoryGirl.create(:miq_server, :guid => 'guid', :zone => zone)
-      MiqServer.stub(:my_server).and_return(miq_server)
+      expect(MiqRegion.my_region.zones).to eq([miq_server.zone])
     end
 
     it "it renders replace_right_cell" do

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -8,12 +8,5 @@ FactoryGirl.define do
     started_on      { Time.now.utc }
     stopped_on      ""
     version         '9.9.9.9'
-
-    trait :my_server do
-      after(:create) do |ms|
-        MiqServer.stub(:my_guid).and_return(ms.guid)
-        MiqServer.my_server_clear_cache
-      end
-    end
   end
 end

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -20,8 +20,4 @@ FactoryGirl.define do
   factory :miq_server_master, :parent => :miq_server do
     is_master      true
   end
-
-  factory :miq_server_not_master, :parent => :miq_server do
-    is_master      false
-  end
 end

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -1,11 +1,20 @@
 FactoryGirl.define do
   factory :miq_server do
+    guid            { MiqUUID.new_guid }
+    zone            { FactoryGirl.build(:zone) }
     sequence(:name) { |n| "miq_server_#{seq_padded_for_sorting(n)}" }
     last_heartbeat  { Time.now.utc }
     status          "started"
     started_on      { Time.now.utc }
     stopped_on      ""
     version         '9.9.9.9'
+
+    trait :my_server do
+      after(:create) do |ms|
+        MiqServer.stub(:my_guid).and_return(ms.guid)
+        MiqServer.my_server_clear_cache
+      end
+    end
   end
 
   factory :miq_server_master, :parent => :miq_server do

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -16,8 +16,4 @@ FactoryGirl.define do
       end
     end
   end
-
-  factory :miq_server_master, :parent => :miq_server do
-    is_master      true
-  end
 end

--- a/spec/factories/small_environment.rb
+++ b/spec/factories/small_environment.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
 
     # Hackery: Due to ntp reload occurring on save, we need to add the servers after saving the zone.
     after(:create) do |z|
-      FactoryGirl.create(:miq_server, :my_server, :is_master => true, :zone => z)
+      EvmSpecHelper.local_miq_server(:is_master => true, :zone => z)
     end
   end
 

--- a/spec/factories/small_environment.rb
+++ b/spec/factories/small_environment.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
 
     # Hackery: Due to ntp reload occurring on save, we need to add the servers after saving the zone.
     after(:create) do |z|
-      FactoryGirl.create(:miq_server_master, :my_server, :zone => z)
+      FactoryGirl.create(:miq_server, :my_server, :is_master => true, :zone => z)
     end
   end
 

--- a/spec/factories/small_environment.rb
+++ b/spec/factories/small_environment.rb
@@ -6,10 +6,7 @@ FactoryGirl.define do
 
     # Hackery: Due to ntp reload occurring on save, we need to add the servers after saving the zone.
     after(:create) do |z|
-      guid   = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(guid)
-      MiqServer.my_server_clear_cache
-      FactoryGirl.create(:miq_server_master, :guid => guid, :zone => z)
+      FactoryGirl.create(:miq_server_master, :my_server, :zone => z)
     end
   end
 

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -4,7 +4,6 @@ module MiqAeEngineSpec
   include MiqAeEngine
   describe MiqAeEngine do
     before(:each) do
-      MiqServer.my_server_clear_cache
       MiqAeDatastore.reset
       EvmSpecHelper.local_guid_miq_server_zone
       @domain = 'SPEC_DOMAIN'

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -4,7 +4,6 @@ module MiqAeObjectSpec
   include MiqAeEngine
   describe MiqAeObject do
     before(:each) do
-      MiqServer.my_server_clear_cache
       MiqAeDatastore.reset
       @domain = 'SPEC_DOMAIN'
       @model_data_dir = File.join(File.dirname(__FILE__), "data")

--- a/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
@@ -4,7 +4,6 @@ module MiqAeDatastoreConverter
   include MiqAeDatastore
   describe "XML2YAML Converter" do
     before(:each) do
-      MiqServer.my_server_clear_cache
       MiqAeDatastore.reset
     end
 

--- a/spec/lib/workers/schedule_worker_spec.rb
+++ b/spec/lib/workers/schedule_worker_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqScheduleWorker::Runner do
   context ".new" do
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server_master, :my_server)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
       @zone = @miq_server.zone
 
       worker_guid = MiqUUID.new_guid

--- a/spec/lib/workers/schedule_worker_spec.rb
+++ b/spec/lib/workers/schedule_worker_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqScheduleWorker::Runner do
   context ".new" do
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
       @zone = @miq_server.zone
 
       worker_guid = MiqUUID.new_guid

--- a/spec/lib/workers/schedule_worker_spec.rb
+++ b/spec/lib/workers/schedule_worker_spec.rb
@@ -3,21 +3,18 @@ require "spec_helper"
 describe MiqScheduleWorker::Runner do
   context ".new" do
     before(:each) do
-      @server_guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@server_guid)
-      @zone       = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server_master, :zone => @zone, :guid => @server_guid)
-      MiqServer.my_server(true)
+      @miq_server = FactoryGirl.create(:miq_server_master, :my_server)
+      @zone = @miq_server.zone
 
-      @worker_guid = MiqUUID.new_guid
-      @worker = FactoryGirl.create(:miq_schedule_worker, :guid => @worker_guid, :miq_server_id => @miq_server.id)
+      worker_guid = MiqUUID.new_guid
+      @worker = FactoryGirl.create(:miq_schedule_worker, :guid => worker_guid, :miq_server_id => @miq_server.id)
 
       MiqScheduleWorker::Runner.any_instance.stub(:initialize_rufus)
       MiqScheduleWorker::Runner.any_instance.stub(:sync_active_roles)
       MiqScheduleWorker::Runner.any_instance.stub(:sync_config)
       MiqScheduleWorker::Runner.any_instance.stub(:set_connection_pool_size)
 
-      @schedule_worker = MiqScheduleWorker::Runner.new(:guid => @worker_guid)
+      @schedule_worker = MiqScheduleWorker::Runner.new(:guid => worker_guid)
     end
 
     context "with a stuck dispatch in each zone" do

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -3,12 +3,7 @@ require "spec_helper"
 describe GenericMailer do
 
   before(:each) do
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-    @zone       = FactoryGirl.create(:zone)
-    @server_name = "EVM"
-    @miq_server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :name => @server_name)
-    MiqServer.my_server(true)
+    @miq_server = FactoryGirl.create(:miq_server, :my_server)
     @args = {
       :to          => "you@bedrock.gov",
       :from        => "me@bedrock.gov",

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe GenericMailer do
 
   before(:each) do
-    @miq_server = FactoryGirl.create(:miq_server, :my_server)
+    @miq_server = EvmSpecHelper.local_miq_server
     @args = {
       :to          => "you@bedrock.gov",
       :from        => "me@bedrock.gov",

--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -4,7 +4,7 @@ describe AssignedServerRole do
   context "and Server Role seeded for 1 Region/Zone" do
     before(:each) do
       MiqRegion.seed
-      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     context "Server Role" do

--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -1,27 +1,10 @@
 require "spec_helper"
 
 describe AssignedServerRole do
-
   context "and Server Role seeded for 1 Region/Zone" do
-
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
       MiqRegion.seed
-
-      @zone         = FactoryGirl.create(:zone)
-      @miq_server   = FactoryGirl.create(
-                    :miq_server,
-                    :guid         => @guid,
-                    :status       => "started",
-                    :name         => "EVM",
-                    :os_priority  => nil,
-                    :is_master    => false,
-                    :zone         => @zone
-                    )
-
-      MiqServer.my_server(true)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server)
     end
 
     context "Server Role" do
@@ -106,56 +89,12 @@ describe AssignedServerRole do
       MiqRegion.stub(:my_region).and_return(@miq_region)
 
       @miq_zone1 = FactoryGirl.create(:zone, :name => "Zone 1", :description => "Test Zone One")
-
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @miq_server_11 = FactoryGirl.create(
-                    :miq_server,
-                    :guid         => @guid,
-                    :status       => "started",
-                    :name         => "Server 1",
-                    :os_priority  => nil,
-                    :is_master    => false,
-                    :zone_id      => @miq_zone1.id
-                    )
-
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @miq_server_12 = FactoryGirl.create(
-                    :miq_server,
-                    :guid         => @guid,
-                    :status       => "started",
-                    :name         => "Server 2",
-                    :os_priority  => nil,
-                    :is_master    => false,
-                    :zone_id      => @miq_zone1.id
-                    )
+      @miq_server_11 = FactoryGirl.create(:miq_server, :zone => @miq_zone1)
+      @miq_server_12 = FactoryGirl.create(:miq_server, :zone => @miq_zone1)
 
       @miq_zone2 = FactoryGirl.create(:zone, :name => "Zone 2", :description => "Test Zone Two")
-
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @miq_server_21 = FactoryGirl.create(
-                    :miq_server,
-                    :guid         => @guid,
-                    :status       => "started",
-                    :name         => "Server 3",
-                    :os_priority  => nil,
-                    :is_master    => false,
-                    :zone_id      => @miq_zone2.id
-                    )
-
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @miq_server_22 = FactoryGirl.create(
-                    :miq_server,
-                    :guid         => @guid,
-                    :status       => "started",
-                    :name         => "Server 4",
-                    :os_priority  => nil,
-                    :is_master    => false,
-                    :zone_id      => @miq_zone2.id
-                    )
+      @miq_server_21 = FactoryGirl.create(:miq_server, :zone => @miq_zone2)
+      @miq_server_22 = FactoryGirl.create(:miq_server, :zone => @miq_zone2)
 
       @server_role_zu = FactoryGirl.create(
                       :server_role,
@@ -326,7 +265,6 @@ describe AssignedServerRole do
     end
 
     it "should set priority for Server Role scope" do
-
       @assigned_server_role_11_zu.set_priority(AssignedServerRole::HIGH_PRIORITY)
       @assigned_server_role_11_zu.priority.should == AssignedServerRole::HIGH_PRIORITY
 
@@ -357,7 +295,5 @@ describe AssignedServerRole do
         @assigned_server_role_11_zl.deactivate_in_zone
         @assigned_server_role_11_zl.active.should be_false
       end
-
   end
-
 end

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -105,13 +105,7 @@ describe AsyncDeleteMixin do
 
   context "with zone and server" do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
-      @zone       = FactoryGirl.create(:zone)
-      @server_name = "EVM"
-      @miq_server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :name => @server_name)
-      MiqServer.my_server(true)
+      FactoryGirl.create(:miq_server, :my_server)
     end
 
     context "with 3 ems clusters" do

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -105,7 +105,7 @@ describe AsyncDeleteMixin do
 
   context "with zone and server" do
     before(:each) do
-      FactoryGirl.create(:miq_server, :my_server)
+      EvmSpecHelper.local_miq_server
     end
 
     context "with 3 ems clusters" do

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe CustomButton do
   context "with no buttons" do
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server_master, :my_server)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
 
       User.any_instance.stub(:role).and_return("admin")
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe CustomButton do
   context "with no buttons" do
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
 
       User.any_instance.stub(:role).and_return("admin")
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -3,11 +3,7 @@ require "spec_helper"
 describe CustomButton do
   context "with no buttons" do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @zone       = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server_master, :zone => @zone, :guid => @guid)
-      MiqServer.my_server(true)
+      @miq_server = FactoryGirl.create(:miq_server_master, :my_server)
 
       User.any_instance.stub(:role).and_return("admin")
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -70,7 +70,7 @@ describe CustomButton do
           h[:user_id].should       == @user2.id
           h[:object_type].should   == @vm.class.base_class.name
           h[:object_id].should     == @vm.id
-          h[:attrs].should         == @ae_attributes
+          expect(h[:attrs]).to include(@ae_attributes)
           h[:instance_name].should == @ae_name
         end
       end

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -57,7 +57,7 @@ describe DatabaseBackup do
 
   context "schedule" do
     before(:each) do
-      FactoryGirl.create(:miq_server, :my_server)
+      EvmSpecHelper.local_miq_server
       MiqServer.my_server_clear_cache
 
       @name = "adhoc schedule"

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -57,10 +57,7 @@ describe DatabaseBackup do
 
   context "schedule" do
     before(:each) do
-      @zone  = FactoryGirl.create(:zone)
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid)
+      FactoryGirl.create(:miq_server, :my_server)
       MiqServer.my_server_clear_cache
 
       @name = "adhoc schedule"

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -58,7 +58,6 @@ describe DatabaseBackup do
   context "schedule" do
     before(:each) do
       EvmSpecHelper.local_miq_server
-      MiqServer.my_server_clear_cache
 
       @name = "adhoc schedule"
       @sanitized_name = "adhoc_schedule"

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -360,7 +360,7 @@ describe Host do
 
   context "host validation" do
     before do
-      FactoryGirl.create(:miq_server, :my_server)
+      EvmSpecHelper.local_miq_server
 
       @password = "v2:{/OViaBJ0Ug+RSW9n7EFGqw==}"
       @host = FactoryGirl.create(:host_vmware_esx)

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -360,9 +360,7 @@ describe Host do
 
   context "host validation" do
     before do
-      @zone = FactoryGirl.create(:zone)
-      @server = FactoryGirl.create(:miq_server, :zone => @zone)
-      MiqServer.stub(:my_server).and_return(@server)
+      FactoryGirl.create(:miq_server, :my_server)
 
       @password = "v2:{/OViaBJ0Ug+RSW9n7EFGqw==}"
       @host = FactoryGirl.create(:host_vmware_esx)

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -42,14 +42,9 @@ module JobProxyDispatcherEmbeddedScanSpec
 
     context "With a zone, server, ems, hosts, vmware vms" do
       before(:each) do
-        @guid = MiqUUID.new_guid
-        MiqServer.stub(:my_guid => @guid)
-        @zone = FactoryGirl.create(:zone)
-        @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :name => "test_server_main_server")
-        MiqServer.my_server(true)
-
+        server = FactoryGirl.create(:miq_server_master, :my_server, :name => "test_server_main_server")
         (NUM_SERVERS - 1).times do |i|
-          FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :name => "test_server_#{i}")
+          FactoryGirl.create(:miq_server, :zone => server.zone, :name => "test_server_#{i}")
         end
 
         #TODO: We should be able to set values so we don't need to stub behavior

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -42,7 +42,7 @@ module JobProxyDispatcherEmbeddedScanSpec
 
     context "With a zone, server, ems, hosts, vmware vms" do
       before(:each) do
-        server = FactoryGirl.create(:miq_server, :my_server, :is_master => true, :name => "test_server_main_server")
+        server = EvmSpecHelper.local_miq_server(:is_master => true, :name => "test_server_main_server")
         (NUM_SERVERS - 1).times do |i|
           FactoryGirl.create(:miq_server, :zone => server.zone, :name => "test_server_#{i}")
         end

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -42,7 +42,7 @@ module JobProxyDispatcherEmbeddedScanSpec
 
     context "With a zone, server, ems, hosts, vmware vms" do
       before(:each) do
-        server = FactoryGirl.create(:miq_server_master, :my_server, :name => "test_server_main_server")
+        server = FactoryGirl.create(:miq_server, :my_server, :is_master => true, :name => "test_server_main_server")
         (NUM_SERVERS - 1).times do |i|
           FactoryGirl.create(:miq_server, :zone => server.zone, :name => "test_server_#{i}")
         end

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -5,7 +5,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
   include JobProxyDispatcherHelper
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server)
+      @server1 = EvmSpecHelper.local_miq_server
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
 

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -5,12 +5,8 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
   include JobProxyDispatcherHelper
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid => @guid)
-      @zone = FactoryGirl.create(:zone)
-      @server1 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-      MiqServer.my_server(true)
-      @server2 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :status => "started")
+      @server1 = FactoryGirl.create(:miq_server, :my_server)
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
 
       # Support old style class methods or new instance style

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -22,7 +22,7 @@ module JobProxyDispatcherSpec
 
       context "With a default zone, server, with hosts with a miq_proxy, vmware vms on storages" do
         before(:each) do
-          @server = FactoryGirl.create(:miq_server, :my_server, :name => "test_server_main_server")
+          @server = EvmSpecHelper.local_miq_server(:name => "test_server_main_server")
 
           (NUM_SERVERS - 1).times do |i|
             FactoryGirl.create(:miq_server, :zone => @server.zone, :name => "test_server_#{i}")

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -22,14 +22,10 @@ module JobProxyDispatcherSpec
 
       context "With a default zone, server, with hosts with a miq_proxy, vmware vms on storages" do
         before(:each) do
-          @guid = MiqUUID.new_guid
-          MiqServer.stub(:my_guid => @guid)
-          @zone = FactoryGirl.create(:zone)
-          @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :name => "test_server_main_server")
-          MiqServer.my_server(true)
+          @server = FactoryGirl.create(:miq_server, :my_server, :name => "test_server_main_server")
 
           (NUM_SERVERS - 1).times do |i|
-            FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :name => "test_server_#{i}")
+            FactoryGirl.create(:miq_server, :zone => @server.zone, :name => "test_server_#{i}")
           end
 
           #TODO: We should be able to set values so we don't need to stub behavior
@@ -44,13 +40,9 @@ module JobProxyDispatcherSpec
 
         # Don't run these tests if we only want to run dispatch for load testing
         unless DISPATCH_ONLY
-          it "should have a zone" do
-            @zone.should_not be_nil
-          end
-
           it "should have a server in default zone" do
+            @server.zone.should_not be_nil
             @server.should_not be_nil
-            @zone.should == @server.zone
           end
 
           it "should have #{NUM_HOSTS} hosts" do

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -6,12 +6,8 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
 
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid => @guid)
-      @zone = FactoryGirl.create(:zone)
-      @server1 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-      MiqServer.my_server(true)
-      @server2 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :status => "started")
+      @server1 = FactoryGirl.create(:miq_server, :my_server)
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end
 

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -6,7 +6,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
 
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server)
+      @server1 = EvmSpecHelper.local_miq_server
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -6,7 +6,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -6,7 +6,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -6,12 +6,8 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid => @guid)
-      @zone = FactoryGirl.create(:zone)
-      @server1 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-      MiqServer.my_server(true)
-      @server2 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :status => "started")
+      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end
 

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -5,7 +5,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
   include JobProxyDispatcherHelper
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -5,12 +5,8 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
   include JobProxyDispatcherHelper
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid => @guid)
-      @zone = FactoryGirl.create(:zone)
-      @server1 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-      MiqServer.my_server(true)
-      @server2 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :status => "started")
+      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end
 

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -5,7 +5,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
   include JobProxyDispatcherHelper
   context "with two servers on same zone, vix disk enabled for all, " do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -6,7 +6,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
   context "two vix disk enabled servers," do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -6,7 +6,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
   context "two vix disk enabled servers," do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -6,12 +6,8 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
   context "two vix disk enabled servers," do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid => @guid)
-      @zone = FactoryGirl.create(:zone)
-      @server1 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-      MiqServer.my_server(true)
-      @server2 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => MiqUUID.new_guid, :status => "started")
+      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       MiqServer.any_instance.stub(:is_vix_disk? => true)
     end
 
@@ -93,7 +89,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
           context "with server proxies active," do
             before(:each) do
               MiqServer.any_instance.stub(:is_proxy_active? => true)
-              @vm.stub(:my_zone).and_return(@zone.name)
+              @vm.stub(:my_zone).and_return(@server1.zone.name)
             end
 
             context "a vm template and invalid VC authentication" do

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -62,7 +62,6 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
               server_roles = [FactoryGirl.create(:server_role, :name => "smartproxy", :max_concurrent => 0)]
 
-              MiqServer.my_server(true)
               @server1.deactivate_all_roles
               @server1.role    = 'smartproxy'
               Host.any_instance.stub(:missing_credentials? => false)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -4,10 +4,10 @@ describe Job do
   context "With a single scan job," do
 
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
 
-      @miq_server = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+      @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
       @zone = @miq_server.zone
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @zone, :name => "Test EMS")
       @host       = FactoryGirl.create(:host)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -4,10 +4,10 @@ describe Job do
   context "With a single scan job," do
 
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
 
-      @miq_server = FactoryGirl.create(:miq_server_master, :my_server)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
       @zone = @miq_server.zone
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @zone, :name => "Test EMS")
       @host       = FactoryGirl.create(:host)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -4,12 +4,11 @@ describe Job do
   context "With a single scan job," do
 
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
+      @server1 = FactoryGirl.create(:miq_server_master, :my_server)
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
 
-      @zone       = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-      MiqServer.stub(:my_server).and_return(@miq_server)
+      @miq_server = FactoryGirl.create(:miq_server_master, :my_server)
+      @zone = @miq_server.zone
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @zone, :name => "Test EMS")
       @host       = FactoryGirl.create(:host)
 

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -4,14 +4,7 @@ describe MiqAlert do
   context "With single server with a single generic worker with the notifier role," do
 
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
-      @zone            = FactoryGirl.create(:zone)
-      @miq_server      = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-      @miq_server.role = 'notifier'
-      MiqServer.stub(:my_server).and_return(@miq_server)
-
+      @miq_server = FactoryGirl.create(:miq_server, :my_server, :role => 'notifier')
       @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
       @vm     = FactoryGirl.create(:vm_vmware)
 
@@ -312,15 +305,9 @@ describe MiqAlert do
   context ".evaluate_hourly_timer" do
     before do
       MiqAlert.any_instance.stub(:validate => true)
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
-      @zone            = FactoryGirl.create(:zone)
-      @miq_server      = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-      MiqServer.stub(:my_server).and_return(@miq_server)
-
-      @ems = FactoryGirl.create(:ems_vmware, :zone => @zone)
-      @ems_other = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone, :name => 'other'))
+      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
+      @ems_other  = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone, :name => 'other'))
       @alert      = FactoryGirl.create(:miq_alert, :enabled => true, :responds_to_events => "_hourly_timer_")
       @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for Alert Id: #{@alert.id}")
       @alert_prof.add_member(@alert)

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -4,7 +4,7 @@ describe MiqAlert do
   context "With single server with a single generic worker with the notifier role," do
 
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server, :my_server, :role => 'notifier')
+      @miq_server = EvmSpecHelper.local_miq_server(:role => 'notifier')
       @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
       @vm     = FactoryGirl.create(:vm_vmware)
 
@@ -305,7 +305,7 @@ describe MiqAlert do
   context ".evaluate_hourly_timer" do
     before do
       MiqAlert.any_instance.stub(:validate => true)
-      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server = EvmSpecHelper.local_miq_server
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
       @ems_other  = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone, :name => 'other'))
       @alert      = FactoryGirl.create(:miq_alert, :enabled => true, :responds_to_events => "_hourly_timer_")

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -46,11 +46,8 @@ describe MiqEvent do
     context ".raise_evm_event" do
       before(:each) do
         @cluster    = FactoryGirl.create(:ems_cluster)
-        @guid       = MiqUUID.new_guid
-        @zone       = FactoryGirl.create(:zone, :name => "test")
-        @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-        MiqServer.stub(:my_guid).and_return(@guid)
-        MiqServer.stub(:my_server).and_return(@miq_server)
+        @miq_server = FactoryGirl.create(:miq_server, :my_server)
+        @zone       = @miq_server.zone
       end
 
       it "will raise an error for missing target" do

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -46,7 +46,7 @@ describe MiqEvent do
     context ".raise_evm_event" do
       before(:each) do
         @cluster    = FactoryGirl.create(:ems_cluster)
-        @miq_server = FactoryGirl.create(:miq_server, :my_server)
+        @miq_server = EvmSpecHelper.local_miq_server
         @zone       = @miq_server.zone
       end
 

--- a/spec/models/miq_host_provision_spec.rb
+++ b/spec/models/miq_host_provision_spec.rb
@@ -25,12 +25,7 @@ describe MiqHostProvision do
 
   context "with default server and zone" do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
-      @zone       = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-      MiqServer.stub(:my_server).and_return(@miq_server)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server)
     end
 
     context "with host and miq_host_provision" do

--- a/spec/models/miq_host_provision_spec.rb
+++ b/spec/models/miq_host_provision_spec.rb
@@ -25,7 +25,7 @@ describe MiqHostProvision do
 
   context "with default server and zone" do
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     context "with host and miq_host_provision" do

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -7,14 +7,7 @@ describe MiqHostProvisionWorkflow do
   context "seeded" do
     context "After setup," do
       before(:each) do
-        @guid = MiqUUID.new_guid
-        MiqServer.stub(:my_guid => @guid)
-
-        @zone = FactoryGirl.create(:zone)
-        MiqServer.stub(:my_zone => @zone)
-
-        @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-        MiqServer.stub(:my_server => @server)
+        @server = FactoryGirl.create(:miq_server, :my_server)
 
         FactoryGirl.create(:user_admin)
 
@@ -38,7 +31,7 @@ describe MiqHostProvisionWorkflow do
 
       context "With a Valid IPMI Host," do
         before(:each) do
-          ems        = FactoryGirl.create(:ems_vmware,  :name => "Test EMS",  :zone => @zone)
+          ems        = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => @server.zone)
           host       = FactoryGirl.create(:host_with_ipmi, :ext_management_system => ems)
           pxe_server = FactoryGirl.create(:pxe_server, :name => 'PXE on 127.0.0.1', :uri_prefix => 'nfs', :uri => 'nfs://127.0.0.1/srv/tftpboot')
           pxe_image  = FactoryGirl.create(:pxe_image, :name => 'VMware ESXi 4.1-260247', :pxe_server => pxe_server)

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -7,7 +7,7 @@ describe MiqHostProvisionWorkflow do
   context "seeded" do
     context "After setup," do
       before(:each) do
-        @server = FactoryGirl.create(:miq_server, :my_server)
+        @server = EvmSpecHelper.local_miq_server
 
         FactoryGirl.create(:user_admin)
 

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -6,16 +6,11 @@ describe MiqProvisionWorkflow do
   context "seeded" do
     context "After setup," do
       before(:each) do
-        @guid = MiqUUID.new_guid
-        MiqServer.stub(:my_guid => @guid)
-
-        @zone = FactoryGirl.create(:zone)
-        MiqServer.stub(:my_zone => @zone)
-
-        @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-        MiqServer.stub(:my_server => @server)
-
+        @server = FactoryGirl.create(:miq_server, :my_server)
+        @zone = @server.zone
+        @guid = @server.guid
         @admin = FactoryGirl.create(:user_admin)
+        expect(MiqServer.my_server).to eq(@server)
 
         FactoryGirl.create(:miq_dialog_provision)
       end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -6,7 +6,7 @@ describe MiqProvisionWorkflow do
   context "seeded" do
     context "After setup," do
       before(:each) do
-        @server = FactoryGirl.create(:miq_server, :my_server)
+        @server = EvmSpecHelper.local_miq_server
         @zone = @server.zone
         @guid = @server.guid
         @admin = FactoryGirl.create(:user_admin)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -5,7 +5,7 @@ describe MiqQueue do
 
   context "#deliver" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     end
 
     it "works with deliver_on" do
@@ -54,9 +54,9 @@ describe MiqQueue do
 
   context "With messages left in dequeue at startup," do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
-      @other_miq_server = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone)
+      @other_miq_server = FactoryGirl.create(:miq_server, :zone => @miq_server.zone)
 
       @worker       = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
       @other_worker = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @other_miq_server.id)
@@ -219,7 +219,7 @@ describe MiqQueue do
 
   context "miq_queue with messages" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @t1 = Time.parse("Wed Apr 20 00:15:00 UTC 2011")
       @t2 = Time.parse("Mon Apr 25 10:30:15 UTC 2011")
@@ -257,7 +257,7 @@ describe MiqQueue do
 
   context "deliver to queue" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @t1 = Time.parse("Wed Apr 20 00:15:00 UTC 2011")
       @msg = FactoryGirl.create(:miq_queue, :zone => @zone.name, :role => "role1", :priority => 20, :created_on => @t1)
@@ -308,9 +308,9 @@ describe MiqQueue do
 
   context "worker" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @miq_server, _ = EvmSpecHelper.create_guid_miq_server_zone
 
-      @worker       = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
+      @worker = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
       @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :task_id => "task123", :handler => @worker)
     end
 
@@ -325,7 +325,7 @@ describe MiqQueue do
 
   context "#put" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @miq_server, _ = EvmSpecHelper.create_guid_miq_server_zone
     end
 
     it "should put one message on queue" do

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqReport do
   before(:each) do
     MiqRegion.seed
-    FactoryGirl.create(:miq_server, :my_server)
+    EvmSpecHelper.local_miq_server
 
     @group = FactoryGirl.create(:miq_group)
     @user  = FactoryGirl.create(:user, :miq_groups => [@group])

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -3,10 +3,7 @@ require "spec_helper"
 describe MiqReport do
   before(:each) do
     MiqRegion.seed
-    guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid => guid)
-    FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone), :guid => guid, :status => "started")
-    MiqServer.my_server(true)
+    FactoryGirl.create(:miq_server, :my_server)
 
     @group = FactoryGirl.create(:miq_group)
     @user  = FactoryGirl.create(:user, :miq_groups => [@group])

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -3,10 +3,7 @@ require "spec_helper"
 describe MiqReportResult do
   before(:each) do
     MiqRegion.seed
-    guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid => guid)
-    FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone), :guid => guid, :status => "started")
-    MiqServer.my_server(true)
+    FactoryGirl.create(:miq_server, :my_server)
 
     @group = FactoryGirl.create(:miq_group)
     @user  = FactoryGirl.create(:user, :miq_groups => [@group])

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqReportResult do
   before(:each) do
     MiqRegion.seed
-    FactoryGirl.create(:miq_server, :my_server)
+    EvmSpecHelper.local_miq_server
 
     @group = FactoryGirl.create(:miq_group)
     @user  = FactoryGirl.create(:user, :miq_groups => [@group])

--- a/spec/models/miq_schedule_filter_spec.rb
+++ b/spec/models/miq_schedule_filter_spec.rb
@@ -3,11 +3,7 @@ require "spec_helper"
 describe "MiqSchedule Filter" do
   context "Getting schedule targets" do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid => @guid)
-      @zone = FactoryGirl.create(:zone)
-      @server1 = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid, :status => "started")
-      MiqServer.stub(:my_server => @server1)
+      @server1 = FactoryGirl.create(:miq_server, :my_server)
 
       # Vm Scan Schedules
       @vm1 = FactoryGirl.create(:vm_vmware, :name => "Test VM 1")

--- a/spec/models/miq_schedule_filter_spec.rb
+++ b/spec/models/miq_schedule_filter_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "MiqSchedule Filter" do
   context "Getting schedule targets" do
     before(:each) do
-      @server1 = FactoryGirl.create(:miq_server, :my_server)
+      @server1 = EvmSpecHelper.local_miq_server
 
       # Vm Scan Schedules
       @vm1 = FactoryGirl.create(:vm_vmware, :name => "Test VM 1")

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -24,7 +24,7 @@ describe MiqServer do
 
       context "remote server" do
         before do
-          _guid, @remote_server, _zone = EvmSpecHelper.remote_guid_miq_server_zone
+          _, @remote_server, _ = EvmSpecHelper.remote_guid_miq_server_zone
         end
 
         it "with no changes in the database" do

--- a/spec/models/miq_server/rhn_mirror_spec.rb
+++ b/spec/models/miq_server/rhn_mirror_spec.rb
@@ -6,9 +6,9 @@ describe "MiqServer" do
       MiqDatabase.seed
       MiqRegion.seed
       ServerRole.seed
-      _, @server1, zone = EvmSpecHelper.create_guid_miq_server_zone
+      _, @server1, _ = EvmSpecHelper.create_guid_miq_server_zone
       @server1.update_attribute(:ipaddress, "1.2.3.4")
-      @server2  = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => zone, :ipaddress => "9.8.7.6")
+      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone, :ipaddress => "9.8.7.6")
     end
 
     context "#configure_rhn_mirror_client" do

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -29,7 +29,7 @@ describe "Server Role Management" do
       MiqRegion.seed
       ServerRole.seed
       @server_roles = ServerRole.all
-      @miq_server   = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server   = EvmSpecHelper.local_miq_server
       @miq_server.deactivate_all_roles
     end
 

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -4,9 +4,6 @@ describe "Server Role Management" do
 
   context "After Setup," do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,license_required,role_scope
         automate,Automation Engine,0,false,automate,region
@@ -32,9 +29,7 @@ describe "Server Role Management" do
       MiqRegion.seed
       ServerRole.seed
       @server_roles = ServerRole.all
-      @zone         = FactoryGirl.create(:zone)
-      @miq_server   = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone, :status => "started", :name => "Server 1")
-      MiqServer.my_server(true)
+      @miq_server   = FactoryGirl.create(:miq_server, :my_server)
       @miq_server.deactivate_all_roles
     end
 

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -46,7 +46,7 @@ describe "Server Monitor" do
 
     context "with 1 Server" do
       before(:each) do
-        @miq_server = FactoryGirl.create(:miq_server, :my_server)
+        @miq_server = EvmSpecHelper.local_miq_server
         @miq_server.monitor_servers
 
         @miq_server.deactivate_all_roles
@@ -234,7 +234,7 @@ describe "Server Monitor" do
 
     context "with 2 Servers in 2 Zones where I am the Master" do
       before(:each) do
-        @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
+        @miq_server1 = EvmSpecHelper.local_miq_server(:is_master => true)
         @miq_server1.deactivate_all_roles
         @miq_server1.role = 'event, ems_operations, scheduler, reporting'
 
@@ -353,7 +353,7 @@ describe "Server Monitor" do
 
     context "with 2 Servers where I am the non-Master" do
       before(:each) do
-        @miq_server1 = FactoryGirl.create(:miq_server, :my_server)
+        @miq_server1 = EvmSpecHelper.local_miq_server
         @miq_server1.deactivate_all_roles
         @miq_server1.role         = 'event, ems_operations, scheduler, reporting'
         @roles1 = [ ['ems_operations', 1], ['event', 2], ['scheduler', 2], ['reporting', 1] ]
@@ -444,7 +444,7 @@ describe "Server Monitor" do
 
     context "with 3 Servers where I am the Master" do
       before(:each) do
-        @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true, :name => "Miq1")
+        @miq_server1 = EvmSpecHelper.local_miq_server(:is_master => true, :name => "Miq1")
         @miq_server1.deactivate_all_roles
         @roles1 = [ ['ems_operations', 2], ['event', 2], ['ems_inventory', 3], ['ems_metrics_coordinator', 2], ]
         @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
@@ -627,7 +627,7 @@ describe "Server Monitor" do
 
     context "with 3 Servers where I am the non-Master" do
       before(:each) do
-        @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :name => "Server 1")
+        @miq_server1 = EvmSpecHelper.local_miq_server(:name => "Server 1")
         MiqServer.my_server(true)
         @miq_server1.deactivate_all_roles
         @miq_server1.role         = 'event, ems_operations, ems_inventory'
@@ -754,7 +754,7 @@ describe "Server Monitor" do
 
       context "with 2 Servers across Zones where there is no master" do
         before(:each) do
-          @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :zone => @zone1, :name => "Server 1")
+          @miq_server1 = EvmSpecHelper.local_miq_server(:zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
 
           @miq_server2 = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone2, :name => "Server 2")
@@ -787,7 +787,7 @@ describe "Server Monitor" do
 
       context "with 2 Servers across Zones where I am the Master" do
         before(:each) do
-          @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true, :zone => @zone1, :name => "Server 1")
+          @miq_server1 = EvmSpecHelper.local_miq_server(:is_master => true, :zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
           @roles1 = [ ['ems_operations', 1], ['event', 1], ['ems_metrics_coordinator', 2], ['scheduler', 1], ['reporting', 1] ]
           @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -4,9 +4,6 @@ describe "Server Monitor" do
 
   context "After Setup," do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,license_required,role_scope
         automate,Automation Engine,0,false,automate,region
@@ -49,9 +46,7 @@ describe "Server Monitor" do
 
     context "with 1 Server" do
       before(:each) do
-        @zone       = FactoryGirl.create(:zone)
-        @miq_server = FactoryGirl.create(:miq_server_not_master, :guid => @guid, :zone => @zone)
-        MiqServer.my_server(true)
+        @miq_server = FactoryGirl.create(:miq_server, :my_server)
         @miq_server.monitor_servers
 
         @miq_server.deactivate_all_roles
@@ -239,13 +234,11 @@ describe "Server Monitor" do
 
     context "with 2 Servers in 2 Zones where I am the Master" do
       before(:each) do
-        @zone        = FactoryGirl.create(:zone)
-
-        @miq_server1 = FactoryGirl.create(:miq_server_not_master, :guid => @guid,            :zone => @zone, :is_master => true)
+        @miq_server1 = FactoryGirl.create(:miq_server_master, :my_server)
         @miq_server1.deactivate_all_roles
         @miq_server1.role = 'event, ems_operations, scheduler, reporting'
 
-        @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :is_master => false)
+        @miq_server2 = FactoryGirl.create(:miq_server, :zone => @miq_server1.zone)
         @miq_server2.deactivate_all_roles
         @miq_server2.role = 'event, ems_operations, scheduler, reporting'
       end
@@ -360,16 +353,14 @@ describe "Server Monitor" do
 
     context "with 2 Servers where I am the non-Master" do
       before(:each) do
-        @zone        = FactoryGirl.create(:zone)
-        @miq_server1 = FactoryGirl.create(:miq_server_not_master, :guid => @guid,            :zone => @zone, :is_master => false)
-        MiqServer.my_server(true)
+        @miq_server1 = FactoryGirl.create(:miq_server, :my_server)
         @miq_server1.deactivate_all_roles
         @miq_server1.role         = 'event, ems_operations, scheduler, reporting'
         @roles1 = [ ['ems_operations', 1], ['event', 2], ['scheduler', 2], ['reporting', 1] ]
         @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
         @miq_server1.activate_roles("ems_operations", 'reporting')
 
-        @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :is_master => true)
+        @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @miq_server1.zone)
         @miq_server2.deactivate_all_roles
         @miq_server2.role         = 'event, ems_operations, scheduler, reporting'
         @roles2 = [ ['ems_operations', 1], ['event', 1], ['scheduler', 1], ['reporting', 1] ]
@@ -453,19 +444,17 @@ describe "Server Monitor" do
 
     context "with 3 Servers where I am the Master" do
       before(:each) do
-        @zone        = FactoryGirl.create(:zone)
-        @miq_server1 = FactoryGirl.create(:miq_server_not_master, :guid => @guid,            :zone => @zone, :name => "Miq1", :is_master => true)
-        MiqServer.my_server(true)
+        @miq_server1 = FactoryGirl.create(:miq_server_master, :my_server, :name => "Miq1")
         @miq_server1.deactivate_all_roles
         @roles1 = [ ['ems_operations', 2], ['event', 2], ['ems_inventory', 3], ['ems_metrics_coordinator', 2], ]
         @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
 
-        @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :name => "Miq2", :is_master => false)
+        @miq_server2 = FactoryGirl.create(:miq_server, :zone => @miq_server1.zone, :name => "Miq2")
         @miq_server2.deactivate_all_roles
         @roles2 = [ ['ems_operations', 1], ['event', 1], ['ems_metrics_coordinator', 3], ['ems_inventory', 2],  ]
         @roles2.each { |role, priority| @miq_server2.assign_role(role, priority) }
 
-        @miq_server3 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :name => "Miq3", :is_master => false)
+        @miq_server3 = FactoryGirl.create(:miq_server, :zone => @miq_server1.zone, :name => "Miq3")
         @miq_server3.deactivate_all_roles
         @roles3 = [ ['ems_operations', 2], ['event', 3], ['ems_inventory', 1], ['ems_metrics_coordinator', 1] ]
         @roles3.each { |role, priority| @miq_server3.assign_role(role, priority) }
@@ -638,19 +627,18 @@ describe "Server Monitor" do
 
     context "with 3 Servers where I am the non-Master" do
       before(:each) do
-        @zone        = FactoryGirl.create(:zone)
-        @miq_server1 = FactoryGirl.create(:miq_server_not_master, :guid => @guid,            :zone => @zone, :name => "Server 1", :is_master => false)
+        @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :name => "Server 1")
         MiqServer.my_server(true)
         @miq_server1.deactivate_all_roles
         @miq_server1.role         = 'event, ems_operations, ems_inventory'
         @miq_server1.activate_roles("ems_operations", "ems_inventory")
 
-        @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :name => "Server 2", :is_master => true)
+        @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @miq_server1.zone, :name => "Server 2")
         @miq_server2.deactivate_all_roles
         @miq_server2.role         = 'event, ems_metrics_coordinator, ems_operations'
         @miq_server2.activate_roles("event", "ems_metrics_coordinator", 'ems_operations')
 
-        @miq_server3 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :name => "Server 3", :is_master => false)
+        @miq_server3 = FactoryGirl.create(:miq_server, :zone => @miq_server2.zone, :name => "Server 3")
         @miq_server3.deactivate_all_roles
         @miq_server3.role         = 'ems_metrics_coordinator, ems_inventory, ems_operations'
         @miq_server3.activate_roles("ems_operations")
@@ -766,12 +754,10 @@ describe "Server Monitor" do
 
       context "with 2 Servers across Zones where there is no master" do
         before(:each) do
-
-          @miq_server1 = FactoryGirl.create(:miq_server_not_master, :guid => @guid,            :zone => @zone1, :status => "started", :name => "Server 1")
-          MiqServer.my_server(true)
+          @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
 
-          @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone2, :status => "started", :name => "Server 2")
+          @miq_server2 = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone2, :name => "Server 2")
           @miq_server2.deactivate_all_roles
         end
 
@@ -801,13 +787,12 @@ describe "Server Monitor" do
 
       context "with 2 Servers across Zones where I am the Master" do
         before(:each) do
-          @miq_server1 = FactoryGirl.create(:miq_server_not_master, :guid => @guid,            :zone => @zone1, :status => "started", :name => "Server 1", :is_master => true)
-          MiqServer.my_server(true)
+          @miq_server1 = FactoryGirl.create(:miq_server_master, :my_server, :zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
           @roles1 = [ ['ems_operations', 1], ['event', 1], ['ems_metrics_coordinator', 2], ['scheduler', 1], ['reporting', 1] ]
           @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
 
-          @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone2, :status => "started", :name => "Server 2", :is_master => false)
+          @miq_server2 = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone2, :name => "Server 2")
           @miq_server2.deactivate_all_roles
           @roles2 = [ ['ems_operations', 1], ['event', 2], ['ems_metrics_coordinator', 1], ['scheduler', 2], ['reporting', 1] ]
           @roles2.each { |role, priority| @miq_server2.assign_role(role, priority) }

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -628,7 +628,6 @@ describe "Server Monitor" do
     context "with 3 Servers where I am the non-Master" do
       before(:each) do
         @miq_server1 = EvmSpecHelper.local_miq_server(:name => "Server 1")
-        MiqServer.my_server(true)
         @miq_server1.deactivate_all_roles
         @miq_server1.role         = 'event, ems_operations, ems_inventory'
         @miq_server1.activate_roles("ems_operations", "ems_inventory")

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -234,7 +234,7 @@ describe "Server Monitor" do
 
     context "with 2 Servers in 2 Zones where I am the Master" do
       before(:each) do
-        @miq_server1 = FactoryGirl.create(:miq_server_master, :my_server)
+        @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true)
         @miq_server1.deactivate_all_roles
         @miq_server1.role = 'event, ems_operations, scheduler, reporting'
 
@@ -360,7 +360,7 @@ describe "Server Monitor" do
         @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
         @miq_server1.activate_roles("ems_operations", 'reporting')
 
-        @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @miq_server1.zone)
+        @miq_server2 = FactoryGirl.create(:miq_server, :is_master => true, :zone => @miq_server1.zone)
         @miq_server2.deactivate_all_roles
         @miq_server2.role         = 'event, ems_operations, scheduler, reporting'
         @roles2 = [ ['ems_operations', 1], ['event', 1], ['scheduler', 1], ['reporting', 1] ]
@@ -444,7 +444,7 @@ describe "Server Monitor" do
 
     context "with 3 Servers where I am the Master" do
       before(:each) do
-        @miq_server1 = FactoryGirl.create(:miq_server_master, :my_server, :name => "Miq1")
+        @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true, :name => "Miq1")
         @miq_server1.deactivate_all_roles
         @roles1 = [ ['ems_operations', 2], ['event', 2], ['ems_inventory', 3], ['ems_metrics_coordinator', 2], ]
         @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
@@ -633,7 +633,7 @@ describe "Server Monitor" do
         @miq_server1.role         = 'event, ems_operations, ems_inventory'
         @miq_server1.activate_roles("ems_operations", "ems_inventory")
 
-        @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @miq_server1.zone, :name => "Server 2")
+        @miq_server2 = FactoryGirl.create(:miq_server, :is_master => true, :zone => @miq_server1.zone, :name => "Server 2")
         @miq_server2.deactivate_all_roles
         @miq_server2.role         = 'event, ems_metrics_coordinator, ems_operations'
         @miq_server2.activate_roles("event", "ems_metrics_coordinator", 'ems_operations')
@@ -787,7 +787,7 @@ describe "Server Monitor" do
 
       context "with 2 Servers across Zones where I am the Master" do
         before(:each) do
-          @miq_server1 = FactoryGirl.create(:miq_server_master, :my_server, :zone => @zone1, :name => "Server 1")
+          @miq_server1 = FactoryGirl.create(:miq_server, :my_server, :is_master => true, :zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
           @roles1 = [ ['ems_operations', 1], ['event', 1], ['ems_metrics_coordinator', 2], ['scheduler', 1], ['reporting', 1] ]
           @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqServer do
   before do
     MiqDatabase.seed
-    guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    _, @server, _ = EvmSpecHelper.create_guid_miq_server_zone
   end
 
   let(:database)    { MiqDatabase.first }
@@ -12,7 +12,7 @@ describe MiqServer do
 
   context "Queue multiple servers" do
     before do
-      FactoryGirl.create(:miq_server_not_master, :zone => @zone, :guid => MiqUUID.new_guid)
+      FactoryGirl.create(:miq_server, :zone => @server.zone)
     end
 
     it ".queue_update_registration_status" do

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -9,11 +9,7 @@ describe "MiqWorker Monitor" do
       MiqServer.any_instance.stub(:get_memory_threshold).and_return(100.megabytes)
       MiqServer.any_instance.stub(:get_restart_interval).and_return(0)
 
-      @guid               = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @zone               = FactoryGirl.create(:zone)
-      @miq_server         = FactoryGirl.create(:miq_server_not_master, :guid => @guid, :zone => @zone)
-      MiqServer.my_server(true)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server)
     end
 
     context "A worker" do
@@ -161,7 +157,7 @@ describe "MiqWorker Monitor" do
 
       context "with expired active messages assigned to workers from multiple" do
         before(:each) do
-          @miq_server2 = FactoryGirl.create(:miq_server_not_master, :guid => MiqUUID.new_guid, :zone => @zone, :status => 'started')
+          @miq_server2 = FactoryGirl.create(:miq_server, :zone => @miq_server.zone)
           @worker1 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
           @worker2 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server2.id)
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -9,7 +9,7 @@ describe "MiqWorker Monitor" do
       MiqServer.any_instance.stub(:get_memory_threshold).and_return(100.megabytes)
       MiqServer.any_instance.stub(:get_restart_interval).and_return(0)
 
-      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     context "A worker" do

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -267,7 +267,7 @@ describe MiqServer do
       context "with an active messsage and a second server" do
         before(:each) do
           @msg = FactoryGirl.create(:miq_queue, :state => 'dequeue')
-          @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @zone)
+          @miq_server2 = FactoryGirl.create(:miq_server, :is_master => true, :zone => @zone)
         end
 
         it "will validate the 'started' first server's active message when called on it" do

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -47,7 +47,6 @@ describe MiqServer do
   context "instance" do
     before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      MiqServer.my_server(true)
     end
 
     it "should have proper guid" do

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -267,8 +267,7 @@ describe MiqServer do
       context "with an active messsage and a second server" do
         before(:each) do
           @msg = FactoryGirl.create(:miq_queue, :state => 'dequeue')
-          @guid2 = MiqUUID.new_guid
-          @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @zone, :guid => @guid2)
+          @miq_server2 = FactoryGirl.create(:miq_server_master, :zone => @zone)
         end
 
         it "will validate the 'started' first server's active message when called on it" do

--- a/spec/models/miq_widget/rss_content_spec.rb
+++ b/spec/models/miq_widget/rss_content_spec.rb
@@ -63,7 +63,7 @@ describe "Widget RSS Content" do
     MiqRegion.seed
     RssFeed.sync_from_yml_dir
 
-    FactoryGirl.create(:miq_server, :my_server)
+    EvmSpecHelper.local_miq_server
 
     @admin       = FactoryGirl.create(:user_admin)
     @admin_group = @admin.current_group

--- a/spec/models/miq_widget/rss_content_spec.rb
+++ b/spec/models/miq_widget/rss_content_spec.rb
@@ -63,10 +63,7 @@ describe "Widget RSS Content" do
     MiqRegion.seed
     RssFeed.sync_from_yml_dir
 
-    guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid => guid)
-    FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone), :guid => guid, :status => "started")
-    MiqServer.my_server(true)
+    FactoryGirl.create(:miq_server, :my_server)
 
     @admin       = FactoryGirl.create(:user_admin)
     @admin_group = @admin.current_group

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -2,12 +2,8 @@ require "spec_helper"
 
 describe MiqWidget do
   before(:each) do
-    guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid => guid)
-    FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone), :guid => guid, :status => "started")
-    MiqServer.my_server(true)
-
     MiqRegion.seed
+    FactoryGirl.create(:miq_server, :my_server)
   end
 
   context "setup" do

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqWidget do
   before(:each) do
     MiqRegion.seed
-    FactoryGirl.create(:miq_server, :my_server)
+    EvmSpecHelper.local_miq_server
   end
 
   context "setup" do

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -34,10 +34,8 @@ describe MiqWorker do
     end
 
     before(:each) do
-      @server_active_role_names = ["foo", "bar"]
-      @server = FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone))
-      MiqServer.stub(:my_server).and_return(@server)
-      @server.stub(:active_role_names).and_return(@server_active_role_names)
+      active_roles = %w(foo bar).map { |rn| FactoryGirl.create(:server_role, :name => rn) }
+      @server = FactoryGirl.create(:miq_server, :my_server, :active_roles => active_roles)
     end
 
     context "clean_active_messages" do

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -35,7 +35,7 @@ describe MiqWorker do
 
     before(:each) do
       active_roles = %w(foo bar).map { |rn| FactoryGirl.create(:server_role, :name => rn) }
-      @server = FactoryGirl.create(:miq_server, :my_server, :active_roles => active_roles)
+      @server = EvmSpecHelper.local_miq_server(:active_roles => active_roles)
     end
 
     context "clean_active_messages" do

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -129,7 +129,7 @@ describe AuthenticationMixin do
 
   context "with server and zone" do
     before(:each) do
-      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server = EvmSpecHelper.local_miq_server
       @data = {:default => {:userid => "test", :password => "blah"}}
     end
 

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -129,17 +129,13 @@ describe AuthenticationMixin do
 
   context "with server and zone" do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-      @zone       = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server_not_master, :guid => @guid, :zone => @zone)
-      MiqServer.my_server(true)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server)
       @data = {:default => {:userid => "test", :password => "blah"}}
     end
 
     context "with multiple zones, emses, and hosts" do
       before(:each) do
-        @zone1 = @zone
+        @zone1 = @miq_server.zone
         @zone2 = FactoryGirl.create(:zone, :name => 'test1')
         @ems1  = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone1)
         @ems2  = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone2)

--- a/spec/models/mixins/timezone_mixin_spec.rb
+++ b/spec/models/mixins/timezone_mixin_spec.rb
@@ -26,7 +26,7 @@ describe TimezoneMixin do
     end
 
     it "#with_current_user_timezone" do
-      FactoryGirl.create(:miq_server, :my_server)
+      EvmSpecHelper.local_miq_server
       test_inst.with_current_user_timezone { Time.zone }.to_s.should == "(GMT+00:00) UTC"
     end
 

--- a/spec/models/mixins/timezone_mixin_spec.rb
+++ b/spec/models/mixins/timezone_mixin_spec.rb
@@ -1,34 +1,21 @@
 require "spec_helper"
 
 describe TimezoneMixin do
-  before do
-    class TestClass
+  let(:test_class) do
+    Class.new do
       include TimezoneMixin
     end
-  end
-
-  before(:each) do
-      guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(guid)
-
-      zone        = FactoryGirl.create(:zone)
-      miq_server  = FactoryGirl.create(:miq_server, :zone => zone, :guid => guid)
-      MiqServer.my_server(true)
-  end
-
-  after do
-    Object.send(:remove_const, "TestClass")
   end
 
   context ".server_timezone" do
     it "server default" do
       expect(MiqServer).to receive(:my_server).and_return(double(:server_timezone => "Eastern Time (US & Canada)"))
-      TestClass.server_timezone.should == "Eastern Time (US & Canada)"
+      test_class.server_timezone.should == "Eastern Time (US & Canada)"
     end
   end
 
   context "with a class instance" do
-    let(:test_inst) { TestClass.new }
+    let(:test_inst) { test_class.new }
 
     it "#with_a_timezone in Hawaii" do
       test_inst.with_a_timezone("Hawaii") { Time.zone }.to_s.should == "(GMT-10:00) Hawaii"
@@ -39,6 +26,7 @@ describe TimezoneMixin do
     end
 
     it "#with_current_user_timezone" do
+      FactoryGirl.create(:miq_server, :my_server)
       test_inst.with_current_user_timezone { Time.zone }.to_s.should == "(GMT+00:00) UTC"
     end
 

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -2,12 +2,7 @@ require "spec_helper"
 
 describe "Service Retirement Management" do
   before(:each) do
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-
-    @zone       = FactoryGirl.create(:zone)
-    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.stub(:my_server).and_return(@miq_server)
+    @miq_server = FactoryGirl.create(:miq_server, :my_server)
     @stack = FactoryGirl.create(:orchestration_stack)
   end
 

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "Service Retirement Management" do
   before(:each) do
-    @miq_server = FactoryGirl.create(:miq_server, :my_server)
+    @miq_server = EvmSpecHelper.local_miq_server
     @stack = FactoryGirl.create(:orchestration_stack)
   end
 

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe PxeServer do
   before(:each) do
-    FactoryGirl.create(:miq_server, :my_server)
+    EvmSpecHelper.local_miq_server
     @pxe_server = FactoryGirl.create(:pxe_server, :uri_prefix => "nfs", :uri => "nfs:///#{@mnt_point}")
   end
 

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -2,12 +2,7 @@ require "spec_helper"
 
 describe PxeServer do
   before(:each) do
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-    @zone       = FactoryGirl.create(:zone)
-    @miq_server = FactoryGirl.create(:miq_server_not_master, :guid => @guid, :zone => @zone)
-    MiqServer.my_server(true)
-
+    FactoryGirl.create(:miq_server, :my_server)
     @pxe_server = FactoryGirl.create(:pxe_server, :uri_prefix => "nfs", :uri => "nfs:///#{@mnt_point}")
   end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "Service Retirement Management" do
   before(:each) do
-    @server = FactoryGirl.create(:miq_server, :my_server)
+    @server = EvmSpecHelper.local_miq_server
     @service = FactoryGirl.create(:service)
   end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -1,14 +1,8 @@
 require "spec_helper"
 
 describe "Service Retirement Management" do
-
   before(:each) do
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-
-    @zone       = FactoryGirl.create(:zone)
-    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.stub(:my_server).and_return(@miq_server)
+    @server = FactoryGirl.create(:miq_server, :my_server)
     @service = FactoryGirl.create(:service)
   end
 
@@ -80,7 +74,7 @@ describe "Service Retirement Management" do
   end
 
   it "#retire_service_resources" do
-    ems = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
     vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
     @service << vm
     expect(@service.service_resources).to have(1).thing
@@ -89,7 +83,7 @@ describe "Service Retirement Management" do
   end
 
   it "#retire_service_resources should get service's retirement_requester" do
-    ems = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
     vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
     userid = 'freddy'
     @service.update_attributes(:retirement_requester => userid)
@@ -100,7 +94,7 @@ describe "Service Retirement Management" do
   end
 
   it "#retire_service_resources should get service's nil retirement_requester" do
-    ems = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
     vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
     @service << vm
     expect(@service.service_resources).to have(1).thing

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -77,7 +77,7 @@ describe Storage do
 
   context "with multiple storages" do
     before(:each) do
-      @server = FactoryGirl.create(:miq_server, :my_server)
+      @server = EvmSpecHelper.local_miq_server
       @zone   = @server.zone
 
       @zone2     = FactoryGirl.create(:zone, :name => 'Bedrock')

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -77,11 +77,8 @@ describe Storage do
 
   context "with multiple storages" do
     before(:each) do
-      @guid   = MiqUUID.new_guid
-      @zone   = FactoryGirl.create(:zone)
-      @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid)
-      MiqServer.stub(:my_guid => @guid)
-      MiqServer.my_server(true)
+      @server = FactoryGirl.create(:miq_server, :my_server)
+      @zone   = @server.zone
 
       @zone2     = FactoryGirl.create(:zone, :name => 'Bedrock')
       @ems1      = FactoryGirl.create(:ems_vmware, :name => "test_vcenter1",     :zone => @zone)

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -2,14 +2,8 @@ require "spec_helper"
 
 describe TimeProfile do
   before(:each) do
-    @guid   = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-
-    @zone   = FactoryGirl.create(:zone)
-    @server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.my_server_clear_cache
-
-    @ems    = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    @server = FactoryGirl.create(:miq_server, :my_server)
+    @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
     EvmSpecHelper.clear_caches
   end
 

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe TimeProfile do
   before(:each) do
-    @server = FactoryGirl.create(:miq_server, :my_server)
+    @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
     EvmSpecHelper.clear_caches
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ describe User do
                   :miq_user_role    => @miq_user_role
                   )
 
-      @miq_server = FactoryGirl.create(:miq_server, :my_server)
+      @miq_server = EvmSpecHelper.local_miq_server
 
       # create User record...
       @user = FactoryGirl.create(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,20 +26,7 @@ describe User do
                   :miq_user_role    => @miq_user_role
                   )
 
-      @guid = MiqUUID.new_guid
-      MiqServer.stub(:my_guid).and_return(@guid)
-
-      @zone         = FactoryGirl.create(:zone)
-      @miq_server   = FactoryGirl.create(
-                    :miq_server,
-                    :guid         => @guid,
-                    :status       => "started",
-                    :name         => "EVM",
-                    :os_priority  => nil,
-                    :is_master    => false,
-                    :zone         => @zone
-                    )
-      MiqServer.my_server(true)
+      @miq_server = FactoryGirl.create(:miq_server, :my_server)
 
       # create User record...
       @user = FactoryGirl.create(

--- a/spec/models/vim_performance_tag_spec.rb
+++ b/spec/models/vim_performance_tag_spec.rb
@@ -3,15 +3,8 @@ require "spec_helper"
 describe VimPerformanceTag do
   before(:each) do
     MiqRegion.seed
-
-    @guid   = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-
-    @zone   = FactoryGirl.create(:zone)
-    @server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.my_server_clear_cache
-
-    @ems    = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    @server = FactoryGirl.create(:miq_server, :my_server)
+    @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
 
     Classification.stub(:category_names_for_perf_by_tag).and_return(["environment"])
     @classification_entries = ["prod", "dev", "test"]

--- a/spec/models/vim_performance_tag_spec.rb
+++ b/spec/models/vim_performance_tag_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe VimPerformanceTag do
   before(:each) do
     MiqRegion.seed
-    @server = FactoryGirl.create(:miq_server, :my_server)
+    @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
 
     Classification.stub(:category_names_for_perf_by_tag).and_return(["environment"])

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "VM Retirement Management" do
   before(:each) do
-    miq_server = FactoryGirl.create(:miq_server, :my_server)
+    miq_server = EvmSpecHelper.local_miq_server
     @ems       = FactoryGirl.create(:ems_vmware, :zone => miq_server.zone)
     @vm = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
   end

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -2,13 +2,8 @@ require "spec_helper"
 
 describe "VM Retirement Management" do
   before(:each) do
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-
-    @zone       = FactoryGirl.create(:zone)
-    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.stub(:my_server).and_return(@miq_server)
-    @ems        = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    miq_server = FactoryGirl.create(:miq_server, :my_server)
+    @ems       = FactoryGirl.create(:ems_vmware, :zone => miq_server.zone)
     @vm = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
   end
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -218,19 +218,13 @@ describe VmOrTemplate do
                                  :storages => [@storage1, @storage2])
         @zone = FactoryGirl.create(:zone, :name => 'zone')
 
-        @svr1 = FactoryGirl.create(:miq_server,
-                                   :name => 'svr1', :status => 'started', :zone => @zone, :guid => MiqUUID.new_guid)
-        @svr2 = FactoryGirl.create(:miq_server,
-                                   :name => 'svr2', :status => 'started', :zone => @zone, :guid => MiqUUID.new_guid)
-        @svr3 = FactoryGirl.create(:miq_server,
-                                   :name => 'svr3', :status => 'started', :zone => @zone, :guid => MiqUUID.new_guid)
+        @svr1 = FactoryGirl.create(:miq_server, :my_server, :name => 'svr1')
+        @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @svr1.zone)
+        @svr3 = FactoryGirl.create(:miq_server, :name => 'svr3', :zone => @svr1.zone)
 
         @svr1_vm = FactoryGirl.create(:vm_redhat, :host => @host1, :name => 'svr1_vm', :miq_server => @svr1)
         @svr2_vm = FactoryGirl.create(:vm_redhat, :host => @host2, :name => 'svr2_vm', :miq_server => @svr2)
         @svr3_vm = FactoryGirl.create(:vm_redhat, :host => @host3, :name => 'svr3_vm', :miq_server => @svr3)
-
-        MiqServer.stub(:my_zone => @zone.name)
-        Vm.stub(:miq_servers_for_scan => [@svr1, @svr2, @svr3])
       end
 
       it "should select SmartProxies with matching VM host affinity" do
@@ -279,17 +273,11 @@ describe VmOrTemplate do
                                  :storage  => @storage1,
                                  :storages => [@storage1])
 
-        @zone = FactoryGirl.create(:zone, :name => 'zone1')
-
-        @svr1 = FactoryGirl.create(:miq_server,
-                                   :name => 'svr1', :status => 'started', :zone => @zone, :guid => MiqUUID.new_guid)
-        @svr2 = FactoryGirl.create(:miq_server,
-                                   :name => 'svr2', :status => 'started', :zone => @zone, :guid => MiqUUID.new_guid)
+        @svr1 = FactoryGirl.create(:miq_server, :my_server, :name => 'svr1')
+        @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @svr1.zone)
 
         @svr1_vm = FactoryGirl.create(:vm_redhat, :host => @host1, :name => 'svr1_vm', :miq_server => @svr1)
         @svr1_vm = FactoryGirl.create(:vm_redhat, :host => @host2, :name => 'svr2_vm', :miq_server => @svr2)
-
-        MiqServer.stub(:my_zone => @zone.name)
       end
 
       it "should select SmartProxies with access to the same NFS storage" do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -218,7 +218,7 @@ describe VmOrTemplate do
                                  :storages => [@storage1, @storage2])
         @zone = FactoryGirl.create(:zone, :name => 'zone')
 
-        @svr1 = FactoryGirl.create(:miq_server, :my_server, :name => 'svr1')
+        @svr1 = EvmSpecHelper.local_miq_server(:name => 'svr1')
         @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @svr1.zone)
         @svr3 = FactoryGirl.create(:miq_server, :name => 'svr3', :zone => @svr1.zone)
 
@@ -273,7 +273,7 @@ describe VmOrTemplate do
                                  :storage  => @storage1,
                                  :storages => [@storage1])
 
-        @svr1 = FactoryGirl.create(:miq_server, :my_server, :name => 'svr1')
+        @svr1 = EvmSpecHelper.local_miq_server(:name => 'svr1')
         @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @svr1.zone)
 
         @svr1_vm = FactoryGirl.create(:vm_redhat, :host => @host1, :name => 'svr1_vm', :miq_server => @svr1)

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -2,15 +2,14 @@ require "spec_helper"
 
 describe VmReconfigureRequest do
   before do
-    @guid1 = MiqUUID.new_guid
-    @zone1 = FactoryGirl.create(:zone, :name => "zone_1")
-    FactoryGirl.create(:miq_server_master, :guid => @guid1, :zone => @zone1)
+    server = FactoryGirl.create(:miq_server_master)
     @request = FactoryGirl.create(:vm_reconfigure_request, :userid => FactoryGirl.create(:user, :userid => "tester").userid)
+    @guid1 = server.guid
+    @zone1 = server.zone
 
-    guid2   = MiqUUID.new_guid
-    @zone2  = FactoryGirl.create(:zone, :name => "zone_2")
-    FactoryGirl.create(:miq_server, :guid => guid2, :zone => @zone2)
-    @vm = FactoryGirl.create(:vm_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware, :zone => @zone2))
+    zone2  = FactoryGirl.create(:zone, :name => "zone_2")
+    FactoryGirl.create(:miq_server, :zone => zone2, :guid => MiqUUID.new_guid)
+    @vm = FactoryGirl.create(:vm_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware, :zone => zone2))
   end
 
   describe '#my_role' do

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe VmReconfigureRequest do
   before do
-    server = FactoryGirl.create(:miq_server_master)
+    server = FactoryGirl.create(:miq_server, :is_master => true)
     @request = FactoryGirl.create(:vm_reconfigure_request, :userid => FactoryGirl.create(:user, :userid => "tester").userid)
     @guid1 = server.guid
     @zone1 = server.zone

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe VmScan do
   context "A single VM Scan Job," do
     before(:each) do
-      @server = FactoryGirl.create(:miq_server, :my_server)
+      @server = EvmSpecHelper.local_miq_server
 
       #TODO: We should be able to set values so we don't need to stub behavior
       MiqServer.any_instance.stub(:is_a_proxy? => true, :has_active_role? => true, :is_vix_disk? => true)

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -3,18 +3,14 @@ require "spec_helper"
 describe VmScan do
   context "A single VM Scan Job," do
     before(:each) do
-      @guid = MiqUUID.new_guid
-      @zone   = FactoryGirl.create(:zone)
-      @server = FactoryGirl.create(:miq_server, :zone => @zone, :guid => @guid)
-      MiqServer.stub(:my_guid => @guid)
-      MiqServer.my_server(true)
+      @server = FactoryGirl.create(:miq_server, :my_server)
 
       #TODO: We should be able to set values so we don't need to stub behavior
       MiqServer.any_instance.stub(:is_a_proxy? => true, :has_active_role? => true, :is_vix_disk? => true)
       ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:authentication_status_ok? => true)
       Vm.stub(:scan_via_ems? => true)
 
-      @ems       = FactoryGirl.create(:ems_vmware,       :name => "Test EMS", :zone => @zone)
+      @ems       = FactoryGirl.create(:ems_vmware,       :name => "Test EMS", :zone => @server.zone)
       @storage   = FactoryGirl.create(:storage,          :name => "test_storage", :store_type => "VMFS")
       @host      = FactoryGirl.create(:host,             :name => "test_host", :hostname => "test_host", :state => 'on', :ext_management_system => @ems)
       @vm        = FactoryGirl.create(:vm_vmware,        :name => "test_vm", :location => "abc/abc.vmx", :raw_power_state => 'poweredOn', :host => @host, :ext_management_system => @ems, :storage => @storage)

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -45,20 +45,33 @@ module EvmSpecHelper
     Tenant.root_tenant
   end
 
+  def self.local_miq_server(attrs = {})
+    remote_miq_server(attrs).tap do |server|
+      MiqServer.stub(:my_guid).and_return(server.guid)
+      MiqServer.my_server_clear_cache
+    end
+  end
+
   def self.local_guid_miq_server_zone
-    remote_guid_miq_server_zone(:my_server)
+    server = local_miq_server
+    [server.guid, server, server.zone]
   end
 
   class << self
     alias_method :create_guid_miq_server_zone, :local_guid_miq_server_zone
   end
 
-  def self.remote_guid_miq_server_zone(server_trait = nil)
+  def self.remote_miq_server(attrs = {})
     create_root_tenant
-    server = FactoryGirl.create(:miq_server, server_trait, :is_master => true)
-    MiqServer.my_server_clear_cache unless server_trait # duplicate work
-    server.zone.clear_association_cache
 
+    server = FactoryGirl.create(:miq_server, attrs)
+    MiqServer.my_server_clear_cache
+    server.zone.clear_association_cache
+    server
+  end
+
+  def self.remote_guid_miq_server_zone
+    server = remote_miq_server
     [server.guid, server, server.zone]
   end
 

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -46,26 +46,20 @@ module EvmSpecHelper
   end
 
   def self.local_guid_miq_server_zone
-    guid, server, zone = remote_guid_miq_server_zone
-    MiqServer.stub(:my_guid).and_return(guid)
-
-    return guid, server, zone
+    remote_guid_miq_server_zone(:my_server)
   end
 
   class << self
     alias_method :create_guid_miq_server_zone, :local_guid_miq_server_zone
   end
 
-  def self.remote_guid_miq_server_zone
+  def self.remote_guid_miq_server_zone(server_trait = nil)
     create_root_tenant
-    guid   = MiqUUID.new_guid
-    zone   = FactoryGirl.create(:zone)
-    server = FactoryGirl.create(:miq_server_master, :guid => guid, :zone => zone)
+    server = FactoryGirl.create(:miq_server_master, server_trait)
+    MiqServer.my_server_clear_cache unless server_trait # duplicate work
+    server.zone.clear_association_cache
 
-    MiqServer.my_server_clear_cache
-    zone.clear_association_cache
-
-    return guid, server, zone
+    [server.guid, server, server.zone]
   end
 
   def self.seed_specific_product_features(*features)
@@ -97,7 +91,6 @@ module EvmSpecHelper
       :description   => "EvmGroup-super_administrator",
       :miq_user_role => admin_role
     )
-
     admin_user = FactoryGirl.create(:user,
       :name           => "Administrator",
       :email          => "admin@example.com",

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -55,7 +55,7 @@ module EvmSpecHelper
 
   def self.remote_guid_miq_server_zone(server_trait = nil)
     create_root_tenant
-    server = FactoryGirl.create(:miq_server_master, server_trait)
+    server = FactoryGirl.create(:miq_server, server_trait, :is_master => true)
     MiqServer.my_server_clear_cache unless server_trait # duplicate work
     server.zone.clear_association_cache
 

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -65,8 +65,6 @@ module EvmSpecHelper
     create_root_tenant
 
     server = FactoryGirl.create(:miq_server, attrs)
-    MiqServer.my_server_clear_cache
-    server.zone.clear_association_cache
     server
   end
 

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -71,11 +71,7 @@ module ServiceTemplateHelper
   end
 
   def build_small_environment
-    @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
-    @zone       = FactoryGirl.create(:zone)
-    @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.stub(:my_server).and_return(@miq_server)
+    @miq_server = FactoryGirl.create(:miq_server, :my_server)
     @ems = FactoryGirl.create(:ems_vmware_with_authentication)
     @host1 =  FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
     @src_vm = FactoryGirl.create(:vm_vmware, :host   => @host1,

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -71,7 +71,7 @@ module ServiceTemplateHelper
   end
 
   def build_small_environment
-    @miq_server = FactoryGirl.create(:miq_server, :my_server)
+    @miq_server = EvmSpecHelper.local_miq_server
     @ems = FactoryGirl.create(:ems_vmware_with_authentication)
     @host1 =  FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
     @src_vm = FactoryGirl.create(:vm_vmware, :host   => @host1,


### PR DESCRIPTION
We have a lot of code focused around creating a miq_server, and stubbing `MiqServer.my_server` to return it.

- make calls to `FactoryGirl.create(:miq_server)` to be more similar, and use same stubbing.
- make calls to `EvmSpecHelper.create_guid_miq_server_zone` more similar to each other. (and leverage above mentioned feature)
- Replace `@class` variables with `instance` variables when dealing with servers, zones, and guids.

We have >4 ways of creating a `MiqServer` environment. I'd prefer to merge this and then have a discussion on which of those courses we want to merge.