### PR TITLE
Add basic support for tenant scoping from parent/child tenants.

### DIFF
--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -6,25 +6,12 @@ module TenancyMixin
       true
     end
 
-    def accessible_tenant_ids(user_or_group)
+    def accessible_tenant_ids(user_or_group, strategy)
       tenant = user_or_group.try(:current_tenant)
       return [] unless tenant
 
-      tenant.accessible_tenant_ids(self)
+      tenant.accessible_tenant_ids(strategy)
     end
 
-    # Any class including this mixin gets the default strategy :ancestor_ids
-    # It can use a different stategy by implementing this method.
-    #
-    # It should accept any of the relationship_mixin methods including:
-    #   :parent_ids
-    #   :ancestor_ids
-    #   :child_ids
-    #   :sibling_ids
-    #   :descendant_ids
-    #   ...
-    def accessible_tenant_ids_strategy
-      :ancestor_ids
-    end
   end
 end

--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -12,6 +12,5 @@ module TenancyMixin
 
       tenant.accessible_tenant_ids(strategy)
     end
-
   end
 end

--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -5,5 +5,26 @@ module TenancyMixin
     def scope_by_tenant?
       true
     end
+
+    def accessible_tenant_ids(user_or_group)
+      tenant = user_or_group.try(:current_tenant)
+      return [] unless tenant
+
+      tenant.accessible_tenant_ids(self)
+    end
+
+    # Any class including this mixin gets the default strategy :ancestor_ids
+    # It can use a different stategy by implementing this method.
+    #
+    # It should accept any of the relationship_mixin methods including:
+    #   :parent_ids
+    #   :ancestor_ids
+    #   :child_ids
+    #   :sibling_ids
+    #   :descendant_ids
+    #   ...
+    def accessible_tenant_ids_strategy
+      :ancestor_ids
+    end
   end
 end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -54,7 +54,7 @@ module Rbac
   #   :sibling_ids
   #   :descendant_ids
   #   ...
-  TENANT_ACCESS_STRATEGY ={
+  TENANT_ACCESS_STRATEGY = {
     'ExtManagementSystem'    => :ancestor_ids,
     'MiqAeNamespace'         => :ancestor_ids,
     'MiqRequest'             => nil, # tenant only
@@ -280,7 +280,6 @@ module Rbac
   def self.accessible_tenant_ids_strategy(klass)
     TENANT_ACCESS_STRATEGY[klass.to_s]
   end
-
 
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)
     find_options = find_options_for_tenant(klass, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -249,7 +249,7 @@ module Rbac
   end
 
   def self.find_options_for_tenant(klass, user_or_group, find_options = {})
-    tenant_id = user_or_group.try(:current_tenant, :id)
+    tenant_id = klass.accessible_tenant_ids(user_or_group)
     return find_options unless tenant_id
 
     tenant_id_clause = {klass.table_name => {:tenant_id => [tenant_id, nil]}}

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -47,6 +47,25 @@ module Rbac
     "VmOrTemplate::ResourcePool"        => :resource_pool,
   }
 
+  # These classes should accept any of the relationship_mixin methods including:
+  #   :parent_ids
+  #   :ancestor_ids
+  #   :child_ids
+  #   :sibling_ids
+  #   :descendant_ids
+  #   ...
+  TENANT_ACCESS_STRATEGY ={
+    'ExtManagementSystem'    => :ancestor_ids,
+    'MiqAeNamespace'         => :ancestor_ids,
+    'MiqRequest'             => nil, # tenant only
+    'MiqRequestTask'         => nil, # tenant only
+    'Provider'               => :ancestor_ids,
+    'ServiceTemplateCatalog' => :ancestor_ids,
+    'ServiceTemplate'        => :ancestor_ids,
+    'Service'                => :descendant_ids,
+    'Vm'                     => :descendant_ids
+  }
+
   NO_SCOPE = :_no_scope_
 
   ########################################################################################
@@ -249,16 +268,21 @@ module Rbac
   end
 
   def self.find_options_for_tenant(klass, user_or_group, find_options = {})
-    tenant_id = klass.accessible_tenant_ids(user_or_group)
-    return find_options unless tenant_id
+    tenant_ids = klass.accessible_tenant_ids(user_or_group, accessible_tenant_ids_strategy(klass))
+    return find_options if tenant_ids.empty?
 
-    tenant_id_clause = {klass.table_name => {:tenant_id => [tenant_id, nil]}}
+    tenant_ids << nil # Return objects not assigned to a tenant until tenant assignment code is done
+    tenant_id_clause = {klass.table_name => {:tenant_id => tenant_ids}}
     find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], tenant_id_clause)
     find_options
   end
 
