### PR TITLE
Remove MiqRegion.seed from most specs

### DIFF
--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -24,7 +24,7 @@ class BlacklistedEvent < ActiveRecord::Base
   def self.seed
     ExtManagementSystem.descendants.each do |ems|
       missing_events = ems.default_blacklisted_event_names - where(:provider_model => ems.name, :ems_id => nil).pluck(:event_name)
-      create(missing_events.collect { |e| {:event_name => e, :provider_model => ems.name, :system => true} })
+      create!(missing_events.collect { |e| {:event_name => e, :provider_model => ems.name, :system => true} })
     end
   end
 

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -54,7 +54,7 @@ class ChargebackRate < ActiveRecord::Base
         rates = cbr.delete(:rates)
         if rec.nil?
           _log.info("Creating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")
-          rec = create(cbr)
+          rec = create!(cbr)
           rec.chargeback_rate_details.create(rates)
         else
           fixture_mtime = File.mtime(fixture_file).utc
@@ -64,7 +64,7 @@ class ChargebackRate < ActiveRecord::Base
             rec.chargeback_rate_details.clear
             rec.chargeback_rate_details.create(rates)
             rec.created_on = fixture_mtime
-            rec.save
+            rec.save!
           end
         end
       end

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -44,19 +44,15 @@ class MiqDatabase < ActiveRecord::Base
   end
 
   def self.seed
-    if exists?
-      db = first
-      db.session_secret_token ||= SecureRandom.hex(64)
-      db.csrf_secret_token    ||= SecureRandom.hex(64)
-      db.update_repo_name     ||= registration_default_value_for_update_repo_name
-      db.save! if db.changed?
-    else
-      create!(
-        :session_secret_token => SecureRandom.hex(64),
-        :csrf_secret_token    => SecureRandom.hex(64),
-        :update_repo_name     => registration_default_value_for_update_repo_name
-      )
+    db = first || new
+    db.session_secret_token ||= SecureRandom.hex(64)
+    db.csrf_secret_token ||= SecureRandom.hex(64)
+    db.update_repo_name ||= registration_default_value_for_update_repo_name
+    if db.changed?
+      _log.info("#{db.new_record? ? "Creating" : "Updating"} MiqDatabase record")
+      db.save!
     end
+    db
   end
 
   def name

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -27,10 +27,8 @@ class MiqEnterprise < ActiveRecord::Base
   include Metric::CiMixin
 
   def self.seed
-    if in_my_region.first.nil?
+    in_my_region.first || create!(:name => "Enterprise", :description => "Enterprise Root Object") do |_|
       _log.info("Creating Enterprise Root Object")
-      create(:name => "Enterprise", :description => "Enterprise Root Object")
-      _log.info("Creating Enterprise Root Object... Complete")
     end
   end
 

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -21,12 +21,12 @@ class MiqEventDefinitionSet < ActiveRecord::Base
       rec = find_by_name(set[:name])
       if rec.nil?
         _log.info("Creating [#{set[:name]}]")
-        rec = create(set)
+        rec = create!(set)
       else
         rec.attributes = set
         if rec.changed?
           _log.info("Updating [#{set[:name]}]")
-          rec.save
+          rec.save!
         end
       end
     end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -109,17 +109,14 @@ class MiqRegion < ActiveRecord::Base
   def self.seed
     # Get the region by looking at an existing MiqDatabase instance's id
     # (ie, 2000000000001 is region 2) and sync this to the file
-    my_region = my_region_number
-    db = MiqDatabase.first
-    if db
-      region = db.region_id
-      raise Exception, "Region [#{my_region}] does not match the database's region [#{region}]" if region != my_region
+    my_region_id = my_region_number
+    db_region_id = MiqDatabase.first.try(:region_id)
+    if db_region_id && db_region_id != my_region_id
+      raise Exception, "Region [#{my_region_id}] does not match the database's region [#{db_region_id}]"
     end
 
-    unless exists?(:region => my_region)
-      _log.info("Creating Region [#{my_region}]")
-      create!(:region => my_region, :description => "Region #{my_region}")
-      _log.info("Creating Region... Complete")
+    create_with(:description => "Region #{my_region_id}").find_or_create_by!(:region => my_region_id) do
+      _log.info("Creating Region [#{my_region_id}]")
     end
   end
 

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -50,12 +50,12 @@ class MiqSearch < ActiveRecord::Base
       rec = find_by_name_and_db(name, db)
       if rec.nil?
         _log.info("Creating [#{name}]")
