### PR TITLE
Fix double `_tree` in div name when replacing a policy tree

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -520,7 +520,8 @@ class MiqPolicyController < ApplicationController
     return add_nodes
   end
 
-  def replace_right_cell(nodetype, replace_trees = [])  # replace_trees can be an array of tree symbols to be replaced
+  # replace_trees can be an array of tree symbols to be replaced
+  def replace_right_cell(nodetype, replace_trees = [], presenter = nil)
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
     @explorer = true
 
@@ -540,9 +541,8 @@ class MiqPolicyController < ApplicationController
     h_buttons, h_xml = build_toolbar_buttons_and_xml('x_history_tb')
 
     # Build a presenter to render the JS
-    presenter = ExplorerPresenter.new(
-      :active_tree => x_active_tree,
-    )
+    presenter ||= ExplorerPresenter.new(:active_tree => x_active_tree)
+
     r = proc { |opts| render_to_string(opts) }
 
     presenter[:open_accord] = params[:accord] if params[:accord] # Open new accordion

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -573,7 +573,7 @@ class MiqPolicyController < ApplicationController
       end
 
       tree = @trees["#{name}_tree".to_sym]
-      presenter[:replace_partials]["#{tree.name}_tree_div".to_sym] = r[
+      presenter[:replace_partials]["#{tree.name}_div".to_sym] = r[
         :partial => "shared/tree",
         :locals  => {
           :tree => tree,

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -202,6 +202,18 @@ describe MiqPolicyController do
     end
   end
 
+  describe '#replace_right_cell' do
+    it 'should replace policy_tree_div when replace_trees contains :policy' do
+      controller.stub(:params).and_return({:action => 'whatever'})
+      controller.instance_eval { @sb = {:active_tree => :policy_tree} }
+      controller.stub(:render).and_return(nil)
+      presenter = ExplorerPresenter.new(:active_tree => :policy_tree)
+
+      controller.send(:replace_right_cell, 'root', [:policy], presenter)
+      expect(presenter[:replace_partials]).to have_key(:policy_tree_div)
+    end
+  end
+
   describe 'x_button' do
     describe 'corresponding methods are called for allowed actions' do
       MiqPolicyController::POLICY_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|


### PR DESCRIPTION
`tree.name` already contains `_tree`, so we only need to add `_div` to that, not `_tree_div`.

Closes #4375 
