### PR TITLE
Fixup tenant quota

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -105,7 +105,6 @@ class Tenant < ActiveRecord::Base
   def get_quotas
     tenant_quotas.each_with_object({}) do |q, h|
       h[q.name.to_sym] = TenantQuota.quota_definitions[q.name.to_sym].merge(:unit => q.unit, :value => q.value, :format => q.format)
-      h
     end.reverse_merge(TenantQuota.quota_definitions)
   end
 
@@ -116,7 +115,7 @@ class Tenant < ActiveRecord::Base
       quotas.each do |name, values|
         next if values[:value].nil?
 
-        q = tenant_quotas.where(:name => name).last || tenant_quotas.build(values.merge(:name => name))
+        q = tenant_quotas.where(:name => name).last || tenant_quotas.build(:name => name)
         q.update_attributes!(values)
         updated_keys << name.to_sym
       end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -117,7 +117,6 @@ class Tenant < ActiveRecord::Base
         next if values[:value].nil?
 
         q = tenant_quotas.where(:name => name).last || tenant_quotas.build(values.merge(:name => name))
-        q.unit ||= q.default_unit
         q.update_attributes!(values)
         updated_keys << name.to_sym
       end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -104,7 +104,7 @@ class Tenant < ActiveRecord::Base
 
   def get_quotas
     tenant_quotas.each_with_object({}) do |q, h|
-      h[q.name.to_sym] = TenantQuota.quota_definitions[q.name.to_sym].merge(:unit => q.unit, :value => q.value, :format => q.format)
+      h[q.name.to_sym] = q.quota_hash
     end.reverse_merge(TenantQuota.quota_definitions)
   end
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -115,9 +115,10 @@ class Tenant < ActiveRecord::Base
       quotas.each do |name, values|
         next if values[:value].nil?
 
-        q = tenant_quotas.where(:name => name).last || tenant_quotas.build(:name => name)
+        name = name.to_s
+        q = tenant_quotas.detect { |tq| tq.name == name } || tenant_quotas.build(:name => name)
         q.update_attributes!(values)
-        updated_keys << name.to_sym
+        updated_keys << name
       end
       # Delete any quotas that were not passed in
       tenant_quotas.destroy_missing(updated_keys)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -120,7 +120,8 @@ class Tenant < ActiveRecord::Base
         updated_keys << name.to_sym
       end
       # Delete any quotas that were not passed in
-      TenantQuota.destroy_all(:tenant => self, :name => (TenantQuota.quota_definitions.keys.sort - updated_keys.sort))
+      tenant_quotas.destroy_missing(updated_keys)
+      # unfortunatly, an extra scope is created in destroy_missing, so we need to reload the records
       clear_association_cache
     end
 

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -5,27 +5,27 @@ class TenantQuota < ActiveRecord::Base
     :cpu_allocated => {
       :unit          => :mhz,
       :format        => :mhz,
-      :text_modifier => "Mhz"
+      :text_modifier => "Mhz".freeze
     },
     :mem_allocated => {
       :unit          => :bytes,
       :format        => :gigabytes_human,
-      :text_modifier => "GB"
+      :text_modifier => "GB".freeze
     },
     :storage_allocated => {
       :unit          => :bytes,
       :format        => :gigabytes_human,
-      :text_modifier => "GB"
+      :text_modifier => "GB".freeze
     },
     :vms_allocated => {
       :unit          => :fixnum,
       :format        => :general_number_precision_0,
-      :text_modifier => "Count"
+      :text_modifier => "Count".freeze
     },
     :templates_allocated => {
       :unit          => :fixnum,
       :format        => :general_number_precision_0,
-      :text_modifier => "Count"
+      :text_modifier => "Count".freeze
     }
   }
 

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -44,6 +44,10 @@ class TenantQuota < ActiveRecord::Base
     end
   end
 
+  def quota_hash
+    self.class.quota_definitions[name.to_sym].merge(:unit => unit, :value => value, :format => format) # attributes
+  end
+
   def format
     self.class.quota_definitions.fetch_path(name.to_sym, :format).to_s
   end

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -44,6 +44,15 @@ class TenantQuota < ActiveRecord::Base
     end
   end
 
