### PR TITLE
Converted Automate/Explorer ns_list from DHTMLX to PatternFly

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -82,3 +82,4 @@
 //= require jquery-hotkeys
 //= require lodash
 //= require miq_formatters
+//= require miq_grid

--- a/app/assets/javascripts/miq_grid.js
+++ b/app/assets/javascripts/miq_grid.js
@@ -1,0 +1,48 @@
+(function($) {
+  $.fn.miqGrid = function() {
+    var table = $(this);
+    var checkall = table.find('thead > tr > th > input.checkall');
+    var checkboxes = table.find("tbody > tr > td > input[type='checkbox']");
+
+    // Maintain a list of checked IDs in a hidden input field for backwards compatibility
+    // TODO: implement this inside the miq_toolbar JS when it was updated to PatternFly
+    var checklist = $("<input type='hidden' id='miq_grid_checks'>").val('')
+    table.append(checklist);
+
+    // table-selectable
+    if (table.hasClass('table-clickable')) {
+      var url = table.find('tbody').data('click-url');
+      table.find('tbody > tr > td:not(.noclick)').click(function (e) {
+        miqSparkleOn();
+        var cid = $(this).parent().data('click-id');
+        miqJqueryRequest(url + '?id=' + cid);
+      });
+    }
+
+    // table-checkable
+    if(table.hasClass('table-checkable')) {
+      checkboxes.click(function (e) {
+        var checked = $.map(checkboxes.filter(':checked'), function (cb) {
+          return cb.value;
+        });
+        checklist.val(checked.join(','));
+        miqSetButtons(checked.length, 'center_tb');
+        if (checked.length == checkboxes.length) {
+          $('input.checkall').prop('checked', true);
+        } else {
+          $('input.checkall').prop('checked', false);
+        }
+      });
+
+      // Handle the click on the "Check all" checkbox
+      checkall.click(function (e) {
+        var unchecked = checkboxes.filter(':not(:checked)');
+        if (unchecked.length > 0) {
+          unchecked.trigger('click');
+        } else {
+          checkboxes.trigger('click');
+        }
+      });
+    }
+  };
+})(jQuery);

--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -22,4 +22,33 @@ module MiqAeClassHelper
       return domain_name, record.id
     end
   end
