### PR TITLE
Bump fog to 2.0 alpha

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -20,9 +20,7 @@ gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
-# TODO(lsmola) point to 1.35 when released, now pointing to ref supporting OpenStack Heat PATCH
-# gem "fog",                     "~>1.35.0",          :require => false
-gem "fog",                                          :require => false, :git => 'https://github.com/fog/fog.git', :ref => 'dd94185'
+gem "fog",                     "~>2.0.0.pre.0",     :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "kubeclient",              "=0.5.1",            :require => false


### PR DESCRIPTION
Bump fog to 2.0 alpha, getting rid of specific commit we are
using in a gemfile.