### PR TITLE
upgrade to latest fog version

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -20,8 +20,7 @@ gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
-gem "fog",                     "~>1.33.0",          :require => false
-gem "fog-core",                "!=1.31.1",          :require => false
+gem "fog",                     "~>1.34.0",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "kubeclient",              "=0.5.1",            :require => false
 gem "linux_admin",             "~>0.11.0",          :require => false


### PR DESCRIPTION
Hoping to get rid of 

```
[fog][DEPRECATION] Calling OpenStack[:orchestration].list_resources(stack, options) is deprecated,  call .list_resources(:stack => stack) or  .list_resources(:stack_name => value, :stack_id => value) instead
```

/cc @blomquisg this is 1.34 (not 2.0.0.pre.0, though that is right around the corner)