### PR TITLE
Fix ordering a service using a service dialog without an element

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1912,6 +1912,7 @@ class CatalogController < ApplicationController
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
         @record.dialog_fields.each do |field|
+          next if field.nil?
           if ["DialogFieldDateControl", "DialogFieldDateTimeControl"].include?(field.type)
             presenter[:build_calendar] = {
               :date_from => field.show_past_dates ? nil : Time.zone.now,


### PR DESCRIPTION
This is to fix situations when ordering a catalog item
using service dialog, which uses multiple tabs, one of
which does not contain any elements.

https://bugzilla.redhat.com/show_bug.cgi?id=1230198