### PR TITLE
Use assets:clobber to remove assets before precompile.

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -38,7 +38,7 @@ namespace :evm do
 
   task :compile_assets do
     ENV["DATABASE_URL"] ||= "postgresql://user:pass@127.0.0.1/dbname"
-    Rake::Task["assets:clean"].invoke
+    Rake::Task["assets:clobber"].invoke
     Rake::Task["assets:precompile"].invoke
   end
 end


### PR DESCRIPTION
We're not concerned with doing rolling deploys so let's just blow away the public/assets directory before precompile.

From: http://edgeguides.rubyonrails.org/command_line.html

"You can precompile the assets in app/assets using rake assets:precompile, and remove older compiled assets using rake assets:clean. The assets:clean task allows for rolling deploys that may still be linking to an old asset while the new assets are being built.

If you want to clear public/assets completely, you can use rake assets:clobber."