### PR TITLE
use previous_breadcrumb_url instead of directly touching @breadcrumbs

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -121,7 +121,7 @@ module ApplicationController::CiProcessing
         else
           session[:flash_msgs] = @flash_array
           render :update do |page|
-            page.redirect_to(@breadcrumbs[-2][:url])               # Go to previous page using breadcrumbs
+            page.redirect_to(previous_breadcrumb_url)
           end
         end
       when "save"
@@ -160,7 +160,7 @@ module ApplicationController::CiProcessing
           else
             session[:flash_msgs] = @flash_array
             render :update do |page|
-              page.redirect_to(@breadcrumbs[-2][:url])               # Go to previous page using breadcrumbs
+              page.redirect_to(previous_breadcrumb_url)
             end
           end
         end
@@ -288,7 +288,7 @@ module ApplicationController::CiProcessing
       else
         session[:flash_msgs] = @flash_array.dup
         render :update do |page|
-          page.redirect_to @breadcrumbs[-2][:url]
+          page.redirect_to previous_breadcrumb_url
         end
       end
       return
@@ -403,7 +403,7 @@ module ApplicationController::CiProcessing
       else
         session[:flash_msgs] = @flash_array
         render :update do |page|
-          page.redirect_to(@breadcrumbs[-2][:url])
+          page.redirect_to(previous_breadcrumb_url)
         end
       end
     when "submit"

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -66,7 +66,7 @@ module ApplicationController::PolicySupport
         replace_right_cell
       else
         @edit = nil                                       # Clear out the session :edit hash
-        redirect_to(@breadcrumbs[-2][:url])               # Go to previous breadcrumb
+        redirect_to(previous_breadcrumb_url)
       end
     else                                                  # First time in,
       protect_build_screen                                #    build the protect screen

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -253,7 +253,7 @@ module ApplicationController::Tags
     else
       @edit = nil # clean out the saved info
       render :update do |page|
-        page.redirect_to(@breadcrumbs[-2][:url])                # Go to previous breadcrumb
+        page.redirect_to(previous_breadcrumb_url)
       end
     end
   end
@@ -272,7 +272,7 @@ module ApplicationController::Tags
     else
       @edit = nil
       render :update do |page|
-        page.redirect_to(@breadcrumbs[-2][:url])                # Go to previous breadcrumb
+        page.redirect_to(previous_breadcrumb_url)
       end
     end
   end

--- a/app/controllers/ontap_file_share_controller.rb
+++ b/app/controllers/ontap_file_share_controller.rb
@@ -84,7 +84,7 @@ class OntapFileShareController < CimInstanceController
       @edit = nil # clean out the saved info
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
       render :update do |page|
-        page.redirect_to(@breadcrumbs[-2][:url])              # Go to previous breadcrumb
+        page.redirect_to(previous_breadcrumb_url)
       end
     else
       sfs.errors.each do |field, msg|
@@ -102,7 +102,7 @@ class OntapFileShareController < CimInstanceController
     @edit = nil # clean out the saved info
     session[:flash_msgs] = @flash_array.dup                   # Put msgs in session for next transaction
     render :update do |page|
-      page.redirect_to(@breadcrumbs[-2][:url])                # Go to previous breadcrumb
+      page.redirect_to(previous_breadcrumb_url)
     end
   end
 

--- a/app/controllers/ontap_storage_system_controller.rb
+++ b/app/controllers/ontap_storage_system_controller.rb
@@ -90,7 +90,7 @@ class OntapStorageSystemController < CimInstanceController
       @edit = nil # clean out the saved info
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
       render :update do |page|
-        page.redirect_to(@breadcrumbs[-2][:url])                # Go to previous breadcrumb
+        page.redirect_to(previous_breadcrumb_url)
       end
     else
       ccs.errors.each do |field, msg|
@@ -108,7 +108,7 @@ class OntapStorageSystemController < CimInstanceController
     @edit = nil # clean out the saved info
     session[:flash_msgs] = @flash_array.dup                   # Put msgs in session for next transaction
     render :update do |page|
-      page.redirect_to(@breadcrumbs[-2][:url])                # Go to previous breadcrumb
+      page.redirect_to(previous_breadcrumb_url)
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -38,7 +38,6 @@ describe ApplicationController do
     end
 
     it "should not raise an error for feature that user has access to" do
-      msg = "The user is not authorized for this task or item."
       lambda do
         controller.send(:assert_privileges, "host_new")
       end.should_not raise_error
@@ -79,6 +78,21 @@ describe ApplicationController do
       @test_user_role[:settings] = {}
       view_yaml = controller.send(:view_yaml_filename, VmCloud.name, {})
       view_yaml.should include("ManageIQ_Providers_CloudManager_Vm.yaml")
+    end
+  end
+
+  context "#previous_breadcrumb_url" do
+    it "should return url when 2 entries" do
+      controller.instance_variable_set(:@breadcrumbs, [{:url => "test_url"}, 'placeholder'])
+      expect(controller.send(:previous_breadcrumb_url)).to eq("test_url")
+    end
+
+    it "should raise for less than 2 entries" do
+      controller.instance_variable_set(:@breadcrumbs, [{}])
+      expect { controller.send(:previous_breadcrumb_url) }.to raise_error
+
+      controller.instance_variable_set(:@breadcrumbs, [])
+      expect { controller.send(:previous_breadcrumb_url) }.to raise_error
     end
   end
 


### PR DESCRIPTION
Still a few places using `@breadcrumbs[-2][:url]`, replaced by a `previous_breadcrumb_url` call. + A test for the current behaviour. :)