### PR TITLE
[api] Enhancement to provide access to service_template pictures

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -90,6 +90,7 @@ class ApiController < ApplicationController
   ATTR_TYPES = {
     :time      => %w(expires_on),
     :url       => %w(href),
+    :resource  => %w(image_href),
     :encrypted => %w(password) |
                   ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
                   ::Vmdb::ConfigurationEncoder::PASSWORD_FIELDS

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -108,10 +108,12 @@ class ApiController
       def gen_attr_type_hash
         @attr_time = {}
         @attr_url  = {}
+        @attr_resource  = {}
         @attr_encrypted = {}
 
         ATTR_TYPES[:time].each { |attr| @attr_time[attr] = true }
         ATTR_TYPES[:url].each  { |attr| @attr_url[attr]  = true }
+        ATTR_TYPES[:resource].each  { |attr| @attr_resource[attr]  = true }
         ATTR_TYPES[:encrypted].each { |attr| @attr_encrypted[attr] = true }
 
         gen_time_attr_type_hash

--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -63,6 +63,8 @@ class ApiController
         normalize_attr(type, :url,  value)
       elsif self.class.attr_type_hash(:encrypted).key?(attr.to_s) || attr.to_s.include?("password")
         normalize_attr(type, :encrypted,  value)
+      elsif self.class.attr_type_hash(:resource).key?(attr.to_s)
+        normalize_attr(type, :resource, value)
       else
         value
       end
@@ -96,6 +98,13 @@ class ApiController
     #
     def normalize_href(type, value)
       normalize_url(type, "#{type}/#{value}")
+    end
+
+    #
+    # Let's normalize href accessible resources
+    #
+    def normalize_resource(_type, value)
+      value.to_s.starts_with?("/") ? "#{@req[:base]}#{value}" : value
     end
 
     #

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -2,6 +2,8 @@ class Picture < ActiveRecord::Base
   has_one :binary_blob, :as => :resource, :dependent => :destroy, :autosave => true
   include ReportableMixin
 
+  virtual_has_one :image_href, :class_name => "String"
+
   URL_ROOT          = Rails.root.join("public").to_s
   DEFAULT_DIRECTORY = File.join(URL_ROOT, "pictures")
   Dir.mkdir(DEFAULT_DIRECTORY) unless File.directory?(DEFAULT_DIRECTORY)
@@ -92,5 +94,9 @@ class Picture < ActiveRecord::Base
 
   def url_path(basepath = URL_ROOT)
     self.class.url_path(self.filename, basepath)
+  end
+
+  def image_href
+    url_path
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -280,6 +280,12 @@
         :identifier: host_protect
       - :name: unassign
         :identifier: host_protect
+  :pictures:
+    :description: Pictures
+    :options:
+    - :collection
+    :methods: *70174834086080
+    :klass: Picture
   :policies:
     :description: Policies
     :options:

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -85,6 +85,11 @@ describe ApiController do
       test_collection_query(:hosts, hosts_url, Host, :guid)
     end
 
+    it "query Pictures" do
+      FactoryGirl.create(:picture)
+      test_collection_query(:pictures, pictures_url, Picture)
+    end
+
     it "query Policies" do
       FactoryGirl.create(:miq_policy)
       test_collection_query(:policies, policies_url, MiqPolicy)

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -17,6 +17,7 @@ describe ApiController do
   let(:ra1)        { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
   let(:ra2)        { FactoryGirl.create(:resource_action, :action => "Retirement", :dialog => dialog2) }
 
+  let(:picture)    { FactoryGirl.create(:picture, :extension => "jpg") }
   let(:template)   { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
 
   before(:each) do
@@ -30,6 +31,7 @@ describe ApiController do
   describe "Service Templates query" do
     before do
       template.resource_actions = [ra1, ra2]
+      template.picture = picture
       api_basic_authorize
     end
 
@@ -48,6 +50,23 @@ describe ApiController do
 
       expect_query_result(:resource_actions, 1, 2)
       expect_result_resources_to_match_hash(["id" => ra1.id, "action" => ra1.action, "dialog_id" => dialog1.id])
+    end
+
+    it "allows queries of the related picture" do
+      run_get service_templates_url(template.id), :attributes => "picture"
+
+      expect_result_to_have_keys(%w(id href picture))
+      expect_result_to_match_hash(@result, "id" => template.id, "href" => service_templates_url(template.id))
+    end
+
+    it "allows queries of the related picture and image_href" do
+      run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
+
+      expect_result_to_have_keys(%w(id href picture))
+      expect_result_to_match_hash(@result["picture"],
+                                  "id"          => picture.id,
+                                  "resource_id" => template.id,
+                                  "image_href"  => /^http:.*#{picture.image_href}$/)
     end
   end
 

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -100,7 +100,7 @@ module ApiSpecHelper
     @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
     collections = %w(automation_requests availability_zones chargebacks clusters conditions
-                     data_stores events features flavors groups hosts policies policy_actions
+                     data_stores events features flavors groups hosts pictures policies policy_actions
                      policy_profiles providers provision_dialogs provision_requests rates
                      reports request_tasks requests resource_pools results roles security_groups
                      servers service_dialogs service_catalogs service_requests service_templates


### PR DESCRIPTION
- Exposing pictures as primary collection /api/pictures
- Providing an href accessible equivalent of url_path as image_href

```
  GET /api/pictures
  GET /api/pictures?expand=resources&attributes=image_href
```

- Accessing pictures of service_templates via virtual attributes
```
  GET /api/service_templates/:id?attributes=picture
  GET /api/service_templates/:id?attributes=picture,picture.image_href
  GET /api/service_templates/:id?attributes=picture,picture.image_href,picture.binary_blob
```
- Added rspecs

https://trello.com/c/upq2AkEg/120-api-provide-picture-url-path-for-service-templates