### PR TITLE
content cut off in selects

### DIFF
--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -10,7 +10,6 @@
                        "ng-model"                    => "scheduleModel.timer_typ",
                        "ng-change"                   => "scheduleTimerTypeChanged()",
                        "checkchange"                 => "",
-                       "data-width"                  => "auto",
                        "selectpicker-for-select-tag" => "")
 
           %span{"ng-show" => "!timerTypeOnce"}= _("every")
@@ -19,7 +18,6 @@
                               "name"                      => "timer_value",
                               "ng-options"                => "timerItem.value as timerItem.text for timerItem in timer_items",
                               "timer-hide"                => "timerTypeOnce",
-                              "data-width"                => "auto",
                               "checkchange"               => ""}
           %input{"type" => "hidden", "ng-value" => "scheduleModel.timer_value", "name" => "timer_value"}
       .form-group
@@ -61,13 +59,11 @@
                        options_for_select(Array.new(24) { |i| i }),
                        "ng-model"    => "scheduleModel.start_hour",
                        "checkchange" => "",
-                       "data-width"  => "auto",
                        "selectpicker-for-select-tag" => "")
           %span h
           = select_tag("start_min",
                        options_for_select(Array.new(12) { |i| i * 5 }),
                        "ng-model"    => "scheduleModel.start_min",
                        "checkchange" => "",
-                       "data-width"  => "auto",
                        "selectpicker-for-select-tag" => "")
           %span m

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -28,7 +28,6 @@
                         @edit[:new][:mem_typ]),
                         "data-miq_sparkle_on" => true,
                         "data-miq_sparkle_off" => true,
-                        "data-width"           => "auto",
                         :class    => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -52,7 +51,6 @@
                           options_for_select((@edit[:new][:cpu_count].nil? ? [["<#{_('Choose')}>", nil]] : []) + @edit[:cpu_options], @edit[:new][:cpu_count].to_i),
                           "data-miq_sparkle_on"  => true,
                           "data-miq_sparkle_off" => true,
-                          "data-width"           => "auto",
                           :class    => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -81,7 +79,6 @@
                            @edit[:new][:cores_per_socket_count].to_i),
                            "data-miq_sparkle_on"  => true,
                            "data-miq_sparkle_off" => true,
-                           "data-width"           => "auto",
                            :class                 => "selectpicker")
               :javascript
                 miqInitSelectPicker();


### PR DESCRIPTION
Setting Select width to "Auto" chops content in some browsers - removing until another method can be found to resize

Old:
![screen shot 2015-09-23 at 11 04 57 am](https://cloud.githubusercontent.com/assets/1287144/10048861/e5c3d1b8-61e2-11e5-8768-383b4c0e7e3a.png)
New:
![screen shot 2015-09-23 at 11 05 30 am](https://cloud.githubusercontent.com/assets/1287144/10048860/e5b80130-61e2-11e5-860e-1966d6258b4e.png)