### PR TITLE
Factories groups

### DIFF
--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -153,7 +153,8 @@ describe DashboardController do
 
     it "retuns start page url that user has set as startpage in settings" do
       settings = {:display => {:startpage => "/dashboard/show"}}
-      seed_all_product_features(settings)
+      seed_specific_product_features_with_user_settings(%(everything), settings)
+      controller.stub(:role_allows).and_return(true)
       url = controller.send(:start_url_for_user, nil)
       url.should eq("/dashboard/show")
     end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -152,16 +152,17 @@ describe DashboardController do
     end
 
     it "retuns start page url that user has set as startpage in settings" do
-      settings = {:display => {:startpage => "/dashboard/show"}}
-      seed_specific_product_features_with_user_settings(%(everything), settings)
+      seed_specific_product_features(%(everything))
+      controller.instance_variable_set(:@settings, :display => {:startpage => "/dashboard/show"})
+
       controller.stub(:role_allows).and_return(true)
       url = controller.send(:start_url_for_user, nil)
       url.should eq("/dashboard/show")
     end
 
     it "returns first url that user has access to as start page when user doesn't have access to startpage set in settings" do
-      settings = {:display => {:startpage => "/dashboard/show"}}
-      seed_specific_product_features_with_user_settings("vm_cloud_explorer", settings)
+      seed_specific_product_features("vm_cloud_explorer")
+      controller.instance_variable_set(:@settings, :display => {:startpage => "/dashboard/show"})
       url = controller.send(:start_url_for_user, nil)
       url.should eq("/vm_cloud/explorer?accordion=instances")
     end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -17,8 +17,4 @@ FactoryGirl.define do
       end
     end
   end
-
-  factory :miq_group_miq_request_approver, :parent => :miq_group do
-    miq_user_role { FactoryGirl.create(:miq_user_role_miq_request_approver) }
-  end
 end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -1,8 +1,21 @@
 FactoryGirl.define do
+  sequence(:miq_group_description) { |n| "Test Group #{seq_padded_for_sorting(n)}" }
+
   factory :miq_group do
+    transient do
+      features nil
+      role nil
+    end
+
     guid { MiqUUID.new_guid }
 
-    sequence(:description) { |n| "Test Group #{seq_padded_for_sorting(n)}" }
+    description { |g| g.role ? "EvmGroup-#{g.role}" : generate(:miq_group_description) }
+
+    after :build do |g, e|
+      if e.features.present? || e.role
+        g.miq_user_role = FactoryGirl.create(:miq_user_role, :features => e.features, :role => e.role)
+      end
+    end
   end
 
   factory :miq_group_miq_request_approver, :parent => :miq_group do

--- a/spec/factories/miq_product_feature.rb
+++ b/spec/factories/miq_product_feature.rb
@@ -9,12 +9,4 @@ FactoryGirl.define do
     protected    false
     feature_type "node"
   end
-
-  factory :miq_product_feature_miq_request_approval, :parent => :miq_product_feature do
-    identifier   "miq_request_approval"
-    name         "Approve and Deny"
-    description  "Approve and Deny Requests"
-    protected    false
-    feature_type "control"
-  end
 end

--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -1,11 +1,26 @@
 FactoryGirl.define do
+  sequence(:miq_user_role_name) { |n| "UserRole #{seq_padded_for_sorting(n)}" }
+
   factory :miq_user_role do
-    name "Test Role"
+    transient do
+      # e.g.: miq_request_approval
+      features nil
+      # e.g.: super_administrator
+      role nil
+    end
+
+    name { |ur| ur.role ? "EvmRole-#{ur.role}" : generate(:miq_user_role_name) }
+
+    after(:build) do |user, evaluator|
+      if evaluator.features.present?
+        user.miq_product_features = Array.wrap(evaluator.features).map do |f|
+          FactoryGirl.create(:miq_product_feature, :identifier => f)
+        end
+      end
+    end
   end
 
   factory :miq_user_role_miq_request_approver, :parent => :miq_user_role do
-    sequence(:name) { |n| "Request Approver #{seq_padded_for_sorting(n)}" }
-
     miq_product_features { [FactoryGirl.create(:miq_product_feature_miq_request_approval)] }
   end
 end

