### PR TITLE
make key_root a class variable

### DIFF
--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -110,12 +110,12 @@ class MiqPassword
   end
 
   def self.key_root
-    @key_root ||= ENV["KEY_ROOT"]
+    @@key_root ||= ENV["KEY_ROOT"]
   end
 
   def self.key_root=(key_root)
     clear_keys
-    @key_root = key_root
+    @@key_root = key_root
   end
 
   def self.clear_keys

--- a/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
@@ -40,4 +40,10 @@ describe MiqAePassword do
       end
     end
   end
+
+  describe ".key_root" do
+    it "has key_root set" do
+      expect(MiqAePassword.key_root).to be
+    end
+  end
 end


### PR DESCRIPTION
fixes a sporadic build error around `MiqAePassword`

/cc @jrafanie @Fryguy 