### PR TITLE
Added only_path => true so url_for returns a relative url.

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -1060,6 +1060,7 @@ module EmsCommon
   def show_link(ems, options = {})
     url_for(options.merge(:controller => @table_name,
                           :action     => "show",
-                          :id         => ems.id))
+                          :id         => ems.id,
+                          :only_path  => true))
   end
 end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -132,3 +132,14 @@ describe EmsContainerController do
     end
   end
 end
+
+describe EmsInfraController do
+  context "#show_link" do
+    let(:ems) { mock_model(EmsInfra) }
+    it "sets relative url" do
+      controller.instance_variable_set(:@table_name, "ems_infra")
+      link = controller.send(:show_link, ems, :display => "vms")
+      link.should eq("/ems_infra/show/#{ems.id}?display=vms")
+    end
+  end
+end


### PR DESCRIPTION
Need url_for to generate relative url to be used/stored in breadcrumbs. This was causing an error when pressing cancel button on migrate screen when going to Migrate task for selected VMs from Provider relationships.

Fixes #4389 
@tenderlove please review, this issue was caused by changes to add show_link method in commit sha: 52458a65fa9368b9fdc30a170e5a3fca4c460543, changes in this commit was returning absolute url causing errors when pressing cancel button