-        create(attrs)
+        create!(attrs)
       else
         # Avoid undoing user changes made to enable/disable default searches which is held in the search_key column
         attrs.delete('search_key')
         rec.attributes = attrs
-        rec.save
+        rec.save!
       end
     end
   end

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -10,12 +10,12 @@ class MiqShortcut < ActiveRecord::Base
       rec = find_by_name(s[:name])
       if rec.nil?
         _log.info("Creating #{s.inspect}")
-        rec = create(s)
+        rec = create!(s)
       else
         rec.attributes = s
         if rec.changed?
           _log.info("Updating #{s.inspect}")
-          rec.save
+          rec.save!
         end
       end
     end

--- a/app/models/pxe_image_type.rb
+++ b/app/models/pxe_image_type.rb
@@ -20,7 +20,7 @@ class PxeImageType < ActiveRecord::Base
 
     seed_data.each do |s|
       _log.info("Creating #{s.inspect}")
-      create(s)
+      create!(s)
     end
   end
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -194,7 +194,9 @@ class Tenant < ActiveRecord::Base
 
   # NOTE: returns the root tenant
   def self.seed
-    root_tenant || create!(:use_config_for_attributes => true)
+    root_tenant || create!(:use_config_for_attributes => true) do |_|
+      _log.info("Creating root tenant")
+    end
   end
 
   private

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -26,15 +26,12 @@ class TimeProfile < ActiveRecord::Base
   end
 
   def self.seed
-    utc_tp = default_time_profile
-
-    if utc_tp.nil?
-      create!(
+    default_time_profile || create!(
         :description          => DEFAULT_TZ,
         :tz                   => DEFAULT_TZ,
         :profile_type         => "global",
-        :rollup_daily_metrics => true
-      )
+        :rollup_daily_metrics => true) do |_|
+      _log.info("Creating global time profile")
     end
   end
 

--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -19,7 +19,7 @@ module VmdbDatabase::Seeding
       db.last_start_time = connection.last_start_time           if connection.respond_to?(:last_start_time)
       db.data_disk       = self.db_disk_size(db.data_directory) if EvmDatabase.local? && db.data_directory
 
-      db.save
+      db.save!
       db
     end
 

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -64,6 +64,8 @@ class EvmDatabase
           rescue => err
             _log.log_backtrace(err)
           end
+        else
+          _log.error("Class #{klass} does not have a seed")
         end
       end
     end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -89,8 +89,7 @@ describe VmInfraController do
 
     context "#x_get_tree_region_kids" do
       it "does not return Cloud Providers nodes for Utilization tree" do
-        MiqRegion.seed
-        region = MiqRegion.my_region
+        region = MiqRegion.seed
         ems_cloud = FactoryGirl.create(:ems_amazon)
         ems_infra = FactoryGirl.create(:ems_redhat)
         controller.instance_variable_set(:@sb, {:trees => {:utilization_tree => {:active_node => "root"}}, :active_tree => :utilization_tree})
@@ -106,12 +105,9 @@ describe VmInfraController do
     end
 
     context "#x_get_tree_custom_kids" do
-      before(:each) do
-        MiqRegion.seed
-        @region = MiqRegion.my_region
-      end
-
       it "Return only Infra Providers nodes for Utilization tree" do
+        @region = MiqRegion.seed
+
         ems_cloud = FactoryGirl.create(:ems_amazon)
         ems_infra = FactoryGirl.create(:ems_redhat)
         folder_node_id = {:id => "folder_e_xx-#{MiqRegion.compress_id(@region.id)}"}

--- a/spec/controllers/configuration_controller_spec.rb
+++ b/spec/controllers/configuration_controller_spec.rb
@@ -17,7 +17,6 @@ describe ConfigurationController do
 
   context "#set_form_vars" do
     before do
-      MiqRegion.seed
       MiqSearch.seed
     end
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -122,8 +122,6 @@ describe DashboardController do
 
   context "#main_tab redirects to correct url when maintab is pressed by limited access user" do
     before do
-      MiqRegion.seed
-
       described_class.any_instance.stub(:set_user_time_zone)
       controller.stub(:check_privileges).and_return(true)
     end
