### PR TITLE
VixDiskLib: Use a well-known IO to pass the URI

### DIFF
--- a/gems/pending/VixDiskLib/VixDiskLib.rb
+++ b/gems/pending/VixDiskLib/VixDiskLib.rb
@@ -107,31 +107,22 @@ class VixDiskLib
     #
     my_env = setup_env
     reader, writer = IO.pipe
-    writerfd = writer.fileno
-    my_env["WRITER_FD"] = writerfd.to_s
-
-    # Ruby 2.0+ automatically closes all descriptors except 0, 1, 2 (input/output/error)
-    # in child processes.  We need the child process (the server) to write it's DRb URI to
-    # the writer descriptor so the client can read it.  Set close_on_exec to false
-    # in the writer descriptor so it doesn't get closed on us.
-    # See: https://bugs.ruby-lang.org/issues/5041
-    writer.close_on_exec = false
 
     server_cmd = "ruby #{SERVER_PATH}/VixDiskLibServer.rb"
     $vim_log.info "VixDiskLib.start_service: running command = #{server_cmd}"
     pid = Kernel.spawn(my_env, server_cmd,
                        [:out, :err]     => [LOG_FILE, "a"],
-                       :unsetenv_others => true,
-                       :close_others    => false,
-                       reader           => :close)
+                       3                => writer,
+                       :unsetenv_others => true)
     writer.close
+    uri = get_uri(reader)
     Process.detach(pid)
     $vim_log.info "VixDiskLibServer Process #{pid} started" if $vim_log
     DRb.start_service
     retry_num = 5
     begin
       sleep 1
-      vix_disk_lib_service = DRbObject.new(nil, get_uri(reader))
+      vix_disk_lib_service = DRbObject.new(nil, uri)
     rescue DRb::DRbConnError => e
       raise VixDiskLibError, "ERROR: VixDiskLib.connect() got #{e} on DRbObject.new_with_uri()" if retry_num == 0
       retry_num -= 1 && retry
@@ -140,16 +131,10 @@ class VixDiskLib
   end
 
   def self.get_uri(reader)
-    if reader.eof
-      #
-      # Error - unable to read the port number written into the pipe by the child (Server).
-      #
-      raise VixDiskLibError, "ERROR: VixDiskLib.connect() Unable to determine port used by VixDiskLib Server."
+    reader.read.tap do |uri|
+      if uri.blank?
+        raise VixDiskLibError, "ERROR: VixDiskLib.connect() Unable to determine port used by VixDiskLib Server."
+      end
     end
-    uri_selected = reader.gets.split("URI:")
-    if uri_selected.length != 2
-      raise VixDiskLibError, "ERROR: VixDiskLib.connect() Unable to determine port used by VixDiskLib Server."
-    end
-    uri_selected[1].chomp
   end
 end

--- a/gems/pending/VixDiskLib/VixDiskLibServer.rb
+++ b/gems/pending/VixDiskLib/VixDiskLibServer.rb
@@ -30,12 +30,6 @@ class VDDKFactory
     @running = nil
   end
 
-  def writer_to_caller
-    writer_fd = ENV['WRITER_FD']
-    writer = IO.new(writer_fd.to_i)
-    writer
-  end
-
   def init
     VdlWrapper.init
     @started = true
@@ -113,9 +107,9 @@ begin
   #
   # Now write the URI used back to the parent (client) process to let it know which port was selected.
   #
-  writer = vddk.writer_to_caller
-  writer.puts "URI:#{uri_used}"
-  writer.flush
+  IO.open(3, 'w') do |io|
+    io.write uri_used
+  end
   #
   # Trap Handlers useful for testing and debugging.
   #


### PR DESCRIPTION
As we can be more confident it's the right thing now, we can lose the 'URI:' prefix.

In passing, also fix retries: previously, we would've attempted to re-read the URI upon retry, when it had already been consumed. That clearly wasn't going to work.

---

@jerryk55 this is entirely untested, mostly because I wouldn't know where to start. Feel free to use/ignore as you see fit...

If it were just some existing isolated code I may not have bothered, but as it sounds like we're about to replicate the pattern, it seemed worth a mention. (Also, I really don't see how that retry could possibly work.)