### PR TITLE
Fix breadcrumbs for container topology

### DIFF
--- a/app/controllers/container_topology_controller.rb
+++ b/app/controllers/container_topology_controller.rb
@@ -5,7 +5,13 @@ class ContainerTopologyController < ApplicationController
   after_action :set_session_data
 
   def show
-
+    # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
+    # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
+    # any other page in the application.
+    if params[:id].nil?
+      @breadcrumbs.clear
+    end
+    drop_breadcrumb(:name => 'Topology', :url => '')
   end
 
   def index

--- a/app/views/layouts/_tabs.html.haml
+++ b/app/views/layouts/_tabs.html.haml
@@ -41,4 +41,7 @@
       - if (@default_search && @default_search.name != @edit[:adv_search_applied][:name]) || !@default_search
         (#{link_to("clear", {:action => 'adv_search_clear'}, :method => :post, :class => 'active')})
     - else
-      = @title
+      - if @layout == "container_topology"
+        = ''
+      - else
+        = @title


### PR DESCRIPTION
The fix contains the following:
1. Display a containers provider name when a topology
is of a specific provider.
2. In all other cases (when navigated to topology not from a provider
page) - do not display breadcrumbs
3. Remove the title Topology from the middle of the screen to avoid
duplication and waste of screen space