### PR TITLE
Fixed bootstrap button in Reports-Schedules

### DIFF
--- a/app/views/layouts/_edit_to_email.html.haml
+++ b/app/views/layouts/_edit_to_email.html.haml
@@ -52,6 +52,6 @@
                            :style             => "float: left; margin-right: 2px",
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %span.input-group-addon
-            %i.fa.fa-plus{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
+          %span.input-group-addon{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
+            %i.fa.fa-plus
   %hr


### PR DESCRIPTION
Fixed bootstrap add button from conversion PR  #4297 

Before:
![7e7a1ce0-5ba9-11e5-9b22-a89f2c90a1c0](https://cloud.githubusercontent.com/assets/9535558/10016154/47274494-6125-11e5-905d-1f11fd71b0b3.png)

After:
![firefox_screenshot_2015-09-22t10-24-30 259z](https://cloud.githubusercontent.com/assets/9535558/10016164/4f2e6a46-6125-11e5-8aba-6647d45c3c1e.png)

@epwinchell @skateman please review