### PR TITLE
Openstack infra adding filesystems and custom attributes to drift

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -100,6 +100,7 @@ class Host < ActiveRecord::Base
 
   include CustomAttributeMixin
   has_many :ems_custom_attributes, -> { where("source = 'VC'") }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  has_many :filesystems_custom_attributes, :through => :filesystems, :source => 'custom_attributes'
 
   acts_as_miq_taggable
   include ReportableMixin

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -152,8 +152,19 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
   end
 
+  def add_unique_names(file, hashes)
+    hashes.each do |x|
+      # Adding unique ID for all custom attributes of a host, otherwise drift filters out the non unique ones
+      section = x[:section] || ""
+      name    = x[:name]    || ""
+      x[:unique_name] = "#{file.name}:#{section}:#{name}"
+    end
+    hashes
+  end
+
   def save_custom_attributes(file)
     hashes = OpenstackConfigurationParser.parse(file.contents)
+    hashes = add_unique_names(file, hashes)
     EmsRefresh.save_custom_attributes_inventory(file, hashes, :scan) if hashes
   end
 end

--- a/db/migrate/20150910153517_add_full_name_to_custom_attributes.rb
+++ b/db/migrate/20150910153517_add_full_name_to_custom_attributes.rb
@@ -1,0 +1,5 @@
+class AddFullNameToCustomAttributes < ActiveRecord::Migration
+  def change
+    add_column :custom_attributes, :unique_name, :text
+  end
+end

--- a/gems/pending/openstack/openstack_configuration_parser.rb
+++ b/gems/pending/openstack/openstack_configuration_parser.rb
@@ -13,7 +13,8 @@ class OpenstackConfigurationParser
   SECTION_REGEXP                       = /^\s*\[(.+?)\]\s*/
   # Its attribute e.g. rpc_thread_pool_size=64, or starting with a #, which is just comment marking a default
   # value. Limited to snake_case words for attribute names and = as delimiter.
