### PR TITLE
assign tenant_id to miq_request and service

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -4,6 +4,7 @@ class MiqRequest < ActiveRecord::Base
   belongs_to :source,            :polymorphic => true
   belongs_to :destination,       :polymorphic => true
   belongs_to :requester,         :class_name  => "User"
+  belongs_to :tenant
   has_many   :miq_approvals,     :dependent   => :destroy
   has_many   :miq_request_tasks, :dependent   => :destroy
 

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -8,6 +8,7 @@ class MiqRequestTask < ActiveRecord::Base
   belongs_to :destination,       :polymorphic => true
   has_many   :miq_request_tasks, :dependent   => :destroy
   belongs_to :miq_request_task
+  belongs_to :tenant
 
   serialize   :phase_context, Hash
   serialize   :options,       Hash

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,6 +1,7 @@
 class Service < ActiveRecord::Base
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
 
+  belongs_to :tenant
   belongs_to :service_template               # Template this service was cloned from
   belongs_to :service                        # Parent Service
   has_many :services, :dependent => :destroy # Child services

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -22,6 +22,9 @@ class Tenant < ActiveRecord::Base
   has_many :miq_groups
   has_many :users, :through => :miq_groups
   has_many :ae_domains, :dependent => :destroy, :class_name => 'MiqAeDomain'
+  has_many :miq_requests, :dependent => :destroy
+  has_many :miq_request_tasks, :dependent => :destroy
+  has_many :services, :dependent => :destroy
 
   # FUTURE: /uploads/tenant/:id/logos/:basename.:extension # may want style
   has_attached_file :logo,

--- a/db/migrate/20150915000737_add_tenant_id_to_miq_request.rb
+++ b/db/migrate/20150915000737_add_tenant_id_to_miq_request.rb
@@ -1,0 +1,7 @@
+class AddTenantIdToMiqRequest < ActiveRecord::Migration
+  def change
+    add_column :miq_requests, :tenant_id, :bigint
+    add_column :miq_request_tasks, :tenant_id, :bigint
+    add_column :services, :tenant_id, :bigint
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -8,6 +8,7 @@ module MiqAeMethodService
     expose :resource,          :association => true
     expose :source,            :association => true
     expose :destination,       :association => true
+    expose :tenant,            :association => true
     expose :authorized?
     expose :approve,   :override_return => true
     expose :deny,      :override_return => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
@@ -9,6 +9,7 @@ module MiqAeMethodService
     expose :miq_request_tasks, :association => true
     expose :source,            :association => true
     expose :destination,       :association => true
+    expose :tenant,            :association => true
     undef :phase_context
 
     def message=(msg)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -18,6 +18,7 @@ module MiqAeMethodService
     expose :direct_service_children,   :association => true
     expose :indirect_service_children, :association => true
     expose :parent_service,            :association => true
+    expose :tenant,                    :association => true
     expose :custom_keys,               :method => :miq_custom_keys
     expose :custom_get,                :method => :miq_custom_get
     expose :custom_set,                :method => :miq_custom_set, :override_return => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_tenant.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_tenant.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceTenant < MiqAeServiceModelBase
     expose :tenant_quotas, :association => true
+    expose :miq_requests,  :association => true
+    expose :miq_request_tasks, :association => true
+    expose :services, :association => true
   end
 end


### PR DESCRIPTION
Add and assign tenant id to `MiqRequest` and `Service`.

- ~~also update existing assign migration per conventions (note, there is a spec for that existing one)~~

/cc @mkanoor @gmcculloug ~~I noticed that requester was not on miq_request_task, so I left it off. It is trivial to add in this PR, so just let me know.~~

*UPDATE:* added `tenant_id` to `MiqRequestTask` and moved migration code out.
