### PR TITLE
Use table lock for seeds

### DIFF
--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -22,11 +22,9 @@ class BlacklistedEvent < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      ExtManagementSystem.descendants.each do |ems|
-        missing_events = ems.default_blacklisted_event_names - where(:provider_model => ems.name, :ems_id => nil).pluck(:event_name)
-        create(missing_events.collect { |e| {:event_name => e, :provider_model => ems.name, :system => true} })
-      end
+    ExtManagementSystem.descendants.each do |ems|
+      missing_events = ems.default_blacklisted_event_names - where(:provider_model => ems.name, :ems_id => nil).pluck(:event_name)
+      create(missing_events.collect { |e| {:event_name => e, :provider_model => ems.name, :system => true} })
     end
   end
 

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -50,11 +50,11 @@ class ChargebackRate < ActiveRecord::Base
       fixture = YAML.load_file(fixture_file)
 
       fixture.each do |cbr|
-        rec = self.find_by_guid(cbr[:guid])
+        rec = find_by_guid(cbr[:guid])
         rates = cbr.delete(:rates)
         if rec.nil?
           _log.info("Creating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")
-          rec = self.create(cbr)
+          rec = create(cbr)
           rec.chargeback_rate_details.create(rates)
         else
           fixture_mtime = File.mtime(fixture_file).utc

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -45,28 +45,26 @@ class ChargebackRate < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      fixture_file = File.join(FIXTURE_DIR, "chargeback_rates.yml")
-      if File.exist?(fixture_file)
-        fixture = YAML.load_file(fixture_file)
+    fixture_file = File.join(FIXTURE_DIR, "chargeback_rates.yml")
+    if File.exist?(fixture_file)
+      fixture = YAML.load_file(fixture_file)
 
-        fixture.each do |cbr|
-          rec = self.find_by_guid(cbr[:guid])
-          rates = cbr.delete(:rates)
-          if rec.nil?
-            _log.info("Creating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")
-            rec = self.create(cbr)
+      fixture.each do |cbr|
+        rec = self.find_by_guid(cbr[:guid])
+        rates = cbr.delete(:rates)
+        if rec.nil?
+          _log.info("Creating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")
+          rec = self.create(cbr)
+          rec.chargeback_rate_details.create(rates)
+        else
+          fixture_mtime = File.mtime(fixture_file).utc
+          if fixture_mtime > rec.created_on
+            _log.info("Updating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")
+            rec.update_attributes(cbr)
+            rec.chargeback_rate_details.clear
             rec.chargeback_rate_details.create(rates)
-          else
-            fixture_mtime = File.mtime(fixture_file).utc
-            if fixture_mtime > rec.created_on
-              _log.info("Updating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")
-              rec.update_attributes(cbr)
-              rec.chargeback_rate_details.clear
-              rec.chargeback_rate_details.create(rates)
-              rec.created_on = fixture_mtime
-              rec.save
-            end
+            rec.created_on = fixture_mtime
+            rec.save
           end
         end
       end

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -427,14 +427,12 @@ class Classification < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      YAML.load_file(FIXTURE_FILE).each do |c|
-        cat = find_by_name(c[:name], my_region_number, (c[:ns] || DEFAULT_NAMESPACE))
-        next if cat
+    YAML.load_file(FIXTURE_FILE).each do |c|
+      cat = find_by_name(c[:name], my_region_number, (c[:ns] || DEFAULT_NAMESPACE))
+      next if cat
 
-        _log.info("Creating #{c[:name]}")
-        add_entries_from_hash(create(c.except(:entries)), c[:entries])
-      end
+      _log.info("Creating #{c[:name]}")
+      add_entries_from_hash(create(c.except(:entries)), c[:entries])
     end
 
     # Fix categories that have a nill parent_id

--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -19,30 +19,28 @@ class CustomizationTemplate < ActiveRecord::Base
   def self.seed
     return unless self == base_class # Prevent subclasses from seeding
 
-    MiqRegion.my_region.lock do
-      current = self.where(:system => true).index_by(&:name)
+    current = self.where(:system => true).index_by(&:name)
 
-      seed_data.each do |s|
-        log_attrs = s.slice(:name, :type, :description)
+    seed_data.each do |s|
+      log_attrs = s.slice(:name, :type, :description)
 
-        rec = current.delete(s[:name])
-        if rec.nil?
-          _log.info("Creating #{log_attrs.inspect}")
-          self.create!(s)
-        else
-          rec.attributes = s.except(:type)
-          if rec.changed?
-            _log.info("Updating #{log_attrs.inspect}")
-            rec.save!
-          end
+      rec = current.delete(s[:name])
+      if rec.nil?
+        _log.info("Creating #{log_attrs.inspect}")
+        self.create!(s)
+      else
+        rec.attributes = s.except(:type)
+        if rec.changed?
+          _log.info("Updating #{log_attrs.inspect}")
+          rec.save!
         end
       end
+    end
 
-      current.values.each do |rec|
-        log_attrs = rec.attributes.slice("id", "name", "type", "description").symbolize_keys
-        _log.info("Deleting #{log_attrs.inspect}")
-        rec.destroy
-      end
+    current.values.each do |rec|
+      log_attrs = rec.attributes.slice("id", "name", "type", "description").symbolize_keys
+      _log.info("Deleting #{log_attrs.inspect}")
+      rec.destroy
     end
   end
 

--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -19,7 +19,7 @@ class CustomizationTemplate < ActiveRecord::Base
   def self.seed
     return unless self == base_class # Prevent subclasses from seeding
 
-    current = self.where(:system => true).index_by(&:name)
+    current = where(:system => true).index_by(&:name)
 
     seed_data.each do |s|
       log_attrs = s.slice(:name, :type, :description)
@@ -27,7 +27,7 @@ class CustomizationTemplate < ActiveRecord::Base
       rec = current.delete(s[:name])
       if rec.nil?
         _log.info("Creating #{log_attrs.inspect}")
-        self.create!(s)
+        create!(s)
       else
         rec.attributes = s.except(:type)
         if rec.changed?

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -21,10 +21,8 @@ class Dialog < ActiveRecord::Base
   def self.seed
     dialog_import_service = DialogImportService.new
 
