### PR TITLE
Set domain priority scoped per tenant

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1500,7 +1500,7 @@ class MiqAeClassController < ApplicationController
       replace_right_cell
     when "add"
       add_ae_ns = if @edit[:typ] == "MiqAeDomain"
-                    current_tenant.ae_domains.new()
+                    current_tenant.ae_domains.new
                   else
                     MiqAeNamespace.new(:parent_id => from_cid(x_node.split('-')[1]))
                   end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1499,12 +1499,11 @@ class MiqAeClassController < ApplicationController
       @in_a_form = false
       replace_right_cell
     when "add"
-      parent_id, tenant = if @edit[:typ] == "MiqAeDomain"
-                            [nil, current_tenant]
-                          else
-                            [from_cid(x_node.split('-')[1]), nil]
-                          end
-      add_ae_ns = @edit[:typ].constantize.new(:parent_id => parent_id, :tenant => tenant)
+      add_ae_ns = if @edit[:typ] == "MiqAeDomain"
+                    current_tenant.ae_domains.new()
+                  else
+                    MiqAeNamespace.new(:parent_id => from_cid(x_node.split('-')[1]))
+                  end
       ns_set_record_vars(add_ae_ns)      # Set the record variables, but don't save
       if add_ae_ns.valid? && !flash_errors? && add_ae_ns.save
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => add_ae_ns.class.name), :name  => add_ae_ns.name})

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1753,7 +1753,7 @@ class MiqAeClassController < ApplicationController
       domains = @edit[:new][:domain_order].reverse!.collect do |domain|
         MiqAeDomain.find_by_name(domain.split(' (Locked)').first).id
       end
-      MiqAeDomain.reset_priority_by_ordered_ids(domains, current_tenant)
+      MiqAeDomain.reset_priority_by_ordered_ids(domains)
       add_flash(_("Priority Order was saved"))
       @sb[:action] = @in_a_form = @edit = session[:edit] = nil  # clean out the saved info
       replace_right_cell([:ae])

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -1,31 +1,37 @@
 class MiqAeDomain < MiqAeNamespace
   default_scope { where(:parent_id => nil).where(arel_table[:name].not_eq("$")) }
   validates_inclusion_of :parent_id, :in => [nil], :message => 'should be nil for Domain'
+  # TODO: Once all the specs start passing in the tenant object, enforce its presence
+  # validates_presence_of :tenant, :message => "object is needed to own the domain"
   after_destroy :squeeze_priorities
-  default_value_for(:priority) { MiqAeDomain.highest_priority + 1 }
   default_value_for :system,  false
   default_value_for :enabled, false
+  before_save :default_priority
   belongs_to :tenant
 
   def self.enabled
     where(:enabled => true)
   end
 
-  def self.reset_priority_by_ordered_ids(ids)
+  def self.reset_priority_by_ordered_ids(ids, tenant)
     ids.each_with_index do |id, priority|
-      MiqAeDomain.where(:id => id).first.try(:update_attributes, :priority => priority + 1)
+      MiqAeDomain.where(:id => id, :tenant => tenant).first.try(:update_attributes, :priority => priority + 1)
     end
   end
 
-  def self.highest_priority
-    MiqAeDomain.order('priority DESC').first.try(:priority).to_i
+  def self.highest_priority(tenant)
+    MiqAeDomain.where(:tenant => tenant).order('priority DESC').first.try(:priority).to_i
+  end
+
+  def default_priority
+    self.priority = (MiqAeDomain.highest_priority(tenant)) + 1 unless priority
   end
 
   private
 
   def squeeze_priorities
-    ids = MiqAeDomain.where('priority > 0').order('priority ASC').collect(&:id)
-    MiqAeDomain.reset_priority_by_ordered_ids(ids)
+    ids = MiqAeDomain.where('priority > 0', :tenant => tenant).order('priority ASC').collect(&:id)
+    MiqAeDomain.reset_priority_by_ordered_ids(ids, tenant)
   end
 
   def self.any_unlocked?

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -13,9 +13,9 @@ class MiqAeDomain < MiqAeNamespace
     where(:enabled => true)
   end
 
-  def self.reset_priority_by_ordered_ids(ids, tenant)
+  def self.reset_priority_by_ordered_ids(ids)
     ids.each_with_index do |id, priority|
-      MiqAeDomain.where(:id => id, :tenant => tenant).first.try(:update_attributes, :priority => priority + 1)
+      MiqAeDomain.find(id).try(:update_attributes, :priority => priority + 1)
     end
   end
 
@@ -31,7 +31,7 @@ class MiqAeDomain < MiqAeNamespace
 
   def squeeze_priorities
     ids = MiqAeDomain.where('priority > 0', :tenant => tenant).order('priority ASC').collect(&:id)
-    MiqAeDomain.reset_priority_by_ordered_ids(ids, tenant)
+    MiqAeDomain.reset_priority_by_ordered_ids(ids)
   end
 
   def self.any_unlocked?

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -15,7 +15,7 @@ class MiqAeDomain < MiqAeNamespace
 
   def self.reset_priority_by_ordered_ids(ids)
     ids.each_with_index do |id, priority|
