### PR TITLE
Allow host to be dynamic in appliance builds

### DIFF
--- a/spa_ui/self_service/client/app/config/api.config.js
+++ b/spa_ui/self_service/client/app/config/api.config.js
@@ -2,7 +2,25 @@
   'use strict';
 
   angular.module('app.config')
-    .constant('API_BASE', 'http://localhost:4000')
     .constant('API_LOGIN', 'admin')
-    .constant('API_PASSWORD', 'smartvm');
+    .constant('API_PASSWORD', 'smartvm')
+    .value('API_BASE', 'http://localhost:4000')
+    .run(origin);
+
+  /** @ngInject */
+  function origin(API_BASE, $location) {
+    var host;
+
+    if (null !== API_BASE) {
+      return;
+    }
+
+    host = $location.protocol() + '//' + $location.host();
+
+    if ('' !== $location.port()) {
+      host = host + ':' + $location.port();
+    }
+
+    API_BASE = host;
+  }
 })();

--- a/spa_ui/self_service/gulp/config.js
+++ b/spa_ui/self_service/gulp/config.js
@@ -286,7 +286,8 @@ module.exports = (function() {
     ngAnnotateOptions: {
       add: true,
       single_quotes: true
-    }
+    },
+    devHost: 'http://localhost:4000'
   };
 
   config.build = {

--- a/spa_ui/self_service/gulp/tasks/optimize.js
+++ b/spa_ui/self_service/gulp/tasks/optimize.js
@@ -6,6 +6,7 @@ var plumber = require('gulp-plumber');
 var csso = require('gulp-csso');
 var ngAnnotate = require('gulp-ng-annotate');
 var uglify = require('gulp-uglify');
+var replace = require('gulp-replace');
 var rev = require('gulp-rev');
 var revReplace = require('gulp-rev-replace');
 var getHeader = require('../utils/getHeader');
@@ -39,6 +40,7 @@ module.exports = function(gulp, options) {
       .pipe(cssFilter.restore())
       // Get the custom javascript
       .pipe(jsAppFilter)
+      .pipe(replace("'" + config.devHost + "'", 'null'))
 
       // FIXME Disabling minifiction and injection until the following issue with ng-annotate has been resolved
       // Issue : https://github.com/olov/ng-annotate/issues/168

--- a/spa_ui/self_service/package.json
+++ b/spa_ui/self_service/package.json
@@ -52,6 +52,7 @@
     "gulp-plumber": "^1.0.0",
     "gulp-print": "^1.1.0",
     "gulp-rename": "^1.2.0",
+    "gulp-replace": "^0.5.0",
     "gulp-rev": "^3.0.1",
     "gulp-rev-replace": "^0.4.0",
     "gulp-ruby-sass": "^1.0.0-alpha.3",


### PR DESCRIPTION
Builds will have no defined host and will use the host serving the application as the API_BASE.

- Development uses a hardcoded URL of http://localhost:4000