### PR TITLE
Disable minification and annotation injections

### DIFF
--- a/spa_ui/self_service/gulp/tasks/optimize.js
+++ b/spa_ui/self_service/gulp/tasks/optimize.js
@@ -39,8 +39,13 @@ module.exports = function(gulp, options) {
       .pipe(cssFilter.restore())
       // Get the custom javascript
       .pipe(jsAppFilter)
-      .pipe(ngAnnotate(config.ngAnnotateOptions))
-      .pipe(uglify())
+
+      // FIXME Disabling minifiction and injection until the following issue with ng-annotate has been resolved
+      // Issue : https://github.com/olov/ng-annotate/issues/168
+      //
+      //.pipe(ngAnnotate(config.ngAnnotateOptions))
+      //.pipe(uglify())
+
       .pipe(getHeader())
       .pipe(jsAppFilter.restore())
       // Get the vendor javascript


### PR DESCRIPTION
An issue exists with ng-annotate [https://github.com/olov/ng-annotate/issues/168] that
causes hoisted functions to be 'injected' too late.

This will cause the built application to throw unknown Provider errors which can be very
 difficult to track down in the minified code. Likewise if annotations are left on and the code
 is still not minified you can run into issues with calling inject on undefined.

 Short term solution is to disable the two commands in the optimize task until the issue is
 resolved. This will result in a larger app.js file only. The lib.js will continue to be minified.