### PR TITLE
Removed unused timeserver comment from console

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -141,7 +141,6 @@ module ApplianceConsole
         dns1     = Env["DNS1"]
         dns2     = Env["DNS2"]
         order    = Env["SEARCHORDER"]
-        # time   = Env["TIMESERVER"]
         timezone = Env["TIMEZONE"]
         region   = File.read(REGION_FILE).chomp  if File.exist?(REGION_FILE)
         version  = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)


### PR DESCRIPTION
Removes the only line in our source tree that references the "timeserver" feature of miqnet.sh
Removing it because it has been commented out.