### PR TITLE
Fixed Automate Method handling

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -92,7 +92,7 @@ module MiqAeEngine
         ws.setters.each { |uri, value| workspace.varset(uri, value) } unless ws.setters.nil?
         ws.delete
       end
-      process_ruby_method_results(rc, msg, final_stderr.presence)
+      process_ruby_method_results(rc, msg, final_stderr)
     end
 
     MIQ_OK    = 0
@@ -191,7 +191,7 @@ RUBY
           stdin.puts(RUBY_METHOD_POSTSCRIPT) unless preamble.blank?
         end
       end
-      return rc, msg, final_stderr.presence
+      return rc, msg, final_stderr
     end
 
     def self.process_ruby_method_results(rc, msg, stderr)
@@ -263,7 +263,6 @@ RUBY
       threads = []
       method_pid = nil
       begin
-        require 'open4'
         status = Open4.popen4(*cmd) do |pid, stdin, stdout, stderr|
           method_pid = pid
           yield stdin if block_given?
@@ -273,7 +272,7 @@ RUBY
           end
           threads << Thread.new do
             stderr.each_line do |msg|
-              msg = msg.strip
+              msg = msg.chomp
               final_stderr << msg
               $miq_ae_logger.error "Method STDERR: #{msg}"
             end
@@ -291,7 +290,7 @@ RUBY
       ensure
         cleanup(method_pid, threads)
       end
-      return rc, msg, final_stderr
+      return rc, msg, final_stderr.presence
     end
 
     def self.cleanup(method_pid, threads)

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -181,17 +181,13 @@ RUBY
 
     def self.run_ruby_method(body, preamble = nil)
       ActiveRecord::Base.connection_pool.release_connection
-      rc = nil
-      final_stderr = []
-      msg = nil
       Bundler.with_clean_env do
-        rc, msg, final_stderr = run_method(Gem.ruby) do |stdin|
+        run_method(Gem.ruby) do |stdin|
           stdin.puts(preamble.to_s)
           stdin.puts(body)
           stdin.puts(RUBY_METHOD_POSTSCRIPT) unless preamble.blank?
         end
       end
-      return rc, msg, final_stderr
     end
 
     def self.process_ruby_method_results(rc, msg, stderr)

--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -31,7 +31,10 @@ describe "MiqAeMethodDispatch" do
           STDERR.puts "Hello from stderr channel"
           STDOUT.puts "Hello from stdout channel"
       end
-      sleep(600)
+      # Intentional Sleep, this process gets terminated by the
+      # Automate Engine, since it thinks its unresponsive
+      # look at long running method spec in this file
+      sleep(60)
     RUBY
   end
 
@@ -88,6 +91,8 @@ describe "MiqAeMethodDispatch" do
   it "long running method" do
     File.delete(@pidfile) if File.exist?(@pidfile)
     setup_model(rip_van_winkle_script)
+    # Set the timeout to 2 seconds so we can terminate
+    # unresponsive method
     send_ae_request_via_queue(@automate_args, 2)
     status, _msg, _ws = deliver_ae_request_from_queue
     expect(status).to eql 'timeout'

--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -15,7 +15,7 @@ describe "MiqAeMethodDispatch" do
                         :instance_name    => @root_instance,
                         :automate_message => 'create'}
     MiqServer.stub(:my_zone).and_return('default')
-    @pidfile        = File.join(Dir.mktmpdir(), "rip_van_winkle.pid")
+    @pidfile = File.join(Dir.mktmpdir, "rip_van_winkle.pid")
     clear_domain
   end
 
@@ -52,7 +52,7 @@ describe "MiqAeMethodDispatch" do
     dom = FactoryGirl.create(:miq_ae_domain, :enabled => true, :name => @domain)
     ns  = FactoryGirl.create(:miq_ae_namespace, :parent_id => dom.id, :name => @namespace)
     @ns_fqname = ns.fqname
