### PR TITLE
Add Monitoring Thread to Watch for Worker Shutdown

### DIFF
--- a/gems/pending/VixDiskLib/VixDiskLibServer.rb
+++ b/gems/pending/VixDiskLib/VixDiskLibServer.rb
@@ -107,19 +107,26 @@ begin
   #
   # Now write the URI used back to the parent (client) process to let it know which port was selected.
   #
-  uri_writer = IO.open(3, 'w')
-  uri_writer.write "#{uri_used}"
-  uri_writer.flush
-  uri_writer.close
+  IO.open(3, 'w') do |uri_writer|
+    uri_writer.write "#{uri_used}"
+  end
 
-  proc_reader = IO.open(4, File::RDONLY | File::SYNC)
+  proc_reader = IO.open(4, 'r')
   #
   # Trap Handlers useful for testing and debugging.
   #
   trap('INT') { vddk.shut_down_service("Interrupt Signal received"); exit }
   trap('TERM') { vddk.shut_down_service("Termination Signal received"); exit }
 
-  Thread.new { $vim_log.info "Monitoring Thread"; proc_reader.read; $vim_log.info "Shutting down VixDiskLibServer - Worker has exited"; exit }
+  Thread.new do 
+    $vim_log.info "Monitoring Thread"
+    #
+    # This will block until the SmartProxyWorker (our parent) exits
+    #
+    proc_reader.read
+    $vim_log.info "Shutting down VixDiskLibServer - Worker has exited"
+    exit
+  end
   #
   # If we haven't been marked as started yet, wait for it.
   # We may return immediately because startup (and more) has already happened.


### PR DESCRIPTION
Added a thread to the VixDiskLibServer to read one end of a pipe that
the SmartProxyWorker has opened.  When the read returns the worker process
has exited so the VixDiskLibServer shuts down.

This fixes the BZ https://bugzilla.redhat.com/show_bug.cgi?id=1258985

This fix was implemented in lieu of previous PR #4277 which passed SIGTERM
from the worker process to the server process.  The new implementation
will handle any signal that has caused the worker to exit including
SIGKILL. The previous PR will be closed.

Instead of using an environment variable to let VixDiskLibServer know which
FD contains the pipe we are using a known FD.  In addition we have changed
the previous logic for the other pipe being used by these two
processes which is used to hand the DRb URI back to the worker so that it
also uses a known FD.

Finally we have fixed the retry logic in the worker to read the URI before
attempting to establish the DRb connection.

The "known FD" and retry logic code come from PR #4318 by @matthewd which
will be closed in lieu of this new one.

@roliveri @jrafanie @hsong-rh please review.