@@ -146,7 +144,6 @@ describe DashboardController do
 
   context "#start_url_for_user" do
     before do
-      MiqRegion.seed
       MiqShortcut.seed
       controller.stub(:check_privileges).and_return(true)
     end

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -5,7 +5,6 @@ describe MiqTaskController do
   context "#tasks_condition" do
     subject { controller.send(:tasks_condition, @opts) }
     before do
-      MiqRegion.seed
       @user = FactoryGirl.create(:user, :userid => 'admin')
       controller.stub(:session => @user)
     end

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -65,6 +65,7 @@ describe OpsController do
       set_user_privileges
       FactoryGirl.create(:vmdb_database)
       EvmSpecHelper.create_guid_miq_server_zone
+      MiqRegion.seed
 
       session[:sandboxes] = { "ops" => { :active_tree => :diagnostics_tree } }
       post :tree_select, :id => 'root', :format => :js
@@ -78,6 +79,7 @@ describe OpsController do
     let(:user) { FactoryGirl.create(:user) }
     before do
       set_user_privileges user
+      MiqRegion.seed
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
     end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -7,6 +7,7 @@ describe OpsController do
   context "::Tenants" do
     before do
       EvmSpecHelper.create_root_tenant
+      MiqRegion.seed
       set_user_privileges
     end
 

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe OpsController do
   before(:each) do
     EvmSpecHelper.create_guid_miq_server_zone
+    MiqRegion.seed
     set_user_privileges
   end
 
@@ -242,6 +243,7 @@ end
 
 describe OpsController do
   before do
+    MiqRegion.seed
     EvmSpecHelper.local_miq_server
     EvmSpecHelper.seed_specific_product_features("ops_rbac")
     feature = MiqProductFeature.find_all_by_identifier("ops_rbac")

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,11 +1,5 @@
 FactoryGirl.define do
   factory :user do
-    # HACK: Due to password_digest callback needing infrastructure to write out
-    #       the new password to disk.
-    before(:create) do
-      MiqRegion.seed
-    end
-
     transient do
       # e.g. "super_administrtor"
       role nil

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -54,7 +54,6 @@ describe ApplicationHelper do
   describe "#role_allows" do
     let(:features) { MiqProductFeature.find_all_by_identifier("everything") }
     before(:each) do
-      MiqRegion.seed
       EvmSpecHelper.seed_specific_product_features("miq_report", "service")
 
       @admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => features)

--- a/spec/lib/workers/schedule_worker_spec.rb
+++ b/spec/lib/workers/schedule_worker_spec.rb
@@ -277,8 +277,7 @@ describe MiqScheduleWorker::Runner do
             # Initialize active_roles
             @schedule_worker.instance_variable_set(:@active_roles, [])
 
-            MiqRegion.seed
-            @region = MiqRegion.my_region
+            @region = MiqRegion.seed
             MiqRegion.stub(:my_region).and_return(@region)
             @schedule_worker.instance_variable_set(:@active_roles, ["ldap_synchronization"])
 
@@ -338,8 +337,7 @@ describe MiqScheduleWorker::Runner do
             stub_server_configuration(Hash.new(5.minutes))
             @schedule_worker.stub(:heartbeat)
 
-            MiqRegion.seed
-            @region = MiqRegion.my_region
+            @region = MiqRegion.seed
             MiqRegion.stub(:my_region).and_return(@region)
             @schedule_worker.instance_variable_set(:@active_roles, ["database_operations"])
 

--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 describe AssignedServerRole do
   context "and Server Role seeded for 1 Region/Zone" do
     before(:each) do
-      MiqRegion.seed
       @miq_server = EvmSpecHelper.local_miq_server
     end
 

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -7,7 +7,6 @@ describe Authentication do
 
   context "with miq events seeded" do
     before(:each) do
-      MiqRegion.seed
       MiqEventDefinition.seed
     end
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -302,8 +302,6 @@ describe Classification do
 
   describe ".seed" do
     before do