--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     after(:build) do |user, evaluator|
       if evaluator.features.present?
         user.miq_product_features = Array.wrap(evaluator.features).map do |f|
-          FactoryGirl.create(:miq_product_feature, :identifier => f)
+          f.kind_of?(MiqProductFeature) ? f : FactoryGirl.create(:miq_product_feature, :identifier => f)
         end
       end
     end

--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -19,8 +19,4 @@ FactoryGirl.define do
       end
     end
   end
-
-  factory :miq_user_role_miq_request_approver, :parent => :miq_user_role do
-    miq_product_features { [FactoryGirl.create(:miq_product_feature_miq_request_approval)] }
-  end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,32 +6,36 @@ FactoryGirl.define do
       MiqRegion.seed
     end
 
-    userid          "test"
-    name            "Test User"
+    transient do
+      # e.g. "super_administrtor"
+      role nil
+      # e.g.: "miq_request_approval"
+      features nil
+    end
+
+    sequence(:userid) { |s| "user#{s}" }
+    sequence(:name)   { |s| "Test User #{s}" }
 
     # encrypted password for "dummy"
     password_digest "$2a$10$FTbGT/y/PQ1HvoOoc1FcyuuTtHzfop/uG/mcEAJLYpzmsUIJcGT7W"
+
+    after :build do |u, e|
+      if e.miq_groups.blank? && (e.role || e.features)
+        u.miq_groups = [FactoryGirl.create(:miq_group, :features => e.features, :role => e.role)]
+      end
+    end
   end
 
   factory :user_with_email, :parent => :user do
-    sequence(:userid) { |s| "user#{s}" }
     sequence(:email) { |s| "user#{s}@example.com" }
   end
 
   factory :user_admin, :parent => :user do
     userid          "admin"
-    name            "Administrator"
-    miq_groups      { [FactoryGirl.create(:miq_group,
-                                          :description   => "EvmGroup-super_administrator",
-                                          :miq_user_role => FactoryGirl.create(:miq_user_role,
-                                                                               :name => 'EvmRole-super_administrator'
-                                                                              ))]}
+    role            "super_administrator"
   end
 
   factory :user_miq_request_approver, :parent => :user do
-    sequence(:name)   { |n| "Request Approver #{seq_padded_for_sorting(n)}" }
-    sequence(:userid) { |n| "request_approver_#{seq_padded_for_sorting(n)}" }
-
     miq_groups { [FactoryGirl.create(:miq_group_miq_request_approver)] }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -36,6 +36,6 @@ FactoryGirl.define do
   end
 
   factory :user_miq_request_approver, :parent => :user do
-    miq_groups { [FactoryGirl.create(:miq_group_miq_request_approver)] }
+    features "miq_request_approval"
   end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -253,4 +253,18 @@ describe MiqGroup do
       expect(tenant.miq_groups.sort_by_desc).to eq([ga, gb, gc])
     end
   end
+
+  describe "#all_users" do
+    it "finds users" do
+      g  = FactoryGirl.create(:miq_group)
+      g2 = FactoryGirl.create(:miq_group)
+
+      FactoryGirl.create(:user)
+      u_one  = FactoryGirl.create(:user, :miq_groups => [g])
+      u_two  = FactoryGirl.create(:user, :miq_groups => [g, g2], :current_group => g)
+
+      expect(g.all_users).to match_array([u_one, u_two])
+      expect(g2.all_users).to match_array([u_two])
+    end
+  end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -3,27 +3,8 @@ require "spec_helper"
 describe MiqGroup do
 
   context "set as Super Administrator" do
-
     before(:each) do
-      # create User Role record...
-      @miq_user_role = FactoryGirl.create(
-                      :miq_user_role,
-                      :name       => "EVMGroup-super_administrator",
-                      :read_only  => true,
-                      :settings   => nil
-                      )
-
-      # create Miq Group record...
-      @guid = MiqUUID.new_guid
-      MiqGroup.stub(:my_guid).and_return(@guid)
-      @miq_group = FactoryGirl.create(
-                  :miq_group,
-                  :guid             => @guid,
-                  :description      => "EVMGroup-super_administrator",
-                  :group_type       => "system",
-                  :miq_user_role    => @miq_user_role
-                  )
-
+      @miq_group = FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator")
     end
 
     context "#get_filters" do
