### PR TITLE
Ensure we require all the runners

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::BaseManager::EventCatcher < MiqWorker
+  require_dependency 'manageiq/providers/base_manager/event_catcher/runner'
+
   include PerEmsWorkerMixin
 
   self.required_roles = ["event"]

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
+  require_dependency 'manageiq/providers/base_manager/refresh_worker/runner'
+
   include PerEmsWorkerMixin
 
   self.required_roles = "ems_inventory"


### PR DESCRIPTION
These base classes were missed; they previously worked because their respective superclasses didn't have a `::Runner`.

Fixes #4447.

As the problem only really manifested when actually spawning the worker process, a spec seems a bit of a stretch right now. :confused: