### PR TITLE
Fixed Analytics tab in Configure -> Configuration accordion

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -34,6 +34,7 @@ module Sandbox
     ae_tree
     alert_profile_tree
     alert_tree
+    analytics_tree
     automate_tree
     bottlenecks_tree
     cb_assignments_tree
@@ -88,6 +89,7 @@ module Sandbox
     action
     alert
     alert_profile
+    analytics
     cb_assignments
     cb_rates
     cb_reports

--- a/app/views/ops/_analytics_details_tab.html.haml
+++ b/app/views/ops/_analytics_details_tab.html.haml
@@ -1,8 +1,9 @@
 - if @sb[:active_tab] == "analytics_details"
   - if @sb[:analytics_rpt]
     %fieldset
-      %h3= @sb[:analytics_rpt].title
-      - if !@sb[:analytics_rpt].table.nil? || @sb[:analytics_rpt].table.data.empty?
+      %h3
+        = @sb[:analytics_rpt].title
+      - if @sb[:analytics_rpt].table.present? && !@sb[:analytics_rpt].table.data.empty?
         = @sb[:analytics_rpt].to_html.html_safe
       - else
         = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -259,6 +259,19 @@ describe OpsController do
     end
   end
 
+  context "#explorer" do
+    it "sets analytics active accordion value" do
+      controller.instance_variable_set(:@sb, {})
+      controller.stub(:role_allows).and_return(false)
+      controller.stub(:get_vmdb_config).and_return(:product => {:analytics => true})
+      controller.stub(:get_node_info)
+      controller.should_receive(:render)
+      controller.send(:explorer)
+      expect(response.status).to eq(200)
+      assigns(:sb)[:active_accord].should eq(:analytics)
+    end
+  end
+
   context "#replace_explorer_trees" do
     it "build trees that are passed in and met other conditions" do
       controller.instance_variable_set(:@sb, {})

--- a/spec/views/ops/_all_tabs.html.haml_spec.rb
+++ b/spec/views/ops/_all_tabs.html.haml_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe "ops/_analytics_details_tab.html.haml" do
+  context "analytics tab selected" do
+    before do
+      assign(:sb, :active_tab => "analytics_details")
+    end
+
+    it "should render analytics detail page successfully" do
+      render :partial => "ops/all_tabs",
+             :locals  => {:x_active_tree => :analytics_tree,
+                          :get_vmdb_config => {:product => {:analytics => true}}}
+      response.should render_template(:partial => "ops/_analytics_details_tab")
+    end
+  end
+end


### PR DESCRIPTION
While working on #4115 I found a bug in "Analytics" tab in accordion. After selecting "Analytics" tab I received error:

    [----] F, [2015-09-08T15:24:34.489082 #21236:2ae6c9edd96c] FATAL -- : Error caught: [ActionController::RoutingError] invalid accordion
    /home/rblanco/devel/manageiq/app/controllers/mixins/sandbox.rb:148:in `x_active_accord='
    /home/rblanco/devel/manageiq/app/controllers/ops_controller.rb:185:in `accordion_select'

![screencapture-localhost-3000-ops-explorer-1441718699403](https://cloud.githubusercontent.com/assets/1187051/9735988/e4c6dcd8-563e-11e5-8ba5-8a21e838355f.png)
![screencapture-localhost-3000-ops-explorer-1441718680855](https://cloud.githubusercontent.com/assets/1187051/9735990/e6594e5a-563e-11e5-9aac-ee17b6c2b689.png)


After changes, "Analytics" tab works for me:
![screencapture-localhost-3000-ops-explorer-1441718869710](https://cloud.githubusercontent.com/assets/1187051/9736021/1bfbc93e-563f-11e5-9355-994460264e5e.png)
