### PR TITLE
Fixed code to show "Add Project to Tenant" button.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1306,14 +1306,6 @@ class ApplicationController < ActionController::Base
     task == "custom_button" && CustomButton.find_by_id(from_cid(button_id))
   end
 
-  def rbac_common_feature_for_buttons(pressed)
-    # return feature that should be checked for the button that came in
-    case pressed
-    when "rbac_project_add", "rbac_tenant_add"
-      "rbac_tenant_add"
-    end
-  end
-
   def check_button_rbac
     # buttons ids that share a common feature id
     common_buttons = %w(rbac_project_add rbac_tenant_add)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1392,4 +1392,12 @@ module ApplicationHelper
   def appliance_name
     MiqServer.my_server.name
   end
+
+  def rbac_common_feature_for_buttons(pressed)
+    # return feature that should be checked for the button that came in
+    case pressed
+    when "rbac_project_add", "rbac_tenant_add"
+      "rbac_tenant_add"
+    end
+  end
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::ToolbarBuilder
 
   delegate :request, :current_user, :to => :@view_context
 
-  delegate :get_vmdb_config, :role_allows, :model_for_vm, :to => :@view_context
+  delegate :get_vmdb_config, :role_allows, :model_for_vm, :rbac_common_feature_for_buttons, :to => :@view_context
   delegate :x_tree_history, :x_node, :x_active_tree, :to => :@view_context
   delegate :is_browser?, :is_browser_os?, :to => :@view_context
 
@@ -384,8 +384,10 @@ class ApplicationHelper::ToolbarBuilder
             return true
         end
       when :rbac_tree
-        return true unless role_allows(:feature => id)
-        return true if %w(rbac_project_add rbac_tenant_add).include?(id) && @record.project?
+        common_buttons = %w(rbac_project_add rbac_tenant_add)
+        feature = common_buttons.include?(id) ? rbac_common_feature_for_buttons(id) : id
+        return true unless role_allows(:feature => feature)
+        return true if common_buttons.include?(id) && @record.project?
         return false
       when :vmdb_tree
         return ["db_connections","db_details","db_indexes","db_settings"].include?(@sb[:active_tab]) ? false : true

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2577,10 +2577,13 @@ describe ApplicationHelper do
     subject { build_toolbar_hide_button_ops(@id) }
     before do
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred')
-      @record = double("record")
+      @record = FactoryGirl.create(:tenant)
       login_as @user
-      EvmSpecHelper.seed_specific_product_features("ops_rbac", "rbac_group_add", "rbac_tenant_delete")
-      feature = MiqProductFeature.find_all_by_identifier(%w(ops_rbac rbac_group_add rbac_tenant_delete))
+      EvmSpecHelper.seed_specific_product_features("ops_rbac",
+                                                   "rbac_group_add",
+                                                   "rbac_tenant_add",
+                                                   "rbac_tenant_delete")
+      feature = MiqProductFeature.find_all_by_identifier(%w(ops_rbac rbac_group_add rbac_tenant_add rbac_tenant_delete))
       test_user_role = FactoryGirl.create(:miq_user_role,
                                           :name                 => "test_user_role",
                                           :miq_product_features => feature)
@@ -2589,7 +2592,7 @@ describe ApplicationHelper do
       @sb = {:active_tree => :rbac_tree}
     end
 
-    %w(rbac_group_add rbac_tenant_delete).each do |id|
+    %w(rbac_group_add rbac_project_add rbac_tenant_add rbac_tenant_delete).each do |id|
       context "when with #{id} button should be visible" do
         before { @id = id }
         it "and record_id" do


### PR DESCRIPTION
- This issue was introduced when all the Access control features were exposed, previously role_allows call used ot return true for all hidden features. Add Tenants & Add Projects both buttons check against a same product feature, so have to check for the common feature id in role_allows call. Moved existing method "rbac_common_feature_for_buttons" to application_helper so that can be used from controller as well as for toolbar building code.
- Added spec test to check visibility of Add Tenant & Project buttons.

@dclarizio please review/test. This was caused by changes in https://github.com/ManageIQ/manageiq/pull/4120

before:
![add_project_button_missing](https://cloud.githubusercontent.com/assets/3450808/9826787/bc90ddd6-58aa-11e5-971e-ad2783d2560b.png)


after:
![add_project_button_displayed](https://cloud.githubusercontent.com/assets/3450808/9826784/b908a496-58aa-11e5-9436-0af36ab1d253.png)