-    MiqRegion.my_region.lock do
-      Dir.glob(ALL_YAML_FILES).each do |file|
-        dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
-      end
+    Dir.glob(ALL_YAML_FILES).each do |file|
+      dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
     end
   end
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1077,8 +1077,8 @@ class MiqAction < ActiveRecord::Base
   end
 
   def self.seed
-    self.create_default_actions
-    self.create_script_actions_from_directory
+    create_default_actions
+    create_script_actions_from_directory
   end
 
   def self.create_default_actions

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1077,10 +1077,8 @@ class MiqAction < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.create_default_actions
-      self.create_script_actions_from_directory
-    end
+    self.create_default_actions
+    self.create_script_actions_from_directory
   end
 
   def self.create_default_actions

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -732,9 +732,9 @@ class MiqAlert < ActiveRecord::Base
 
       alist.each do |alert_hash|
         guid = alert_hash["guid"] || alert_hash[:guid]
-        rec = self.find_by_guid(guid)
+        rec = find_by_guid(guid)
         if rec.nil?
-          alert = self.create(alert_hash)
+          alert = create(alert_hash)
           _log.info("Added sample Alert: #{alert.description}")
           if action
             alert.options = {:notifications => {action.action_type.to_sym => action.options}}

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -718,29 +718,27 @@ class MiqAlert < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      action_fixture_file = File.join(FIXTURE_DIR, "miq_alert_default_action.yml")
-      if File.exist?(action_fixture_file)
-        action_hash = YAML.load_file(action_fixture_file)
-        action = MiqAction.new(action_hash)
-      else
-        action = nil
-      end
+    action_fixture_file = File.join(FIXTURE_DIR, "miq_alert_default_action.yml")
+    if File.exist?(action_fixture_file)
+      action_hash = YAML.load_file(action_fixture_file)
+      action = MiqAction.new(action_hash)
+    else
+      action = nil
+    end
 
-      alert_fixture_file = File.join(FIXTURE_DIR, "miq_alerts.yml")
-      if File.exist?(alert_fixture_file)
-        alist = YAML.load_file(alert_fixture_file)
+    alert_fixture_file = File.join(FIXTURE_DIR, "miq_alerts.yml")
+    if File.exist?(alert_fixture_file)
+      alist = YAML.load_file(alert_fixture_file)
 
-        alist.each do |alert_hash|
-          guid = alert_hash["guid"] || alert_hash[:guid]
-          rec = self.find_by_guid(guid)
-          if rec.nil?
-            alert = self.create(alert_hash)
-            _log.info("Added sample Alert: #{alert.description}")
-            if action
-              alert.options = {:notifications => {action.action_type.to_sym => action.options}}
-              alert.save
-            end
+      alist.each do |alert_hash|
+        guid = alert_hash["guid"] || alert_hash[:guid]
+        rec = self.find_by_guid(guid)
+        if rec.nil?
+          alert = self.create(alert_hash)
+          _log.info("Added sample Alert: #{alert.description}")
+          if action
+            alert.options = {:notifications => {action.action_type.to_sym => action.options}}
+            alert.save
           end
         end
       end

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -45,12 +45,11 @@ class MiqDatabase < ActiveRecord::Base
 
   def self.seed
     if self.exists?
