### PR TITLE
Fixed HAML indentation

### DIFF
--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -21,27 +21,27 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('instance_name', "#{url}")
-    .form-group
-      %label.col-md-2.control-label
-        = _("Message")
-      .col-md-8
-        = text_field_tag("object_message",
-                         resolve[:new][:object_message],
-                         :maxlength         => MAX_NAME_LEN,
-                         :class             => "form-control",
-                         "data-miq_observe" => {:interval => '.5',
-                                                :url      => url}.to_json)
-        - unless is_browser_ie?
-          = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
-    .form-group
-      %label.col-md-2.control-label
-        = _("Request")
-      .col-md-8
-        = text_field_tag("object_request",
-                         resolve[:new][:object_request],
-                         :maxlength         => MAX_NAME_LEN,
-                         :class            => "form-control",
-                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+.form-group
+  %label.col-md-2.control-label
+    = _("Message")
+  .col-md-8
+    = text_field_tag("object_message",
+                     resolve[:new][:object_message],
+                     :maxlength         => MAX_NAME_LEN,
+                     :class             => "form-control",
+                     "data-miq_observe" => {:interval => '.5',
+                                            :url      => url}.to_json)
+    - unless is_browser_ie?
+      = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
+.form-group
+  %label.col-md-2.control-label
+    = _("Request")
+  .col-md-8
+    = text_field_tag("object_request",
+                     resolve[:new][:object_request],
+                     :maxlength         => MAX_NAME_LEN,
+                     :class            => "form-control",
+                     "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 - if form_action != "miq_action"
   - if ae_custom_button
     %hr


### PR DESCRIPTION
Incorrect HAML indentation was hiding some of the fields while trying to add/edit Action type "Invoke a Custom Automation".

https://bugzilla.redhat.com/show_bug.cgi?id=1263494

@dclarizio please review

before:
![before_fix](https://cloud.githubusercontent.com/assets/3450808/9911314/85e8a78c-5c6f-11e5-8d5b-d23a98781984.png)

after:
![invoke_custom_action](https://cloud.githubusercontent.com/assets/3450808/9911316/8b99ec54-5c6f-11e5-9e08-6306e28b49c7.png)