-    create_method_class(:namespace => @ns_fqname, :name => @method_class, 
+    create_method_class(:namespace => @ns_fqname, :name => @method_class,
                         :method_script => method_script)
     create_root_class(:namespace => @ns_fqname, :name => @root_class)
   end
@@ -86,13 +86,13 @@ describe "MiqAeMethodDispatch" do
   end
 
   it "long running method" do
-    File.delete(@pidfile) if File.exists?(@pidfile)
+    File.delete(@pidfile) if File.exist?(@pidfile)
     setup_model(rip_van_winkle_script)
     send_ae_request_via_queue(@automate_args, 2)
-    status, _, _ = deliver_ae_request_from_queue
+    status, _msg, _ws = deliver_ae_request_from_queue
     expect(status).to eql 'timeout'
     pid = File.read(@pidfile).to_i
-    expect{Process.getpgid(pid)}.to raise_error(Errno::ESRCH)
+    expect { Process.getpgid(pid) }.to raise_error(Errno::ESRCH)
   end
 
   it "run method that writes to stderr and stdout" do

--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+include AutomationSpecHelper
+
+describe "MiqAeMethodDispatch" do
+  before do
+    @method_name     = 'MY_METHOD'
+    @method_instance = 'MY_METHOD_INSTANCE'
+    @method_class    = 'MY_METHOD_CLASS'
+    @domain          = 'SPEC_DOMAIN'
+    @namespace       = 'NS1'
+    @root_class      = "TOP_OF_THE_WORLD"
+    @root_instance   = "EVEREST"
+    @automate_args   = {:namespace        => @namespace,
+                        :class_name       => @root_class,
+                        :instance_name    => @root_instance,
+                        :automate_message => 'create'}
+    MiqServer.stub(:my_zone).and_return('default')
+    @pidfile        = File.join(Dir.mktmpdir(), "rip_van_winkle.pid")
+    clear_domain
+  end
+
+  def clear_domain
+    MiqAeDomain.find_by_name(@domain).try(:destroy)
+  end
+
+  def rip_van_winkle_script
+    <<-'RUBY'
+      pidfile    = $evm.inputs['pidfile']
+      File.open(pidfile, 'w') { |file| file.write(Process.pid.to_s) }
+      10.times do
+          STDERR.puts "Hello from stderr channel"
+          STDOUT.puts "Hello from stdout channel"
+      end
+      sleep(600)
+    RUBY
+  end
+
+  def std_script
+    <<-'RUBY'
+      pidfile    = $evm.inputs['pidfile']
+      File.open(pidfile, 'w') { |file| file.write(Process.pid.to_s) }
+      $evm.root['method_pid'] = Process.pid
+      10.times do
+          STDERR.puts "Hello from stderr channel"
+          STDOUT.puts "Hello from stdout channel"
+      end
+      exit(MIQ_OK)
+    RUBY
+  end
+
+  def setup_model(method_script)
+    dom = FactoryGirl.create(:miq_ae_domain, :enabled => true, :name => @domain)
+    ns  = FactoryGirl.create(:miq_ae_namespace, :parent_id => dom.id, :name => @namespace)
+    @ns_fqname = ns.fqname
+    create_method_class(:namespace => @ns_fqname, :name => @method_class, 
+                        :method_script => method_script)
+    create_root_class(:namespace => @ns_fqname, :name => @root_class)
+  end
+
+  def create_method_class(attrs = {})
+    params = {'pidfile' => {'aetype'        => 'attribute',
+                            'datatype'      => 'string',
+                            'default_value' => @pidfile}
+             }
+    method_script = attrs.delete(:method_script)
+    ae_fields = {'execute' => {:aetype => 'method', :datatype => 'string'}}
+    ae_instances = {@method_instance => {'execute' => {:value => @method_name}}}
+    ae_methods = {@method_name => {:scope => 'instance', :location => 'inline',
+                                   :data => method_script,
+                                   :language => 'ruby', 'params' => params}}
+
+    FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_instances' => ae_instances,
+                                   'ae_methods'   => ae_methods))
+  end
+
+  def create_root_class(attrs = {})
+    ae_fields = {'rel1' => {:aetype => 'relationship', :datatype => 'string'}}
+    fqname = "/#{@domain}/#{@namespace}/#{@method_class}/#{@method_instance}"
+    ae_instances = {@root_instance => {'rel1' => {:value => fqname}}}
+    FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_methods'   => {},
+                                   'ae_instances' => ae_instances))
+  end
+
+  it "long running method" do
+    File.delete(@pidfile) if File.exists?(@pidfile)
+    setup_model(rip_van_winkle_script)
+    send_ae_request_via_queue(@automate_args, 2)
+    status, _, _ = deliver_ae_request_from_queue
+    expect(status).to eql 'timeout'
+    pid = File.read(@pidfile).to_i
+    expect{Process.getpgid(pid)}.to raise_error(Errno::ESRCH)
+  end
+
+  it "run method that writes to stderr and stdout" do
+    setup_model(std_script)
+    send_ae_request_via_queue(@automate_args)
+    _, _, ws = deliver_ae_request_from_queue
+    pid = File.read(@pidfile).to_i
+    expect(ws.root['method_pid']).to eql pid
+  end
+end

--- a/spec/support/automation_spec_helper.rb
+++ b/spec/support/automation_spec_helper.rb
@@ -57,11 +57,13 @@ module AutomationSpecHelper
       :instance_name => 'instance1')
   end
 
-  def send_ae_request_via_queue(args)
-    MiqQueue.put(:role        => 'automate',
+  def send_ae_request_via_queue(args, timeout = nil)
+    queue_args = {:role       => 'automate',
                  :class_name  => 'MiqAeEngine',
                  :method_name => 'deliver',
-                 :args        => [args])
+                 :args        => [args]}
+    queue_args.merge!(:msg_timeout => timeout) if timeout
+    MiqQueue.put(queue_args)
   end
 
   def deliver_ae_request_from_queue

--- a/spec/support/automation_spec_helper.rb
+++ b/spec/support/automation_spec_helper.rb
@@ -58,10 +58,10 @@ module AutomationSpecHelper
   end
 
   def send_ae_request_via_queue(args, timeout = nil)
-    queue_args = {:role       => 'automate',
-                 :class_name  => 'MiqAeEngine',
-                 :method_name => 'deliver',
-                 :args        => [args]}
+    queue_args = {:role        => 'automate',
+                  :class_name  => 'MiqAeEngine',
+                  :method_name => 'deliver',
+                  :args        => [args]}
     queue_args.merge!(:msg_timeout => timeout) if timeout
     MiqQueue.put(queue_args)
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1258648

Addressed the following issues
(1) Flush stderr and stdout in separate threads, prior to this it would
    cause deadlock if the stderr was not drained.
(2) Ensure block makes sure that the Automate method is terminated
    if it doesn't respond by the :msg_timeout specified in the queue.
    This used to leave orphaned processes.
(3) Terminate the stdout and stderr reading threads in the ensure block.

Added a spec with automate method that writes to stdout/stderr and sleeps
waiting to be terminated.