### PR TITLE
Service catalog entry point mixup fix

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -25,7 +25,7 @@
   content: "\e602";
 }
 .pficon-close:before {
-  color: $color-critical;
+  // color: $color-critical;
 }
 .pficon-folder-close-blue:before {
   content: "\e607";

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -12,14 +12,14 @@
         .col-md-4
           = text_field_tag("name",
                            @edit[:new][:name].to_s,
-                           :maxlength => 40,
-                           :class     => "form-control",
+                           :maxlength         => 40,
+                           :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         .col-md-4
           = text_field_tag("description",
                            @edit[:new][:description],
-                           :maxlength => 60,
-                           :class     => "form-control",
+                           :maxlength         => 60,
+                           :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         .col-md-3
           = check_box_tag("display", "1", @edit[:new][:display],
@@ -35,48 +35,47 @@
           - catalog_id = @edit[:new][:catalog_id]
           = select_tag('catalog_id',
                        options_for_select(([["<#{_('Unassigned')}>", nil]]) + available_catalogs, catalog_id),
-                       "class" => "form-control",
                        "data-miq_sparkle_on" => true,
-                       :class    => "selectpicker")
+                       :class                => "selectpicker")
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent('catalog_id', '#{url}')
       .form-group
-        %label.col-md-2.control-label= _('Dialog')
+        %label.col-md-2.control-label
+          = _('Dialog')
         .col-md-4
           %p.form-control-static
             - available_dialogs =  @edit[:new][:available_dialogs].invert.to_a.sort_by { |a| a.first.downcase }
             - options = [["<#{_('No Dialog')}>", nil]] + available_dialogs
             = select_tag('dialog_id',
                           options_for_select(options, @edit[:new][:dialog_id]),
-                          "class" => "form-control",
                           "data-miq_sparkle_on" => true,
-                          :class    => "selectpicker")
+                          :class                => "selectpicker")
             :javascript
               miqSelectPickerEvent('dialog_id', '#{url}')
 
       - if @edit[:new][:st_prov_type] == "generic_orchestration"
         - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
         .form-group
-          %label.col-md-2.control-label= _('Orchestration Template')
+          %label.col-md-2.control-label
+            = _('Orchestration Template')
           .col-md-8
             = select_tag('template_id',
                           options_for_select(opts, @edit[:new][:template_id]),
-                          "class" => "form-control",
                           "data-miq_sparkle_on" => true,
-                          :class    => "selectpicker")
+                          :class                => "selectpicker")
             :javascript
               miqSelectPickerEvent('template_id', '#{url}')
         - if @edit[:new][:template_id]
         - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
           .form-group
-            %label.col-md-2.control-label= _('Provider')
+            %label.col-md-2.control-label
+              = _('Provider')
             .col-md-8
               = select_tag('manager_id',
                            options_for_select(opts, @edit[:new][:manager_id]),
-                           "class" => "form-control",
                            "data-miq_sparkle_on" => true,
-                            :class    => "selectpicker")
+                           :class               => "selectpicker")
               :javascript
                 miqSelectPickerEvent('manager_id', '#{url}')
       .form-group
@@ -84,46 +83,69 @@
           = _('Provisioning Entry Point')
           %br
           = _('State Machine (NS/Cls/Inst)')
