### PR TITLE
Automate | Services | Changed CatalogItemInitialization automate method for Orchestration provisioning.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/catalogiteminitization.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/catalogiteminitization.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CatalogItemInitization
+    inherits: 
+    description: default
+  fields:
+  - pre1:
+      value: "/Service/Provisioning/StateMachines/Methods/CatalogItemInitialization"
+  - pre2:
+      value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/Preprovision"

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -156,6 +156,17 @@ def set_option_on_provision_task(dialog_options_hash, prov)
   end
 end
 
+def set_option_on_destination(dialog_options_hash, destination)
+  dialog_options_hash.each do |key, value|
+    log_and_update_message(:info, "Adding Option: {#{key} => #{value}} to Destination id: #{destination.id}")
+    destination.set_dialog_option(destination_key_name(key), value)
+  end
+end
+
+def destination_key_name(key)
+  key.to_s.starts_with?("dialog_") ? key.to_s : "dialog_#{key}"
+end
+
 def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, dialog_tags_hash)
   provision_task.miq_request_tasks.each do |prov|
     log_and_update_message(:info, "Grandchild Task: #{prov.id} Desc: #{prov.description} type: #{prov.source_type}")
@@ -166,6 +177,8 @@ def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, di
 end
 
 def pass_dialog_values_to_children(dialog_options_hash, dialog_tags_hash)
+  set_option_on_destination(dialog_options_hash, @task.destination)
+
   @task.miq_request_tasks.each do |t|
     child_service = t.destination
     log_and_update_message(:info, "Child Service: #{child_service.name}")

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -164,7 +164,9 @@ def set_option_on_destination(dialog_options_hash, destination)
 end
 
 def destination_key_name(key)
-  key.to_s.starts_with?("dialog_") ? key.to_s : "dialog_#{key}"
+  key = key.to_s
+  return key if key.include?("::") || key.starts_with?("dialog_")
+  "dialog_#{key}"
 end
 
 def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, dialog_tags_hash)

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -78,6 +78,7 @@ describe "CatalogItemInitialization Automate Method" do
       stp.save
       run_automate_method(stp)
       stp.reload
+      check_destination_options(stp.destination, required_options)
       request_task = stp.miq_request_tasks[0].miq_request_tasks[0]
       check_vm_task(request_task, required_options, required_tags)
     end
@@ -95,6 +96,10 @@ describe "CatalogItemInitialization Automate Method" do
     def check_tags(request_task, required_tags)
       tags = request_task.get_tags
       required_tags.each { |k, v| tags[k].should eql(v) }
+    end
+
+    def check_destination_options(service, required_options)
+      required_options.each { |k, v| service.options[:dialog]["dialog_#{k}"].should eql(v) }
     end
   end
 end


### PR DESCRIPTION
Changed CatalogItemInitialization automate method to pass dialog
fields to the Orchestration provision item when used with a bundle.

CatalogBundleInitialization/CatalogItemInitialization methods were
designed to work with VM provisioning, before Orchestration provisioning
 was introduced. These methods were designed to assist in passing
parameters from a bundle service down to individual VM provision tasks.
Orchestration provisioning uses a different configuration of tasks to
perform provisioning which is not supported by the current methods.

https://bugzilla.redhat.com/show_bug.cgi?id=1260436