### PR TITLE
[Openstack] Delete rabbit queues when the connection closes

### DIFF
--- a/gems/pending/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/gems/pending/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -98,7 +98,7 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
       @options[:topics].each do |exchange, topic|
         amqp_exchange = channel.topic(exchange)
         queue_name = "miq-#{@client_ip}-#{exchange}"
-        @queues[exchange] = channel.queue(queue_name).bind(amqp_exchange, :routing_key => topic)
+        @queues[exchange] = channel.queue(queue_name, :auto_delete => true, :exclusive => true).bind(amqp_exchange, :routing_key => topic)
       end
     end
   end


### PR DESCRIPTION
To gather events from OpenStack, ManageIQ creates a queue in RabbitMQ that binds to an exchange.  The queue should be configured to ensure that only the ManageIQ connection can use the queue (since it's not really shared with anyone) and that the queue should be deleted after the connection is closed (since there's no reason to keep the queue open after ManageIQ closes the connection and is no longer collecting events from OpenStack). 

https://github.com/ruby-amqp/bunny/blob/40db27fd829e95233e0a9a91b76e14efb39528d0/lib/bunny/queue.rb#L26-L27