-        .col-md-8
-          %table
-            %tr
-              %td
-                = text_field_tag("fqname", @edit[:new][:fqname],
-                                  :class     => "form-control",
-                                  :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
-              %td
-                #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
-                  - alt_str = _("Remove this Provisioning Entry Point")
-                  = link_to(image_tag('/images/toolbars/discard.png', :class => "rollover small", :alt => _(alt_str)),
-                            {:action => 'ae_tree_select_discard', :typ => "provision"},
-                            "data-miq_sparkle_on" => true,
-                            "data-miq_sparkle_off" => true,
-                            "data-confirm" => _("Are you sure you want to remove this Provisioning Entry Point?"),
-                            :remote => true,
-                            :title => _("Remove this Provisioning Entry Point"))
-      - unless @edit[:new][:st_prov_type] == "generic_orchestration"
-        .form-group
-          %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
-            = _('Retirement Entry Point')
-            %br
-            = _('State Machine (NS/Cls/Inst)')
-          .col-md-8
-            %table
-              %tr
-                %td
-                  = text_field_tag("reconfigure_fqname",
-                                   @edit[:new][:reconfigure_fqname],
-                                   :class     => "form-control",
-                                   :onFocus => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
-                                   "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-                %td
-                  #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
-                    = link_to(image_tag('/images/toolbars/discard.png',
-                                        :class => "rollover small",
-                                        :alt => "Remove this Reconfigure Entry Point"),
-                              {:action => 'ae_tree_select_discard', :typ => "reconfigure"},
-                              "data-miq_sparkle_on" => true,
-                              "data-miq_sparkle_off" => true,
-                              "data-confirm" => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                              :remote => true,
-                              :title => _("Remove this Reconfigure Entry Point"))
+        .col-md-8{:title => @edit[:new][:fqname]}
+          .input-group
+            = text_field_tag("fqname",
+                             @edit[:new][:fqname],
+                             :class   => "form-control",
+                             :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
+            %span.input-group-btn
+              #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
+                = link_to({:action => 'ae_tree_select_discard',
+                           :typ => "provision"},
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          "data-confirm"         => _("Are you sure you want to remove this Provisioning Entry Point?"),
+                          :remote                => true,
+                          :class                 => "btn btn-default",
+                          :title                 => _("Remove this Provisioning Entry Point")) do
+                  %i.pficon.pficon-close
+            %span.input-group-addon{:style => "visibility:hidden"}
+      .form-group
+        %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
+          = _('Reconfigure Entry Point')
+          %br
+          = _('State Machine (NS/Cls/Inst)')
+        .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
+          .input-group
+            = text_field_tag("reconfigure_fqname",
+                             @edit[:new][:reconfigure_fqname],
+                             :class             => "form-control",
+                             :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
+                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %span.input-group-btn
+              #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
+                = link_to({:action => 'ae_tree_select_discard',
+                           :typ => "reconfigure"},
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          "data-confirm"         => _("Are you sure you want to remove this Reconfigure Entry Point?"),
+                          :remote                => true,
+                          :class                 => "btn btn-default",
+                          :title                 => _("Remove this Reconfigure Entry Point")) do
+                  %i.pficon.pficon-close
+            %span.input-group-addon{:style => "visibility:hidden"}
+
+      .form-group
+        %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
+          = _('Retirement Entry Point')
+          %br
+          = _('State Machine (NS/Cls/Inst)')
+        .col-md-8{:title => @edit[:new][:retire_fqname]}
+          .input-group
+            = text_field_tag("retire_fqname",
+                             @edit[:new][:retire_fqname],
+                             :class   => "form-control",
+                             :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
+            %span.input-group-btn
+              #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
+                = link_to({:action => 'ae_tree_select_discard',
+                           :typ => "retire"},
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          "data-confirm"         => _("Are you sure you want to remove this Retirement Entry Point?"),
+                          :remote                => true,
+                          :class                 => "btn btn-default",
+                          :title                 => _("Remove this Retirement Entry Point")) do
+                  %i.pficon.pficon-close
+            %span.input-group-addon{:style => "visibility:hidden"}


### PR DESCRIPTION
 #4343
2f12272#diff-9a137f94b921af8f4aa1cf3ab1e7fc4eR89

1.
Before:
![firefox_screenshot_2015-09-15t08-52-00 407z](https://cloud.githubusercontent.com/assets/9535558/9872178/db0261c8-5b97-11e5-8550-5ad401bf9304.png)

After:
![firefox_screenshot_2015-09-16t10-23-04 771z](https://cloud.githubusercontent.com/assets/9535558/9902305/b5b7d124-5c6d-11e5-973b-906a6f26c10a.png)

Not populated:
![firefox_screenshot_2015-09-17t10-19-50 073z](https://cloud.githubusercontent.com/assets/9535558/9930789/775b736c-5d36-11e5-9f4a-e902c1d27ecd.png)



@epwinchell please review, not sure if this is enough, but at least it looks ok.