### PR TITLE
Fix rails 4 undefined method `ago' for x:Fixnum

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -34,7 +34,7 @@ module Metric::Capture
     value = if value.kind_of?(Fixnum) # Default unit is minutes
               value.minutes.ago.utc
             else
-              value.to_i_with_method.ago.utc unless value.nil?
+              value.to_i_with_method.seconds.ago.utc unless value.nil?
             end
     return value
   end

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -135,17 +135,17 @@ class MiqStorageMetric < ActiveRecord::Base
     return nil if value.nil?
 
     value = value.to_i.days if value.kind_of?(Fixnum) # Default unit is days
-    value = value.to_i_with_method.ago.utc unless value.nil?
+    value = value.to_i_with_method.seconds.ago.utc unless value.nil?
     return value
   end
 
   def self.derived_metrics_count_by_date(older_than)
     return metrics_count_by_date(older_than, self.derived_metrics_classes)
-    end
+  end
 
   def self.metrics_rollups_count_by_date(older_than)
     return metrics_count_by_date(older_than, self.metrics_rollup_classes)
-    end
+  end
 
   def self.metrics_count_by_date(older_than, metrics_classes)
     count = 0

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -1,53 +1,71 @@
 require "spec_helper"
 
 describe Metric::Capture do
-  context ".capture_threshold" do
+
+  shared_examples "captures a threshold" do |capture_fixnum, capture|
+    let(:threshold_default) { 10 }
+    let(:capture_rt) { 2 }
+    let(:time) { Time.utc(2013, 4, 22, 8, 31) }
+
     before do
-      @capture    = 20
-      @capture_rt = 2
       settings =  {:performance =>
-                    {:capture_threshold             => {:vm => @capture,    :host => @capture},
-                     :capture_threshold_with_alerts => {:vm => @capture_rt, :host => @capture_rt}
+                    {:capture_threshold             => {:vm => capture,    :host => capture},
+                     :capture_threshold_with_alerts => {:vm => capture_rt, :host => capture_rt}
                     }
                   }
       stub_server_configuration(settings)
-      @time = Time.utc(2013, 4, 22, 8, 31)
     end
 
     it "realtime vm uses capture_threshold_with_alerts minutes ago" do
-      @target = FactoryGirl.build(:vm_vmware)
-      MiqAlert.stub(:target_needs_realtime_capture?).with(@target).and_return(true)
+      target = FactoryGirl.build(:vm_vmware)
+      MiqAlert.stub(:target_needs_realtime_capture?).with(target).and_return(true)
 
-      Timecop.freeze(@time) do
-        Metric::Capture.capture_threshold(@target).should == @capture_rt.minutes.ago.utc
+      Timecop.freeze(time) do
+        expect(described_class.capture_threshold(target)).to eq capture_rt.minutes.ago.utc
       end
     end
 
     it "realtime host uses capture_threshold_with_alerts minutes ago" do
-      @target = FactoryGirl.build(:host_vmware)
-      MiqAlert.stub(:target_needs_realtime_capture?).with(@target).and_return(true)
+      target = FactoryGirl.build(:host_vmware)
+      MiqAlert.stub(:target_needs_realtime_capture?).with(target).and_return(true)
 
-      Timecop.freeze(@time) do
-        Metric::Capture.capture_threshold(@target).should == @capture_rt.minutes.ago.utc
+      Timecop.freeze(time) do
+        expect(described_class.capture_threshold(target)).to eq capture_rt.minutes.ago.utc
       end
     end
 
     it "non-realtime vm uses capture_threshold minutes ago" do
-      @target = FactoryGirl.build(:vm_vmware)
-      MiqAlert.stub(:target_needs_realtime_capture?).with(@target).and_return(false)
+      target = FactoryGirl.build(:vm_vmware)
+      MiqAlert.stub(:target_needs_realtime_capture?).with(target).and_return(false)
 
-      Timecop.freeze(@time) do
-        Metric::Capture.capture_threshold(@target).should == @capture.minutes.ago.utc
+      Timecop.freeze(time) do
+        result = threshold_default.minutes.ago.utc
+        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
+        expect(described_class.capture_threshold(target)).to eq result
       end
     end
 
     it "non-realtime host uses capture_threshold minutes ago" do
-      @target = FactoryGirl.build(:host_vmware)
-      MiqAlert.stub(:target_needs_realtime_capture?).with(@target).and_return(false)
+      target = FactoryGirl.build(:host_vmware)
+      MiqAlert.stub(:target_needs_realtime_capture?).with(target).and_return(false)
 
-      Timecop.freeze(@time) do
-        Metric::Capture.capture_threshold(@target).should == @capture.minutes.ago.utc
+      Timecop.freeze(time) do
+        result = threshold_default.minutes.ago.utc
+        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
+        expect(described_class.capture_threshold(target)).to eq result
       end
     end
+  end
+
+  context ".capture_threshold with Fixnum" do
+    include_examples "captures a threshold", 20, 20
+  end
+
+  context ".capture_threshold with String" do
+    include_examples "captures a threshold", 50, "50.minutes"
+  end
+
+  context ".capture_threshold handles nil" do
+    include_examples "captures a threshold", nil, nil
   end
 end

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe Metric::Capture do
-
   shared_examples "captures a threshold" do |capture_fixnum, capture|
     let(:threshold_default) { 10 }
     let(:capture_rt) { 2 }

--- a/spec/models/miq_storage_metric_spec.rb
+++ b/spec/models/miq_storage_metric_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe MiqStorageMetric do
-
   let(:time) { Time.utc(2013, 4, 22, 8, 31) }
 
   context ".purge_date" do
@@ -32,7 +31,5 @@ describe MiqStorageMetric do
         expect(described_class.purge_date(:token)).to eq nil
       end
     end
-
   end
-
 end

--- a/spec/models/miq_storage_metric_spec.rb
+++ b/spec/models/miq_storage_metric_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe MiqStorageMetric do
+
+  let(:time) { Time.utc(2013, 4, 22, 8, 31) }
+
+  context ".purge_date" do
+    it "using Fixnum" do
+      stub_server_configuration(:storage => {:metrics_history => {:token => 20}})
+      Timecop.freeze(time) do
+        expect(described_class.purge_date(:token)).to eq 20.days.ago.utc
+      end
+    end
+
+    it "using Time Unit days" do
+      stub_server_configuration(:storage => {:metrics_history => {:token => "20.days"}})
+      Timecop.freeze(time) do
+        expect(described_class.purge_date(:token)).to eq 20.days.ago.utc
+      end
+    end
+
+    it "using Time Unit minutes" do
+      stub_server_configuration(:storage => {:metrics_history => {:token => "20.minutes"}})
+      Timecop.freeze(time) do
+        expect(described_class.purge_date(:token)).to eq 20.minutes.ago.utc
+      end
+    end
+
+    it "handles nill" do
+      stub_server_configuration(:storage => {:metrics_history => {:token => nil}})
+      Timecop.freeze(time) do
+        expect(described_class.purge_date(:token)).to eq nil
+      end
+    end
+
+  end
+
+end

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -1,6 +1,8 @@
 module ConfigurationHelper
   def stub_server_configuration(config, config_name = "vmdb")
-    configuration = double(:config => config, :merge_from_template_if_missing => nil)
+    configuration = double(:config                         => config,
+                           :merge_from_template_if_missing => nil,
+                           :merge_from_template            => nil)
     allow(VMDB::Config).to receive(:new).with(config_name).and_return(configuration)
   end
 end

--- a/tools/purge_miq_report_results.rb
+++ b/tools/purge_miq_report_results.rb
@@ -19,7 +19,7 @@ if opts[:remaining_given]
 elsif opts[:date_given]
   Trollop::die :date, "must be a number with method (e.g. 6.months)" unless opts[:date].number_with_method?
   purge_mode  = :date
-  purge_value = opts[:date].to_i_with_method.ago.utc
+  purge_value = opts[:date].to_i_with_method.seconds.ago.utc
 else
   purge_mode, purge_value = MiqReportResult.purge_mode_and_value
 end


### PR DESCRIPTION
Prior to rails 4 #ago could be sent from a Fixnum.
As of rails 4 #to_i_with_method output must be sent
to #seconds when dealing with time objects.

Fixes: #4261