### PR TITLE
Added containers permissions

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -4,6 +4,7 @@
 - :clo
 - :inf
 - :con
+- :cnt
 - :aut
 - :opt
 - :set
@@ -15,4 +16,5 @@
 - ems-type:ec2
 - ems-type:openstack
 - ems-type:kubernetes
+- ems-type:openshift
 - ems-type:foreman_provisioning


### PR DESCRIPTION
The containers tab wont appear without ```:cnt``` in this file. 
```ems-type:openshift``` is sort of a guess.
@tenderlove Please review. Any explanation about this file and the working around it would be greatly appreciated.
cc @abonas @simon3z 