### PR TITLE
remove deprecation warning :miq_derived_metrics

### DIFF
--- a/app/models/miq_cim_metric.rb
+++ b/app/models/miq_cim_metric.rb
@@ -3,10 +3,9 @@ require 'wbem'
 require 'net_app_manageability/types'
 
 class MiqCimMetric < MiqStorageMetric
-  has_many  :miq_derived_metrics,
+  has_many  :miq_derived_metrics, -> { order :position },
         :class_name   => "MiqCimDerivedMetric",
         :foreign_key  => "miq_storage_metric_id",
-        :order      => :position,
         :dependent    => :destroy
 
   def rollup(curMetric, counterInfo)


### PR DESCRIPTION
Yay, another deprecation warning means we are exercising more code in tests

```
DEPRECATION WARNING: The following options in your MiqCimMetric.has_many :miq_derived_metrics declaration are deprecated: :order. Please use a scope block instead.

. (called from <class:MiqCimMetric> at app/models/miq_cim_metric.rb:6)
```