### PR TITLE
remove unnecessary return for with_a_timezone

### DIFF
--- a/app/models/mixins/timezone_mixin.rb
+++ b/app/models/mixins/timezone_mixin.rb
@@ -2,19 +2,18 @@ module TimezoneMixin
   extend ActiveSupport::Concern
 
   def with_a_timezone(timezone)
-    curr_tz = Time.zone # Save current time zone setting
-    Time.zone = timezone
-
-    result = yield
-
-    Time.zone = curr_tz # Restore current time zone setting
-
-    return result
+    curr_tz = Time.zone
+    begin
+      Time.zone = timezone
+      yield
+    ensure
+      Time.zone = curr_tz
+    end
   end
 
   def with_current_user_timezone
     timezone = User.current_user.try(:get_timezone) || self.class.server_timezone
-    self.with_a_timezone(timezone) { yield }
+    with_a_timezone(timezone) { yield }
   end
 
   module ClassMethods


### PR DESCRIPTION
NOTE: there are already specs for testing the return value

`yield` already does the right thing.

@matthewd thoughts?