-      MiqAeDomain.find(id).try(:update_attributes, :priority => priority + 1)
+      MiqAeDomain.find_by!(:id => id).update_attributes(:priority => priority + 1)
     end
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -20,11 +20,11 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def self.highest_priority(tenant)
-    MiqAeDomain.where(:tenant => tenant).order('priority DESC').first.try(:priority).to_i
+    MiqAeDomain.where(:tenant => tenant).maximum('priority').to_i
   end
 
   def default_priority
-    self.priority = (MiqAeDomain.highest_priority(tenant)) + 1 unless priority
+    self.priority = MiqAeDomain.highest_priority(tenant) + 1 unless priority
   end
 
   private

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -63,10 +63,10 @@ describe MiqAeClassController do
   context "#domains_priority_edit" do
     it "sets priority of domains" do
       set_user_privileges
-      FactoryGirl.create(:miq_ae_namespace, :name => "test1", :parent => nil, :priority => 1)
-      FactoryGirl.create(:miq_ae_namespace, :name => "test2", :parent => nil, :priority => 2)
-      FactoryGirl.create(:miq_ae_namespace, :name => "test3", :parent => nil, :priority => 3)
-      FactoryGirl.create(:miq_ae_namespace, :name => "test4", :parent => nil, :priority => 4)
+      FactoryGirl.create(:miq_ae_domain, :name => "test1", :parent => nil, :priority => 1)
+      FactoryGirl.create(:miq_ae_domain, :name => "test2", :parent => nil, :priority => 2)
+      FactoryGirl.create(:miq_ae_domain, :name => "test3", :parent => nil, :priority => 3)
+      FactoryGirl.create(:miq_ae_domain, :name => "test4", :parent => nil, :priority => 4)
       order = %w(test3 test2 test4 test1)
       edit = {
         :new     => {:domain_order => order},

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
 
   factory :miq_ae_domain, :parent => :miq_ae_namespace, :class => "MiqAeDomain" do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
-    tenant EvmSpecHelper.create_root_tenant
+    tenant { EvmSpecHelper.create_root_tenant }
     enabled true
     trait :with_methods do
       transient do

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
 
   factory :miq_ae_domain, :parent => :miq_ae_namespace, :class => "MiqAeDomain" do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
-    priority 1
+    tenant EvmSpecHelper.create_root_tenant
     enabled true
     trait :with_methods do
       transient do

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -1,23 +1,27 @@
 require "spec_helper"
 
 describe MiqAeDomain do
+  before do
+    EvmSpecHelper.local_guid_miq_server_zone
+  end
+
   it "should use the highest priority when not specified" do
-    MiqAeDomain.create(:name => 'TEST1')
-    MiqAeDomain.create(:name => 'TEST2', :priority => 10)
-    d3 = MiqAeDomain.create(:name => 'TEST3')
+    FactoryGirl.create(:miq_ae_domain, :name => 'TEST1')
+    FactoryGirl.create(:miq_ae_domain, :name => 'TEST2', :priority => 10)
+    d3 = FactoryGirl.create(:miq_ae_domain, :name => 'TEST3')
     d3.priority.should eql(11)
   end
 
   context "reset priority" do
     before do
       initial = {'TEST1' => 11, 'TEST2' => 12, 'TEST3' => 13, 'TEST4' => 14}
-      initial.each { |dom, pri| MiqAeDomain.create(:name => dom, :priority => pri) }
+      initial.each { |dom, pri| FactoryGirl.create(:miq_ae_domain, :name => dom, :priority => pri) }
     end
 
     it "should change priority based on ordered list of ids" do
       after = {'TEST4' => 1, 'TEST3' => 2, 'TEST2' => 3, 'TEST1' => 4}
       ids   = after.collect { |dom, _| MiqAeDomain.find_by_fqname(dom).id }
-      MiqAeDomain.reset_priority_by_ordered_ids(ids)
+      MiqAeDomain.reset_priority_by_ordered_ids(ids, Tenant.root_tenant)
       after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
     end
 
@@ -41,7 +45,7 @@ describe MiqAeDomain do
 
     it "after all domains are deleted" do
       %w(TEST1 TEST2 TEST3 TEST4).each { |name| MiqAeDomain.find_by_fqname(name).destroy }
-      d1 = MiqAeDomain.create(:name => 'TEST1')
+      d1 = FactoryGirl.create(:miq_ae_domain, :name => 'TEST1')
       d1.priority.should eql(1)
     end
   end
@@ -180,5 +184,4 @@ describe MiqAeDomain do
     attrs[:enabled] = true unless attrs.key?(:enabled)
     attrs
   end
-
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -21,7 +21,7 @@ describe MiqAeDomain do
     it "should change priority based on ordered list of ids" do
       after = {'TEST4' => 1, 'TEST3' => 2, 'TEST2' => 3, 'TEST1' => 4}
       ids   = after.collect { |dom, _| MiqAeDomain.find_by_fqname(dom).id }
-      MiqAeDomain.reset_priority_by_ordered_ids(ids, Tenant.root_tenant)
+      MiqAeDomain.reset_priority_by_ordered_ids(ids)
       after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
     end
 


### PR DESCRIPTION
(1) Updated miq_ae_domain factory to create a default domain
(2) Controller passes in the tenant when creating a new domain
(3) Before saving a domain set the priority based on the max value
    from the list of domains in the tenant