-      MiqRegion.seed
-
       YAML.stub(:load_file).and_return([
         {:name         => "cc",
          :description  => "Cost Center",

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -103,7 +103,6 @@ describe DialogFieldTagControl do
 
   context "dialog field tag control and Classification seeded" do
     before(:each) do
-      MiqRegion.seed
       cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment",  :single_value => true,  :parent_id => 0)
       add_entry(cat, :name=>"dev",  :description=>"Development")
       add_entry(cat, :name=>"test", :description=>"Test")

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -7,7 +7,6 @@ describe Dialog do
     let(:all_yaml_files) { test_file_path.join("{,*/**/}*.{yaml,yml}") }
 
     before do
-      MiqRegion.seed
       DialogImportService.stub(:new).and_return(dialog_import_service)
       dialog_import_service.stub(:import_all_service_dialogs_from_yaml_file)
     end

--- a/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
+++ b/spec/models/ems_refresh/refreshers/scvmm_refresher_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
   before(:each) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(:miq_region)
     @ems = FactoryGirl.create(:ems_microsoft_with_authentication, :zone => zone,
         :hostname => "scvmm1111.manageiq.com", :ipaddress => "192.168.252.90", :security_protocol => "ssl")
     data_file = File.join(File.dirname(__FILE__), %w{.. .. .. tools scvmm_data get_inventory_output.yml})

--- a/spec/models/manageiq/providers/redhat/infra_provider/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_provider/provision_workflow_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
-  before do
-    MiqRegion.seed
-  end
-
   context "With a Valid Template," do
     let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
     let(:provider) { FactoryGirl.create(:ems_redhat) }

--- a/spec/models/metric/ci_mixin/capture/openstack_infra_spec.rb
+++ b/spec/models/metric/ci_mixin/capture/openstack_infra_spec.rb
@@ -5,7 +5,6 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
                                      %w(.. .. .. .. tools openstack_data openstack_data_test_helper)))
 
   before :each do
-    MiqRegion.seed
     _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
     @mock_meter_list = OpenstackMeterListData.new

--- a/spec/models/metric/ci_mixin/capture/openstack_spec.rb
+++ b/spec/models/metric/ci_mixin/capture/openstack_spec.rb
@@ -5,7 +5,6 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                      %w(.. .. .. .. tools openstack_data openstack_data_test_helper)))
 
   before :each do
-    MiqRegion.seed
     _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
     @mock_meter_list = OpenstackMeterListData.new

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -5,7 +5,6 @@ describe Metric::CiMixin::Capture do
                                      %w(.. .. .. tools openstack_data openstack_data_test_helper)))
 
   before :each do
-    MiqRegion.seed
     _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
     @mock_meter_list = OpenstackMeterListData.new

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe MiqAction do
-  before(:each) { MiqRegion.seed }
-
   context "#action_custom_automation" do
     before(:each) do
       @vm   = FactoryGirl.create(:vm_vmware)

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -8,7 +8,6 @@ describe MiqAlert do
       @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
       @vm     = FactoryGirl.create(:vm_vmware)
 
-      MiqRegion.seed
       MiqAlert.seed
       @events_to_alerts = MiqAlert.all.inject([]) do |arr,a|
         next(arr) if a.responds_to_events.nil?

--- a/spec/models/miq_compare_spec.rb
+++ b/spec/models/miq_compare_spec.rb
@@ -6,7 +6,6 @@ describe MiqCompare do
       vm1 = FactoryGirl.create(:vm_vmware)
       vm2 = FactoryGirl.create(:vm_vmware)
 
-      MiqRegion.seed
       MiqReport.seed_report("vms", "compare")
 
       report = MiqReport.find_by_name("VMs: Compare Template")

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -2,8 +2,7 @@ require "spec_helper"
 
 describe MiqDatabase do
   it "has a size" do
-    MiqDatabase.seed
-    db = MiqDatabase.first
+    db = MiqDatabase.seed
     expect(db.size).to be >= 0
   end
 

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -2,10 +2,6 @@ require "spec_helper"
 
 describe MiqEvent do
   context "seeded" do
-    before(:each) do
-      MiqRegion.seed
-    end
-
     context ".raise_evm_job_event" do
       it "vm" do
         obj = FactoryGirl.create(:vm_redhat)

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -7,13 +7,11 @@ describe MiqProductFeature do
 
   context ".seed" do
     it "empty table" do
-      MiqRegion.seed
       MiqProductFeature.seed
       MiqProductFeature.count.should eq(@expected_feature_count)
     end
 
     it "run twice" do
-      MiqRegion.seed
       MiqProductFeature.seed
       MiqProductFeature.seed
       MiqProductFeature.count.should eq(@expected_feature_count)
