### PR TITLE
Updated Tenant Quotas

### DIFF
--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -3,9 +3,9 @@ class TenantQuota < ActiveRecord::Base
 
   QUOTA_BASE = {
     :cpu_allocated => {
-      :unit          => :mhz,
-      :format        => :mhz,
-      :text_modifier => "Mhz".freeze
+      :unit          => :fixnum,
+      :format        => :general_number_precision_0,
+      :text_modifier => "Count".freeze
     },
     :mem_allocated => {
       :unit          => :bytes,
@@ -40,7 +40,7 @@ class TenantQuota < ActiveRecord::Base
 
   def self.quota_definitions
     @quota_definitions ||= QUOTA_BASE.each_with_object({}) do |(name, value), h|
-      h[name] = value.merge(:description => I18n.t("dictionary.tenants.#{name}"), :value => nil)
+      h[name] = value.merge(:description => I18n.t("dictionary.tenants.#{name}"), :value => nil, :warn_value => nil)
     end
   end
 
@@ -54,7 +54,7 @@ class TenantQuota < ActiveRecord::Base
   end
 
   def quota_hash
-    self.class.quota_definitions[name.to_sym].merge(:unit => unit, :value => value, :format => format) # attributes
+    self.class.quota_definitions[name.to_sym].merge(:unit => unit, :value => value, :warn_value => warn_value, :format => format) # attributes
   end
 
   def format

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -33,6 +33,8 @@ class TenantQuota < ActiveRecord::Base
 
   validates :name, :inclusion => {:in => NAMES}
   validates :unit, :value, :presence => true
+  validates :value, :numericality => { :greater_than => 0 }
+  validates :warn_value, :numericality => { :greater_than => 0 }, :if => "warn_value.present?"
 
   before_validation(:on => :create) do
     self.unit = default_unit unless unit.present?

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -33,8 +33,8 @@ class TenantQuota < ActiveRecord::Base
 
   validates :name, :inclusion => {:in => NAMES}
   validates :unit, :value, :presence => true
-  validates :value, :numericality => { :greater_than => 0 }
-  validates :warn_value, :numericality => { :greater_than => 0 }, :if => "warn_value.present?"
+  validates :value, :numericality => {:greater_than => 0}
+  validates :warn_value, :numericality => {:greater_than => 0}, :if => "warn_value.present?"
 
   before_validation(:on => :create) do
     self.unit = default_unit unless unit.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1088,7 +1088,7 @@ en:
       scan:                   analysis
 
     tenants:
-      cpu_allocated: Allocated CPU in Mhz
+      cpu_allocated: Allocated Virtual CPUs
       mem_allocated: Allocated Memory in GB
       storage_allocated: Allocated Storage in GB
       vms_allocated: Allocated Number of Virtual Machines

--- a/db/migrate/20150914203523_add_warn_value_to.rb
+++ b/db/migrate/20150914203523_add_warn_value_to.rb
@@ -1,0 +1,5 @@
+class AddWarnValueTo < ActiveRecord::Migration
+  def change
+    add_column    :tenant_quotas, :warn_value, :float
+  end
+end

--- a/db/migrate/20150914203523_add_warn_value_to.rb
+++ b/db/migrate/20150914203523_add_warn_value_to.rb
@@ -1,5 +1,5 @@
 class AddWarnValueTo < ActiveRecord::Migration
   def change
-    add_column    :tenant_quotas, :warn_value, :float
+    add_column :tenant_quotas, :warn_value, :float
   end
 end

--- a/spec/factories/tenant_quota.rb
+++ b/spec/factories/tenant_quota.rb
@@ -2,8 +2,9 @@ FactoryGirl.define do
   factory :tenant_quota do
     factory :tenant_quota_cpu do
       name :cpu_allocated
-      unit "mhz"
-      value 4096
+      unit "FIXNUM"
+      value 16
+      warn_value 12
     end
   end
 end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -18,6 +18,14 @@ describe TenantQuota do
       expect(described_class.new(:name => :cpu_allocated, :unit => "fixnum")).not_to be_valid
     end
 
+    it "rejects 0 value" do
+      expect(described_class.new(:name => :cpu_allocated, :value => 0)).not_to be_valid
+    end
+
+    it "rejects 0 warn_value" do
+      expect(described_class.new(:name => :cpu_allocated, :value => 1, :warn_value => 0)).not_to be_valid
+    end
+
     it "defaults missing unit" do
       expect(described_class.new(:name => :cpu_allocated, :value => 16)).to be_valid
     end

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -18,10 +18,6 @@ describe TenantQuota do
       expect(described_class.new(:name => :cpu_allocated, :unit => "fixnum")).not_to be_valid
     end
 
-    it "rejects 0 value" do
-      expect(described_class.new(:name => :cpu_allocated, :value => 0)).not_to be_valid
-    end
-
     it "rejects 0 warn_value" do
       expect(described_class.new(:name => :cpu_allocated, :value => 1, :warn_value => 0)).not_to be_valid
     end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -451,8 +451,8 @@ describe Tenant do
 
       tq_cpu = tq[0]
       expect(tq_cpu.name).to eql "cpu_allocated"
-      expect(tq_cpu.unit).to eql "mhz"
-      expect(tq_cpu.format).to eql "mhz"
+      expect(tq_cpu.unit).to eql "fixnum"
+      expect(tq_cpu.format).to eql "general_number_precision_0"
       expect(tq_cpu.value).to eql 1024.0
 
       tq_mem = tq[1]
@@ -520,6 +520,7 @@ describe Tenant do
           :vms_allocated => {
               :unit          => "fixnum",
               :value         => 20.0,
+              :warn_value    => nil,
               :format        => "general_number_precision_0",
               :text_modifier => "Count",
               :description   => "Allocated Number of Virtual Machines"
@@ -527,6 +528,7 @@ describe Tenant do
           :mem_allocated => {
               :unit          => "bytes",
               :value         => 4096.0,
+              :warn_value    => nil,
               :format        => "gigabytes_human",
               :text_modifier => "GB",
               :description   => "Allocated Memory in GB"
@@ -534,6 +536,7 @@ describe Tenant do
           :storage_allocated => {
               :unit          => :bytes,
               :value         => nil,
+              :warn_value    => nil,
               :format        => :gigabytes_human,
               :text_modifier => "GB",
               :description   => "Allocated Storage in GB"


### PR DESCRIPTION
- Changed allocated cpu to be a count of virtual cpus instead mhz
- Added warn_value column for setting a value where a warning can be issued when exceeded. This aligns with automate.