### PR TITLE
Corrects problem calling show_link with bad value

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -37,7 +37,7 @@ module EmsCommon
       @timeline = @timeline_filter = true
       @lastaction = "show_timeline"
       tl_build_timeline                       # Create the timeline report
-      drop_breadcrumb(:name => "Timelines", :url => show_link(@record.id, :refresh => "n", :display => "timeline"))
+      drop_breadcrumb(:name => "Timelines", :url => show_link(@record, :refresh => "n", :display => "timeline"))
     elsif ["instances","images","miq_templates","vms"].include?(@display) || session[:display] == "vms" && params[:display].nil?
       if @display == "instances"
         title = "Instances"

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -151,4 +151,25 @@ describe EmsInfraController do
         _("Provider is not ready to be scaled, another operation is in progress."))
     end
   end
+
+  describe "#show" do
+    before(:each) do
+      session[:settings] = {:views => {}}
+      set_user_privileges
+      get :show, {:id => ems.id}.merge(url_params)
+    end
+    let(:url_params) { {} }
+    let(:ems) do
+      FactoryGirl.create(:ems_infra)
+    end
+    subject do
+      response.status
+    end
+    it { should eq 200 }
+
+    context "display=timeline" do
+      let(:url_params) { {:display => 'timeline'} }
+      it { should eq 200 }
+    end
+  end
 end


### PR DESCRIPTION
show_link method assumes its first parameter to be ActiveRecord instance
- it calls .id on it.
When show_link method was introduced in
52458a65fa9368b9fdc30a170e5a3fca4c460543
@record.id was used as it was used to generate url for link before.
This patch corrects that. Without it MIQ generates error when user is
trying to view page like /ems_infra/show/1?display=timeline