### PR TITLE
let caller method render flash message for sublist screens. 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1245,6 +1245,7 @@ class ApplicationController < ActionController::Base
   def flash_errors?
     Array(@flash_array).any? { |f| f[:level] == :error }
   end
+  helper_method(:flash_errors?)
 
   # Handle the breadcrumb array by either adding, or resetting to, the passed in breadcrumb
   def drop_breadcrumb(new_bc, onlyreplace=false) # if replace = true, only add this bc if it was already there
@@ -1967,6 +1968,38 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def render_or_redirect_partial(pfx)
+    if @redirect_controller
+      if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
+        render :update do |page|
+          if flash_errors?
+            page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          else
+            page.redirect_to :controller => @redirect_controller,
+                             :action     => @refresh_partial,
+                             :id         => @redirect_id,
+                             :prov_type  => @prov_type,
+                             :prov_id    => @prov_id
+          end
+        end
+      else
+        render :update do |page|
+          page.redirect_to :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
+        end
+      end
+    else
+      if params[:pressed] == "ems_cloud_edit" && params[:id]
+        render :update do |page|
+          page.redirect_to edit_ems_cloud_path(params[:id])
+        end
+      else
+        render :update do |page|
+          page.redirect_to :action => @refresh_partial, :id => @redirect_id
+        end
+      end
+    end
+  end
+
   # RJS code to show tag box effects and replace the main list view area
   def replace_gtl_main_div(options={})
     action_url = options[:action_url] || @lastaction
@@ -2061,8 +2094,10 @@ class ApplicationController < ActionController::Base
     task_supported?(typ) if typ
     return if performed?
 
-    @in_a_form = true
     @redirect_controller = "miq_request"
+    # non-explorer screens will perform render in their respective button method
+    return if flash_errors?
+    @in_a_form = true
     if request.parameters[:pressed].starts_with?("host_")       # need host id for host prov
       @org_controller = "host"                                  # request originated from controller
       @refresh_partial = "prov_edit"
@@ -2600,7 +2635,7 @@ class ApplicationController < ActionController::Base
     add_flash(_("%{task} does not apply to at least one of the selected %{model}") %
                 {:model => model_type,
                  :task  => type.capitalize}, :error)
-    render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+    render_flash { |page| page << '$(\'#main_div\').scrollTop();' } if @explorer
   end
 
   def set_gettext_locale

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -107,21 +107,7 @@ class AvailabilityZoneController < ApplicationController
 
     if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                 "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/cim_instance_controller.rb