+  def self.accessible_tenant_ids_strategy(klass)
+    TENANT_ACCESS_STRATEGY[klass.to_s]
+  end
+
+
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)
-    # TODO: check if these find_options should be duplicated/modified in place
     find_options = find_options_for_tenant(klass, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
 
     return find_targets_with_direct_rbac(klass, scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -64,6 +64,11 @@ class Tenant < ActiveRecord::Base
     self.class.descendants_of(self).where(:divisible => false)
   end
 
+  # See TenancyMixin for the strategy
+  def accessible_tenant_ids(klass = nil)
+    send(klass.accessible_tenant_ids_strategy).append(id)
+  end
+
   def name
     tenant_attribute(:name, :company)
   end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -64,9 +64,8 @@ class Tenant < ActiveRecord::Base
     self.class.descendants_of(self).where(:divisible => false)
   end
 
-  # See TenancyMixin for the strategy
-  def accessible_tenant_ids(klass = nil)
-    send(klass.accessible_tenant_ids_strategy).append(id)
+  def accessible_tenant_ids(strategy = nil)
+    (strategy ? send(strategy) : []).append(id)
   end
 
   def name

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -92,6 +92,21 @@ describe Rbac do
           expect(results).to eq [@owned_object]
         end
       end
+
+      it "by default, sees parent tenant's Vm" do
+        child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+        child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
+        results,            = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => child_group.id)
+        expect(results).to eq [@owned_object]
+      end
+
+      it "by default, can't see descendant tenant's Vm" do
+        child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+        @owned_object.tenant = child_tenant
+        @owned_object.save
+        results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
+        expect(results).to eq []
+      end
     end
   end
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -103,7 +103,7 @@ describe Rbac do
           expect(results).to eq []
         end
 
-        it "by default, can see descendant tenant's Vm" do
+        it "can see descendant tenant's Vm" do
           child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           @owned_vm.tenant     = child_tenant
           @owned_vm.save
@@ -113,14 +113,14 @@ describe Rbac do
       end
 
       context "tenant access strategy of ancestor_ids (parents)" do
-        it "by default, can see parent tenant's EMS" do
+        it "can see parent tenant's EMS" do
           child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
           results,            = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :miq_group_id => child_group.id)
           expect(results).to eq [@owned_ems]
         end
 
-        it "by default, can't see descendant tenant's EMS" do
+        it "can't see descendant tenant's EMS" do
           child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           @owned_ems.tenant    = child_tenant
           @owned_ems.save
@@ -130,20 +130,19 @@ describe Rbac do
       end
 
       context "tenant access strategy of nil (tenant only)" do
-        it "by default, can see tenant's request task" do
-          child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+        it "can see tenant's request task" do
           results,            = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
           expect(results).to eq [@owned_request_task]
         end
 
-        it "by default, can't see parent tenant's request task" do
+        it "can't see parent tenant's request task" do
           child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
           results,            = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => child_group.id)
           expect(results).to eq []
         end
 
-        it "by default, can't see descendant tenant's request task" do
+        it "can't see descendant tenant's request task" do
           child_tenant               = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           @owned_request_task.tenant = child_tenant
           @owned_request_task.save

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -107,7 +107,7 @@ describe Rbac do
           child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           @owned_vm.tenant     = child_tenant
           @owned_vm.save
-          results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
+          results, = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
           expect(results).to eq [@owned_vm]
         end
       end
@@ -124,14 +124,14 @@ describe Rbac do
           child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           @owned_ems.tenant    = child_tenant
           @owned_ems.save
-          results,             = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :miq_group_id => @owner_group.id)
+          results, = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :miq_group_id => @owner_group.id)
           expect(results).to eq []
         end
       end
 
       context "tenant access strategy of nil (tenant only)" do
         it "can see tenant's request task" do
-          results,            = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
+          results, = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
           expect(results).to eq [@owned_request_task]
         end
 
@@ -146,7 +146,7 @@ describe Rbac do
           child_tenant               = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
           @owned_request_task.tenant = child_tenant
           @owned_request_task.save
-          results,                   = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
+          results, = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
           expect(results).to eq []
         end
       end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -107,6 +107,16 @@ describe Rbac do
         results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
         expect(results).to eq []
       end
+
+      it "with child_ids strategy can see child tenant's Vm" do
+        VmOrTemplate.stub(:accessible_tenant_ids_strategy => :child_ids)
+
+        child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+        @owned_object.tenant = child_tenant
+        @owned_object.save
+        results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
+        expect(results).to eq [@owned_object]
+      end
     end
   end
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -31,12 +31,12 @@ describe Rbac do
     klass_factory_names.each_slice(2) do |klass, factory_name|
       context "#{klass} basic filtering" do
         before do
