### PR TITLE
Use restful methods to get the summary links instead of URL mangling with Addressable::URI

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -53,7 +53,7 @@ module EmsCloudHelper::TextualSummary
     num   = @ems.number_of(:vms)
     h     = {:label => label, :image => "vm", :value => num}
     if num > 0 && role_allows(:feature => "vm_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @ems, :display => 'instances')
+      h[:link]  = ems_cloud_path(@ems.id, :display => 'instances')
       h[:title] = "Show all #{label}"
     end
     h
@@ -64,7 +64,7 @@ module EmsCloudHelper::TextualSummary
     num = @ems.number_of(:miq_templates)
     h = {:label => label, :image => "vm", :value => num}
     if num > 0 && role_allows(:feature => "miq_template_show_list")
-      h[:link]  = url_for(:action => 'show', :id => @ems, :display => 'images')
+      h[:link] = ems_cloud_path(@ems.id, :display => 'images')
       h[:title] = "Show all #{label}"
     end
     h

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -14,12 +14,6 @@ module TextualSummaryHelper
       summary
     when Symbol
       result = send("textual_#{summary}")
-      if result.kind_of?(Hash) && result[:link] && controller.send(:restful?)
-        restful_path = controller.send("#{controller_name}_path")
-        url = Addressable::URI.parse(restful_path)
-        url.query_values = (url.query_values || {}).merge(:display => summary)
-        result[:link] = url.to_s
-      end
       return result if result.kind_of?(Hash) && result[:label]
 
       automatic_label = context.class.human_attribute_name(summary, :default => summary.to_s.titleize)
@@ -117,14 +111,14 @@ module TextualSummaryHelper
         h[:link] = link
       elsif collection.respond_to?(:proxy_association)
         if controller.send(:restful?)
-          restful_path = controller.send("#{controller_name}_path")
-          url = Addressable::URI.parse(restful_path)
-          url.query_values = (url.query_values || {}).merge(:display => collection.proxy_association.reflection.name)
-          h[:link] = url.to_s
+          h[:link] = send("#{controller_name}_path",
+                          collection.proxy_association.owner,
+                          :display => collection.proxy_association.reflection.name)
         else
-          h[:link] = url_for(:action  => 'show',
-                             :id      => collection.proxy_association.owner,
-                             :display => collection.proxy_association.reflection.name)
+          h[:link] = url_for(:controller => controller_name,
+                             :action     => 'show',
+                             :id         => collection.proxy_association.owner,
+                             :display    => collection.proxy_association.reflection.name)
         end
       else
         h[:link] = url_for(:controller => controller_collection,

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe EmsCloudHelper do
+  before do
+    controller.send(:extend, EmsCloudHelper)
+    self.class.send(:include, EmsCloudHelper)
+  end
+
+  context "textual_instances" do
+    def role_allows(_)
+      true
+    end
+
+    it "sets restful path for instances in summary for restful controllers" do
+      controller.stub(:restful?).and_return(true)
+      controller.stub(:controller_name).and_return("ems_cloud")
+      Zone.first || FactoryGirl.create(:zone)
+      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
+      FactoryGirl.create(:vm_openstack)
+      @ems = ManageIQ::Providers::Openstack::CloudManager.first
+      vms = ManageIQ::Providers::Openstack::CloudManager::Vm.first
+      vms.update_attributes(:ems_id => @ems.id)
+      result = textual_instances
+      expect(result[:link]).to eq("/ems_cloud/#{@ems.id}?display=instances")
+    end
+  end
+
+  context "textual_images" do
+    def role_allows(_)
+      true
+    end
+
+    it "sets restful path for images in summary for restful controllers" do
+      controller.stub(:restful?).and_return(true)
+      controller.stub(:controller_name).and_return("ems_cloud")
+      Zone.first || FactoryGirl.create(:zone)
+      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
+      FactoryGirl.create(:template_cloud)
+      @ems = ManageIQ::Providers::Openstack::CloudManager.first
+      template = MiqTemplate.first
+      template.update_attributes(:ems_id => @ems.id)
+      result = textual_images
+      expect(result[:link]).to eq("/ems_cloud/#{@ems.id}?display=images")
+    end
+  end
+end

--- a/spec/helpers/textual_summary_helper_spec.rb
+++ b/spec/helpers/textual_summary_helper_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe TextualSummaryHelper do
+  before do
+    controller.send(:extend, TextualSummaryHelper)
+    self.class.send(:include, TextualSummaryHelper)
+  end
+
+  context "textual_collection_link" do
+    def role_allows(_)
+      true
+    end
+
+    it "uses the restful path to retrieve the summary screen link for a restful controller" do
+      controller.stub(:restful?).and_return(true)
+      controller.stub(:controller_name).and_return("ems_cloud")
+      Zone.first || FactoryGirl.create(:zone)
+      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
+      FactoryGirl.create(:availability_zone_openstack)
+      ems = ManageIQ::Providers::Openstack::CloudManager.first
+      az = AvailabilityZone.first
+      az.update_attributes(:ems_id => ems.id)
+      result = textual_collection_link(ems.availability_zones)
+      expect(result[:link]).to eq("/ems_cloud/#{ems.id}?display=availability_zones")
+    end
+
+    it "uses the controller-action-id path to retrieve the summary screen link for a non-restful controller" do
+      controller.stub(:restful?).and_return(false)
+      controller.stub(:controller_name).and_return("ems_infra")
+      Zone.first || FactoryGirl.create(:zone)
+      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
+      FactoryGirl.create(:availability_zone_openstack)
+      ems = ManageIQ::Providers::Openstack::CloudManager.first
+      az = AvailabilityZone.first
+      az.update_attributes(:ems_id => ems.id)
+      result = textual_collection_link(ems.availability_zones)
+      expect(result[:link]).to eq("/ems_infra/show/#{ems.id}?display=availability_zones")
+    end
+  end
+end


### PR DESCRIPTION
This is a follow-up PR for https://github.com/ManageIQ/manageiq/pull/4189
Also a follow-up action on the discussion <a href=https://gitter.im/ManageIQ/manageiq/ui?at=55f0998f24362d5253fe7711>here</a>