### PR TITLE
containers: remove extra relationship in container

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -5,7 +5,6 @@ class Container < ActiveRecord::Base
   has_one    :container_group, :through => :container_definition
   has_one    :ext_management_system, :through => :container_group
   has_one    :container_node, :through => :container_group
-  delegate   :ext_management_system, :to => :container_group
   has_one    :container_replicator, :through => :container_group
   has_one    :container_project, :through => :container_group
   belongs_to :container_definition


### PR DESCRIPTION
The extra relationship (implemented using delegate) has been mistakenly introduced in #3329 probably with a wrong rebase on #3889.

cc @zakiva 