-          @owned_object = FactoryGirl.create(factory_name, :tenant => @owner_tenant)
+          @owned_vm = FactoryGirl.create(factory_name, :tenant => @owner_tenant)
         end
 
         it ".search with :userid, finds user's tenant #{klass}" do
           results, = Rbac.search(:class => klass, :results_format => :objects, :userid => @owner_user.userid)
-          expect(results).to eq [@owned_object]
+          expect(results).to eq [@owned_vm]
         end
 
         it ".search with :userid filters out other tenants" do
@@ -48,13 +48,15 @@ describe Rbac do
 
     context "Advanced filtering" do
       before do
-        @owned_object = FactoryGirl.create(:vm_vmware, :tenant => @owner_tenant)
+        @owned_vm           = FactoryGirl.create(:vm_vmware, :tenant => @owner_tenant)
+        @owned_ems          = FactoryGirl.create(:ems_vmware, :tenant => @owner_tenant)
+        @owned_request_task = FactoryGirl.create(:miq_request_task, :tenant => @owner_tenant)
       end
 
       it ".search with User.with_userid finds user's tenant object" do
         User.with_userid(@owner_user.userid) do
           results, = Rbac.search(:class => "Vm", :results_format => :objects)
-          expect(results).to eq [@owned_object]
+          expect(results).to eq [@owned_vm]
         end
       end
 
@@ -67,7 +69,7 @@ describe Rbac do
 
       it ".search with :miq_group_id, finds user's tenant object" do
         results, = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
-        expect(results).to eq [@owned_object]
+        expect(results).to eq [@owned_vm]
       end
 
       it ".search with :miq_group_id filters out other tenants" do
@@ -89,33 +91,65 @@ describe Rbac do
           @other_user.miq_groups = [@owner_group]
           @other_user.save
           results, = Rbac.search(:class => "Vm", :results_format => :objects)
-          expect(results).to eq [@owned_object]
+          expect(results).to eq [@owned_vm]
         end
       end
 
-      it "by default, sees parent tenant's Vm" do
-        child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
-        child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
-        results,            = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => child_group.id)
-        expect(results).to eq [@owned_object]
+      context "tenant access strategy of descendant_ids (children)" do
+        it "can't see parent tenant's Vm" do
+          child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
+          results,            = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => child_group.id)
+          expect(results).to eq []
+        end
+
+        it "by default, can see descendant tenant's Vm" do
+          child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          @owned_vm.tenant     = child_tenant
+          @owned_vm.save
+          results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
+          expect(results).to eq [@owned_vm]
+        end
       end
 
-      it "by default, can't see descendant tenant's Vm" do
-        child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
-        @owned_object.tenant = child_tenant
-        @owned_object.save
-        results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
-        expect(results).to eq []
+      context "tenant access strategy of ancestor_ids (parents)" do
+        it "by default, can see parent tenant's EMS" do
+          child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
+          results,            = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :miq_group_id => child_group.id)
+          expect(results).to eq [@owned_ems]
+        end
+
+        it "by default, can't see descendant tenant's EMS" do
+          child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          @owned_ems.tenant    = child_tenant
+          @owned_ems.save
+          results,             = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :miq_group_id => @owner_group.id)
+          expect(results).to eq []
+        end
       end
 
-      it "with child_ids strategy can see child tenant's Vm" do
-        VmOrTemplate.stub(:accessible_tenant_ids_strategy => :child_ids)
+      context "tenant access strategy of nil (tenant only)" do
+        it "by default, can see tenant's request task" do
+          child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          results,            = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
+          expect(results).to eq [@owned_request_task]
+        end
 
-        child_tenant         = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
-        @owned_object.tenant = child_tenant
-        @owned_object.save
-        results,             = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group_id => @owner_group.id)
-        expect(results).to eq [@owned_object]
+        it "by default, can't see parent tenant's request task" do
+          child_tenant        = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          child_group         = FactoryGirl.create(:miq_group, :tenant => child_tenant)
+          results,            = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => child_group.id)
+          expect(results).to eq []
+        end
+
+        it "by default, can't see descendant tenant's request task" do
+          child_tenant               = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          @owned_request_task.tenant = child_tenant
+          @owned_request_task.save
+          results,                   = Rbac.search(:class => "MiqRequestTask", :results_format => :objects, :miq_group_id => @owner_group.id)
+          expect(results).to eq []
+        end
       end
     end
   end


### PR DESCRIPTION
This PR implements the scoping of CIs owned by related (parents, children) tenants base on the following rules:

* ext_management_systems  : All parent tenants
* miq_ae_namespaces           : All parent tenants
* miq_requests                        : Tenant only
* miq_request_tasks               : Tenant only
* providers                              : All parent tenants
* service_template_catalogs  : All parent tenants
* service_templates (item)      : All parent tenants
* services                               : All child tenants
* vms                                      : All child tenants

https://trello.com/c/1PHsfqkK