### PR TITLE
appliance_console_cli help if no arguments available

### DIFF
--- a/gems/pending/appliance_console/cli.rb
+++ b/gems/pending/appliance_console/cli.rb
@@ -39,6 +39,10 @@ module ApplianceConsole
       name.presence.in?(["localhost", "127.0.0.1", nil])
     end
 
+    def set_host?
+      options[:host]
+    end
+
     def key?
       options[:key] || options[:fetch_key] || (local_database? && !key_configuration.key_exist?)
     end
@@ -48,11 +52,23 @@ module ApplianceConsole
     end
 
     def local_database?
-      hostname && local?(hostname)
+      database? && local?(hostname)
     end
 
     def certs?
       options[:postgres_client_cert] || options[:postgres_server_cert] || options[:http_cert]
+    end
+
+    def uninstall_ipa?
+      options[:uninstall_ipa]
+    end
+
+    def install_ipa?
+      options[:ipaserver]
+    end
+
+    def tmp_disk?
+      options[:tmpdisk]
     end
 
     def initialize(options = {})
@@ -108,12 +124,12 @@ module ApplianceConsole
     end
 
     def run
-      Env[:host] = options[:host] if options[:host]
+      Env[:host] = options[:host] if set_host?
       create_key if key?
-      set_db if hostname
-      config_tmp_disk if options[:tmpdisk]
-      uninstall_ipa if options[:uninstall_ipa]
-      install_ipa if options[:ipaserver]
+      set_db if database?
+      config_tmp_disk if tmp_disk?
+      uninstall_ipa if uninstall_ipa?
+      install_ipa if install_ipa?
       install_certs if certs?
     rescue AwesomeSpawn::CommandResultError => e
       say e.result.output

--- a/gems/pending/appliance_console/cli.rb
+++ b/gems/pending/appliance_console/cli.rb
@@ -124,6 +124,7 @@ module ApplianceConsole
     end
 
     def run
+      Trollop.educate unless set_host? || key? || database? || tmp_disk? || uninstall_ipa? || install_ipa? || certs?
       Env[:host] = options[:host] if set_host?
       create_key if key?
       set_db if database?

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -14,7 +14,8 @@ describe ApplianceConsole::Cli do
   it "should not set hostname if none specified" do
     ApplianceConsole::Env.should_not_receive(:[]=).with(:host, anything)
 
-    subject.parse([]).run
+    subject.stub(:create_key) # just give it something to do
+    subject.parse(%w(--key)).run
   end
 
   it "should set database host to localhost if running locally" do


### PR DESCRIPTION
If the user passes in no arguments to `appliance_console`, help is displayed to let the user know what options are available.

Before: if a user typed `fix_auth` without any arguments, we simply update the database without warning.

/cc @Fryguy @jrafanie @carbonin If we don't want to update this, then lets at least get in the helper methods.

... I had this in an old branch and I'm spring cleaning (in the fall)