### PR TITLE
[api] Provide access to picture for services and service_requests

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -14,6 +14,7 @@ class Service < ActiveRecord::Base
   virtual_has_many   :vms
   virtual_has_many   :all_vms
   virtual_column     :v_total_vms,            :type => :integer,  :uses => :vms
+  virtual_has_one    :picture
 
   include ServiceMixin
   include OwnershipMixin

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -7,6 +7,9 @@ class ServiceTemplateProvisionRequest < MiqRequest
   validates_inclusion_of :request_state,  :in => %w{ pending finished } + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"
   validate               :must_have_user
 
+  virtual_has_one :picture
+  virtual_has_one :service_template
+
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
 
@@ -16,6 +19,15 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   def my_zone
     nil
+  end
+
+  def picture
+    st = service_template
+    st.picture if st.present?
+  end
+
+  def service_template
+    ServiceTemplate.find_by_id(source_id)
   end
 
   def requested_task_idx

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -1,0 +1,71 @@
+#
+# Rest API Request Tests - Picture specs
+#
+# - Query picture and image_href of service_templates  /api/service_templates/:id?attributes=picture,picture.image_href
+# - Query picture and image_href of services           /api/services/:id?attributes=picture,picture.image_href
+# - Query picture and image_href of service_requests   /api/service_requests/:id?attributes=picture,picture.image_href
+#
+require 'spec_helper'
+
+describe ApiController do
+  include Rack::Test::Methods
+
+  let(:dialog1)  { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
+  let(:ra1)      { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
+  let(:picture)  { FactoryGirl.create(:picture, :extension => "jpg") }
+  let(:template) do
+    FactoryGirl.create(:service_template,
+                       :name             => "ServiceTemplate",
+                       :resource_actions => [ra1],
+                       :picture          => picture)
+  end
+  let(:service) { FactoryGirl.create(:service, :service_template_id => template.id) }
+  let(:service_request) do
+    FactoryGirl.create(:service_template_provision_request,
+                       :description => 'Service Request',
+                       :userid      => api_config(:user),
+                       :source_id   => template.id)
+  end
+
+  before(:each) do
+    init_api_spec_env
+    api_basic_authorize
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  def expect_result_to_include_picture_href(source_id)
+    expect_result_to_match_hash(@result, "id" => source_id)
+    expect_result_to_have_keys(%w(id href picture))
+    expect_result_to_match_hash(@result["picture"],
+                                "id"          => picture.id,
+                                "resource_id" => template.id,
+                                "image_href"  => /^http:.*#{picture.image_href}$/)
+  end
+
+  describe "Queries of Service Templates" do
+    it "allows queries of the related picture and image_href" do
+      run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
+
+      expect_result_to_include_picture_href(template.id)
+    end
+  end
+
+  describe "Queries of Services" do
+    it "allows queries of the related picture and image_href" do
+      run_get services_url(service.id), :attributes => "picture,picture.image_href"
+
+      expect_result_to_include_picture_href(service.id)
+    end
+  end
+
+  describe "Queries of Service Requests" do
+    it "allows queries of the related picture and image_href" do
+      run_get service_requests_url(service_request.id), :attributes => "picture,picture.image_href"
+
+      expect_result_to_include_picture_href(service_request.id)
+    end
+  end
+end


### PR DESCRIPTION
Extending the virtual attribute picture to:
/api/services
/api/service_templates

With this following is now doable:

GET /api/services?expand=resources&attributes=picture,picture.image_href
GET /api/service_requests?expand=resources&attributes=picture,picture.image_href
GET /api/service_templates?expand=resources&attributes=picture,picture.image_href

https://trello.com/c/Vpcpc5RJ