### PR TITLE
Rename topology section to Overview

### DIFF
--- a/app/views/ems_container/_main.html.haml
+++ b/app/views/ems_container/_main.html.haml
@@ -7,7 +7,7 @@
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                                :items => textual_group_relationships}
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Topology"),
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Overview"),
                                                                :items => textual_group_topology}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
                                                                     :items => textual_group_smart_management}


### PR DESCRIPTION
The change removes duplicity of  names of the section and the link inside the section to have the same name (topology)