### PR TITLE
Delete unused rabbit queues (part 2)

### DIFF
--- a/gems/pending/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/gems/pending/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -117,7 +117,8 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
     end
 
     # notifications.* is a poorly named extra-old legacy queue
-    channel.queue_delete("notifications.*") if connection.queue_exists?(queue_name)
+    queue_name = "notifications.*"
+    channel.queue_delete(queue_name) if connection.queue_exists?(queue_name)
 
     channel.close
   end


### PR DESCRIPTION
[First PR](https://github.com/ManageIQ/manageiq/pull/4474) accidentally referenced an out of scope variable.

This is attempt 2, now with a test.

https://bugzilla.redhat.com/show_bug.cgi?id=1265289

Fixes #4484 