### PR TITLE
Azure deployments refresh

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -5,6 +5,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_dependency 'manageiq/providers/azure/cloud_manager/refresh_worker'
   require_dependency 'manageiq/providers/azure/cloud_manager/refresher'
   require_dependency 'manageiq/providers/azure/cloud_manager/vm'
+  require_dependency 'manageiq/providers/azure/cloud_manager/orchestration_stack'
 
   alias_attribute :azure_tenant_id, :uid_ems
 

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ::OrchestrationStack
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -261,15 +261,16 @@ module ManageIQ::Providers
                            name)
         child_stacks, resources = stack_resources(deployment)
         new_result = {
-          :type        => ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.name,
-          :ems_ref     => deployment.fetch_path('id'),
-          :name        => name,
-          :description => name,
-          :status      => deployment.fetch_path('properties', 'provisioningState'),
-          :children    => child_stacks,
-          :resources   => resources,
-          :outputs     => stack_outputs(deployment),
-          :parameters  => stack_parameters(deployment),
+          :type           => ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.name,
+          :ems_ref        => deployment.fetch_path('id'),
+          :name           => name,
+          :description    => name,
+          :status         => deployment.fetch_path('properties', 'provisioningState'),
+          :children       => child_stacks,
+          :resources      => resources,
+          :outputs        => stack_outputs(deployment),
+          :parameters     => stack_parameters(deployment),
+          :resource_group => deployment.fetch_path('resourceGroup'),
 
           :orchestration_template => stack_template(deployment)
         }

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -284,7 +284,7 @@ module ManageIQ::Providers
 
       def download_template(uri)
         require 'open-uri'
-        open(uri) {|f| f.read }
+        open(uri) { |f| f.read }
       rescue => e
         _log.error("Failed to download Azure template #{uri}. Reason: #{e.inspect}")
         nil
@@ -328,7 +328,7 @@ module ManageIQ::Providers
           resource_name = resource.fetch_path('properties', 'targetResource', 'resourceName')
           uid = resource_uid(@subscription_id, group, resource_type.downcase, resource_name)
 
-          @resource_to_stack[uid] =  stack_uid
+          @resource_to_stack[uid] = stack_uid
           child_stacks << uid if resource_type.downcase == TYPE_DEPLOYMENT
           @data_index.fetch_path(:orchestration_stack_resources, uid)
         end

--- a/db/migrate/20151001110220_add_resource_group_to_orchestration_stack.rb
+++ b/db/migrate/20151001110220_add_resource_group_to_orchestration_stack.rb
@@ -1,0 +1,5 @@
+class AddResourceGroupToOrchestrationStack < ActiveRecord::Migration
+  def change
+    add_column :orchestration_stacks, :resource_group, :string
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -35,22 +35,29 @@ describe ManageIQ::Providers::Azure::CloudManager do
       assert_specific_flavor
       assert_specific_vm_powered_on
       assert_specific_vm_powered_off
+      assert_specific_orchestration_template
+      assert_specific_orchestration_stack
     end
   end
 
   def assert_table_counts
     ExtManagementSystem.count.should eql(1)
     Flavor.count.should eql(41)
-    AvailabilityZone.count.should eql(2)
-    VmOrTemplate.count.should eql(5)
-    Vm.count.should eql(5)
-    Disk.count.should eql(7)
+    AvailabilityZone.count.should eql(3)
+    VmOrTemplate.count.should eql(8)
+    Vm.count.should eql(8)
+    Disk.count.should eql(10)
     GuestDevice.count.should eql(0)
-    Hardware.count.should eql(5)
-    Network.count.should eql(10)
-    OperatingSystem.count.should eql(5)
+    Hardware.count.should eql(8)
+    Network.count.should eql(16)
+    OperatingSystem.count.should eql(8)
     Relationship.count.should eql(0)
-    MiqQueue.count.should eql(5)
+    MiqQueue.count.should eql(8)
+    OrchestrationTemplate.count.should eql(3)
+    OrchestrationStack.count.should eql(7)
+    OrchestrationStackParameter.count.should eql(80)
+    OrchestrationStackOutput.count.should eql(7)
+    OrchestrationStackResource.count.should eql(36)
   end
 
   def assert_ems
@@ -59,9 +66,11 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :uid_ems     => "a50f9983-d1a2-4a8d-be7d-123456789012"
     )
     @ems.flavors.size.should eql(41)
-    @ems.availability_zones.size.should eql(2)
-    @ems.vms_and_templates.size.should eql(5)
-    @ems.vms.size.should eql(5)
+    @ems.availability_zones.size.should eql(3)
+    @ems.vms_and_templates.size.should eql(8)
+    @ems.vms.size.should eql(8)
+    @ems.orchestration_stacks.size.should eql(7)
+    @ems.direct_orchestration_stacks.size.should eql(6)
   end
 
   def assert_specific_flavor
