### PR TITLE
Support Azure power ops

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -46,4 +46,27 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
     true
   end
+
+  # Operations
+
+  def vm_start(vm, _options = {})
+    vm.provider_service.start(vm.name, vm.resource_group)
+    vm.update_attributes!(:raw_power_state => "VM starting")
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
+  def vm_stop(vm, _options = {})
+    vm.provider_service.stop(vm.name, vm.resource_group)
+    vm.update_attributes!(:raw_power_state => "VM stopping")
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
+  def vm_restart(vm, _options = {})
+    vm.provider_service.restart(vm.name, vm.resource_group)
+    vm.update_attributes!(:raw_power_state => "VM starting")
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
+  include_concern 'Power'
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -1,0 +1,9 @@
+module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
+  def validate_suspend
+    validate_unsupported("Suspend Operation")
+  end
+
+  def validate_pause
+    validate_unsupported("Pause Operation")
+  end
+end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -32,6 +32,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   VENDOR_TYPES = {
     # DB            Displayed
+    "azure"     => "Azure",
     "vmware"    => "VMware",
     "microsoft" => "Microsoft",
     "xen"       => "XenSource",

--- a/spec/factories/vm_azure.rb
+++ b/spec/factories/vm_azure.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :vm_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Vm", :parent => :vm_cloud do
+    location "westus"
+    vendor   "azure"
+    raw_power_state "VM running"
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ManageIQ::Providers::Azure::CloudManager::Vm do
+  context "#is_available?" do
+    let(:ems) { FactoryGirl.create(:ems_azure) }
+    let(:host) { FactoryGirl.create(:host, :ext_management_system => ems) }
+    let(:vm) { FactoryGirl.create(:vm_azure, :ext_management_system => ems, :host => host) }
+
+    let(:power_state_on)  { "VM running" }
+    let(:power_state_off) { "VM stopped" }
+    let(:power_state_suspended) { "VM stopping" }
+
+    context("with :start") do
+      let(:state) { :start }
+      include_examples "Vm operation is available when not powered on"
+    end
+
+    context("with :stop") do
+      let(:state) { :stop }
+      include_examples "Vm operation is available when powered on"
+    end
+  end
+end


### PR DESCRIPTION
This adds power operations to the UI for the Azure cloud provider. I've also added some basic specs and a factory. I did have to update the app/models/vm_or_template.rb file to support azure as a vendor type, too.