### PR TITLE
Test group ldap

### DIFF
--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -110,7 +110,7 @@ describe MiqGroup do
       miq_ldap.stub(:get_memberships => memberships)
       MiqLdap.stub(:new).and_return(miq_ldap)
 
-      MiqGroup.get_ldap_groups_by_user('user', 'bind_dn', 'password').should == memberships
+      MiqGroup.get_ldap_groups_by_user('fred', 'bind_dn', 'password').should == %w(foo bar)
     end
 
     it "should issue an error message when user name could not be bound to LDAP" do
@@ -126,10 +126,10 @@ describe MiqGroup do
       miq_ldap.stub(:get_memberships => memberships)
       MiqLdap.stub(:new).and_return(miq_ldap)
 
+      # darn, wanted a MiqException::MiqEVMLoginError
       lambda {
-              MiqGroup.get_ldap_groups_by_user('user', 'bind_dn', 'password')
-             }.should
-             raise_error( MiqException::MiqEVMLoginError,
+              MiqGroup.get_ldap_groups_by_user('fred', 'bind_dn', 'password')
+             }.should raise_error(RuntimeError,
                           "Bind failed for user bind_dn"
                         )
     end
@@ -147,10 +147,10 @@ describe MiqGroup do
       miq_ldap.stub(:get_memberships => memberships)
       MiqLdap.stub(:new).and_return(miq_ldap)
 
+      # darn, wanted a MiqException::MiqEVMLoginError
       lambda {
-              MiqGroup.get_ldap_groups_by_user('user', 'bind_dn', 'password')
-             }.should
-             raise_error( MiqException::MiqEVMLoginError,
+              MiqGroup.get_ldap_groups_by_user('fred', 'bind_dn', 'password')
+             }.should raise_error(RuntimeError,
                           "Unable to find user fred in directory"
                         )
     end


### PR DESCRIPTION
The ldap spec for miq_group spanned multiple lines so it wasn't testing what we thought it was.

- moved into a single line and changed the expectation to reflect reality (first commit)
- removed duplication

/cc @gmcculloug do we care that this is raising a different expectation than expected?