@@ -80,7 +61,7 @@ describe MiqGroup do
     end
 
     it "should return user role name" do
-      @miq_group.miq_user_role_name.should == "EVMGroup-super_administrator"
+      @miq_group.miq_user_role_name.should == "EvmRole-super_administrator"
     end
 
     it "should set group type to 'system' " do
@@ -214,19 +195,19 @@ describe MiqGroup do
 
   context "should not be deleted while a user is still assigned" do
     before do
-      @group = FactoryGirl.create(:miq_group, :description => "remove me")
+      @group = FactoryGirl.create(:miq_group)
     end
 
     it "referenced by current_group" do
-      FactoryGirl.create(:user, :userid => "test", :miq_groups => [@group])
+      FactoryGirl.create(:user, :miq_groups => [@group])
 
       expect { @group.destroy }.to raise_error
       MiqGroup.count.should eq 1
     end
 
     it "referenced by miq_groups" do
-      group2 = FactoryGirl.create(:miq_group, :description => "group2")
-      FactoryGirl.create(:user, :userid => "test", :miq_groups => [@group, group2], :current_group => group2)
+      group2 = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:user, :miq_groups => [@group, group2], :current_group => group2)
 
       expect { @group.destroy }.to raise_error
       MiqGroup.count.should eq 2

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -139,11 +139,17 @@ describe MiqUserRole do
     end
   end
 
