### PR TITLE
Explicitly specified log level for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,6 +35,7 @@ Vmdb::Application.configure do
 
   # See everything in the log (default is :info)
   # config.log_level = :debug
+  config.log_level = :info
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new


### PR DESCRIPTION
Currently the default for production logging is info, but
in rails 5 all defaults will be debug.  This also prevents
lots of deprecation warning messages.

https://bugzilla.redhat.com/show_bug.cgi?id=1264569