### PR TITLE
Fixed to load correct screen when pressing buttons under Lifecycle.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2081,7 +2081,7 @@ class ApplicationController < ActionController::Base
       end
     else
       @org_controller = "vm"                                      #request originated from controller
-      @refresh_partial = "pre_prov"
+      @refresh_partial = typ ? "prov_edit" : "pre_prov"
     end
     if typ
       vms = find_checked_items

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -783,7 +783,8 @@ module ApplicationController::MiqRequestMethods
     @edit[:key]                 = "prov_edit__#{@edit[:req_id] || "new"}"
     options                     = req.try(:get_options) || {}  # Use existing request options, if passed in
     @edit[:new]                 = options unless @workflow_exists
-    @edit[:org_controller]      = params[:org_controller] if params[:org_controller]  # request originated from controller
+    # request originated from controller
+    @edit[:org_controller]      = params[:org_controller] ? params[:org_controller] : "vm"
     @edit[:wf], pre_prov_values = workflow_instance_from_vars(req)
 
     if @edit[:wf]

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -20,6 +20,15 @@ describe EmsInfraController do
       controller.send(:flash_errors?).should_not be_true
     end
 
+    it "when VM Migrate is pressed" do
+      vm = FactoryGirl.create(:vm_vmware)
+      ems = FactoryGirl.create("ems_vmware")
+      post :button, :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => 1, :id => ems.id
+      controller.send(:flash_errors?).should_not be_true
+      response.body.should include("/miq_request/prov_edit?")
+      expect(response.status).to eq(200)
+    end
+
     it "when VM Retire is pressed" do
       controller.should_receive(:retirevms).once
       post :button, :pressed => "vm_retire", :format => :js


### PR DESCRIPTION
When pressing Publish, Migrate, Clone buttons under Lifecycle toolbar button from list of VMs under a Provider thru relationship was loading pre provisioning dialog, it should load the workflow dialog directly. Pre-provisioning dialog is only supposed to show when Adding a new Provisioning request directly from VM explorers.

https://bugzilla.redhat.com/show_bug.cgi?id=1263845

@dclarizio please review.

before:
Migrate VMs under provider -
![provider_vms_migrate](https://cloud.githubusercontent.com/assets/3450808/9943862/f34a787c-5d51-11e5-83b4-7f32aa66640e.png)
Migrate directly from VMx -
![vmx](https://cloud.githubusercontent.com/assets/3450808/9943878/09687a3c-5d52-11e5-8f6a-d19bd71b8996.png)

after:
Migrate VMs under provider -
![after_fix](https://cloud.githubusercontent.com/assets/3450808/9943918/30dcf872-5d52-11e5-900c-f46d50fb9108.png)
