### PR TITLE
remove unused create_pxe_install

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1839,16 +1839,6 @@ class Host < ActiveRecord::Base
     miq_cim_instance.try(:logical_disks_size) || 0
   end
 
-  def create_pxe_install_request(values, requester_id, auto_approve = false)
-    values[:host_ids] = [id]
-    MiqHostProvisionRequest.create_request(values, requester_id, auto_approve)
-  end
-
-  def update_pxe_install_request(request, values, requester_id)
-    values[:host_ids] = [id]
-    MiqHostProvisionRequest.update_request(request, values, requester_id)
-  end
-
   #
   # Metric methods
   #


### PR DESCRIPTION
/cc @brandondunne @gmcculloug @jrafanie Do you guys see where this is called?

`grep pxe_install` shows nothing (was hoping it would show some dynamic name derivitation or something. Not sure how else it could be called.

If it is called, I'll need to change the caller site, otherwise, would prefer to remove.

thanks.