### PR TITLE
Handle ec2 security groups with empty firewall rules.

### DIFF
--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -218,6 +218,7 @@ module EmsRefresh::SaveInventoryCloud
     firewall_rules       = ems.security_groups.collect(&:firewall_rules).flatten
     firewall_rules.each do |fr|
       fr_hash = firewall_rule_hashes[fr.id]
+      next if fr_hash.nil?
       fr_hash[:source_security_group_id] = fr_hash.fetch_path(:source_security_group, :id)
       fr.update_attribute(:source_security_group_id, fr_hash[:source_security_group_id])
     end

--- a/spec/models/ems_refresh/refreshers/ec2_refresher_security_group_spec.rb
+++ b/spec/models/ems_refresh/refreshers/ec2_refresher_security_group_spec.rb
@@ -1,63 +1,61 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
-    let(:hashes_with_empty_security_group_rules) {
-      [
-        {:type=>"ManageIQ::Providers::Amazon::CloudManager::SecurityGroup",
-         :ems_ref=>"sg-e94055ac",
-         :name=>"default",
-         :description=>"default group",
-         :cloud_network=>nil,
-         :orchestration_stack=>nil,
-         :firewall_rules=>
-          [
-            {:direction=>nil,
-              :host_protocol=>nil,
-              :port=>nil,
-              :end_port=>nil,
-              :source_security_group=>nil,
-            },
-            {:direction=>nil,
-              :host_protocol=>nil,
-              :port=>nil,
-              :end_port=>nil,
-              :source_security_group=>nil,
-            },
-            {:direction=>"inbound",
-              :host_protocol=>"ICMP",
-              :port=>-1,
-              :end_port=>-1,
-              :source_security_group=>nil,
-            },
-          ]
-        },
-        {:type=>"ManageIQ::Providers::Amazon::CloudManager::SecurityGroup",
-         :ems_ref=>"sg-2b87746f",
-         :name=>"EmsRefreshSpec-SecurityGroup-OtherRegion",
-         :description=>"EmsRefreshSpec-SecurityGroup-OtherRegion",
-         :cloud_network=>nil,
-         :orchestration_stack=>nil,
-         :firewall_rules=>
-          [
-            {:direction=>"inbound",
-             :host_protocol=>"TCP",
-             :port=>0,
-             :end_port=>65535,
-             :source_ip_range=>"0.0.0.0/0"
-            }
-          ]
-        },
-       ]
-    }
+  let(:hashes) do
+    [
+      {:type                => 'ManageIQ::Providers::Amazon::CloudManager::SecurityGroup',
+       :ems_ref             => 'sg-e94055ac',
+       :name                => 'default',
+       :description         => 'default group',
+       :cloud_network       => nil,
+       :orchestration_stack => nil,
+       :firewall_rules      => [
+         {:direction             => nil,
+          :host_protocol         => nil,
+          :port                  => nil,
+          :end_port              => nil,
+          :source_security_group => nil
+         },
+         {:direction             => nil,
+          :host_protocol         => nil,
+          :port                  => nil,
+          :end_port              => nil,
+          :source_security_group => nil
+         },
+         {:direction             => 'inbound',
+          :host_protocol         => 'ICMP',
+          :port                  => -1,
+          :end_port              => -1,
+          :source_security_group => nil
+         }]
+      },
+      {:type                => 'ManageIQ::Providers::Amazon::CloudManager::SecurityGroup',
+       :ems_ref             => 'sg-2b87746f',
+       :name                => 'EmsRefreshSpec-SecurityGroup-OtherRegion',
+       :description         => 'EmsRefreshSpec-SecurityGroup-OtherRegion',
+       :cloud_network       => nil,
+       :orchestration_stack => nil,
+       :firewall_rules      => [
+         {:direction       => 'inbound',
+          :host_protocol   => 'TCP',
+          :port            => 0,
+          :end_port        => 65_535,
+          :source_ip_range => '0.0.0.0/0'
+         }]
+      }
+    ]
+  end
+
   before(:each) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_amazon, :zone => zone)
-
   end
 
   context '.save_security_groups_inventory' do
-    it "should not raise an exception with empty security group firewall rules" do
-      expect{EmsRefresh.save_security_groups_inventory(@ems, hashes_with_empty_security_group_rules)}.to_not raise_error
+    it 'should not raise an exception with empty firewall rules' do
+      expect do
+        EmsRefresh.save_security_groups_inventory(@ems, hashes)
+      end.to_not raise_error
     end
   end
 end

--- a/spec/models/ems_refresh/refreshers/ec2_refresher_security_group_spec.rb
+++ b/spec/models/ems_refresh/refreshers/ec2_refresher_security_group_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
+    let(:hashes_with_empty_security_group_rules) {
+      [
+        {:type=>"ManageIQ::Providers::Amazon::CloudManager::SecurityGroup",
+         :ems_ref=>"sg-e94055ac",
+         :name=>"default",
+         :description=>"default group",
+         :cloud_network=>nil,
+         :orchestration_stack=>nil,
+         :firewall_rules=>
+          [
+            {:direction=>nil,
+              :host_protocol=>nil,
+              :port=>nil,
+              :end_port=>nil,
+              :source_security_group=>nil,
+            },
+            {:direction=>nil,
+              :host_protocol=>nil,
+              :port=>nil,
+              :end_port=>nil,
+              :source_security_group=>nil,
+            },
+            {:direction=>"inbound",
+              :host_protocol=>"ICMP",
+              :port=>-1,
+              :end_port=>-1,
+              :source_security_group=>nil,
+            },
+          ]
+        },
+        {:type=>"ManageIQ::Providers::Amazon::CloudManager::SecurityGroup",
+         :ems_ref=>"sg-2b87746f",
+         :name=>"EmsRefreshSpec-SecurityGroup-OtherRegion",
+         :description=>"EmsRefreshSpec-SecurityGroup-OtherRegion",
+         :cloud_network=>nil,
+         :orchestration_stack=>nil,
+         :firewall_rules=>
+          [
+            {:direction=>"inbound",
+             :host_protocol=>"TCP",
+             :port=>0,
+             :end_port=>65535,
+             :source_ip_range=>"0.0.0.0/0"
+            }
+          ]
+        },
+       ]
+    }
+  before(:each) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(:ems_amazon, :zone => zone)
+
+  end
+
+  context '.save_security_groups_inventory' do
+    it "should not raise an exception with empty security group firewall rules" do
+      expect{EmsRefresh.save_security_groups_inventory(@ems, hashes_with_empty_security_group_rules)}.to_not raise_error
+    end
+  end
+end

--- a/spec/models/ems_refresh/save_inventory_cloud_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_cloud_spec.rb
@@ -52,10 +52,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   context '.save_security_groups_inventory' do
-    it 'should not raise an exception with empty firewall rules' do
-      expect do
-        EmsRefresh.save_security_groups_inventory(@ems, hashes)
-      end.to_not raise_error
+    it 'should handle empty firewall rules' do
+      expect(EmsRefresh.save_security_groups_inventory(@ems, hashes).uniq(&:id).count).to eq(4)
     end
   end
 end


### PR DESCRIPTION
This code change will handle the case where an ec2 security group is defined with empty firewall rules.

Fixes #4359