### PR TITLE
Prevent a submit action from a disabled Validate

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -31,6 +31,7 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
     $scope.afterGet = false;
     $scope.saveable = miqService.saveable;
     $scope.validateClicked = miqService.validateWithREST;
+    $scope.disabledClick = miqService.disabledClick;
     $scope.modelCopy = angular.copy( $scope.emsCommonModel );
     $scope.formFieldsUrl = $attrs.formFieldsUrl;
     $scope.createUrl = $attrs.createUrl;

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -91,6 +91,10 @@ ManageIQ.angularApplication.service('miqService', function() {
     }
   };
 
+  this.disabledClick = function($event) {
+    $event.preventDefault();
+  };
+
   this.serializeModel = function(model) {
     serializedObj = angular.copy( model );
     for(var k in serializedObj){

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -9,10 +9,11 @@
 
 %div{'ng-show' => ng_show}
   = button_tag("Validate",
-                 :class    => "btn btn-primary btn-xs btn-disabled",
-                 :alt      => "Validate",
-                 :title    => "Validate",
-                 "ng-show" => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()")
+                 :class     => "btn btn-primary btn-xs btn-disabled",
+                 :alt       => "Validate",
+                 :title     => "Validate",
+                 "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()",
+                 "ng-click" => "disabledClick($event)")
   = button_tag("Validate",
                  :class     => "btn btn-primary btn-xs",
                  :alt       => verify_title_on,

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -166,4 +166,12 @@ describe('miqService', function() {
       expect(window.miqAjaxButton).toHaveBeenCalledWith('/host/create/new?button=validate&type=default', true);
     });
   });
+
+  describe('#disabledClick', function() {
+    it('prevents a submit action', function() {
+      var event = $.Event('click');
+      testService.disabledClick(event);
+      expect(event.isDefaultPrevented()).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
Although ```ng-disabled``` is the right way to go to disable all events from the ```Validate button```, it styles the button to a gray color which is not desirable. Since we need the button to be light blue (disabled blue), we cannot use ```ng-disabled```.

Fixes #4374