+++ b/app/controllers/cim_instance_controller.rb
@@ -94,21 +94,7 @@ class CimInstanceController < ApplicationController
 
     if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                 "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -101,25 +101,7 @@ class CloudTenantController < ApplicationController
       end
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller => @redirect_controller,
-                             :action     => @refresh_partial,
-                             :id         => @redirect_id,
-                             :prov_type  => @prov_type,
-                             :prov_id    => @prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action => @refresh_partial, :id => @redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -205,21 +205,7 @@ class EmsClusterController < ApplicationController
       end
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                    "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -533,27 +533,7 @@ module EmsCommon
       end
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                    "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        if params[:pressed] == "ems_cloud_edit" && params[:id]
-          render :update do |page|
-            page.redirect_to edit_ems_cloud_path(params[:id])
-          end
-        else
-          render :update do |page|
-            page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -89,21 +89,7 @@ class FlavorController < ApplicationController
 
     if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                 "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -552,7 +552,17 @@ class HostController < ApplicationController
         if @redirect_controller
           if ["host_miq_request_new","#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
             render :update do |page|
-              page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id, :org_controller=>@org_controller, :escape=>false
+              if flash_errors?
+                page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+              else
+                page.redirect_to :controller     => @redirect_controller,
+                                 :action         => @refresh_partial,
+                                 :id             => @redirect_id,
+                                 :prov_type      => @prov_type,
+                                 :prov_id        => @prov_id,
+                                 :org_controller => @org_controller,
+                                 :escape         => false
+              end
             end
           else
             render :update do |page|

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -136,25 +136,7 @@ class OrchestrationStackController < ApplicationController
       end
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                 "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller => @redirect_controller,
-                             :action     => @refresh_partial,
-                             :id         => @redirect_id,
-                             :prov_type  => @prov_type,
-                             :prov_id    => @prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action => @refresh_partial, :id => @redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/repository_controller.rb
+++ b/app/controllers/repository_controller.rb
@@ -203,21 +203,7 @@ class RepositoryController < ApplicationController
       end
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                    "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -157,14 +157,14 @@ class ResourcePoolController < ApplicationController
     return if ["resource_pool_tag","resource_pool_protect"].include?(params[:pressed]) && @flash_array == nil   # Tag screen showing, so return
 
     if !@flash_array && !@refresh_partial # if no button handler ran, show not implemented msg
-        add_flash(_("Button not yet implemented"), :error)
-        @refresh_partial = "layouts/flash_msg"
-        @refresh_div     = "flash_msg_div"
-      elsif @flash_array && @lastaction == "show"
-        @record = identify_record(params[:id])
-        @refresh_partial = "layouts/flash_msg"
-        @refresh_div     = "flash_msg_div"
-      end
+      add_flash(_("Button not yet implemented"), :error)
+      @refresh_partial = "layouts/flash_msg"
+      @refresh_div     = "flash_msg_div"
+    elsif @flash_array && @lastaction == "show"
+      @record = identify_record(params[:id])
+      @refresh_partial = "layouts/flash_msg"
+      @refresh_div     = "flash_msg_div"
+    end
 
     if !@flash_array.nil? && params[:pressed] == "resource_pool_delete" && @single_delete
       render :update do |page|
@@ -172,21 +172,7 @@ class ResourcePoolController < ApplicationController
       end
     elsif ["#{pfx}_miq_request_new","#{pfx}_migrate","#{pfx}_clone",
            "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -90,21 +90,7 @@ class SecurityGroupController < ApplicationController
 
     if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                 "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -150,21 +150,7 @@ class StorageController < ApplicationController
       end
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new","#{pfx}_clone",
                                                    "#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-      if @redirect_controller
-        if ["#{pfx}_clone","#{pfx}_migrate","#{pfx}_publish"].include?(params[:pressed])
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id, :prov_type=>@prov_type, :prov_id=>@prov_id
-          end
-        else
-          render :update do |page|
-            page.redirect_to :controller=>@redirect_controller, :action=>@refresh_partial, :id=>@redirect_id
-          end
-        end
-      else
-        render :update do |page|
-          page.redirect_to :action=>@refresh_partial, :id=>@redirect_id
-        end
-      end
+      render_or_redirect_partial(pfx)
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -165,7 +165,6 @@ describe ApplicationController do
       vm2 = FactoryGirl.create(:vm_microsoft)
       controller.instance_variable_set(:@_params, :pressed         => "vm_migrate",
                                                   :miq_grid_checks => "#{vm1.id},#{vm2.id}")
-      controller.should_receive(:render)
       controller.send(:prov_redirect, "migrate")
       assigns(:flash_array).first[:message].should include("does not apply to at least one of the selected")
     end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -130,6 +130,36 @@ describe EmsContainerController do
         ManageIQ::Providers::Kubernetes::ContainerManager.last.authentication_token("bearer").should == "valid-token"
       end
     end
+
+    context "#button" do
+      before(:each) do
+        set_user_privileges
+        FactoryGirl.create(:vmdb_database)
+        EvmSpecHelper.create_guid_miq_server_zone
+      end
+
+      it "when VM Migrate is pressed for unsupported type" do
+        controller.stub(:role_allows).and_return(true)
+        vm = FactoryGirl.create(:vm_microsoft)
+        post :button, :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1"
+        controller.send(:flash_errors?).should be_true
+        assigns(:flash_array).first[:message].should include('does not apply')
+      end
+
+      it "when VM Migrate is pressed for supported type" do
+        controller.stub(:role_allows).and_return(true)
+        vm = FactoryGirl.create(:vm_vmware)
+        post :button, :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1"
+        controller.send(:flash_errors?).should_not be_true
+      end
+
+      it "when VM Migrate is pressed for supported type" do
+        controller.stub(:role_allows).and_return(true)
+        vm = FactoryGirl.create(:vm_vmware)
+        post :button, :pressed => "vm_edit", :format => :js, "check_#{vm.id}" => "1"
+        controller.send(:flash_errors?).should_not be_true
+      end
+    end
   end
 end
 


### PR DESCRIPTION
- Fixed respective 'button' methods to render flash message partial when task(clone,migrate,publish) are not supported for selected items when user trees to perform these tasks from list of VMs thru relationships. render_flash_not_applicable_to_model will only render flash message when performing tasks directly from VM explorers.
- Added spec test to verify fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1263326

@martinpovolny @dclarizio please review and suggest if there is another way this issue can be fixed. To recreate the issue Go to Infrastructure Providers, Go to SCVMM Provider summary screen, from there Click on VMs in the relationships box, Select one or more VMs from the list and click on Migrate selected Items button under Lifecycle button. You should see double render error in the log, you should be able to see this behavior for any of the CIs that have link to view VMs in the relationship box on their respective summary screens. Selected VM has to be the one that do not support Migrate task, which is why i used VMs under a SCVMM provider. Let me know if you have questions or need help recreating this issue.