+  # remove all quotas that are not listed in the keys to keep
+  # e.g.: tenant.tenant_quotas.destroy_missing_quotas(include_keys)
+  # NOTE: these are already local, no need to hit db to find them
+  def self.destroy_missing(keep)
+    keep = keep.map(&:to_s)
+    deletes = all.select { |tq| !keep.include?(tq.name) }
+    delete(deletes)
+  end
+
   def quota_hash
     self.class.quota_definitions[name.to_sym].merge(:unit => unit, :value => value, :format => format) # attributes
   end

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -34,6 +34,10 @@ class TenantQuota < ActiveRecord::Base
   validates :name, :inclusion => {:in => NAMES}
   validates :unit, :value, :presence => true
 
+  before_validation(:on => :create) do
+    self.unit = default_unit unless unit.present?
+  end
+
   def self.quota_definitions
     return @quota_definitions if @quota_definitions
 

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -39,12 +39,8 @@ class TenantQuota < ActiveRecord::Base
   end
 
   def self.quota_definitions
-    return @quota_definitions if @quota_definitions
-
-    @quota_definitions = QUOTA_BASE.each_with_object({}) do |q, h|
-      name, value = q
+    @quota_definitions ||= QUOTA_BASE.each_with_object({}) do |(name, value), h|
       h[name] = value.merge(:description => I18n.t("dictionary.tenants.#{name}"), :value => nil)
-      h
     end
   end
 

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -29,7 +29,7 @@ class TenantQuota < ActiveRecord::Base
     }
   }
 
-  NAMES = QUOTA_BASE.stringify_keys
+  NAMES = QUOTA_BASE.keys.map(&:to_s)
 
   validates :name, :inclusion => {:in => NAMES}
   validates :unit, :value, :presence => true

--- a/spec/factories/tenant_quota.rb
+++ b/spec/factories/tenant_quota.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :tenant_quota do
+    factory :tenant_quota_cpu do
+      name :cpu_allocated
+      unit "mhz"
+      value 4096
+    end
+  end
+end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -42,4 +42,46 @@ describe TenantQuota do
       expect(FactoryGirl.build(:tenant_quota_cpu).default_unit).to eq("mhz")
     end
   end
+
+  describe "#quota_hash" do
+    it "has cpu_allocated attributes" do
+      expect(described_class.new(:name => "cpu_allocated", :value => 4096).tap(&:valid?).quota_hash).to eq(
+        :unit          => "mhz",
+        :value         => 4096.0,
+        :format        => "mhz",
+        :text_modifier => "Mhz",
+        :description   => "Allocated CPU in Mhz"
+      )
+    end
+
+    it "has vms_allocated attributes" do
+      expect(described_class.new(:name => "vms_allocated", :value => 20).tap(&:valid?).quota_hash).to eq(
+        :unit          => "fixnum",
+        :value         => 20.0,
+        :format        => "general_number_precision_0",
+        :text_modifier => "Count",
+        :description   => "Allocated Number of Virtual Machines"
+      )
+    end
+
+    it "has mem_allocated attributes" do
+      expect(described_class.new(:name => "mem_allocated", :value => 4096).tap(&:valid?).quota_hash).to eq(
+        :unit          => "bytes",
+        :value         => 4096.0,
+        :format        => "gigabytes_human",
+        :text_modifier => "GB",
+        :description   => "Allocated Memory in GB"
+      )
+    end
+
+    it "has nil attributes" do
+      expect(described_class.new(:name => "storage_allocated").tap(&:valid?).quota_hash).to eq(
+        :unit          => "bytes",
+        :value         => nil,
+        :format        => "gigabytes_human",
+        :text_modifier => "GB",
+        :description   => "Allocated Storage in GB"
+      )
+    end
+  end
 end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -84,4 +84,18 @@ describe TenantQuota do
       )
     end
   end
+
+  describe ".destroy_missing" do
+    let(:tenant2) { FactoryGirl.create(:tenant, :parent => root_tenant) }
+
+    it "removes extra quotas only from object in question" do
+      tenant.tenant_quotas.create(:name => :vms_allocated, :value => 20)
+      tenant.tenant_quotas.create(:name => :mem_allocated, :value => 4096)
+      tenant2.tenant_quotas.create(:name => :cpu_allocated, :value => 1024)
+
+      tenant.tenant_quotas.destroy_missing([:vms_allocated])
+      expect(tenant.tenant_quotas.count).to eq(1)
+      expect(tenant2.tenant_quotas.count).to eq(1)
+    end
+  end
 end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -20,7 +20,16 @@ describe TenantQuota do
 
     it "rejects missing unit" do
       expect { described_class.create!(:name => :cpu_allocated, :value => 4096) }.to raise_error
