### PR TITLE
Temporarily disable azure refresh spec test

### DIFF
--- a/spec/models/ems_refresh/refreshers/azure_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/azure_refresher_spec.rb
@@ -14,6 +14,8 @@ describe EmsAzure do
   end
 
   it "will perform a full refresh" do
+    pending("This test fails sporadically")
+
     2.times do # Run twice to verify that a second run with existing data does not change anything
       @ems.reload
       VCR.use_cassette(described_class.name.underscore, :allow_unused_http_interactions => true) do


### PR DESCRIPTION
We will enable the test after we resolve this problem: https://github.com/ManageIQ/manageiq/issues/4260