### PR TITLE
Populate resource_to_stack hash when collecting stack resources

### DIFF
--- a/app/models/manageiq/providers/openstack/refresh_parser_common/orchestration_stacks.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/orchestration_stacks.rb
@@ -163,6 +163,7 @@ module ManageIQ::Providers
 
           raw_resources.collect do |resource|
             physical_id = resource.physical_resource_id
+            @resource_to_stack[physical_id] = stack.id
             @data_index.fetch_path(:orchestration_stack_resources, physical_id)
           end
         end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1262461

The fix is to restore one line that was accidentally deleted by commit d12268585c1097b