### PR TITLE
Don't use rails runner to launch scripts, require config/environment

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -19,10 +19,7 @@ class EvmApplication
     _log.info("EVM Startup initiated")
 
     MiqServer.kill_all_workers
-    rr      = File.expand_path(Rails.root)
-    runner  = File.join(rr, "bin/rails runner")
-    program = File.join(rr, "lib/workers/bin/evm_server.rb")
-    command_line = "#{runner} #{program}"
+    command_line = "#{Gem.ruby} #{Rails.root.join(*%w(lib workers bin evm_server.rb)).expand_path}"
 
     env_options = {}
     env_options["EVMSERVER"] = "true" if MiqEnvironment::Command.is_appliance?

--- a/lib/workers/bin/evm_server.rb
+++ b/lib/workers/bin/evm_server.rb
@@ -1,7 +1,4 @@
-if defined?(Vmdb::Application) && Vmdb::Application.initialized?
-  require "workers/evm_server"
-  EvmServer.start(*ARGV)
-else
-  puts "run with rails runner evm_server.rb"
-  exit 1
-end
+require File.expand_path("../../../config/environment", __dir__)
+require "workers/evm_server"
+
+EvmServer.start(*ARGV)


### PR DESCRIPTION
~~This will require a bit more work to get the workers to launch properly and to ensure the `MiqEnvironment::Process.is_*?` methods can understand workers and the server no longer launching via rails runner.~~ 

Update:  MiqEnvironment::Process is gone :tada: , see #3593 

The primary use cases for rails runner are for
* quick in-line ruby evaluation such as `rails runner 'puts User.first.name'`
* shebang line at the top of executables

While it supports passing the path to a ruby script, it leads to weird
errors if the file is not found for any reason:

`$ bin/rails r "/home/joe/run.rb"`
  => `unknown regexp option - j (SyntaxError)`

`$ bin/rails r "joe/run.rb"`
  => `undefined local variable or method `joe' for main:Object (NameError)`

Since this is NOT the typical use case for rails runner, it's safer to
use ruby to load our launcher and require config/environment in the
launcher.

A nice side effect is $PROGRAM_NAME can be reliably used to detect what
type of worker the current process is:
`manageiq/lib/workers/bin/evm_server.rb`