### PR TITLE
Use base class for bottleneck event where clause

### DIFF
--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -103,14 +103,14 @@ class BottleneckEvent < ActiveRecord::Base
 
   def self.event_where_clause(obj)
     ids_hash = self.child_types_and_ids(obj)
-    result = ["(resource_type = '#{obj.class.name}' AND resource_id = #{obj.id})"]
+    result = ["(resource_type = '#{obj.class.base_class.name}' AND resource_id = #{obj.id})"]
     ids_hash.each { |k,v| result.push("(resource_type = '#{k}' AND resource_id in (#{v.join(",")}))") }
     return result.join(" OR ")
   end
 
   def self.child_types_and_ids(obj)
     result = {}
-    relats = case obj.class.name
+    relats = case obj.class.base_class.name
     when "MiqEnterprise"
       [:ext_management_systems, :storages]
     when "MiqRegion"
@@ -127,7 +127,7 @@ class BottleneckEvent < ActiveRecord::Base
       recs = obj.send(r)
       next if recs.blank?
 
-      result[recs.first.class.name] = recs.collect(&:id)
+      result[recs.first.class.base_class.name] = recs.collect(&:id)
       recs.each do |child|
         self.child_types_and_ids(child).each do |k,v|
           result[k] ||= []

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -7,4 +7,73 @@ describe BottleneckEvent do
       expect(BottleneckEvent.future_event_definitions_for_obj(ManageIQ::Providers::Vmware::InfraManager::Host.new)).not_to be_empty
     end
   end
+
+  describe ".event_where_clause" do
+    it "queries enterprises" do
+      ent = FactoryGirl.create(:miq_enterprise)
+      query = described_class.event_where_clause(ent)
+      expect(query).to match(/resource_type = 'MiqEnterprise'/)
+    end
+
+    it "queries enterprises with ems" do
+      ent = FactoryGirl.create(:miq_enterprise)
+      FactoryGirl.create(:ext_management_system)
+      query = described_class.event_where_clause(ent)
+      expect(query).to match(/resource_type = 'MiqEnterprise'.*resource_type = 'ExtManagementSystem'/)
+    end
+
+    it "queries enterprises with storage" do
+      ent = FactoryGirl.create(:miq_enterprise)
+      FactoryGirl.create(:storage)
+      query = described_class.event_where_clause(ent)
+      expect(query).to match(/resource_type = 'MiqEnterprise'.*resource_type = 'Storage'/)
+    end
+
+    it "queries regions" do
+      reg = FactoryGirl.create(:miq_region)
+      query = described_class.event_where_clause(reg)
+      expect(query).to match(/resource_type = 'MiqRegion'/)
+    end
+
+    it "queries regions with ems" do
+      reg = FactoryGirl.create(:miq_region)
+      FactoryGirl.create(:ext_management_system)
+      query = described_class.event_where_clause(reg)
+      expect(query).to match(/resource_type = 'MiqRegion'.*resource_type = 'ExtManagementSystem'/)
+    end
+
+    it "queries regions with storage" do
+      reg = FactoryGirl.create(:miq_region)
+      FactoryGirl.create(:storage)
+      query = described_class.event_where_clause(reg)
+      expect(query).to match(/resource_type = 'MiqRegion'.*resource_type = 'Storage'/)
+    end
+
+    it "queries ems" do
+      ems = FactoryGirl.create(:ext_management_system)
+      query = described_class.event_where_clause(ems)
+      expect(query).to match(/resource_type = 'ExtManagementSystem'/)
+    end
+
+    it "queries ems with cluster" do
+      ems = FactoryGirl.create(:ext_management_system)
+      FactoryGirl.create(:ems_cluster, :ext_management_system => ems)
+      query = described_class.event_where_clause(ems)
+      expect(query).to match(/resource_type = 'ExtManagementSystem'.*resource_type = 'EmsCluster'/)
+    end
+
+    it "queries ems with host" do
+      ems = FactoryGirl.create(:ext_management_system)
+      FactoryGirl.create(:host, :ext_management_system => ems)
+      query = described_class.event_where_clause(ems)
+      expect(query).to match(/resource_type = 'ExtManagementSystem'.*resource_type = 'Host'/)
+    end
+
+    it "queries cluster with host" do
+      cluster = FactoryGirl.create(:ems_cluster)
+      FactoryGirl.create(:host, :ems_cluster => cluster)
+      query = described_class.event_where_clause(cluster)
+      expect(query).to match(/resource_type = 'EmsCluster'.*resource_type = 'Host'/)
+    end
+  end
 end


### PR DESCRIPTION
After various class name changes, `obj.class.name` no longer matched what was expected for this method.  `obj.class.base_class.name` returns the proper string.

https://bugzilla.redhat.com/show_bug.cgi?id=1258072