### PR TITLE
Fix for double render error while cloning a VM or a template

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -493,6 +493,7 @@ module EmsCommon
         powerbutton_hosts(params[:pressed].split("_")[1..-1].join("_")) # Handle specific power button
       else
         process_vm_buttons(pfx)
+        return if @flash_array
         # Control transferred to another screen, so return
         return if ["host_tag", "#{pfx}_policy_sim", "host_scan", "host_refresh","host_protect",
                     "host_compare","#{pfx}_compare", "#{pfx}_tag","#{pfx}_retire",

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -158,3 +158,38 @@ describe EmsContainerController do
     end
   end
 end
+
+describe EmsInfraController do
+  context "button pressed='miq_template_clone'" do
+    describe "#button" do
+      before do
+        EvmSpecHelper.seed_specific_product_features("ems_infra_new")
+        feature = MiqProductFeature.find_all_by_identifier(["ems_infra_new"])
+        test_user_role = FactoryGirl.create(:miq_user_role,
+                                            :name                 => "test_user_role",
+                                            :miq_product_features => feature)
+        test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
+        user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+
+        allow(user).to receive(:server_timezone).and_return("UTC")
+        described_class.any_instance.stub(:set_user_time_zone)
+        controller.stub(:check_privileges).and_return(true)
+        controller.stub(:assert_privileges).and_return(true)
+        login_as user
+      end
+
+      it "correctly sets flash message when template cannot be cloned" do
+        ems_infra = FactoryGirl.create(:ext_management_system)
+        template = FactoryGirl.create(:template_vmware)
+        VmOrTemplate.stub(:cloneable?).and_return(false)
+        post :button,
+             :id              => ems_infra.id,
+             :pressed         => "miq_template_clone",
+             :miq_grid_checks => ActiveRecord::Base.compress_id(template.id)
+        flash_array = controller.instance_variable_get(:@flash_array)
+        expect(flash_array.first[:message]).to include("Clone does not apply to at least one of the selected items")
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the selected VM or Template cannot be cloned, return after the flash message is rendered to avoid a double render error.

https://bugzilla.redhat.com/show_bug.cgi?id=1258408