### PR TITLE
Fix @table_name to reflect the correct controller name

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -10,7 +10,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def self.table_name
-    @table_name ||= "foreman_provider"
+    @table_name ||= "provider_foreman"
   end
 
   def index
@@ -18,7 +18,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def show_list
-    redirect_to :action => 'explorer'
+    redirect_to :action => 'explorer', :flash_msg => @flash_array ? @flash_array[0][:message] : nil
   end
 
   def new

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -50,6 +50,8 @@ describe ProviderForemanController do
     get :explorer
     accords = controller.instance_variable_get(:@accords)
     expect(accords.size).to eq(2)
+    breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
+    expect(breadcrumbs[0]).to include(:url => '/provider_foreman/show_list')
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end


### PR DESCRIPTION
The url for the Cancel button in the provisioning dialog is retrieved from ```@breadcrumbs[:url]``` as seen <a href=https://github.com/ManageIQ/manageiq/blob/master/app/controllers/application_controller/miq_request_methods.rb#L563>here</a>

```@breadcrumbs[:url]``` is constructed using ```self.table_name``` which was incorrect for foreman causing a routing issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1264815