### PR TITLE
[api] Enhancement to support custom action buttons

### DIFF
--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -100,6 +100,21 @@ class ApiController
       end
     end
 
+    def custom_action_resource(type, id, data = nil)
+      action = @req[:action].downcase
+      id ||= @req[:c_id]
+      if id.blank?
+        raise BadRequestError, "Must specify and id for invoking the custom action #{action} on a #{type} resource"
+      end
+
+      api_log_info("Invoking #{action} on #{type} id #{id}")
+      resource = resource_search(id, type, collection_class(type))
+      unless resource_custom_action_names(resource).include?(action)
+        raise BadRequestError, "Unsupported Custom Action #{action} for the #{type} resource specified"
+      end
+      invoke_custom_action(type, resource, action, data)
+    end
+
     private
 
     def add_subcollection_data_to_resource(resource, type, subcollection_data)
@@ -129,6 +144,25 @@ class ApiController
       add_href_to_result(result, type, id)
       log_result(result)
       result
+    end
+
+    def invoke_custom_action(type, resource, action, _data)
+      custom_button = resource_custom_action_button(resource, action)
+      raise BadRequestError, "Custom Actions with Dialogs are not supported" if custom_button.resource_action.dialog_id
+
+      result = begin
+        custom_button.invoke(resource)
+        action_result(true, "Invoked custom action #{action} for #{type} id: #{resource.id}")
+      rescue => err
+        action_result(false, err.to_s)
+      end
+      add_href_to_result(result, type, resource.id)
+      log_result(result)
+      result
+    end
+
+    def resource_custom_action_button(resource, action)
+      resource.custom_action_buttons.find { |b| b.name.downcase == action.downcase }
     end
   end
 end

--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -87,7 +87,9 @@ class ApiController
       else
         target = "#{action}_resource"
         typed_target = "#{target}_#{type}"
-        respond_to?(typed_target) ? typed_target : target
+        return typed_target if respond_to?(typed_target)
+        return target if respond_to?(target)
+        return "custom_action_resource" if resource_can_have_custom_actions(type)
       end
     end
 

--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -67,7 +67,7 @@ class ApiController
 
     def delete_subcollection_resource(type, id = nil)
       raise BadRequestError,
-            "Must specify and id for destroying a #{type} subcollection resource" if id.nil?
+            "Must specify an id for destroying a #{type} subcollection resource" if id.nil?
 
       parent_resource = parent_resource_obj
       typed_target    = "delete_resource_#{type}"
@@ -89,7 +89,7 @@ class ApiController
         typed_target = "#{target}_#{type}"
         return typed_target if respond_to?(typed_target)
         return target if respond_to?(target)
-        return "custom_action_resource" if resource_can_have_custom_actions(type)
+        resource_can_have_custom_actions(type) ? "custom_action_resource" : "undefined_api_method"
       end
     end
 

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -89,6 +89,7 @@ class ApiController
       end
 
       expand_actions(json, type, opts)
+      expand_resource_custom_actions(resource, json, type)
       json
     end
 
@@ -326,6 +327,22 @@ class ApiController
           aspecs.each { |action_spec| add_child js, normalize_hash(type, action_spec) }
         end
       end
+    end
+
+    def expand_resource_custom_actions(resource, json, type)
+      return unless render_attr("actions") && resource_can_have_custom_actions(type)
+
+      href = json.attributes!["href"]
+      json.actions do |js|
+        resource_custom_action_names(resource).each do |action|
+          add_child js, "name" => action, "method" => :post, "href" => href
+        end
+      end
+    end
+
+    def resource_custom_action_names(resource)
+      return [] unless resource.respond_to?(:custom_action_buttons)
+      Array(resource.custom_action_buttons).collect(&:name).collect(&:downcase)
     end
 
     def render_resource_attr(resource, attr)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -16,6 +16,11 @@ class Service < ActiveRecord::Base
   virtual_column     :v_total_vms,            :type => :integer,  :uses => :vms
   virtual_has_one    :picture
 