-  ATTRIBUTE_REGEXP                     = /^\s*[#\;]*\s*([\w]+)\s*[=]\s*(.*?)\s*$/
+  ATTRIBUTE_REGEXP                     = /^\s*([\w]+)\s*[=]\s*(.*?)\s*$/
+  COMMENTED_ATTRIBUTE_REGEXP           = /^\s*[#\;]+([\w]+)\s*[=]\s*(.*?)\s*$/
   # Anything starting with #
   COMMENTED_LINE_REGEXP                = /^\s*[#\;]+\s*(.*?)$/
   # Description is the same as commented line, but it is expected, that immediately after block of description, there
@@ -66,7 +67,7 @@ class OpenstackConfigurationParser
       if (match = line.match(SECTION_REGEXP))
         # Section in a format e.g. [DEFAULT], we save it without braces, section applies until new one is defined
         section = match[1]
-      elsif (match = line.match(ATTRIBUTE_REGEXP))
+      elsif (match = (line.match(ATTRIBUTE_REGEXP) || line.match(COMMENTED_ATTRIBUTE_REGEXP)))
         # Its attribute e.g. rpc_thread_pool_size=64, or starting with a #, which is just comment marking a default
         # value.
         # Look if we already have the attribute, cause it can be redefined multiple times, last occurrence counts and

--- a/product/compare/hosts.yaml
+++ b/product/compare/hosts.yaml
@@ -119,6 +119,29 @@ include:
     - value
     key:
     - name
+  filesystems:
+    group: Configuration
+    columns:
+    - name
+    - md5
+    - size
+    - permissions
+    - owner
+    - group
+    - mtime
+    key:
+    - name
+  filesystems_custom_attributes:
+    group: Configuration
+    columns:
+    - unique_name
+    - name
+    - section
+    - value
+    - value_interpolated
+    - source
+    key:
+    - unique_name
   categories:
     group: Categories
     columns:
@@ -178,6 +201,19 @@ col_order:
 - lans.tag
 - advanced_settings.name
 - advanced_settings.value
+- filesystems.name
+- filesystems.md5
+- filesystems.size
+- filesystems.permissions
+- filesystems.owner
+- filesystems.group
+- filesystems.mtime
+- filesystems_custom_attributes.unique_name
+- filesystems_custom_attributes.name
+- filesystems_custom_attributes.section
+- filesystems_custom_attributes.value
+- filesystems_custom_attributes.value_interpolated
+- filesystems_custom_attributes.source
 - categories.department
 - categories.customer
 - categories.environment
@@ -234,6 +270,19 @@ headers:
 - Tag
 - Key
 - Value
+- Name
+- md5
+- Size
+- Permissions
+- Owner
+- Group
+- Mtime
+- Unique Name
+- Name
+- Section
+- Value
+- Value Interpolated
+- Source
 - Department
 - Customer
 - Environment
@@ -243,13 +292,13 @@ headers:
 - Service Level
 
 # Condition(s) string for the SQL query
-conditions: 
+conditions:
 
 # Order string for the SQL query
 order:
 
 # Columns to sort the report on, in order
-sortby: 
+sortby:
 
 # Group rows (y=yes,n=no,c=count)
 group:

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -16,16 +16,18 @@ describe Host do
       :vmm_vendor         => "VMware",
       :v_total_vms        => 0,
 
-      :advanced_settings  => [],
-      :groups             => [],
-      :guest_applications => [],
-      :lans               => [],
-      :patches            => [],
-      :switches           => [],
-      :system_services    => [],
-      :tags               => [],
-      :users              => [],
-      :vms                => [],
+      :advanced_settings             => [],
+      :filesystems                   => [],
+      :filesystems_custom_attributes => [],
+      :groups                        => [],
+      :guest_applications            => [],
+      :lans                          => [],
+      :patches                       => [],
+      :switches                      => [],
+      :system_services               => [],
+      :tags                          => [],
+      :users                         => [],
+      :vms                           => [],
     }
   end
 

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_custom_attributes_parsing_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_custom_attributes_parsing_spec.rb
@@ -8,7 +8,9 @@ describe ManageIQ::Providers::Openstack::InfraManager::Host do
 [DEFAULT]
 # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-# novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
+# Verbosity of SQL debugging information: 0=None,
+# 100=Everything. (integer value) (the verbosity tests = inside comment)
+#novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
 novncproxy_base_url=http://0.0.0.0:6089/vnc_auto.html
 test=test_value
     EOT
@@ -21,7 +23,7 @@ test=test_value
 # =========Start Global Config Option for Distributed L3 Router===============
 # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-# novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
+#novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
 novncproxy_base_url=http://0.0.0.0:6089/vnc_auto.html
 test=test_value
     EOT
@@ -33,7 +35,7 @@ test=test_value
 
       # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-#         novncproxy_base_url  =http://127.0.0.1:6080/vnc_auto.html
+#novncproxy_base_url  =http://127.0.0.1:6080/vnc_auto.html
  novncproxy_base_url   =  http://0.0.0.0:6089/vnc_auto.html
 
    test=test_value
@@ -55,10 +57,10 @@ test=test_value
 [DEFAULT]
 # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-# novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
+#novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
 novncproxy_base_url=http://0.0.0.0:6089/vnc_auto.html
 novncproxy_base_url=http://0.0.0.0:6090/vnc_auto.html
-# novncproxy_base_url=http://127.0.0.1:6081/vnc_auto.html
+#novncproxy_base_url=http://127.0.0.1:6081/vnc_auto.html
 test=test_value
     EOT
   end
@@ -68,7 +70,7 @@ test=test_value
 [DEFAULT]
 # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-# novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
+#novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
 novncproxy_base_url:http://0.0.0.0:6089/vnc_auto.html
 test=test_value
     EOT
@@ -79,7 +81,7 @@ test=test_value
 [DEFAULT]
 # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-# novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
+#novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
 novncproxy_base_url=http://0.0.0.0:6089/
   vnc_auto.html
 test=test_value
@@ -103,7 +105,7 @@ test=test_value
 [DEFAULT]
 # Location of VNC console proxy, in the form
 # "http://127.0.0.1:6080/vnc_auto.html" (string value)
-# novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
+#novncproxy_base_url=http://127.0.0.1:6080/vnc_auto.html
 novncproxy_base_url=http://0.0.0.0:6089/
    #vnc_auto.html
    vnc_auto.html
@@ -117,7 +119,7 @@ test=test_value
     <<-EOT
 [DEFAULT]
 
-# instances_path=$instances_base_path/${instances_sub_path}
+#instances_path=$instances_base_path/${instances_sub_path}
 
 #
 # Options defined in nova.virt.libvirt.imagecache
@@ -131,7 +133,7 @@ image_cache_subdirectory_name = glance
 # locations (string value)
 #image_info_filename_pattern=$instances_path/${image_cache_subdirectory_name}/%(image)s.info
 #image=fedora.qcow
-# image_cache_subdirectory_name = nova
+#image_cache_subdirectory_name = nova
     EOT
   end
 
@@ -198,7 +200,10 @@ image_cache_subdirectory_name = glance
         files = [FactoryGirl.create(:filesystem_openstack_conf, :contents => filesystem_openstack_conf_nice)]
         host.refresh_custom_attributes_from_conf_files(files)
 
-        assert_custom_attribute('novncproxy_base_url', standard_nice_format)
+        assert_custom_attribute('novncproxy_base_url', standard_nice_format(
+          :description => "Location of VNC console proxy, in the form\n\"http://127.0.0.1:6080/vnc_auto.html\" (string"\
+                          " value)\nVerbosity of SQL debugging information: 0=None,\n100=Everything. (integer value)"\
+                          " (the verbosity tests = inside comment)"))
         assert_custom_attribute('test', standard_nice_test_format)
         assert_custom_attributes_count(2)
         expect(files.first.custom_attributes.count).to eq 2


### PR DESCRIPTION
Adding filesystems and their custom attributes into drift

Making possible to collection of records to have include.
So we can show custom attributes of the filesystems.