### PR TITLE
Pictures are not always available on disk for consumption by other UI's

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -97,6 +97,7 @@ class Picture < ActiveRecord::Base
   end
 
   def image_href
+    sync_to_disk
     url_path
   end
 end


### PR DESCRIPTION
When an API request comes in to request the picture's image_href, let's
sync_to_disk if needed as the intent is to access the image by href.

This would also allow other UI's to request us to sync all our pictures
to disk via:

    GET /api/pictures?expand=resources&attributes=image_href