### PR TITLE
fix report_controller deprecated Model.all

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -388,7 +388,7 @@ class ReportController < ApplicationController
   end
 
   def rebuild_trees
-    rep = MiqReportResult.all(:conditions=>set_saved_reports_condition, :limit=>1, :order => 'created_on desc', :select => "created_on")
+    rep = MiqReportResult.where(set_saved_reports_condition).limit(1).order('created_on desc').select("created_on").to_a
     return false if rep[0].nil?
     build_trees = rep[0].created_on > @sb[:rep_tree_build_time]
     # save last tree build time to decide if tree needs to be refreshed automatically

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -388,9 +388,9 @@ class ReportController < ApplicationController
   end
 
   def rebuild_trees
-    rep = MiqReportResult.where(set_saved_reports_condition).limit(1).order('created_on desc').select("created_on").to_a
-    return false if rep[0].nil?
-    build_trees = rep[0].created_on > @sb[:rep_tree_build_time]
+    rep = MiqReportResult.where(set_saved_reports_condition).limit(1).order('created_on desc').pluck("created_on").first
+    return false unless rep
+    build_trees = rep > @sb[:rep_tree_build_time]
     # save last tree build time to decide if tree needs to be refreshed automatically
     @sb[:rep_tree_build_time] = Time.now.utc if build_trees
     build_trees


### PR DESCRIPTION
fix deprecation warning

```
DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`). (called from rebuild_trees at /home/travis/build/ManageIQ/manageiq/app/controllers/report_controller.rb:391)
```