### PR TITLE
In the vmdb suite, verify loading rails won't access the database

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -8,6 +8,19 @@ namespace :test do
     ENV['VERBOSE']   ||= "false"
   end
 
+  task :verify_no_db_access_loading_rails_environment do
+    ENV["DATABASE_URL"] = "postgresql://non_existing_user:pass@127.0.0.1/vmdb_development"
+    begin
+      puts "** Confirming rails environment does not connect to the database"
+      Rake::Task['environment'].invoke
+    rescue ActiveRecord::NoDatabaseError
+      STDERR.write "Detected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n"
+      raise
+    ensure
+      ENV.delete("DATABASE_URL")
+    end
+  end
+
   task :setup_db => :initialize do
     puts "** Preparing database"
     Rake::Task['evm:db:reset'].invoke

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -3,7 +3,7 @@ require_relative "./evm_test_helper"
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :vmdb do
-    task :setup => :setup_db
+    task :setup => [:verify_no_db_access_loading_rails_environment, :setup_db]
   end
 
   desc "Run all specs except migrations, replication, and automation"


### PR DESCRIPTION
Use a bogus user in a DATABASE_URL so we can detect when we add code
in an initializer, model (loaded via an initializer), etc. that depends
on connecting to the database.

We cannot connect to the database as part of Rails initialization as
assets:precompile and other tasks do not require a database.

In travis you'll see:
```
$ [[ -z "$TEST_SUITE" ]] || bundle exec rake test:$TEST_SUITE:setup
** Confirming rails environment does not connect to the database
** Preparing database
```

If you add a db connection request in an initializer or somewhere called when the Rails app is loaded, it will blow up.

Related: #4254