### PR TITLE
Style1 tables in Provision converted to patternfly

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -7,7 +7,6 @@
 - return if field_hash.blank?
 - field_id = dialog.to_s + "__" + field.to_s
 - disabled ||= false
-- pfx = "miq_request/"
 
 - unless [:hide, :ignore].include?(field_hash[:display])
   = render :partial => "layouts/dhtmlx_tags", :locals => {:control => "calendar"}
@@ -16,7 +15,7 @@
     // Create from/to date JS vars to limit calendar starting from
     ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}");
   - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter].include?(field)
-    -# ### Filter Pull Down fields, show them only if there are any values
+    -# Filter Pull Down fields, show them only if there are any values
     - unless field_hash[:values].blank?
       .form-group
         %label.col-md-2.control-label
@@ -32,11 +31,11 @@
             - else
               - opts += Array(field_hash[:values].invert).sort_by(&:first)
             = select_tag(field_id,
-                        options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
-                        :style                 => "width: auto;",
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        :class    => "selectpicker")
+                         options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
+                         :style                 => "width: auto;",
+                         "data-miq_sparkle_on"  => true,
+                         "data-miq_sparkle_off" => true,
+                         :class    => "selectpicker")
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent("#{field_id}", "#{url}")
@@ -49,7 +48,7 @@
             = field_hash[:notes]
   - else
     .form-group
