### PR TITLE
Tenant scoping on vms

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -36,6 +36,8 @@ class MiqGroup < ActiveRecord::Base
 
   FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
 
+  alias_method :current_tenant, :tenant
+
   def name
     self.description
   end

--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -1,0 +1,9 @@
+module TenancyMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def scope_by_tenant?
+      true
+    end
+  end
+end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -248,20 +248,8 @@ module Rbac
     end
   end
 
-  def self.group(user_or_group)
-    case user_or_group
-    when User
-      user_or_group.current_group
-    when MiqGroup
-      user_or_group
-    when NilClass
-    else
-      raise
-    end
-  end
-
   def self.find_options_for_tenant(klass, user_or_group, find_options = {})
-    tenant_id = group(user_or_group).try(:tenant_id)
+    tenant_id = user_or_group.try(:current_tenant, :id)
     return find_options unless tenant_id
 
     tenant_id_clause = {klass.table_name => {:tenant_id => [tenant_id, nil]}}

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -264,16 +264,14 @@ module Rbac
     tenant_id = group(user_or_group).try(:tenant_id)
     return find_options unless tenant_id
 
-    tenant_id_clause = ["#{klass.table_name}.tenant_id = ? OR #{klass.table_name}.tenant_id IS NULL", tenant_id]
+    tenant_id_clause = {klass.table_name => {:tenant_id => [tenant_id, nil]}}
     find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], tenant_id_clause)
     find_options
   end
 
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)
-    if klass.scope_by_tenant?
-      # TODO: check if these find_options should be duplicated/modified in place
-      find_options = find_options_for_tenant(klass, user_or_group, find_options)
-    end
+    # TODO: check if these find_options should be duplicated/modified in place
+    find_options = find_options_for_tenant(klass, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
 
     return find_targets_with_direct_rbac(klass, scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
     return find_targets_with_indirect_rbac(klass, scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,8 @@ class User < ActiveRecord::Base
 
   virtual_has_many :active_vms, :class_name => "VmOrTemplate"
 
-  delegate   :miq_user_role, :to => :current_group, :allow_nil => true
+  delegate   :miq_user_role,  :to => :current_group, :allow_nil => true
+  delegate   :current_tenant, :to => :current_group, :allow_nil => true
 
   validates_presence_of   :name, :userid, :region
   validates_uniqueness_of :userid, :scope => :region

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -27,6 +27,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   include EventMixin
   include ProcessTasksMixin
+  include TenancyMixin
 
   has_many :ems_custom_attributes, -> { where "source = 'VC'" }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -17,6 +17,56 @@ describe Rbac do
     @user  = FactoryGirl.create(:user, :miq_groups => [@group])
   end
 
+  context "tenant scoping" do
+    before do
+      default_tenant = Tenant.seed
+
+      @owner_tenant  = FactoryGirl.create(:tenant, :divisible => false, :parent => default_tenant)
+      @owner_group   = FactoryGirl.create(:miq_group, :tenant => @owner_tenant)
+      @owner_user    = FactoryGirl.create(:user, :userid => 'foo', :miq_groups => [@owner_group])
+
+      @other_tenant  = FactoryGirl.create(:tenant, :divisible => false, :parent => default_tenant)
+      @other_group   = FactoryGirl.create(:miq_group, :tenant => @other_tenant)
+      @other_user    = FactoryGirl.create(:user, :userid => 'bar', :miq_groups => [@other_group])
+
+      @owner_vm      = FactoryGirl.create(:vm_vmware, :tenant => @owner_tenant)
+    end
+
+    it ".search with :userid, finds user's tenant vms" do
+      results, = Rbac.search(:class => "Vm", :results_format => :objects, :userid => @owner_user.userid)
+      expect(results).to eq [@owner_vm]
+    end
+
+    it ".search with :userid filters out other tenants" do
+      results, = Rbac.search(:class => "Vm", :results_format => :objects, :userid => @other_user.userid)
+      expect(results).to eq []
+    end
+
+    it ".search with User.with_userid finds user's tenant vms" do
+      User.with_userid(@owner_user.userid) do
+        results, = Rbac.search(:class => "Vm", :results_format => :objects)
+        expect(results).to eq [@owner_vm]
+      end
+    end
+
+    it ".search with User.with_userid filters out other tenants" do
+      User.with_userid(@other_user.userid) do
+        results, = Rbac.search(:class => "Vm", :results_format => :objects)
+        expect(results).to eq []
+      end
+    end
+
+    it ".search with :miq_group_id, finds user's tenant vms" do
+      results, = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
+      expect(results).to eq [@owner_vm]
+    end
+
+    it ".search with :miq_group_id filters out other tenants" do
+      results, = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @other_group.id)
+      expect(results).to eq []
+    end
+  end
+
   context "with Hosts" do
     before(:each) do
       @host1 = FactoryGirl.create(:host, :name => "Host1", :hostname => "host1.local")

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -65,6 +65,24 @@ describe Rbac do
       results, = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @other_group.id)
       expect(results).to eq []
     end
+
+    it ".search with User.with_userid leaving tenant" do
+      User.with_userid(@owner_user.userid) do
+        @owner_user.miq_groups = [@other_group]
+        @owner_user.save
+        results, = Rbac.search(:class => "Vm", :results_format => :objects)
+        expect(results).to eq []
+      end
+    end
+
+    it ".search with User.with_userid joining tenant" do
+      User.with_userid(@other_user.userid) do
+        @other_user.miq_groups = [@owner_group]
+        @other_user.save
+        results, = Rbac.search(:class => "Vm", :results_format => :objects)
+        expect(results).to eq [@owner_vm]
+      end
+    end
   end
 
   context "with Hosts" do


### PR DESCRIPTION
* Include tenancy mixin to provide the `scope_by_tenant?` for VmOrTemplate
* Scope Rbac.search by tenant only if the class `respond_to?(:scope_by_tenant?)`
* Add current_tenant to user/group through MiqGroup#tenant. 

Returns vms without a tenant and ones in my tenant.
If there is no tenant, no filtering by tenant is done.

https://trello.com/c/1uf5urJz/

@gtanzillo @Fryguy @kbrock Please review, throw :tomato: 