### PR TITLE
Use the pre-installed ruby 2.2 to save 20-30 seconds per test suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
   postgresql: '9.4'
 before_install:
 - "echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc"
+- travis_retry gem install bundler -v ">= 1.8.4"
 - "[[ -f certs/v2_key.dev ]] && cp certs/v2_key.dev certs/v2_key"
 - "[[ -n \"$GEM\" ]] || echo \"1\" > REGION"
 - "[[ -n \"$GEM\" ]] || cp config/database.pg.yml config/database.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- "2.2.3"
+- "2.2"
 sudo: false
 cache: bundler
 env:


### PR DESCRIPTION
Since we run 8 test suites per PR/merge build, that's roughly 2.5 - 4 minutes savings.

I'd like to use the latest ruby 2.2.x but it might not be worth the cost.

From a recent build on manageiq, it takes ~0.31s to use the pre-built ruby 2.2.0:

```
$ rvm use 2.2 --install --binary --fuzzy
Using /home/travis/.rvm/gems/ruby-2.2.0
```

From a recent build on another repo that uses 2.2 as the
.travis.yml version, it takes 21.80 seconds (20-30 average) to
build ruby 2.2.3 since it has to download the source and build it:

```
$ rvm use 2.2.3 --install --binary --fuzzy
ruby-2.2.3 is not installed - installing.
Searching for binary rubies, this might take some time.
Found remote file https://s3.amazonaws.com/travis-rubies/binaries/ubuntu/12.04/x86_64/ruby-2.2.3.tar.bz2
Checking requirements for ubuntu.
Requirements installation successful.
ruby-2.2.3 - #configure
ruby-2.2.3 - #download
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.1M  100 21.1M    0     0  54.7M      0 --:--:-- --:--:-- --:--:-- 55.0M
No checksum for downloaded archive, recording checksum in user configuration.
ruby-2.2.3 - #validate archive
ruby-2.2.3 - #extract
ruby-2.2.3 - #validate binary
ruby-2.2.3 - #setup
ruby-2.2.3 - #gemset created /home/travis/.rvm/gems/ruby-2.2.3@global
ruby-2.2.3 - #importing gemset /home/travis/.rvm/gemsets/global.gems................................................
ruby-2.2.3 - #generating global wrappers........
ruby-2.2.3 - #uninstalling gem rubygems-bundler-1.4.4.
ruby-2.2.3 - #gemset created /home/travis/.rvm/gems/ruby-2.2.3
ruby-2.2.3 - #importing gemset /home/travis/.rvm/gemsets/default.gems....................
ruby-2.2.3 - #generating default wrappers........
chown: changing ownership of `/home/travis/.rvm/user/installs': Operation not permitted
Using /home/travis/.rvm/gems/ruby-2.2.3
```