### PR TITLE
performance: report derived logical cpus

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -42,6 +42,7 @@ module Metric::Common
     virtual_column :v_derived_host_count,          :type => :integer
     virtual_column :v_derived_cpu_reserved_pct,    :type => :float
     virtual_column :v_derived_memory_reserved_pct, :type => :float
+    virtual_column :v_derived_logical_cpus_used,   :type => :float
   end
 
   def v_find_min_max(vcol)
@@ -133,6 +134,11 @@ module Metric::Common
   def v_derived_memory_reserved_pct
     return nil if self.derived_memory_reserved.nil? || self.derived_memory_available.nil? || derived_memory_available == 0
     (self.derived_memory_reserved / self.derived_memory_available * 100)
+  end
+
+  def v_derived_logical_cpus_used
+    return nil if cpu_usage_rate_average.nil? || derived_vm_numvcpus.nil? || derived_vm_numvcpus == 0
+    (cpu_usage_rate_average * derived_vm_numvcpus) / 100.0
   end
 
   def apply_time_profile(profile)

--- a/spec/models/metric/common_spec.rb
+++ b/spec/models/metric/common_spec.rb
@@ -56,4 +56,23 @@ describe Metric::Common do
       res.should be_false
     end
   end
+
+  it ".v_derived_logical_cpus_used" do
+    m = Metric.new
+
+    # cpu_rate, num_vcpus, logical_cpus_used
+    metrics_exercises = [
+      [0, 8, 0], [10, 8, 0.8], [50, 8, 4], [75, 8, 6], [100, 8, 8],
+      [nil, 8, nil], [nil, 4, nil],
+      [0, 0, nil], [10, 0, nil], [50, 0, nil],
+      [0, nil, nil], [10, nil, nil], [50, nil, nil],
+      [nil, nil, nil],
+    ]
+
+    metrics_exercises.each do |cpu_rate, num_vcpus, expected|
+      m.cpu_usage_rate_average = cpu_rate
+      m.derived_vm_numvcpus = num_vcpus
+      expect(m.v_derived_logical_cpus_used).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
It is important to store the number of logical cpu used by an entity (container/vm/etc.) so that it's possible to compare it with other ones running on other hosts (with possibly different core counts).