@@ -94,12 +103,12 @@ describe ManageIQ::Providers::Azure::CloudManager do
     v = ManageIQ::Providers::Azure::CloudManager::Vm.where(:name => "ERP", :raw_power_state => "VM running").first
     v.should have_attributes(
       :template              => false,
-      :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\ERP",
+      :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\microsoft.compute/virtualmachines\\ERP",
       :ems_ref_obj           => nil,
-      :uid_ems               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\ERP",
+      :uid_ems               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\microsoft.compute/virtualmachines\\ERP",
       :vendor                => "Microsoft",
       :power_state           => "on",
-      :location              => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\ERP",
+      :location              => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\microsoft.compute/virtualmachines\\ERP",
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
@@ -152,7 +161,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
     network = v.hardware.networks.where(:description => "public").first
     network.should have_attributes(
       :description => "public",
-      :ipaddress   => "137.135.124.168",
+      :ipaddress   => "40.76.27.54",
       :hostname    => "ipconfig1"
     )
     network = v.hardware.networks.where(:description => "private").first
@@ -183,12 +192,12 @@ describe ManageIQ::Providers::Azure::CloudManager do
   def assert_specific_vm_powered_off_attributes(v)
     v.should have_attributes(
       :template              => false,
-      :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\MIQ2",
+      :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\microsoft.compute/virtualmachines\\MIQ2",
       :ems_ref_obj           => nil,
-      :uid_ems               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\MIQ2",
+      :uid_ems               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\microsoft.compute/virtualmachines\\MIQ2",
       :vendor                => "Microsoft",
       :power_state           => "off",
-      :location              => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\MIQ2",
+      :location              => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\ComputeVMs\\microsoft.compute/virtualmachines\\MIQ2",
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
@@ -223,5 +232,84 @@ describe ManageIQ::Providers::Azure::CloudManager do
     v.hardware.guest_devices.size.should eql(0)
     v.hardware.nics.size.should eql(0)
     v.hardware.networks.size.should eql(2)
+  end
+
+  def assert_specific_orchestration_template
+    @orch_template = OrchestrationTemplateAzure.where(:name => "spec-deployment1-dont-delete").first
+    @orch_template.should have_attributes(
+      :md5 => "3036f29db21966d557c9865e107d93b0",
+    )
+    @orch_template.description.should eql('contentVersion: 1.0.0.0')
+    @orch_template.content.should start_with("{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"")
+  end
+
+  def assert_specific_orchestration_stack
+    @orch_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(:name => "spec-deployment1-dont-delete").first
+    @orch_stack.should have_attributes(
+      :status      => "Succeeded",
+      :description => 'spec-deployment1-dont-delete',
+      :ems_ref     => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment1-dont-delete',
+    )
+
+    assert_specific_orchestration_stack_parameters
+    assert_specific_orchestration_stack_resources
+    assert_specific_orchestration_stack_outputs
+    assert_specific_orchestration_stack_associations
+  end
+
+  def assert_specific_orchestration_stack_parameters
+    parameters = @orch_stack.parameters.order("ems_ref")
+    parameters.should have(13).items
+
+    # assert one of the parameter models
+    parameters[1].should have_attributes(
+      :name    => "adminUsername",
+      :value   => "serveradmin",
+      :ems_ref => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment1-dont-delete\adminUsername'
+    )
+  end
+
+  def assert_specific_orchestration_stack_resources
+    resources = @orch_stack.resources.order("ems_ref")
+    resources.should have(9).items
+
+    # assert one of the resource models
+    resources.first.should have_attributes(
+      :name                   => "myAvSet",
+      :logical_resource       => "myAvSet",
+      :physical_resource      => "6543c69e-1c83-47d1-96a6-d08d612fea76",
+      :resource_category      => "Microsoft.Compute/availabilitySets",
+      :resource_status        => "Succeeded",
+      :resource_status_reason => "OK",
+      :ems_ref                => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/availabilitySets/myAvSet'
+    )
+  end
+
+  def assert_specific_orchestration_stack_outputs
+    outputs = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(:name => "spec-deployment2-dont-delete").first.outputs
+    outputs.should have(1).items
+    outputs[0].should have_attributes(
+      :key         => "siteUri",
+      :value       => "hard-coded output for test",
+      :description => "siteUri",
+      :ems_ref     => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment2-dont-delete\siteUri'
+    )
+  end
+
+  def assert_specific_orchestration_stack_associations
+    # orchestration stack belongs to a provider
+    @orch_stack.ext_management_system.should eql(@ems)
+
+    # orchestration stack belongs to an orchestration template
+    @orch_stack.orchestration_template.should eql(@orch_template)
+
+    # orchestration stack can be nested
+    parent_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(:name => "spec-deployment2-dont-delete").first
+    child_stack  = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(:name => "spec-nested-deployment-dont-delete").first
+    child_stack.parent.should eql(parent_stack)
+
+    # orchestration stack can have vms
+    vm = ManageIQ::Providers::Azure::CloudManager::Vm.where(:name => "spec-VM1").first
+    vm.orchestration_stack.should eql(@orch_stack)
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -246,9 +246,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
   def assert_specific_orchestration_stack
     @orch_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(:name => "spec-deployment1-dont-delete").first
     @orch_stack.should have_attributes(
-      :status      => "Succeeded",
-      :description => 'spec-deployment1-dont-delete',
-      :ems_ref     => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment1-dont-delete',
+      :status         => "Succeeded",
+      :description    => 'spec-deployment1-dont-delete',
+      :resource_group => 'ComputeVMs',
+      :ems_ref        => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment1-dont-delete',
     )
 
     assert_specific_orchestration_stack_parameters

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
@@ -5,16 +5,16 @@ http_interactions:
     uri: https://login.windows.net/a50f9983-d1a2-4a8d-be7d-123456789012/oauth2/token
     body:
       encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-123456789012&client_secret=0+dVmFpJLU0T9gqFWDkWnX9MY3FPb5l1123456789012%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-123456789012&client_secret=Ha1SNn2RgLZ6ORXydHYq%2BeCLSZYYF5P4W5DHLx8uuIs%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Length:
-      - '188'
+      - '186'
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 320fcc3e-f57f-4205-ae4c-f9d1f953a4b1
+      - e662858e-7f5d-4bc1-8007-3932a133fdc5
       Client-Request-Id:
-      - a0f05d78-d3ba-4bb7-986b-4d7e6c7ff646
+      - 2b71869b-016f-4f3d-9e0c-582de6b477a0
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_38
+      - ESTSFE_IN_85
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -46,18 +46,18 @@ http_interactions:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 09 Sep 2015 16:16:07 GMT
+      - Tue, 22 Sep 2015 13:35:26 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"expires_in":"3600","token_type":"Bearer","expires_on":"1441818967","not_before":"1441815067","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA"}'
+      string: '{"expires_in":"3599","token_type":"Bearer","expires_on":"1442932526","not_before":"1442928626","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g"}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:10 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -70,11 +70,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -97,15 +97,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 91abd9a1-a3cc-4c56-964e-436096b78697
+      - d422e01d-d18a-4599-a3e1-2a459fe9cd74
       X-Ms-Correlation-Request-Id:
-      - 91abd9a1-a3cc-4c56-964e-436096b78697
+      - d422e01d-d18a-4599-a3e1-2a459fe9cd74
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161607Z:91abd9a1-a3cc-4c56-964e-436096b78697
+      - EASTUS:20150922T133527Z:d422e01d-d18a-4599-a3e1-2a459fe9cd74
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:07 GMT
+      - Tue, 22 Sep 2015 13:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -117,7 +117,7 @@ http_interactions:
         fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
         UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:10 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -130,11 +130,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -155,17 +155,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14995'
+      - '14999'
       X-Ms-Request-Id:
-      - 510bb5b1-1701-46d9-b1a9-8a4f7dc887bd
+      - a29241b6-d792-4c28-9293-92a141dfe8ef
       X-Ms-Correlation-Request-Id:
-      - 510bb5b1-1701-46d9-b1a9-8a4f7dc887bd
+      - a29241b6-d792-4c28-9293-92a141dfe8ef
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161608Z:510bb5b1-1701-46d9-b1a9-8a4f7dc887bd
+      - EASTUS:20150922T133527Z:a29241b6-d792-4c28-9293-92a141dfe8ef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:07 GMT
+      - Tue, 22 Sep 2015 13:35:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -189,165 +189,176 @@ http_interactions:
         dA+7zLY+nk6rdV8nqB1RLY8fxjCwxh+2P/xBaHJ6Vmho6CC3HTqP9Ua079br
         5aSqeozy/xn8g0jz/xujoD4H0O11e8s+uJc4Xz/J2il8Ex8HAOphNUFDQ1Z6
         IUAsJJcS0v3mSMqf9kjV85SkhQUYNGWYOg/B/DnnicFgvuhTaYLO6Q/7hQHA
-        H4SoODAKV9qIm+VwMX8Dsv4xNBusXVjVkEajvzE1xSU5UbeboWJ58UXGQZ8/
-        JYDfm6RFtqLkApr2p4emYetlVrfLvL5DDfSzTUjvEWKEVqcPmpI4e743pJJs
-        +Um1WKyXhUB5WefneZ0viQIfCHq9QjLgGwHO4Iem5gdvstLkCEAPHw2A6iGm
-        r1BTHwVhapoNNy89IeAv7F/MlD4nMwT9Xd40nMrAAjGQP/AG/cGQ/MZRehDn
-        0v/AufnNLHuSUe6EQPtjB6AeNV7lsz63RrDv4ejkkP/AuBxtBID9k7/kZhhx
-        8BsrpoAa8gdeoT86Wol/DtG8pzbcB/Y9+tSgLRpDkTN/cEP9KzoLxJUHNAvU
-        VP5ARCN/0OTQ/9z8BB9KzON/RPNHs9eZDZq06duvk+kiTH4W0aJZfD+F87OI
-        CzPsCfsULoCi174eWoM93F3kbV1MXRfdoSuPG25inhbuCT4CKwa/McMzz/Gn
-        /cbKzQwLLGs+kP5CmbJ/idDgffsHGtAfHQmKy4T7VEEYtEQStDfzB7+pf0VJ
-        TZNH/9tEXXr1Ylk1bTF9nbct2dceeYGIRxUlnBDBYMdfy0eWEoyp/aszev6S
-        3wpA8NchVKEhurZ/4GX6A5+ZOeEXQUPzQY+Q7gPblj41XQkNFS/zBzfUv24g
-        LxN4wAJIxE4GeLVuQQp/HgCpNzMz8tyLJbRPfDJ0iIwexmE+4C+ZaPobzxQP
-        iT+VCTJD5o8YRvhR8Ie8YmeRYdm/ZDbQl/0DDeiPzmw72mtj9wE3wSDoU/5d
-        6e3wMH8DtP0DcAjDdC/det3S8hHcOMHVvEZfmq+ic0eKhyNq1kI0i8EfCBpo
-        VmlOO1PDduGpnZ+vYR2CfoI/Bjv1+OFuU1b9mIOpoUzARARBzQf8JU+m/vYj
-        ruCvfjYn6C7Sij+app+raXq/abrRw4hyCvED/e/rdPTB4C+Lul1n5RcUWhTL
-        H7EZ4WH+Bmj7B+AQhj9b2oD+5/4YVA1TGjLbh/5S6e27jAH+Reuqzb4+SPPH
-        IOIdJvv57ShG6UrUo//djnoi+cMqRnDkcehvPyJeh3g9kgklgmFwp+FHQCz4
-        jQmLwdHv9Fu/sY6NYWEA5gPpz9KaQdi/hGZ43/6BBvRHZ04chbSx+4CboMf3
-        Jxkh8X6JgUAJBH/Q/9wfg+rB//Pr93mbwOlF3l5VNdKEYZ+RwEkZR9/oorV5
-        dvlLxwQ9PpHZD7iFYYQfBX/IK5ZFGJb9S3gEfdk/0ID++DoMY5Axts/gYf4G
-        aPsH4BCGP1uGcRPPUHo4n51xBv9HUyN/A7T9A3AIwx/61PxsexMXtARxlV2/
-        Xq9WNJp89pTyjrJM8LPUIc3kz6ZC5C43qq3XbVXTLNGLPmbosIdrI02HVhSZ
-        J1QUmJXAVuYD/pJZWn/7kWzwV19vmrcneYuu3Cf2D514mvbO7P1siw6nnJSb
-        lEV+OGmnDlvehfKOCK1MEnOOmwf6Q2Y2+Ej4BfNo/8DL9Ac+MyzNL4I9zAeO
-        c9As+MC2pU/5d8stpmPzNzqyfwCOoKS/sdR0mcl+ZLmfgdi/Ao6PEp7IS/97
-        P/KquzscK3zTPX3j8AXsz+IApIMPBvuzFpvTwkrP+/wwiMWCxv/Ngqyas58F
-        oD93Zvf26yuZpz4pmdFF1egE+lh/Y+3Ass+fRjRE8BErhPAjaWU1B8Oyf3Ev
-        quv4XSg084GoSTSxf+DtuL5hgu7ep5byB/2vt8i7u+d/yBTt0EfDKBN/04s/
-        Is8wee7m79p8Kd38iFIbKUXG92vlEIEn/U6/RWgRfMSjDj+SVpZGDMv+xb0o
-        gfjdr00xUlL0Pyipm+kg9mvYQApajL3+9v9DMryeZmVOfPD/o8GTlHzjUmPJ
-        9CM9wx/GKOaIERLmh9HlXSJJ3OURMjE19befr9Ny93LxuvjBjzyJYQKtm4gr
-        LvjysPS3n7f0Wa0nZdHMqRN6uzQfozMgJEPT39K9j3Rc/Glk9MFHPM7wI2ll
-        qcKw7F/ci5KE3/05phFhFVc/31if3Gs86HqatdlJtVzmUwzYxwwd9nCdSlPC
-        54tsSQzfn01QC5MwhPxBiBoh1unCQftZg+w0/qu8WZd9B+aDu+KU3wui+IZE
-        3/v2wv0Mz+KzbEpJFnTi4wJwPexmtnk/b2Kx6kjREJIPCUlqK38AY/vHA/rD
-        om8+pP/1P0RuIPywy8Pmw53Ih8PuajDOrx27CBlur1+CpKJ+yW8FIPjrEKqo
-        G3Rt/8DL9Ac+MxqKX3QqKzovRBH6322I8jUDGSFAgL18ZKkAzN1f/y+nCYur
-        J0Q3SG4UPvEx/a/DnfwJ/c98ONj58Q/Wdf7hGHzj0hhD2HHQ9WtCfoEZ+H8N
-        csRvotq7nPxDxIrxGtbUz7O3kAkfceDTGwrojLYma07v+AMSCWCBjI5N1SXh
-        Q9h0QDs4IcyvD8jZVGoRsak3QGbYAyTLL9+QyD/PJgSSgNvuAaWPUDbpdt1V
-        D6o7WL9AmXi/WYXFLcLWRGejgvCJ/QMvxmeAOOP+9p7PGTTIDr75krIF1XJB
-        Su//U3hTdzLdXaxvBdEIDv3vptmvpmsQ5+kTesnHAaB7WEFkJlkzKDIYM5GE
-        Pt5orkAnaca/KT170+FWMdEs+MC2HaQwGaMDeoX+oN/of6ADUWHzgGAW/r8/
-        KMInzjuCMeP4/8qh8GCG+HSRFRRPXBToAgOil/1xA3SPEjN+q0eGi7KaZOUm
-        1JyVgp9MqBFiHdhttXqeX+alYPaz0weZf3KcuIMN3so30xelD1rp6lU+rRak
-        FEg4GNDPRm+XxCYEPzc9unk9W55X9YJ/JTDffM8X+RLikb9uqlf5L1oT49M7
-        33w3JEnUC7/54eC5gwHBuKbPaa3/OS/3+0gAZg+tctqs6uqnKcmA5gFenSAC
-        Mm0knX9nhSC2DX/bP6A76A/RKEF0IR9ZtcKQwxZ41zXgv/hzbgr9YTAI3kL3
-        9Btb3i9eP3vDKNAH5k/9PvhT4fAHHbyc2kLL4AOLx+B0YYa22yLv2V75ghCL
-        fxP/cG/gc/pf7PNiOQCdvhiCha8cOOasYR65Oy2r9WyWr8rqmjTCj5jGdut4
-        BC2DDyweP5+YhqgyoO9+xCLcMvjA4rGZRRzBmeSk6SMW4PSSxvDt9a3CNwuh
-        N0sOtw3IxunlfmPKOaIJPYJXGFb4Eb+rZOSv0ZX5oMM8whl4w/6B7ugP6cvS
-        Hp+av6IkJjPLqYmNpH2WZy0ljkAs+tcSEjB6pD13bX3CDnWOVIg3v4QCvevD
-        IxV8Wczova8HkEH6oyInQUdF3mpxMWdd7vcJWD0syBNcVUuaLrT20fA5IYoS
-        8TD9T10Zxc/+Qf8D6QnFTn9X+QTq74fUG7l/SNNSww/vLAY/K/O6rddlvwvm
-        T4Kv7M+/bWBhbaZCwdLgS4lIAprYP/A2/SEwvQHp2+FHeJN+Y/ENvnBKAE2C
-        DxgMkKBPAykdIhkRypGM/jdAsnVbNVMiXJPHVxEwMEEOKMlvMkpLK25i/+Jm
-        SijGEEibD4RYaGL/wNv0h8AMqMFvhx/hTfrt/w2Uo2B02bb0e5dktwG7ixyr
-        +UO+ifXhwIZdGDp84BAsSJfujC8hflg3FvjXAvup/wf9L94H+Jii2Hx2+m5F
-        nDS0JgZmA90sJ9FvwnmWf7mJ/YubKfMy14CRzAfCwGhi/8Db9IfANBzK3fDb
-        4Ud4k377fwM337yciJEJdsBJfpNhWmJxE/sXN1NKMYrA2nwg1EIT+wfepj8E
-        ZkAOfjv8CG/Sbz+7pMOSSZRaN64zYiyCD7CQ32RgljzcxP7FzZQ2jBTwNB8I
-        fdDE/oG36Q+BGRCA3w4/wpv02w+FWEwu3xFy7t3vlV//ZEbahSD69ASMHoUv
-        0bBH1shwgbj8Jl9aioJC7i9upuTkcWBo5gP+MkYfbhn2x2D5N5kIvGv/wJf0
-        h6Oifus+YIjomz69FVl99be7t7370HM6idJRst1t8mmd/4h8700+Guz7WapN
-        4LmDAUmoliCc3zuA9vB5S+10raSLkUf1KHKEjy5GEhYdsA5OCPPrA3IOBLUA
-        C74fZIYdJ9Xz6qKYEjSCa3sGgB4uV1X99rysrrpdK2MHXBj8wQwUfi+vWO4H
-        X7q/mPDK+vwu+NF8wE0ZBjfzf6OZ6jC6/IGv6Y+AnX2e1+/dB9wEncZnntiy
-        k80g4naIRSOR6epS65YQGWZ8wr7I6rd5uyrp8y9rCqjJl6A+/P4BtodRdlHn
-        eTTnycMN5wf0w29D2LJYMo6dXt573AqJYcXH+yJvwXoEz+8LIHq909p4u85K
-        faOLgh2V5Rj67etzorwZkI3bhB8FfzC8gFHxif0DnW8g+e59ail/0P8ct/CH
-        JOsdFiKCdsizWk/KYnr28ng2o28aouGPCBQQaCmMc7Zs8/qc+PBHBOoQqKyy
-        2ZOszJZTgk6v/Yg4HnGUe17n03VNq9qf19V69SMidYhERGnzN9mEEmL00o9I
-        45EmtF6fU7LlKrv+EZU6VAIxfkQj92GMRtNquaTlbob7I9IEpMlWK/KBmB4/
-        4p44iRwxQsL8MLp0ce7Pbe/vl6b/RnE4mefTt0+XzQuKho4vs6LMJkVJ/gTB
-        so2o6x8KLusmu+gZ6p/Fni39f4h9zpbND2hJuNvjRxdlNcnKQUGj/+3fCu7d
-        4589yPT8rAE/eXH8xenPGvSXb179rMH+4vf+WQP95vd+87MG+/Wrn/ymYZNN
-        OT8vpotsSXJcr+rqvIg43jf0sr+9d7Cxlyk01hvp6gvp6gbl9Z5dcqcD2aGq
-        Lahbhvzt9QRj87EDzB6+FhJaB2i5HKBaXPcBG20Ydvo0Zq3db2y3YaTpd/rt
-        dg4Av6suA3+NrswHndSluAF4w/6B7ugP6cs6JvjU/BUlNS1XPiT9SCQmAg9S
-        6e6yT+QfkW2AbCwMYH+m3SYZcERSnNwHjDKGQp/2x+v/9v8Lqm0w/B5RMGL6
-        1n1gqUSf/v+QSsxdVgqJtZzW+9KQKyvPlk1xMWdX1edEgOvxJmJmBobWAZWB
-        uYz6RgRJPd/b3tuhpvQHOVi7tMpk/9ih/xHqhHin66atajIMiu1JtTwvLrpY
-        RLvbBLQslm/fZPVFZCnWDCgKszuEwQ6ICELnLvwoWILExNg4dRRZcA+A6PcG
-        IL3+G1K207pYSbe3QIFGtkv/o6b0B7ES/W+z9xv0cJc8hMuC1pR+GH1Z2lKr
-        94i13q9L82c8GXt7cecvXbOvqVGklQqXvm7/Eq0B8PYPNKA/OromrgDdpwzi
-        myFfE8yYo11Ix5+NvtrsguWH3v/mu4Le+NmBTFMpTP1e4DcqjNfkUczWZV4T
-        RL83AOn1/9PVZFqV5UDyT/gvYElmofAjaWX5Ekzo/gJzGaHgd8F+5gNuyjC4
-        Gf8WcLL8gS/pjw5bBzigCf3GUtbhbP8DfhcYxPmdpuuA6Pv1ZkzpEKDF/YUf
-        SStLHwzU/QWEDXH4XeBqPuCmDIOb8W9CIHxj/8CX9MfPBbWYXgNcmWf1FIj4
-        5ASkHoEbbvk6ry8LsXoBkTFUQp0+Brry20aS2kEYMvJ7+ru8GdCG24cfCV0B
-        lv5w5AEg+iAgdJRQJLZ7FKBSW/qDqPZg+97u9ktLNaJZhwQkwVNaF2QKIDTY
-        EBV8Mx0SqeJMvRH8DRPO6D9ZA6TfHaD0ELAw0NpHoE9v9wGTHFNLnwYThpbB
-        b8zpmED6nX673bTzu8oo/DW6Mh8Es25YBG/YP9Ad/SF9WXbEp+avKHFputSf
-        J9J2qMR8AYZgUn0NroC8UlP6w3XDHVn6Uy/eHP6iklr7SABWDy0aS5x7gtEq
-        ESM01vkJvhCyBR8xMP5N3zK/6ZQweH+OgnmQP9Ce/hDoFrHOZDoO0+buA26C
-        PgYnj/7nVKIhNf0PpCZCd0jnqPUjytH/vg7l7k4JP5aCgtjzR2Sk/70HGa1K
-        2aBNZOAWWUYhpAzQpN9+3lKxIWNHIKjhj+j2Neh2d5a12SRrfiS/RCn639eg
-        IH6Su/Xl5KcRy13+iJJEMfrf16BkNlsUywK9UAryR2QUin0gGW3+mbKZkdyd
-        EMIizyiFlALa9NvPe6rSx0TObFLmTwmnVT57+iPNSYN11Ps6JJ1W9AvT9EfE
-        pME6ur0/MYvFilCi9j8i39cn3+k7/PsjnUkUMYN19Ht/ohIePyKkGayj2fsT
-        8ryo86usLGtaXfj/NBV/TqloYp3X+XRdU7D9siqL6Y9SF4Z2H07QL/K2LqY/
-        oqeQ7v3pma1nlEtbXvyIMWmwjmbvT0h4lotFvpzls9OSwBfTl1VV/oieQrr3
-        p6cR9B+x6M8CSafVconUUbX8EVFpsI5+H0LU5kcm6RumKH77Imve/kj4ZbCO
-        gN8wVe/+yMt3ZHx/2pqPVz+y+JZg70/FXNymHxHR0ev9ibhusosfSTKRif73
-        NcgH3ShacsFW/Gl+TgsbQscOTQX3gDKMVfgRMA9+YxKDFvQ7/dZvrERjWBih
-        +cANHs2CD2xb+lTQsiTlnuxfAfHlDzSgPwLSb6Lpe5Hv55xo0p8dP4OwfwkB
-        8L79Aw3oj2+GGuZj1mhKkQ0MFYzKTS7j943i8MPp2VfnQx3L9ATdM83Dj4BH
-        8Ntt2UHA2/nmN+xfMuFobv9AA/ojmH3FyGeqDoX8D2zbb5Rus2GmkSEGFGAc
-        wo+AZ/Db/w8oyDRcZou8WWVTEPCLYlpXTXXejl9j2fQCKPo0Bog+1aXp8XRa
-        rZf95QKg51GlRzj+zRKE2+gQ7TjMB0IgNLF/4G36Q4gczAG/HX4U/CGvhB0D
-        uXTrdUvDuRMn3v3tHfpfzyzu7vkfMl07VKJeZFWlS6BvthsH+Wezl6iL9M12
-        MZ3n07cviDePL7OizCZFSXkBev1nr8cOH9+FNimmvWEaTqGPwXzym37mcY9+
-        a/krxm7K1syp3ySf4036jQUt+MLpCDQJPmAwQII+DXRPlMikQOh/0CG3p6Nq
-        4g3mG0gJohiu/Kaf/TykLNN2SDvXebY4XmblNdk50NGfA4CKzApeoYTFT1cT
-        vBAQPhgKCNIhp45YaGS/EvqhAf3Bb/H7PDiM1xCdP4jQUb8WMHif/pAu+m35
-        N0dTfBZ8wH2gU/o0ILKbp7PljPqLEp0UxkMQnXUF/fGp/wf9z/3Bc2P+uEd/
-        WJXCH9LX9D/MHs1dZwYcxTvUx9AdVQ26PGKMk377EfXlD6at+SOg/kaC3/1F
-        66rNunT/oeJClHLid5dIcbGs4KO+zlsszHRx88iuv3ksYEjKX+Mjjyswke6v
-        jXOhjRmK+Yb/4OZ+L4ZLgAp9L3/gZfoDnxle4hfBBuYDxyFoFnxg28Z5gqhL
-        /4sLEoHwaPkeVkV/+3lLSiamb1EW1qI069WKhk9wfWIDRI/8RI+4J6sEDEbL
-        uIUfBX9g6I7IAsD+yV9yM4w5+I3nUKiHT+wfeIX+6MwW/wSFDDXxjvndERKf
-        Bh/Y9+KUJcF/QJTdfqmC72sDIjcRu0M6pTLJ/du8HynJ6APyMALhR8EfGK6j
-        lwCwf/KX3AwDC377/wL5mIBxbr0smnVWNi0ta1f0mk9lAO/RPRNflJp+DYJj
-        WPIbqCO/BQ0ETEh2+xe/raRi4KCH+UCIjib2D7xNf3RmwNGUG0fJSUJO/3Nm
-        iMlJn+xt731K5CRixqlyd1VXP01L2fTCz1/qMH18ZnPO9nfzCbX2aQeYPWo2
-        RUsxTv6uzZfSb4ecHZyBqRko/87EklHib/uHDlnIuImyDDlsgXddA/6LP+em
-        PqmDt9A9/cY64ovXz94wCvSB+VO/D/5UOPxBB6/O7PgfWDzoU3xJUINAjz8D
-        aO8zh6r3IWNobLFpYf7mXvSvKG+Qzjkg3qCm8ge0kv3jlh4g0gvyB+Uadr0/
-        PAD0B/2vz4P0Pyg84sAoTzVlRWH0jzjrR5z1TXNWsWzabEm5GXrhRyyFbh0H
-        oWXwgcWDPsWXBPVHLNVjKVFWP2KsHzHWN8xYlqV+ZAnpgw5ejpnQMvjA4kGf
-        4kuC+iPu6nFXR239iMfogw5ejqXQMvjA4kGf4kuC+iMe83hstZ6URTOnlOVX
-        tBr2I5Yy3ToOQsvgA4sHfYovCeqPWMpjKWInWkBAxiKTBfISBP0RW6Fbx0Vo
-        GXxg8aBP8SVB/RFbeWwlf5xUNJ6q/JGiMt06BkLL4AOLB32KLwnqjzgKTKQc
-        ZdUTDXT69kcsZbp1HISWwQcWD/oUXxLUH7GUx1LkS7Wv4bYfN01xscxnb6pv
-        kzF8QcaQXv4Re6Fbx01oGXxg8aBP8SVB3cxe1M6h+v8+9oqxiER1cJHAFU8K
-        QmN58SPlY7p1zICWwQcWD/oUXxLU/59yh8T8P+IR80EHL8cSaBl8YPGgT/El
-        Qf3/HY8QEWrlgh9xhHTrGAAtgw8sHvQpviSo/5/mCP7jG3RZpnndFucFcdGP
-        1kRst4590DL4wOJBn+JLgvojfvL4idKIl3n9LKsXP2In063jHrQMPrB40Kf4
-        kqD+iJ18doJDRM1+xEjo1vENWgYfWDzoU3xJUH/ESF1GEs+aGv+IndCt4x60
-        DD6weNCn+JKg/oidPHaq18u2WPRU0/8bBhHFV9h/kbd1Mf3/JNJP8/NiWQjK
-        /59Cn1WODuL/w6j/f5H+zhXVQfx/GPX/L9KfmajOp9VikS9nivD/+5B/D63/
-        /6OxXORVnV8wpv9fHoYwGTVfFJQWm82AcjieH/l3///072LcgJw55cpPl5dF
-        XS1JUv//4u27mcOnwQcWCH2KL/kVb4b4M8D3PnP9eB8yXjJZroX5m3vRv77x
-        qTR/vIeGuO30312sy7Z4VZX5y6oqf8QN/Bnge5+5frwPGS+Zb9fC/M296F//
-        n+KGq6p+m9c/YgXMMH8G+N5nrh/vQ8ZLJtu1wN/4m3vRv37YrEBT//VZQfzq
-        Lhv8f3AI/x8MDaKDCRS1ju3/fyP6/8lseYpUB/b/s+H8/2SeOjxYLJs2W07/
-        X5m4vH3Q9z4D1en8eTfg/3fz74cN3ZdWO24C9fNglDq7P79G+/8XXp7lq7K6
-        xnif2zH8f3k8RaMzmbuZXGaLPLvMijKblAhq/r87ummZNU0x/aKaFGX+mjLy
-        BXEkvfb/lRHxmDAdzSqbYkAv8qtXeVlMx8cvv6DG/nCBeo8A2XRa0Tpnd8wa
-        15pAkENSiQKDjzhq5N840OTf5M0w4LV/MQzEqxyU0gf8Hv8eJTMRZgcjvWnY
-        rylhf1EXs/HpgtiSmvvDBLBbD9whNIQtj1J/4/ich8ifytgDEjGM8KPgD3nF
-        Eohh2b8k+4C+7B9oQH90MhkuI6CN3QfcBIOIU5j4kFkvRtT1lKSheULa+W0z
-        PinzrH76hGD7lASYHm1p7SSbZA192SFuB+uAEEB8M52FAPjE/qHUECIG4OQj
-        S0nuElQwXeBN9zX/xe/FCOd/qt3zl36PUeISu9L/QFwibYdI05JgUnMC9iMa
-        MY3w3/8Dp1j7g+8RAQA=
+        H4SoODAKV9qIm+VwMX8Dsv4xNBusXVjVkEajvzE1xSU5UbeboeLieJmV120x
+        Bd39aUEfvYnKBuYIo6ER0lwM4XkgqAlOii+rZUKQ0Bvo5y6F3dnz7G0+xBzv
+        2fHGvhqy/JQ4+TnoCpqkzYolQfy56fVuSa7P66x5U73NCfY3j4ODF8K+FcAb
+        2cVCvEsyLfqNWqzL3iR+M93ZTr4J8NzBkHQuL77IOCXjYwDAPZwW2YpSf2jq
+        IyQahKZu62VWtzTTd6iBfjY4maRSaKaBVqeP9x73ICSw20m1WKyXhUB5Wefn
+        eZ0viQIfCHq9Ip2RfyPAGfzQ1PzgTVaaDB7o4aMBUD3E9BVq6qNghIs+NvPS
+        M1H8hf2LTYZvZxiC/i5vGjvCwAIjJX/gDfqDIfmNo/Qgu0L/c/y7kS4nGWU2
+        CbQ/dgDqUeNVPutzawT7Ho7OSvIfGJejjQCwf/KX3AwjDn4jZdahhvyBV+iP
+        js/AP4do3jPq7gP7Hn1q0BZ7rsiZP7ih/hWdBeJKaBFqKn8g3yB/0OTQ/9z8
+        BB9KRsL/iOaPZq8zGzRp07dfJw9NmPwsokWz+H4K52cRF2bYE/b4XXqDXvt6
+        aA32cHeRt3UxdV10h648briJeVq4J/gIrBj8xgzPPMef9hsrNzMssKz5QPoL
+        Zcr+JUKD9+0faEB/dCQoLhPuUwVh0BJJ0N7MH/ym/hUlNU0e/W8TdenVi2XV
+        kL/7Om9bsq898gIRjypKOCGCwY6/lo8sJRhT+1dn9PwlvxWA4K9DqEJDdG3/
+        wMv0Bz4zc8Ivgobmgx4h3Qe2LX1quhIaKl7mD26of91AXibwgAWQfBoZ4NW6
+        BSn8eQCk3szMKK4ultA+8cnQITJ6GIf5gL9koulvPFM8JP5UJsgMmT9iGOFH
+        wR/yip1FhmX/ktlAX/YPNKA/OrPtaK+N3QfcBIOgT/l3pbfDw/wN0PYPwCEM
+        071063VLLjzcOMHVvEZfmq+ic0eKh/NdrIVoFoM/ENLTrNKcdqaG7cLTaqHz
+        8zWsQ9BP8Mdgpx4/3G3KqufECzWUCZiIIKj5gL/kydTffsQV/NXP5gTdRdL/
+        R9P0/41putHDiKJAHdH/vk5HHwz+sqjbdVZ+QaEFJSu64IS8ylU8K5gh8wF/
+        ydyhv/2Izfir6CRsZDP6n/tjkOemNGS2D0Vvom7fZQzwL1pXbfb1QZo/BhHv
+        MNnPb0cxSleiHv3vdtQTyR9WMYIjj0N/+xHxOsTrkUwoEQyDOw0/AmLBb0xY
+        DI5+p9/6jXVsDAsDMB9If5bWDML+JTTD+/YPNKA/OnPiKKSN3QfcBD2+P8kI
+        ifdLDARKIPiD/uf+GFQP/p9fv8/bBE4v8vaqqpEmDPuMBE7KOPpGF63Ns8tf
+        Oibo8YnMfsAtDCP8KPhDXrEswrDsX8Ij6Mv+gQb0x9dhGIOMsX0GD/M3QNs/
+        AIcw/NkyjJt4htLD+eyMM/g/mhr5G6DtH4BDGP7Qp+Zn25u4oCWIq+z69Xq1
+        otHks6eUd5Rlgp+lDmkmfzYVIne5UW29lrVFetHHDB32cO0sQ9IrPsLCEyoK
+        zEpgK/MBf8ksrb/9SDb4q683zduTvEVX7hP7h048TXtn9n62RYdTTspNyiI/
+        nLRThy3vQnlHhFYmiTnHzQP9ITMbfCT8gnm0f+Bl+gOfGZbmF8Ee5gPHOWgW
+        fGDb0qf8u+UW07H5Gx3ZPwBHUNLfWGq6zGQ/stzPQOxfAcdHCU/kpf+9H3nV
+        3R2OFb7pnr5x+AL2Z3EA0sEHg/1Zi81pYaXnfX4YxGJB4/9mQVbN2c8C0J87
+        s3v79ZXMU5+UzOiianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX1XX8
+        LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P/c0jCTvENAjbNM
+        gE4v/oh+H0C/u/m7Nl8KxB+R8sNISfb9a6UpMRD6nX6LECv4iLEPP5JWlogM
+        y/7FvSgF+V0Qw3wgVEQT+wfepj8cBfVb94GFQp/eTFLSnvQ/aM+bqSeGddhy
+        y2B4zPrbj4inxHs9zcqceO7nPclIZD9EhC0df061IoiyiaREjP8vkjT8/Ees
+        +rNE17tLyUCfLdu8PidP9UeUfl9KO2qFlPuGod8l8sQDFiEZU1Z/+9EUDRHx
+        cvG6+MGPmJwo9nUpuG4iobgMiMetv/2IgEMEXK0nZdHMCR69bT8GXOAkY9ff
+        /t9IxG+GHIRAXJl9HfDcQTzX8jRrs5NqucynGIaPBGD30JpKU+r6i2xJfN6f
+        I9AApB3C8yBEjRDrdOGg/axBdqbiVd6sy76j/8Fdcab/BVF8Q37/fXvhfoZn
+        8Vk2pdwqOvFxAbgedjPbvJ8utVh1ZGMIyYeEJLWVP4Cx/eMB/WHRNx/S//of
+        IiUYfri/vbsX+3An8uFwWBeM82vnE4QMt9cagXLUL/mtAAR/HUIVJYKu7R94
+        mf7AZ0bv8ItOEUXnhShC/7sNUb5mmkAIEGAvH1kqAHP31//LacLi6gnRDZIb
+        hU98TP/rcCd/Qv8zHw52fvyDdZ1/OAbfuDTGEHYcdP2akF9gBv5fgxzxm6j2
+        Lif/ELFivIY19fPsLWTCRxz49IYCOqOtWSyjd/wBiQSwQEbHpuqS8CFsOqAd
+        nBDm1wfkbCq1iNjUGyAz7AGS5ZdvSOSfZxMCScBt94DSRyibdLvuqgfVHaxf
+        oEy836zC4hZha6KzUUH4xP6BF+MzQJxxf3vP5wwaZAfffEkZh2q5IKX3/ym8
+        qTuZ7i7Wt4JoBIf+d9PsV9M1iPP0Cb3k4wDQPawgMpOsGRQZjJlIQh9vNFeg
+        kzTj35SevelwwRGaBR/YtoMUJmN0QK/QH/Qb/Q90ICpsHhDMwv/3B0X4xHlH
+        MGYc/185FB7MEJ8usoLiiYsCXWBA9LI/boDuUWLGb/XIcFFWk6zchJqzUvCT
+        CTVCrAO7rVbP88u8FMx+dvog80+OE3ewwVv5ZvqipEArXb3Kp9WClAIJBwP6
+        2ejtktiE4OemRzevZ8vzql7wrwTmm+/5Il9CPPLXTfUq/0VrYnx655vvhiSJ
+        euE3Pxw8dzAgGNf0eTFtnk/RkY8EYPbQKqfNqq5+mpIMaB7g1QkiINNG0vl3
+        Vghi2/C3/QO6g/4QjRJEF/KRVSsMOWyBd10D/os/56bQHwaD4C10T7+x5f3i
+        9bM3jAJ9YP7U74M/FQ5/0MHLqS20DD6weAxOF2Zouy3ynu2VLwix+DfxD/cG
+        Pqf/xT4vlgPQ6YshWPjKgWPOGuaRu9OyWs9m+aqsrkkj/IhpbLeOR9Ay+MDi
+        8fOJaYgqA/ruRyzCLYMPLB6bWcQRnElOmj5iAU4vaQzfXt8qfLMQerPkcNuA
+        bJxe7jemnCMa6NGZGIYVfsTvKhn5a3RlPugwj3AG3rB/oDv6Q/qytMen5q8o
+        icnMcmpiI2mf5VlLiSMQi/61hASMHmnPXVufsEOdIxXizS+hQO/68EgFXxYz
+        eu/rAWSQ/qjISdBRkbdaXMxZl/t9AlYPC/IEV9WSpgutfTR8ToiiRDxM/1NX
+        RvGzf9D/QHpCsdPfVT6B+vsh9UbuH9K01PDDO4vBz8q8but12e+C+ZPgK/vz
+        bxtYWJupULA0+FIikoAm9g+8TX8ITG9A+nb4Ed6k31h8gy+cEkCT4AMGAyTo
+        00BKh0hGhHIko/8NkGzdVs2UCNfk8VUEDEyQA0rym4zS0oqb2L+4mRKKMQTS
+        5gMhFprYP/A2/SEwA2rw2+FHeJN++38D5SgYXbYt/d4l2W3A7iLHav6Qb2J9
+        OLBhF4YOHzgEC9KlO+NLiB/WjQX+tcB+6v9B/4v3AT6mKDafnb5bEScNrYmB
+        2UA3y0n0m3Ce5V9uYv/iZsq8zDVgJPOBMDCa2D/wNv0hMAMO5bfDj/Am/fb/
+        Bm6+eTkRIxPsgJP8JsO0xOIm9i9uppRiFIG1+UCohSb2D7xNfwjMgBz8dvgR
+        3qTffnZJhyWTKLVuXGfEWAQfYCG/ycAsebiJ/YubKW0YKeBpPhD6oIn9A2/T
+        HwIzIAC/HX6EN+m3HwqxmFy+I+Tcu98rv/7JjLQLQfTpCRg9Cl+iYY+skeEC
+        cflNvrQUBYXcX9xMycnjwNDMB/xljD7cMuyPwfJvMhF41/6BL+kPR0X91n3A
+        ENE3fXorsvrqb3dve/eh53QSpaNku9vk0zr/Efnem3w02PezVJvAcwcDklAt
+        QTi/dwDt4fOW2ulaSRcjj+pR5AgfXYwkLDpgHZwQ5tcH5BwIagEWfD/IDDtO
+        qufVRTElaATX9gwAPVyuqvrteVlddbtWxg64MPiDGSj8Xl6x3A++dH8x4ZX1
+        +V3wo/mAmzIMbub/RjPVYXT5A1/THwE7+zyv37sPuAk6jc88sWUnm0HE7RCL
+        RiLT1aXWLSEyzPiEfZHVb/N2VdLnX9YUUJMvQX34/QNsD6Psos7zaM6ThxvO
+        D+iH34awZbFkHDu9vPe4FRLDio/3Rd6C9Qie3xdA9HqntfF2nZX6RhcFOyrL
+        MfTb1+dEeTMgG7cJPwr+YHgBo+IT+wc6pz8CRh2m2+59ait/0P8c8/CHJPod
+        jiL6dqi1Wk/KYnr28ng2o28aIumP6GU+jNFrKWx1tmzz+py49Ef0ch/G6FVW
+        2exJVmbLKUGn135EK/kwRivlrdf5dF3TivjndbVe/Yhm7sMYzYhGbf4mm1Bu
+        jV76EaXkwxilQrv4OaVxrrLrHxHNfRgjGmjzI5KBOvzhbUg2rZZLWmZnuD+i
+        lPkwRqlstSLfi8nzI966FcUcbUI6/TC6dNH3z23v77d48I3icDLPp2+fLpsX
+        FKMdX2ZFmU2KkjwVgmUbUdc/FFzWTXbRs/m37Nnr5NY9W/o3H41+WH3Ols0P
+        aKG6O8qPLspqkpWDgkb/278V3LvHP3uQ6flZA37y4viL05816C/fvPpZg/3F
+        7/2zBvrN7/3mZw3261c/+U3DJhNzfl5MF9mS5Lhe1dV5EfHhb+hlf3vvYGMv
+        U2isN9LVF9LVDcrrg7vM39G3TfOKbGF+UtTTddFT1mKzyb4OdfLeuoMRGUid
+        VW1Bo+fOv72eABfCz2KMXntjsJDQOsDcJUjVD3AfsPWHu0GfxnwI9xt7E4YG
+        t3VL+F11ZPhrdGU+CBwQ45zgDfsHuqM/pC/rLuFT81d0Mmgt9yGRmkhMBB6k
+        0t1ln8g/ItsA2VgmIYVMu02i6IikOLkPGGUMhT7tj9f/7f8nVKOX4v6HRxTF
+        wX3AKAJ1+rQ/Pv+3/09SielkpZCI5LTel4ZcWXm2bIqLOSthn6YA16My4nwG
+        htYBlYG5jPpGBElh39ve26Gm9Afp6l1agrN/7ND/CHVCvNN101Y12SfF9qRa
+        nhcXXSyi3W0CWhbLt2+y+iKyTm0GFIXZHcJgB0QEoXMXfhQsQWJibJw6CnC4
+        B0D0ewOQXv8NKdtpXayk21ugQCPbpf9RU/qDWIn+5xtSwmpTD3fJUbksaMHt
+        h9GXpS21eo+Q7/26NH/Gs823F3f+0jX7mhpFWqlw6ev2L9EaAG//QAP6o6Nr
+        4grQfcogvhnyNcGMOdqFdPzZ6KvNLlh+6P1vvivojZ8dyDSVwtTvBX6jwnhN
+        HsVsXeY1QfR7A5Be/z9dTaZVWQ5kKIX/ApZkFgo/klaWL8GE7i8wlxEKfhfs
+        Zz7gpgyDm/FvASfLH/iS/uiwdYADmtBvLGUdzvY/4HeBAX3Kv6dnyxmjYqCZ
+        v4GA/hGdCprZA5qKrze5SjLTJ49A0Ak+klaWlIyS/QtjM3TkdzEs8wE3ZRjc
+        jH8TWuIb+we+pD/+X05YJu0Ar+dZPQXOPuUBqTcXDbd8ndeXhdjSYD4YKX+8
+        9NtG6vMYMV5DcX5Pf5c3zcAZGLcPP5IpAFj6w1ESgOiDYE6ihCJlcLC9+5Da
+        yh97FIrLH0TCB9v3drdfWhISATv0ICUxpbVVJgeijw2Bx1DvX6PDr9kTjzMG
+        lCYjLmEbITHO9AcP4Ab+YgI9WQO+3zdA9rCxMNDax6Y/ve4DnmFwEn0a8Ada
+        Br+xDIJf6Hf67XZcxu8qX/LX6Mp8EDCZ4Ui8Yf9Ad/SH9GW5H5+av6KUJobQ
+        oIRI26GSZQQm1dfiBoLMc+i64Y4s/akXbw5/UUmtfSQAq4cWjSXOSsFolYgR
+        Guv8BF8I2YKPGBj/pm+Z33RKGLw/R8E8yB9oT38IdItYZzIdh2lz9wE3QR+D
+        k0f/cxrYkJr+B1IToTukc9T6EeXof1+HcnenhB9LQUHs+SMy0v/eg4xWpWzQ
+        JjJwiyyjEFIGaNJvP2+p2JCxIxDU8Ed0+xp0uzvL2mySNT+SX6IU/e9rUBA/
+        yd36cvLTCEgvf0RJohj972tQMpstimWBXiiP+rNMRqKHRzz3m1LNDtF8IJT7
+        /x4ZbRKdUrKRBKTwk0WeUQoZDmjTbz/vmZM+JnJmkzJ/Sjit8tnTH2lOGqyj
+        3tch6bSiX5imPyImDdbR7f2JWSxWhBK1/xH5vj75Tt/h3x/pTKKIGayj3/sT
+        lfD4ESHNYB3N3p+Q50WdX2VlWdMSyY+oKAR7fyqaWOd1Pl3XFGy/rMpi+qPU
+        haHdhxP0i7yti+mP6Cmke396ZusZ5dKWFz9iTBqso9n7ExKe5WKRL2f57LQk
+        8MX0ZVWVP6KnkO796WkE/Ucs+rNA0mm1XCJ1VC1/RFQarKPfhxC1+ZFJ+oYp
+        it++yJq3PxJ+Gawj4DdM1bs/8vIdGd+ftubj1Y8sviXY+1MxF7fpR0R09Hp/
+        Iq6b7OJHkkxkov99DfJBN4qWXLAVf5qf08KG0LFDU8E9oAxjFX4EzIPfmMSg
+        Bf1Ov/UbK9EYFkZoPnCDR7PgA9uWPhW0LEm5J/tXQHz5Aw3oj4D0m2j6XuT7
+        OSea9GfHzyDsX0IAvG//QAP645uhhvmYNZpSZANDBaNyk8v4faM4/HB69tX5
+        UMcyPUH3TPPwI+AR/HZbdhDwdr75DfuXTDia2z/QgP4IZl8x8pmqQyH/A9v2
+        G6XbbJhpZIgBBRiH8CPgGfz2/wMKMg2X2SJvVtkUBPyimNZVU52349dYNr0A
+        ij6NAaJPdWl6PJ1W62V/uQDoeVTpEY5/swThNjpEOw7zwXeYQGhC3wbUEiIH
+        c8Bvhx8Ff8grtuMOvR01tTv3ATcBWvQpviRw6V669bolItyJk/z+9s6n27v3
+        6QX5g/7nLCvPQoemhJOswXTJ+c2Aj7o43wzo6Tyfvn1BPHV8mRVlNilKiufp
+        9W++pw7f3YX0F9PesMwc0cdgFvlNP/PmTb+1/NBhD37hZ4sv8Sb9xoIRfOGY
+        Dk2CDxgMkKBPA96NEpcEnv4Hmb89HVVzbjC3QEoQxXDlN/3s5yFlmbZD2rTO
+        s8XxMiuvyS6Bjv4cAFRkVvAKJRh+uprghYDwwVBAkA45dcRCI/uV0A8N6A9+
+        i9/nwWG8huj8QYSO+rWAwfv0h3TRb8u/OZris+AD7gOd0qcBkd08nS1n1F+U
+        6KQbHoLoRld86v9B/3N/8NyYP+7RH1al8If0Nf0Ps0dz15kBR/EO9TF0R1WD
+        Lo8Y46TffkR9+YNpa/4IqL+R4Hd/0bpqsy7df6i4EKWc+N0lUlwsK/iUr/MW
+        Cyld3Dyy628eCxiS8tfykeUKTKT7a+NcaGOGYr7hP7h52ItwCVCxf+Bl+gOf
+        GV7iF8EG5gPHIWgWfGDbxnmCqEv/iwsSgfBo+R5WRX/7eUtKJqZvURbWojTr
+        1YqGT3B9YgNEj/xEj7gvqQQMRsu4hR8Ff2DojsgCwP7JX3IzjDn4jedQqIdP
+        7B94hf7ozBb/BIUMNfGO+d0REp8GH9j34pQlwX9AlN1+qYLvawMiNxG7Qzql
+        Msn927wf2cjoA/IwAuFHwR8YrqOXALB/8pfcDAMLfvv/AvmYgHFuvSyadVY2
+        LS1DV/SaT2UA79E9E1+Umn4NgmNY8huoI78FDQRMSHb7F7+tpGLgoIf5QIiO
+        JvYPvE1/dGbA0ZQbR8lJQk7/c2aIyUmf7G3vfUrkJGLGqXJ3VVc/TUvP9MLP
+        X+owfXxmc872d/MJtfZpB5g9ajZFSzFO/q7Nl9Jvh5wdnIGpGSj/zsSSUeJv
+        +4cOWci4ibIMOWyBd10D/os/56Y+qYO30D39xjrii9fP3jAK9IH5U78P/lQ4
+        /EEHr87s+B9YPOhTfElQg0CPPwNo7zOHqvchY2hssWlh/uZe9K8ob5DOOSDe
+        oKbyB7SS/eOWHuCe/WN/e3fX+8MDQH/Q//o8SP+DwiMOjPJUU1YURv+Is37E
+        Wd80ZxXLps2WlJuhF37EUujWcRBaBh9YPOhTfElQf8RSPZYSZfUjxvoRY33D
+        jGVZ6keWkD7o4OWYCS2DDywe9Cm+JKg/4q4ed3XU1o94jD7o4OVYCi2DDywe
+        9Cm+JKg/4jGPx1brSVk0c0pZfkWrYT9iKdOt4yC0DD6weNCn+JKgfvMsJaP9
+        /yRLETvRAgIyFpksjJcg6I/YCt06LkLL4AOLB32KLwnqj9jKYyv546Si8VTl
+        jxSV6dYxEFoGH1g86FN8SVB/xFFgIuUoq55ooNO3P2Ip063jILQMPrB40Kf4
+        kqD+iKU8liJfqn0Nt/24aYqLZT57U32bjOELMob08o/YC906bkLL4AOLB32K
+        Lwnq/6fZK8YiEtXBRQJXPCkIjeXFj5SP6dYxA1oGH1g86FN8SVD/f8odEvP/
+        iEfMBx28HEugZfCBxYM+xZcE9f93PEJEqJULfsQR0q1jALQMPrB40Kf4kqD+
+        f5oj+I9v0GWZ5nVbnBfERT9aE7HdOvZBy+ADiwd9ii8J6o/4yeMnSiNe5vWz
+        rF78iJ1Mt4570DL4wOJBn+JLgvojdvLZCQ4RNfsRI6FbxzdoGXxg8aBP8SVB
+        /REjdRlJPGtq/CN2QreOe9Ay+MDiQZ/iS4L6I3by2KleL9ti0VNN/28YRBRf
+        Yf9F3tbF9P+TSD/Nz4tlISj/fwp9Vjk6iP8Po/7/Rfo7V1QH8f9h1P+/SH9m
+        ojqfVotFvpwpwv/vQz6i9alFbEQ/tLEwXoLkz9ZYLvKqzi+Y6v9fnhJhMmq+
+        KCgtNpsB5XA8P/Lv/v/p38W4ATlzypWfLi+LulqS1vn/i7fvZg6fBh9YIPQp
+        vuRXvBnizwDf+8z1433IeMlkuRbmb+5F//rGp9L88R4a4rbTf3exLtviVVXm
+        L6uq/BE38GeA733m+vE+ZLxkvl0L8zf3on/9f4obrqr6bV7/iBUww/wZ4Huf
+        uX68DxkvmWzXwvzNvehf/59iBfGru2zw/8Eh/H8wNIgOJlDUOrb//43o/yez
+        5SlSHdj/z4bz/5N56vBgsWzabDn9f2Xi8vZB3/sMVKfz592A/9/Nvx82dF9a
+        7bgJ1M+DUers/vwa7f9feHmWr8rqGuN9bsfw/+XxFI3OZO5mcpkt8uwyK8ps
+        UiKo+f/u6KZl1jTF9ItqUpT5a8rIF8SR9Nr/d0dEqH6RLSmqw0QdT6cVrWJ2
+        R/T/0TiY85/uRf5Tvw/+VDj8QQcvFzmjZfCBxYM+xZcE9ecmlGZWsBN+6zm+
+        O62Wy3wqc/yj+ZZu3fSiZfCBxYM+xZcE9f+r8308/f9Lqovn0L3If+r3wZ8K
+        hz/o4OVmGC2DDywe9Cm+JKj/35py+vRHc+3h5aYWLYMPLB70Kb4kqP+fm+sf
+        TbTp1s0rWgYfWDzoU3xJUP8/MdHBRHvK/EeTbrp1c4yWwQcWD/oUXxLU/3dM
+        Oss34qNmlU0h3C/yq1d5WUzHxy+/IJC+6ANKXxkoW1DbgAuENgZDJqKgF3zE
+        w+HfmAL8m7xpqcpN7F8MA4RkatEH/B7/Hh0xRSo7NGJqyH+YOKQ37Nf5cnZR
+        F7Px6YLiRGruDxPAbj1wh9AQtjxK/Y15j4fIn8rYAxIxjPCj4A95xRKIYdm/
+        RLLQl/0DDeiPjpQ6VtXG7gNugkHEKUyBIXgqStT1lMLT5gmlS94245Myz+qn
+        Twi2T0mA6dF2lrXZJGvoyw5xO1gHhADim+ksBMAn9g+lhhAxACcfWUpyl6CC
+        6QJvuq/5L34vRjj/U+2ev/R7jBKX2JX+B+ISaTtEmpYEk5oTsB/RiGmE//4f
+        snsHe6cmAQA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:11 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestUS/vmSizes?api-version=2015-06-15
@@ -360,11 +371,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -389,18 +400,18 @@ http_interactions:
       X-Ms-Served-By:
       - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130855169261357120
       X-Ms-Request-Id:
-      - 71a48f45-6211-4810-a389-e1849e6ca98b
+      - 9cfd6f29-499f-4e50-821f-bf0774b013aa
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14754'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - b9984861-88e6-43bf-9c6f-473d410d0afc
+      - 72d607cd-6199-44ea-929f-85d7a51d31a8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161608Z:b9984861-88e6-43bf-9c6f-473d410d0afc
+      - EASTUS:20150922T133528Z:72d607cd-6199-44ea-929f-85d7a51d31a8
       Date:
-      - Wed, 09 Sep 2015 16:16:08 GMT
+      - Tue, 22 Sep 2015 13:35:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -428,7 +439,7 @@ http_interactions:
         hP5QusPsD+V9GOxnPdLvGUJ/LN1x9sfyfiy2SVyGrCQjctvR9AyhP5reUPvD
         sVYSP77/Gye/5P8B+lw3CX4gAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:11 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/AustraliaEast/vmSizes?api-version=2015-06-15
@@ -441,11 +452,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -462,27 +473,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 4b62b50b-3541-4abd-a4ec-1927b6e3c005
+      - 664d48c5-e5c9-47ff-9eea-6e0689f01f08
       X-Ms-Correlation-Request-Id:
-      - 4b62b50b-3541-4abd-a4ec-1927b6e3c005
+      - 664d48c5-e5c9-47ff-9eea-6e0689f01f08
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161610Z:4b62b50b-3541-4abd-a4ec-1927b6e3c005
+      - EASTUS:20150922T133528Z:664d48c5-e5c9-47ff-9eea-6e0689f01f08
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:09 GMT
+      - Tue, 22 Sep 2015 13:35:27 GMT
       Content-Length:
-      - '439'
+      - '419'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''AustraliaEast'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:13 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/AustraliaSoutheast/vmSizes?api-version=2015-06-15
@@ -495,11 +506,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -516,27 +527,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 7564955b-2d97-46d3-9263-bd77e2b40257
+      - a6112219-0889-4c1a-8af6-0a04e8e3d5a0
       X-Ms-Correlation-Request-Id:
-      - 7564955b-2d97-46d3-9263-bd77e2b40257
+      - a6112219-0889-4c1a-8af6-0a04e8e3d5a0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161610Z:7564955b-2d97-46d3-9263-bd77e2b40257
+      - EASTUS:20150922T133528Z:a6112219-0889-4c1a-8af6-0a04e8e3d5a0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:10 GMT
+      - Tue, 22 Sep 2015 13:35:28 GMT
       Content-Length:
-      - '444'
+      - '424'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''AustraliaSoutheast'' and API version
         ''2015-06-15'' for type ''locations/vmSizes''. The supported api-versions
-        are ''2014-12-01-preview, 2015-05-01-preview, 2015-06-15''. The supported
-        locations are ''eastus, eastus2, westus, centralus, northcentralus, southcentralus,
-        northeurope, westeurope, eastasia, southeastasia, japaneast, japanwest''."}}'
+        are ''2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus,
+        eastus2, westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
+        eastasia, southeastasia, japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:13 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralUS/vmSizes?api-version=2015-06-15
@@ -549,11 +560,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -576,20 +587,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - d0384330-e545-43f0-a33e-6355987bc2f8_130841918403972752
+      - d0384330-e545-43f0-a33e-6355987bc2f8_130816036240523800
       X-Ms-Request-Id:
-      - 012a2417-43d4-4884-bf27-1af204564945
+      - 43b5852d-35fd-41df-b94d-185b5bf4461f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14721'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - e3bf252f-9886-4b4b-ad53-d7d49db6ebe8
+      - 68740592-aecc-4736-96b5-d2de72d2eb24
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161610Z:e3bf252f-9886-4b4b-ad53-d7d49db6ebe8
+      - EASTUS:20150922T133529Z:68740592-aecc-4736-96b5-d2de72d2eb24
       Date:
-      - Wed, 09 Sep 2015 16:16:10 GMT
+      - Tue, 22 Sep 2015 13:35:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -609,7 +620,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:13 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS/vmSizes?api-version=2015-06-15
@@ -622,11 +633,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -649,20 +660,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - f43831ce-5ddb-4c37-be9f-4ae89ba8f428
+      - f504d544-9759-49bb-9805-17550dc63c5c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14609'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - 374c0a6e-cc24-4474-a4d1-95ab38ecb086
+      - 13d25851-b18a-4930-9ce9-81e19bd3e606
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161610Z:374c0a6e-cc24-4474-a4d1-95ab38ecb086
+      - EASTUS:20150922T133529Z:13d25851-b18a-4930-9ce9-81e19bd3e606
       Date:
-      - Wed, 09 Sep 2015 16:16:10 GMT
+      - Tue, 22 Sep 2015 13:35:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -682,7 +693,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
         Ktcfyzc6MccPNwzlG5mXjWO5xbzYweDH93/j5Jf8P459xE4rEgAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:14 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS2/vmSizes?api-version=2015-06-15
@@ -695,11 +706,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -722,20 +733,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 772c4f26-4447-4b91-947d-0c7008c93042_130856936580485914
+      - 772c4f26-4447-4b91-947d-0c7008c93042_130815979149733956
       X-Ms-Request-Id:
-      - 1d200207-3e3d-49d1-aa2c-427a557821fe
+      - 657f6316-cdd1-47c6-b234-93de20202f86
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14804'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - 071d7269-0eab-420c-bca7-ebb6c5ca5bc9
+      - b3da82b6-879b-4fd8-a0e1-55504e1e681b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161611Z:071d7269-0eab-420c-bca7-ebb6c5ca5bc9
+      - EASTUS:20150922T133529Z:b3da82b6-879b-4fd8-a0e1-55504e1e681b
       Date:
-      - Wed, 09 Sep 2015 16:16:10 GMT
+      - Tue, 22 Sep 2015 13:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -762,7 +773,7 @@ http_interactions:
         z8r78NfPekTZNYT+ULrD7A/lfRjsZz2i7BlCfyzdcfbH8n4stklcvhEr2TOE
         /mh6Q+0Px1pJ/Pj+b5z8kv8Hiegpl+YeAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:14 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthCentralUS/vmSizes?api-version=2015-06-15
@@ -775,53 +786,67 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
-      code: 502
-      message: Forbidden
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '115'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
       Expires:
       - "-1"
+      Vary:
+      - Accept-Encoding
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 7c62b12c-d882-44db-9576-141ebc6501ac_130837949188104606
+      - 7c62b12c-d882-44db-9576-141ebc6501ac_130825254263102756
       X-Ms-Request-Id:
-      - 9ff46040-98df-4e7c-b804-dfa070b2a53e
+      - 6c266af9-dd2c-4c2c-8aaa-28971250073e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
-      X-Ms-Failure-Cause:
-      - service
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14774'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 76d70aef-c7fd-4110-8b55-dff0b0e62509
+      - 90cdb1a6-fd82-4b93-b606-5d3921ed20ca
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161611Z:76d70aef-c7fd-4110-8b55-dff0b0e62509
+      - EASTUS:20150922T133529Z:90cdb1a6-fd82-4b93-b606-5d3921ed20ca
       Date:
-      - Wed, 09 Sep 2015 16:16:11 GMT
-      Connection:
-      - close
+      - Tue, 22 Sep 2015 13:35:29 GMT
     body:
-      encoding: UTF-8
-      string: "{\r\n  \"error\": {\r\n    \"code\": \"SubscriptionNotRegistered\",\r\n
-        \   \"message\": \"Subscription is not registered.\"\r\n  }\r\n}"
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/LtbYZyf8NQPES/9lA2
+        MtfNQ3kP7vp0w0h+1rlr7+DTBx6IyEjeg70ebBjJzzp73X9wb98jV2QkN7PX
+        k6wppv8ftyM6hp9tI7K/8/DToTF8uBHRQfxsW5BPd/cHJePDDYgO4mfbeuzu
+        7R0Ms9MHWw8dxc+26djbv/9gmKFu1Lc3y7ZVU09/tkXj/u7eztBIbuSqG0XD
+        jeNnWzp2d8gCDg3kRsa6UTzcQH62JYT17dBAbuatG0XEjeRnW0pY6w6N5GZb
+        /l5SsklMvG6+9lh2N7HXzbPyHvy1u0lSftYZ7OZpeQ8G290kKz/rHPZN+Fje
+        WDZJy643+197MAe7D4dV8e7u/qcHHskio7l3e218fLBhMF4vX3ss9x7uhirX
+        H8s3OjHHDzcM5RuZl41jucW82MHgx/d/4+SX/D8NTgNIKxIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:14 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SouthCentralUS/vmSizes?api-version=2015-06-15
@@ -834,11 +859,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -863,18 +888,18 @@ http_interactions:
       X-Ms-Served-By:
       - fc40acc7-ed1e-42ad-b741-4062ad55bf5e_130857118179167515
       X-Ms-Request-Id:
-      - c1ea29eb-cd5f-4d44-ac06-114715e06822
+      - 7ab9bb18-19ca-478d-a3fa-92366cc5b612
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14794'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - dcd4c08b-f63d-4ff0-b0ba-de523567c738
+      - 6a996e0a-5805-4299-ba77-1e8f068fb160
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161612Z:dcd4c08b-f63d-4ff0-b0ba-de523567c738
+      - EASTUS:20150922T133530Z:6a996e0a-5805-4299-ba77-1e8f068fb160
       Date:
-      - Wed, 09 Sep 2015 16:16:12 GMT
+      - Tue, 22 Sep 2015 13:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -894,7 +919,7 @@ http_interactions:
         /2sP5mD34bAq3t3d//TAI1lkNPdur42PDzYMxuvla4/l3sPdUOX6Y/lGJ+b4
         4YahfCPzsnEst5gXOxj8+P5vnPyS/we/VNoCKxIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:15 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthEurope/vmSizes?api-version=2015-06-15
@@ -907,11 +932,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -936,18 +961,18 @@ http_interactions:
       X-Ms-Served-By:
       - bb344ebd-a325-41d8-9824-737950975d04_130841567632133308
       X-Ms-Request-Id:
-      - 188e9791-a015-4d06-b570-1bd98bee772e
+      - 42fe2ce1-c880-4c83-bd04-1975e0099583
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14803'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 6d33f9e2-55e9-4441-8d20-84ee05835eb5
+      - 981e9eb7-dd14-482a-af0d-866ab0ee6710
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161612Z:6d33f9e2-55e9-4441-8d20-84ee05835eb5
+      - EASTUS:20150922T133530Z:981e9eb7-dd14-482a-af0d-866ab0ee6710
       Date:
-      - Wed, 09 Sep 2015 16:16:12 GMT
+      - Tue, 22 Sep 2015 13:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -967,7 +992,7 @@ http_interactions:
         /2sP5mD34bAq3t3d//TAI1lkNPdur42PDzYMxuvla4/l3sPdUOX6Y/lGJ+b4
         4YahfCPzsnEst5gXOxj8+P5vnPyS/we/VNoCKxIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:15 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestEurope/vmSizes?api-version=2015-06-15
@@ -980,11 +1005,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1007,20 +1032,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 7147639b-1e2e-4238-a5eb-b3bdfc3af2dc_130855174230110197
+      - 7147639b-1e2e-4238-a5eb-b3bdfc3af2dc_130856447109702442
       X-Ms-Request-Id:
-      - 8e0f71ad-97dd-4cd3-8bd3-3bfb70b5aefa
+      - 10e34af6-da0f-4e94-8798-24e4c33cd769
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14608'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 81e87ac1-0675-4f4d-b1b7-c68ef14175c4
+      - 64abe71f-0c73-4057-b8ce-1ba89dfcf716
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161613Z:81e87ac1-0675-4f4d-b1b7-c68ef14175c4
+      - EASTUS:20150922T133531Z:64abe71f-0c73-4057-b8ce-1ba89dfcf716
       Date:
-      - Wed, 09 Sep 2015 16:16:13 GMT
+      - Tue, 22 Sep 2015 13:35:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1037,18 +1062,18 @@ http_interactions:
         8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
         UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
         aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bfz5z7a43Ht4b88nSjCW
-        m3ns9uLy+c+2tDw4+HT/ntcsGMnNLHZ7afn8Z1tYdu8/IMr76PpDuQWDvYe4
-        fP6zLi33dsnF3/MR9kezt/fw3gOvm8ho3kdcNvn4PnN87dF8Sr7x/n0fYX80
-        +/cPHvhAIqP59D1E5vXPtvR3xcIfC7HgNyf8r3+2pb8nFf5QusPsD+U9pP/1
-        z7b490TCH0pvnP2xvI/0v/5ZF/+eSPij6Q21P5r3kf7XP+vi/3D3wf0dn5X8
-        0fSG2h/Ne0j/8cGGwXgc8LXHcu/hbhht+WO5WWTeg82OH24YyjfCZRvH8s3K
-        zNONWvmbiPQ7QbA/lG8y0N+okz0sv/Y49g4efOq1CgbSGWN/ILcXlKcbNbJH
-        rp+VgdwcUt7etjzdqI49en3tkZAnFoi1P5KbDf77SckmMfH6+dpj6eLrj+Xm
-        WXkf/vpZj/S72tYfSneY/aG8D4P9rEf6PWXrj6U7zv5Y3o/FNonLkF1hRG47
-        mp6D4o+mN9T+cKz3gh/f/42TX/L/AGpBnP9+IAAA
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjufce2vj1Jnn5JsxKR+P6Q/km
+        rcrrTcLiYfm1x7F38OBTr1UwkM4Y+wN5D6l/vUlUPHL9rAzkZv31HkL/epOg
+        ePT62iO5/2AvkGt/JDerr/eR+de7m8TE6+drj6WLrz+Wm2flffjrZ92sdNWt
+        P5TuMPtDeR8G+1k3Kz1l64+lO87+WN6PxTaJyzdiV/b2Ht574AEKRtMban84
+        72FXPv/Zlpd7D+/t+UQJxnIzl91eYD7/2RaXBwef7t/zmgUjuZnHbi8vn/+s
+        SwspZBqMaxcM5RYM9h7y8vnPurTc26XU0Z6PsD+aniz1R/M+4rIpd+Qzx9ce
+        zaeUc9m/7yPsj2b//sEDH0hkNJ++h8hsdCq9br72aLpi4Y+FWPCbE/6NbqWH
+        wdceSU8q/KF0h9kfyntI/0bH0sPgaw+lJxL+UHrj7I/lfaR/o2/5jYh/TyT8
+        0fSG2h/N+0j/65918X+4++D+js9K/mh6Q+2P5j2k//hgw2A8DvjaY7n3cDeM
+        t/yx3Cwy78Fmxw83DGWIyxiNb2Qs7yMz+PH93zj5Jf8PJ1HupH4gAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:16 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastAsia/vmSizes?api-version=2015-06-15
@@ -1061,11 +1086,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1088,20 +1113,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 87669224-8edb-4099-85ed-2799f5f9b5ce_130816178115351722
+      - 87669224-8edb-4099-85ed-2799f5f9b5ce_130822667094478250
       X-Ms-Request-Id:
-      - 02fb578e-5458-4b7d-8158-37449b7898e9
+      - 3080ce52-6d08-4efe-8d12-8129e42a999c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14607'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - f6a2d1fd-a4fd-4d52-9e40-a6aa707b83f1
+      - 7bc67380-fcff-4565-9eac-818194bb5cab
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161614Z:f6a2d1fd-a4fd-4d52-9e40-a6aa707b83f1
+      - EASTUS:20150922T133532Z:7bc67380-fcff-4565-9eac-818194bb5cab
       Date:
-      - Wed, 09 Sep 2015 16:16:14 GMT
+      - Tue, 22 Sep 2015 13:35:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1121,7 +1146,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:17 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SoutheastAsia/vmSizes?api-version=2015-06-15
@@ -1134,11 +1159,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1161,20 +1186,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 5766a2f8-6aed-48ac-b876-204ebc3aecb8_130832035741435100
+      - 5766a2f8-6aed-48ac-b876-204ebc3aecb8_130838925153952052
       X-Ms-Request-Id:
-      - d9b9d108-c803-41f4-a79a-e53c40a96a8b
+      - dea6eea2-8488-43bf-a510-333ae23b6678
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14753'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 5f9051bc-b144-463b-8291-579931aa7a99
+      - 203bc185-0df6-4aac-92a4-2fd4fc848390
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161615Z:5f9051bc-b144-463b-8291-579931aa7a99
+      - EASTUS:20150922T133534Z:203bc185-0df6-4aac-92a4-2fd4fc848390
       Date:
-      - Wed, 09 Sep 2015 16:16:15 GMT
+      - Tue, 22 Sep 2015 13:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1197,7 +1222,7 @@ http_interactions:
         YD/rZqWnbP2xdMfZH8v7sdgmcflG7Mre3sN7DzxAwWh6Q+0Px9oV/Pj+b5z8
         kv8HuPmU0+sWAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:19 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/JapanEast/vmSizes?api-version=2015-06-15
@@ -1210,11 +1235,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1239,18 +1264,18 @@ http_interactions:
       X-Ms-Served-By:
       - 7d6892c1-2e0d-495d-9582-fb397c5a0378_130816136595468189
       X-Ms-Request-Id:
-      - da133de6-1dcd-40af-97a4-d579acb8ab62
+      - a6ff13b5-4cdd-4168-9d91-a30cb8415fd8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14773'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - e2924a04-e73b-4144-b284-3f0b1707c6e2
+      - 83edf09b-c9bc-4d9f-b0f4-2c127806960a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161616Z:e2924a04-e73b-4144-b284-3f0b1707c6e2
+      - EASTUS:20150922T133535Z:83edf09b-c9bc-4d9f-b0f4-2c127806960a
       Date:
-      - Wed, 09 Sep 2015 16:16:16 GMT
+      - Tue, 22 Sep 2015 13:35:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1273,7 +1298,7 @@ http_interactions:
         I+Eoa2gkNyuw9xH63U1i4nXztceyu4m9bp6V9+Cvn3WzspHBbp6W92Cwn3Wz
         spHDvlmz8rNvVQ52Hw6r4vexKvjx/d84+SX/D5kL4gSDGAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:19 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:37 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/JapanWest/vmSizes?api-version=2015-06-15
@@ -1286,11 +1311,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1313,20 +1338,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - fc53dbcb-0031-4257-b5fa-88f40bc084fc_130816135595421386
+      - fc53dbcb-0031-4257-b5fa-88f40bc084fc_130816135595421385
       X-Ms-Request-Id:
-      - ece5be83-5807-491c-b0f5-531d726fc3df
+      - 30e22e92-4f70-4b14-a97f-8b6bf746206b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14793'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - e85b3514-540f-4dfe-89be-9797cf481975
+      - 9e97a4a3-fb38-4a65-8e44-5b3b6c953e04
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161617Z:e85b3514-540f-4dfe-89be-9797cf481975
+      - EASTUS:20150922T133536Z:9e97a4a3-fb38-4a65-8e44-5b3b6c953e04
       Date:
-      - Wed, 09 Sep 2015 16:16:17 GMT
+      - Tue, 22 Sep 2015 13:35:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1349,7 +1374,7 @@ http_interactions:
         dbOykcFunpb3YLCfdbOykcO+WbPys29VDnYfDqvi97Eq+PH93zj5Jf8P0E9I
         R+sWAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:20 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/BrazilSouth/vmSizes?api-version=2015-06-15
@@ -1362,11 +1387,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1383,27 +1408,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - c758f43f-6328-45f5-8263-e9a87547a90a
+      - ef26bb71-5e20-4b26-9c23-7b33c056d7cb
       X-Ms-Correlation-Request-Id:
-      - c758f43f-6328-45f5-8263-e9a87547a90a
+      - ef26bb71-5e20-4b26-9c23-7b33c056d7cb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161617Z:c758f43f-6328-45f5-8263-e9a87547a90a
+      - EASTUS:20150922T133536Z:ef26bb71-5e20-4b26-9c23-7b33c056d7cb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:17 GMT
+      - Tue, 22 Sep 2015 13:35:36 GMT
       Content-Length:
-      - '437'
+      - '417'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''BrazilSouth'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestIndia/vmSizes?api-version=2015-06-15
@@ -1416,11 +1441,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1437,27 +1462,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 778f68ab-bbda-4697-8c5e-750479ee5e6c
+      - 1da760ed-a434-4417-976a-60b221b1d070
       X-Ms-Correlation-Request-Id:
-      - 778f68ab-bbda-4697-8c5e-750479ee5e6c
+      - 1da760ed-a434-4417-976a-60b221b1d070
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161618Z:778f68ab-bbda-4697-8c5e-750479ee5e6c
+      - EASTUS:20150922T133536Z:1da760ed-a434-4417-976a-60b221b1d070
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:17 GMT
+      - Tue, 22 Sep 2015 13:35:36 GMT
       Content-Length:
-      - '435'
+      - '415'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''WestIndia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SouthIndia/vmSizes?api-version=2015-06-15
@@ -1470,11 +1495,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1491,27 +1516,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 46a5f8ba-8ade-4bbb-882f-42a4f2079923
+      - 67a4ddf7-378a-45a3-9d5d-4d92342627ea
       X-Ms-Correlation-Request-Id:
-      - 46a5f8ba-8ade-4bbb-882f-42a4f2079923
+      - 67a4ddf7-378a-45a3-9d5d-4d92342627ea
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161618Z:46a5f8ba-8ade-4bbb-882f-42a4f2079923
+      - EASTUS:20150922T133537Z:67a4ddf7-378a-45a3-9d5d-4d92342627ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:17 GMT
+      - Tue, 22 Sep 2015 13:35:36 GMT
       Content-Length:
-      - '436'
+      - '416'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''SouthIndia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralIndia/vmSizes?api-version=2015-06-15
@@ -1524,11 +1549,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1545,27 +1570,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - d03ec4d6-a14f-43c2-b913-240607a739c0
+      - 45bd994a-87e9-4f09-8f13-c79f1569a9fe
       X-Ms-Correlation-Request-Id:
-      - d03ec4d6-a14f-43c2-b913-240607a739c0
+      - 45bd994a-87e9-4f09-8f13-c79f1569a9fe
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161618Z:d03ec4d6-a14f-43c2-b913-240607a739c0
+      - EASTUS:20150922T133537Z:45bd994a-87e9-4f09-8f13-c79f1569a9fe
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:17 GMT
+      - Tue, 22 Sep 2015 13:35:36 GMT
       Content-Length:
-      - '438'
+      - '418'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''CentralIndia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:21 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestUS/vmSizes?api-version=2015-06-15
@@ -1578,11 +1603,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1607,18 +1632,18 @@ http_interactions:
       X-Ms-Served-By:
       - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130855169261357120
       X-Ms-Request-Id:
-      - 558e866b-9737-46a9-8002-34c8fc0230fc
+      - 5de960d3-243a-4e19-a9f9-d3fab42ba8d5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14720'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 07b74ed9-7812-4110-9e27-959510428646
+      - 47cb3c86-3775-4b52-b336-9d9f1150ce98
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161618Z:07b74ed9-7812-4110-9e27-959510428646
+      - EASTUS:20150922T133537Z:47cb3c86-3775-4b52-b336-9d9f1150ce98
       Date:
-      - Wed, 09 Sep 2015 16:16:18 GMT
+      - Tue, 22 Sep 2015 13:35:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1646,7 +1671,7 @@ http_interactions:
         hP5QusPsD+V9GOxnPdLvGUJ/LN1x9sfyfiy2SVyGrCQjctvR9AyhP5reUPvD
         sVYSP77/Gye/5P8B+lw3CX4gAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS2/vmSizes?api-version=2015-06-15
@@ -1659,11 +1684,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -1686,20 +1711,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 772c4f26-4447-4b91-947d-0c7008c93042_130856936580485914
+      - 772c4f26-4447-4b91-947d-0c7008c93042_130815979149733956
       X-Ms-Request-Id:
-      - b49a357b-2c87-48e0-a339-d6226d1fe257
+      - f4960b79-9cf6-4b90-ad5c-3c497e1b2f7c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14719'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 2f48ab0c-a047-41e5-be1a-c635e4d45068
+      - 514f8e46-855e-41b5-896b-36707c05c5ab
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161619Z:2f48ab0c-a047-41e5-be1a-c635e4d45068
+      - EASTUS:20150922T133537Z:514f8e46-855e-41b5-896b-36707c05c5ab
       Date:
-      - Wed, 09 Sep 2015 16:16:18 GMT
+      - Tue, 22 Sep 2015 13:35:37 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1726,7 +1751,7 @@ http_interactions:
         z8r78NfPekTZNYT+ULrD7A/lfRjsZz2i7BlCfyzdcfbH8n4stklcvhEr2TOE
         /mh6Q+0Px1pJ/Pj+b5z8kv8Hiegpl+YeAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthCentralUS/vmSizes?api-version=2015-06-15
@@ -1739,53 +1764,67 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
-      code: 502
-      message: Forbidden
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '115'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
       Expires:
       - "-1"
+      Vary:
+      - Accept-Encoding
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 7c62b12c-d882-44db-9576-141ebc6501ac_130837949188104606
+      - 7c62b12c-d882-44db-9576-141ebc6501ac_130825254263102756
       X-Ms-Request-Id:
-      - 4e7b3da5-dd26-47c6-aec6-1b92196b4592
+      - bc6ef8b4-23e8-4d20-b6d0-72750cc3e488
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
-      X-Ms-Failure-Cause:
-      - service
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14749'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 653c0e15-7d52-4d53-a0f6-bc5eb61982e8
+      - b969470a-2794-4397-8404-71350486e063
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161619Z:653c0e15-7d52-4d53-a0f6-bc5eb61982e8
+      - EASTUS:20150922T133538Z:b969470a-2794-4397-8404-71350486e063
       Date:
-      - Wed, 09 Sep 2015 16:16:19 GMT
-      Connection:
-      - close
+      - Tue, 22 Sep 2015 13:35:37 GMT
     body:
-      encoding: UTF-8
-      string: "{\r\n  \"error\": {\r\n    \"code\": \"SubscriptionNotRegistered\",\r\n
-        \   \"message\": \"Subscription is not registered.\"\r\n  }\r\n}"
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/LtbYZyf8NQPES/9lA2
+        MtfNQ3kP7vp0w0h+1rlr7+DTBx6IyEjeg70ebBjJzzp73X9wb98jV2QkN7PX
+        k6wppv8ftyM6hp9tI7K/8/DToTF8uBHRQfxsW5BPd/cHJePDDYgO4mfbeuzu
+        7R0Ms9MHWw8dxc+26djbv/9gmKFu1Lc3y7ZVU09/tkXj/u7eztBIbuSqG0XD
+        jeNnWzp2d8gCDg3kRsa6UTzcQH62JYT17dBAbuatG0XEjeRnW0pY6w6N5GZb
+        /l5SsklMvG6+9lh2N7HXzbPyHvy1u0lSftYZ7OZpeQ8G290kKz/rHPZN+Fje
+        WDZJy643+197MAe7D4dV8e7u/qcHHskio7l3e218fLBhMF4vX3ss9x7uhirX
+        H8s3OjHHDzcM5RuZl41jucW82MHgx/d/4+SX/D8NTgNIKxIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/global/vmSizes?api-version=2015-06-15
@@ -1798,11 +1837,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1819,27 +1858,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - a03c45e8-56bb-4eb1-b6c0-ac4f10975eaa
+      - d295ccd3-f37b-4ee6-b6a6-dad4a4754edc
       X-Ms-Correlation-Request-Id:
-      - a03c45e8-56bb-4eb1-b6c0-ac4f10975eaa
+      - d295ccd3-f37b-4ee6-b6a6-dad4a4754edc
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161619Z:a03c45e8-56bb-4eb1-b6c0-ac4f10975eaa
+      - EASTUS:20150922T133538Z:d295ccd3-f37b-4ee6-b6a6-dad4a4754edc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:19 GMT
+      - Tue, 22 Sep 2015 13:35:37 GMT
       Content-Length:
-      - '432'
+      - '412'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''global'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTWestUS/vmSizes?api-version=2015-06-15
@@ -1852,11 +1891,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1873,27 +1912,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 9b33fea7-b065-4d27-acf4-5ce4db21be60
+      - 9cc2da2a-a9e4-4212-bede-e8c9525388cf
       X-Ms-Correlation-Request-Id:
-      - 9b33fea7-b065-4d27-acf4-5ce4db21be60
+      - 9cc2da2a-a9e4-4212-bede-e8c9525388cf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161619Z:9b33fea7-b065-4d27-acf4-5ce4db21be60
+      - EASTUS:20150922T133538Z:9cc2da2a-a9e4-4212-bede-e8c9525388cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:19 GMT
+      - Tue, 22 Sep 2015 13:35:37 GMT
       Content-Length:
-      - '436'
+      - '416'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''MSFTWestUS'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:22 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTEastUS/vmSizes?api-version=2015-06-15
@@ -1906,11 +1945,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1927,27 +1966,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - a55fdf31-a2ca-4ac5-bef5-f7c6add546bb
+      - c11e867a-7f58-4781-9f36-7c97be3e8ecd
       X-Ms-Correlation-Request-Id:
-      - a55fdf31-a2ca-4ac5-bef5-f7c6add546bb
+      - c11e867a-7f58-4781-9f36-7c97be3e8ecd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161620Z:a55fdf31-a2ca-4ac5-bef5-f7c6add546bb
+      - EASTUS:20150922T133538Z:c11e867a-7f58-4781-9f36-7c97be3e8ecd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:19 GMT
+      - Tue, 22 Sep 2015 13:35:38 GMT
       Content-Length:
-      - '436'
+      - '416'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''MSFTEastUS'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTEastAsia/vmSizes?api-version=2015-06-15
@@ -1960,11 +1999,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -1981,27 +2020,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 95716462-91af-4782-ba09-03b04cf61c95
+      - a9d569f1-df3a-4698-9bb2-21441b9e8f22
       X-Ms-Correlation-Request-Id:
-      - 95716462-91af-4782-ba09-03b04cf61c95
+      - a9d569f1-df3a-4698-9bb2-21441b9e8f22
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161620Z:95716462-91af-4782-ba09-03b04cf61c95
+      - EASTUS:20150922T133538Z:a9d569f1-df3a-4698-9bb2-21441b9e8f22
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:19 GMT
+      - Tue, 22 Sep 2015 13:35:38 GMT
       Content-Length:
-      - '438'
+      - '418'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''MSFTEastAsia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTNorthEurope/vmSizes?api-version=2015-06-15
@@ -2014,11 +2053,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 400
@@ -2035,27 +2074,27 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 595dc3ef-649c-4692-9056-bfbd2d9ee508
+      - 750d7014-3c70-4324-bd8a-685d112d2355
       X-Ms-Correlation-Request-Id:
-      - 595dc3ef-649c-4692-9056-bfbd2d9ee508
+      - 750d7014-3c70-4324-bd8a-685d112d2355
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161620Z:595dc3ef-649c-4692-9056-bfbd2d9ee508
+      - EASTUS:20150922T133539Z:750d7014-3c70-4324-bd8a-685d112d2355
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:19 GMT
+      - Tue, 22 Sep 2015 13:35:39 GMT
       Content-Length:
-      - '441'
+      - '421'
     body:
       encoding: UTF-8
       string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
         resource provider found for location ''MSFTNorthEurope'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2014-12-01-preview,
-        2015-05-01-preview, 2015-06-15''. The supported locations are ''eastus, eastus2,
-        westus, centralus, northcentralus, southcentralus, northeurope, westeurope,
-        eastasia, southeastasia, japaneast, japanwest''."}}'
+        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
+        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
+        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
+        japaneast, japanwest''."}}'
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastAsia/vmSizes?api-version=2015-06-15
@@ -2068,11 +2107,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2095,20 +2134,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 87669224-8edb-4099-85ed-2799f5f9b5ce_130816178115351722
+      - 87669224-8edb-4099-85ed-2799f5f9b5ce_130822667094478250
       X-Ms-Request-Id:
-      - f02e9d28-47fd-4960-97ab-2c056ad7f0e0
+      - b914e5db-bd89-4b0c-be7f-a545dd2e1026
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14602'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 81b41ac5-5a0b-442f-951e-da62c2b151bf
+      - 9dfabba6-ffc3-43f8-a7b0-32a28807c615
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161620Z:81b41ac5-5a0b-442f-951e-da62c2b151bf
+      - EASTUS:20150922T133540Z:9dfabba6-ffc3-43f8-a7b0-32a28807c615
       Date:
-      - Wed, 09 Sep 2015 16:16:20 GMT
+      - Tue, 22 Sep 2015 13:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2128,7 +2167,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:23 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralUS/vmSizes?api-version=2015-06-15
@@ -2141,11 +2180,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2168,20 +2207,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - d0384330-e545-43f0-a33e-6355987bc2f8_130841918403972752
+      - d0384330-e545-43f0-a33e-6355987bc2f8_130816036240523800
       X-Ms-Request-Id:
-      - 521a9518-055b-46d4-bae6-73c81cdd81a5
+      - 001748fb-1e26-4eb9-97dd-605bd55fb5bf
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14795'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 06fb8301-9868-41dd-bc4c-a3a5b480760f
+      - 0598762f-0f7c-4a5b-8f8b-8254bc7e65b3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161621Z:06fb8301-9868-41dd-bc4c-a3a5b480760f
+      - EASTUS:20150922T133540Z:0598762f-0f7c-4a5b-8f8b-8254bc7e65b3
       Date:
-      - Wed, 09 Sep 2015 16:16:20 GMT
+      - Tue, 22 Sep 2015 13:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2201,7 +2240,7 @@ http_interactions:
         N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
         EAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
@@ -2214,11 +2253,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2237,17 +2276,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14599'
+      - '14986'
       X-Ms-Request-Id:
-      - adffbff2-5123-4e05-a323-548485c007af
+      - 4051fad3-c176-41b2-b355-85b5ecb037ac
       X-Ms-Correlation-Request-Id:
-      - adffbff2-5123-4e05-a323-548485c007af
+      - 4051fad3-c176-41b2-b355-85b5ecb037ac
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:adffbff2-5123-4e05-a323-548485c007af
+      - EASTUS:20150922T133540Z:4051fad3-c176-41b2-b355-85b5ecb037ac
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:21 GMT
+      - Tue, 22 Sep 2015 13:35:40 GMT
       Content-Length:
       - '373'
     body:
@@ -2263,287 +2302,7 @@ http_interactions:
         c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq/PxzL
         7/+S/wf1Haxm0wQAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14794'
-      X-Ms-Request-Id:
-      - 108bf6f4-c163-453b-8e03-257e6f4854ab
-      X-Ms-Correlation-Request-Id:
-      - 108bf6f4-c163-453b-8e03-257e6f4854ab
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:108bf6f4-c163-453b-8e03-257e6f4854ab
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 09 Sep 2015 16:16:21 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14715'
-      X-Ms-Request-Id:
-      - b5c94d58-2f43-4df5-977a-0faa7c172eb8
-      X-Ms-Correlation-Request-Id:
-      - b5c94d58-2f43-4df5-977a-0faa7c172eb8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:b5c94d58-2f43-4df5-977a-0faa7c172eb8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14793'
-      X-Ms-Request-Id:
-      - 2e980b4d-07ca-4fbb-a822-ceae951f834d
-      X-Ms-Correlation-Request-Id:
-      - 2e980b4d-07ca-4fbb-a822-ceae951f834d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:2e980b4d-07ca-4fbb-a822-ceae951f834d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 09 Sep 2015 16:16:21 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14598'
-      X-Ms-Request-Id:
-      - 86ac6a27-e0c3-4b0f-a798-6663bfc2c429
-      X-Ms-Correlation-Request-Id:
-      - 86ac6a27-e0c3-4b0f-a798-6663bfc2c429
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:86ac6a27-e0c3-4b0f-a798-6663bfc2c429
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 09 Sep 2015 16:16:21 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14714'
-      X-Ms-Request-Id:
-      - ffb8eb8f-0aae-42fd-8469-16c901d2f960
-      X-Ms-Correlation-Request-Id:
-      - ffb8eb8f-0aae-42fd-8469-16c901d2f960
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:ffb8eb8f-0aae-42fd-8469-16c901d2f960
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
@@ -2556,11 +2315,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2583,20 +2342,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - ef18827a-74ad-413c-9273-9fd99f9da5e2
+      - 41f22ab9-1b57-4420-8693-f24fbfa871f1
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14716'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - ae16d8e7-aa1f-4669-b60a-92e1052fb43e
+      - 35946c3e-e9ac-4f42-8a2f-775a6486f012
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:ae16d8e7-aa1f-4669-b60a-92e1052fb43e
+      - EASTUS:20150922T133541Z:35946c3e-e9ac-4f42-8a2f-775a6486f012
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:40 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2606,11 +2365,12 @@ http_interactions:
         8rot8oa+tR/jizJrz6t68dVqlrX502qRFcuTar1sqd39UaThs2xdtmG7e367
         y6Ju11n5RTadF0vuTpGRx+sbz0fFjFp8dLdZT5ppXazaolo2d/c/3Tvfy84P
         tvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz2f7B/bt13lTrepp/XlfrVXP35Nun
-        z7Zfvvry6V0a62Uxy+vm7hfFtK6a6rwdn1SL1brN73awc2995OP1S9wf3ze/
-        /hI7yG8Q53l+vv2yrmYbcc4us6LMJkVZtNev87a5exx+sPeRQ22ZLTD/H21o
-        0l6vuMnNHXkvldU0wzjxYp417bpRgjGpiEi/5P8BPK5MPoECAAA=
+        z7Zfvvry6V0a62Uxy+vm7hfFtK6a6rwdn1SL1brN73awc2995OP1S7wB/b8O
+        5Zdfvn7z+avT19tPT38yxNr98X3zqxvJN4j2PD/ffllXs41oZ5dZUWaToiza
+        69d529w9Dj/Y+8ihtswW4NqPNjRpr1fc5OaOvJfKapphnHgxz5p23SjBmFRE
+        pF/y/wAyNDwxNwMAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
@@ -2623,11 +2383,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2650,20 +2410,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - ab2ec26a-5e20-4a2d-aa25-ea589c6b086b
+      - 09aab6d0-f85f-421a-9eb5-e34ef418ec37
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14766'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 23096cda-d671-4f2b-b9ee-2b691459b079
+      - 7781132e-cdb6-448e-816e-0dc5545e62de
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:23096cda-d671-4f2b-b9ee-2b691459b079
+      - EASTUS:20150922T133541Z:7781132e-cdb6-448e-816e-0dc5545e62de
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:40 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2676,12 +2436,13 @@ http_interactions:
         Xn715vQnv3h9lwZ7Wczyurn7RTGtq6Y6b8cn1WK1bvO7HfTunnz79Nnr01c/
         efpq9yMftV/ijen/fVifvnr5/yFsvzj7ib0QXffH982vbgjfIL6C0E9+0WzE
         N7vMijKbFGXRXr/O2+bucfjB7kcOt2W2gIB9tKFJe73iJjd35L1UVtMMA8WL
-        eda060YpxrQiKv2S/wckkSE04gMAAA==
+        eda060YpZuhiJ/VHsmzI2UHv7uuXpyfbP/nFjlJOHkM/ef5finJH97g//l8p
+        Hovr40v6xeNeIxX9b75hYcAPoskv+X8Ar+8O+u8GAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2691,11 +2452,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2714,17 +2475,297 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14765'
+      - '14983'
       X-Ms-Request-Id:
-      - e0eacfe5-f2c9-449f-8392-96836ae91bf0
+      - 88227ab6-9f03-4012-8fc9-964367b9ddab
       X-Ms-Correlation-Request-Id:
-      - e0eacfe5-f2c9-449f-8392-96836ae91bf0
+      - 88227ab6-9f03-4012-8fc9-964367b9ddab
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161622Z:e0eacfe5-f2c9-449f-8392-96836ae91bf0
+      - EASTUS:20150922T133541Z:88227ab6-9f03-4012-8fc9-964367b9ddab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:41 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - d0f12d1a-7814-4f86-b4f2-5a34a81a4119
+      X-Ms-Correlation-Request-Id:
+      - d0f12d1a-7814-4f86-b4f2-5a34a81a4119
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133541Z:d0f12d1a-7814-4f86-b4f2-5a34a81a4119
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:41 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 7b1d927d-d26e-49bf-97e0-ced2c36a369d
+      X-Ms-Correlation-Request-Id:
+      - 7b1d927d-d26e-49bf-97e0-ced2c36a369d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133542Z:7b1d927d-d26e-49bf-97e0-ced2c36a369d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:41 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - d2556e17-8878-45d4-98e8-11c2da410f40
+      X-Ms-Correlation-Request-Id:
+      - d2556e17-8878-45d4-98e8-11c2da410f40
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133542Z:d2556e17-8878-45d4-98e8-11c2da410f40
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:42 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 25170235-01c3-4184-8325-13ead6865fdc
+      X-Ms-Correlation-Request-Id:
+      - 25170235-01c3-4184-8325-13ead6865fdc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133542Z:25170235-01c3-4184-8325-13ead6865fdc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:42 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 8d1f8ba9-19c5-49e1-97fb-950e1c202286
+      X-Ms-Correlation-Request-Id:
+      - 8d1f8ba9-19c5-49e1-97fb-950e1c202286
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133542Z:8d1f8ba9-19c5-49e1-97fb-950e1c202286
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:42 GMT
       Content-Length:
       - '373'
     body:
@@ -2740,10 +2781,10 @@ http_interactions:
         c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq/PxzL
         7/+S/wf1Haxm0wQAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:25 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2753,11 +2794,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2776,30 +2817,65 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14597'
+      - '14982'
       X-Ms-Request-Id:
-      - 89cbfd8f-7413-4b43-bff1-02eedef82882
+      - 8a79ed6c-bf03-474e-95e5-8ab0ea0fcaee
       X-Ms-Correlation-Request-Id:
-      - 89cbfd8f-7413-4b43-bff1-02eedef82882
+      - 8a79ed6c-bf03-474e-95e5-8ab0ea0fcaee
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:89cbfd8f-7413-4b43-bff1-02eedef82882
+      - EASTUS:20150922T133543Z:8a79ed6c-bf03-474e-95e5-8ab0ea0fcaee
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:42 GMT
       Content-Length:
-      - '133'
+      - '1683'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8ffLZaz6qp5
+        ndeXeb23s3Pwau/1y93tvZ3d+we793d37z+4f/+j0UfLbEF4ffTe763qapXX
+        bZE3Hz36xR+tsprgtHnNf5XVNMPA8Ht7vQL8121dLC/oPSXER3nWtOvmo19C
+        nxR1u87KL7LpvFjmLzLgM/zey6ppL4gU20/zy/7br4sfUKPht1+32XKW1bPf
+        /3gHL2ezRbH8qslrocLwe5O6WmYXc8a3aas6u8iPp9NqvWxvwndK00S0mt3f
+        3eMuFd8XeXtV1W9vettOMl5dyjtnS6LzeTa9kVQrQ6pZfrl/774H4nU+XddF
+        e82sdBOYLsWZaC+zpiFIxMvuRQDN9XW0u8yKMpsUJXX0Or+RUMdh8z2AmBXZ
+        xbJq2mLavP4gqpO40dBvemuWn2frssULq/WkLKZnq+PZjIbe3PRml0ad19/w
+        a8OvP70mBiymH/0SenVRzfDR2XJa55DprKSGNJbLoiGRoveIh1u0eL2eTvN8
+        ls/o+7ZY5E2bLVb0OSR1e+fh9u79N7ufPtrdebRzb/zgwc7up59++lPUdLau
+        VTg/evlmd++LB+N7Bw/2du69pu+mVV3nJX99RlP70d45CfvO/Wz73vkk297f
+        PZhsH0wPZtv3732a3/t0L/t0735OrzF2MxZ+UnA0lLxZEX8SAKdWTqrFak14
+        jz4igrAeA1HkDf8TeklFREW6oVeMQkFzozm+/0tGN7151/EPcVRLtBsGxuDi
+        qKus0qt+d3i9hwAxGZpaER3uj3rrvNvhmfd6V/tlEST5Ybkefp/+Iz7IV/ly
+        li+nrMJpKPJB8yVxBv31zZspyyWekVLS3lX8Hd3udpVXSHzC7RZAvJdEgPsq
+        kQjxwxmp8v/dLosGmsPh2xvkwPveKzrEACBY5ediXgew/dke7f+rZjOife6S
+        BVu23ihuO/AILA9KhBba08/V/BuR7Om0gELeEHqEGITgvRQZN4/4hztGVTuh
+        7n3vcUaheC9Gx/pD4/cOlk7F/hD1dLVuSTTIVv1icUHf12/vcFL/NXhf0skr
+        xYYaGZFxwxgS0XBqDBu+33sROfckuQNwkJ69Sbn55ZDvApw2vd2hKXUdvvl9
+        oqm+fPeb5FHSaTbkha+/Dayusjofy18cvOLXyXVVcuz6YJei13sH9/aIO4Rr
+        OEh4vxdJNH5Ogl478P6rP4p4vZfR9Tb3LV3r+wFz3wQjQIDJ9cOJdTsgXlIY
+        dl7Vi2eISJ9Wi6xYnoD6m8De2wDnq9WMwsZbAoLG6My6aPPhVyyfff7qNd52
+        iuwDQ/dBQO+LUSY66mWdnxfvNr24uzPeG++Md+7ufor3SG8RH92Etpc7kBfe
+        o5+9fbzW0aU3dRjwaefdm0jztfINz4ivBpINB9u7B292Hz66/+mje/vjnXsP
+        Dh7cjyQbHnxx/+H44f379w8+/TSWbnj44MGDvcm9/e1s/1OyCQf3su3swcNP
+        t2ef3pucf3r/fPLw/AG9xsjBQWHrTCOJxOxqbKk10YNtCGgib/if0Euqn1Sf
+        whkxqhzNjc6ORd2dNyPG+z2AdeR2+FV+OT5qFRB61QeO13vdhdL9tXpTjU6v
+        +rDxeq83pZS+Mdwb9dV5kyQJr1gT8D7vdqTivd7VflnR04yw6Rh+n/4jZudA
+        6/+1GRUoVmscwzkjxG4BwXtJlBPragsSRPzhjFGF+25XZO727KrDuDfMISDe
+        OzrKHtQf3khVoO92pJXnktqLkXQI9wY58L73io4xAAhm/uGMz0yC6gerSe1b
+        Hqa9wQ287L2ig3PQMHM/F1I5gKp7y0P6Gxnn/3tmMGIVNaR1+N92yBFYHpQu
+        FbSbn6s5N3pUx6B/em95qPcIoK27L3uvdEfL4/zhjqxnX917HqKDY+u97r30
+        /4LRqf0LPQD3rofs4AgNiACE92J/lD80ue2g6Kw82xZr1B2uNw3SQfBe0gEG
+        IMlZ+iXf/yX/D95s6CkTIQAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2809,11 +2885,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2832,30 +2908,67 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14792'
+      - '14983'
       X-Ms-Request-Id:
-      - f87d1360-4b39-43b5-bdd4-6be31031aedc
+      - 8afa22a0-0651-4bac-96c9-4b2766fc3869
       X-Ms-Correlation-Request-Id:
-      - f87d1360-4b39-43b5-bdd4-6be31031aedc
+      - 8afa22a0-0651-4bac-96c9-4b2766fc3869
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:f87d1360-4b39-43b5-bdd4-6be31031aedc
+      - EASTUS:20150922T133543Z:8afa22a0-0651-4bac-96c9-4b2766fc3869
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:42 GMT
       Content-Length:
-      - '133'
+      - '1791'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2865,11 +2978,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2888,17 +3001,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14596'
+      - '14984'
       X-Ms-Request-Id:
-      - 38ef512a-fca0-4179-8e1d-970d9551c7b4
+      - 10d57b10-5bb6-49f5-bfb7-4f1db9772eb1
       X-Ms-Correlation-Request-Id:
-      - 38ef512a-fca0-4179-8e1d-970d9551c7b4
+      - 10d57b10-5bb6-49f5-bfb7-4f1db9772eb1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:38ef512a-fca0-4179-8e1d-970d9551c7b4
+      - EASTUS:20150922T133543Z:10d57b10-5bb6-49f5-bfb7-4f1db9772eb1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:42 GMT
       Content-Length:
       - '133'
     body:
@@ -2908,10 +3021,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2921,11 +3034,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -2944,17 +3057,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14790'
+      - '14984'
       X-Ms-Request-Id:
-      - c77c2be2-a6d9-4019-ba05-2cf950c5b8d1
+      - ae354b35-a1a0-44d7-8a37-834a71ef8f64
       X-Ms-Correlation-Request-Id:
-      - c77c2be2-a6d9-4019-ba05-2cf950c5b8d1
+      - ae354b35-a1a0-44d7-8a37-834a71ef8f64
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:c77c2be2-a6d9-4019-ba05-2cf950c5b8d1
+      - EASTUS:20150922T133543Z:ae354b35-a1a0-44d7-8a37-834a71ef8f64
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:43 GMT
       Content-Length:
       - '133'
     body:
@@ -2964,10 +3077,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2977,11 +3090,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3000,17 +3113,106 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14789'
+      - '14984'
       X-Ms-Request-Id:
-      - 0119f25a-354d-478f-a1a4-4328839d8e17
+      - c841c5a4-f22f-45f1-95d1-99367e6ddedb
       X-Ms-Correlation-Request-Id:
-      - 0119f25a-354d-478f-a1a4-4328839d8e17
+      - c841c5a4-f22f-45f1-95d1-99367e6ddedb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:0119f25a-354d-478f-a1a4-4328839d8e17
+      - EASTUS:20150922T133543Z:c841c5a4-f22f-45f1-95d1-99367e6ddedb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:43 GMT
+      Content-Length:
+      - '1594'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97e/t5Ho4+W2YLQ++jrvr6q
+        q1Vet0XefPToF3+0ymoCR+34r7KaZhgmfm+vV+jmdVsXywt6T8nyUZ417br5
+        6JfQJ0XdrrPyi2w6L5b5iwxoDb/3xdlP9F96XfyAvht+6UnWFNPf/3gHb2az
+        RbH8qslrIcDwS5O6WmYXc8axaas6u8iPp9NqvWxvwtFO1P2DvQd4XbF9kbdX
+        Vf321q/j1aW8c4ZJOKfJuMXLB59+6r35Op+u66K9Zia66W2lLtPoZdY0BICY
+        17UHrFzfonazIrtYVk1bTJvXH0Yhkg7C96bXZvl5ti5bvLBaT8pierY6ns1I
+        TJqb3tSBdd56w62H33p6TUxSTD/6JfTqoprho7PltM4heVlJDUkKLouGWJ3e
+        e91mLVq8Xk+neT7LZ/R9Wyzyps0WK/ocErS9c7C9e/Bm9+DR/oNH+5+O9x7s
+        3vv04U9Ry9m6Vpn56OWb3ftf7I1J0EgJPHxNX06rus5L/v6M5uOj3Yc70717
+        +7PtB/d2z7f370/y7cm9g2x79mByMN2d5Pfu5Qf0GmM3Y6EkNURDyZsVsRAB
+        cFJ/Ui1Wa8J79BERhLUNiCJv+J/QS8rFKnMNvWIEHc2NRH//l4xuevOu45vX
+        edsS7YaBMbg46ipO9KrfHV7vIUC8haZWiob7o94673Z45r3e1X5ZbowMDr9P
+        /xEj5Kt8OcuXU1atNBT5oPmSWIP++uaNieUSz5Qoae8q/o5ueA/6JaQ5oXSL
+        d72XRFyhBgAMw/7hjEu5/W6XIaEeHHa9IQ285r2iAwIcsMHPxZwNIPnNju3/
+        DTMVUR93yfQsWw/n2w4zAsuD4kauHfxcza2RqZ4uAj08hHvDHnzRe8mNksf3
+        wx2RaolQQ952VNGXvRf9kf3QOLeDnNN/eA/qzuF308Dcu95LOigFhnFV65Z4
+        m6zFLxbP7X292w5z9F+D/yOdvFIkqJFhfof9kIwx/Q1n3ap5RCw9CezAGSSa
+        IfjN74QcBAw2vdShF3XEL3yfyKTv3P0mmYwUzgdEezv7D2nahR28sbzf68Tn
+        PyfR3umrl/2Xbor2yBFfzrJ69vsfcwT1tUTi/zsBX16vHtw/8N4MePmmt5XA
+        TKNbBHwhWUR9ucbSzAG3E/H5q9d42wn1h4aLg5DeF6VMRPhlnZ8X7za9uLsz
+        3h3vjHfu7kKffETyTeS+CW8vXpUX3qOfvX281lE1N3Wo09l56yai/GyGuXuP
+        9nbH93YePtzdOejHubtf7D0cP9jb3Xmw8yAW6BL/Zw938ofbk0lOge5slwLd
+        6af3tndn5+cHsyzbvX//Pr3G+MEMs1WiwUSiRbU21JpIwooWZJE3/E/oJZVe
+        VTewvUbHoblRZrF4r/NmxIwNAmNwcdSVxelVvzu83kMgFNCv1ZsqLXrVh43X
+        e73pcPWN4d6or86bJAt4xWq593m3w93v9a72y3rN6Mjh9+k/4lj29/9fG5Cr
+        /g9ni1C6xbveS6JYnDH5YY1LWftuh2/dW6zxHZ69wQ0A8F7RoYUQMbE/nBGq
+        3ul5uVDVDsneuAZe817RcQEO5uvngisHkPxmx/b/hpmKKHKNRxzOtx1mBJYH
+        xY1cO/i5mlujNRR7/dN7y0O6N3Rt3X3Ze0XH6aBhnD/ckfXsCGbaQ3FwVL0X
+        vZd0XID0wx+RavjQut12VNGXvRf9kf3QZLKDnLNdPzt2j8YleQ6y9P8vTaYw
+        /Q1n3ap5ROF4uqUDZ5BohuA3vxNyEDDY9FKHXtTRDS/oCPVPj4FiLw24B+4l
+        9QZ+yS/5/i/5fwDEuVqotB8AAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 7682559c-3188-4213-98a1-9417cffc7019
+      X-Ms-Correlation-Request-Id:
+      - 7682559c-3188-4213-98a1-9417cffc7019
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133544Z:7682559c-3188-4213-98a1-9417cffc7019
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:43 GMT
       Content-Length:
       - '133'
     body:
@@ -3020,7 +3222,1255 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 194f61f4-98b7-477c-903d-32be1c73d126
+      X-Ms-Correlation-Request-Id:
+      - 194f61f4-98b7-477c-903d-32be1c73d126
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133544Z:194f61f4-98b7-477c-903d-32be1c73d126
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:44 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/deployments/Microsoft.WindowsServer2008R2SP1-2015815115755/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 6daadc67-afc5-4f4b-818b-81f02f5a1ad3
+      X-Ms-Correlation-Request-Id:
+      - 6daadc67-afc5-4f4b-818b-81f02f5a1ad3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133544Z:6daadc67-afc5-4f4b-818b-81f02f5a1ad3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:43 GMT
+      Content-Length:
+      - '1081'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8ffLZaz6qp5
+        ndeXeb23s3Pwau/1y93tvZ3d+we793d37z+4f/9utcrrTHB4uHfy6cGnT/Yf
+        7B08PD05Pv1o9JH99gw4RxqsajRpi7z56NEvxl+XRUPNi+XF6zZrabwfvV5P
+        p3k+y2fUui0WedNmixV9DjS2dx5u795/s/vpo92dRzv3xnt7uw93Hj78KWo6
+        W0vH1PLlm3tf3N8fP7y3v3d/b/81fdnW2fQt9cFYZbMsu//pQb796c7u/vb+
+        LL+//fDBDsHOp3v39/PJ/sHuDr1D/bbr5qSaAakvfy/6pM3qi7x9pUQF/t/8
+        zDBFZnntz8tJtVit2/zuZVG366z8IpvOi2Xe3H1ZNe0FQdp+ml/enRXZxZI+
+        KKav87alsTZ3swuaYMKbmnBnb65XhPVHNwPuw/KgvMgWgBJ0Lj39kl/yS0Y/
+        GzT5Zrh1/8Hx8cn+vdMnp/d37n/66UMakv2W+SLSgGaDmnw4t+7Q/w7Gu7v3
+        9nYeHvS49cEX+w/GB5/e/3Tv4YMet95/8PBhdv/e7vb9e/cm2/uTbG97sreb
+        b2ef7u7f39t7mJ1PHtA71O//h7iV0KPfGOZtmdJ7JcKB/y/nvWd7Dz/dffYp
+        cdez+w+eHN+jwdhveZYjDYi21ORDee/+o/sHj/Z2xrv3Pr23u/tpj/d2x/vE
+        lvce7PUYb3aw++nsPN/bzmezbHv/0/OcGG9/uj2Z7k6JI/d3Du6f0zvUqWO8
+        kzon1BifnyPue5G3V1X99u5Sfp4t27w+z6bEfyvDLrP8cv/efcKR/mDAPRYc
+        BOK9pEzYhfr/bj58ur9//9MTYoUHnx7sP3iwS+Ox3/KkRxoQlanJN8KHuw/G
+        u5/eJ4br68DdvfHeg3u7e7t9RjzY2Zs+2J99ur138GCP7PX9yfbk/GB/Oz/Y
+        zT+9Ry7A3r0eI/6casAO+7zOp+u6aK/13UBtOX66iQlDKN6LyogB2P93c+HB
+        /b3TZ/dOT58+efLw04enn9Jg7Lcy4/0GRGdq8s1w4cH4/u7Dhw939/tceG/8
+        6b2d/Qc7D3tcOLn/6b179/bz7dm9yQ4R7v697YPpven2bH+ye7DzcEYQD+gd
+        6vX/ZVy4Wk/KYnq2Op7N6P2GNGHAKo6RBjmwB8F7aYD7vv9L/h9+ZeSfwQwA
+        AA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 4d7516a1-8347-4aa3-9b8e-5831bf2a1c29
+      X-Ms-Correlation-Request-Id:
+      - 4d7516a1-8347-4aa3-9b8e-5831bf2a1c29
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133544Z:4d7516a1-8347-4aa3-9b8e-5831bf2a1c29
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:44 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - a6bd926a-3b01-42da-bc1c-f25ac4fe64a9
+      X-Ms-Correlation-Request-Id:
+      - a6bd926a-3b01-42da-bc1c-f25ac4fe64a9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133545Z:a6bd926a-3b01-42da-bc1c-f25ac4fe64a9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:45 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:47 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 22 Sep 2015 13:35:45 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2136-IAD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Tue, 22 Sep 2015 13:40:45 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 9ad5065d-ecec-440a-8a41-c45280c86812
+      X-Ms-Correlation-Request-Id:
+      - 9ad5065d-ecec-440a-8a41-c45280c86812
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133545Z:9ad5065d-ecec-440a-8a41-c45280c86812
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:44 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:47 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 22 Sep 2015 13:35:45 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2129-IAD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Tue, 22 Sep 2015 13:40:45 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - ed71081b-0a86-4f8a-bd3a-d0982a7a03f9
+      X-Ms-Correlation-Request-Id:
+      - ed71081b-0a86-4f8a-bd3a-d0982a7a03f9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133546Z:ed71081b-0a86-4f8a-bd3a-d0982a7a03f9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:45 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:48 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"c3cab515fe95f2d1af1cd81d968b4051c9072a85"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      Content-Length:
+      - '1906'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 22 Sep 2015 13:35:46 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2123-IAD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Tue, 22 Sep 2015 13:40:46 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": "5",
+                      "numberOfProbes": "2"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143242/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 2d9d83a1-c8dc-4efb-9ed0-2ce9f287d62f
+      X-Ms-Correlation-Request-Id:
+      - 2d9d83a1-c8dc-4efb-9ed0-2ce9f287d62f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133546Z:2d9d83a1-c8dc-4efb-9ed0-2ce9f287d62f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:46 GMT
+      Content-Length:
+      - '1061'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97e/t7dapXXmaByb2/3dP/h
+        8fG9Z/v7u5/unnw0+sh+ewbUIw1WNZq0Rd589OgX46/LoqHmxfLidZu1NOyP
+        Xq+n0zyf5TNq3RaLvGmzxYo+BxrbOwfbuwdvdg8e7T94tL8/vr9zf/fh/f2f
+        oqaztXRMLV++uffF/f3xzqd793bv3XtNX7Z1Nn1LfTBWDw/2DvKH9/e2z3ey
+        ve39B/lkm4b66fb+5OFOtnv/Hn2wT+9Qv+26OalmQOrL34s+abP6Im9fKW2B
+        /zc/QUyRWV7703NSLVbrNr97WdTtOiu/yKbzYplTi7OfuDsrsotl1bTF9HXe
+        tjTE5m52QfNG6Jo+3lyvCNmPbobXh+VBeZEtGAr1KR38kl/yS0Y/GxT4Rln0
+        +P7ewc7D3d2nnz7Ze3j/3j0akP2WmSHSgKaAmnwDLHrv0f2d8b1PP93b63Po
+        7s4X+7vjTw92H3y6/2mPRffun5/f371/vp3f259t7+/v3d8+2H/wYPtg73z3
+        4ICEaW9yTu9Qv//vZ1HCyoC6LSd6rzi2+/8Gw+2dHO8dPNi5f7r76f37nz79
+        lIZiv5Wp7TcgglKTD2e4e/ce7RyM7z84eEic3OO4T8f39z99eBDhttnBvdnO
+        p7u72+d7UyLf/vlk++F0b3d779Pdhw9397N7O3vomDp13HZS54QaPv65YrkX
+        eXtV1W/vLuXnGeblnOaH3zv4FIQ18Hp8N/iu95JyngL7/wTzHe+fHDy5d3z6
+        9Nm9g/2Dh/dpNPZbnulIAyItNflmmI8U2qf3Pt399GGP+Xbvj8lOP/z0/kGP
+        +x7sZJ9O7z3Y3d6Z3p+SEd4lc3x/J9/ePX+w9+ne/nk+m0zpHerVcd/Pqa4z
+        zLNaT8pierY6ns3o/YYYD1rKMdAg1/Ve9F5SrgOk/0+w3JOdew+efPrwZG/3
+        KZnSE9hP+y1Pb6QBEZWafFMsR/bw03v7D/os9+l498H+7s79vsJ7eH9nd38y
+        2duePcwebO8fZPe3Jwek9WYPH2bT2b3dnfMMokG9/r+M5VRfvc6n67por/Vd
+        MIvjoEG2i77svRiy3vd/yf8DXFNc0IoMAAA=
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 5bbdf394-ba69-4edd-84e8-c0049d04766f
+      X-Ms-Correlation-Request-Id:
+      - 5bbdf394-ba69-4edd-84e8-c0049d04766f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133546Z:5bbdf394-ba69-4edd-84e8-c0049d04766f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:46 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - e2bbf309-09d4-4ef6-a784-863c92c80993
+      X-Ms-Correlation-Request-Id:
+      - e2bbf309-09d4-4ef6-a784-863c92c80993
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133546Z:e2bbf309-09d4-4ef6-a784-863c92c80993
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:46 GMT
+      Content-Length:
+      - '373'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq/PxzL
+        7/+S/wf1Haxm0wQAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:48 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3033,11 +4483,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3060,20 +4510,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - a71e5cb1-bcba-41e7-907a-0fe732bddbe6
+      - e227c885-46ad-4942-ace6-27d3347c84d5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14748'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - 0bc1e3c1-a24b-456a-9d1b-57c880bfc346
+      - 467c3c28-79b9-40ff-a53b-fea503528c10
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:0bc1e3c1-a24b-456a-9d1b-57c880bfc346
+      - EASTUS:20150922T133547Z:467c3c28-79b9-40ff-a53b-fea503528c10
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3096,9 +4546,16 @@ http_interactions:
         nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
         RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
         iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhM8A8SyF/y/wDbEyEhJwgAAA==
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3111,11 +4568,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3138,20 +4595,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - 065f0551-29fc-4ef4-98c7-98d95d66f64f
+      - 9e0c5ac3-c7ef-4c0d-bded-4b46c09af56f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14791'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - 1e3749ab-ef26-415f-88da-4c62dbc590b1
+      - e4684b02-abc4-445f-9b7f-98b3b4ed2a37
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:1e3749ab-ef26-415f-88da-4c62dbc590b1
+      - EASTUS:20150922T133547Z:e4684b02-abc4-445f-9b7f-98b3b4ed2a37
       Date:
-      - Wed, 09 Sep 2015 16:16:22 GMT
+      - Tue, 22 Sep 2015 13:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3188,10 +4645,298 @@ http_interactions:
         AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
         HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
         WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTuEfJD2/5P8BxF53
-        EuIgAAA=
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 11451bdb-39c3-4543-9e3a-fc2fc41fa187
+      X-Ms-Correlation-Request-Id:
+      - 11451bdb-39c3-4543-9e3a-fc2fc41fa187
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133547Z:11451bdb-39c3-4543-9e3a-fc2fc41fa187
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - cafdde37-41ca-43b4-9659-a2c0e311137c
+      X-Ms-Correlation-Request-Id:
+      - cafdde37-41ca-43b4-9659-a2c0e311137c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133548Z:cafdde37-41ca-43b4-9659-a2c0e311137c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - ab992eeb-dab3-4cc3-8981-73f0464c1f9d
+      X-Ms-Correlation-Request-Id:
+      - ab992eeb-dab3-4cc3-8981-73f0464c1f9d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133548Z:ab992eeb-dab3-4cc3-8981-73f0464c1f9d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - fe0aa3c6-54b2-4645-92cb-a17e23ddc29c
+      X-Ms-Correlation-Request-Id:
+      - fe0aa3c6-54b2-4645-92cb-a17e23ddc29c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133548Z:fe0aa3c6-54b2-4645-92cb-a17e23ddc29c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - c60ed056-9c52-4320-829a-d95be3a1cfbb
+      X-Ms-Correlation-Request-Id:
+      - c60ed056-9c52-4320-829a-d95be3a1cfbb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133548Z:c60ed056-9c52-4320-829a-d95be3a1cfbb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 22 Sep 2015 13:35:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520/?api-version=2015-06-15
@@ -3204,11 +4949,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3227,24 +4972,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"6b1e8729-538b-40d3-a97b-7bb7e15f9ad6"
+      - W/"46c9c6e9-fce9-4b85-a25f-053a43fa9dda"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 47667046-31a0-4351-b2ff-e6cdf4533982
+      - 306e9c23-a5a3-4ea5-a1e9-0afbf32a1ff1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14764'
+      - '14979'
       X-Ms-Correlation-Request-Id:
-      - a9b32a38-6f24-4e4e-a646-7d8504ca30fd
+      - f22b19d3-2dad-4848-9a70-d33b2f5f0c83
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161623Z:a9b32a38-6f24-4e4e-a646-7d8504ca30fd
+      - EASTUS:20150922T133548Z:f22b19d3-2dad-4848-9a70-d33b2f5f0c83
       Date:
-      - Wed, 09 Sep 2015 16:16:23 GMT
+      - Tue, 22 Sep 2015 13:35:48 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3253,19 +4998,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
         0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
         Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PPp3s5gcP9h5u3793
-        MCFUZve2s4cPJtsPJpMH+e7984fZ7NPf9yN9kcCs8rot8oZe56HLh5dFQ+Mq
-        lhev26xlSrxeT6d5Pstn8iY1s8NZC0n2Dj6dnN/foe52d6fb+3v3H25Pds5n
-        2+d7n97bnR7k9/Z2du3LxeqkWp4XF+s6YwoSgO/JV6nBA4+diGI15fYWAp7/
-        d83F3e6Y6IMY0l93suTB7PSmTB58dYuJk4caF5fU5Ozl8WxG1AC0j3Z3xnvj
-        nfH+YNOyrKY8uC/ydl4x9Z9e0xwV0+4r60lZTOkNCzxAlVr8kOeugxDNnX3v
-        Ix+zXxKOg9CjWSdMf47Rvyzqdp2V+qf/FmFAGDZ3Z/l5ti7bcDDuD/ur/vJ9
-        HedHs2XzOm9bYplgluTz+pLQoY+/Z5rTF9lqVRb57Gn4vXxtqPfRIpsqpenb
-        j3Z2tneebt873t7d3T74dPvBPcMtH+XLbFISZz2r6qusnhEW1P48K5vctKDB
-        Yciv8+m6Ltprphq1cYj+kGciho/3rtLfEoJkZ5HV14RiW6/toHQ6v8im82IJ
-        Mf2hD+ekWqzWbW4YSzHx3jIDwQ8ZzUdG+IFgnjXtuqFGv+T/AQyR8K0yBwAA
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9j+dPpx+mj/cPp/S
+        P/uTg/vb2d59QuX+vWz/3nn2cDbLft+P9EUCs8rrtsgbep2HLh9eFg2Nq1he
+        vG6zlinxej2d5vksn8mb1MwOZy0k2Tv4dHJ+f+fedra7O93e37v/cHuycz7b
+        Pt/79N7u9CC/t7eza18uVifV8ry4WNcZU5AAfE++Sg0eeOxEFKspt7cQ8Py/
+        ay7udsdEH8SQ/rqTJQ9mpzdl8uCrW0ycPNS4uKQmZy+PZzOiBqB9tLsz3hvv
+        jPcHm5ZlNeXBfZG384qp//Sa5qiYdl9ZT8piSm9Y4AGq1OKHPHcdhGju7Hsf
+        +Zj9knAchB7NOmH6c4z+ZVG366zUP/23CAPCsLk7y8+zddmGg3F/2F/1l+/r
+        OD+aLZvXedsSywSzJJ/Xl4QOffw905y+yFarsshnT8Pv5WtDvY8W2VQpTd9+
+        tLOzvfN0+97x9u7u9sGn2w/uGW75KF9mk5I461lVX2X1jLCg9udZ2eSmBQ0O
+        Q36dT9d10V4z1aiNQ/SHPBMxfLx3lf6WECQ7i6y+JhTbem0HpdP5RTadF0uI
+        6Q99OCfVYrVuc8NYion3lhkIfshoPjLCDwTzrGnXDTX6Jf8PTzEhLTIHAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:26 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod/?api-version=2015-06-15
@@ -3278,11 +5023,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3301,24 +5046,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"64935193-beb9-4554-b351-6509f17b4aff"
+      - W/"a7883c39-700f-4d10-af79-b733641b9812"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2b79a96b-545a-42db-a778-7ff4364dd926
+      - 9f710327-62a2-4c44-bd34-847c8bbd8d4a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14747'
+      - '14981'
       X-Ms-Correlation-Request-Id:
-      - 35b318d0-202a-4753-bb2e-89663ee19611
+      - a2eef950-33f6-4133-a336-8184033f597d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161624Z:35b318d0-202a-4753-bb2e-89663ee19611
+      - EASTUS:20150922T133549Z:a2eef950-33f6-4133-a336-8184033f597d
       Date:
-      - Wed, 09 Sep 2015 16:16:23 GMT
+      - Tue, 22 Sep 2015 13:35:48 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3327,15 +5072,160 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
         vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
         P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/+nT/4b37uw/vbU/yycPt
-        /fv397cn9MH2p/d3Hp7vPpjsZ+fnv+9H+iJ1u8rrtsgbep0HLR9eFg0Nqlhe
-        vG6zlmnwej2d5vks1y6pGeEiY1kLPWY792Y7uw9m259OdogAB3vn2w/3ppPt
-        h7uTbHJv5969g50H9uVipaPBm7v3Hox3790f7+7dH+/t2jZ23GVZTTNQ+Yu8
-        ndOg6ZWn1zQ5xdS2LWZl/qZY5NW6PVt+USzXLQ9p336/OqmW58XFumZA9JWO
-        Ft8xxLs/rOlcys+zZZvX59mUpnOK9+iV2f29nbsdTBv6YMof7H4kGP8S/Pgl
-        PLCPDGEwgDxr2nVDjX7J/wOWusr3vgIAAA==
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/yh4cHNyb3nu4/WBn53yb
+        et7Zzs4fPNyePLh379P93cnDg9293/cjfZG6XeV1W+QNvc6Dlg8vi4YGVSwv
+        XrdZyzR4vZ5O83yWa5fUjHCRsayFHrOde7Od3Qez7U8nO0SAg73z7Yd708n2
+        w91JNrm3c+/ewc4D+3Kx0tHgzd17D8a79+6Pd/fuj/d2bRs77rKsphmo/EXe
+        zmnQ9MrTa5qcYmrbFrMyf1Ms8mrdni2/KJbrloe0b79fnVTL8+JiXTMg+kpH
+        i+8Y4t0f1nQu5efZss3r82xK0znFe/TK7P7ezt0Opg19MOUPdj8SjH8JfvwS
+        HthHhjAYQJ417bqhRr/k/wEVJwA3vgIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435/?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"46048ef2-d999-4c80-9536-733a15783368"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ebeac7f8-56e5-4b1e-90e2-48403fc9a467
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Correlation-Request-Id:
+      - 33fa4534-d0a7-46a9-b34b-417250826bed
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133549Z:33fa4534-d0a7-46a9-b34b-417250826bed
+      Date:
+      - Tue, 22 Sep 2015 13:35:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT/a/3Rn/yA/
+        39uePXz4cHt/erCz/fD+vU+3H9y7l+3ef3Bw796nB7/vR/oidb7K67bIG3qd
+        CSAfXhYNDa1YXrxus5bp8Xo9neb5LJ/Jm9SMsJARrYUqu1m+e2+yO9k+ONh/
+        sL3/8MH+9uTB/v3t+/lkej7ZuTeZPDywLxerk2p5Xlys64yJSAC+J1+lBg88
+        djqK1ZTb7xoIeP5fNx13u8OiD2J4f935kgcT1Js1efDVLeZOHmpcXFKTs5fH
+        sxkNAtA+2t0Z7413xspZ5vGalmU15cF9kbfziifg6TVNUzHtvrKelMWU3rDA
+        A1SpxQ95+joI0fS9NNP3NL/8yEful4RDIQxp7gnZn+MRXBZ1u85K/dN/izAg
+        DJu7s/w8W5dtOBj3h/1Vf/m+jvOj2bJ5nbctcU0wUfJ5fUno0MffM83pi2y1
+        Kot89jT8Xr421PtokU2V2PTtRzs72ztPt+8db+/ubR/Q/54YhvkoX2aTkpjr
+        WVVfZfWMsKD251nZ5KYFDQ5Dfp1P13XRXjPVqI1D9Ic8EzF8ovxkaUEStMjq
+        a8Kyrdd2XDqjX2TTebGEsP7QR3RSLVbrNje8pZjEx4IfMqCPjBYAjnnWtOuG
+        Gv2S/wfrMbJ1RAcAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev/?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0055b621-9718-4519-bcec-bd46e5bd2d63"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5410c3a8-ff4e-467d-a474-2646546f2f8c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Correlation-Request-Id:
+      - d8e60bf3-f826-48b4-93ac-0f50ef39aa2d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133549Z:d8e60bf3-f826-48b4-93ac-0f50ef39aa2d
+      Date:
+      - Tue, 22 Sep 2015 13:35:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vRzs79+5NP
+        93a3Hz7YPdjev7/7cHsyzafbk9n+p/n9yWxv9um93/cjfZF6XuV1W+QNvc5D
+        lw8vi4bGVSwvXrdZy5R4vZ5O83yWz+RNakYoyHDWQpL8YbazfzDLt3fz2e72
+        /sPzT7ezyd759qezfO/T/dmns52dfftysdIB4c39nfHu7v74/s54xzaw4y7L
+        apqByl/k7bzinp5e0/wUU9u2mJX5m2KRV+v2bPlFsVy3PJ59+/3qpFqeFxfr
+        mgHRVzpUfMcQ7/6wpnMpP8+WbV6fZ1OazpWZzll+uX/v/t0Osg19MOUPdj8S
+        pH8JfvwSHttHhjYYQ5417bqhRr/k/wF6Zli+xAIAAA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863/?api-version=2015-06-15
@@ -3348,11 +5238,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3371,24 +5261,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"43540b18-1a23-40f7-ac42-feac456d45f7"
+      - W/"9ba8daad-9155-4a4a-831e-9da861211f54"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e886af89-df8b-43b2-8677-c7fc0803c977
+      - e427756a-37b9-42af-8e39-caa2eed0abf1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14791'
+      - '14978'
       X-Ms-Correlation-Request-Id:
-      - a7f55c7d-2aef-41dc-98cd-980b45234aa2
+      - 329b645b-eda0-4a87-ab93-03cba7e49f17
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161624Z:a7f55c7d-2aef-41dc-98cd-980b45234aa2
+      - EASTUS:20150922T133550Z:329b645b-eda0-4a87-ab93-03cba7e49f17
       Date:
-      - Wed, 09 Sep 2015 16:16:23 GMT
+      - Tue, 22 Sep 2015 13:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3397,18 +5287,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
         73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
         O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9aP/e/f2d
-        ye7B9m62d4+wOX+wnU3397bPc/px/9PZ/v3zB7/vR/oi9b3K67bIG3qdxy8f
-        XhYNDa1YXrxus5bJ8Xo9neb5LJ/Jm9TMjmgtVJnku7O92f5kO7u3N93enx7s
-        bk/Od2bbu/cefHrv4YNsbzbJ7cvF6qRanhcX6zpjIhKA78lXqcEDj52NYjXl
-        9rsGAp7/103H3e6w6IMY3l93vuTBBPVmTR58dYu5k4caF5fU5Ozl8WxGBAG0
-        j3Z3xvjv/mDTsqymPLgv8nZe8QQ8vaZpKqadV2hWiF70fYAhffHDnrXLom7X
-        Wal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/sr/rL93WkH82Wzeu8bYnYIJ4dqHwO
-        rsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8mU1KovWzqr7K6hlBp1bnWdnkpgUh
-        jbG8zqfrumivmR7UxiHww6ZxDCFqd/YT+v6uktaOUSfli2w6L5bg0h8+7vq1
-        4Q9FJZBpgzV+COofGfYHjnnWtOuGGv2S/wcObvq6PAYAAA==
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96OEkO5hl
+        2Wz74e79+9v72X62fXBvN99+OMsOPt3d2909v7//+36kL1Lfq7xui7yh13n8
+        8uFl0dDQiuXF6zZrmRyv19Npns/ymbxJzeyI1kKVSb4725vtT7aze3vT7f3p
+        we725Hxntr1778Gn9x4+yPZmk9y+XKxOquV5cbGuMyYiAfiefJUaPPDY2ShW
+        U26/ayDg+X/ddNztDos+iOH9dedLHkxQb9bkwVe3mDt5qHFxSU3OXh7PZkQQ
+        QPtod2eM/+4PNi3LasqD+yJv5xVPwNNrmqZi2nmFZoXoRd8HGNIXP+xZuyzq
+        dp2V+mfwGuFAODZ3Z/l5ti7bj3xMf4n7w/6qv3xfR/rRbNm8ztuWiA3i2YHK
+        5+AKfPw905y+yFarsshnT8Pv5etfos0+ypfZpCRaP6vqq6yeEXRqdZ6VTW5a
+        ENIYy+t8uq6L9prpQW0cAj9sGscQonZnP6Hv7ypp7Rh1Ur7IpvNiCS794eOu
+        Xxv+UFQCmTZY44eg/pFhf+CYZ027bqjRL/l/AJLUj0E8BgAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505/?api-version=2015-06-15
@@ -3421,11 +5311,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3444,24 +5334,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"a3ade26f-f849-46d1-84aa-d4797441aa45"
+      - W/"53a93614-3aac-409b-9873-efbd0b4e1494"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 531eaa64-024b-4da7-92a4-90513303098c
+      - c5239bb9-ac7b-4cfc-94c8-68202d4f9f0a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14713'
+      - '14978'
       X-Ms-Correlation-Request-Id:
-      - f6f4df03-3b39-40dd-a66b-61d11ec6dd07
+      - 702882d1-8974-4029-8fff-016b35467837
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161624Z:f6f4df03-3b39-40dd-a66b-61d11ec6dd07
+      - EASTUS:20150922T133550Z:702882d1-8974-4029-8fff-016b35467837
       Date:
-      - Wed, 09 Sep 2015 16:16:23 GMT
+      - Tue, 22 Sep 2015 13:35:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3470,19 +5360,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
         PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
         2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+36U3ctm+d6n59vnB/sP
-        t/c/ne1uH+xn2fZs/8HDB/v7u1m2f//3/UhfpD5Xed0WeUOv83jlw8uioSEV
-        y4vXbdby8F+vp9M8n+UzeZOa2ZGshRqfZrufzh7MDrbvP8zPafjns+2H04z+
-        3Jl8en/26XSSZzv25WJ1Ui3Pi4t1nTHxCMD35KvU4IHHUr9YTbn9roGA5/81
-        03C3Oxz6IIbv150neTAxvdmSB1/dYs7kocbFJTU5e3k8mxEhAO2j3Z0x/jsY
-        bFqW1ZQH90Xezism/NNrmp5i2n1lPSmLKb1hgQeoUosf9rR1MKJpO3318iMf
-        qV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2d2f5ebYu23A47g/7q/7yfR3p
-        R7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW+exp+L18bej30SKbKpXp2492
-        drZ3nm7fO97e3d3+9OH2sZP/fJlNSmKrZ1V9ldUzwoLan2dlk5sWNDiM+XU+
-        XddFe810ozYO0R/2XMQQ8jnJ0oBkZpHV14RdW6/teHQqv8im82IJ8fzhj0S/
-        NlylqARjwA8ZyEdG3oFbnjXtuqFGv+T/Ab/UQiEVBwAA
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350/1728N6nu/vb97Js
+        Slg8nGw/PHhwbzs/n8x2Jvv57v7D/d/3I32R+lzldVvkDb3O45UPL4uGhlQs
+        L163WcvDf72eTvN8ls/kTWpmR7IWanya7X46ezA72L7/MD+njs9n2w+nGf25
+        M/n0/uzT6STPduzLxeqkWp4XF+s6Y+IRgO/JV6nBA4+lfrGacvtdAwHP/2um
+        4W53OPRBDN+vO0/yYGJ6syUPvrrFnMlDjYtLanL28ng2I0IA2ke7O2P8dzDY
+        tCyrKQ/ui7ydV0z4p9c0PcW0+8p6UhZTesMCD1ClFj/saetgRNN2+urlRz5S
+        vyQcAmFGU01I/lxjflnU7Tor9c/gNcKBcGzuzvLzbF224XDcH/ZX/eX7OtKP
+        Zsvmdd62xC/BFMnn9SXhQx9/zzSnL7LVqizy2dPwe/na0O+jRTZVKtO3H+3s
+        bO883b53vL27u/3pp9v3HhpW+ShfZpOS2OpZVV9l9YywoPbnWdnkpgUNDmN+
+        nU/XddFeM92ojUP0hz0XMYR8TrI0IJlZZPU1YdfWazsencovsum8WEI8f/gj
+        0a8NVykqwRjwQwbykZF34JZnTbtuqNEv+X8AEqWdCRUHAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP/?api-version=2015-06-15
@@ -3495,11 +5385,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3518,24 +5408,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"bc6b2845-efff-4ec8-b430-1839fec0180a"
+      - W/"eea885b0-60d3-42d7-8209-e137d1024492"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2fa58d87-ecd4-4239-825f-d3943c60f503
+      - 37966e56-5f17-4b4a-9a74-c595c35f9ec0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14712'
+      - '14978'
       X-Ms-Correlation-Request-Id:
-      - 2c223226-7a26-4c0d-a0e5-321c599c3a10
+      - 7ac8e571-ea73-48dd-b585-c485af7a1748
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161624Z:2c223226-7a26-4c0d-a0e5-321c599c3a10
+      - EASTUS:20150922T133550Z:7ac8e571-ea73-48dd-b585-c485af7a1748
       Date:
-      - Wed, 09 Sep 2015 16:16:24 GMT
+      - Tue, 22 Sep 2015 13:35:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3544,15 +5434,15 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
         m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
         H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9Hk+mnk72D/fvb+fn5
-        +fZ+Pj3Ynuzf29nePbj38Dyf7uwe7GS/70f6InW4yuu2yBt6nUcqH14WDY2n
-        WF68brOWB/56PZ3m+SyfyZvUjLCQYayFFOcP9vf27n16f3uyt3ewvb+/t799
-        cJB/ur0/ebD76cOHkwfTTx/Yl4uVjgNv7t57MN69d3+8u7c/3v30wDayQy7L
-        apqBwl/k7bzi3p5e05QUU9u2mJX5m2KRV+v2bPlFsSSKAva+/X51Ui3Pi4t1
-        zYDoKx0uvmOId39oU7mUn2fLNq/PsylNZV6v7u/cv9tBsqEPpvzB7keC7C/B
-        j1/CY/rI0AS451nTrhtq9Ev+H2Ho2tmvAgAA
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9HeZ4dHNyf7Gx/ujO7
+        t72/N3uwfbC383A73733YLa7s7e//3Dv9/1IX6QOV3ndFnlDr/NI5cPLoqHx
+        FMuL123W8sBfr6fTPJ/lM3mTmhEWMoy1kOL8wf7e3r1P729P9vYOtvf39/a3
+        Dw7yT7f3Jw92P334cPJg+ukD+3Kx0nHgzf2d8YNPx3sPxvf3bQM73LKsphmo
+        +0Xezivu6ek1TUcxtW2LWZm/KRZ5tW7Pll8US6Im4O7b71cn1fK8uFjXDIi+
+        0qHiO4Z494c2jUv5ebZs8/o8m9I05vXq/s79ux0kG/pgyh/sfiTI/hL8+CU8
+        po8MTYB7njXtuqFGv+T/ASHfJj6rAgAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:27 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727/?api-version=2015-06-15
@@ -3565,11 +5455,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3588,24 +5478,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"a7c6975c-315a-4fb3-bb79-a88452aa7c31"
+      - W/"ba9e83d0-002e-45d6-9a15-96029feda884"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 83b8669d-d5b4-4e12-b772-91fba59bc25d
+      - 9e67bb14-a669-4963-a089-37740e04078d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14788'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - f5e26d11-4c58-404d-86c1-7740e7dd1dfb
+      - 0599bdf7-946e-4785-a5c2-5156f0fa9696
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161625Z:f5e26d11-4c58-404d-86c1-7740e7dd1dfb
+      - EASTUS:20150922T133551Z:0599bdf7-946e-4785-a5c2-5156f0fa9696
       Date:
-      - Wed, 09 Sep 2015 16:16:24 GMT
+      - Tue, 22 Sep 2015 13:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3614,19 +5504,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
         xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
         2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8oeTD99+OD+dPve
-        7v1se/98cm97MnnwcDs7ONi/v5fR1/d2f9+P9EXqdJXXbZE39DqPWD68LBoa
-        U7G8eN1mLRPg9Xo6zfNZPpM3qZkdylrIsT/NH9zb37+/Pd2Z3t/ez/Pz7ezT
-        g/Pth9ns0zzPpg/29+7bl4vVSbU8Ly7WdcbUIwDfk69SgwceS/9iNeX2uwYC
-        nv/3zMPd7njogxjCX3ei5MHM9KZLHnx1i0mThxoXl9Tk7OXxbEaUALSPdnfG
-        +O/hYNOyrKY8uC/ydl4x5Z9e0/wU0+4r60lZTOkNCzxAlVr8sOetgxHN2xdn
-        P7H3kY/VLwnHQKjRZBOWP9eoXxZ1u85K/TN4jXAgHJu7s/w8W5dtOBz3h/1V
-        f/m+jvSj2bJ5nbctMUwwR/J5fUn40MffM83pi2y1Kot89jT8Xr429PsoX2aT
-        kvjlWVVfZfWMoFOr86xsctOCkMZYXufTdV2010wPauMQ+GHTOIYQtXMsYgen
-        s/FFNp0XS4jYDx9p/dowhqJCLTx08UNw/sgILZDLs6ZdN9Tol/w/GfAPr90G
-        AAA=
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5pkD/ODe7Od7Z2d
+        PULj/ozQyHbvbz/8dGfv4Xk+yw4O9n/fj/RF6nSV122RN/Q6j1g+vCwaGlOx
+        vHjdZi0T4PV6Os3zWT6TN6mZHcpayLE/zR/c29+/vz3dmd7f3s/z8+3s04Nz
+        6n32aZ5n0wf7e/fty8XqpFqeFxfrOmPqEYDvyVepwQOPpX+xmnL7XQMBz/97
+        5uFudzz0QQzhrztR8mBmetMlD766xaTJQ42LS2py9vJ4NiNKANpHuztj/Pdw
+        sGlZVlMe3Bd5O6+Y8k+vaX6KafeV9aQspvSGBR6gSi1+2PPWwYjm7Yuzn9j7
+        yMfql4RjINRosgnLn2vUL4u6XWel/hm8RjgQjs3dWX6ercs2HI77w/6qv3xf
+        R/rRbNm8ztuWGCaYI/m8viR86OPvmeb0RbZalUU+exp+L18b+n2UL7NJSfzy
+        rKqvsnpG0KnVeVY2uWlBSGMsr/Ppui7aa6YHtXEI/LBpHEOI2jkWsYPT2fgi
+        m86LJUTsh4+0fm0YQ1GhFh66+CE4f2SEFsjlWdOuG2r0S/4f595IUN0GAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:28 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2/?api-version=2015-06-15
@@ -3639,11 +5528,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3662,24 +5551,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"480171a3-bd2b-4a07-92e4-6282e3ef1d5d"
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b6f41d53-b644-4a29-ab9f-8aaa028011eb
+      - 952b411d-507e-402c-a374-a58e43f00a61
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14763'
+      - '14979'
       X-Ms-Correlation-Request-Id:
-      - 35ed8e6f-af3d-4f65-803e-02408317d95e
+      - 403973c2-c551-410c-89d8-1f172e871967
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161625Z:35ed8e6f-af3d-4f65-803e-02408317d95e
+      - EASTUS:20150922T133551Z:403973c2-c551-410c-89d8-1f172e871967
       Date:
-      - Wed, 09 Sep 2015 16:16:24 GMT
+      - Tue, 22 Sep 2015 13:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3688,15 +5577,15 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
         cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
         2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+0f7Ow+2M3ubU9m
-        e5Pt/WznwfbDvXx/+1PCIb+Xn+/O7s9+34/0RepxlddtkTf0Oo9VPrwsGhpQ
-        sbx43WYtD/31ejrN81k+kzepGaEh41gLLXbyg/2D/OFkO5/s7G/vT/bvbT+8
-        P324vb//cH+yc/7pwfRA8aWX7XDKsppmoN4XeTuvGNDTa6J3MbVti1mZvykW
-        ebVuz5ZfFEuiFtDdt9+vTqrleXGxrhkQfaUjwXcM8e4PbZqW8vNs2eb1eTal
-        aVoUv2jvwd6Dux0sG/pgyh/sfiTY/hL8+CU8qI8MUYB8njXtuqFGv+T/Aca0
-        e0SNAgAA
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX6QeV3ndFnlDr/NY5cPLoqEB
+        FcuL123W8tBfr6fTPJ/lM3mTmhEaMo610GInP9g/yB9OtvPJzj71vn9v++H9
+        KeGx/3B/snP+6cH0QPGll+1wyrKaZqDeF3k7rxjQ02uidzG1bYtZmb8pFnm1
+        bs+WXxRLohbQ3bffr06q5Xlxsa4ZEH2lI8F3DPHuD22alvLzbNnm9Xk2pWla
+        FL9o78Heg7sdLBv6YMof7H4k2P4S/PglPKiPDFGAfJ417bqhRr/k/wHOv218
+        jQIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:28 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426/?api-version=2015-06-15
@@ -3709,11 +5598,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3736,20 +5625,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1dae7d8c-d76c-4805-b03e-cea420711c6a
+      - 1c95087d-82c2-457c-93d1-6cbc51b3e7d0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14762'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - 1169ebc7-78e5-4b8f-b03f-bee56be2fd74
+      - 2b1ca175-00a8-4c76-b508-0ac00f02e53c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161625Z:1169ebc7-78e5-4b8f-b03f-bee56be2fd74
+      - EASTUS:20150922T133551Z:2b1ca175-00a8-4c76-b508-0ac00f02e53c
       Date:
-      - Wed, 09 Sep 2015 16:16:25 GMT
+      - Tue, 22 Sep 2015 13:35:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3770,7 +5659,7 @@ http_interactions:
         1+MUO0adlC+y6bxYQuB++Ljr14Y/FBVq0ccaPwT1j4wkA8c8a9p1Q41+yf8D
         HN36UAcHAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:28 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1/?api-version=2015-06-15
@@ -3783,11 +5672,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3810,20 +5699,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - de10054b-29e7-4b32-b4e1-398c6bc1bed2
+      - d1bdef9b-cd8d-4ad1-a6c9-bc68be4253c9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14790'
+      - '14977'
       X-Ms-Correlation-Request-Id:
-      - 2b891342-d467-4732-a9b2-d94f57fcb8e3
+      - 80133360-7077-4c3c-9c52-3309ea802e86
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161627Z:2b891342-d467-4732-a9b2-d94f57fcb8e3
+      - EASTUS:20150922T133552Z:80133360-7077-4c3c-9c52-3309ea802e86
       Date:
-      - Wed, 09 Sep 2015 16:16:26 GMT
+      - Tue, 22 Sep 2015 13:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3840,7 +5729,159 @@ http_interactions:
         Kc3WovhFU3l3d3/v07sdZBv6YMof7H4kSP8S/PglPLaPDG0whjxr2nVDjX7J
         /wN3lSOVogIAAA==
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0/?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"b02efa6d-5d26-454e-bffe-91d2a5417b8e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 80c82376-0d89-4376-b8f4-13947b6b7d0f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - a35a40f4-4caf-435c-9c82-f6768edafa35
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133552Z:a35a40f4-4caf-435c-9c82-f6768edafa35
+      Date:
+      - Tue, 22 Sep 2015 13:35:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9FkZy8/zz6dbd+f
+        7X26vX9/P9+enJ/n2w93Z3vZ/f3dB5OD/Pf9SF+kbld53RZ5Q6/zqOXDy6Kh
+        URXLi9dt1jIRXq+n0zyf5TN5k5rZwayFIPcPHk53dx7s0+Bnu9TxZLL9cO/g
+        wfYke3D+6afTfULAvVysTqrleXGxrjOmHwH4nnyVGjzw2DkoVlNuv2sg4Pl/
+        00zc7Y6IPoih/HWnSh7MTW/C5MFXt5g2eahxcUlNzl4ez2ZEC0D7aHdnjP/u
+        DzYty2rKg/sib+cV0/7pNc1QMe28QhNCpKLvAwzpix/2hF0WdbvOSv1Tp+sn
+        X5y+uUsoEIrN3df8c3v3Ix/TXxIOp6yy2ZOszJbTvH6STd/my5mS7WVVlaCd
+        5V15OsMmED/sgfso67CfP7k76SN/VweEP0IiEBn8P78/TJOz5aRaL2cvsvbV
+        umTO/P8IPYoQ8buvnr7c/skvdjaSwf1hP9dfDIU+mi2b13nbkhyCFnbw8nl9
+        SRjQx98zzemLbLUqi3z2NPxevja8+NEim+rE0bcf7exs7zzdvne8vbu7/fDh
+        9r17RgQ/ypfZpCRxfVbVV1k9Iyyo/XlWNrlpQRK9yOpr+rit1/ZTlZUvsum8
+        WEJ5OMR/WLOlXxuxVVR0vtzEML2FLsSHopKAYJ417bqhRr/k/wGcQBgYwQcA
+        AA==
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1/?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"dc2de49e-9c0d-4b01-8be3-2c206480eca6"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2249a2ef-d55e-4d25-8953-659ede8e8d66
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - ed2bb02a-6d27-4d34-8938-dc222dc5cd51
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133552Z:ed2bb02a-6d27-4d34-8938-dc222dc5cd51
+      Date:
+      - Tue, 22 Sep 2015 13:35:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9FsujfL9x/m2w+n
+        O7Pt/cnO7vbBJL+3vTfd2/l0/2Ann2af/r4f6YvU7Sqv2yJv6HUetXx4WTQ0
+        qmJ58brNWibC6/V0muezfCZvUjM7mLUQ5MHO7P7O/ft723t757vb+/c/zbcn
+        s73z7YeT3fPd/N7++Xm+Y18uVifV8ry4WNcZ048AfE++Sg0eeOwcFKspt9cR
+        y/P/ppm42x0RfRBD+etOlTyYm96EyYOvbjFt8lDj4pKanL08ns2IFoD20e7O
+        GP/tDzYty2rKg/sib+cV0/7pNc1QMe28QhNCpKLvAwzpix/2hF0WdbvOSv1T
+        p+snX5y+uUsoEIrN3df8c3v3Ix/TXxIOp6yy2ZOszJbTvH6STd/my5mS7WVV
+        laCd5V15OsMmED/sgfso67CfP7k76SN/VweEP0IiEBn8P78/TJOz5aRaL2cv
+        svbVumTO/P8IPYoQ8buvnr7c/skvNpPB/WE/118MhT6aLZvXeduSHIIWdvDy
+        eX1JGNDH3zPN6YtstSqLfPY0/F6+Nrz40SKb6sTRtx/t7GzvPN2+d7y9u7v9
+        8On2s1Mjgh/ly2xSkrg+q+qrrJ4RFtT+PCub3LQgiV5k9TV93NZr+6nKyhfZ
+        dF4soTwc4j+s2dKvjdgqKjpfbmKY3kIX4kNRSUAwz5p23VCjX/L/ALoy+cjB
+        BwAA
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
@@ -3853,11 +5894,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3880,20 +5921,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - efb073ac-e2e9-4fe1-b94d-5af26e4c2a04
+      - 8272aaec-a14e-45ef-925b-f3510c06cbc2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14761'
+      - '14979'
       X-Ms-Correlation-Request-Id:
-      - 46c5f91b-2b52-4ce7-8275-4356bac7cffc
+      - 402f645f-1bf1-4278-9739-468107eabf1f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161627Z:46c5f91b-2b52-4ce7-8275-4356bac7cffc
+      - EASTUS:20150922T133552Z:402f645f-1bf1-4278-9739-468107eabf1f
       Date:
-      - Wed, 09 Sep 2015 16:16:26 GMT
+      - Tue, 22 Sep 2015 13:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3903,15 +5944,92 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3ce0v/e
-        7H76iP639+CTnZ1HOzsfmca/RH75Pn78EgYBTN8CQ6WKpclHy0ygnszz820i
-        y8z1GaWm9y6eDRRt1tNpns9yDyIeR9Gz5XnV+Y7QDAnqg02HIIaUOdjePXiz
-        +/DR/u6j3Xvj3Xu7e7v39zsUIrqYX5lK+vf3Ge5H+bs2X6JToKAjt6O2FPui
-        mNZVU5234zNqfDFvm/FPfvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5
-        /oQcIOL9Tx/d2xnf2z14sNthM2GsKObVVV6j5/xuvV6iQ6+bWyNMkmLelkZC
-        wN84+SX/D828ogJaBAAA
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3cebu/t
+        vdm99+je/Uf3732ys/NoZ+cj0/iXyC/fx49fwiCA6VtgqFSxNPlomQnUk3l+
+        vk1kmbk+o9T03sWzgaLNejrN81nuQcTjKHq2PK863xGaIUF9sOkQxJAyB9u7
+        B292Hz7a3320e2+8e293b/f+fodCRBfzK1NJ//4+w/0of9fmS3QKFHTkdtSW
+        Yl8U07pqqvN2fEaNL+ZtM/7JL54W2cWyatpi2rzO25awbrRTv4M+YR349yLo
+        EDHfn5ADRLz/6aN7O+N7uwcPdvceBEQUxopiXl3lNXrO79brJTr0urk1wiQp
+        5m1pJAT8jZNf8v8AFM0p3FoEAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
+      X-Ms-Request-Id:
+      - 8b6df7c6-e949-42e5-9266-a8edd4ea4300
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - 9f3a1aed-3f77-44c4-98b7-393d756a4304
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133553Z:9f3a1aed-3f77-44c4-98b7-393d756a4304
+      Date:
+      - Tue, 22 Sep 2015 13:35:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50d740/Hu7sOD8YO9ex/x
+        a9SsabN23eQNNfiefJQaEHg+mlaznL776GVdXRaAVCwvXtM7+d1mPZ3m+Syf
+        GVh4Pirzy7zEC2fL8yr4ZlY0NIRrvLxGdx+9yrPZddBkkTdNdsH9fb7Om5ZH
+        kBZNWq+X6DjNlrM0o25XLf5a5lfptFqeFxfrOmsJt2YcgGuLBcPa29m9v73z
+        cHtv783uvUf37j/a3/lkZ+fRzs5HpvEvkV++r29/lL9r8yVG+23qsSQSEpgo
+        edrrFXfxRTGtq6Y6b8fHP1jX+fhpkV0sq6Ytps34LMtee3+HKNL72oc3U7vj
+        vfHOeCdoKRNF33rd08fvOT/0xuAM0XcDc+TaKKHsL9/Hj1/CQPDyW7ykhLJ4
+        frTMZB5eEgEu6rzZfppfuo51ZCELeq/j+dkepg82HYLYZafd+292P3208+mj
+        3Xvj+/v7uzsH+x22ItKYX5lQ+rew2UeTqmp9vrBTS6NdNlWZv57WObHhvGqf
+        lNXkq7qgJh/N23bVPLp7dzrPz1d1Nbu/u7czntD342lFjHdVLGfVVTNe5u1d
+        dDBzHWyv6CfoP9s+n57fm03z6fb55GC2vf/w/P72w9nBdHuyez+fTc/PH+zs
+        T+/60zW+zRvjxiI8nixWTAblDStQGKbOso6WvjUM4qTojBpfzNtm/JNfeCR6
+        nbcQfE+EWIDCV99DAPntW4jfR8168j5celItVtWSdJdw2N0fIpN6KvTF3WOe
+        AnmY8/AI9+H5/4zkeYNy85hankqbvJV3m+Z8XZaBUaHXe4J78Gbn3qOdB4/2
+        HryXwPbJZUn1fmQaItH7k6c/NlFKDx/dvzf+9NOHOwe7e8EYRR6jmFdXeY2e
+        87tqbr1ubo3wT36RmrelkRDwN05+yf8DCNPaY+QIAAA=
+    http_version: 
+  recorded_at: Tue, 22 Sep 2015 13:35:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
@@ -3924,11 +6042,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -3951,20 +6069,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - c0ed9fc3-f75c-4ef5-9951-6dff906b2060
+      - bc95c704-f7df-4e7e-b765-0334cc92e71a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14760'
+      - '14979'
       X-Ms-Correlation-Request-Id:
-      - 7017e5bf-4a3a-4bf3-8980-8dc9bbd82925
+      - bff47906-e3b8-44af-abfc-905293777d86
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161627Z:7017e5bf-4a3a-4bf3-8980-8dc9bbd82925
+      - EASTUS:20150922T133553Z:bff47906-e3b8-44af-abfc-905293777d86
       Date:
-      - Wed, 09 Sep 2015 16:16:26 GMT
+      - Tue, 22 Sep 2015 13:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3974,15 +6092,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsP6X9vdj99RP/be/DJzs6jnZ2P
-        TONfIr98Hz9+CYMAUm+BjBLADv+jZSZQp/P8vMnry7zedb1GSee9jWcD+Zr1
-        dJrns3zmIOJx5Dtbnled7wjRkHo+2HQIYkibg+1dos2DR/sHj/bujw/uH3y6
-        93C/QyOijPmV6aR/f5/hfpS/a3OaApoGgqojt6O2NPuimNZVU5234zNqfDFv
-        m/FPfvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcSMSH9/fu7e3s
-        BUQU1opiXl3lNXrO787yrCyrKf3qd3VrpEk0fAjSUAj5Gye/5P8BhHf1008E
-        AAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsPt/f23uzee3Tv/qP79z7Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqdJ6fN3l9mde7rtco6by38Wwg
+        X7OeTvN8ls8cRDyOfGfL86rzHSEaUs8Hmw5BDGlzsL378M3ug0f7B4/27o8P
+        7h98uvdwv0Mjooz5lemkf3+f4X6Uv2tzmgKaBoKqI7ejtjT7opjWVVOdt+Mz
+        anwxb5vxT37xtMgullXTFtPmdd62hHWjnfod9AnrwL8XQYeI+f6E3EjEh/f3
+        7u3t7AVEFNaKYl5d5TV6zu/O8qwsqyn96nd1a6RJNHwI0lAI+Rsnv+T/AQXl
+        hGJPBAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
@@ -3995,11 +6113,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -4022,37 +6140,38 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - 72ce7cf6-9ed1-4879-98c4-6a67d72766ab
+      - 0e5398ca-f124-43db-9a5d-a01f7e00c0b9
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14711'
+      - '14976'
       X-Ms-Correlation-Request-Id:
-      - 15496e1a-d996-4f4c-bfdf-3eddaaedb02e
+      - 14f1c3cc-ec7b-42fa-8737-585966b66364
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161627Z:15496e1a-d996-4f4c-bfdf-3eddaaedb02e
+      - EASTUS:20150922T133554Z:14f1c3cc-ec7b-42fa-8737-585966b66364
       Date:
-      - Wed, 09 Sep 2015 16:16:26 GMT
+      - Tue, 22 Sep 2015 13:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsP6X9vdj99RP/be/DJzs6jnZ2P
-        TONfIr98Hz9+CYMAUm+BjBLADv+jZSZQT1+9dL1FSea9hWcD2Zr1dJrns3zm
-        IOJxZDtbnled7wjBkGo+2HQIYkiTg+3dgze7Dx/de/Bod3d872B3b2+nSxui
-        iPmV6aN/f5/hfpS/a3MiPZGfoOrI7agtrb4opnXVVOft+IwaX8zbZvyTXzwt
-        sotl1bTFtHmdty1h3Winfgd9wjrw70XQIWK+PyGHiHjwaPfB+N69/Xv7u/cC
-        IgpLRTGvrvIaPed36/USHXrd3BphEgfztjQSAv7GyS/5fwDY/VFDPwQAAA==
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50XePnxfL9Tv+eHtvvDPe
+        vfcRv02tmzZr103eULvvyUepgYTno2k1y+m7j17W1WUBgMXy4jW9k99t1tNp
+        ns/ymYGF56Myv8xLvHC2PK+Cb2ZFQyO5xstrdPfRqzybXQdNFnnTZBfc3+fr
+        vGkZ47Ro0nq9RMdptpylGXW7avHXMr9Kp9XyvLhY11lLuDXjAFxbLBjW3s7u
+        /e2dh9t7e2927z26d//R/qef7Ow82tn5yDT+JfLL9/Xtj/J3bb7EaL9NPZZE
+        SQLzve/jy1/CTTCYt/wh/vIo9tEykz5PX710uESp7L2F530pTW8M0pq+IwRD
+        avtg0yGIXYrt7r/Z/RQUu//p+NPdvQc7+wcdyhFFzK9MH/1bKOnoCBR05HbU
+        llZfFNO6aqrzdnxGjS/mbTP+yS+eFtnFsmraYtq8zlvMd6Od+h30CevAvxdB
+        h4j5/oQcIiL+N76/c+/TT/dCIgpLRTGvrvIaPed3VQK8bm6N8E9+YeTHdIgf
+        NFu/5P8Bp/EQLn4EAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
@@ -4065,11 +6184,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -4092,20 +6211,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - 2d3418ab-4c57-4810-8a3f-6a8fd5a84966
+      - 67a97224-d86a-4e5f-a6a5-18379e712a81
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14759'
+      - '14976'
       X-Ms-Correlation-Request-Id:
-      - 785a538e-bb09-4f9e-959e-beae45be27b2
+      - 80192e98-43df-4a0b-ad3f-371bbf48aa0e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161627Z:785a538e-bb09-4f9e-959e-beae45be27b2
+      - EASTUS:20150922T133554Z:80192e98-43df-4a0b-ad3f-371bbf48aa0e
       Date:
-      - Wed, 09 Sep 2015 16:16:27 GMT
+      - Tue, 22 Sep 2015 13:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4115,14 +6234,14 @@ http_interactions:
         pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsP6X9vdj99RP/bO/hkZ+fRzs5H
-        pvEvkV++jx+/hEEAqbdARglgh//RMhOoX5z9xJ7rLkoz7zU8G+jWrKfTPJ/l
-        MwcRj6Pb2fK86nxHGIZk88GmQxBDohxs7+2+2b3/6P6DR/sPxp/e2z/Y2X3Y
-        IQ6RxPzKBNK/v89wP8rftTnRnuhPUHXkdtSOWMW0rprqvB2fUeOLeduMf/KL
-        p0V2sayatpg2r/O2Jawb7dTvoE9YB/69CDpEzPcn5GYiPnxwb2/nfkBE4ako
-        5tVVXqPn/O4sz8qymtKvfle3RppkwocgDYWQv3HyS/4f6UHKLUgEAAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsPt/f23uzee3Tv/qP7+5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1i7Of2HPdRWnmvYZnA92a9XSa
+        57N85iDicXQ7W55Xne8Iw5BsPth0CGJIlIPtvd03u0SRB4/2H4w/vbd/sLP7
+        sEMcIon5lQmkf3+f4X6Uv2tzoj3Rn6DqyO2oHbGKaV011Xk7PqPGF/O2Gf/k
+        F0+L7GJZNW0xbV7nbUtYN9qp30GfsA78exF0iJjvT8jNRHz44N7ezv2AiMJT
+        Ucyrq7xGz/ndWZ6VZTWlX/2ubo00yYQPQRoKIX/j5Jf8P0wRYJlIBAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:30 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:56 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
@@ -4135,11 +6254,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -4162,20 +6281,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130853644837866706
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
       X-Ms-Request-Id:
-      - ba2b9f50-ca47-427e-8dff-32c424d3ecda
+      - 4743a28b-05d1-469c-b0e6-cdad2a7e84ae
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14789'
+      - '14976'
       X-Ms-Correlation-Request-Id:
-      - bedf1771-7f12-46ef-b237-3dcf1914fc54
+      - 21156725-d48c-4d51-8803-52e0a21e0b08
       X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T161628Z:bedf1771-7f12-46ef-b237-3dcf1914fc54
+      - EASTUS:20150922T133554Z:21156725-d48c-4d51-8803-52e0a21e0b08
       Date:
-      - Wed, 09 Sep 2015 16:16:27 GMT
+      - Tue, 22 Sep 2015 13:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4184,19 +6303,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
         6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
         Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbOw/p
-        f292P31E/9s7+GRn59HOzkem8S+RX76PH7+EQQCpt0BGCWCH/9EyE6hfnP3E
-        SbVYrdt81/UaJZ33Np4N5GvW02mez/KZg4jHke9seV51viNEQ+r5YNMhiCFt
-        Drb3HrzZPXh0n8jzYHz/0737B3sPOzQiyphfmU70t4K0o7O0mWVtRni9/f8X
-        ZQ7GuzsP9z/d3fsGKLPnev35RRn8+D7D/Sh/1+YktiS6BFVHbkdtKfZFMa2r
-        pjpvx2fU+GLeNuOf/OJpkV0sq6Ytps3rvG0J60Y79TvoE9aBfy+CDhHz/Qm5
-        mYgPdh8+3LsfELHPShbz6iqv0XN+d5ZnZVlN6Ve/q1sjTerUhyANhZC/cfJL
-        /h942u5XSAYAAA==
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbOw+3
+        9/be7N57dO/+o/v7n+zsPNrZ+cg0/iXyy/fx45cwCCD1FsgoAezwP1pmAvWL
+        s584qRardZvvul6jpPPexrOBfM16Os3zWT5zEPE48p0tz6vOd4RoSD0fbDoE
+        MaTNwfbegze7B4/uf/po98H4/qd79w/2HnZoRJQxvzKd6G8FaUdnaTPL2ozw
+        evv/L8ocjHd3Hu5/urv3DVBmz/X684sy+PF9hvtR/q7NSWxJdAmqjtyO2lLs
+        i2JaV0113o7PqPHFvG3GP/nF0yK7WFZNW0yb13nbEtaNdup30CesA/9eBB0i
+        5vsTcjMRH+w+fLh3PyBin5Us5tVVXqPn/O4sz8qymtKvfle3RprUqQ9BGgoh
+        f+Pkl/w/g++U/UgGAAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:16:31 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4206,11 +6325,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -4220,6 +6339,8 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Content-Encoding:
@@ -4228,31 +6349,46 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14499'
-      X-Ms-Request-Id:
-      - e1e5f8ec-ece6-426e-811a-80db1a16d212
-      X-Ms-Correlation-Request-Id:
-      - e1e5f8ec-ece6-426e-811a-80db1a16d212
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T162757Z:e1e5f8ec-ece6-426e-811a-80db1a16d212
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
+      X-Ms-Request-Id:
+      - 37cfa6b5-1193-4c3d-a145-bbcbf5daafee
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - b7393ade-0bcf-4e1d-883f-d7862d3a54cf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133554Z:b7393ade-0bcf-4e1d-883f-d7862d3a54cf
       Date:
-      - Wed, 09 Sep 2015 16:27:56 GMT
-      Content-Length:
-      - '133'
+      - Tue, 22 Sep 2015 13:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50d740/Hu7sOD8YO9ex/x
+        a9SsabN23eQNNfiefJQaEHg+mlaznL776GVdXRaAVCwvXtM7+d1mPZ3m+Syf
+        GVh4Pirzy7zEC2fL8yr4ZlY0NIRrvLxGdx+9yrPZddBkkTdNdsH9fb7Om5ZH
+        kBZNWq+X6DjNlrM0o25XLf5a5lfptFqeFxfrOmsJt2YcgGuLBcPa29m9v73z
+        cHtv783uvUf37j+6v/PJzs6jnZ2PTONfIr98Hz9+CYMAum+BplLF0uSjZSZQ
+        qwZNXIdRUnov4nlfctIbgwSl7wiBkKQ+2HQIYo8su292Hz7av//o3u54f//+
+        zr3dDnWIJuZXppD+/X0G+9GkqtqnRXaxrJq2mAINHTINdtlUZf56Wuf5splX
+        7ZOymnxVF9Tko3nbrppHd+82q3y627RVTfO+O55Qg/G0qvPxVbGcVVfNeJm3
+        d9HDzPWwjXcuFzvbebb7IM/29rezWTbb3t+f3tvODg4ebu/s7N87n+zt3n94
+        vscdbP/kFzvj27QeNxbX8WSxYgooP/RnV4dJ373XrA7N6PvP5tBMPny0czDe
+        f3CPpnIvmEoZShTz6iqv0XN+V2XN6+bWCP/kF0ZSTYf4QTzzS/4fjlKCqOEE
+        AAA=
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:28:00 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4262,11 +6398,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
+      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDI5Mjg2MjYsIm5iZiI6MTQ0MjkyODYyNiwiZXhwIjoxNDQyOTMyNTI2LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.jpbHdxjqSlVdzjFRUfGiWciDEYenTbWinA1-GPeUgNP5iF_uyr9lZ2cVDpChNFI9s2_s4QLwvJkolSogZxV6UID8upE68Wi-ktQcrjmSiZi6dgue2zgER9r-8KLjYeS-9cZ88cUtB9vpyDYgFTFQZHjnLAKOfhERqF2aFfsL9jLRoLeggi6zyD4ZGecnP4AXSldp5xGDsK7b7sttvbtnSDKajc6HVbbv_6auIUbgjnJmiHkwyH0yahRWMTdjvDQlC32RMhvla1j895pkS_PP9AkTIPV_8-FOJ0RXY9A7Bh_JrIxhlRGsQxetCRj-u6o4XO9PiTUYBzw3KCjwIqjm1g
   response:
     status:
       code: 200
@@ -4276,6 +6412,8 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Content-Encoding:
@@ -4284,82 +6422,41 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14761'
-      X-Ms-Request-Id:
-      - e9664dbd-ac1e-45de-a836-f9eec5684ef5
-      X-Ms-Correlation-Request-Id:
-      - e9664dbd-ac1e-45de-a836-f9eec5684ef5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T162758Z:e9664dbd-ac1e-45de-a836-f9eec5684ef5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130857843494101757
+      X-Ms-Request-Id:
+      - 1da25ac3-5434-4644-baa3-74c0c32d22d7
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - f5a2e33f-dc1a-466a-8cb5-cbcc14d68a7e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20150922T133554Z:f5a2e33f-dc1a-466a-8cb5-cbcc14d68a7e
       Date:
-      - Wed, 09 Sep 2015 16:27:58 GMT
-      Content-Length:
-      - '133'
+      - Tue, 22 Sep 2015 13:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd372zsPt/f23uzee3Tv/qP79z/Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zARq1aCJ6zBKNe9FPBso16yn0zyf
+        5TMHEY+j3NnyvOp8RwiEhPPBpkMQe2TZfbP78NH+/Ud7B+P79/fv7+x1qEM0
+        Mb8yhfTv7zPYjyZV1T4tsotl1bTFFGjokGmwy6Yq89fTOs+Xzbxqn5TV5Ku6
+        oCYfzdt21Ty6e7dZ5dPdpq1qmtnd8YQajKdVnY+viuWsumrGy7y9ix5mrodt
+        vHO52N3emdzP9rL98+3d2acPtvd3Z/l2trs33b63O9t5sPvpw71P94iu1Hj7
+        J7/YHd+m9bixuI4nixVTQPmhP7s6TPruvWZ1aEbffzZjM7m38+j+zqPdh+P9
+        h7v3DnZDRpehRDGvrvIaPRPKbbVaBd3cGmESS/O2NBI++Y2TX/L/AH8Ys3XH
+        BAAA
     http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:28:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.0.0p576
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDE4MTUwNjcsIm5iZiI6MTQ0MTgxNTA2NywiZXhwIjoxNDQxODE4OTY3LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.ac4s3TpDYWozILVh8AnBnZC129Vd1QI-X6CdcJJZQcGVoyCX6POxlKbaPctYA4HhGxi0cOmlJKSu8UgFjPM5oF7ZhezAr1KEk5D7TXh-V05cubhSVP4OhofiasQxeMUF2DgTN00tmgWHdt9u919T_wrplTPd_Z41JULpw40lxxA70Hg_NHaDJRBt1gsihtcvWYK5RRoyaT9g7lAJS9uy-oJJHv2cf1d63dG0DyhmeiCJeEzjaL36BlHBjA-7ncbirqxHhZtTySx5xtPMwnwQxLj1EvYzteTD_NWMHiQ87ut-FYeIG_7vwOIenr_fPht4-5p7qZqM9877y548WITXXA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14753'
-      X-Ms-Request-Id:
-      - b94f5095-6e21-4a48-b6de-dc75719a456a
-      X-Ms-Correlation-Request-Id:
-      - b94f5095-6e21-4a48-b6de-dc75719a456a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20150909T162758Z:b94f5095-6e21-4a48-b6de-dc75719a456a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 09 Sep 2015 16:27:58 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 09 Sep 2015 16:28:01 GMT
+  recorded_at: Tue, 22 Sep 2015 13:35:56 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Provider refresh now scans through Azure deployments and converts them into orchestration stacks. In Azure deployments are created from templates. If a deployment is created through a template URL, this URL is included in the deployment information returned by Azure resource manager API. If a deployment is created directly from a template, the content of the template is not retrievable through the API. This is a limitation comparing with other providers such as OpenStack or AWS.

During the refresh if a template URL can be obtained, its content will be downloaded and saved as `OrchestrationTemplateAzure`. Otherwise the stack is left without an associated template.

Each stack can have multiple resources, parameters, and outputs. Some resources have models in manageiq such as instances, security groups, and networks. Currently only instances are linked with stacks. The linkage between other types can be added in the future.