### PR TITLE
More report spec cleanup (speedup and simplification)

### DIFF
--- a/spec/factories/miq_report.rb
+++ b/spec/factories/miq_report.rb
@@ -9,18 +9,6 @@ FactoryGirl.define do
     association     :miq_group
   end
 
-  factory :miq_report_with_null_condition, :parent => :miq_report do
-    conditions nil
-  end
-
-  factory :miq_report_wo_null_but_nil_condition, :parent => :miq_report  do
-    conditions 'CRAP'
-  end
-
-  factory :miq_report_with_non_nil_condition, :parent => :miq_report  do
-    conditions MiqExpression.new({"FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Month", "Last Month"]}})
-  end
-
   factory :miq_report_with_results, :parent => :miq_report do
     miq_report_results { [FactoryGirl.create(:miq_report_result)] }
   end

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -36,7 +36,7 @@ describe MiqReport do
 
   context 'to_chart' do
     it "raises an exception for missing sortby or type" do
-      rpt = FactoryGirl.create(:miq_report_with_non_nil_condition)
+      rpt = FactoryGirl.create(:miq_report)
 
       # Can't create a graph without a sortby column
       expect { rpt.to_chart(@report_theme, @show_title, @options) }.to raise_exception


### PR DESCRIPTION
This is a followup to #4222 and saves another 3.5 seconds locally 16.58 -> 13.1. 

The basic idea is most of these examples share the same setup but most examples don't need everything in the setup and far too many objects/database rows are created for each example.  In addition, it's not clear what exactly is needed by each example and therefore it's hard to reason how the code works.  Finally, all of this extra work being done is slow.

The general strategy is to extract each example into the toplevel describe with no common setup and add just the pieces it needs until you can get the test to pass.

There's more to do to get rid of the remaining slow examples but this fixes a few more.

cc @gtanzillo 