### PR TITLE
Run coveralls on CI only since it's not useful locally and simplecov has some overhead

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 
-require 'coveralls'
-Coveralls.wear!('rails') { add_filter("/spec/") }
+if ENV["CI"]
+  require 'coveralls'
+  Coveralls.wear!('rails') { add_filter("/spec/") }
+end
 
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
Note, coveralls can't be run locally because it wants to run rake test.

Besides, simplecov produces much easier to consume html so run
simplecov locally if you want code coverage information.

A fast spec [1], which finishes in 1.2 seconds, with coveralls
enabled creates 2+ million objects in simplecov:

[1] gems/pending/spec/appliance_console/cli_spec.rb

```
946267  .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/source_file.rb 81  T_STRING
733387  .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/source_file.rb 170 T_STRING
254898  .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/filter.rb  33  T_STRING
122107  .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/source_file.rb 97  T_OBJECT
104770  .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/source_file.rb 170 T_ARRAY
104769  .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/source_file.rb 170 T_REGEXP
45352 .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/defaults.rb  7 T_STRING
44189 .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/filter.rb  33  T_REGEXP
44187 .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/filter.rb  33  T_NODE
44185 .../.gem/ruby/2.2.3/gems/simplecov-0.10.0/lib/simplecov/filter.rb  33  T_ARRAY
```

```
$ bundle exec rspec -r './benchmark_allocations_no_block.rb' --seed 1 gems/pending/spec/appliance_console/cli_spec.rb | grep simplecov | sort -nr | head -n 10
```

**benchmark_allocations_no_block.rb**

```
require 'allocation_tracer'

ObjectSpace::AllocationTracer.setup(%i{path line type})
ObjectSpace::AllocationTracer.trace

at_exit{
  results = ObjectSpace::AllocationTracer.stop

  puts ObjectSpace::AllocationTracer.header.join("\t")
  results.sort_by {|k, v| k}.each {|k, v|
    puts ([v[0]]+k).join("\t")
  }
}
```