### PR TITLE
Schedule editor select styling update

### DIFF
--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -10,6 +10,7 @@
                        "ng-model"                    => "scheduleModel.timer_typ",
                        "ng-change"                   => "scheduleTimerTypeChanged()",
                        "checkchange"                 => "",
+                       "data-width"                  => "auto",
                        "selectpicker-for-select-tag" => "")
 
           %span{"ng-show" => "!timerTypeOnce"}= _("every")
@@ -18,6 +19,7 @@
                               "name"                      => "timer_value",
                               "ng-options"                => "timerItem.value as timerItem.text for timerItem in timer_items",
                               "timer-hide"                => "timerTypeOnce",
+                              "data-width"                => "auto",
                               "checkchange"               => ""}
           %input{"type" => "hidden", "ng-value" => "scheduleModel.timer_value", "name" => "timer_value"}
       .form-group
@@ -55,11 +57,13 @@
                        options_for_select(Array.new(24) { |i| i }),
                        "ng-model"    => "scheduleModel.start_hour",
                        "checkchange" => "",
+                       "data-width"  => "auto",
                        "selectpicker-for-select-tag" => "")
           %span h
           = select_tag("start_min",
                        options_for_select(Array.new(12) { |i| i * 5 }),
                        "ng-model"    => "scheduleModel.start_min",
                        "checkchange" => "",
+                       "data-width"  => "auto",
                        "selectpicker-for-select-tag" => "")
           %span m


### PR DESCRIPTION
Parent issue: #3139

changed select width to "auto" for selects with numbers, etc

Old:
<img width="873" alt="screen shot 2015-09-15 at 2 21 48 pm" src="https://cloud.githubusercontent.com/assets/1287144/9885810/1f263b00-5bb5-11e5-80a2-c984c224f0cd.png">
New:
<img width="901" alt="screen shot 2015-09-15 at 2 17 59 pm" src="https://cloud.githubusercontent.com/assets/1287144/9885811/1f57af96-5bb5-11e5-9b22-d629148421d2.png">