@@ -25,7 +23,6 @@ describe MiqProductFeature do
       unchanged = FactoryGirl.create(:miq_product_feature_everything)
       unchanged_orig_updated_at = unchanged.updated_at
 
-      MiqRegion.seed
       MiqProductFeature.seed
       MiqProductFeature.count.should eq(@expected_feature_count)
       expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/models/miq_provision_amazon_workflow_spec.rb
+++ b/spec/models/miq_provision_amazon_workflow_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
-  before(:each) do
-    MiqRegion.seed
-  end
-
   context "With a user" do
     let(:admin) { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
 

--- a/spec/models/miq_provision_microsoft_workflow_spec.rb
+++ b/spec/models/miq_provision_microsoft_workflow_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
-  before do
-    MiqRegion.seed
-  end
-
   context "With a Valid Template," do
     let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
     let(:provider) { FactoryGirl.create(:ems_microsoft) }

--- a/spec/models/miq_provision_openstack_workflow_spec.rb
+++ b/spec/models/miq_provision_openstack_workflow_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
-  before do
-    MiqRegion.seed
-  end
-
   context "With a user" do
     let(:admin) { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
 

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -29,6 +29,7 @@ describe MiqProvisionRequestTemplate do
 
   describe '#create_tasks_for_service' do
     before do
+      MiqRegion.seed
       ManageIQ::Providers::Vmware::InfraManager::Provision.any_instance.stub(:get_hostname).and_return('hostname')
       MiqAeEngine.stub(:resolve_automation_object).and_return(double(:root => 'miq'))
     end

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -55,6 +55,7 @@ describe MiqProvision do
         end
 
         it "should create a valid target_name and hostname" do
+          MiqRegion.seed
           @vm_prov.after_request_task_create
           @vm_prov.get_option(:vm_target_name).should == @target_vm_name
 
@@ -75,7 +76,7 @@ describe MiqProvision do
 
         context "when auto naming sequence exceeds the range" do
           before do
-            region = MiqRegion.my_region
+            region = MiqRegion.seed
             region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
             region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
           end

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe MiqReport do
   before(:each) do
-    MiqRegion.seed
     EvmSpecHelper.local_miq_server
 
     @group = FactoryGirl.create(:miq_group)

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -2,8 +2,6 @@ require "spec_helper"
 
 describe MiqReport::ImportExport do
   before do
-    MiqRegion.seed
-
     @user       = FactoryGirl.create(:user_admin)
     @old_report = FactoryGirl.create(:miq_report, 
                                      :name      => "Test Report",

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe MiqReportResult do
   before(:each) do
-    MiqRegion.seed
     EvmSpecHelper.local_miq_server
 
     @group = FactoryGirl.create(:miq_group)

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -25,8 +25,6 @@ describe MiqReport do
   end
 
   it "paged_view_search on vmdb_* tables" do
-    MiqRegion.seed
-
     # Create EVM tables/indexes and hourly metric data...
     table = FactoryGirl.create(:vmdb_table_evm, :name => "accounts")
     index = FactoryGirl.create(:vmdb_index, :name => "accounts_pkey", :vmdb_table => table)
@@ -62,8 +60,6 @@ describe MiqReport do
     OS_LIST = %w{_none_ windows ubuntu windows ubuntu}
 
     before(:each) do
-      MiqRegion.seed
-
       # TODO: Move this setup to the examples that need it.
       @tags = {
         2  => "/managed/environment/prod",

--- a/spec/models/miq_schedule_filter_spec.rb
+++ b/spec/models/miq_schedule_filter_spec.rb
@@ -43,7 +43,6 @@ describe "MiqSchedule Filter" do
 
     context "for a scheduled report" do
       before(:each) do
-        MiqRegion.seed
         MiqReport.seed_report("Vendor and Guest OS")
         @report = MiqReport.first
         @report_schedule = FactoryGirl.create(:miq_schedule,

--- a/spec/models/miq_server/rhn_mirror_spec.rb
+++ b/spec/models/miq_server/rhn_mirror_spec.rb
@@ -3,8 +3,6 @@ require "spec_helper"
 describe "MiqServer" do
   context "RhnMirror" do
     before do
-      MiqDatabase.seed
-      MiqRegion.seed
       ServerRole.seed
       _, @server1, _ = EvmSpecHelper.create_guid_miq_server_zone
       @server1.update_attribute(:ipaddress, "1.2.3.4")

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -6,13 +6,11 @@ describe MiqUserRole do
   end
   context ".seed" do
     it "empty table" do
-      MiqRegion.seed
       MiqUserRole.seed
       MiqUserRole.count.should == @expected_user_role_count
     end
 
     it "run twice" do
-      MiqRegion.seed
       MiqUserRole.seed
       MiqUserRole.seed
       MiqUserRole.count.should == @expected_user_role_count
@@ -23,7 +21,6 @@ describe MiqUserRole do
       unchanged = FactoryGirl.create(:miq_user_role, :name => "xxx", :read_only => false)
       unchanged_orig_updated_at = unchanged.updated_at
 
-      MiqRegion.seed
       MiqUserRole.seed
 
       MiqUserRole.count.should == @expected_user_role_count + 1
@@ -34,8 +31,6 @@ describe MiqUserRole do
 
   context "testing allows methods" do
     before(:each) do
-      MiqRegion.seed
-
       EvmSpecHelper.seed_specific_product_features(%w(
         dashboard_add
         dashboard_view

--- a/spec/models/miq_widget/chart_content_spec.rb
+++ b/spec/models/miq_widget/chart_content_spec.rb
@@ -3,8 +3,6 @@ require "spec_helper"
 describe "Widget Chart Content" do
   let(:widget) { MiqWidget.find_by_description("chart_vendor_and_guest_os") }
   before(:each) do
-    MiqRegion.seed
-
     _guid, _server, _zone = EvmSpecHelper.create_guid_miq_server_zone
 
     RssFeed.sync_from_yml_dir

--- a/spec/models/miq_widget/report_content_spec.rb
+++ b/spec/models/miq_widget/report_content_spec.rb
@@ -20,7 +20,6 @@ describe "Widget Report Content" do
   '))}
 
   before(:each) do
-    MiqRegion.seed
     RssFeed.sync_from_yml_dir
     MiqReport.seed_report("Vendor and Guest OS")
 

--- a/spec/models/miq_widget/rss_content_spec.rb
+++ b/spec/models/miq_widget/rss_content_spec.rb
@@ -60,7 +60,6 @@ describe "Widget RSS Content" do
   EOF
 
   before(:each) do
-    MiqRegion.seed
     RssFeed.sync_from_yml_dir
 
     EvmSpecHelper.local_miq_server

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe MiqWidget do
   before(:each) do
-    MiqRegion.seed
     EvmSpecHelper.local_miq_server
   end
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -157,7 +157,6 @@ describe Rbac do
     before(:each) do
       User.stub(:server_timezone => "UTC")
 
-      MiqRegion.seed
       @tags = {
         2 => "/managed/environment/prod",
         3 => "/managed/environment/dev",

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -4,7 +4,6 @@ describe ResourceActionWorkflow do
 
   context "#create" do
     before(:each) do
-      MiqRegion.seed
       @admin = FactoryGirl.create(:user_admin)
 
       @dialog       = FactoryGirl.create(:dialog, :label => 'dialog')

--- a/spec/models/rr_pending_change_spec.rb
+++ b/spec/models/rr_pending_change_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe RrPendingChange do
-  before(:each) do
-    MiqRegion.seed
-  end
-
   it ".table_name" do
     described_class.table_name.should == "rr#{MiqRegion.my_region_number}_pending_changes"
   end

--- a/spec/models/rss_feed/import_export_spec.rb
+++ b/spec/models/rss_feed/import_export_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe RssFeed::ImportExport do
   before do
-    MiqRegion.seed
     @user = FactoryGirl.create(:user_admin)
   end
 

--- a/spec/models/rss_feed/rss_feed_spec.rb
+++ b/spec/models/rss_feed/rss_feed_spec.rb
@@ -12,7 +12,6 @@ describe RssFeed do
     end
 
     it "#generate 2 hosts in newest_hosts rss" do
-      MiqRegion.seed
       RssFeed.sync_from_yml_file("newest_hosts")
       feed_container = RssFeed.where(:name => "newest_hosts").first.generate
       feed_container[:text].should == <<-EOXML
@@ -47,7 +46,6 @@ EOXML
 
   context ".sync_from_yml_dir" do
     before(:each) do
-      MiqRegion.seed
       RssFeed.seed
     end
 
@@ -81,7 +79,6 @@ EOXML
     end
 
     it "when the yaml file is updated" do
-      MiqRegion.seed
       RssFeed.seed
       old_count = RssFeed.count
 

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -16,7 +16,6 @@ describe TimeProfile do
 
   context "will seed the database" do
     before(:each) do
-      MiqRegion.seed
       TimeProfile.seed
     end
 
@@ -104,7 +103,6 @@ describe TimeProfile do
 
   context "profiles_for_user" do
     before(:each) do
-      MiqRegion.seed
       TimeProfile.seed
     end
 
@@ -130,7 +128,6 @@ describe TimeProfile do
 
   context "profile_for_user_tz" do
     before(:each) do
-      MiqRegion.seed
       TimeProfile.seed
     end
 

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -4,7 +4,6 @@ require 'bcrypt'
 describe "User Password" do
   context "With admin user" do
     before(:each) do
-      MiqRegion.seed
       guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @old = 'smartvm'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,12 +1,8 @@
 require "spec_helper"
 
 describe User do
-
   context "id set as Administrator" do
-
     before(:each) do
-      MiqRegion.seed
-
       # create User Role record...
       miq_user_role = FactoryGirl.create(
                       :miq_user_role,
@@ -458,8 +454,6 @@ describe User do
   end
 
   context ".seed" do
-    before { MiqRegion.seed }
-
     it "empty database" do
       User.seed
       expect(User.where(:userid => "admin").first.current_group).to be_nil

--- a/spec/models/vim_performance_tag_spec.rb
+++ b/spec/models/vim_performance_tag_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe VimPerformanceTag do
   before(:each) do
-    MiqRegion.seed
     @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
 

--- a/spec/models/vm_migrate_workflow_spec.rb
+++ b/spec/models/vm_migrate_workflow_spec.rb
@@ -1,11 +1,6 @@
 require "spec_helper"
 
 describe VmMigrateWorkflow do
-
-  before do
-    MiqRegion.seed
-  end
-
   context "With a Valid Template," do
     let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
     let(:provider) { FactoryGirl.create(:ems_vmware) }
@@ -31,9 +26,7 @@ describe VmMigrateWorkflow do
 
           workflow.allowed_hosts.should == [workflow.ci_to_hash_struct(host)]
         end
-
       end
     end
   end
-
 end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -262,7 +262,6 @@ EOF
 
     context ".export_queue" do
       before(:each) do
-        MiqRegion.seed
         EvmSpecHelper.create_guid_miq_server_zone
         @ids = VmdbTable.find_all_by_name(@populated_tables).collect(&:id)
         @dest_zip = File.join(VmdbTable.export_output_dir, "evm_export.zip")

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -40,9 +40,7 @@ module EvmSpecHelper
   end
 
   def self.create_root_tenant
-    MiqRegion.seed
     Tenant.seed
-    Tenant.root_tenant
   end
 
   def self.local_miq_server(attrs = {})

--- a/spec/views/miq_request/_prov_options.html.erb_spec.rb
+++ b/spec/views/miq_request/_prov_options.html.erb_spec.rb
@@ -6,7 +6,6 @@ describe 'miq_request/_prov_options.html.haml' do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       view.stub(:get_vmdb_config).and_return({:server => {}, :session => {}})
-      MiqRegion.seed
 
       # Create roles/groups
       role1   = FactoryGirl.create(:miq_user_role, :name    => 'EvmRole-super_administrator')


### PR DESCRIPTION
Followup to #4437 - ~~first 3 commits are from over there.~~

Now that a typical seed does not lock on `MiqRegion.my_region`, there is no reason to always create a region for seeding.  Remove these from specs.

Also in store:

- more consistent logging
- seeds more stringent with `save!` calls
- `find_or_update_by!`, typically returning the record being seeded (for easier access from tests)
- fewer queries: convert a `create` and `update` into just a `create`.

Outstanding: The slowest part of the 3 second no-op seed is loading `features`. If we add file date checking or something, then we could probably cut this time further in half. Since all servers are blocking on each other while running through this scenario, performance wise, this may have a significant impact on server startup times across a cluster.

/cc @Fryguy look at other PR first, this just lets you know what is next
/cc @matthewd thanks
/cc @dmetzger57 fyi