### PR TITLE
merge workflow's create_request methods

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -58,7 +58,7 @@ class AutomationRequest < MiqRequest
     'automate'
   end
 
-  def log_request_success(requester_id, mode)
+  def log_request_success(_requester_id, _mode)
     # currently we do not log successful automation requests
   end
 end

--- a/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
@@ -3,16 +3,6 @@ class ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow < Mi
     'miq_provision_configured_system_foreman_dialogs'
   end
 
-  def create_request(values, requester_id, auto_approve = false)
-    event_message = "Configured System Provisioning requested by <#{requester_id}> for ConfiguredSystem:#{values[:src_configured_system_ids].inspect}"
-    super(values, requester_id, 'ConfiguredSystem', 'configured_system_provision_request_created', event_message, auto_approve)
-  end
-
-  def update_request(request, values, requester_id)
-    event_message = "Configured System Provisioning request updated by <#{requester_id}> for ConfiguredSystem:#{values[:src_configured_system_ids].inspect}"
-    super(request, values, requester_id, 'ConfiguredSystem', 'configured_system_provision_request_updated', event_message)
-  end
-
   def get_source_and_targets(_refresh = false)
   end
 

--- a/app/models/miq_host_provision_request.rb
+++ b/app/models/miq_host_provision_request.rb
@@ -61,6 +61,10 @@ class MiqHostProvisionRequest < MiqRequest
     "host"
   end
 
+  def event_name(mode)
+    "host_provision_request_#{mode}"
+  end
+
   private
 
   def default_description

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -19,14 +19,12 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
     false
   end
 
-  def create_request(values, requester_id, auto_approve=false)
-    event_message = "Host Provisioning requested by <#{requester_id}> for Host:#{values[:src_host_ids].inspect}"
-    super(values, requester_id, 'Host', 'host_provision_request_created', event_message, auto_approve) { update_selected_storage_names(values) }
+  def create_request(values, requester_id, auto_approve = false)
+    super(values, requester_id, auto_approve) { update_selected_storage_names(values) }
   end
 
   def update_request(request, values, requester_id)
-    event_message = "Host Provisioning request updated by <#{requester_id}> for Host:#{values[:src_host_ids].inspect}"
-    super(request, values, requester_id, 'Host', 'host_provision_request_updated', event_message) { update_selected_storage_names(values) }
+    super(request, values, requester_id) { update_selected_storage_names(values) }
   end
 
   def get_source_and_targets(refresh=false)

--- a/app/models/miq_provision_configured_system_request.rb
+++ b/app/models/miq_provision_configured_system_request.rb
@@ -37,6 +37,10 @@ class MiqProvisionConfiguredSystemRequest < MiqRequest
     "configured_system"
   end
 
+  def event_name(mode)
+    "configured_system_provision_request_#{mode}"
+  end
+
   private
 
   def default_description

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -9,7 +9,7 @@ class MiqProvisionRequest < MiqRequest
   include ReportableMixin
 
   TASK_DESCRIPTION  = 'VM Provisioning'
-  SOURCE_CLASS_NAME = 'VmOrTemplate'
+  SOURCE_CLASS_NAME = 'Vm'
   ACTIVE_STATES     = %w(migrated) + base_class::ACTIVE_STATES
 
   validates_inclusion_of :request_state,
@@ -130,5 +130,13 @@ class MiqProvisionRequest < MiqRequest
     } if source.orphaned?
 
     {:valid => true, :message => nil}
+  end
+
+  def event_name(mode)
+    "vm_provision_request_#{mode}"
+  end
+
+  def my_records
+    "#{SOURCE_CLASS_NAME}:#{source_id.inspect}"
   end
 end

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -55,16 +55,14 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       password_helper(values, true)
       return nil
     else
-      event_message = "VM Provisioning requested by <#{requester_id}> for Vm:#{values[:src_vm_id].inspect}"
-      super(values, requester_id, 'Vm', 'vm_provision_request_created', event_message, auto_approve)
+      super
     end
   end
 
   def update_request(request, values, requester_id)
-    event_message = "VM Provisioning request updated by <#{requester_id}> for Vm:#{values[:src_vm_id].inspect}"
     request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
     request.src_vm_id = request.get_option(:src_vm_id)
-    super(request, values, requester_id, 'Vm', 'vm_provision_request_updated', event_message)
+    super
   end
 
   def refresh_field_values(values, _requester_id)

--- a/app/models/vm_migrate_workflow.rb
+++ b/app/models/vm_migrate_workflow.rb
@@ -11,16 +11,6 @@ class VmMigrateWorkflow < MiqRequestWorkflow
     'vm_migrate_dialogs'
   end
 
-  def create_request(values, requester_id, auto_approve=false)
-    event_message = "VM Migrate requested by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
-    super(values, requester_id, 'Vm', 'vm_migrate_request_created', event_message, auto_approve)
-  end
-
-  def update_request(request, values, requester_id)
-    event_message = "VM Migrate request updated by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
-    super(request, values, requester_id, 'Vm', 'vm_migrate_request_updated', event_message)
-  end
-
   def get_source_and_targets(refresh=false)
     return @target_resource if @target_resource && refresh == false
 

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -243,26 +243,26 @@ describe MiqRequestWorkflow do
   context "#create_request" do
     it "sets requester_group" do
       values = {}
-      request = workflow.create_request(values, workflow.requester.userid, MiqRequestWorkflow, 'name', 'message')
+      request = workflow.create_request(values, workflow.requester.userid)
       expect(request.options[:requester_group]).to eq(workflow.requester.miq_group_description)
     end
 
     it "doesnt set owner_group" do
       values = {}
-      request = workflow.create_request(values, workflow.requester.userid, MiqRequestWorkflow, 'name', 'message')
+      request = workflow.create_request(values, workflow.requester.userid)
       expect(request.options[:owner_group]).not_to be
     end
 
     it "handles bad owner email" do
       values = {:owner_email => "bogus"}
-      request = workflow.create_request(values, workflow.requester.userid, MiqRequestWorkflow, 'name', 'message')
+      request = workflow.create_request(values, workflow.requester.userid)
       expect(request.options[:owner_group]).not_to be
     end
 
     it "sets owner group" do
       owner = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
       values = {:owner_email => owner.email}
-      request = workflow.create_request(values, workflow.requester.userid, MiqRequestWorkflow, 'name', 'message')
+      request = workflow.create_request(values, workflow.requester.userid)
       expect(request.options[:owner_email]).to eq(owner.email)
       expect(request.options[:owner_group]).to eq(owner.current_group.description)
     end


### PR DESCRIPTION
We want to pass tenant into `create_request` and `update_request`. But currently, there are many implementations of the `create_request` method. This removes a number of the implementations by extracting the logging code.


/cc @gmcculloug 