### PR TITLE
Freeze two different strings to reduce String allocations

### DIFF
--- a/gems/pending/util/extensions/miq-yaml.rb
+++ b/gems/pending/util/extensions/miq-yaml.rb
@@ -10,7 +10,7 @@ module Psych
           o.children.each_slice(2) { |k,v|
           key = accept(k)
 
-          if key == '<<'
+          if key == '<<'.freeze
             case v
             when Nodes::Alias
               hash.merge! accept(v)
@@ -24,7 +24,7 @@ module Psych
 
           # We need to migrate all old YAML before we can remove this
           #### Reapply the instance variables, see https://github.com/tenderlove/psych/issues/43
-          elsif key.to_s[0..5] == "__iv__"
+          elsif key.to_s[0..5] == "__iv__".freeze
             hash.instance_variable_set(key.to_s[6..-1], accept(v))
 
           else


### PR DESCRIPTION
miq-yaml.rb is responsible for creating nearly 40,000 objects when
loading the Rails environment.

By freezing the strings `"<<"` and `"__iv__"`, we allocate nearly 38%
less objects in miq-yaml.rb.

```ruby
require 'allocation_tracer'

ObjectSpace::AllocationTracer.setup(%i{path line type})

result = ObjectSpace::AllocationTracer.trace do
  require './config/environment'
end

puts ObjectSpace::AllocationTracer.header.join("\t")
result.sort_by{|k, v| k}.each{|k, v|
  puts ([v[0]]+k).join("\t")
}
```

```
$ ruby benchmark_allocations.rb | grep "miq-yaml.rb" | sort -nr
20378 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 27  T_STRING
7145  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 13  T_STRING
6064  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 10  T_NODE
3032  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 10  T_ARRAY
1034  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 31  T_STRING
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 8 T_NODE
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 7 T_NODE
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 6 T_NODE
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 1 T_STRING
```

```
$ ruby benchmark_allocations.rb | grep "miq-yaml.rb" | sort -nr
13237 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 27  T_STRING
6064  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 10  T_NODE
3032  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 10  T_ARRAY
1034  /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 31  T_STRING
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 8 T_NODE
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 7 T_NODE
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 6 T_NODE
1 /Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb 1 T_STRING
```