### PR TITLE
Add azure to the permission store

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -13,6 +13,7 @@
 - ems-type:openstack_infra
 - ems-type:rhevm
 - ems-type:vmwarews
+- ems-type:azure
 - ems-type:ec2
 - ems-type:openstack
 - ems-type:kubernetes


### PR DESCRIPTION
Ems type 'Azure' is missing from the dropdown in the Add Cloud Provider screen.
Added it to the permission store.

Related to PR #2244