### PR TITLE
Fixed bootstrap conversion in Reports-Schedules

### DIFF
--- a/app/views/layouts/_edit_to_email.html.haml
+++ b/app/views/layouts/_edit_to_email.html.haml
@@ -52,6 +52,8 @@
                            :style             => "float: left; margin-right: 2px",
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %span.input-group-addon{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
-            %i.fa.fa-plus
+          %span.input-group-btn
+            .btn.btn-default{:alt => t = _("Add"), :title => t, :onclick => "miqAjaxButton('#{url_for(:action => action_url, :button => "add_email", :id => "#{record.id || "new"}")}');"}
+              %i.fa.fa-plus
+
   %hr


### PR DESCRIPTION
Fixed fix PR #4467. Corrected CSS classes.

Before:
![47274494-6125-11e5-905d-1f11fd71b0b3](https://cloud.githubusercontent.com/assets/9535558/10069875/466487de-62af-11e5-91a4-3c225ddb3592.png)

After:
![firefox_screenshot_2015-09-24t09-28-00 117z](https://cloud.githubusercontent.com/assets/9535558/10069883/569870b6-62af-11e5-900f-9f69c67b576f.png)

@epwinchell @skateman please review