### PR TITLE
Fix to show Service name on Service Summary screen.

### DIFF
--- a/spa_ui/self_service/client/app/states/services/list/list.state.js
+++ b/spa_ui/self_service/client/app/states/services/list/list.state.js
@@ -70,7 +70,7 @@
     };
 
     function handleClick(item, e) {
-      $state.go('services.details', {requestId: item.id});
+      $state.go('services.details', {serviceId: item.id});
     };
 
     function filterChange(filters) {


### PR DESCRIPTION
@dclarizio please review

before:
![service_summary](https://cloud.githubusercontent.com/assets/3450808/9860294/4113dc7a-5af9-11e5-8f8f-55d92fa354b1.png)

after:
![service_summary_new](https://cloud.githubusercontent.com/assets/3450808/9860298/479fb8c0-5af9-11e5-8f83-d609697441ff.png)
