### PR TITLE
Changes show_list for container_images to show a warning for missing registries

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -78,7 +78,7 @@ module ContainerSummaryHelper
       {
         :label => ui_lookup(:model => ContainerImageRegistry.name),
         :image => "container_image_registry_unknown",
-        :value => "Unknown image source"
+        :value => @record.display_registry
       }
     else
       textual_link(@record.container_image_registry)

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -15,6 +15,7 @@ class ContainerImage < ActiveRecord::Base
   delegate :my_zone, :to => :ext_management_system
 
   acts_as_miq_taggable
+  virtual_column :display_registry, :type => :string
 
   def full_name
     result = ""
@@ -38,6 +39,10 @@ class ContainerImage < ActiveRecord::Base
 
   # The guid is required by the smart analysis infrastructure
   alias_method :guid, :docker_id
+
+  def display_registry
+    container_image_registry.present? ? container_image_registry.full_name : "Unknown image source"
+  end
 
   def scan
     ext_management_system.scan_job_create(self.class.name, id)

--- a/product/views/ContainerImage.yaml
+++ b/product/views/ContainerImage.yaml
@@ -22,12 +22,10 @@ cols:
 - name
 - tag
 - image_ref
+- display_registry
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-  container_image_registry:
-    columns:
-    - full_name
   ext_management_system:
     columns:
     - name
@@ -41,7 +39,7 @@ col_order:
 - ext_management_system.name
 - tag
 - image_ref
-- container_image_registry.full_name
+- display_registry
 
 # Column titles, in order
 headers:

--- a/spec/models/container_image_spec.rb
+++ b/spec/models/container_image_spec.rb
@@ -13,6 +13,15 @@ describe ContainerImage do
     expect(image.full_name).to eq("docker.io:1234/fedora:v1")
   end
 
+  it "#display_registry" do
+    image = ContainerImage.new(:name => "fedora")
+    expect(image.display_registry).to eq("Unknown image source")
+
+    reg = ContainerImageRegistry.new(:name => "docker.io", :host => "docker.io", :port => "1234")
+    image.container_image_registry = reg
+    expect(image.display_registry).to eq("docker.io:1234")
+  end
+
   it "#docker_id" do
     image = FactoryGirl.create(:container_image, :image_ref => "docker://id")
     expect(image.docker_id).to eq("id")


### PR DESCRIPTION
@abonas Please review
![registry_warningshow_list](https://cloud.githubusercontent.com/assets/11256940/9718582/e248f932-5585-11e5-8a80-c8bebf7c6185.png)