+  virtual_has_one    :custom_actions
+  virtual_has_one    :custom_action_buttons
+
+  delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
+
   include ServiceMixin
   include OwnershipMixin
   include CustomAttributeMixin

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -30,6 +30,20 @@ class ServiceTemplate < ActiveRecord::Base
 
   default_value_for :service_type,  'unknown'
 
+  virtual_has_one :custom_actions, :class_name => "Hash"
+  virtual_has_one :custom_action_buttons, :class_name => "Array"
+
+  def custom_actions
+    {
+      :buttons       => custom_buttons,
+      :button_groups => custom_button_sets.collect { |s| s.serializable_hash.merge(:buttons => s.children) }
+    }
+  end
+
+  def custom_action_buttons
+    custom_buttons + custom_button_sets.collect(&:children).flatten
+  end
+
   def custom_buttons
     CustomButton.buttons_for(self).select { |b| b.parent.nil? }
   end

--- a/config/api.yml
+++ b/config/api.yml
@@ -685,6 +685,7 @@
     :description: Services
     :options:
     - :collection
+    - :custom_actions
     :methods: *70174834084700
     :klass: Service
     :subcollections:

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -1,0 +1,183 @@
+#
+# Rest API Request Tests - Custom Actions
+#
+# - Querying custom actions and custom action buttons of service templates
+#       GET /api/service_templates/:id?attributes=custom_actions
+#       GET /api/service_templates/:id?attributes=custom_action_buttons
+#
+# - Querying custom actions and custom action buttons of services
+#       GET /api/services/:id?attributes=custom_actions
+#       GET /api/services/:id?attributes=custom_action_buttons
+#
+# - Querying a service should also return in its actions the list
+#   of custom actions.
+#       GET /api/services/:id
+#
+# - Triggering a custom action on a service (case insensitive)
+#       POST /api/services/:id
+#          { "action" : "<custom_action_button_name>" }
+#
+require 'spec_helper'
+
+describe ApiController do
+  include Rack::Test::Methods
+
+  before(:each) do
+    init_api_spec_env
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  let(:template1) { FactoryGirl.create(:service_template, :name => "template1") }
+  let(:svc1) { FactoryGirl.create(:service, :name => "svc1", :service_template_id => template1.id) }
+
+  let(:button1) do
+    FactoryGirl.create(:custom_button,
+                       :name        => "button1",
+                       :description => "button one",
+                       :applies_to  => template1,
+                       :userid      => api_config(:user))
+  end
+
+  let(:button2) do
+    FactoryGirl.create(:custom_button,
+                       :name        => "button2",
+                       :description => "button two",
+                       :applies_to  => template1,
+                       :userid      => api_config(:user))
+  end
+
+  let(:button3) do
+    FactoryGirl.create(:custom_button,
+                       :name        => "button3",
+                       :description => "button three",
+                       :applies_to  => template1,
+                       :userid      => api_config(:user))
+  end
+
+  let(:button_group1) do
+    FactoryGirl.create(:custom_button_set,
+                       :name        => "button_group1",
+                       :description => "button group one",
+                       :set_data    => {:applies_to_id => template1.id, :applies_to_class => template1.class.name},
+                       :owner       => template1)
+  end
+
+  def create_custom_buttons
+    button1
+    button_group1.replace_children([button2, button3])
+  end
+
+  def expect_result_to_have_custom_actions_hash
+    expect_result_to_have_keys(%w(custom_actions))
+    custom_actions = @result["custom_actions"]
+    expect(custom_actions.keys).to match_array(%w(buttons button_groups))
+    expect(custom_actions["buttons"].size).to eq(1)
+    expect(custom_actions["button_groups"].size).to eq(1)
+    expect(custom_actions["button_groups"].first["buttons"].size).to eq(2)
+  end
+
+  describe "Querying services with no custom actions" do
+    it "returns core actions as authorized" do
+      api_basic_authorize action_identifier(:services, :edit)
+
+      run_get services_url(svc1.id)
+
+      expect_result_to_have_keys(%w(id href actions))
+      expect(@result["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
+    end
+  end
+
+  describe "Querying services with custom actions" do
+    before(:each) do
+      create_custom_buttons
+    end
+
+    it "returns core actions as authorized including custom action buttons" do
+      api_basic_authorize action_identifier(:services, :edit)
+
+      run_get services_url(svc1.id)
+
+      expect_result_to_have_keys(%w(id href actions))
+      expect(@result["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
+    end
+
+    it "supports the custom_actions attribute" do
+      api_basic_authorize action_identifier(:services, :edit)
+
+      run_get services_url(svc1.id), :attributes => "custom_actions"
+
+      expect_result_to_have_keys(%w(id href))
+      expect_result_to_have_custom_actions_hash
+    end
+
+    it "supports the custom_action_buttons attribute" do
+      api_basic_authorize action_identifier(:services, :edit)
+
+      run_get services_url(svc1.id), :attributes => "custom_action_buttons"
+
+      expect_result_to_have_keys(%w(id href custom_action_buttons))
+      expect(@result["custom_action_buttons"].size).to eq(3)
+    end
+  end
+
+  describe "Querying service_templates with custom actions" do
+    before(:each) do
+      create_custom_buttons
+    end
+
+    it "returns core actions as authorized excluding custom action buttons" do
+      api_basic_authorize action_identifier(:service_templates, :edit)
+
+      run_get service_templates_url(template1.id)
+
+      expect_result_to_have_keys(%w(id href actions))
+      action_specs = @result["actions"]
+      expect(action_specs.size).to eq(1)
+      expect(action_specs.first["name"]).to eq("edit")
+    end
+
+    it "supports the custom_actions attribute" do
+      api_basic_authorize
+
+      run_get service_templates_url(template1.id), :attributes => "custom_actions"
+
+      expect_result_to_have_keys(%w(id href))
+      expect_result_to_have_custom_actions_hash
+    end
+
+    it "supports the custom_action_buttons attribute" do
+      api_basic_authorize
+
+      run_get service_templates_url(template1.id), :attributes => "custom_action_buttons"
+
+      expect_result_to_have_keys(%w(id href custom_action_buttons))
+      expect(@result["custom_action_buttons"].size).to eq(3)
+    end
+  end
+
+  describe "Services with custom actions" do
+    before(:each) do
+      create_custom_buttons
+      button1.resource_action = FactoryGirl.create(:resource_action)
+    end
+
+    it "accepts a custom action" do
+      api_basic_authorize
+
+      run_post(services_url(svc1.id), gen_request(:button1, "button_key1" => "value", "button_key2" => "value"))
+
+      expect_single_action_result(:success => true, :message => /.*/, :href => services_url(svc1.id))
+    end
+
+    it "accepts a custom action as case insensitive" do
+      api_basic_authorize
+
+      run_post(services_url(svc1.id), gen_request(:BuTtOn1, "button_key1" => "value", "button_key2" => "value"))
+
+      expect_single_action_result(:success => true, :message => /.*/, :href => services_url(svc1.id))
+    end
+  end
+end


### PR DESCRIPTION
- Added custom_actions virtual attribute to service_templates
- Added custom_action_buttons virtual attribute to service_templates
- Delegating custom_actions and custom_action_buttons from services to their service_template
- When queries services, expand the available actions to include custom action buttons
- Update Rest API parser to allow non api.yml specified actions when custom actions are allowed for resources.
- Implemented a generic custom action method for verifying and invoking a custom action
- Support simple button actions and return REST API action result signature

https://trello.com/c/7C2VEFGM/122-api-add-support-for-custom-service-button-actions