### PR TITLE
Teach the routing helpers how our controllers are laid out

### DIFF
--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -17,7 +17,7 @@ module AvailabilityZoneHelper::TextualSummary
   #
 
   def textual_ems_cloud
-    textual_link(@record.ext_management_system, :as => EmsCloud)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_instances

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -19,7 +19,7 @@ module CloudTenantHelper::TextualSummary
   # Items
   #
   def textual_ems_cloud
-    textual_link(@record.ext_management_system, :as => EmsCloud)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_security_groups

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -1,7 +1,6 @@
 module ContainerSummaryHelper
   def textual_ems
-    textual_link(@record.ext_management_system, :as         => ManageIQ::Providers::ContainerManager,
-                                                :controller => 'ems_container')
+    textual_link(@record.ext_management_system)
   end
 
   def textual_container_project

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -71,7 +71,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_ems_infra
-    textual_link(@record.try(:provider).try(:infra_ems), :as => EmsInfra)
+    textual_link(@record.try(:provider).try(:infra_ems))
   end
 
   def textual_availability_zones

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -98,7 +98,7 @@ module EmsClusterHelper::TextualSummary
   end
 
   def textual_ems
-    textual_link(@record.ext_management_system, :as => EmsInfra)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_parent_datacenter

--- a/app/helpers/flavor_helper/textual_summary.rb
+++ b/app/helpers/flavor_helper/textual_summary.rb
@@ -72,7 +72,7 @@ module FlavorHelper::TextualSummary
   end
 
   def textual_ems_cloud
-    textual_link(@record.ext_management_system, :as => EmsCloud)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_instances

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -238,7 +238,7 @@ module HostHelper::TextualSummary
   end
 
   def textual_ems
-    textual_link(@record.ext_management_system, :as => EmsInfra)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_cluster

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -40,7 +40,7 @@ module OrchestrationStackHelper::TextualSummary
   end
 
   def textual_ems_cloud
-    textual_link(@record.ext_management_system, :as => EmsCloud)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_orchestration_template

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -43,7 +43,7 @@ module SecurityGroupHelper::TextualSummary
   end
 
   def textual_ems_cloud
-    textual_link(@record.ext_management_system, :as => EmsCloud)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_instances

--- a/app/helpers/sti_routing_helper.rb
+++ b/app/helpers/sti_routing_helper.rb
@@ -1,0 +1,40 @@
+module StiRoutingHelper
+  include ActionDispatch::Routing::PolymorphicRoutes
+
+  def ui_base_model(klass)
+    if klass <= ExtManagementSystem
+      klass.base_manager
+    else
+      klass.base_model
+    end
+  end
+
+  # NB: This differs from model_to_controller; until they're unified,
+  # make sure you have the right one.
+  def controller_for_model(klass)
+    model = ui_base_model(klass)
+    if klass <= VmOrTemplate
+      controller_for_vm(klass)
+    elsif model.respond_to?(:db_name)
+      model.db_name.underscore
+    else
+      model.name.underscore
+    end
+  end
+
+  def polymorphic_path(record, *)
+    if record.kind_of?(ActiveRecord::Base)
+      klass = ui_base_model(record.class)
+      record = record.becomes(klass) unless record.class == klass
+    end
+    super
+  end
+
+  def polymorphic_url(record, *)
+    if record.kind_of?(ActiveRecord::Base)
+      klass = ui_base_model(record.class)
+      record = record.becomes(klass) unless record.class == klass
+    end
+    super
+  end
+end

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -140,11 +140,11 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_ems
-    textual_link(@record.ext_management_system, :as => EmsCloud)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_ems_infra
-    textual_link(@record.ext_management_system.try(:provider).try(:infra_ems), :as => EmsInfra)
+    textual_link(@record.ext_management_system.try(:provider).try(:infra_ems))
   end
 
   def textual_cluster

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -233,7 +233,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_ems
-    textual_link(@record.ext_management_system, :as => EmsInfra)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_cluster

--- a/app/helpers/vm_infra_helper/textual_summary.rb
+++ b/app/helpers/vm_infra_helper/textual_summary.rb
@@ -169,7 +169,7 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_ems
-    textual_link(@record.ext_management_system, :as => EmsInfra)
+    textual_link(@record.ext_management_system)
   end
 
   def textual_cluster

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -7,6 +7,11 @@ class CloudManager < BaseManager
   require_dependency 'manageiq/providers/cloud_manager/provision_workflow'
   require_dependency 'manageiq/providers/cloud_manager/vm'
 