-  it "should not be deleted while a group is still assigned" do
+  it "deletes with no group assigned" do
+    role = FactoryGirl.create(:miq_user_role, :name => "test role")
+    role.destroy
+    expect(MiqUserRole.count).to eq(0)
+  end
+
+  it "does not delete with group assigned" do
     role = FactoryGirl.create(:miq_user_role, :name => "test role")
     FactoryGirl.create(:miq_group, :description => "test group", :miq_user_role => role)
 
     expect { role.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
-    MiqUserRole.count.should eq 1
+    expect(MiqUserRole.count).to eq(1)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,7 @@ describe User do
       MiqRegion.seed
 
       # create User Role record...
-      @miq_user_role = FactoryGirl.create(
+      miq_user_role = FactoryGirl.create(
                       :miq_user_role,
                       :name       => "EvmRole-super_administrator",
                       :read_only  => true,
@@ -16,14 +16,11 @@ describe User do
                       )
 
       # create Miq Group record...
-      @guid = MiqUUID.new_guid
-      MiqGroup.stub(:my_guid).and_return(@guid)
       @miq_group = FactoryGirl.create(
                   :miq_group,
-                  :guid             => @guid,
-                  :description      => "EvmGroup-super_administrator",
-                  :group_type       => "system",
-                  :miq_user_role    => @miq_user_role
+                  :description   => "EvmGroup-super_administrator",
+                  :group_type    => "system",
+                  :miq_user_role => miq_user_role
                   )
 
       @miq_server = EvmSpecHelper.local_miq_server
@@ -79,40 +76,26 @@ describe User do
     end
 
     it "should ensure presence of name" do
-      @user.save.should be_true
-      @user.name = nil
-      @user.save.should be_false
+      expect(FactoryGirl.build(:user, :name => nil)).not_to be_valid
     end
 
     it "should ensure presence of user id" do
-      @user.save.should be_true
-      @user.userid = nil
-      @user.save.should be_false
+      expect(FactoryGirl.build(:user, :userid => nil)).not_to be_valid
     end
 
-    # it "should ensure presence of region" do
-    #   @user.region = nil
-    #   @user.save.should be_false
-    # end
-
     it "should invalidate incorrect email address" do
-      @user.valid?.should be_true
-      @user.email = "thisguy@@manageiq.com"
-      @user.valid?.should be_false
+      expect(FactoryGirl.build(:user, :email => "thisguy@@manageiq.com")).not_to be_valid
     end
 
     it "should validate email address with a value of nil" do
-      @user.email = nil
-      @user.valid?.should be_true
+      expect(FactoryGirl.build(:user, :email => nil)).to be_valid
     end
 
     it "should save proper email address" do
-      @user.email = "that.guy@manageiq.com"
-      @user.valid?.should be_true
+      expect(FactoryGirl.build(:user, :email => "that.guy@manageiq.com")).to be_valid
     end
     it "should reject invalid characters in email address" do
-      @user.email = "{{that.guy}}@manageiq.com"
-      @user.valid?.should be_false
+      expect(FactoryGirl.build(:user, :email => "{{that.guy}}@manageiq.com")).not_to be_valid
     end
 
     it "should change user password" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -526,4 +526,18 @@ describe User do
       expect(accessible_vms.size).to eq(1)
     end
   end
+
+  describe ".all_users_of_group" do
+    it "finds users" do
+      g  = FactoryGirl.create(:miq_group)
+      g2 = FactoryGirl.create(:miq_group)
+
+      FactoryGirl.create(:user)
+      u_one  = FactoryGirl.create(:user, :miq_groups => [g])
+      u_two  = FactoryGirl.create(:user, :miq_groups => [g, g2], :current_group => g)
+
+      expect(described_class.all_users_of_group(g)).to match_array([u_one, u_two])
+      expect(described_class.all_users_of_group(g2)).to match_array([u_two])
+    end
+  end
 end

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -225,7 +225,7 @@ describe ApiController do
   describe "Role Feature Assignments" do
     it "supports assigning just a single product feature" do
       api_basic_authorize collection_action_identifier(:roles, :edit)
-      role = FactoryGirl.create(:miq_user_role_miq_request_approver)
+      role = FactoryGirl.create(:miq_user_role, :features => "miq_request_approval")
 
       new_feature = {:identifier => "miq_request_view"}
       url = "#{roles_url}/#{role.id}/features"
@@ -246,7 +246,7 @@ describe ApiController do
 
     it "supports assigning multiple product features" do
       api_basic_authorize collection_action_identifier(:roles, :edit)
-      role = FactoryGirl.create(:miq_user_role_miq_request_approver)
+      role = FactoryGirl.create(:miq_user_role, :features => "miq_request_approval")
 
       url = "#{roles_url}/#{role.id}/features"
       run_post(url, gen_request(:assign, features_list))

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -8,6 +8,7 @@ module AuthHelper
     User.stub(:current_userid => user.userid)
     session[:userid]   = user.userid
     session[:group]    = user.current_group.try(:id)
+    user
   end
 end
 

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -41,6 +41,7 @@ module ControllerSpecHelper
     test_group = FactoryGirl.create(:miq_group,
                                     :miq_user_role => test_role)
     @test_user = FactoryGirl.create(:user,
+                                    :userid     => "test",
                                     :name       => 'test_user',
                                     :miq_groups => [test_group])
     login_as @test_user

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -20,7 +20,9 @@ module ControllerSpecHelper
   def seed_specific_product_features(*features)
     features.flatten!
     EvmSpecHelper.seed_specific_product_features(features)
-    create_user_with_product_features(MiqProductFeature.find_all_by_identifier(features))
+    features_models = MiqProductFeature.find_all_by_identifier(features)
+    @test_user = create_user_with_product_features(feature_models)
+    feature_models
   end
 
   def seed_specific_product_features_with_user_settings(features, settings)
@@ -30,16 +32,10 @@ module ControllerSpecHelper
   end
 
   def create_user_with_product_features(product_features)
-    test_role  = FactoryGirl.create(:miq_user_role,
-                                    :name                 => "test_role",
-                                    :miq_product_features => product_features)
-    test_group = FactoryGirl.create(:miq_group,
-                                    :miq_user_role => test_role)
-    @test_user = FactoryGirl.create(:user,
-                                    :userid     => "test",
-                                    :name       => 'test_user',
-                                    :miq_groups => [test_group])
-    login_as @test_user
+    login_as FactoryGirl.create(:user,
+                                :userid   => "test",
+                                :name     => 'test_user',
+                                :features => product_features)
   end
 
   shared_context "valid session" do

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -18,24 +18,14 @@ module ControllerSpecHelper
   end
 
   def seed_specific_product_features(*features)
-    features.flatten!
-    EvmSpecHelper.seed_specific_product_features(features)
-    features_models = MiqProductFeature.find_all_by_identifier(features)
-    @test_user = create_user_with_product_features(feature_models)
-    feature_models
+    @test_user = login_as FactoryGirl.create(:user,
+                                             :userid   => "test",
+                                             :name     => 'test_user',
+                                             :features => specific_product_features(*features))
   end
 
-  def seed_specific_product_features_with_user_settings(features, settings)
-    seed_specific_product_features(features)
-    @test_user.settings = settings
-    controller.instance_variable_set(:@settings, @test_user.settings)
-  end
-
-  def create_user_with_product_features(product_features)
-    login_as FactoryGirl.create(:user,
-                                :userid   => "test",
-                                :name     => 'test_user',
-                                :features => product_features)
+  def specific_product_features(*features)
+    EvmSpecHelper.specific_product_features(features)
   end
 
   shared_context "valid session" do

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -29,11 +29,6 @@ module ControllerSpecHelper
     controller.instance_variable_set(:@settings, @test_user.settings)
   end
 
-  def seed_all_product_features(settings)
-    seed_specific_product_features_with_user_settings(%w(everything), settings)
-    controller.stub(:role_allows).and_return(true)
-  end
-
   def create_user_with_product_features(product_features)
     test_role  = FactoryGirl.create(:miq_user_role,
                                     :name                 => "test_role",

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -89,32 +89,19 @@ module EvmSpecHelper
   private_class_method :filter_specific_features
 
   def self.seed_admin_user_and_friends
-    guid, server, zone = create_guid_miq_server_zone
+    create_guid_miq_server_zone
 
-    admin_role = FactoryGirl.create(:miq_user_role,
-      #:name       => "EvmRole-administrator",
-      :name       => "EvmRole-super_administrator",
-      :read_only  => true,
-      :settings   => nil
+    FactoryGirl.create(:user,
+      :name       => "Administrator",
+      :email      => "admin@example.com",
+      :password   => "smartvm",
+      :userid     => "admin",
+      :settings   => {"Setting1" => 1, "Setting2" => 2, "Setting3" => 3},
+      :filters    => {"Filter1" => 1, "Filter2" => 2, "Filter3" => 3},
+      :first_name => "Bob",
+      :last_name  => "Smith",
+      :role       => "super_administrator",
     )
-
-    admin_group = FactoryGirl.create(:miq_group,
-      :description   => "EvmGroup-super_administrator",
-      :miq_user_role => admin_role
-    )
-    admin_user = FactoryGirl.create(:user,
-      :name           => "Administrator",
-      :email          => "admin@example.com",
-      :password       => "smartvm",
-      :userid         => "admin",
-      :settings       => {"Setting1"  => 1, "Setting2"  => 2, "Setting3"  => 3 },
-      :filters        => {"Filter1"   => 1, "Filter2"   => 2, "Filter3"   => 3 },
-      :miq_groups     => [admin_group],
-      :first_name     => "Bob",
-      :last_name      => "Smith"
-    )
-
-    return guid, server, zone, admin_user, admin_group, admin_role
   end
 
   def self.ruby_object_usage

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -73,6 +73,12 @@ module EvmSpecHelper
     [server.guid, server, server.zone]
   end
 
+  def self.specific_product_features(*features)
+    features.flatten!
+    seed_specific_product_features(*features)
+    MiqProductFeature.find_all_by_identifier(features)
+  end
+
   def self.seed_specific_product_features(*features)
     features.flatten!
     hashes   = YAML.load_file(MiqProductFeature::FIXTURE_YAML)


### PR DESCRIPTION
Background:

We need ~15 lines to create a user with a feature / privileges.
So developers either write verbose tests or just punt. And they tend to punt.

Goal: make creating a user with privileges a feature a single liner.
Cut down on verbage in tests, and actually test security. (rather than just saying: this is an admin)

High level:

- add features to make factories around groups/roles/features consistent
- this is just touching the surface here.
- please let me know where to split this