### PR TITLE
add topology dbl click navigation to entity page

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -31,6 +31,7 @@ angular.module('topologyApp', ['kubernetesUI'])
     $scope.$on('$destroy', function() {
         $interval.cancel(promise);
     });
+
 }])
 
 .run(function($rootScope) {
@@ -61,25 +62,10 @@ angular.module('topologyApp', ['kubernetesUI'])
                                 return "#bbb";
                         }});
             added.append("title");
+            added.on("dblclick", function(d) {return dblclick(d)});
             added.append("image")
                 .attr("xlink:href",function(d) {
-                    var image_url = "/images/icons/new/";
-                    switch (d.item.kind) {
-                        case "Service":
-                        case "Node":
-                        case "Replicator":
-                            image_url += "container_" + d.item.kind.toLowerCase() + ".png";
-                            break;
-                        case "VM":
-                        case "Host":
-                        case "Container":
-                            image_url += d.item.kind.toLowerCase() + ".png";
-                            break;
-                        case "Pod":
-                            image_url += "container_group.png";
-                            break;
-                    }
-                    return image_url;
+                    return "/images/icons/new/" + class_name(d) + ".png";
                 })
                 .attr("y", function(d) { return getDimensions(d).y})
                 .attr("x", function(d) { return getDimensions(d).x})
@@ -88,11 +74,37 @@ angular.module('topologyApp', ['kubernetesUI'])
 
 
             vertices.selectAll("title").text(function(d) { return "Name: " + d.item.name + "\nType: " + d.item.kind + "\nStatus: " + d.item.status });
-            //vertices.selectAll("use").classed("running", function(d) { return true; });
+
 
             /* Don't do default rendering */
             ev.preventDefault();
         });
+
+        function class_name(d) {
+            var class_name = "";
+            switch (d.item.kind) {
+                case "Service":
+                case "Node":
+                case "Replicator":
+                    class_name = "container_" + d.item.kind.toLowerCase();
+                    break;
+                case "VM":
+                case "Host":
+                case "Container":
+                    class_name = d.item.kind.toLowerCase();
+                    break;
+                case "Pod":
+                    class_name = "container_group";
+                    break;
+            }
+            return class_name;
+        }
+
+        function dblclick(d) {
+            var url = '/' + class_name(d) + '/show/' + d.item.miq_id;
+            window.location.assign(url);
+
+        }
 
         function getDimensions(d) {
             switch (d.item.kind) {

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -55,7 +55,7 @@ class ContainerTopologyService
          else entity.ems_ref
          end
 
-    {:id => id, :name => entity.name, :status => status, :kind => kind}
+    {:id => id, :name => entity.name, :status => status, :kind => kind, :miq_id => entity.id}
   end
 
   def entity_status(entity, kind)

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -42,15 +42,15 @@ describe ContainerTopologyService do
     it "topology contains the expected structure and content" do
       ems = FactoryGirl.create(:ems_kubernetes)
       container_condition = ContainerCondition.create(:name => 'Ready', :status => 'True')
-      container = Container.create(:name => "ruby-example", :ems_ref => '3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift
+      container = Container.create(:name => "ruby-example", :id => 10, :ems_ref => '3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift
 /mysql-55-centos7:latest', :state => 'running')
       container_def = ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container)
 
-      container_node = ContainerNode.create(:ext_management_system => ems, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition])
-      container_replicator = ContainerReplicator.create(:ext_management_system => ems, :ems_ref => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
+      container_node = ContainerNode.create(:ext_management_system => ems, :id => 1, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition])
+      container_replicator = ContainerReplicator.create(:ext_management_system => ems, :id => 7, :ems_ref => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
                                                         :name => "replicator1")
-      container_group = ContainerGroup.create(:ext_management_system => ems, :container_node => container_node, :container_replicator => container_replicator, :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb", :phase => "Running", :container_definitions => [container_def])
-      container_service = ContainerService.create(:ext_management_system => ems, :container_groups => [container_group], :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+      container_group = ContainerGroup.create(:ext_management_system => ems, :id => 15, :container_node => container_node, :container_replicator => container_replicator, :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb", :phase => "Running", :container_definitions => [container_def])
+      container_service = ContainerService.create(:ext_management_system => ems, :id => 3, :container_groups => [container_group], :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name => "service1")
       container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
       topology = container_topology_service.build_topology
@@ -58,15 +58,17 @@ describe ContainerTopologyService do
       topology[:relations].size.should eql 4
 
       topology[:items].key? "905c90ba-3e00-11e5-a0d2-18037327aaeb"
+
       topology[:items]["905c90ba-3e00-11e5-a0d2-18037327aaeb"].should eql(:id => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :name => "127.0.0.1",
-                                                                          :status => "Ready", :kind => "Node")
+                                                                          :status => "Ready", :kind => "Node", :miq_id => 1)
       topology[:items]["8f8ca74c-3a41-11e5-a79a-001a4a231290"].should eql(:id => "8f8ca74c-3a41-11e5-a79a-001a4a231290", :name => "replicator1",
-                                                                          :status => "unknown", :kind => "Replicator")
+                                                                          :status => "unknown", :kind => "Replicator", :miq_id => 7)
       topology[:items]["95e49048-3e00-11e5-a0d2-18037327aaeb"].should eql(:id => "95e49048-3e00-11e5-a0d2-18037327aaeb", :name => "service1",
-                                                                          :status => "unknown", :kind => "Service")
+                                                                          :status => "unknown", :kind => "Service", :miq_id => 3)
       topology[:items]["96c35ccd-3e00-11e5-a0d2-18037327aaeb"].should eql(:id => "96c35ccd-3e00-11e5-a0d2-18037327aaeb", :name => "myPod",
-                                                                          :status => "Running", :kind => "Pod")
-      topology[:items]["3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest"].should eql(:id => "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest", :name => "ruby-example", :status => "running", :kind => "Container")
+                                                                          :status => "Running", :kind => "Pod", :miq_id => 15)
+      topology[:items]["3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest"].should eql(:id => "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest", :name => "ruby-example", :status => "running", :kind => "Container",  :miq_id => 10)
+
 
       topology[:relations].should include(:source => "96c35ccd-3e00-11e5-a0d2-18037327aaeb", :target => "8f8ca74c-3a41-11e5-a79a-001a4a231290")
     end


### PR DESCRIPTION
This adds the ability to double click an item on the topology view (host, pod, container, etc.), and it navigates to this entity's summary page.