### PR TITLE
merge automation_request, vm_reconfigure_request

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -5,6 +5,7 @@ class AutomationRequest < MiqRequest
   DEFAULT_NAMESPACE = "SYSTEM"
   DEFAULT_CLASS     = "PROCESS"
   DEFAULT_INSTANCE  = "AUTOMATION_REQUEST"
+  SOURCE_CLASS_NAME = nil
 
   ##############################################
   # uri_parts:  instance=IIII|message=MMMM or any subset thereof
@@ -39,18 +40,6 @@ class AutomationRequest < MiqRequest
     self.create_request(options, userid, auto_approve)
   end
 
-  def self.create_request(options, userid, auto_approve=false)
-    request = self.create(:options => options, :userid => userid, :request_type => 'automation')
-    request.save!  # Force validation errors to raise now
-
-    request.set_description
-    request.create_request
-    request.call_automate_event_queue("request_created")
-    request.approve(userid, "Auto-Approved") if auto_approve == true
-
-    return request.reload # if approved, need to reload
-  end
-
   def self.zone(options)
     zone_name = options[:attrs][:miq_zone]
     return nil if zone_name.blank?
@@ -69,4 +58,7 @@ class AutomationRequest < MiqRequest
     'automate'
   end
 
+  def log_request_success(requester_id, mode)
+    # currently we do not log successful automation requests
+  end
 end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -1,5 +1,4 @@
 class ServiceTemplateProvisionRequest < MiqRequest
-
   TASK_DESCRIPTION  = 'Service_Template_Provisioning'
   SOURCE_CLASS_NAME = 'ServiceTemplate'
   ACTIVE_STATES     = %w{ migrated } + self.base_class::ACTIVE_STATES
@@ -39,13 +38,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
     req_task_attrs['options'][:pass] = idx
   end
 
-  def self.create_request(values, requester_id, auto_approve=false)
-    event_message = "#{TASK_DESCRIPTION} requested by <#{requester_id}> for ServiceTemplate:#{values[:src_id]}"
-    super(values, requester_id, auto_approve, request_types.first, SOURCE_CLASS_NAME, event_message)
-  end
-
-  def self.update_request(request, values, requester_id)
-    event_message = "#{TASK_DESCRIPTION} request updated by <#{requester_id}> for ServiceTemplate:#{values[:src_id]}"
-    super(request, values, requester_id, SOURCE_CLASS_NAME, event_message)
+  def my_records
+    "#{self.class::SOURCE_CLASS_NAME}:#{get_option(:src_id)}"
   end
 end

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -6,16 +6,6 @@ class VmReconfigureRequest < MiqRequest
   validates_inclusion_of :request_state,  :in => %w{ pending finished } + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"
   validate               :must_have_user
 
-  def self.create_request(values, requester_id, auto_approve=false)
-    event_message = "#{TASK_DESCRIPTION} requested by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
-    super(values, requester_id, auto_approve, request_types.first, SOURCE_CLASS_NAME, event_message)
-  end
-
-  def self.update_request(request, values, requester_id)
-    event_message = "#{TASK_DESCRIPTION} request updated by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
-    super(request, values, requester_id, SOURCE_CLASS_NAME, event_message)
-  end
-
   def self.request_limits(options)
     # Memory values are in megabytes
     default_max_vm_memory = 255.gigabyte / 1.megabyte
@@ -97,5 +87,4 @@ class VmReconfigureRequest < MiqRequest
   def my_role
     'ems_operations'
   end
-
 end


### PR DESCRIPTION
We need to add tenant to the workspace, request, and task.

By extracting the logging routine, we are able to merge the `create_request` factory method implementations.

1. disabled logging for automate (since that is original behavior) Can enable if you want.
2. If logging, need `SOURCE_CLASS_NAME` for automate.
3. Change logging from `<#{request.userid}>` to `[#{request.userid}]` to make similar to workflows.
4. Added "for record ..." to make like similar to workflows.

/cc @gmcculloug If you like this, I'm going to convert workspaces to use these same methods.