### PR TITLE
RSOP - Rename forgotten .miq_events -> .miq_event_definitions

### DIFF
--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -63,7 +63,7 @@ module MiqPolicyController::Rsop
       rsop_put_objects_in_sb(find_filtered(Vm, :all), :vms)
       rsop_put_objects_in_sb(find_filtered(Storage, :all), :datastores)
       @rsop_events = MiqEventDefinitionSet.all.collect{|e|[e.description, e.id.to_s]}.sort
-      @rsop_event_sets = MiqEventDefinitionSet.find(@sb[:rsop][:event]).miq_events.collect{|e|[e.description, e.id.to_s]}.sort if @sb[:rsop][:event] != nil
+      @rsop_event_sets = MiqEventDefinitionSet.find(@sb[:rsop][:event]).miq_event_definitions.collect{|e|[e.description, e.id.to_s]}.sort if @sb[:rsop][:event] != nil
       render :layout => "application"
     end
   end
@@ -84,7 +84,7 @@ module MiqPolicyController::Rsop
       @sb[:rsop][:filter_value] = params[:filter_value] == "<Choose>" ? nil : params[:filter_value]
     end
     @rsop_events = MiqEventDefinitionSet.all.collect{|e|[e.description, e.id.to_s]}.sort
-    @rsop_event_sets = MiqEventDefinitionSet.find(@sb[:rsop][:event]).miq_events.collect{|e|[e.description, e.id.to_s]}.sort if @sb[:rsop][:event] != nil
+    @rsop_event_sets = MiqEventDefinitionSet.find(@sb[:rsop][:event]).miq_event_definitions.collect{|e|[e.description, e.id.to_s]}.sort if @sb[:rsop][:event] != nil
     render :update do |page|                    # Use JS to update the display
       session[:changed] = @sb[:rsop][:filter_value] && @sb[:rsop][:event_value] ? true : false
       page.replace("rsop_form_div", :partial=>"rsop_form")


### PR DESCRIPTION
Right now, going to Control/Simulation and picking any type on the left leads to

```
undefined method `miq_events' for #<MiqEventDefinitionSet:0x00557b84dfc3e8> [miq_policy/rsop_option_changed]
```

Seems like a simple case of forgotten method rename when MiqEvent got renamed to MiqEventDefinition.