+
+  describe "#format" do
+    it "has cpu" do
+      expect(FactoryGirl.build(:tenant_quota_cpu).format).to eq("mhz")
     end
   end
 
+  describe "#default_unit" do
+    it "has cpu" do
+      expect(FactoryGirl.build(:tenant_quota_cpu).default_unit).to eq("mhz")
+    end
+  end
 end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -1,15 +1,10 @@
 require 'spec_helper'
 
 describe TenantQuota do
-  let(:settings) {{}}
-  let(:tenant)   {Tenant.new(:domain => 'x.com', :parent => default_tenant)}
-
-  let(:default_tenant) do
-    Tenant.seed
-    Tenant.default_tenant
-  end
+  let(:tenant) { FactoryGirl.create(:tenant, :parent => root_tenant) }
 
   let(:root_tenant) do
+    MiqRegion.seed
     Tenant.seed
     Tenant.root_tenant
   end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -9,17 +9,27 @@ describe TenantQuota do
     Tenant.root_tenant
   end
 
-  context "validations" do
+  describe "#valid?" do
     it "rejects invalid name" do
-      expect { described_class.create!(:name => "XXX") }.to raise_error
+      expect(described_class.new(:name => "XXX")).not_to be_valid
     end
 
     it "rejects missing value" do
-      expect { described_class.create!(:name => :cpu_allocated, :unit => "mhz") }.to raise_error
+      expect(described_class.new(:name => :cpu_allocated, :unit => "mhz")).not_to be_valid
     end
 
-    it "rejects missing unit" do
-      expect { described_class.create!(:name => :cpu_allocated, :value => 4096) }.to raise_error
+    it "defaults missing unit" do
+      expect(described_class.new(:name => :cpu_allocated, :value => 4096)).to be_valid
+    end
+
+    it "accepts valid quota" do
+      expect(described_class.new(:name => :cpu_allocated, :unit => "mhz", :value => 4096)).to be_valid
+    end
+
+    it "accepts string name" do
+      expect(described_class.new(:name => "cpu_allocated", :unit => "mhz", :value => 4096)).to be_valid
+    end
+  end
 
   describe "#format" do
     it "has cpu" do

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -95,18 +95,22 @@ describe Tenant do
     end
   end
 
-  it ".all_tenants" do
-    FactoryGirl.create(:tenant, :parent => root_tenant)
-    FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
+  describe ".all_tenants" do
+    it "returns divisible projects (root and created is divisible)" do
+      FactoryGirl.create(:tenant, :parent => root_tenant)
+      FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
 
-    expect(Tenant.all_tenants.count).to eql 2 # The one we created + the default tenant
+      expect(Tenant.all_tenants.count).to eql(2)
+    end
   end
 
-  it ".all_projects" do
-    FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
-    FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
+  describe ".app_projects" do
+    it "returns non-divisible projects (root is divisible))" do
+      FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
+      FactoryGirl.create(:tenant, :parent => root_tenant, :divisible => false)
 
-    expect(Tenant.all_projects.count).to eql 2 # Should not return the default tenant
+      expect(Tenant.all_projects.count).to eql 2
+    end
   end
 
   context "subtenants and subprojects" do


### PR DESCRIPTION
I'm working with @mkanoor around automate `tenant_quota`s.

Overview:

1. Many more tests and a `tenant_quota` factory.
2. Removed N+1's around quota create and delete.
3. Specs use in memory (build) vs database (create) where possible.
4. Move logic from `tenant` object to `tenant_quota` for a) creating the quota hash, b) destroying missing quotas, and c) general knowledge of quota_definitions internal data structure.
 

/cc @jrafanie @gtanzillo Please review.

---

/cc @matthewd me obsessing:
Do you have Ideas on how to get rid of the `clear_association_cache` from `tenant.rb`?
At the end of `destroy_missing`, `size == 2`. But when it returns from that scope, it "reverts the scope" and `tenant_quotas` then shows `size == 3`. I'm guessing the problem is around it needing to clone the scope, but not sure why it is doing that.

It is better than before, but I want to get away from our constant reload the relation type code (like we do in inventory)

