### PR TITLE
Reduced feature spec

### DIFF
--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -1,15 +1,16 @@
 require "spec_helper"
 
 describe MiqProductFeature do
-  before do
-    @expected_feature_count = 846
+  before(:all) do
+    MiqRegion.seed
+    MiqProductFeature.seed
+    @expected_feature_count = MiqProductFeature.count
+    MiqProductFeature.destroy_all
   end
 
   context ".seed" do
-    it "empty table" do
-      MiqRegion.seed
-      MiqProductFeature.seed
-      MiqProductFeature.count.should eq(@expected_feature_count)
+    it "sanity" do
+      @expected_feature_count.should_not eq(0)
     end
 
     it "run twice" do


### PR DESCRIPTION
Currently, this spec tests the number of enabled features in the system. The number has to be incremented by every developer adding a new feature. The reduced spec tests only the functionality of adding new features on top of others and not the overall number by assuming that reading the features into an empty DB is okay. This saves developers the routine of incrementing this number manually.

@simon3z @abonas @blomquisg 