### PR TITLE
Pass TERM Signal to VixDiskLibServer

### DIFF
--- a/gems/pending/VixDiskLib/VixDiskLib.rb
+++ b/gems/pending/VixDiskLib/VixDiskLib.rb
@@ -136,6 +136,7 @@ class VixDiskLib
       raise VixDiskLibError, "ERROR: VixDiskLib.connect() got #{e} on DRbObject.new_with_uri()" if retry_num == 0
       retry_num -= 1 && retry
     end
+    trap("TERM") { kill("TERM", pid); $vim_log.warn "TERM Signal Received - exiting"; exit }
     vix_disk_lib_service
   end
 


### PR DESCRIPTION
Catch TERM signals in the SmartProxyWorker code that starts the
VixDiskLibServer so that if the worker gets the signal, it will
be sent to the VixDiskLibServer prior to exiting.  The VixDiskLibServer
already has a handler for TERM signals which causes it to shut down.

This is one of a couple of PRs required to handle the following BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1258985

@roliveri @Fryguy @jrafanie Please review.