### PR TITLE
Tell RuboCop to not check extra spacing in HAML files

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -57,6 +57,7 @@ linters:
       - Metrics/LineLength
       - Style/AlignParameters
       - Style/BlockNesting
+      - Style/ExtraSpacing
       - Style/FileName
       - Style/FinalNewline
       - Style/IfUnlessModifier


### PR DESCRIPTION
To accept method arguments aligned like this:
```haml
= text_field_tag("name",
                 @edit[:new][:name],
                 :maxlength               => MAX_NAME_LEN,
                 :class                       => "form-control",
                 "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
```