### PR TITLE
Azure - Prepend subscriber ID to instance UID

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -10,13 +10,14 @@ module ManageIQ::Providers
       end
 
       def initialize(ems, options = nil)
-        @ems        = ems
-        config      = ems.connect
-        @vmm        = ::Azure::Armrest::VirtualMachineService.new(config)
-        @asm        = ::Azure::Armrest::AvailabilitySetService.new(config)
-        @options    = options || {}
-        @data       = {}
-        @data_index = {}
+        @ems             = ems
+        config           = ems.connect
+        @subscription_id = config.subscription_id
+        @vmm             = ::Azure::Armrest::VirtualMachineService.new(config)
+        @asm             = ::Azure::Armrest::AvailabilitySetService.new(config)
+        @options         = options || {}
+        @data            = {}
+        @data_index      = {}
       end
 
       def ems_inv_to_hashes
@@ -100,10 +101,10 @@ module ManageIQ::Providers
       end
 
       def parse_instance(instance)
-        uid               = instance.fetch_path('resourceGroup') + "\\" + instance.fetch_path('name')
-        series_name       = instance.fetch_path('properties', 'hardwareProfile', 'vmSize')
-        az                = instance.fetch_path('properties', 'availabilitySet', 'id')
-        series            = @data_index.fetch_path(:flavors, series_name)
+        uid         = "#{@subscription_id}\\#{instance.fetch_path('resourceGroup')}\\#{instance.fetch_path('name')}"
+        series_name = instance.fetch_path('properties', 'hardwareProfile', 'vmSize')
+        az          = instance.fetch_path('properties', 'availabilitySet', 'id')
+        series      = @data_index.fetch_path(:flavors, series_name)
 
         new_result = {
           :type             => 'ManageIQ::Providers::Azure::CloudManager::Vm',

--- a/spec/models/ems_refresh/refreshers/azure_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/azure_refresher_spec.rb
@@ -88,12 +88,12 @@ describe ManageIQ::Providers::Azure::CloudManager do
     v = ManageIQ::Providers::Azure::CloudManager::Vm.where(:name => "ERP", :raw_power_state => "VM running").first
     v.should have_attributes(
       :template              => false,
-      :ems_ref               => "ComputeVMs\\ERP",
+      :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\ERP",
       :ems_ref_obj           => nil,
-      :uid_ems               => "ComputeVMs\\ERP",
+      :uid_ems               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\ERP",
       :vendor                => "Microsoft",
       :power_state           => "on",
-      :location              => "ComputeVMs\\ERP",
+      :location              => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\ERP",
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
@@ -177,12 +177,12 @@ describe ManageIQ::Providers::Azure::CloudManager do
   def assert_specific_vm_powered_off_attributes(v)
     v.should have_attributes(
       :template              => false,
-      :ems_ref               => "ComputeVMs\\MIQ2",
+      :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\MIQ2",
       :ems_ref_obj           => nil,
-      :uid_ems               => "ComputeVMs\\MIQ2",
+      :uid_ems               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\MIQ2",
       :vendor                => "Microsoft",
       :power_state           => "off",
-      :location              => "ComputeVMs\\MIQ2",
+      :location              => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\MIQ2",
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 2e1b8a87-6499-4c46-ba7a-e18f3c1786c1
+      - 320fcc3e-f57f-4205-ae4c-f9d1f953a4b1
       Client-Request-Id:
-      - 40274929-88f2-4d46-80e4-983d4d2acb3d
+      - a0f05d78-d3ba-4bb7-986b-4d7e6c7ff646
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_57
+      - ESTSFE_IN_38
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -46,18 +46,18 @@ http_interactions:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 08 Sep 2015 13:26:37 GMT
+      - Wed, 09 Sep 2015 16:16:07 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"expires_in":"3599","token_type":"Bearer","expires_on":"1441722398","not_before":"1441718498","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg"}'
+      string: '{"expires_in":"3600","token_type":"Bearer","expires_on":"1441818967","not_before":"1441815067","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA"}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:39 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -97,15 +97,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 35eac3ec-e4c7-482f-b694-5b7f2019e252
+      - 91abd9a1-a3cc-4c56-964e-436096b78697
       X-Ms-Correlation-Request-Id:
-      - 35eac3ec-e4c7-482f-b694-5b7f2019e252
+      - 91abd9a1-a3cc-4c56-964e-436096b78697
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132640Z:35eac3ec-e4c7-482f-b694-5b7f2019e252
+      - EASTUS:20150909T161607Z:91abd9a1-a3cc-4c56-964e-436096b78697
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:40 GMT
+      - Wed, 09 Sep 2015 16:16:07 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -117,7 +117,7 @@ http_interactions:
         fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
         UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:40 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -134,7 +134,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -155,17 +155,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Request-Id:
-      - fc58c6fa-4591-4c4e-a689-04526d285a76
+      - 510bb5b1-1701-46d9-b1a9-8a4f7dc887bd
       X-Ms-Correlation-Request-Id:
-      - fc58c6fa-4591-4c4e-a689-04526d285a76
+      - 510bb5b1-1701-46d9-b1a9-8a4f7dc887bd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132640Z:fc58c6fa-4591-4c4e-a689-04526d285a76
+      - EASTUS:20150909T161608Z:510bb5b1-1701-46d9-b1a9-8a4f7dc887bd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:39 GMT
+      - Wed, 09 Sep 2015 16:16:07 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -303,51 +303,51 @@ http_interactions:
         rZf95QKg51GlRzj+zRKE2+gQ7TjMB0IgNLF/4G36Q4gczAG/HX4U/CGvhB0D
         uXTrdUvDuRMn3v3tHfpfzyzu7vkfMl07VKJeZFWlS6BvthsH+Wezl6iL9M12
         MZ3n07cviDePL7OizCZFSXkBev1nr8cOH9+FNimmvWEaTqGPwXzym37mcY9+
-        G/KX8jGz5jfJ2HiTfmPJCr5wSgFNgg8YDJCgTwNlE6UqaQz6H5TG7QmnqneD
-        vQZSgiiGK7/pZz8fSMnEHNK/dZ4tjpdZeU2WDITziQ5QkWnAK5SS+OlqghcC
-        SgdDAUE65NQRC43sV0I/NKA/+C1+nweH8Rqi8wcROurXAgbv0x/SRb8t/+Zo
-        is+CD7gPdEqf3kxkUgGfgsgs/fQH/c/9weQ3f9yjP6xe4A/pa/ofJoimp0Nk
-        R9QOgTE6R7jY8H5EYCLwRpre/UXrqs26pP3Z7p7G7+Tm7qzILpYV3MfXeYs1
-        ky46HjH1N29iA6rLR3auMT3ur4DC+iW/FYDgr0OoMtfo2v6Bl+kPfGY4gl/E
-        ZJoP3DyjWfCBbRuf6f1tIejNtHsPfa+//bwhHRPPV/ULq+qb9WpFwyW4PnEB
-        okduGn/ciVSCBaNl3MKPgj8wdEdUAWD/5C+5GcYc/MZzJtTDJ/YPvEJ/dGaH
-        f4JChpp4x/zuCIlPgw/se3HKkmA/IMpuv1TB9qWdyE3E7pBOqUxy/TbvByky
-        +oA8jED4UfAHhuvoJQDsn/wlN8PAgt/+v0A+JmCcWy+LZp2VTUsryhW95lMZ
-        wHt0z8QrpKZfg+AYlvwG6shvQQMBE5Ld/sVvK6kYOOhhPhCio4n9A2/TH50Z
-        cDTlxlFykpDT/5yZYXLSJ3vbe58SOYmYcarcXdXVT9MqMr3w85c6TB+f2ZwX
-        /N18Qq192gFmj5pN0VK0kb9r86X02yFnB2dgagbKvzOxZJT42/6hQxYybqIs
-        Qw5b4F3XgP/iz7mpT+rgLXRPv7GO+OL1szeMAn1g/tTvgz8VDn/QwaszO/4H
-        Fg/6FF8S1CDk4s8A2vvMoep9yBieLclvoj9MC/M396J/RXmDdM4B8QY1lT+g
-        lewft/TwENnLHxTm73p/eADoD/pfnwfpf1B4xIFRnmrKigLaH3HWjzjrm+as
-        Ytm02ZKyJPTCj1gK3ToOQsvgA4sHfYovCeqPWKrHUqKsfsRYP2Ksb5ixLEv9
-        yBLSBx28HDOhZfCBxYM+xZcE9Ufc1eOujtr6EY/RBx28HEuhZfCBxYM+xZcE
-        9Uc85vHYaj0pi2ZOKcqvaF3qRyxlunUchJbBBxYP+hRfEtQfsZTHUsROtECA
-        jEUma9MlCPojtkK3jovQMvjA4kGf4kuC+iO28thK/jipaDxV+SNFZbp1DISW
-        wQcWD/oUXxLUH3EUmEg5yqonGuj07Y9YynTrOAgtgw8sHvQpviSoP2Ipj6XI
-        l2pfw20/bpriYpnP3lTfJmP4gowhvfwj9kK3jpvQMvjA4kGf4kuC+v8B9mKu
-        II5irjB/MHvFWESiOrhI4IonBXH58uJHysd065gBLYMPLB70Kb4kqP8/5Q6J
-        +X/EI+aDDl6OJdAy+MDiQZ/iS4L6/zseISLUygU/4gjp1jEAWgYfWDzoU3xJ
-        UP8/zRH8xzfoskzzui3OC+KiH62J2G4d+6Bl8IHFgz7FlwT1R/zk8ROlES/z
-        +llWL37ETqZbxz1oGXxg8aBP8SVB/RE7+ewEh4ia/YiR0K3jG7QMPrB40Kf4
-        kqD+iJG6jCSeNTX+ETuhW8c9aBl8YPGgT/ElQf0RO3nsVK+XbbHoqab/Nwwi
-        iq+w/yJv62L6/0mkn+bnxbIQlP8/hT6rHB3E/4dR//8i/Z0rqoP4/zDq/1+k
-        PzNRnU+rxSJfzhTh//ch/x5a//9HY7nIqzq/YEz/vzwMYTJqvigoLTabAeVw
-        PD/y7/7/6d/FuAE5c8qVny4vi7pakqT+/8XbdzOHT4MPLBD6FF/yK94M8WeA
-        733m+vE+ZLxkslwL8zf3on9941Np/ngPDXHb6b+7WJdt8aoq85dVVf6IG/gz
-        wPc+c/14HzJeMt+uhfmbe9G//j/FDVdV/Tavf8QKmGH+DPC9z1w/3oeMl0y2
-        a2H+5l70r58TVqDZ/1qsIH51lw3efwiOGYln6X/uD0bH/PGzwc0yhP8PhgbR
-        wQSKWsf2/78R/f9ktjxFqgP7/9lw/n8yTx0eLJZNmy2n/69MXN4+6Hufgep0
-        /rwb8P+7+ffDhu5Lqx03gfp5MEqd3Z9fo/3/Cy/P8lVZXWO8z+0Y/r88nqLR
-        mczdTC6zRZ5dZkWZTUoENf/fHd20zJqmmH5RTYoyf00Z+YI4kl77/8qIeEyY
-        jmaVTTGgF/nVq7wspuPjl19QY3+4QL1HgGw6rWidsztmjWtNIMghqUSBwUcc
-        NfJvHGjyb/JmGPDavxgG4lUOSukDfo9/j5KZCLODkd407NeUsL+oi9n4dEFs
-        Sc39YQLYrQfuEBrClkepv3F8zkPkT2XsAYkYRvhR8Ie8YgnEsOxfkn1AX/YP
-        NKA/OpkMlxHQxu4DboJBxClMfMisFyPqekrS0Dwh7fy2GZ+UeVY/fUKwfUoC
-        TI+2tHaSTbKGvuwQt4N1QAggvpnOQgB8Yv9QaggRA3DykaUkdwkqmC7wpvua
-        /+L3YoTzP9Xu+Uu/xyhxiV3pfyAukbZDpGlJMKk5AfsRjZhG+O//AYShMptq
-        EQEA
+        a/krxm7K1syp3ySf4036jQUt+MLpCDQJPmAwQII+DXRPlMikQOh/0CG3p6Nq
+        4g3mG0gJohiu/Kaf/TykLNN2SDvXebY4XmblNdk50NGfA4CKzApeoYTFT1cT
+        vBAQPhgKCNIhp45YaGS/EvqhAf3Bb/H7PDiM1xCdP4jQUb8WMHif/pAu+m35
+        N0dTfBZ8wH2gU/o0ILKbp7PljPqLEp0UxkMQnXUF/fGp/wf9z/3Bc2P+uEd/
+        WJXCH9LX9D/MHs1dZwYcxTvUx9AdVQ26PGKMk377EfXlD6at+SOg/kaC3/1F
+        66rNunT/oeJClHLid5dIcbGs4KO+zlsszHRx88iuv3ksYEjKX+Mjjyswke6v
+        jXOhjRmK+Yb/4OZ+L4ZLgAp9L3/gZfoDnxle4hfBBuYDxyFoFnxg28Z5gqhL
+        /4sLEoHwaPkeVkV/+3lLSiamb1EW1qI069WKhk9wfWIDRI/8RI+4J6sEDEbL
+        uIUfBX9g6I7IAsD+yV9yM4w5+I3nUKiHT+wfeIX+6MwW/wSFDDXxjvndERKf
+        Bh/Y9+KUJcF/QJTdfqmC72sDIjcRu0M6pTLJ/du8HynJ6APyMALhR8EfGK6j
+        lwCwf/KX3AwDC377/wL5mIBxbr0smnVWNi0ta1f0mk9lAO/RPRNflJp+DYJj
+        WPIbqCO/BQ0ETEh2+xe/raRi4KCH+UCIjib2D7xNf3RmwNGUG0fJSUJO/3Nm
+        iMlJn+xt731K5CRixqlyd1VXP01L2fTCz1/qMH18ZnPO9nfzCbX2aQeYPWo2
+        RUsxTv6uzZfSb4ecHZyBqRko/87EklHib/uHDlnIuImyDDlsgXddA/6LP+em
+        PqmDt9A9/cY64ovXz94wCvSB+VO/D/5UOPxBB6/O7PgfWDzoU3xJUINAjz8D
+        aO8zh6r3IWNobLFpYf7mXvSvKG+Qzjkg3qCm8ge0kv3jlh4g0gvyB+Uadr0/
+        PAD0B/2vz4P0Pyg84sAoTzVlRWH0jzjrR5z1TXNWsWzabEm5GXrhRyyFbh0H
+        oWXwgcWDPsWXBPVHLNVjKVFWP2KsHzHWN8xYlqV+ZAnpgw5ejpnQMvjA4kGf
+        4kuC+iPu6nFXR239iMfogw5ejqXQMvjA4kGf4kuC+iMe83hstZ6URTOnlOVX
+        tBr2I5Yy3ToOQsvgA4sHfYovCeqPWMpjKWInWkBAxiKTBfISBP0RW6Fbx0Vo
+        GXxg8aBP8SVB/RFbeWwlf5xUNJ6q/JGiMt06BkLL4AOLB32KLwnqjzgKTKQc
+        ZdUTDXT69kcsZbp1HISWwQcWD/oUXxLUH7GUx1LkS7Wv4bYfN01xscxnb6pv
+        kzF8QcaQXv4Re6Fbx01oGXxg8aBP8SVB3cxe1M6h+v8+9oqxiER1cJHAFU8K
+        QmN58SPlY7p1zICWwQcWD/oUXxLU/59yh8T8P+IR80EHL8cSaBl8YPGgT/El
+        Qf3/HY8QEWrlgh9xhHTrGAAtgw8sHvQpviSo/5/mCP7jG3RZpnndFucFcdGP
+        1kRst4590DL4wOJBn+JLgvojfvL4idKIl3n9LKsXP2In063jHrQMPrB40Kf4
+        kqD+iJ18doJDRM1+xEjo1vENWgYfWDzoU3xJUH/ESF1GEs+aGv+IndCt4x60
+        DD6weNCn+JKg/oidPHaq18u2WPRU0/8bBhHFV9h/kbd1Mf3/JNJP8/NiWQjK
+        /59Cn1WODuL/w6j/f5H+zhXVQfx/GPX/L9KfmajOp9VikS9nivD/+5B/D63/
+        /6OxXORVnV8wpv9fHoYwGTVfFJQWm82AcjieH/l3///072LcgJw55cpPl5dF
+        XS1JUv//4u27mcOnwQcWCH2KL/kVb4b4M8D3PnP9eB8yXjJZroX5m3vRv77x
+        qTR/vIeGuO30312sy7Z4VZX5y6oqf8QN/Bnge5+5frwPGS+Zb9fC/M296F//
+        n+KGq6p+m9c/YgXMMH8G+N5nrh/vQ8ZLJtu1wN/4m3vRv37YrEBT//VZQfzq
+        Lhv8f3AI/x8MDaKDCRS1ju3/fyP6/8lseYpUB/b/s+H8/2SeOjxYLJs2W07/
+        X5m4vH3Q9z4D1en8eTfg/3fz74cN3ZdWO24C9fNglDq7P79G+/8XXp7lq7K6
+        xnif2zH8f3k8RaMzmbuZXGaLPLvMijKblAhq/r87ummZNU0x/aKaFGX+mjLy
+        BXEkvfb/lRHxmDAdzSqbYkAv8qtXeVlMx8cvv6DG/nCBeo8A2XRa0Tpnd8wa
+        15pAkENSiQKDjzhq5N840OTf5M0w4LV/MQzEqxyU0gf8Hv8eJTMRZgcjvWnY
+        rylhf1EXs/HpgtiSmvvDBLBbD9whNIQtj1J/4/ich8ifytgDEjGM8KPgD3nF
+        Eohh2b8k+4C+7B9oQH90MhkuI6CN3QfcBIOIU5j4kFkvRtT1lKSheULa+W0z
+        PinzrH76hGD7lASYHm1p7SSbZA192SFuB+uAEEB8M52FAPjE/qHUECIG4OQj
+        S0nuElQwXeBN9zX/xe/FCOd/qt3zl36PUeISu9L/QFwibYdI05JgUnMC9iMa
+        MY3w3/8Dp1j7g+8RAQA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:40 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestUS/vmSizes?api-version=2015-06-15
@@ -364,7 +364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -389,18 +389,18 @@ http_interactions:
       X-Ms-Served-By:
       - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130855169261357120
       X-Ms-Request-Id:
-      - c59a1c14-e27e-4620-9d46-f625541848da
+      - 71a48f45-6211-4810-a389-e1849e6ca98b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14754'
       X-Ms-Correlation-Request-Id:
-      - 466b9ebc-312d-4949-b3bb-3816aed1e8c5
+      - b9984861-88e6-43bf-9c6f-473d410d0afc
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132641Z:466b9ebc-312d-4949-b3bb-3816aed1e8c5
+      - EASTUS:20150909T161608Z:b9984861-88e6-43bf-9c6f-473d410d0afc
       Date:
-      - Tue, 08 Sep 2015 13:26:40 GMT
+      - Wed, 09 Sep 2015 16:16:08 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -428,7 +428,7 @@ http_interactions:
         hP5QusPsD+V9GOxnPdLvGUJ/LN1x9sfyfiy2SVyGrCQjctvR9AyhP5reUPvD
         sVYSP77/Gye/5P8B+lw3CX4gAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:41 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/AustraliaEast/vmSizes?api-version=2015-06-15
@@ -445,7 +445,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -462,15 +462,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 0f1ad5b1-cd7b-45b7-b203-0814b88fe445
+      - 4b62b50b-3541-4abd-a4ec-1927b6e3c005
       X-Ms-Correlation-Request-Id:
-      - 0f1ad5b1-cd7b-45b7-b203-0814b88fe445
+      - 4b62b50b-3541-4abd-a4ec-1927b6e3c005
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132641Z:0f1ad5b1-cd7b-45b7-b203-0814b88fe445
+      - EASTUS:20150909T161610Z:4b62b50b-3541-4abd-a4ec-1927b6e3c005
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:41 GMT
+      - Wed, 09 Sep 2015 16:16:09 GMT
       Content-Length:
       - '439'
     body:
@@ -482,7 +482,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:41 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/AustraliaSoutheast/vmSizes?api-version=2015-06-15
@@ -499,7 +499,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -516,15 +516,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 5a297c6b-b030-4aa3-9077-18b0b4a4e76b
+      - 7564955b-2d97-46d3-9263-bd77e2b40257
       X-Ms-Correlation-Request-Id:
-      - 5a297c6b-b030-4aa3-9077-18b0b4a4e76b
+      - 7564955b-2d97-46d3-9263-bd77e2b40257
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132641Z:5a297c6b-b030-4aa3-9077-18b0b4a4e76b
+      - EASTUS:20150909T161610Z:7564955b-2d97-46d3-9263-bd77e2b40257
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:41 GMT
+      - Wed, 09 Sep 2015 16:16:10 GMT
       Content-Length:
       - '444'
     body:
@@ -536,7 +536,7 @@ http_interactions:
         locations are ''eastus, eastus2, westus, centralus, northcentralus, southcentralus,
         northeurope, westeurope, eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:41 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralUS/vmSizes?api-version=2015-06-15
@@ -553,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -578,18 +578,18 @@ http_interactions:
       X-Ms-Served-By:
       - d0384330-e545-43f0-a33e-6355987bc2f8_130841918403972752
       X-Ms-Request-Id:
-      - 496f004f-90e8-4bdc-b086-76e0d087e726
+      - 012a2417-43d4-4884-bf27-1af204564945
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14721'
       X-Ms-Correlation-Request-Id:
-      - deb6da57-c1eb-464c-8a0e-c8e3787803b7
+      - e3bf252f-9886-4b4b-ad53-d7d49db6ebe8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132642Z:deb6da57-c1eb-464c-8a0e-c8e3787803b7
+      - EASTUS:20150909T161610Z:e3bf252f-9886-4b4b-ad53-d7d49db6ebe8
       Date:
-      - Tue, 08 Sep 2015 13:26:41 GMT
+      - Wed, 09 Sep 2015 16:16:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -609,7 +609,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:42 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS/vmSizes?api-version=2015-06-15
@@ -626,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -649,20 +649,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - 7eb6f549-7426-42f7-85a8-7e6367fa456d
+      - f43831ce-5ddb-4c37-be9f-4ae89ba8f428
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14609'
       X-Ms-Correlation-Request-Id:
-      - 3589a4a8-016b-4748-9920-b42caa53a315
+      - 374c0a6e-cc24-4474-a4d1-95ab38ecb086
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132642Z:3589a4a8-016b-4748-9920-b42caa53a315
+      - EASTUS:20150909T161610Z:374c0a6e-cc24-4474-a4d1-95ab38ecb086
       Date:
-      - Tue, 08 Sep 2015 13:26:42 GMT
+      - Wed, 09 Sep 2015 16:16:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -682,7 +682,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
         Ktcfyzc6MccPNwzlG5mXjWO5xbzYweDH93/j5Jf8P459xE4rEgAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:42 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS2/vmSizes?api-version=2015-06-15
@@ -699,7 +699,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -722,20 +722,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 772c4f26-4447-4b91-947d-0c7008c93042_130815979149733956
+      - 772c4f26-4447-4b91-947d-0c7008c93042_130856936580485914
       X-Ms-Request-Id:
-      - 7c407282-fe37-44be-9e68-3c46d6473606
+      - 1d200207-3e3d-49d1-aa2c-427a557821fe
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14804'
       X-Ms-Correlation-Request-Id:
-      - f9cd44bc-6304-44ee-8bf1-d30ae498078a
+      - 071d7269-0eab-420c-bca7-ebb6c5ca5bc9
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132642Z:f9cd44bc-6304-44ee-8bf1-d30ae498078a
+      - EASTUS:20150909T161611Z:071d7269-0eab-420c-bca7-ebb6c5ca5bc9
       Date:
-      - Tue, 08 Sep 2015 13:26:42 GMT
+      - Wed, 09 Sep 2015 16:16:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -762,7 +762,7 @@ http_interactions:
         z8r78NfPekTZNYT+ULrD7A/lfRjsZz2i7BlCfyzdcfbH8n4stklcvhEr2TOE
         /mh6Q+0Px1pJ/Pj+b5z8kv8Hiegpl+YeAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:43 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthCentralUS/vmSizes?api-version=2015-06-15
@@ -779,7 +779,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 502
@@ -800,20 +800,20 @@ http_interactions:
       X-Ms-Served-By:
       - 7c62b12c-d882-44db-9576-141ebc6501ac_130837949188104606
       X-Ms-Request-Id:
-      - bba5588d-9337-45a6-bbc4-c6a036fc9a76
+      - 9ff46040-98df-4e7c-b804-dfa070b2a53e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Failure-Cause:
       - service
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14774'
       X-Ms-Correlation-Request-Id:
-      - ff3c92ae-9d1b-4be2-a08d-dc5d0ed37b9f
+      - 76d70aef-c7fd-4110-8b55-dff0b0e62509
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132643Z:ff3c92ae-9d1b-4be2-a08d-dc5d0ed37b9f
+      - EASTUS:20150909T161611Z:76d70aef-c7fd-4110-8b55-dff0b0e62509
       Date:
-      - Tue, 08 Sep 2015 13:26:42 GMT
+      - Wed, 09 Sep 2015 16:16:11 GMT
       Connection:
       - close
     body:
@@ -821,7 +821,7 @@ http_interactions:
       string: "{\r\n  \"error\": {\r\n    \"code\": \"SubscriptionNotRegistered\",\r\n
         \   \"message\": \"Subscription is not registered.\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:43 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SouthCentralUS/vmSizes?api-version=2015-06-15
@@ -838,7 +838,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -863,18 +863,18 @@ http_interactions:
       X-Ms-Served-By:
       - fc40acc7-ed1e-42ad-b741-4062ad55bf5e_130857118179167515
       X-Ms-Request-Id:
-      - 9d1d751e-dfff-48f5-ae25-5aff74d77bd2
+      - c1ea29eb-cd5f-4d44-ac06-114715e06822
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14794'
       X-Ms-Correlation-Request-Id:
-      - ebdabc17-971e-424c-bdd6-75c06618a1e8
+      - dcd4c08b-f63d-4ff0-b0ba-de523567c738
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132643Z:ebdabc17-971e-424c-bdd6-75c06618a1e8
+      - EASTUS:20150909T161612Z:dcd4c08b-f63d-4ff0-b0ba-de523567c738
       Date:
-      - Tue, 08 Sep 2015 13:26:43 GMT
+      - Wed, 09 Sep 2015 16:16:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -894,7 +894,7 @@ http_interactions:
         /2sP5mD34bAq3t3d//TAI1lkNPdur42PDzYMxuvla4/l3sPdUOX6Y/lGJ+b4
         4YahfCPzsnEst5gXOxj8+P5vnPyS/we/VNoCKxIAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:43 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthEurope/vmSizes?api-version=2015-06-15
@@ -911,7 +911,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -936,18 +936,18 @@ http_interactions:
       X-Ms-Served-By:
       - bb344ebd-a325-41d8-9824-737950975d04_130841567632133308
       X-Ms-Request-Id:
-      - 91247ef8-6f61-43d5-9306-6a3258dfbfe5
+      - 188e9791-a015-4d06-b570-1bd98bee772e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14803'
       X-Ms-Correlation-Request-Id:
-      - 888d79ac-8399-4f82-b428-da395601fe6c
+      - 6d33f9e2-55e9-4441-8d20-84ee05835eb5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132644Z:888d79ac-8399-4f82-b428-da395601fe6c
+      - EASTUS:20150909T161612Z:6d33f9e2-55e9-4441-8d20-84ee05835eb5
       Date:
-      - Tue, 08 Sep 2015 13:26:43 GMT
+      - Wed, 09 Sep 2015 16:16:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -967,7 +967,7 @@ http_interactions:
         /2sP5mD34bAq3t3d//TAI1lkNPdur42PDzYMxuvla4/l3sPdUOX6Y/lGJ+b4
         4YahfCPzsnEst5gXOxj8+P5vnPyS/we/VNoCKxIAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:44 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestEurope/vmSizes?api-version=2015-06-15
@@ -984,7 +984,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1009,18 +1009,18 @@ http_interactions:
       X-Ms-Served-By:
       - 7147639b-1e2e-4238-a5eb-b3bdfc3af2dc_130855174230110197
       X-Ms-Request-Id:
-      - e0935bae-02d8-4515-8a24-cf17bd41a144
+      - 8e0f71ad-97dd-4cd3-8bd3-3bfb70b5aefa
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14608'
       X-Ms-Correlation-Request-Id:
-      - 36abde90-68bc-45e7-917f-56c995246f53
+      - 81e87ac1-0675-4f4d-b1b7-c68ef14175c4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132644Z:36abde90-68bc-45e7-917f-56c995246f53
+      - EASTUS:20150909T161613Z:81e87ac1-0675-4f4d-b1b7-c68ef14175c4
       Date:
-      - Tue, 08 Sep 2015 13:26:44 GMT
+      - Wed, 09 Sep 2015 16:16:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1048,7 +1048,7 @@ http_interactions:
         WXkf/vpZj/S72tYfSneY/aG8D4P9rEf6PWXrj6U7zv5Y3o/FNonLkF1hRG47
         mp6D4o+mN9T+cKz3gh/f/42TX/L/AGpBnP9+IAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:45 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastAsia/vmSizes?api-version=2015-06-15
@@ -1065,7 +1065,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1090,18 +1090,18 @@ http_interactions:
       X-Ms-Served-By:
       - 87669224-8edb-4099-85ed-2799f5f9b5ce_130816178115351722
       X-Ms-Request-Id:
-      - 16e19764-4e95-4083-ad4c-d635bffd5b6a
+      - 02fb578e-5458-4b7d-8158-37449b7898e9
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14607'
       X-Ms-Correlation-Request-Id:
-      - d484ba6d-fbee-433c-a17e-bfe57d475821
+      - f6a2d1fd-a4fd-4d52-9e40-a6aa707b83f1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132646Z:d484ba6d-fbee-433c-a17e-bfe57d475821
+      - EASTUS:20150909T161614Z:f6a2d1fd-a4fd-4d52-9e40-a6aa707b83f1
       Date:
-      - Tue, 08 Sep 2015 13:26:45 GMT
+      - Wed, 09 Sep 2015 16:16:14 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1121,7 +1121,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:46 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:17 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SoutheastAsia/vmSizes?api-version=2015-06-15
@@ -1138,7 +1138,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1163,18 +1163,18 @@ http_interactions:
       X-Ms-Served-By:
       - 5766a2f8-6aed-48ac-b876-204ebc3aecb8_130832035741435100
       X-Ms-Request-Id:
-      - fe42bbbd-4a17-42f5-aa61-4abd43e62fd6
+      - d9b9d108-c803-41f4-a79a-e53c40a96a8b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14753'
       X-Ms-Correlation-Request-Id:
-      - de534070-efa0-4834-b654-6c1702e59989
+      - 5f9051bc-b144-463b-8291-579931aa7a99
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132647Z:de534070-efa0-4834-b654-6c1702e59989
+      - EASTUS:20150909T161615Z:5f9051bc-b144-463b-8291-579931aa7a99
       Date:
-      - Tue, 08 Sep 2015 13:26:47 GMT
+      - Wed, 09 Sep 2015 16:16:15 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1197,7 +1197,7 @@ http_interactions:
         YD/rZqWnbP2xdMfZH8v7sdgmcflG7Mre3sN7DzxAwWh6Q+0Px9oV/Pj+b5z8
         kv8HuPmU0+sWAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:47 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/JapanEast/vmSizes?api-version=2015-06-15
@@ -1214,7 +1214,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1239,18 +1239,18 @@ http_interactions:
       X-Ms-Served-By:
       - 7d6892c1-2e0d-495d-9582-fb397c5a0378_130816136595468189
       X-Ms-Request-Id:
-      - 39864f77-ba64-41cc-8de1-d6953222a70d
+      - da133de6-1dcd-40af-97a4-d579acb8ab62
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14773'
       X-Ms-Correlation-Request-Id:
-      - c7a62758-0d1c-4a51-9974-20882977ad93
+      - e2924a04-e73b-4144-b284-3f0b1707c6e2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132648Z:c7a62758-0d1c-4a51-9974-20882977ad93
+      - EASTUS:20150909T161616Z:e2924a04-e73b-4144-b284-3f0b1707c6e2
       Date:
-      - Tue, 08 Sep 2015 13:26:48 GMT
+      - Wed, 09 Sep 2015 16:16:16 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1273,7 +1273,7 @@ http_interactions:
         I+Eoa2gkNyuw9xH63U1i4nXztceyu4m9bp6V9+Cvn3WzspHBbp6W92Cwn3Wz
         spHDvlmz8rNvVQ52Hw6r4vexKvjx/d84+SX/D5kL4gSDGAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:48 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/JapanWest/vmSizes?api-version=2015-06-15
@@ -1290,7 +1290,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1315,18 +1315,18 @@ http_interactions:
       X-Ms-Served-By:
       - fc53dbcb-0031-4257-b5fa-88f40bc084fc_130816135595421386
       X-Ms-Request-Id:
-      - e52dbe59-7619-4f51-948d-acbd32ea268a
+      - ece5be83-5807-491c-b0f5-531d726fc3df
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14793'
       X-Ms-Correlation-Request-Id:
-      - 3b517142-79ca-496d-93ed-26d4c079c6a0
+      - e85b3514-540f-4dfe-89be-9797cf481975
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132649Z:3b517142-79ca-496d-93ed-26d4c079c6a0
+      - EASTUS:20150909T161617Z:e85b3514-540f-4dfe-89be-9797cf481975
       Date:
-      - Tue, 08 Sep 2015 13:26:48 GMT
+      - Wed, 09 Sep 2015 16:16:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1349,7 +1349,7 @@ http_interactions:
         dbOykcFunpb3YLCfdbOykcO+WbPys29VDnYfDqvi97Eq+PH93zj5Jf8P0E9I
         R+sWAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:49 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/BrazilSouth/vmSizes?api-version=2015-06-15
@@ -1366,7 +1366,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1383,15 +1383,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - d8239b7f-e2f4-494f-9da2-17edb250ea31
+      - c758f43f-6328-45f5-8263-e9a87547a90a
       X-Ms-Correlation-Request-Id:
-      - d8239b7f-e2f4-494f-9da2-17edb250ea31
+      - c758f43f-6328-45f5-8263-e9a87547a90a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132649Z:d8239b7f-e2f4-494f-9da2-17edb250ea31
+      - EASTUS:20150909T161617Z:c758f43f-6328-45f5-8263-e9a87547a90a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:48 GMT
+      - Wed, 09 Sep 2015 16:16:17 GMT
       Content-Length:
       - '437'
     body:
@@ -1403,7 +1403,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:49 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestIndia/vmSizes?api-version=2015-06-15
@@ -1420,7 +1420,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1437,15 +1437,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - eb470c38-5e22-4c74-8e29-e63e51f5a696
+      - 778f68ab-bbda-4697-8c5e-750479ee5e6c
       X-Ms-Correlation-Request-Id:
-      - eb470c38-5e22-4c74-8e29-e63e51f5a696
+      - 778f68ab-bbda-4697-8c5e-750479ee5e6c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132649Z:eb470c38-5e22-4c74-8e29-e63e51f5a696
+      - EASTUS:20150909T161618Z:778f68ab-bbda-4697-8c5e-750479ee5e6c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:49 GMT
+      - Wed, 09 Sep 2015 16:16:17 GMT
       Content-Length:
       - '435'
     body:
@@ -1457,7 +1457,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:49 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SouthIndia/vmSizes?api-version=2015-06-15
@@ -1474,7 +1474,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1491,15 +1491,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 86304b4d-b5cb-4806-8da0-a2c859dc2dbc
+      - 46a5f8ba-8ade-4bbb-882f-42a4f2079923
       X-Ms-Correlation-Request-Id:
-      - 86304b4d-b5cb-4806-8da0-a2c859dc2dbc
+      - 46a5f8ba-8ade-4bbb-882f-42a4f2079923
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132649Z:86304b4d-b5cb-4806-8da0-a2c859dc2dbc
+      - EASTUS:20150909T161618Z:46a5f8ba-8ade-4bbb-882f-42a4f2079923
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:48 GMT
+      - Wed, 09 Sep 2015 16:16:17 GMT
       Content-Length:
       - '436'
     body:
@@ -1511,7 +1511,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:49 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralIndia/vmSizes?api-version=2015-06-15
@@ -1528,7 +1528,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1545,15 +1545,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 71c7d389-d2bc-4e01-bb0a-8941e5232d17
+      - d03ec4d6-a14f-43c2-b913-240607a739c0
       X-Ms-Correlation-Request-Id:
-      - 71c7d389-d2bc-4e01-bb0a-8941e5232d17
+      - d03ec4d6-a14f-43c2-b913-240607a739c0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132649Z:71c7d389-d2bc-4e01-bb0a-8941e5232d17
+      - EASTUS:20150909T161618Z:d03ec4d6-a14f-43c2-b913-240607a739c0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:48 GMT
+      - Wed, 09 Sep 2015 16:16:17 GMT
       Content-Length:
       - '438'
     body:
@@ -1565,7 +1565,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:50 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestUS/vmSizes?api-version=2015-06-15
@@ -1582,7 +1582,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1607,18 +1607,18 @@ http_interactions:
       X-Ms-Served-By:
       - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130855169261357120
       X-Ms-Request-Id:
-      - d49a1108-3c06-4a47-94fb-8d82bc8454c4
+      - 558e866b-9737-46a9-8002-34c8fc0230fc
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14720'
       X-Ms-Correlation-Request-Id:
-      - 46651191-642d-47c8-ad7e-8561ecd08e96
+      - 07b74ed9-7812-4110-9e27-959510428646
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132650Z:46651191-642d-47c8-ad7e-8561ecd08e96
+      - EASTUS:20150909T161618Z:07b74ed9-7812-4110-9e27-959510428646
       Date:
-      - Tue, 08 Sep 2015 13:26:49 GMT
+      - Wed, 09 Sep 2015 16:16:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1646,7 +1646,7 @@ http_interactions:
         hP5QusPsD+V9GOxnPdLvGUJ/LN1x9sfyfiy2SVyGrCQjctvR9AyhP5reUPvD
         sVYSP77/Gye/5P8B+lw3CX4gAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:50 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS2/vmSizes?api-version=2015-06-15
@@ -1663,7 +1663,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -1686,20 +1686,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 772c4f26-4447-4b91-947d-0c7008c93042_130815979149733956
+      - 772c4f26-4447-4b91-947d-0c7008c93042_130856936580485914
       X-Ms-Request-Id:
-      - 14711e70-b296-469a-bf9a-f7479ebc08ef
+      - b49a357b-2c87-48e0-a339-d6226d1fe257
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14719'
       X-Ms-Correlation-Request-Id:
-      - 7cf2a79c-0d2e-43bc-9fd2-52418fc5610e
+      - 2f48ab0c-a047-41e5-be1a-c635e4d45068
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132650Z:7cf2a79c-0d2e-43bc-9fd2-52418fc5610e
+      - EASTUS:20150909T161619Z:2f48ab0c-a047-41e5-be1a-c635e4d45068
       Date:
-      - Tue, 08 Sep 2015 13:26:49 GMT
+      - Wed, 09 Sep 2015 16:16:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1726,7 +1726,7 @@ http_interactions:
         z8r78NfPekTZNYT+ULrD7A/lfRjsZz2i7BlCfyzdcfbH8n4stklcvhEr2TOE
         /mh6Q+0Px1pJ/Pj+b5z8kv8Hiegpl+YeAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:50 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthCentralUS/vmSizes?api-version=2015-06-15
@@ -1743,7 +1743,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 502
@@ -1764,20 +1764,20 @@ http_interactions:
       X-Ms-Served-By:
       - 7c62b12c-d882-44db-9576-141ebc6501ac_130837949188104606
       X-Ms-Request-Id:
-      - a247a4a6-e663-4fd9-9a46-6d4eadaef1f9
+      - 4e7b3da5-dd26-47c6-aec6-1b92196b4592
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Failure-Cause:
       - service
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14749'
       X-Ms-Correlation-Request-Id:
-      - 4459b087-e929-471f-93ce-76f3e3ead19e
+      - 653c0e15-7d52-4d53-a0f6-bc5eb61982e8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132650Z:4459b087-e929-471f-93ce-76f3e3ead19e
+      - EASTUS:20150909T161619Z:653c0e15-7d52-4d53-a0f6-bc5eb61982e8
       Date:
-      - Tue, 08 Sep 2015 13:26:50 GMT
+      - Wed, 09 Sep 2015 16:16:19 GMT
       Connection:
       - close
     body:
@@ -1785,7 +1785,7 @@ http_interactions:
       string: "{\r\n  \"error\": {\r\n    \"code\": \"SubscriptionNotRegistered\",\r\n
         \   \"message\": \"Subscription is not registered.\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:51 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/global/vmSizes?api-version=2015-06-15
@@ -1802,7 +1802,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1819,15 +1819,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - a35d6aae-5392-4b35-a54c-d9d193eca3a2
+      - a03c45e8-56bb-4eb1-b6c0-ac4f10975eaa
       X-Ms-Correlation-Request-Id:
-      - a35d6aae-5392-4b35-a54c-d9d193eca3a2
+      - a03c45e8-56bb-4eb1-b6c0-ac4f10975eaa
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132651Z:a35d6aae-5392-4b35-a54c-d9d193eca3a2
+      - EASTUS:20150909T161619Z:a03c45e8-56bb-4eb1-b6c0-ac4f10975eaa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:50 GMT
+      - Wed, 09 Sep 2015 16:16:19 GMT
       Content-Length:
       - '432'
     body:
@@ -1839,7 +1839,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:51 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTWestUS/vmSizes?api-version=2015-06-15
@@ -1856,7 +1856,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1873,15 +1873,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 226faaab-ffd0-4be5-8fa7-d7a8fba70e49
+      - 9b33fea7-b065-4d27-acf4-5ce4db21be60
       X-Ms-Correlation-Request-Id:
-      - 226faaab-ffd0-4be5-8fa7-d7a8fba70e49
+      - 9b33fea7-b065-4d27-acf4-5ce4db21be60
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132651Z:226faaab-ffd0-4be5-8fa7-d7a8fba70e49
+      - EASTUS:20150909T161619Z:9b33fea7-b065-4d27-acf4-5ce4db21be60
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:50 GMT
+      - Wed, 09 Sep 2015 16:16:19 GMT
       Content-Length:
       - '436'
     body:
@@ -1893,7 +1893,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:51 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTEastUS/vmSizes?api-version=2015-06-15
@@ -1910,7 +1910,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1927,15 +1927,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - ccbfd8a1-6a8f-4439-8e3e-74b11516d1ef
+      - a55fdf31-a2ca-4ac5-bef5-f7c6add546bb
       X-Ms-Correlation-Request-Id:
-      - ccbfd8a1-6a8f-4439-8e3e-74b11516d1ef
+      - a55fdf31-a2ca-4ac5-bef5-f7c6add546bb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132651Z:ccbfd8a1-6a8f-4439-8e3e-74b11516d1ef
+      - EASTUS:20150909T161620Z:a55fdf31-a2ca-4ac5-bef5-f7c6add546bb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:50 GMT
+      - Wed, 09 Sep 2015 16:16:19 GMT
       Content-Length:
       - '436'
     body:
@@ -1947,7 +1947,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:51 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTEastAsia/vmSizes?api-version=2015-06-15
@@ -1964,7 +1964,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -1981,15 +1981,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - f2dc259c-8e32-48a1-a703-7a8e25e09013
+      - 95716462-91af-4782-ba09-03b04cf61c95
       X-Ms-Correlation-Request-Id:
-      - f2dc259c-8e32-48a1-a703-7a8e25e09013
+      - 95716462-91af-4782-ba09-03b04cf61c95
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132651Z:f2dc259c-8e32-48a1-a703-7a8e25e09013
+      - EASTUS:20150909T161620Z:95716462-91af-4782-ba09-03b04cf61c95
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:50 GMT
+      - Wed, 09 Sep 2015 16:16:19 GMT
       Content-Length:
       - '438'
     body:
@@ -2001,7 +2001,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:51 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTNorthEurope/vmSizes?api-version=2015-06-15
@@ -2018,7 +2018,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 400
@@ -2035,15 +2035,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - b3f51a12-7cec-42f6-86a4-2c9afdc4810b
+      - 595dc3ef-649c-4692-9056-bfbd2d9ee508
       X-Ms-Correlation-Request-Id:
-      - b3f51a12-7cec-42f6-86a4-2c9afdc4810b
+      - 595dc3ef-649c-4692-9056-bfbd2d9ee508
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132651Z:b3f51a12-7cec-42f6-86a4-2c9afdc4810b
+      - EASTUS:20150909T161620Z:595dc3ef-649c-4692-9056-bfbd2d9ee508
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:51 GMT
+      - Wed, 09 Sep 2015 16:16:19 GMT
       Content-Length:
       - '441'
     body:
@@ -2055,7 +2055,7 @@ http_interactions:
         westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
         eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:51 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastAsia/vmSizes?api-version=2015-06-15
@@ -2072,7 +2072,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2097,18 +2097,18 @@ http_interactions:
       X-Ms-Served-By:
       - 87669224-8edb-4099-85ed-2799f5f9b5ce_130816178115351722
       X-Ms-Request-Id:
-      - 0385894e-5f38-4c66-9eee-ee60ddfb4fe8
+      - f02e9d28-47fd-4960-97ab-2c056ad7f0e0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14602'
       X-Ms-Correlation-Request-Id:
-      - 4ed26d4d-3d4c-490d-8e0c-0c6a17a14575
+      - 81b41ac5-5a0b-442f-951e-da62c2b151bf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132651Z:4ed26d4d-3d4c-490d-8e0c-0c6a17a14575
+      - EASTUS:20150909T161620Z:81b41ac5-5a0b-442f-951e-da62c2b151bf
       Date:
-      - Tue, 08 Sep 2015 13:26:51 GMT
+      - Wed, 09 Sep 2015 16:16:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2128,7 +2128,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:52 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralUS/vmSizes?api-version=2015-06-15
@@ -2145,7 +2145,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2170,18 +2170,18 @@ http_interactions:
       X-Ms-Served-By:
       - d0384330-e545-43f0-a33e-6355987bc2f8_130841918403972752
       X-Ms-Request-Id:
-      - d772ec56-55a4-4d1f-a9e8-15839bee6de2
+      - 521a9518-055b-46d4-bae6-73c81cdd81a5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14795'
       X-Ms-Correlation-Request-Id:
-      - b778b4a4-74a4-4357-8f81-be1ccd831ab2
+      - 06fb8301-9868-41dd-bc4c-a3a5b480760f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132652Z:b778b4a4-74a4-4357-8f81-be1ccd831ab2
+      - EASTUS:20150909T161621Z:06fb8301-9868-41dd-bc4c-a3a5b480760f
       Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
+      - Wed, 09 Sep 2015 16:16:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2201,7 +2201,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:52 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
@@ -2218,7 +2218,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2237,17 +2237,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14599'
       X-Ms-Request-Id:
-      - a54f28f0-170f-4a11-abb9-286c89c37901
+      - adffbff2-5123-4e05-a323-548485c007af
       X-Ms-Correlation-Request-Id:
-      - a54f28f0-170f-4a11-abb9-286c89c37901
+      - adffbff2-5123-4e05-a323-548485c007af
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132652Z:a54f28f0-170f-4a11-abb9-286c89c37901
+      - EASTUS:20150909T161622Z:adffbff2-5123-4e05-a323-548485c007af
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
+      - Wed, 09 Sep 2015 16:16:21 GMT
       Content-Length:
       - '373'
     body:
@@ -2263,175 +2263,7 @@ http_interactions:
         c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq/PxzL
         7/+S/wf1Haxm0wQAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - d7e0b20e-5003-416d-bc99-0131d0519751
-      X-Ms-Correlation-Request-Id:
-      - d7e0b20e-5003-416d-bc99-0131d0519751
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132653Z:d7e0b20e-5003-416d-bc99-0131d0519751
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 4fe0e98a-4ad5-43aa-b7ea-c676b31fa0d1
-      X-Ms-Correlation-Request-Id:
-      - 4fe0e98a-4ad5-43aa-b7ea-c676b31fa0d1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132653Z:4fe0e98a-4ad5-43aa-b7ea-c676b31fa0d1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 8aff65b6-7016-4056-8c0a-50e794d3d23b
-      X-Ms-Correlation-Request-Id:
-      - 8aff65b6-7016-4056-8c0a-50e794d3d23b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132652Z:8aff65b6-7016-4056-8c0a-50e794d3d23b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
@@ -2448,7 +2280,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2467,17 +2299,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14794'
       X-Ms-Request-Id:
-      - 0177a627-df79-47a6-8985-96e858c5f19e
+      - 108bf6f4-c163-453b-8e03-257e6f4854ab
       X-Ms-Correlation-Request-Id:
-      - 0177a627-df79-47a6-8985-96e858c5f19e
+      - 108bf6f4-c163-453b-8e03-257e6f4854ab
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132653Z:0177a627-df79-47a6-8985-96e858c5f19e
+      - EASTUS:20150909T161622Z:108bf6f4-c163-453b-8e03-257e6f4854ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
+      - Wed, 09 Sep 2015 16:16:21 GMT
       Content-Length:
       - '133'
     body:
@@ -2487,7 +2319,175 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14715'
+      X-Ms-Request-Id:
+      - b5c94d58-2f43-4df5-977a-0faa7c172eb8
+      X-Ms-Correlation-Request-Id:
+      - b5c94d58-2f43-4df5-977a-0faa7c172eb8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T161622Z:b5c94d58-2f43-4df5-977a-0faa7c172eb8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:16:22 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14793'
+      X-Ms-Request-Id:
+      - 2e980b4d-07ca-4fbb-a822-ceae951f834d
+      X-Ms-Correlation-Request-Id:
+      - 2e980b4d-07ca-4fbb-a822-ceae951f834d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T161622Z:2e980b4d-07ca-4fbb-a822-ceae951f834d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:16:21 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14598'
+      X-Ms-Request-Id:
+      - 86ac6a27-e0c3-4b0f-a798-6663bfc2c429
+      X-Ms-Correlation-Request-Id:
+      - 86ac6a27-e0c3-4b0f-a798-6663bfc2c429
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T161622Z:86ac6a27-e0c3-4b0f-a798-6663bfc2c429
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:16:21 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
@@ -2504,7 +2504,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2523,17 +2523,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14714'
       X-Ms-Request-Id:
-      - 94db3190-e2c1-4681-91f7-b8ddca761ce7
+      - ffb8eb8f-0aae-42fd-8469-16c901d2f960
       X-Ms-Correlation-Request-Id:
-      - 94db3190-e2c1-4681-91f7-b8ddca761ce7
+      - ffb8eb8f-0aae-42fd-8469-16c901d2f960
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132652Z:94db3190-e2c1-4681-91f7-b8ddca761ce7
+      - EASTUS:20150909T161622Z:ffb8eb8f-0aae-42fd-8469-16c901d2f960
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
       Content-Length:
       - '133'
     body:
@@ -2543,75 +2543,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
-      X-Ms-Request-Id:
-      - ef5d173b-87a6-44d9-85eb-f1e1528726ab
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 025497e7-488e-4488-94c6-1e055fe9986d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132653Z:025497e7-488e-4488-94c6-1e055fe9986d
-      Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/jizJrz6t68dVqlrX502qRFcuTar1sqd39UaThs2xdtmG7e367
-        y6Ju11n5RTadF0vuTpGRx+sbz0fFjFp8dLdZT5ppXazaolo2d/c/3Tvfy84P
-        tvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz2f7B/bt13lTrepp/XlfrVXP35Msv
-        Xn715vQnv3h9lwZ7Wczyurn7RTGtq6Y6b8cn1WK1bvO7HfTunnz79Nnr01c/
-        efpq9yMftV/ijen/fVifvnr5/yFsvzj7ib0QXffH982vbgjfIL6C0E9+0WzE
-        N7vMijKbFGXRXr/O2+bucfjB7kcOt2W2gIB9tKFJe73iJjd35L1UVtMMA8WL
-        eda060YpxrQiKv2S/wckkSE04gMAAA==
-    http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
@@ -2628,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2651,20 +2583,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - e90c14a1-550f-43a2-a76c-5c2c63a9af84
+      - ef18827a-74ad-413c-9273-9fd99f9da5e2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14716'
       X-Ms-Correlation-Request-Id:
-      - 9bdb4d96-a7fd-4493-a0d4-0aa713a8462f
+      - ae16d8e7-aa1f-4669-b60a-92e1052fb43e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132653Z:9bdb4d96-a7fd-4493-a0d4-0aa713a8462f
+      - EASTUS:20150909T161622Z:ae16d8e7-aa1f-4669-b60a-92e1052fb43e
       Date:
-      - Tue, 08 Sep 2015 13:26:52 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2678,7 +2610,75 @@ http_interactions:
         /hI7yG8Q53l+vv2yrmYbcc4us6LMJkVZtNev87a5exx+sPeRQ22ZLTD/H21o
         0l6vuMnNHXkvldU0wzjxYp417bpRgjGpiEi/5P8BPK5MPoECAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:53 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      X-Ms-Request-Id:
+      - ab2ec26a-5e20-4a2d-aa25-ea589c6b086b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14766'
+      X-Ms-Correlation-Request-Id:
+      - 23096cda-d671-4f2b-b9ee-2b691459b079
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T161622Z:23096cda-d671-4f2b-b9ee-2b691459b079
+      Date:
+      - Wed, 09 Sep 2015 16:16:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/jizJrz6t68dVqlrX502qRFcuTar1sqd39UaThs2xdtmG7e367
+        y6Ju11n5RTadF0vuTpGRx+sbz0fFjFp8dLdZT5ppXazaolo2d/c/3Tvfy84P
+        tvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz2f7B/bt13lTrepp/XlfrVXP35Msv
+        Xn715vQnv3h9lwZ7Wczyurn7RTGtq6Y6b8cn1WK1bvO7HfTunnz79Nnr01c/
+        efpq9yMftV/ijen/fVifvnr5/yFsvzj7ib0QXffH982vbgjfIL6C0E9+0WzE
+        N7vMijKbFGXRXr/O2+bucfjB7kcOt2W2gIB9tKFJe73iJjd35L1UVtMMA8WL
+        eda060YpxrQiKv2S/wckkSE04gMAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
@@ -2695,7 +2695,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2714,17 +2714,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14765'
       X-Ms-Request-Id:
-      - abbc90a7-6e86-4b03-8ce6-f33679a99de0
+      - e0eacfe5-f2c9-449f-8392-96836ae91bf0
       X-Ms-Correlation-Request-Id:
-      - abbc90a7-6e86-4b03-8ce6-f33679a99de0
+      - e0eacfe5-f2c9-449f-8392-96836ae91bf0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132653Z:abbc90a7-6e86-4b03-8ce6-f33679a99de0
+      - EASTUS:20150909T161622Z:e0eacfe5-f2c9-449f-8392-96836ae91bf0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:53 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
       Content-Length:
       - '373'
     body:
@@ -2740,7 +2740,7 @@ http_interactions:
         c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq/PxzL
         7/+S/wf1Haxm0wQAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:54 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2757,7 +2757,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2776,17 +2776,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14597'
       X-Ms-Request-Id:
-      - 8dfabce0-f2ef-47d1-9127-141296c43ff1
+      - 89cbfd8f-7413-4b43-bff1-02eedef82882
       X-Ms-Correlation-Request-Id:
-      - 8dfabce0-f2ef-47d1-9127-141296c43ff1
+      - 89cbfd8f-7413-4b43-bff1-02eedef82882
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:8dfabce0-f2ef-47d1-9127-141296c43ff1
+      - EASTUS:20150909T161623Z:89cbfd8f-7413-4b43-bff1-02eedef82882
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
       Content-Length:
       - '133'
     body:
@@ -2796,63 +2796,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 878d2995-c674-437e-8bee-2d45d25a6de7
-      X-Ms-Correlation-Request-Id:
-      - 878d2995-c674-437e-8bee-2d45d25a6de7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:878d2995-c674-437e-8bee-2d45d25a6de7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2869,7 +2813,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -2888,17 +2832,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14792'
       X-Ms-Request-Id:
-      - 2e500c5f-4556-46ad-bdc9-6a9e5ac6f4de
+      - f87d1360-4b39-43b5-bdd4-6be31031aedc
       X-Ms-Correlation-Request-Id:
-      - 2e500c5f-4556-46ad-bdc9-6a9e5ac6f4de
+      - f87d1360-4b39-43b5-bdd4-6be31031aedc
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:2e500c5f-4556-46ad-bdc9-6a9e5ac6f4de
+      - EASTUS:20150909T161623Z:f87d1360-4b39-43b5-bdd4-6be31031aedc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:53 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
       Content-Length:
       - '133'
     body:
@@ -2908,63 +2852,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - ffae1007-64b8-4ff4-9c68-2366eb4c0aad
-      X-Ms-Correlation-Request-Id:
-      - ffae1007-64b8-4ff4-9c68-2366eb4c0aad
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:ffae1007-64b8-4ff4-9c68-2366eb4c0aad
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2981,7 +2869,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3000,17 +2888,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14596'
       X-Ms-Request-Id:
-      - 9e8bf0b3-75e9-4f27-ba42-2682c6bef974
+      - 38ef512a-fca0-4179-8e1d-970d9551c7b4
       X-Ms-Correlation-Request-Id:
-      - 9e8bf0b3-75e9-4f27-ba42-2682c6bef974
+      - 38ef512a-fca0-4179-8e1d-970d9551c7b4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:9e8bf0b3-75e9-4f27-ba42-2682c6bef974
+      - EASTUS:20150909T161623Z:38ef512a-fca0-4179-8e1d-970d9551c7b4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:26:53 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
       Content-Length:
       - '133'
     body:
@@ -3020,7 +2908,119 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14790'
+      X-Ms-Request-Id:
+      - c77c2be2-a6d9-4019-ba05-2cf950c5b8d1
+      X-Ms-Correlation-Request-Id:
+      - c77c2be2-a6d9-4019-ba05-2cf950c5b8d1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T161623Z:c77c2be2-a6d9-4019-ba05-2cf950c5b8d1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:16:22 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14789'
+      X-Ms-Request-Id:
+      - 0119f25a-354d-478f-a1a4-4328839d8e17
+      X-Ms-Correlation-Request-Id:
+      - 0119f25a-354d-478f-a1a4-4328839d8e17
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T161623Z:0119f25a-354d-478f-a1a4-4328839d8e17
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:16:22 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3037,7 +3037,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3060,20 +3060,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - 21aa82c1-2eb5-46e6-8fc5-c1b4ef7a04ca
+      - a71e5cb1-bcba-41e7-907a-0fe732bddbe6
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14748'
       X-Ms-Correlation-Request-Id:
-      - 57e14a8c-ab24-439a-8a6b-4630bf2b31a6
+      - 0bc1e3c1-a24b-456a-9d1b-57c880bfc346
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:57e14a8c-ab24-439a-8a6b-4630bf2b31a6
+      - EASTUS:20150909T161623Z:0bc1e3c1-a24b-456a-9d1b-57c880bfc346
       Date:
-      - Tue, 08 Sep 2015 13:26:53 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3098,7 +3098,7 @@ http_interactions:
         iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
         37Z/MFpXPd/SFIARZ+spzK82EkNgWuhM8A8SyF/y/wDbEyEhJwgAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3115,7 +3115,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3138,20 +3138,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - 63996d2b-6461-4360-8632-16cf6d141fe2
+      - 065f0551-29fc-4ef4-98c7-98d95d66f64f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14791'
       X-Ms-Correlation-Request-Id:
-      - fe21cfc1-69d5-44a1-87d0-10587c91da5a
+      - 1e3749ab-ef26-415f-88da-4c62dbc590b1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132654Z:fe21cfc1-69d5-44a1-87d0-10587c91da5a
+      - EASTUS:20150909T161623Z:1e3749ab-ef26-415f-88da-4c62dbc590b1
       Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
+      - Wed, 09 Sep 2015 16:16:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3191,7 +3191,7 @@ http_interactions:
         6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTuEfJD2/5P8BxF53
         EuIgAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520/?api-version=2015-06-15
@@ -3208,7 +3208,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3231,20 +3231,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2f7eeb57-3915-4869-befa-1c6819c476c4
+      - 47667046-31a0-4351-b2ff-e6cdf4533982
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14764'
       X-Ms-Correlation-Request-Id:
-      - bdd0c709-a225-491d-8b2b-c0463c07a725
+      - a9b32a38-6f24-4e4e-a646-7d8504ca30fd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132655Z:bdd0c709-a225-491d-8b2b-c0463c07a725
+      - EASTUS:20150909T161623Z:a9b32a38-6f24-4e4e-a646-7d8504ca30fd
       Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
+      - Wed, 09 Sep 2015 16:16:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3265,7 +3265,7 @@ http_interactions:
         Yciv8+m6Ltprphq1cYj+kGciho/3rtLfEoJkZ5HV14RiW6/toHQ6v8im82IJ
         Mf2hD+ekWqzWbW4YSzHx3jIDwQ8ZzUdG+IFgnjXtuqFGv+T/AQyR8K0yBwAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod/?api-version=2015-06-15
@@ -3282,7 +3282,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3305,20 +3305,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b8a5230d-247a-46b4-8f55-d25e86733b65
+      - 2b79a96b-545a-42db-a778-7ff4364dd926
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14747'
       X-Ms-Correlation-Request-Id:
-      - 5914761a-a89b-4fda-b01c-c58bd6cddd4f
+      - 35b318d0-202a-4753-bb2e-89663ee19611
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132655Z:5914761a-a89b-4fda-b01c-c58bd6cddd4f
+      - EASTUS:20150909T161624Z:35b318d0-202a-4753-bb2e-89663ee19611
       Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
+      - Wed, 09 Sep 2015 16:16:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3335,7 +3335,7 @@ http_interactions:
         Ft8xxLs/rOlcys+zZZvX59mUpnOK9+iV2f29nbsdTBv6YMof7H4kGP8S/Pgl
         PLCPDGEwgDxr2nVDjX7J/wOWusr3vgIAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:55 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863/?api-version=2015-06-15
@@ -3352,7 +3352,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3375,20 +3375,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 59e688b9-c1bf-4729-9584-bacece129e78
+      - e886af89-df8b-43b2-8677-c7fc0803c977
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14791'
       X-Ms-Correlation-Request-Id:
-      - d94349af-51a5-453f-bd3f-be174a6d2dfa
+      - a7f55c7d-2aef-41dc-98cd-980b45234aa2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132655Z:d94349af-51a5-453f-bd3f-be174a6d2dfa
+      - EASTUS:20150909T161624Z:a7f55c7d-2aef-41dc-98cd-980b45234aa2
       Date:
-      - Tue, 08 Sep 2015 13:26:54 GMT
+      - Wed, 09 Sep 2015 16:16:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3408,7 +3408,7 @@ http_interactions:
         jbG8zqfrumivmR7UxiHww6ZxDCFqd/YT+v6uktaOUSfli2w6L5bg0h8+7vq1
         4Q9FJZBpgzV+COofGfYHjnnWtOuGGv2S/wcObvq6PAYAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:56 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505/?api-version=2015-06-15
@@ -3425,7 +3425,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3448,20 +3448,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0248c942-0b71-4aa4-bd7c-c2a8141329d6
+      - 531eaa64-024b-4da7-92a4-90513303098c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14713'
       X-Ms-Correlation-Request-Id:
-      - 83af065f-65e5-41f1-a4e2-551e254bde6b
+      - f6f4df03-3b39-40dd-a66b-61d11ec6dd07
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132656Z:83af065f-65e5-41f1-a4e2-551e254bde6b
+      - EASTUS:20150909T161624Z:f6f4df03-3b39-40dd-a66b-61d11ec6dd07
       Date:
-      - Tue, 08 Sep 2015 13:26:55 GMT
+      - Wed, 09 Sep 2015 16:16:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3482,7 +3482,7 @@ http_interactions:
         XddFe810ozYO0R/2XMQQ8jnJ0oBkZpHV14RdW6/teHQqv8im82IJ8fzhj0S/
         NlylqARjwA8ZyEdG3oFbnjXtuqFGv+T/Ab/UQiEVBwAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:56 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP/?api-version=2015-06-15
@@ -3499,7 +3499,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3522,20 +3522,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - adf2ddac-0c77-4529-a67a-17bb956c31cd
+      - 2fa58d87-ecd4-4239-825f-d3943c60f503
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14712'
       X-Ms-Correlation-Request-Id:
-      - 5d30b76e-223f-4ca5-81f8-e439b8be9bcc
+      - 2c223226-7a26-4c0d-a0e5-321c599c3a10
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132656Z:5d30b76e-223f-4ca5-81f8-e439b8be9bcc
+      - EASTUS:20150909T161624Z:2c223226-7a26-4c0d-a0e5-321c599c3a10
       Date:
-      - Tue, 08 Sep 2015 13:26:56 GMT
+      - Wed, 09 Sep 2015 16:16:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3552,7 +3552,7 @@ http_interactions:
         zYDoKx0uvmOId39oU7mUn2fLNq/PsylNZV6v7u/cv9tBsqEPpvzB7keC7C/B
         j1/CY/rI0AS451nTrhtq9Ev+H2Ho2tmvAgAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:56 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727/?api-version=2015-06-15
@@ -3569,7 +3569,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3592,20 +3592,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ebdcca9b-f7ee-4b19-a1b1-53b66172cf4e
+      - 83b8669d-d5b4-4e12-b772-91fba59bc25d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14788'
       X-Ms-Correlation-Request-Id:
-      - 892cec80-11ae-457c-98ca-c14e2fd58da0
+      - f5e26d11-4c58-404d-86c1-7740e7dd1dfb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132656Z:892cec80-11ae-457c-98ca-c14e2fd58da0
+      - EASTUS:20150909T161625Z:f5e26d11-4c58-404d-86c1-7740e7dd1dfb
       Date:
-      - Tue, 08 Sep 2015 13:26:55 GMT
+      - Wed, 09 Sep 2015 16:16:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3626,7 +3626,7 @@ http_interactions:
         s/FFNp0XS4jYDx9p/dowhqJCLTx08UNw/sgILZDLs6ZdN9Tol/w/GfAPr90G
         AAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:57 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2/?api-version=2015-06-15
@@ -3643,7 +3643,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3666,20 +3666,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 743a3f2c-7599-41e3-845b-206b98907c5c
+      - b6f41d53-b644-4a29-ab9f-8aaa028011eb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14763'
       X-Ms-Correlation-Request-Id:
-      - 79aecadb-2b02-4bd1-ac29-50156e30afd8
+      - 35ed8e6f-af3d-4f65-803e-02408317d95e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132656Z:79aecadb-2b02-4bd1-ac29-50156e30afd8
+      - EASTUS:20150909T161625Z:35ed8e6f-af3d-4f65-803e-02408317d95e
       Date:
-      - Tue, 08 Sep 2015 13:26:55 GMT
+      - Wed, 09 Sep 2015 16:16:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3696,7 +3696,7 @@ http_interactions:
         aVoUv2jvwd6Dux0sG/pgyh/sfiTY/hL8+CU8qI8MUYB8njXtuqFGv+T/Aca0
         e0SNAgAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:57 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426/?api-version=2015-06-15
@@ -3713,7 +3713,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3736,20 +3736,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 14473f1c-c0bd-4c8f-aa28-56bb44c95475
+      - 1dae7d8c-d76c-4805-b03e-cea420711c6a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14762'
       X-Ms-Correlation-Request-Id:
-      - fb50fe44-d3b8-4346-a7d9-cff9ec291a30
+      - 1169ebc7-78e5-4b8f-b03f-bee56be2fd74
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132657Z:fb50fe44-d3b8-4346-a7d9-cff9ec291a30
+      - EASTUS:20150909T161625Z:1169ebc7-78e5-4b8f-b03f-bee56be2fd74
       Date:
-      - Tue, 08 Sep 2015 13:26:56 GMT
+      - Wed, 09 Sep 2015 16:16:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3770,7 +3770,7 @@ http_interactions:
         1+MUO0adlC+y6bxYQuB++Ljr14Y/FBVq0ccaPwT1j4wkA8c8a9p1Q41+yf8D
         HN36UAcHAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:57 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1/?api-version=2015-06-15
@@ -3787,7 +3787,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3810,20 +3810,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 48c1fd77-c884-4752-9804-0f700cc07c07
+      - de10054b-29e7-4b32-b4e1-398c6bc1bed2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14790'
       X-Ms-Correlation-Request-Id:
-      - 32af4f41-935e-412e-97af-3fbbdfbd1f32
+      - 2b891342-d467-4732-a9b2-d94f57fcb8e3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132657Z:32af4f41-935e-412e-97af-3fbbdfbd1f32
+      - EASTUS:20150909T161627Z:2b891342-d467-4732-a9b2-d94f57fcb8e3
       Date:
-      - Tue, 08 Sep 2015 13:26:57 GMT
+      - Wed, 09 Sep 2015 16:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3840,7 +3840,7 @@ http_interactions:
         Kc3WovhFU3l3d3/v07sdZBv6YMof7H4kSP8S/PglPLaPDG0whjxr2nVDjX7J
         /wN3lSOVogIAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:57 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
@@ -3857,7 +3857,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3880,20 +3880,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - b3cfa0d9-da5f-4cef-87f3-c50f88206343
+      - efb073ac-e2e9-4fe1-b94d-5af26e4c2a04
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14761'
       X-Ms-Correlation-Request-Id:
-      - 54468d70-dfee-45d7-be9f-0046bc893dee
+      - 46c5f91b-2b52-4ce7-8275-4356bac7cffc
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132657Z:54468d70-dfee-45d7-be9f-0046bc893dee
+      - EASTUS:20150909T161627Z:46c5f91b-2b52-4ce7-8275-4356bac7cffc
       Date:
-      - Tue, 08 Sep 2015 13:26:57 GMT
+      - Wed, 09 Sep 2015 16:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3903,15 +3903,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3cebu8c
-        vNm992jv00f3Dz7Z2Xm0s/ORafxL5Jfv48cvYRDA9C0wVKpYmny0zATqyTw/
-        3yayzFyfUWp67+LZQNFmPZ3m+Sz3IOJxFD1bnled7wjNkKA+2HQIYkiZg+1d
-        oszDR/u7j3bvjXfv7e7t3t/vUIjoYn5lKunf32e4H+Xv2nyJToGCjtyO2lLs
-        i2JaV0113o7PqPHFvG3GP/nF0yK7WFZNW0yb13nbEtaNdup30CesA/9eBB0i
-        5vsTcoCI9z99dG9nfG/34MHu3oOAiMJYUcyrq7xGz/nder1Eh143t0aYJMW8
-        LY2EgL9x8kv+HzVWm/haBAAA
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3ce0v/e
+        7H76iP639+CTnZ1HOzsfmca/RH75Pn78EgYBTN8CQ6WKpclHy0ygnszz820i
+        y8z1GaWm9y6eDRRt1tNpns9yDyIeR9Gz5XnV+Y7QDAnqg02HIIaUOdjePXiz
+        +/DR/u6j3Xvj3Xu7e7v39zsUIrqYX5lK+vf3Ge5H+bs2X6JToKAjt6O2FPui
+        mNZVU5234zNqfDFvm/FPfvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5
+        /oQcIOL9Tx/d2xnf2z14sNthM2GsKObVVV6j5/xuvV6iQ6+bWyNMkmLelkZC
+        wN84+SX/D828ogJaBAAA
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:58 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
@@ -3928,7 +3928,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -3951,20 +3951,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - df1cd6cb-1052-408d-9ba4-bc186af23011
+      - c0ed9fc3-f75c-4ef5-9951-6dff906b2060
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14760'
       X-Ms-Correlation-Request-Id:
-      - 402f35f4-17f9-48d5-b083-ddbd9deb940a
+      - 7017e5bf-4a3a-4bf3-8980-8dc9bbd82925
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132658Z:402f35f4-17f9-48d5-b083-ddbd9deb940a
+      - EASTUS:20150909T161627Z:7017e5bf-4a3a-4bf3-8980-8dc9bbd82925
       Date:
-      - Tue, 08 Sep 2015 13:26:57 GMT
+      - Wed, 09 Sep 2015 16:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3974,15 +3974,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsPt3cO3uzee7T36aP7B5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgJ1Os/Pm7y+zOtd12uUdN7beDaQ
-        r1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcghrQ52N59+Gb3waP9g0d798cH
-        9w8+3Xu436ERUcb8ynTSv7/PcD/K37U5TQFNA0HVkdtRW5p9UUzrqqnO2/EZ
-        Nb6Yt834J794WmQXy6ppi2nzOm9bwrrRTv0O+oR14N+LoEPEfH9CbiTiw/t7
-        9/Z29gIiCmtFMa+u8ho953dneVaW1ZR+9bu6NdIkGj4EaSiE/I2TX/L/AF2d
-        +iVPBAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsP6X9vdj99RP/be/DJzs6jnZ2P
+        TONfIr98Hz9+CYMAUm+BjBLADv+jZSZQp/P8vMnry7zedb1GSee9jWcD+Zr1
+        dJrns3zmIOJx5Dtbnled7wjRkHo+2HQIYkibg+1dos2DR/sHj/bujw/uH3y6
+        93C/QyOijPmV6aR/f5/hfpS/a3OaApoGgqojt6O2NPuimNZVU5234zNqfDFv
+        m/FPfvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcSMSH9/fu7e3s
+        BUQU1opiXl3lNXrO787yrCyrKf3qd3VrpEk0fAjSUAj5Gye/5P8BhHf1008E
+        AAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:58 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
@@ -3999,7 +3999,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -4022,20 +4022,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - 3e38af01-4ded-4212-b375-71dc56555cb0
+      - 72ce7cf6-9ed1-4879-98c4-6a67d72766ab
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14711'
       X-Ms-Correlation-Request-Id:
-      - 5a95edac-ca72-4bec-bdb1-4086f92b6c60
+      - 15496e1a-d996-4f4c-bfdf-3eddaaedb02e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132658Z:5a95edac-ca72-4bec-bdb1-4086f92b6c60
+      - EASTUS:20150909T161627Z:15496e1a-d996-4f4c-bfdf-3eddaaedb02e
       Date:
-      - Tue, 08 Sep 2015 13:26:58 GMT
+      - Wed, 09 Sep 2015 16:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4045,14 +4045,14 @@ http_interactions:
         pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsPt3cO3uzee7T36aP7B5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19NVL11uUZN5beDaQrVlPp3k+
-        y2cOIh5HtrPledX5jhAMqeaDTYcghjQ52N4lmjx8dO/Bo93d8b2D3b29nQcd
-        2hBFzK9MH/37+wz3o/xdmxPpifwEVUduR21p9UUxraumOm/HZ9T4Yt4245/8
-        4mmRXSyrpi2mzeu8bQnrRjv1O+gT1oF/L4IOEfP9CTlExINHuw/G9+7t39vf
-        vRcQUVgqinl1ldfoOb9br5fo0Ovm1giTOJi3pZEQ8DdOfsn/A2Ued7E/BAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsP6X9vdj99RP/be/DJzs6jnZ2P
+        TONfIr98Hz9+CYMAUm+BjBLADv+jZSZQT1+9dL1FSea9hWcD2Zr1dJrns3zm
+        IOJxZDtbnled7wjBkGo+2HQIYkiTg+3dgze7Dx/de/Bod3d872B3b2+nSxui
+        iPmV6aN/f5/hfpS/a3MiPZGfoOrI7agtrb4opnXVVOft+IwaX8zbZvyTXzwt
+        sotl1bTFtHmdty1h3Winfgd9wjrw70XQIWK+PyGHiHjwaPfB+N69/Xv7u/cC
+        IgpLRTGvrvIaPed36/USHXrd3BphEgfztjQSAv7GyS/5fwDY/VFDPwQAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:58 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
@@ -4069,7 +4069,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -4092,20 +4092,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - e371921a-9229-412b-aca7-25b815efd45b
+      - 2d3418ab-4c57-4810-8a3f-6a8fd5a84966
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14759'
       X-Ms-Correlation-Request-Id:
-      - 8bb04386-cccf-44a1-8abb-648df1bf1725
+      - 785a538e-bb09-4f9e-959e-beae45be27b2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132658Z:8bb04386-cccf-44a1-8abb-648df1bf1725
+      - EASTUS:20150909T161627Z:785a538e-bb09-4f9e-959e-beae45be27b2
       Date:
-      - Tue, 08 Sep 2015 13:26:58 GMT
+      - Wed, 09 Sep 2015 16:16:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4115,14 +4115,14 @@ http_interactions:
         pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsPt3cO3uzee7T36aP7Dz/Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqF2c/see6i9LMew3PBro16+k0
-        z2f5zEHE4+h2tjyvOt8RhiHZfLDpEMSQKAfbe7tvdu8/uv/g0f6D8af39g92
-        drvEIZKYX5lA+vf3Ge5H+bs2J9oT/QmqjtyO2hGrmNZVU5234zNqfDFvm/FP
-        fvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcTMSHD+7t7dwPiCg8
-        FcW8uspr9JzfneVZWVZT+tXv6tZIk0z4EKShEPI3Tn7J/wMFyBhCSAQAAA==
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsP6X9vdj99RP/bO/hkZ+fRzs5H
+        pvEvkV++jx+/hEEAqbdARglgh//RMhOoX5z9xJ7rLkoz7zU8G+jWrKfTPJ/l
+        MwcRj6Pb2fK86nxHGIZk88GmQxBDohxs7+2+2b3/6P6DR/sPxp/e2z/Y2X3Y
+        IQ6RxPzKBNK/v89wP8rftTnRnuhPUHXkdtSOWMW0rprqvB2fUeOLeduMf/KL
+        p0V2sayatpg2r/O2Jawb7dTvoE9YB/69CDpEzPcn5GYiPnxwb2/nfkBE4ako
+        5tVVXqPn/O4sz8qymtKvfle3RppkwocgDYWQv3HyS/4f6UHKLUgEAAA=
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:59 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
@@ -4139,7 +4139,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -4162,20 +4162,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130847944029557556
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
       X-Ms-Request-Id:
-      - b221af43-5658-4406-b616-229a2eefb243
+      - ba2b9f50-ca47-427e-8dff-32c424d3ecda
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14789'
       X-Ms-Correlation-Request-Id:
-      - ef80f07b-d76c-4b48-ae32-672ffb80dd5a
+      - bedf1771-7f12-46ef-b237-3dcf1914fc54
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T132658Z:ef80f07b-d76c-4b48-ae32-672ffb80dd5a
+      - EASTUS:20150909T161628Z:bedf1771-7f12-46ef-b237-3dcf1914fc54
       Date:
-      - Tue, 08 Sep 2015 13:26:58 GMT
+      - Wed, 09 Sep 2015 16:16:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4184,19 +4184,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
         6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
         Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbOw+3
-        dw7e7N57tPfpo/sPP9nZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOoX
-        Zz9xUi1W6zbfdb1GSee9jWcD+Zr1dJrns3zmIOJx5Dtbnled7wjRkHo+2HQI
-        Ykibg+29B292Dx7d//TR7oPx/U/37h/sdWlElDG/Mp3obwVpR2dpM8vajPB6
-        +/8vyhyMd3ce7n+6u/cNUGbP9frzizL48X2G+1H+rs1JbEl0CaqO3I7aUuyL
-        YlpXTXXejs+o8cW8bcY/+cXTIrtYVk1bTJvXedsS1o126nfQJ6wD/14EHSLm
-        +xNyMxEf7D58uHc/IGKflSzm1VVeo+f87izPyrKa0q9+V7dGmtSpD0EaCiF/
-        4+SX/D80OtavSAYAAA==
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbOw/p
+        f292P31E/9s7+GRn59HOzkem8S+RX76PH7+EQQCpt0BGCWCH/9EyE6hfnP3E
+        SbVYrdt81/UaJZ33Np4N5GvW02mez/KZg4jHke9seV51viNEQ+r5YNMhiCFt
+        Drb3HrzZPXh0n8jzYHz/0737B3sPOzQiyphfmU70t4K0o7O0mWVtRni9/f8X
+        ZQ7GuzsP9z/d3fsGKLPnev35RRn8+D7D/Sh/1+YktiS6BFVHbkdtKfZFMa2r
+        pjpvx2fU+GLeNuOf/OJpkV0sq6Ytps3rvG0J60Y79TvoE9aBfy+CDhHz/Qm5
+        mYgPdh8+3LsfELHPShbz6iqv0XN+d5ZnZVlN6Ve/q1sjTerUhyANhZC/cfJL
+        /h942u5XSAYAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:26:59 GMT
+  recorded_at: Wed, 09 Sep 2015 16:16:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4210,7 +4210,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE3MTg0OTgsIm5iZiI6MTQ0MTcxODQ5OCwiZXhwIjoxNDQxNzIyMzk4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.IhlTYT2vMdrXSqc70gJqByIn9vew-01Y4fYnWrRwTOOlL08ULbFmoI72dO_0xTltdRuf1pUZIBlv94zw_1Ktv50kiDm5frcz-IYBQCouLKxjEiVWpKum_wPZSjd7MNsOuLWy5Q9iVmeFch2mglLFOtxSCPVoN1aMjzJyWd1fYXN3UwppU4n3hH5hUzAskWvbgy82yCzCwrCrPYJmaU9MLv2g6TvNfFSjWbdB86SvFDk0Z81Ww_f_63qy-6SlRDRBM-HCykbRJNlhu_ps3AwLMPDwRxMR-L2wpZ4rTrsin5NETFLu31V6r5GqzsL80mXpAHMJkFMNV1oZ3futscaHOg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
   response:
     status:
       code: 200
@@ -4229,17 +4229,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14499'
       X-Ms-Request-Id:
-      - 83563c08-2f7f-4df0-ac16-f4a0e10b9607
+      - e1e5f8ec-ece6-426e-811a-80db1a16d212
       X-Ms-Correlation-Request-Id:
-      - 83563c08-2f7f-4df0-ac16-f4a0e10b9607
+      - e1e5f8ec-ece6-426e-811a-80db1a16d212
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150908T133228Z:83563c08-2f7f-4df0-ac16-f4a0e10b9607
+      - EASTUS:20150909T162757Z:e1e5f8ec-ece6-426e-811a-80db1a16d212
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 08 Sep 2015 13:32:28 GMT
+      - Wed, 09 Sep 2015 16:27:56 GMT
       Content-Length:
       - '133'
     body:
@@ -4249,5 +4249,117 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 08 Sep 2015 13:32:29 GMT
+  recorded_at: Wed, 09 Sep 2015 16:28:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14761'
+      X-Ms-Request-Id:
+      - e9664dbd-ac1e-45de-a836-f9eec5684ef5
+      X-Ms-Correlation-Request-Id:
+      - e9664dbd-ac1e-45de-a836-f9eec5684ef5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T162758Z:e9664dbd-ac1e-45de-a836-f9eec5684ef5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:27:58 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:28:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14753'
+      X-Ms-Request-Id:
+      - b94f5095-6e21-4a48-b6de-dc75719a456a
+      X-Ms-Correlation-Request-Id:
+      - b94f5095-6e21-4a48-b6de-dc75719a456a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150909T162758Z:b94f5095-6e21-4a48-b6de-dc75719a456a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 09 Sep 2015 16:27:58 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 09 Sep 2015 16:28:01 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
In the absence of a guid to uniquely identify an Azure instance we prepend the user's subscriber ID to the UID to ensure uniqueness. The compete UID is now:   "subscriber_id\resource_group\instance_name"