-      %label.col-md-2.control-label{:valign => "top"}
+      %label.control-label.col-md-2
         = field_hash[:description]
         - if @edit && @edit[:new] && [:vm_description].include?(field)
           (
@@ -58,32 +57,44 @@
           \/ #{field_hash[:max_length]})
         - if @edit && field_hash[:required] && field_hash[:display] == :edit
           *
-      -# ### Text fields
-      - if [:cpu_limit, :cpu_reserve, :dns_servers, :dns_suffixes, :gateway, :hostname, :ip_addr, :linux_host_name, :linux_domain_name, :mac_address, :owner_address, :owner_city, :owner_company, :owner_country, :owner_department, :owner_email, :owner_first_name, :owner_last_name, :owner_load_ldap, :owner_office, :owner_manager, :owner_manager_mail, :owner_manager_phone, :owner_phone, :owner_phone_mobile, :owner_state, :owner_title, :owner_zip, :request_notes, :subnet_mask, :memory_limit, :memory_reserve, :root_password, :sysprep_password, :sysprep_domain_admin, :sysprep_domain_password, :sysprep_workgroup_name, :sysprep_full_name, :sysprep_organization, :sysprep_product_id, :sysprep_computer_name, :sysprep_per_server_max_connections, :vm_description, :vm_name, :wins_servers].include?(field)
-        .col-md-8
+      -# Text fields
+      - if [:cpu_limit, :cpu_reserve, :dns_servers, :dns_suffixes, :gateway,
+        :hostname, :ip_addr, :linux_host_name, :linux_domain_name,
+        :mac_address, :owner_address, :owner_city, :owner_company,
+        :owner_country, :owner_department, :owner_email, :owner_first_name,
+        :owner_last_name, :owner_load_ldap, :owner_office, :owner_manager,
+        :owner_manager_mail, :owner_manager_phone, :owner_phone,
+        :owner_phone_mobile, :owner_state, :owner_title, :owner_zip,
+        :request_notes, :subnet_mask, :memory_limit, :memory_reserve,
+        :root_password, :sysprep_password, :sysprep_domain_admin,
+        :sysprep_domain_password, :sysprep_workgroup_name, :sysprep_full_name,
+        :sysprep_organization, :sysprep_product_id, :sysprep_computer_name,
+        :sysprep_per_server_max_connections, :vm_description, :vm_name,
+        :wins_servers].include?(field)
+        .col-md-4
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field
             - if [:root_password, :sysprep_password, :sysprep_domain_password].include?(field)
               = password_field_tag(field_id, options[field],
-                                    :maxlength         => MAX_NAME_LEN,
-                                    :class             => "form-control",
-                                    :disabled          => disabled,
-                                    "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                :maxlength         => MAX_NAME_LEN,
+                :disabled          => disabled,
+                :class             => "form-control",
+                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             - elsif [:request_notes, :vm_description].include?(field)
               = text_area_tag(field_id, options[field],
-                                :maxlength                     => field_hash[:max_length],
-                                :class             => "form-control",
-                                :size                          => "25x4",
-                                :counter                       => "description_count",
-                                "data-miq_check_max_length"    => true,
-                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                :maxlength                     => field_hash[:max_length],
+                :size                          => "25x4",
+                :class                         => "form-control",
+                :counter                       => "description_count",
+                "data-miq_check_max_length"    => true,
+                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             - else
               - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
               = text_field_tag(field_id, options[field],
-                                :maxlength         => len,
-                                :class             => "form-control",
-                                :disabled          => disabled,
-                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+                :maxlength         => len,
+                :class             => "form-control",
+                :disabled          => disabled,
+                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
             -# Just show the field value
             - if [:root_password, :sysprep_password, :sysprep_domain_password].include?(field)
@@ -93,7 +104,7 @@
             - else
               = options[field]
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
-            -#  Display notes if available
+            -# Display notes if available
             = field_hash[:notes]
         .col-md-2
           - if field == :owner_email
@@ -101,8 +112,8 @@
             - if @edit && field_hash[:display] == :edit && fh[:display] == :show && !@edit[:stamp_typ]
               = button_tag(_('Lookup'),
                 :class   => "btn btn-primary",
-                :alt     => "LDAP Group Lookup",
-                :title   => "LDAP Group Lookup",
+                :alt     => _("LDAP Group Lookup"),
+                :title   => _("LDAP Group Lookup"),
                 :onclick => "miqAjaxButton('#{url_for(:controller => 'miq_request',
                   :action                                         => 'retrieve_email',
                   :field                                          => fh[:pressed][:method],
@@ -133,6 +144,7 @@
             -# Allow editing of the text field
             = text_field_tag(field_id, options[field].kind_of?(Array) ? options[field].last : options[field],
               :maxlength         => MAX_NAME_LEN,
+              :class             => "form-control",  
               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - elsif @edit && field_hash[:display] == :edit && field_hash[:values] && !@edit[:stamp_typ]
             -# Allow editing of the text field
@@ -164,12 +176,12 @@
         .col-md-8
           = text_area_tag(field_id, options[field],
             :readonly => "readonly",
+            :class    => "form-control",
             :style    => "width: 600px; height: 250px;")
       - elsif [:ldap_ous].include?(field)
-        -# ### dhtmlxree control for tags fields
+        -# dhtmlxree control for tags fields
         .col-md-8
-          - tree_id = "ldap_ous_treebox"
-          %div{:id => tree_id, :style => "color:#000; overflow: hidden;"}
+          %div{:id => "ldap_ous_treebox", :style => "color:#000; overflow: hidden;"}
           - if @edit && @edit[:req_id]
             - click = @edit[:req_id]
           - elsif @miq_request
@@ -178,7 +190,7 @@
             - click = 'new'
 
           = render(:partial => "layouts/dynatree",
-            :locals         => {:tree_id => tree_id,
+            :locals         => {:tree_id => "ldap_ous_treebox",
               :tree_name                 => session[:tree_name],
               :json_tree                 => @ldap_ous_tree,
               :onclick                   => "miqOnClickProvLdapOus",
@@ -190,7 +202,7 @@
             -# Display notes if available
             = field_hash[:notes]
       - elsif [:placement_folder_name].include?(field)
-        -# ### wider Pull Down field that fits into 1280 wide screens
+        -# wider Pull Down field that fits into 1280 wide screens
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of this pulldown field
@@ -209,15 +221,15 @@
               - else
                 - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
             = select_tag(field_id,
-                        options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
-                        :disabled              => disabled,
-                        :style                 => "width:auto;",
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        :class    => "selectpicker")
+              options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
+              :disabled              => disabled,
+              :style                 => "width:auto;",
+              :class                 => "selectpicker",
+              "data-miq_sparkle_on"  => true,
+              "data-miq_sparkle_off" => true)
             :javascript
               miqInitSelectPicker();
-              miqSelectPickerEvent("#{field_id}", "#{url}")
+              miqSelectPickerEvent("#{field_id}", "#{url}");
           - else
             -# Just show the field value
             = options[field].last
@@ -231,11 +243,9 @@
                :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
                :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory, :vm_maximum_memory].include?(field)
-        -# ### Pull Down fields
-        -# ### Multiple select Pull Down fields
+        -# Multiple select Pull Down fields
         - multiple = field == :security_groups
-        - td_class = field == :security_groups ? "wider" : "wide"
-        .col-md-8{:class => td_class}
+        .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of this pulldown field
             - if field_hash[:values].blank?
@@ -253,15 +263,15 @@
               - else
                 - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
             = select_tag(field_id,
-                        options_for_select(opts, (options[field].kind_of?(Array) && !multiple) ? options[field].first : options[field]),
-                        :multiple              => multiple,
-                        :disabled              => disabled,
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        :class    => "selectpicker")
+              options_for_select(opts, (options[field].kind_of?(Array) && !multiple) ? options[field].first : options[field]),
+              :multiple              => multiple,
+              :disabled              => disabled,
+              :class                 => "selectpicker",
+              "data-miq_sparkle_on"  => true,
+              "data-miq_sparkle_off" => true)
             :javascript
               miqInitSelectPicker();
-              miqSelectPickerEvent("#{field_id}", "#{url}")
+              miqSelectPickerEvent("#{field_id}", "#{url}");
           - else
             -# Just show the field value
             - if multiple
@@ -276,10 +286,9 @@
             -# Display notes if available
             = field_hash[:notes]
       - elsif [:tag_ids, :vm_tags].include?(field)
-        -# ### dhtmlxree control for tags fields
+        -# dhtmlxree control for tags fields
         .col-md-8
-          - tree_id = "all_tags_treebox"
-          %div{:id => tree_id, :style => "color:#000; overflow: hidden;"}
+          %div{:id => "all_tags_treebox", :style => "color:#000; overflow: hidden;"}
           - if @edit && @edit[:req_id]
             - check = @edit[:req_id]
           - elsif @miq_request
@@ -287,12 +296,12 @@
           - else
             - check = 'new'
           = render(:partial => "layouts/dynatree",
-            :locals         => {:tree_id   => tree_id,
+            :locals         => {:tree_id   => "all_tags_treebox",
               :tree_name                   => "all_tags_tree",
               :json_tree                   => @all_tags_tree,
               :oncheck                     => "miqOnCheckProvTags",
               :check_url                   => "/miq_request/prov_field_changed/#{check}",
-              :exp_tree                    => @edit ? false : true,
+              :exp_tree                    => !@edit,
               :no_tree_lines               => true,
               :multi_lines                 => true,
               :checkboxes                  => true,
@@ -304,37 +313,40 @@
             = field_hash[:notes]
           .note
             = _("* Only a single value can be assigned from these Tag Categories")
-      - elsif [:attached_ds, :iso_image_id, :placement_availability_zone, :placement_cluster_name, :placement_dc_name, :placement_ds_name, :placement_ems_name, :placement_host_name, :placement_rp_name, :pxe_image_id, :windows_image_id, :src_configured_system_ids, :src_host_ids, :src_vm_id, :sysprep_custom_spec, :customization_template_id].include?(field)
-        -# ### Pull Down fields that need to be sorted on description
+      - elsif [:attached_ds, :iso_image_id, :placement_availability_zone, :placement_cluster_name,
+        :placement_dc_name, :placement_ds_name, :placement_ems_name, :placement_host_name,
+        :placement_rp_name, :pxe_image_id, :windows_image_id, :src_configured_system_ids,
+        :src_host_ids, :src_vm_id, :sysprep_custom_spec, :customization_template_id].include?(field)
+        -# Pull Down fields that need to be sorted on description
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of this pulldown field
             - if field == :src_vm_id
               -# grid for src_vm_id
-              = render :partial => "#{pfx}prov_vm_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_vm_grid", :locals => {:field_id => field_id}
             - elsif field == :placement_host_name
               -# grid for hosts
-              = render :partial => "#{pfx}prov_host_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_host_grid", :locals => {:field_id => field_id}
             - elsif field == :placement_ds_name
               -# grid for datastores
-              = render :partial => "#{pfx}prov_ds_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_ds_grid", :locals => {:field_id => field_id}
             - elsif field == :attached_ds
               -# grid for datastores
-              = render :partial => "#{pfx}prov_ds_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_ds_grid", :locals => {:field_id => field_id}
             - elsif field == :sysprep_custom_spec
               -# grid for sysprep_custom_spec
-              = render :partial => "#{pfx}prov_vc_grid", :locals => {:field_id => field_id, :spec_required => field_hash[:required]}
+              = render :partial => "miq_request/prov_vc_grid", :locals => {:field_id => field_id, :spec_required => field_hash[:required]}
             - elsif field == :customization_template_id
               -# grid for customization script
-              = render :partial => "#{pfx}prov_template_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_template_grid", :locals => {:field_id => field_id}
             - elsif field == :pxe_image_id
               -# grid for pxe_images
-              = render :partial => "#{pfx}prov_pxe_img_grid", :locals  => {:field_id => field_id}
+              = render :partial => "miq_request/prov_pxe_img_grid", :locals  => {:field_id => field_id}
             - elsif field == :iso_image_id
               -# grid for iso_images
-              = render :partial => "#{pfx}prov_iso_img_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_iso_img_grid", :locals => {:field_id => field_id}
             - elsif field == :windows_image_id
-              = render :partial => "#{pfx}prov_windows_image_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_windows_image_grid", :locals => {:field_id => field_id}
             - else
               - if field_hash[:values].blank?
                 - opts = [["<#{_('No Choices Available')}>", nil]]
@@ -348,22 +360,22 @@
                   - opts = [["<#{_('None')}>", nil]]
                 - opts += Array(field_hash[:values].invert).sort_by { |a| a.first.downcase }
               = select_tag(field_id,
-                          options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
-                          :style                 => "width: auto;",
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :class    => "selectpicker")
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent("#{field_id}", "#{url}")
+                options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
+                :style                 => "width: auto;",
+                :class                 => "selectpicker",
+                "data-miq_sparkle_on"  => true,
+                "data-miq_sparkle_off" => true)
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent("#{field_id}", "#{url}");
           - else
             -# Just show the field value
             - if field == :src_host_ids
               -# read only grid for src_host_id
-              = render :partial => "#{pfx}prov_host_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_host_grid", :locals => {:field_id => field_id}
             - elsif field == :src_configured_system_ids
               -# read only grid for src_configured_system_ids
-              = render :partial => "#{pfx}prov_configured_system_grid", :locals => {:field_id => field_id}
+              = render :partial => "miq_request/prov_configured_system_grid", :locals => {:field_id => field_id}
             - elsif field == :attached_ds
               -# Description is in the second, last, array element
               = options[:attached_ds_names].to_miq_a.join(",")
@@ -373,7 +385,8 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:pxe_server_id, :number_of_vms, :number_of_cpus, :number_of_sockets, :cores_per_socket, :snapshot, :sysprep_enabled].include?(field)
+      - elsif [:pxe_server_id, :number_of_vms, :number_of_cpus,
+        :number_of_sockets, :cores_per_socket, :snapshot, :sysprep_enabled].include?(field)
         -# ### Pull Down for fields that dont need <None> in the list
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
@@ -390,14 +403,14 @@
               - else
                 - opts += Array(field_hash[:values].invert).sort_by(&:first)
             = select_tag(field_id,
-                        options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
-                        :disabled              => disabled,
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        :class    => "selectpicker")
+              options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
+              :disabled              => disabled,
+              :class                 => "selectpicker",
+              "data-miq_sparkle_on"  => true,
+              "data-miq_sparkle_off" => true)
             :javascript
               miqInitSelectPicker();
-              miqSelectPickerEvent("#{field_id}", "#{url}")
+              miqSelectPickerEvent("#{field_id}", "#{url}");
           - else
             -# Just show the field value
             -# Description is in the second, last, array element
@@ -427,22 +440,22 @@
                   - opts = [["<#{_('None')}>", nil]]
                 - opts += field_hash[:values]
               = select_tag(field_id,
-                          options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
-                          :disabled              => disabled,
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :class    => "selectpicker")
+                options_for_select(opts, options[field].kind_of?(Array) ? options[field].first : options[field]),
+                :disabled              => disabled,
+                :class                 => "selectpicker",
+                "data-miq_sparkle_on"  => true,
+                "data-miq_sparkle_off" => true)
               :javascript
                 miqInitSelectPicker();
-                miqSelectPickerEvent("#{field_id}", "#{url}")
+                miqSelectPickerEvent("#{field_id}", "#{url}");
           - else
             -# Just show the field value %>
             -# Description is in the second, last, array element
             = options[field].last
       - elsif [:linked_clone, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid,
                :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory].include?(field)
-        -# ### Checkbox fields
-        .col-md-8{:style => "vertical-align: top;"}
+        -# Checkbox fields
+        .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field
             - checked = options[field] && options[field][0].to_s == "true"
@@ -461,7 +474,7 @@
             -# Display notes if available
             = field_hash[:notes]
       - elsif [:addr_mode, :disk_format, :sysprep_identification, :schedule_type].include?(field)
-        -# ### Radio Button fields
+        -# Radio Button fields
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field
@@ -487,8 +500,7 @@
               "data-miq_observe_date" => {:url => url}.to_json)
           - else
             = options[:start_date]
-        </tr><tr>
-        %label.col-md-2.control-label
+        %label.control-label.col-md-2
           = _("Starting Time (%s)") % get_timezone_abbr(current_user)
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]


### PR DESCRIPTION
Parent issue: #3139

Before:
![screencapture-localhost-3000-catalog-explorer-1442238820475](https://cloud.githubusercontent.com/assets/1187051/9851591/bafc4df6-5af9-11e5-9184-e5f080206098.png)
After:
![screencapture-localhost-3000-catalog-explorer-1442236405692](https://cloud.githubusercontent.com/assets/1187051/9851590/ba0e1b36-5af9-11e5-9202-c20f6383037a.png)

Before:
![screencapture-localhost-3000-catalog-explorer-1442239078739](https://cloud.githubusercontent.com/assets/1187051/9851593/bc6ab038-5af9-11e5-87ab-6439a0b2e81f.png)
After:
![screencapture-localhost-3000-catalog-explorer-1442236416627](https://cloud.githubusercontent.com/assets/1187051/9851592/bb968c18-5af9-11e5-8c0a-8fdc20d53edc.png)


@epwinchell 
this partial is also used in here: _Infrastructure -> Virtual Machines -> VMs -> [select one] -> Lifecycle -> Provision request -> [select one] -> continue_.
It would make a lot of screenshots to cover all places where this partial is used.
