### PR TITLE
Fix IP address lookup on VMware hosts

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -233,9 +233,10 @@ module RefreshParser
       require 'ipaddr'
       default_gw = IPAddr.new(default_gw)
 
-      vnics   = inv.fetch_path("config", "network", "consoleVnic")
-      vnics ||= inv.fetch_path("config", "network", "vnic")
-      vnics.to_miq_a.each do |vnic|
+      network = inv.fetch_path("config", "network")
+      vnics   = network['consoleVnic'].to_miq_a + network['vnic'].to_miq_a
+
+      vnics.each do |vnic|
         ip = vnic.fetch_path("spec", "ip", "ipAddress")
         subnet_mask = vnic.fetch_path("spec", "ip", "subnetMask")
         next if ip.blank? || subnet_mask.blank?


### PR DESCRIPTION
IP address lookup for VMware was falsely returning no results, with the following message in evm.log:

IP lookup for host in VIM inventory data...Failed. Falling back to reverse lookup.
IP lookup by hostname [per410b-t4.manageiq.com]...Failed with the following error: getaddrinfo: Name or service not known

This was because the code was doing an ||= with an empty array rather than concatenating, which just returned the empty array.