### PR TITLE
Adding volume_types to env builder

### DIFF
--- a/spec/tools/environment_builders/openstack/services/volume/builder.rb
+++ b/spec/tools/environment_builders/openstack/services/volume/builder.rb
@@ -33,23 +33,14 @@ module Openstack
 
         def find_or_create_volume_types
           @data.volume_types.each do |volume_type|
-            # TODO(lsmola) Fog is commiiing
-            # @volume_types << volume_type = find_or_create(@service.volume_types, volume_type)
-            @volume_types << volume_type = find(service_volume_types(@service), volume_type)
+            @volume_types << volume_type = find_or_create(@service.volume_types, volume_type)
 
             find_or_create_volumes(volume_type)
           end
         end
 
-        # TODO(lsmola) Delete when in fog
-        def service_volume_types(volume_service)
-          # volume types are not available via the Fog API directly
-          volume_service.request(:expects => 200, :method => "GET", :path => "types").body["volume_types"]
-        end
-
         def find_or_create_volumes(volume_type)
-          # volume_type_name = volume_type.name
-          volume_type_name = volume_type['name']
+          volume_type_name = volume_type.name
           volume_type_data = @data.volumes(volume_type_name)
 
           return if volume_type_data.blank?


### PR DESCRIPTION
Adding volume_types to env builder, as that model was released in
new fog version.