### PR TITLE
Gather disk info for Cloud Inventory.

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -40,7 +40,6 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     $aws_log.info("#{log_header}...Complete")
 
     filter_unused_disabled_flavors
-    clean_up_extra_flavor_keys
 
     @data
   end
@@ -180,8 +179,6 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :supports_paravirtual     => flavor[:virtualization_type].include?(:paravirtual),
       :block_storage_based_only => flavor[:ebs_only],
       :cloud_subnet_required    => flavor[:vpc_only],
-
-      # Extra keys
       :disk_size                => flavor[:instance_store_size],
       :disk_count               => flavor[:instance_store_volumes]
     }
@@ -546,13 +543,6 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
         child_stack[:parent] = stack if child_stack
       end
       stack.delete(:children)
-    end
-  end
-
-  def clean_up_extra_flavor_keys
-    @data[:flavors].each do |f|
-      f.delete(:disk_size)
-      f.delete(:disk_count)
     end
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -484,7 +484,6 @@ module ManageIQ::Providers
       disks = new_result[:hardware][:disks]
       dev = "vda"
 
-      # TODO: flavor[:disk_size] == 0 should take disk size from image size.
       if (sz = flavor[:disk_size]) == 0
         sz = 1.gigabytes
       end

--- a/db/migrate/20150911152048_add_disk_info_to_flavors.rb
+++ b/db/migrate/20150911152048_add_disk_info_to_flavors.rb
@@ -1,0 +1,6 @@
+class AddDiskInfoToFlavors < ActiveRecord::Migration
+  def change
+    add_column :flavors, :disk_size, :bigint
+    add_column :flavors, :disk_count, :integer
+  end
+end

--- a/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/ec2_refresher_spec.rb
@@ -104,6 +104,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :supports_hvm             => false,
       :supports_paravirtual     => true,
       :block_storage_based_only => true,
+      :disk_size                => 0,
+      :disk_count               => 0
     )
 
     @flavor.ext_management_system.should == @ems

--- a/spec/models/ems_refresh/refreshers/openstack/refresh_spec_common.rb
+++ b/spec/models/ems_refresh/refreshers/openstack/refresh_spec_common.rb
@@ -155,24 +155,6 @@ module Openstack
       expect(@ems.miq_templates.size).to      eq images_count
     end
 
-    def name_to_disk_info(name)
-      case name
-      when "m1.tiny"
-        # grizzly has a 0 size disk for m1.tiny others have 1G
-        @environment == :grizzly ? [0, 0] : [1.gigabytes, 1]
-      when "m1.small"
-        [20.gigabytes, 1]
-      when "m1.medium"
-        [40.gigabytes, 1]
-      when "m1.large"
-        [80.gigabytes, 1]
-      when "m1.xlarge"
-        [160.gigabytes, 1]
-      when "m1.ems_refresh_spec"
-        [1.gigabytes, 1]
-      end
-    end
-
     def assert_specific_flavor
       assert_objects_with_hashes(ManageIQ::Providers::Openstack::CloudManager::Flavor.all,
                                  compute_data.flavors,
@@ -181,15 +163,13 @@ module Openstack
                                  [:is_public, :disk, :ephemeral, :swap]) # TODO(lsmola) model blacklisted attrs
 
       ManageIQ::Providers::Openstack::CloudManager::Flavor.all.each do |flavor|
-        disk_size, disk_count = name_to_disk_info(flavor.name)
-
         expect(flavor.ext_management_system).to eq @ems
         # TODO(lsmola) expose below to Builder's data
         expect(flavor.enabled).to               eq true
         expect(flavor.cpu_cores).to             eq nil
         expect(flavor.description).to           eq nil
-        expect(flavor.disk_size).to             eq disk_size
-        expect(flavor.disk_count).to            eq disk_count
+        expect(flavor.disk_size).to_not         be_nil
+        expect(flavor.disk_count).to            eq flavor.disk_size == 0 ? 0 : 1
       end
     end
 


### PR DESCRIPTION
Both Amazon and OpenStack Cloud have disk information for flavors.

This PR allows for the capture of both the image size and the volume count.

Since OpenStack does not provide volume count, it will always be one as long
is the disk size greater than non-zero

https://bugzilla.redhat.com/show_bug.cgi?id=1260196