+  class << model_name
+    define_method(:route_key) { "ems_clouds" }
+    define_method(:singular_route_key) { "ems_cloud" }
+  end
+
   has_many :availability_zones,            :foreign_key => :ems_id, :dependent => :destroy
   has_many :flavors,                       :foreign_key => :ems_id, :dependent => :destroy
   has_many :cloud_tenants,                 :foreign_key => :ems_id, :dependent => :destroy

--- a/spec/helpers/textual_summary_helper_spec.rb
+++ b/spec/helpers/textual_summary_helper_spec.rb
@@ -2,39 +2,43 @@ require "spec_helper"
 
 describe TextualSummaryHelper do
   before do
-    controller.send(:extend, TextualSummaryHelper)
-    self.class.send(:include, TextualSummaryHelper)
+    login_as @user = FactoryGirl.create(:user)
+    @user.stub(:role_allows?).and_return(true)
   end
 
-  context "textual_collection_link" do
-    def role_allows(_)
-      true
+  context "textual_link" do
+    context "with a restfully-routed model" do
+      it "uses the restful path to retrieve the summary screen link" do
+        ems = FactoryGirl.create(:ems_openstack)
+        ems.availability_zones << FactoryGirl.create(:availability_zone_openstack)
+
+        result = helper.textual_link(ems.availability_zones)
+        expect(result[:link]).to eq("/ems_cloud/#{ems.id}?display=availability_zones")
+      end
+
+      it "uses the restful path for the base show screen" do
+        ems = FactoryGirl.create(:ems_openstack)
+
+        result = helper.textual_link(ems)
+        expect(result[:link]).to eq("/ems_cloud/#{ems.id}")
+      end
     end
 
-    it "uses the restful path to retrieve the summary screen link for a restful controller" do
-      controller.stub(:restful?).and_return(true)
-      controller.stub(:controller_name).and_return("ems_cloud")
-      Zone.first || FactoryGirl.create(:zone)
-      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
-      FactoryGirl.create(:availability_zone_openstack)
-      ems = ManageIQ::Providers::Openstack::CloudManager.first
-      az = AvailabilityZone.first
-      az.update_attributes(:ems_id => ems.id)
-      result = textual_collection_link(ems.availability_zones)
-      expect(result[:link]).to eq("/ems_cloud/#{ems.id}?display=availability_zones")
-    end
+    context "with a non-restful model" do
+      it "uses the controller-action-id path to retrieve the summary screen link" do
+        ems = FactoryGirl.create(:ems_openstack_infra)
+        ems.hosts << FactoryGirl.create(:host)
 
-    it "uses the controller-action-id path to retrieve the summary screen link for a non-restful controller" do
-      controller.stub(:restful?).and_return(false)
-      controller.stub(:controller_name).and_return("ems_infra")
-      Zone.first || FactoryGirl.create(:zone)
-      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
-      FactoryGirl.create(:availability_zone_openstack)
-      ems = ManageIQ::Providers::Openstack::CloudManager.first
-      az = AvailabilityZone.first
-      az.update_attributes(:ems_id => ems.id)
-      result = textual_collection_link(ems.availability_zones)
-      expect(result[:link]).to eq("/ems_infra/show/#{ems.id}?display=availability_zones")
+        result = helper.textual_link(ems.hosts)
+        expect(result[:link]).to eq("/ems_infra/show/#{ems.id}?display=hosts")
+      end
+
+      it "uses the controller-action-id path for the base show screen" do
+        ems = FactoryGirl.create(:ems_openstack_infra)
+
+        result = helper.textual_link(ems)
+        expect(result[:link]).to eq("/ems_infra/show/#{ems.id}")
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ Coveralls.wear!('rails') { add_filter("/spec/") }
 
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
+require 'application_helper'
+
 require 'rspec/autorun'
 require 'rspec/rails'
 require 'rspec/fire'


### PR DESCRIPTION
Namely, teach them about STI, and the fact that the UI's idea of a base model can be more specific than ActiveRecord::Base.base_model.

Once we're working with the right class, we also need to account for the shorter-than-default route_key we're using. This is leaking a UI concept into the model (for now, at least)... but it's not too bad, because it was really already there.

With the right route key, we're able to determine whether the model has RESTful routes defined, and rely on [STI-aware] polymorphic_path if so.

The above changes eliminate a number of custom `:as` parameters to `textual_link`; it now knows what to do automatically.

Finally, the helper specs are rewritten to work on the right object; by calling via `helper`, we avoid confusing (and duplicative) setup.