### PR TITLE
Force color to be required before azure-armrest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,12 @@ gem "sass-rails"
 # Vendored and required
 gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-2"
 
+# HACK: Force color to be required before azure-armrest. color is lazy required
+#   by ruport.  However, due to a bug in color, it detects the top level
+#   constant "Azure" and fails.
+#   See https://github.com/halostatue/color/pull/24
+gem "color"
+
 # Vendored but not required
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-7"


### PR DESCRIPTION
color is lazy required by ruport. However, due to a bug in color, it
detects the top level constant "Azure" and fails.

See https://github.com/halostatue/color/pull/24

Fixes #4269 

@matthewd Please review.