### PR TITLE
Tenant migrate miq requests

### DIFF
--- a/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
+++ b/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
@@ -1,4 +1,4 @@
-class AssignTenant < ActiveRecord::Migration
+class AssignTenantToMiqRequest < ActiveRecord::Migration
   class Tenant < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
 
@@ -6,10 +6,6 @@ class AssignTenant < ActiveRecord::Migration
     def self.root_tenant
       Tenant.where(:ancestry => nil).first || Tenant.create!(:use_config_for_attributes => true)
     end
-  end
-
-  class ExtManagementSystem < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   class MiqAeNamespace < ActiveRecord::Base
@@ -20,11 +16,11 @@ class AssignTenant < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class Provider < ActiveRecord::Base
+  class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class TenantQuota < ActiveRecord::Base
+  class Provider < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
 
@@ -32,14 +28,34 @@ class AssignTenant < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
+  class MiqRequest < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqRequestTask < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Service < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ServiceTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ServiceTemplateCatalog < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
   def change
-    models = [ExtManagementSystem, MiqAeNamespace, MiqGroup,
-              Provider, TenantQuota, Vm]
+    models = [ExtManagementSystem, MiqAeNamespace, MiqGroup, Provider, Vm,
+              MiqRequest, MiqRequestTask, Service, ServiceTemplate, ServiceTemplateCatalog]
 
     # only create a root tenant if there are records in the db
     return unless MiqGroup.exists?
 
-    say_with_time "assigning tenant to models" do
+    say_with_time "assigning tenant to models pt2" do
       root_tenant = Tenant.root_tenant
       models.each do |model|
         model.where(:tenant_id => nil).update_all(:tenant_id => root_tenant.id)

--- a/spec/migrations/20150915001329_assign_tenant_to_miq_request_spec.rb
+++ b/spec/migrations/20150915001329_assign_tenant_to_miq_request_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+require_migration
+
+describe AssignTenantToMiqRequest do
+  let(:tenant_stub)           { migration_stub(:Tenant) }
+  let(:miq_group_stub)        { migration_stub(:MiqGroup) }
+  let(:ems_stub)              { migration_stub(:ExtManagementSystem) }
+  let(:miq_ae_namespace_stub) { migration_stub(:MiqAeNamespace) }
+  let(:provider_stub)         { migration_stub(:Provider) }
+  let(:vm_stub)               { migration_stub(:Vm) }
+  let(:miq_request_stub)      { migration_stub(:MiqRequest) }
+  let(:miq_request_task_stub) { migration_stub(:MiqRequestTask) }
+  let(:service_stub)          { migration_stub(:Service) }
+  let(:service_template_stub) { migration_stub(:ServiceTemplate) }
+  let(:service_catalog_stub) { migration_stub(:ServiceTemplateCatalog) }
+
+  let(:stubs) do
+    [
+      ems_stub, miq_ae_namespace_stub, miq_group_stub, provider_stub, vm_stub,
+      miq_request_stub, miq_request_task_stub, service_stub, service_template_stub, service_catalog_stub
+    ]
+  end
+
+  migration_context :up do
+    describe "#root_tenant" do
+      it "doesnt create tenant if no records exist" do
+        migrate
+
+        expect(tenant_stub.count).to eq(0)
+      end
+
+      it "creates tenant if needed" do
+        miq_group_stub.create!
+        migrate
+
+        expect(tenant_stub.count).to eq(1)
+        expect(tenant_stub.first).to be_use_config_for_attributes
+      end
+
+      it "doesnt creates additional root_tenant" do
+        tenant_stub.create!
+        miq_group_stub.create!
+
+        migrate
+
+        expect(tenant_stub.count).to eq(1)
+        # make sure tenant was not modified
+        expect(tenant_stub.first).not_to be_use_config_for_attributes
+      end
+    end
+
+    it "updates existing records" do
+      tenant_stub.root_tenant
+      miq_group_stub.create!
+
+      stubs.map(&:create!)
+
+      migrate
+
+      expect(tenant_stub.count).to eq(1)
+      stubs.each do |stub|
+        expect(stub.where(:tenant_id => nil).exists?).to be_false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This migrates populates existing `miq_requests.tenant_id`.

This also circles back to an existing migration `db/migrate/20150903162623_assign_tenant.rb` to add a say clause. as noted, this currently has specs.