+
+  def record_name(rec)
+    column = rec.display_name.blank? ? :name : :display_name
+    rec_name = if rec.kind_of?(MiqAeNamespace) && rec.domain? && (!rec.editable? || !rec.enabled)
+                 add_read_only_suffix(rec, rec.send(column))
+               else
+                 rec.send(column)
+               end
+    rec_name = rec_name.gsub(/\n/, "\\n")
+    rec_name = rec_name.gsub(/\t/, "\\t")
+    rec_name = rec_name.gsub(/"/, "'")
+    rec_name = CGI.escapeHTML(rec_name)
+    rec_name.gsub(/\\/, "&#92;")
+  end
+
+  def class_prefix(cls)
+    case cls.to_s.split("::").last
+    when "MiqAeClass"
+      "aec"
+    when "MiqAeNamespace"
+      "aen"
+    when "MiqAeInstance"
+      "aei"
+    when "MiqAeField"
+      "Field"
+    when "MiqAeMethod"
+      "aem"
+    end
+  end
 end

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -1,20 +1,34 @@
 #ns_list_div
   - if !@in_a_form
     = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
-    .checkall
-      %input#Toggle1{:type => "checkbox", :name => "masterToggle", :onclick => "miqCheck_AE_All('center_tb', 'ns_list_grid');"}
-      (#{_('Check All')})
-    = render :partial => 'layouts/dhtmlxgrid',
-      :locals  => {:options => {:grid_id    => "ns_list_grid_div",
-        :grid_name                          => "ns_list_grid",
-        :grid_url                           => "/miq_ae_class/tree_select/",
-        :grid_xml                           => @grid_xml,
-        :autosize                           => true,
-        :set_sizes                          => true,
-        :no_resize                          => true,
-        :skin                               => "style3",
-        :alt_row                            => true,
-        :div_in_js                          => true}}
+    %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
+      %thead
+        %th.narrow
+          %input.checkall{:type => 'checkbox', :title => _('Check All')}
+        %th
+        %th= _('Name')
+        %th= _('Description')
+        %th= _('Enabled')
+      %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
+        - @grid_data.each do |record|
+          - next if record.name == '$'
+          - cls_cid = "#{class_prefix(record.class)}-#{ActiveRecord::Base.compress_id(record.id)}"
+          %tr{'data-click-id' => cls_cid}
+            %td.narrow.noclick
+              %input{:type => 'checkbox', :value => cls_cid}
+            %td.narrow
+              %i.fa.fa-2x.fa-globe
+            %td
+              = record_name(record)
+            %td
+              = record.description
+            %td
+              = record.enabled
+    :javascript
+      $(function () {
+        $('#ns_list_grid').miqGrid();
+      });
+
   - else
     - url = url_for(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
     = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}

--- a/spec/javascripts/miq_grid_spec.js
+++ b/spec/javascripts/miq_grid_spec.js
@@ -1,0 +1,59 @@
+describe('miq_grid.js', function () {
+  beforeEach(function () {
+    window.miqSetButtons = function() {}; // mock toolbar
+    var html = "<table class=\"table-clickable table-checkable\"><thead><tr><th><input type=\"checkbox\" class=\"checkall\"/></th><th>Title</th></tr></thead><tbody data-click-url=\"/test/\"><tr data-click-id=\"check_1\"><td class=\"noclick\"><input type=\"checkbox\" value=\"check_1\"/></td><td>Item 1</td></tr><tr data-click-id=\"check_2\"><td class=\"noclick\"><input type=\"checkbox\" value=\"check_2\" /></td><td>Item 2</td></tr><tr data-click-id=\"check_3\"><td class=\"noclick\"><input type=\"checkbox\" value=\"check_3\" /></td><td>Item 3</td></tr></tbody></table>";
+    setFixtures(html);
+    $('table').miqGrid();
+  });
+
+  it('creates the list of selected items', function () {
+    expect($('#miq_grid_checks').length).toEqual(1);
+  });
+
+  describe('.checkall', function () {
+
+    it('checks itself if all checkboxes were checked', function () {
+      $('.checkall').trigger('click');
+      expect($('.checkall').prop('checked')).toEqual(true);
+    })
+
+    it('unchecks itself if at least one checkbox was unchecked', function () {
+      $('.checkall').trigger('click');
+      $(".noclick > input[type='checkbox']").first().trigger('click');
+      expect($('.checkall').prop('checked')).toEqual(false);
+    });
+
+    it('checks all the checkboxes when none is checked', function () {
+      $('.checkall').trigger('click');
+      expect($(".noclick > input[type='checkbox']:checked").length).toEqual(3);
+    });
+
+    it('unchecks all the checkboxes when each is checked', function () {
+      $('.checkall').trigger('click');
+      expect($(".noclick > input[type='checkbox']:checked").length).toEqual(3);
+      $('.checkall').trigger('click');
+      expect($(".noclick > input[type='checkbox']:not(:checked)").length).toEqual(3);
+    });
+
+    it('checks the remaining checkboxes when not all are checked', function () {
+      $(".noclick > input[type='checkbox']").first().trigger('click');
+      expect($(".noclick > input[type='checkbox']:checked").length).toEqual(1);
+      $('.checkall').trigger('click');
+      expect($(".noclick > input[type='checkbox']:checked").length).toEqual(3);
+    });
+  })
+
+  it('appends checked elements to the list of selected items', function () {
+    $(".noclick > input[type='checkbox']").first().trigger('click');
+    expect($('#miq_grid_checks').val()).toEqual('check_1');
+    $(".noclick > input[type='checkbox']").last().trigger('click');
+    expect($('#miq_grid_checks').val()).toEqual('check_1,check_3');
+  });
+
+  it('sends an ajax POST request when clicking on a table row', function () {
+    spyOn(window, 'miqJqueryRequest');
+    $("tbody > tr > td:not(.noclick)").last().trigger('click');
+    expect(miqJqueryRequest).toHaveBeenCalledWith('/test/?id=check_3');
+  })
+
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -15,6 +15,7 @@ src_files:
   - assets/angular-mocks
   - assets/jquery
   - javascripts/miq_application.js
+  - javascripts/miq_grid.js
   - javascripts/miq_angular_application.js
   - javascripts/services/miq_service.js
   - javascripts/services/miq_db_backup_service.js


### PR DESCRIPTION
#### Changes
* Instead of generating XML, the HTML table is rendered directly in HAML
* Implemented new table checkbox selection strategy (`.table-checkable`)
* Implemented new table row clicking strategy with `data-` attributes (`.table-clickable`)
* The checkbox for selecting all elements was moved into the table

#### Screenshot before:
![screenshot from 2015-09-18 12-50-35](https://cloud.githubusercontent.com/assets/649130/9957836/f4128daa-5e03-11e5-8c25-241edccb8bfd.png)

#### Screenshot after:
![screenshot from 2015-09-23 14-52-44](https://cloud.githubusercontent.com/assets/649130/10045408/c9ca705a-6202-11e5-99d2-c037368b4a59.png)

Parent issue: #3979