### PR TITLE
Call encrypt_column when including PasswordMixin, don't rely on magic.

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -10,6 +10,7 @@ class Authentication < ActiveRecord::Base
 
   include PasswordMixin
   encrypt_column :auth_key
+  encrypt_column :password
 
   belongs_to :resource, :polymorphic => true
 

--- a/app/models/mixins/password_mixin.rb
+++ b/app/models/mixins/password_mixin.rb
@@ -1,10 +1,6 @@
 module PasswordMixin
   extend ActiveSupport::Concern
 
-  included do
-    encrypt_column(:password) if self.columns_hash.include?("password")
-  end
-
   module ClassMethods
     def encrypted_columns
       @@encrypted_columns ||= []    # rubocop:disable Style/ClassVars

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Authentication do
+  it ".encrypted_columns" do
+    expect(described_class.encrypted_columns).to include('password', 'auth_key')
+  end
+
   context "with miq events seeded" do
     before(:each) do
       MiqRegion.seed


### PR DESCRIPTION
Delegating encrypt_column to when PasswordMixin is included caused us
to call columns_hash on constant load during Rails startup which
connects to the database.  The class including the module knows if it
has a password column and should explitly tell us to encrypt_column.

Fixes #4254

I have confirmed this change works with the change in #4257 to detect db access when loading Rails environment.

@matthewd @Fryguy Please review.  Thanks for the suggestion.