### PR TITLE
add tags to tenant

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -6,6 +6,7 @@ class Tenant < ActiveRecord::Base
   DEFAULT_URL = nil
 
   include ReportableMixin
+  acts_as_miq_taggable
 
   default_value_for :name,        "My Company"
   default_value_for :description, "Tenant for My Company"


### PR DESCRIPTION
now that tenant is in automate's `$evm.object`, it wants
`tenant` to be taggable. Which we want for other reasons too

/cc @gmcculloug adding tags to tenants
/cc @abellotti @mkanoor this should fix automate issue