### PR TITLE
containers: projects are not openshift specific

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -7,8 +7,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
 
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
-  has_many :container_routes,                      :foreign_key => :ems_id, :dependent => :destroy
-  has_many :container_projects,                    :foreign_key => :ems_id, :dependent => :destroy
+  has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
 
   DEFAULT_PORT = 8443
   default_value_for :port, DEFAULT_PORT


### PR DESCRIPTION
In #3340 the container_projects relationship has been added to the container manager mixin making the openshift one redundant. This patch removes the superfuous definition.
