### PR TITLE
Brakeman controller name - fix Hakiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ unless ENV['APPLIANCE']
   end
 
   group :test do
-    gem "brakeman",         "~>3.0.5",  :require => false
+    gem "brakeman",         "~>3.1.0",  :require => false
     gem "capybara",         "~>2.1.0",  :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
     gem "shoulda-matchers", "~>1.0.0",  :require => false

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -31,4 +31,4 @@
 -# if set by controller, set up to run as JS after onload is done
 - if @miq_after_onload
   :javascript
-    var miq_after_onload = '#{@miq_after_onload.html_safe}';
+    var miq_after_onload = '#{j @miq_after_onload}';

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -39,7 +39,7 @@
 
       :javascript
         ManageIQ.browser = "#{j browser_info(:name_ui)}";
-        ManageIQ.controller = "#{j request.parameters[:controller]}";
+        ManageIQ.controller = "#{j controller_name}";
 
       %style html, body{width:100%; height:100%; margin:0px; padding:0px; overflow:hidden;}
 


### PR DESCRIPTION
1. Upgrade to latest brakeman. This will show a few more errors. It should hide a few around parameters in javascript and `j`.
2. fix a `html_safe` that should be a `j`
3. use `controller_name` instead of `params[:controller]` (this error should go away, but it is better to use the proper controller_name) - see note below.

@skateman Do you think using `controller_name` will cause an issue around [miq_request_controller](https://github.com/kbrock/manageiq/blob/master/app/controllers/miq_request_controller.rb#L98)? I can revert this change if you are concerned.
