### PR TITLE
[api] Adding support for resource_actions subcollection

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -63,6 +63,7 @@ class ApiController < ApplicationController
   include_concern "Rates"
   include_concern "Reports"
   include_concern 'RequestTasks'
+  include_concern 'ResourceActions'
   include_concern 'Roles'
   include_concern 'ServiceCatalogs'
   include_concern 'ServiceDialogs'

--- a/app/controllers/api_controller/resource_actions.rb
+++ b/app/controllers/api_controller/resource_actions.rb
@@ -1,0 +1,10 @@
+class ApiController
+  module ResourceActions
+    #
+    # Resource Actions Subcollection Supporting Methods
+    #
+    def resource_actions_query_resource(object)
+      object.resource_actions
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -480,6 +480,12 @@
     - :collection
     :methods: *70174834086080
     :klass: MiqRequest
+  :resource_actions:
+    :description: Resource Actions
+    :options:
+    - :subcollection
+    :methods: *70174834086080
+    :klass: ResourceAction
   :resource_pools:
     :description: Resource Pools
     :options:
@@ -617,6 +623,7 @@
     :methods: *70174834084700
     :klass: ServiceTemplate
     :subcollections:
+    - :resource_actions
     - :tags
     - :service_requests
     - :service_dialogs

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -11,12 +11,44 @@ require 'spec_helper'
 describe ApiController do
   include Rack::Test::Methods
 
+  let(:dialog1)    { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
+  let(:dialog2)    { FactoryGirl.create(:dialog, :label => "ServiceDialog2") }
+
+  let(:ra1)        { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
+  let(:ra2)        { FactoryGirl.create(:resource_action, :action => "Retirement", :dialog => dialog2) }
+
+  let(:template)   { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
+
   before(:each) do
     init_api_spec_env
   end
 
   def app
     Vmdb::Application
+  end
+
+  describe "Service Templates query" do
+    before do
+      template.resource_actions = [ra1, ra2]
+      api_basic_authorize
+    end
+
+    it "queries all resource actions of a Service Template" do
+      run_get "#{service_templates_url(template.id)}/resource_actions", :expand => "resources"
+
+      resource_actions = template.resource_actions
+      expect_query_result(:resource_actions, resource_actions.count, resource_actions.count)
+      expect_result_resources_to_include_data("resources", "action" => resource_actions.pluck(:action))
+    end
+
+    it "queries a specific resource action of a Service Template" do
+      run_get "#{service_templates_url(template.id)}/resource_actions",
+              :expand => "resources",
+              :filter => ["action='Provision'"]
+
+      expect_query_result(:resource_actions, 1, 2)
+      expect_result_resources_to_include_data("resources", "action" => %w(Provision))
+    end
   end
 
   describe "Service Templates edit" do

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -47,7 +47,7 @@ describe ApiController do
               :filter => ["action='Provision'"]
 
       expect_query_result(:resource_actions, 1, 2)
-      expect_result_resources_to_include_data("resources", "action" => %w(Provision))
+      expect_result_resources_to_match_hash(["id" => ra1.id, "action" => ra1.action, "dialog_id" => dialog1.id])
     end
   end
 


### PR DESCRIPTION
Exposing resource_actions as a formal subcollection of service_templates

/api/service_templates/:id/resource_actions

This allows queries like:
  /api/service_templates/:id/resource_actions
  /api/service_templates/:id/resource_actions/:resource_action_id
  /api/service_templates/:id/resource_actions?expand=resources
  /api/service_templates/:id/resource_actions?expand=resources&filter[]="action='Provision'"

https://trello.com/c/XRvWnZ9M/123-api-expose-resource-actions-as-subcollection-of-service-templates