### PR TITLE
Add a few service dialog fields to the self service UI

### DIFF
--- a/spa_ui/self_service/client/app/states/marketplace/details/details.html
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.html
@@ -15,16 +15,63 @@
         <dd>{{ ::vm.serviceTemplate.long_description || vm.serviceTemplate.description }}</dd>
       </dl>
     </section>
+
     <hr>
+
     <section>
       <div class="well well-sm">
-        Area reserved for service template form.
+        <div ng-repeat="dialog in ::vm.dialogs">
+          <h1>{{ dialog.label }}</h1>
+
+          <tabset>
+            <tab ng-repeat="dialogTab in dialog.dialog_tabs" heading="{{ dialogTab.label }}">
+              <div ng-repeat="dialogGroup in dialogTab.dialog_groups">
+                <div class="panel panel-default">
+                  <div class="panel-heading">
+                    <strong>{{ dialogGroup.label }}</strong>
+                  </div>
+                  <div class="panel-body">
+
+                    <div ng-repeat="dialogField in dialogGroup.dialog_fields" ng-init="inputTitle = dialogField.description">
+                      <div class="col-sm-3">
+                        {{ dialogField.label }}
+                      </div>
+
+                      <div ng-switch on="dialogField.type" class="col-sm-9">
+                        <input
+                          ng-switch-when="DialogFieldTextBox"
+                          type="{{ dialogField.options.protected ? 'password' : 'text' }}"
+                          title="{{ inputTitle }}"
+                          value="{{ dialogField.default_value }}">
+                        </input>
+                        <textarea
+                          ng-switch-when="DialogFieldTextAreaBox"
+                          title="{{ inputTitle }}"
+                          rows="4">{{ dialogField.default_value }}</textarea>
+                        <input
+                          ng-switch-when="DialogFieldCheckBox"
+                          type="checkbox"
+                          title="{{ inputTitle }}"
+                          checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
+                        </input>
+                        <span ng-switch-default style="display: hidden"></span>
+                      </div>
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </tab>
+          </tabset>
+
+        </div>
       </div>
     </section>
   </div>
+
   <div class="panel-footer">
     <div class="form-group text-right">
-      <button type="button" class="btn btn-default btn-xs">Cancel</button>
+      <button ui-sref="^" type="button" class="btn btn-default btn-xs">Cancel</button>
       <button type="button" class="btn btn-primary">Request</button>
     </div>
   </div>

--- a/spa_ui/self_service/client/app/states/marketplace/details/details.html
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.html
@@ -30,35 +30,55 @@
                   <div class="panel-heading">
                     <strong>{{ dialogGroup.label }}</strong>
                   </div>
+
                   <div class="panel-body">
+                    <div
+                      ng-repeat="dialogField in dialogGroup.dialog_fields"
+                      ng-init="inputTitle = dialogField.description"
+                      class="form-horizontal">
 
-                    <div ng-repeat="dialogField in dialogGroup.dialog_fields" ng-init="inputTitle = dialogField.description">
-                      <div class="col-sm-3">
-                        {{ dialogField.label }}
-                      </div>
+                      <div class="form-group">
+                        <div class="col-sm-3">
+                          {{ dialogField.label }}
+                        </div>
 
-                      <div ng-switch on="dialogField.type" class="col-sm-9">
-                        <input
-                          ng-switch-when="DialogFieldTextBox"
-                          type="{{ dialogField.options.protected ? 'password' : 'text' }}"
-                          title="{{ inputTitle }}"
-                          value="{{ dialogField.default_value }}">
-                        </input>
-                        <textarea
-                          ng-switch-when="DialogFieldTextAreaBox"
-                          title="{{ inputTitle }}"
-                          rows="4">{{ dialogField.default_value }}</textarea>
-                        <input
-                          ng-switch-when="DialogFieldCheckBox"
-                          type="checkbox"
-                          title="{{ inputTitle }}"
-                          checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
-                        </input>
-                        <span ng-switch-default style="display: hidden"></span>
+                        <div ng-switch on="dialogField.type" class="col-sm-9">
+                          <input
+                            ng-switch-when="DialogFieldTextBox"
+                            ng-disabled="{{ dialogField.read_only }}"
+                            class="form-control"
+                            type="{{ dialogField.options.protected ? 'password' : 'text' }}"
+                            title="{{ inputTitle }}"
+                            value="{{ dialogField.default_value }}">
+                          </input>
+                          <textarea
+                            ng-switch-when="DialogFieldTextAreaBox"
+                            ng-disabled="{{ dialogField.read_only }}"
+                            class="form-control"
+                            title="{{ inputTitle }}"
+                            rows="4">{{ dialogField.default_value }}</textarea>
+                          <input
+                            ng-switch-when="DialogFieldCheckBox"
+                            ng-disabled="{{ dialogField.read_only }}"
+                            class="form-control"
+                            type="checkbox"
+                            title="{{ inputTitle }}"
+                            checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
+                          </input>
+                          <select
+                            ng-switch-when="DialogFieldDropDownList"
+                            ng-disabled="{{ dialogField.read_only }}"
+                            class="form-control">
+                            <option ng-repeat="fieldValue in dialogField.values" value="{{ fieldValue[0] }}">
+                              {{ fieldValue[1] }}
+                            </option>
+                          </select>
+                          <span ng-switch-default style="display: hidden"></span>
+                        </div>
                       </div>
                     </div>
-
                   </div>
+
                 </div>
               </div>
             </tab>

--- a/spa_ui/self_service/client/app/states/marketplace/details/details.state.js
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.state.js
@@ -18,6 +18,7 @@
         controllerAs: 'vm',
         title: 'Service Template Details',
         resolve: {
+          dialogs: resolveDialogs,
           serviceTemplate: resolveServiceTemplate
         }
       }
@@ -30,10 +31,18 @@
   }
 
   /** @ngInject */
-  function StateController(serviceTemplate) {
+  function resolveDialogs($stateParams, CollectionsApi) {
+    var options = {expand: true, attributes: 'content'};
+
+    return CollectionsApi.query('service_templates/' + $stateParams.serviceTemplateId + '/service_dialogs', options);
+  }
+
+  /** @ngInject */
+  function StateController(dialogs, serviceTemplate) {
     var vm = this;
 
     vm.title = 'Service Template Details';
+    vm.dialogs = dialogs.resources[0].content;
     vm.serviceTemplate = serviceTemplate;
   }
 })();


### PR DESCRIPTION
As requested by @dclarizio, pulling the first few dialog fields from #4356 into a separate PR. Specs to come later along with more fields.

With this PR, text fields, text areas, checkboxes, and drop downs are supported. The actual submitting of dialogs is also still a WIP.

The styling is not finalized, but I did try to make it look at least somewhat nicer than just a basic dump of fields.