-      self.first.lock do |db|
-        db.session_secret_token ||= SecureRandom.hex(64)
-        db.csrf_secret_token    ||= SecureRandom.hex(64)
-        db.update_repo_name     ||= registration_default_value_for_update_repo_name
-        db.save! if db.changed?
-      end
+      db = first
+      db.session_secret_token ||= SecureRandom.hex(64)
+      db.csrf_secret_token    ||= SecureRandom.hex(64)
+      db.update_repo_name     ||= registration_default_value_for_update_repo_name
+      db.save! if db.changed?
     else
       self.create!(
         :session_secret_token => SecureRandom.hex(64),

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -44,14 +44,14 @@ class MiqDatabase < ActiveRecord::Base
   end
 
   def self.seed
-    if self.exists?
+    if exists?
       db = first
       db.session_secret_token ||= SecureRandom.hex(64)
       db.csrf_secret_token    ||= SecureRandom.hex(64)
       db.update_repo_name     ||= registration_default_value_for_update_repo_name
       db.save! if db.changed?
     else
-      self.create!(
+      create!(
         :session_secret_token => SecureRandom.hex(64),
         :csrf_secret_token    => SecureRandom.hex(64),
         :update_repo_name     => registration_default_value_for_update_repo_name

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -16,7 +16,7 @@ class MiqDialog < ActiveRecord::Base
   include ReportableMixin
 
   def self.seed
-    self.sync_from_dir
+    sync_from_dir
   end
 
   def self.sync_from_dir

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -16,9 +16,7 @@ class MiqDialog < ActiveRecord::Base
   include ReportableMixin
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.sync_from_dir
-    end
+    self.sync_from_dir
   end
 
   def self.sync_from_dir

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -27,12 +27,10 @@ class MiqEnterprise < ActiveRecord::Base
   include Metric::CiMixin
 
   def self.seed
-    MiqRegion.my_region.lock do
-      if self.in_my_region.first.nil?
-        _log.info("Creating Enterprise Root Object")
-        self.create(:name => "Enterprise", :description => "Enterprise Root Object")
-        _log.info("Creating Enterprise Root Object... Complete")
-      end
+    if self.in_my_region.first.nil?
+      _log.info("Creating Enterprise Root Object")
+      self.create(:name => "Enterprise", :description => "Enterprise Root Object")
+      _log.info("Creating Enterprise Root Object... Complete")
     end
   end
 

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -27,9 +27,9 @@ class MiqEnterprise < ActiveRecord::Base
   include Metric::CiMixin
 
   def self.seed
-    if self.in_my_region.first.nil?
+    if in_my_region.first.nil?
       _log.info("Creating Enterprise Root Object")
-      self.create(:name => "Enterprise", :description => "Enterprise Root Object")
+      create(:name => "Enterprise", :description => "Enterprise Root Object")
       _log.info("Creating Enterprise Root Object... Complete")
     end
   end

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -113,8 +113,8 @@ class MiqEventDefinition < ActiveRecord::Base
 
   def self.seed
     MiqEventDefinitionSet.seed
-    self.seed_default_events
-    self.seed_default_definitions
+    seed_default_events
+    seed_default_definitions
   end
 
   def self.seed_default_events

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -113,10 +113,8 @@ class MiqEventDefinition < ActiveRecord::Base
 
   def self.seed
     MiqEventDefinitionSet.seed
-    MiqRegion.my_region.lock do
-      self.seed_default_events
-      self.seed_default_definitions
-    end
+    self.seed_default_events
+    self.seed_default_definitions
   end
 
   def self.seed_default_events

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -6,29 +6,27 @@ class MiqEventDefinitionSet < ActiveRecord::Base
   FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
 
   def self.seed
-    MiqRegion.my_region.lock do
-      fname = File.join(FIXTURE_DIR, "#{self.to_s.pluralize.underscore}.csv")
-      data  = File.read(fname).split("\n")
-      cols  = data.shift.split(",")
+    fname = File.join(FIXTURE_DIR, "#{self.to_s.pluralize.underscore}.csv")
+    data  = File.read(fname).split("\n")
+    cols  = data.shift.split(",")
 
-      data.each do |s|
-        next if s =~ /^#.*$/ # skip commented lines
+    data.each do |s|
+      next if s =~ /^#.*$/ # skip commented lines
 
-        arr = s.split(",")
+      arr = s.split(",")
 
-        set = {}
-        cols.each_index {|i| set[cols[i].to_sym] = arr[i]}
+      set = {}
+      cols.each_index {|i| set[cols[i].to_sym] = arr[i]}
 
-        rec = self.find_by_name(set[:name])
-        if rec.nil?
-          _log.info("Creating [#{set[:name]}]")
-          rec = self.create(set)
-        else
-          rec.attributes = set
-          if rec.changed?
-            _log.info("Updating [#{set[:name]}]")
-            rec.save
-          end
+      rec = self.find_by_name(set[:name])
+      if rec.nil?
+        _log.info("Creating [#{set[:name]}]")
+        rec = self.create(set)
+      else
+        rec.attributes = set
+        if rec.changed?
+          _log.info("Updating [#{set[:name]}]")
+          rec.save
         end
       end
     end

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -6,7 +6,7 @@ class MiqEventDefinitionSet < ActiveRecord::Base
   FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
 
   def self.seed
-    fname = File.join(FIXTURE_DIR, "#{self.to_s.pluralize.underscore}.csv")
+    fname = File.join(FIXTURE_DIR, "#{to_s.pluralize.underscore}.csv")
     data  = File.read(fname).split("\n")
     cols  = data.shift.split(",")
 
@@ -18,10 +18,10 @@ class MiqEventDefinitionSet < ActiveRecord::Base
       set = {}
       cols.each_index {|i| set[cols[i].to_sym] = arr[i]}
 
-      rec = self.find_by_name(set[:name])
+      rec = find_by_name(set[:name])
       if rec.nil?
         _log.info("Creating [#{set[:name]}]")
-        rec = self.create(set)
+        rec = create(set)
       else
         rec.attributes = set
         if rec.changed?
@@ -31,5 +31,4 @@ class MiqEventDefinitionSet < ActiveRecord::Base
       end
     end
   end
-
 end

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -16,7 +16,7 @@ class MiqEventDefinitionSet < ActiveRecord::Base
       arr = s.split(",")
 
       set = {}
-      cols.each_index {|i| set[cols[i].to_sym] = arr[i]}
+      cols.each_index { |i| set[cols[i].to_sym] = arr[i] }
 
       rec = find_by_name(set[:name])
       if rec.nil?

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -88,7 +88,7 @@ class MiqGroup < ActiveRecord::Base
       groups_to_roles = role_map.inject({}) {|h, g| h[g.keys.first] = g[g.keys.first]; h}
       seq = 1
       order.each do |g|
-        group = self.find_by_description(g) || self.new(:description => g)
+        group = find_by_description(g) || new(:description => g)
         user_role = MiqUserRole.find_by_name("EvmRole-#{groups_to_roles[g]}")
         if user_role.nil?
           _log.warn("Unable to find user_role 'EvmRole-#{groups_to_roles[group]}' for group '#{g}'")

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -77,36 +77,34 @@ class MiqGroup < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      role_map_file = File.expand_path(File.join(FIXTURE_DIR, "role_map.yaml"))
-      root_tenant = Tenant.root_tenant
-      if File.exist?(role_map_file)
-        filter_map_file = File.expand_path(File.join(FIXTURE_DIR, "filter_map.yaml"))
-        ldap_to_filters = File.exist?(filter_map_file) ? YAML.load_file(filter_map_file) : {}
+    role_map_file = File.expand_path(File.join(FIXTURE_DIR, "role_map.yaml"))
+    root_tenant = Tenant.root_tenant
+    if File.exist?(role_map_file)
+      filter_map_file = File.expand_path(File.join(FIXTURE_DIR, "filter_map.yaml"))
+      ldap_to_filters = File.exist?(filter_map_file) ? YAML.load_file(filter_map_file) : {}
 
-        role_map = YAML.load_file(role_map_file)
-        order = role_map.collect(&:keys).flatten
-        groups_to_roles = role_map.inject({}) {|h, g| h[g.keys.first] = g[g.keys.first]; h}
-        seq = 1
-        order.each do |g|
-          group = self.find_by_description(g) || self.new(:description => g)
-          user_role = MiqUserRole.find_by_name("EvmRole-#{groups_to_roles[g]}")
-          if user_role.nil?
-            _log.warn("Unable to find user_role 'EvmRole-#{groups_to_roles[group]}' for group '#{g}'")
-            next
-          end
-          group.miq_user_role = user_role
-          group.sequence      = seq
-          group.filters       = ldap_to_filters[g]
-          group.group_type    = "system"
-          group.tenant        = root_tenant
-
-          mode = group.new_record? ? "Created" : "Added"
-          group.save!
-          _log.info("#{mode} Group: #{group.description} with Role: #{user_role.name}")
-
-          seq += 1
+      role_map = YAML.load_file(role_map_file)
+      order = role_map.collect(&:keys).flatten
+      groups_to_roles = role_map.inject({}) {|h, g| h[g.keys.first] = g[g.keys.first]; h}
+      seq = 1
+      order.each do |g|
+        group = self.find_by_description(g) || self.new(:description => g)
+        user_role = MiqUserRole.find_by_name("EvmRole-#{groups_to_roles[g]}")
+        if user_role.nil?
+          _log.warn("Unable to find user_role 'EvmRole-#{groups_to_roles[group]}' for group '#{g}'")
+          next
         end
+        group.miq_user_role = user_role
+        group.sequence      = seq
+        group.filters       = ldap_to_filters[g]
+        group.group_type    = "system"
+        group.tenant        = root_tenant
+
+        mode = group.new_record? ? "Created" : "Added"
+        group.save!
+        _log.info("#{mode} Group: #{group.description} with Role: #{user_role.name}")
+
+        seq += 1
       end
     end
   end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -85,7 +85,7 @@ class MiqGroup < ActiveRecord::Base
 
       role_map = YAML.load_file(role_map_file)
       order = role_map.collect(&:keys).flatten
-      groups_to_roles = role_map.inject({}) {|h, g| h[g.keys.first] = g[g.keys.first]; h}
+      groups_to_roles = role_map.each_with_object({}) { |g, h| h[g.keys.first] = g[g.keys.first] }
       seq = 1
       order.each do |g|
         group = find_by_description(g) || new(:description => g)

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -359,7 +359,7 @@ class MiqPolicy < ActiveRecord::Base
   end
 
   def self.seed
-    self.all.each do |p|
+    all.each do |p|
       attrs = {}
       attrs[:towhat] = "Vm"      if p.towhat.nil?
       attrs[:active] = true      if p.active.nil?

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -359,16 +359,14 @@ class MiqPolicy < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.all.each do |p|
-        attrs = {}
-        attrs[:towhat] = "Vm"      if p.towhat.nil?
-        attrs[:active] = true      if p.active.nil?
-        attrs[:mode]   = "control" if p.mode.nil?
-        if attrs.empty?
-          _log.info("Updating [#{p.name}]")
-          p.update_attributes(attrs)
-        end
+    self.all.each do |p|
+      attrs = {}
+      attrs[:towhat] = "Vm"      if p.towhat.nil?
+      attrs[:active] = true      if p.active.nil?
+      attrs[:mode]   = "control" if p.mode.nil?
+      if attrs.empty?
+        _log.info("Updating [#{p.name}]")
+        p.update_attributes(attrs)
       end
     end
   end

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -116,12 +116,10 @@ class MiqPolicySet < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.all.each do |ps|
-        if ps.mode.nil?
-          _log.info("Updating [#{ps.name}]")
-          ps.update_attribute(:mode, "control")
-        end
+    self.all.each do |ps|
+      if ps.mode.nil?
+        _log.info("Updating [#{ps.name}]")
+        ps.update_attribute(:mode, "control")
       end
     end
   end

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -116,7 +116,7 @@ class MiqPolicySet < ActiveRecord::Base
   end
 
   def self.seed
-    self.all.each do |ps|
+    all.each do |ps|
       if ps.mode.nil?
         _log.info("Updating [#{ps.name}]")
         ps.update_attribute(:mode, "control")

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -73,9 +73,7 @@ class MiqProductFeature < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.seed_features
-    end
+    self.seed_features
   end
 
   def self.seed_features

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -73,7 +73,7 @@ class MiqProductFeature < ActiveRecord::Base
   end
 
   def self.seed
-    self.seed_features
+    seed_features
   end
 
   def self.seed_features

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -109,16 +109,16 @@ class MiqRegion < ActiveRecord::Base
   def self.seed
     # Get the region by looking at an existing MiqDatabase instance's id
     # (ie, 2000000000001 is region 2) and sync this to the file
-    my_region = self.my_region_number
+    my_region = my_region_number
     db = MiqDatabase.first
     if db
       region = db.region_id
       raise Exception, "Region [#{my_region}] does not match the database's region [#{region}]" if region != my_region
     end
 
-    unless self.exists?(:region => my_region)
+    unless exists?(:region => my_region)
       _log.info("Creating Region [#{my_region}]")
-      self.create!(:region => my_region, :description => "Region #{my_region}")
+      create!(:region => my_region, :description => "Region #{my_region}")
       _log.info("Creating Region... Complete")
     end
   end

--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -7,12 +7,10 @@ module MiqReport::Seeding
     COMPARE_DIR = File.expand_path(File.join(Rails.root, "product/compare"))
 
     def seed
-      MiqRegion.my_region.lock do
-        # Force creation of model instances for all report yaml files that exist in the product/reports directories
-        # that don't already have an instance in the model
-        MiqReport.sync_from_dir("report")
-        MiqReport.sync_from_dir("compare")
-      end
+      # Force creation of model instances for all report yaml files that exist in the product/reports directories
+      # that don't already have an instance in the model
+      MiqReport.sync_from_dir("report")
+      MiqReport.sync_from_dir("compare")
     end
 
     def seed_report(pattern, type = "report")

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -38,26 +38,24 @@ class MiqSearch < ActiveRecord::Base
 
   FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
   def self.seed
-    MiqRegion.my_region.lock do
-      fixture_file = File.join(FIXTURE_DIR, "miq_searches.yml")
-      slist        = YAML.load_file(fixture_file) if File.exist?(fixture_file)
-      slist      ||= []
+    fixture_file = File.join(FIXTURE_DIR, "miq_searches.yml")
+    slist        = YAML.load_file(fixture_file) if File.exist?(fixture_file)
+    slist      ||= []
 
-      slist.each do |search|
-        attrs = search['attributes']
-        name  = attrs['name']
-        db    = attrs['db']
+    slist.each do |search|
+      attrs = search['attributes']
+      name  = attrs['name']
+      db    = attrs['db']
 
-        rec = self.find_by_name_and_db(name, db)
-        if rec.nil?
-          _log.info("Creating [#{name}]")
-          self.create(attrs)
-        else
-          # Avoid undoing user changes made to enable/disable default searches which is held in the search_key column
-          attrs.delete('search_key')
-          rec.attributes = attrs
-          rec.save
-        end
+      rec = self.find_by_name_and_db(name, db)
+      if rec.nil?
+        _log.info("Creating [#{name}]")
+        self.create(attrs)
+      else
+        # Avoid undoing user changes made to enable/disable default searches which is held in the search_key column
+        attrs.delete('search_key')
+        rec.attributes = attrs
+        rec.save
       end
     end
   end

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -40,7 +40,7 @@ class MiqSearch < ActiveRecord::Base
   def self.seed
     fixture_file = File.join(FIXTURE_DIR, "miq_searches.yml")
     slist        = YAML.load_file(fixture_file) if File.exist?(fixture_file)
-    slist      ||= []
+    slist ||= []
 
     slist.each do |search|
       attrs = search['attributes']

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -47,10 +47,10 @@ class MiqSearch < ActiveRecord::Base
       name  = attrs['name']
       db    = attrs['db']
 
-      rec = self.find_by_name_and_db(name, db)
+      rec = find_by_name_and_db(name, db)
       if rec.nil?
         _log.info("Creating [#{name}]")
-        self.create(attrs)
+        create(attrs)
       else
         # Avoid undoing user changes made to enable/disable default searches which is held in the search_key column
         attrs.delete('search_key')

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -190,15 +190,13 @@ class MiqServer < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      unless self.exists?(:guid => self.my_guid)
-        _log.info("Creating Default MiqServer with guid=[#{self.my_guid}], zone=[#{Zone.default_zone.name}]")
-        self.create!(:guid => self.my_guid, :zone => Zone.default_zone)
-        self.my_server_clear_cache
-        _log.info("Creating Default MiqServer... Complete")
-      end
-      self.my_server
+    unless self.exists?(:guid => self.my_guid)
+      _log.info("Creating Default MiqServer with guid=[#{self.my_guid}], zone=[#{Zone.default_zone.name}]")
+      self.create!(:guid => self.my_guid, :zone => Zone.default_zone)
+      self.my_server_clear_cache
+      _log.info("Creating Default MiqServer... Complete")
     end
+    self.my_server
   end
 
   def self.start

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -190,13 +190,13 @@ class MiqServer < ActiveRecord::Base
   end
 
   def self.seed
-    unless self.exists?(:guid => self.my_guid)
-      _log.info("Creating Default MiqServer with guid=[#{self.my_guid}], zone=[#{Zone.default_zone.name}]")
-      self.create!(:guid => self.my_guid, :zone => Zone.default_zone)
-      self.my_server_clear_cache
+    unless exists?(:guid => my_guid)
+      _log.info("Creating Default MiqServer with guid=[#{my_guid}], zone=[#{Zone.default_zone.name}]")
+      create!(:guid => my_guid, :zone => Zone.default_zone)
+      my_server_clear_cache
       _log.info("Creating Default MiqServer... Complete")
     end
-    self.my_server
+    my_server
   end
 
   def self.start

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -3,29 +3,27 @@ class MiqShortcut < ActiveRecord::Base
   has_many :miq_widgets, :through => :miq_widget_shortcuts
 
   def self.seed
-    MiqRegion.my_region.lock do
-      names = []
-      seed_data.each_with_index do |s, index|
-        names << s[:name]
-        s[:sequence] = index
-        rec = self.find_by_name(s[:name])
-        if rec.nil?
-          _log.info("Creating #{s.inspect}")
-          rec = self.create(s)
-        else
-          rec.attributes = s
-          if rec.changed?
-            _log.info("Updating #{s.inspect}")
-            rec.save
-          end
+    names = []
+    seed_data.each_with_index do |s, index|
+      names << s[:name]
+      s[:sequence] = index
+      rec = self.find_by_name(s[:name])
+      if rec.nil?
+        _log.info("Creating #{s.inspect}")
+        rec = self.create(s)
+      else
+        rec.attributes = s
+        if rec.changed?
+          _log.info("Updating #{s.inspect}")
+          rec.save
         end
       end
+    end
 
-      self.all.each do |rec|
-        next if names.include?(rec.name)
-        _log.info("Deleting #{rec.inspect}")
-        rec.destroy
-      end
+    self.all.each do |rec|
+      next if names.include?(rec.name)
+      _log.info("Deleting #{rec.inspect}")
+      rec.destroy
     end
   end
 

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -7,10 +7,10 @@ class MiqShortcut < ActiveRecord::Base
     seed_data.each_with_index do |s, index|
       names << s[:name]
       s[:sequence] = index
-      rec = self.find_by_name(s[:name])
+      rec = find_by_name(s[:name])
       if rec.nil?
         _log.info("Creating #{s.inspect}")
-        rec = self.create(s)
+        rec = create(s)
       else
         rec.attributes = s
         if rec.changed?
@@ -20,7 +20,7 @@ class MiqShortcut < ActiveRecord::Base
       end
     end
 
-    self.all.each do |rec|
+    all.each do |rec|
       next if names.include?(rec.name)
       _log.info("Deleting #{rec.inspect}")
       rec.destroy

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -152,10 +152,10 @@ class MiqUserRole < ActiveRecord::Base
   end
 
   def self.seed
-    self.seed_from_array(YAML.load_file(FIXTURE_YAML))
+    seed_from_array(YAML.load_file(FIXTURE_YAML))
 
     Dir.glob(File.join(FIXTURE_PATH, "*.yml")).each do |fixture|
-      self.seed_from_array(YAML.load_file(fixture), true)
+      seed_from_array(YAML.load_file(fixture), true)
     end
   end
 

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -152,12 +152,10 @@ class MiqUserRole < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.seed_from_array(YAML.load_file(FIXTURE_YAML))
+    self.seed_from_array(YAML.load_file(FIXTURE_YAML))
 
-      Dir.glob(File.join(FIXTURE_PATH, "*.yml")).each do |fixture|
-        self.seed_from_array(YAML.load_file(fixture), true)
-      end
+    Dir.glob(File.join(FIXTURE_PATH, "*.yml")).each do |fixture|
+      self.seed_from_array(YAML.load_file(fixture), true)
     end
   end
 

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -585,7 +585,7 @@ class MiqWidget < ActiveRecord::Base
   end
 
   def self.seed
-    self.sync_from_dir
+    sync_from_dir
     MiqWidgetSet.seed
   end
 

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -585,9 +585,7 @@ class MiqWidget < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.sync_from_dir
-    end
+    self.sync_from_dir
     MiqWidgetSet.seed
   end
 

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -69,9 +69,7 @@ class MiqWidgetSet < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.sync_from_dir
-    end
+    self.sync_from_dir
   end
 
   def self.find_with_same_order(ids)

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -69,7 +69,7 @@ class MiqWidgetSet < ActiveRecord::Base
   end
 
   def self.seed
-    self.sync_from_dir
+    sync_from_dir
   end
 
   def self.find_with_same_order(ids)

--- a/app/models/pxe_image_type.rb
+++ b/app/models/pxe_image_type.rb
@@ -16,11 +16,11 @@ class PxeImageType < ActiveRecord::Base
   end
 
   def self.seed
-    return if PxeImageType.any?
+    return if any?
 
     seed_data.each do |s|
       _log.info("Creating #{s.inspect}")
-      self.create(s)
+      create(s)
     end
   end
 

--- a/app/models/pxe_image_type.rb
+++ b/app/models/pxe_image_type.rb
@@ -18,11 +18,9 @@ class PxeImageType < ActiveRecord::Base
   def self.seed
     return if PxeImageType.any?
 
-    MiqRegion.my_region.lock do
-      seed_data.each do |s|
-        _log.info("Creating #{s.inspect}")
-        self.create(s)
-      end
+    seed_data.each do |s|
+      _log.info("Creating #{s.inspect}")
+      self.create(s)
     end
   end
 

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -155,8 +155,6 @@ class RssFeed < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      RssFeed.sync_from_yml_dir
-    end
+    RssFeed.sync_from_yml_dir
   end
 end

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -155,6 +155,6 @@ class RssFeed < ActiveRecord::Base
   end
 
   def self.seed
-    RssFeed.sync_from_yml_dir
+    sync_from_yml_dir
   end
 end

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -50,8 +50,8 @@ class ScanItem < ActiveRecord::Base
   end
 
   def self.seed
-    self.sync_from_dir
-    self.preload_default_profile
+    sync_from_dir
+    preload_default_profile
   end
 
   def self.preload_default_profile

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -50,10 +50,8 @@ class ScanItem < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      self.sync_from_dir
-      self.preload_default_profile
-    end
+    self.sync_from_dir
+    self.preload_default_profile
   end
 
   def self.preload_default_profile

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -21,7 +21,7 @@ class ServerRole < ActiveRecord::Base
       arr = a.split(",")
 
       action = {}
-      cols.each_index {|i| action[cols[i].to_sym] = arr[i]}
+      cols.each_index { |i| action[cols[i].to_sym] = arr[i] }
 
       rec = where(:name => action[:name]).first
       if rec.nil?

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -12,28 +12,26 @@ class ServerRole < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      data = self.seed_data.split("\n")
-      cols = data.shift.split(",")
+    data = self.seed_data.split("\n")
+    cols = data.shift.split(",")
 
-      data.each do |a|
-        next if a =~ /^#.*$/ # skip commented lines
+    data.each do |a|
+      next if a =~ /^#.*$/ # skip commented lines
 
-        arr = a.split(",")
+      arr = a.split(",")
 
-        action = {}
-        cols.each_index {|i| action[cols[i].to_sym] = arr[i]}
+      action = {}
+      cols.each_index {|i| action[cols[i].to_sym] = arr[i]}
 
-        rec = self.where(:name => action[:name]).first
-        if rec.nil?
-          _log.info("Creating Server Role [#{action[:name]}]")
-          rec = self.create(action)
-        else
-          rec.attributes = action
-          if rec.changed?
-            _log.info("Updating Server Role [#{action[:name]}]")
-            rec.save
-          end
+      rec = self.where(:name => action[:name]).first
+      if rec.nil?
+        _log.info("Creating Server Role [#{action[:name]}]")
+        rec = self.create(action)
+      else
+        rec.attributes = action
+        if rec.changed?
+          _log.info("Updating Server Role [#{action[:name]}]")
+          rec.save
         end
       end
     end

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -12,7 +12,7 @@ class ServerRole < ActiveRecord::Base
   end
 
   def self.seed
-    data = self.seed_data.split("\n")
+    data = seed_data.split("\n")
     cols = data.shift.split(",")
 
     data.each do |a|
@@ -23,10 +23,10 @@ class ServerRole < ActiveRecord::Base
       action = {}
       cols.each_index {|i| action[cols[i].to_sym] = arr[i]}
 
-      rec = self.where(:name => action[:name]).first
+      rec = where(:name => action[:name]).first
       if rec.nil?
         _log.info("Creating Server Role [#{action[:name]}]")
-        rec = self.create(action)
+        rec = create(action)
       else
         rec.attributes = action
         if rec.changed?

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -188,10 +188,9 @@ class Tenant < ActiveRecord::Base
     roots.first
   end
 
+  # NOTE: returns the root tenant
   def self.seed
-    MiqRegion.my_region.lock do
-      Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => true)
-    end
+    Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => true)
   end
 
   private

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -190,7 +190,7 @@ class Tenant < ActiveRecord::Base
 
   # NOTE: returns the root tenant
   def self.seed
-    Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => true)
+    root_tenant || create!(:use_config_for_attributes => true)
   end
 
   private

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -26,17 +26,15 @@ class TimeProfile < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      utc_tp = default_time_profile
+    utc_tp = default_time_profile
 
-      if utc_tp.nil?
-        TimeProfile.create!(
-          :description          => DEFAULT_TZ,
-          :tz                   => DEFAULT_TZ,
-          :profile_type         => "global",
-          :rollup_daily_metrics => true
-        )
-      end
+    if utc_tp.nil?
+      TimeProfile.create!(
+        :description          => DEFAULT_TZ,
+        :tz                   => DEFAULT_TZ,
+        :profile_type         => "global",
+        :rollup_daily_metrics => true
+      )
     end
   end
 

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -29,7 +29,7 @@ class TimeProfile < ActiveRecord::Base
     utc_tp = default_time_profile
 
     if utc_tp.nil?
-      TimeProfile.create!(
+      create!(
         :description          => DEFAULT_TZ,
         :tz                   => DEFAULT_TZ,
         :profile_type         => "global",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -307,19 +307,16 @@ class User < ActiveRecord::Base
   private
 
   def self.seed
-    MiqRegion.my_region.lock do
-      user = self.in_my_region.find_by_userid("admin")
-      if user.nil?
-        _log.info("Creating default admin user...")
-        user = self.create(:userid => "admin", :name => "Administrator", :password => "smartvm")
-        _log.info("Creating default admin user... Complete")
-      end
-
-      admin_group     = MiqGroup.in_my_region.find_by_description("EvmGroup-super_administrator")
-      user.miq_groups = [admin_group] if admin_group
-      user.save
-
+    user = self.in_my_region.find_by_userid("admin")
+    if user.nil?
+      _log.info("Creating default admin user...")
+      user = self.create(:userid => "admin", :name => "Administrator", :password => "smartvm")
+      _log.info("Creating default admin user... Complete")
     end
+
+    admin_group     = MiqGroup.in_my_region.find_by_description("EvmGroup-super_administrator")
+    user.miq_groups = [admin_group] if admin_group
+    user.save
   end
 
   # Save the current user from the session object as a thread variable to allow lookup from other areas of the code

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -307,10 +307,10 @@ class User < ActiveRecord::Base
   private
 
   def self.seed
-    user = self.in_my_region.find_by_userid("admin")
+    user = in_my_region.find_by_userid("admin")
     if user.nil?
       _log.info("Creating default admin user...")
-      user = self.create(:userid => "admin", :name => "Administrator", :password => "smartvm")
+      user = create(:userid => "admin", :name => "Administrator", :password => "smartvm")
       _log.info("Creating default admin user... Complete")
     end
 

--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -3,11 +3,9 @@ module VmdbDatabase::Seeding
 
   module ClassMethods
     def seed
-      MiqDatabase.first.lock do
-        db = seed_self
-        db.seed
-        db
-      end
+      db = seed_self
+      db.seed
+      db
     end
 
     def seed_self

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -44,12 +44,10 @@ class Zone < ActiveRecord::Base
   end
 
   def self.seed
-    MiqRegion.my_region.lock do
-      unless self.exists?(:name => 'default')
-        _log.info("Creating default zone...")
-        self.create(:name => "default", :description => "Default Zone")
-        _log.info("Creating default zone... Complete")
-      end
+    unless self.exists?(:name => 'default')
+      _log.info("Creating default zone...")
+      self.create(:name => "default", :description => "Default Zone")
+      _log.info("Creating default zone... Complete")
     end
   end
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -44,9 +44,9 @@ class Zone < ActiveRecord::Base
   end
 
   def self.seed
-    unless self.exists?(:name => 'default')
+    unless exists?(:name => 'default')
       _log.info("Creating default zone...")
-      self.create(:name => "default", :description => "Default Zone")
+      create(:name => "default", :description => "Default Zone")
       _log.info("Creating default zone... Complete")
     end
   end

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -48,7 +48,7 @@ class EvmDatabase
     # Only 1 machine can go through this at a time
     # Populating the DB takes 20 seconds
     # Not populating the db takes 3 seconds
-    MiqDatabase.with_lock(:share_row_exclusive, 10.minutes) do
+    MiqDatabase.with_lock(10.minutes) do
       classes.each do |klass|
         begin
           klass = klass.constantize if klass.kind_of?(String)

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -48,7 +48,7 @@ class EvmDatabase
     # Only 1 machine can go through this at a time
     # Populating the DB takes 20 seconds
     # Not populating the db takes 3 seconds
-    MiqDatabase.with_lock do
+    MiqDatabase.with_lock(:share_row_exclusive, 10.minutes) do
       classes.each do |klass|
         begin
           klass = klass.constantize if klass.kind_of?(String)

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -45,20 +45,25 @@ class EvmDatabase
     classes ||= PRIMORDIAL_CLASSES + (seedable_model_class_names - PRIMORDIAL_CLASSES)
     classes  -= exclude_list
 
-    classes.each do |klass|
-      begin
-        klass = klass.constantize if klass.kind_of?(String)
-      rescue
-        _log.error("Class #{klass} does not exist")
-        next
-      end
-
-      if klass.respond_to?(:seed)
-        _log.info("Seeding #{klass}")
+    # Only 1 machine can go through this at a time
+    # Populating the DB takes 20 seconds
+    # Not populating the db takes 3 seconds
+    MiqDatabase.with_lock do
+      classes.each do |klass|
         begin
-          klass.seed
-        rescue => err
-          _log.log_backtrace(err)
+          klass = klass.constantize if klass.kind_of?(String)
+        rescue
+          _log.error("Class #{klass} does not exist")
+          next
+        end
+
+        if klass.respond_to?(:seed)
+          _log.info("Seeding #{klass}")
+          begin
+            klass.seed
+          rescue => err
+            _log.log_backtrace(err)
+          end
         end
       end
     end

--- a/lib/extensions/ar_table_lock.rb
+++ b/lib/extensions/ar_table_lock.rb
@@ -1,0 +1,25 @@
+module ArTableLock
+  # Creates mutex by locking on a database table in SQL.
+  # Please use record level locking over this
+  #
+  # passing in mode has been disabled due to brakeman
+  #
+  # if a different mode is desired, we'll work around issue later
+  #
+  # possible modes:
+  # "ACCESS SHARE", "ROW SHARE", "ROW EXCLUSIVE", "SHARE", "EXCLUSIVE",
+  #  "SHARE UPDATE EXCLUSIVE", "SHARE ROW EXCLUSIVE", "ACCESS EXCLUSIVE"
+  #
+  # details on locks can be found on postgres docs:
+  #   can be fount http://www.postgresql.org/docs/9.4/static/explicit-locking.html
+  #
+  def with_lock
+    mode = "SHARE ROW EXCLUSIVE"
+    transaction do
+      connection.execute("LOCK TABLE #{table_name} in #{mode} MODE")
+      yield
+    end
+  end
+end
+
+ActiveRecord::Base.send(:extend, ArTableLock)

--- a/lib/extensions/ar_table_lock.rb
+++ b/lib/extensions/ar_table_lock.rb
@@ -2,25 +2,15 @@ module ArTableLock
   # Creates mutex by locking on a database table in SQL.
   # Please use record level locking over this
   #
-  # default mode: share_row_exclusive
-  # possible modes:
-  #   :share_update_exclusive, :SUE "SHARE UPDATE EXCLUSIVE"
-  #     This mode protects a table against concurrent schema changes and VACUUM runs.
-  #   :share_row_exclusive,    :SRU "SHARE ROW EXCLUSIVE"
+  #   "SHARE ROW EXCLUSIVE"
   #     This mode protects a table against concurrent data changes.
   #     It is self-exclusive so that only one session can hold it at a time.
-  # "ACCESS SHARE", "ROW SHARE", "ROW EXCLUSIVE", "SHARE", "EXCLUSIVE",
-  #  "SHARE UPDATE EXCLUSIVE", "SHARE ROW EXCLUSIVE", "ACCESS EXCLUSIVE"
   #
   # details on locks can be found on postgres docs:
   #   can be fount http://www.postgresql.org/docs/9.4/static/explicit-locking.html
   #
-  def with_lock(mode = :share_row_exclusive, timeout = 60.seconds)
-    lock = case mode
-           when :share_update_exclusive, :SUE then "SHARE UPDATE EXCLUSIVE"
-           when :share_row_exclusive,    :SRU then "SHARE ROW EXCLUSIVE"
-           else raise "unknown lock mode <#{mode.inspect}>"
-           end
+  def with_lock(timeout = 60.seconds)
+    lock = "SHARE ROW EXCLUSIVE"
 
     transaction do
       _log.debug "Acquiring lock on #{name} (table: #{table_name}..."

--- a/lib/extensions/ar_table_lock.rb
+++ b/lib/extensions/ar_table_lock.rb
@@ -2,22 +2,36 @@ module ArTableLock
   # Creates mutex by locking on a database table in SQL.
   # Please use record level locking over this
   #
-  # passing in mode has been disabled due to brakeman
-  #
-  # if a different mode is desired, we'll work around issue later
-  #
+  # default mode: share_row_exclusive
   # possible modes:
+  #   :share_update_exclusive, :SUE "SHARE UPDATE EXCLUSIVE"
+  #     This mode protects a table against concurrent schema changes and VACUUM runs.
+  #   :share_row_exclusive,    :SRU "SHARE ROW EXCLUSIVE"
+  #     This mode protects a table against concurrent data changes.
+  #     It is self-exclusive so that only one session can hold it at a time.
   # "ACCESS SHARE", "ROW SHARE", "ROW EXCLUSIVE", "SHARE", "EXCLUSIVE",
   #  "SHARE UPDATE EXCLUSIVE", "SHARE ROW EXCLUSIVE", "ACCESS EXCLUSIVE"
   #
   # details on locks can be found on postgres docs:
   #   can be fount http://www.postgresql.org/docs/9.4/static/explicit-locking.html
   #
-  def with_lock
-    mode = "SHARE ROW EXCLUSIVE"
+  def with_lock(mode = :share_row_exclusive, timeout = 60.seconds)
+    lock = case mode
+           when :share_update_exclusive, :SUE then "SHARE UPDATE EXCLUSIVE"
+           when :share_row_exclusive,    :SRU then "SHARE ROW EXCLUSIVE"
+           else raise "unknown lock mode <#{mode.inspect}>"
+           end
+
     transaction do
-      connection.execute("LOCK TABLE #{table_name} in #{mode} MODE")
-      yield
+      _log.debug "Acquiring lock on #{name} (table: #{table_name}..."
+      connection.execute("LOCK TABLE #{table_name} in #{lock} MODE")
+      _log.debug "Acquired lock on #{name} (table: #{table_name}..."
+
+      begin
+        Timeout.timeout(timeout) { yield }
+      ensure
+        _log.debug "Releasing lock on #{name} (table: #{table_name}..."
+      end
     end
   end
 end

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -180,17 +180,15 @@ module MiqAeDatastore
   end
 
   def self.seed
-    MiqRegion.my_region.lock(:shared, 1800) do
-      ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
-      unless ns
-        _log.info "Seeding ManageIQ domain..."
-        begin
-          reset_to_defaults
-        rescue => err
-          _log.error "Seeding... Reset failed, #{err.message}"
-        else
-          _log.info "Seeding... Complete"
-        end
+    ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
+    unless ns
+      _log.info "Seeding ManageIQ domain..."
+      begin
+        reset_to_defaults
+      rescue => err
+        _log.error "Seeding... Reset failed, #{err.message}"
+      else
+        _log.info "Seeding... Complete"
       end
     end
   end


### PR DESCRIPTION
GOAL: remove locks and extra records needed to run seeds from specs.

Use a table lock instead of a row level lock for seeds

1. This removes inter record dependencies
2. This allows us to lock around creating database and region records
3. seeding 21 -> 18 seconds. And no op seeding 3.5 -> 2.5 seconds.

Made region and database creation more standard.
Left region detection code in `region.seed`, but if you have pointers, I can cleanup.

/cc @matthewd @Fryguy thanks for pointers

Followup: I am removing a bunch of `MiqRegion.seed` calls from specs.