### PR TITLE
Method to create automate attrs from object array

### DIFF
--- a/app/models/service_template/filter.rb
+++ b/app/models/service_template/filter.rb
@@ -6,7 +6,7 @@ module ServiceTemplate::Filter
       attrs = {'request' => 'SERVICE_PROVISION_INFO', 'message' => 'include_service'}
       st = ServiceTemplate.find(service_template_id)
       obj_array = [parent_svc_task.get_user, st, parent_svc, parent_svc_task]
-      MiqAeEngine.create_automation_attributes_from_obj_array(obj_array, attrs)
+      MiqAeEngine.set_automation_attributes_from_objects(obj_array, attrs)
       uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => parent_svc_task)
       automate_result_include_service_template?(uri, st.name)
     end

--- a/app/models/service_template/filter.rb
+++ b/app/models/service_template/filter.rb
@@ -5,7 +5,8 @@ module ServiceTemplate::Filter
     def include_service_template?(parent_svc_task, service_template_id, parent_svc = nil)
       attrs = {'request' => 'SERVICE_PROVISION_INFO', 'message' => 'include_service'}
       st = ServiceTemplate.find(service_template_id)
-      set_automation_attrs([parent_svc_task.get_user, st, parent_svc, parent_svc_task], attrs)
+      obj_array = [parent_svc_task.get_user, st, parent_svc, parent_svc_task]
+      MiqAeEngine.create_automation_attributes_from_obj_array(obj_array, attrs)
       uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => parent_svc_task)
       automate_result_include_service_template?(uri, st.name)
     end
@@ -15,15 +16,6 @@ module ServiceTemplate::Filter
       result = ws.root['include_service'].nil? ? true : ws.root['include_service']
       _log.info("Include Service Template <#{name}> : <#{result}>")
       result
-    end
-
-    def set_automation_attrs(objects, attrs)
-      Array.wrap(objects).each do |object|
-        next unless object
-        key   = MiqAeEngine.create_automation_attribute_key(object)
-        value = MiqAeEngine.create_automation_attribute_value(object)
-        attrs[key] = value
-      end
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -261,10 +261,10 @@ module MiqAeEngine
     end.join(",")
   end
 
-  def self.create_automation_attributes_from_obj_array(objects, attrs_hash)
-    Array.wrap(objects).each do |object|
-      next unless object
+  def self.set_automation_attributes_from_objects(objects, attrs_hash)
+    Array.wrap(objects).compact.each do |object|
       key   = create_automation_attribute_key(object)
+      raise "Key: #{key} already exists in hash" if attrs_hash.key?(key)
       value = create_automation_attribute_value(object)
       attrs_hash[key] = value
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -261,6 +261,15 @@ module MiqAeEngine
     end.join(",")
   end
 
+  def self.create_automation_attributes_from_obj_array(objects, attrs_hash)
+    Array.wrap(objects).each do |object|
+      next unless object
+      key   = create_automation_attribute_key(object)
+      value = create_automation_attribute_value(object)
+      attrs_hash[key] = value
+    end
+  end
+
   def self.create_automation_object(name, attrs, options = {})
     # args
     if options[:fqclass]

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -385,6 +385,20 @@ module MiqAeEngineSpec
         MiqAeEngine.create_automation_attributes("").should == ""
       end
 
+     it "with an array of nil objects" do
+       hash = {}
+       MiqAeEngine.create_automation_attributes_from_obj_array([nil, nil], hash)
+       expect(hash).to be_empty
+     end
+
+     it "with an array of nil and valid objects" do
+       hash = {:a => 'A', 'b' => 'b'}
+       expected_hash = hash.merge("VmOrTemplate::vm" => Vm.first.id, "Host::host" => Host.first.id)
+       MiqAeEngine.create_automation_attributes_from_obj_array([Vm.first, nil, Host.first], hash)
+       expect(hash).to eq(expected_hash)
+     end
+
+
     end
 
     context ".automation_attribute_is_array?" do

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -384,19 +384,30 @@ module MiqAeEngineSpec
         MiqAeEngine.create_automation_attributes("").should == ""
         MiqAeEngine.create_automation_attributes("").should == ""
       end
+    end
 
+    context ".set_automation_attributes_from_objects" do
+      before(:each) do
+        FactoryGirl.create(:small_environment)
+      end
       it "with an array of nil objects" do
         hash = {}
-        MiqAeEngine.create_automation_attributes_from_obj_array([nil, nil], hash)
+        MiqAeEngine.set_automation_attributes_from_objects([nil, nil], hash)
         expect(hash).to be_empty
       end
 
       it "with an array of nil and valid objects" do
         hash = {:a => 'A', 'b' => 'b'}
         expected_hash = hash.merge("VmOrTemplate::vm" => Vm.first.id, "Host::host" => Host.first.id)
-        MiqAeEngine.create_automation_attributes_from_obj_array([Vm.first, nil, Host.first], hash)
+        MiqAeEngine.set_automation_attributes_from_objects([Vm.first, nil, Host.first], hash)
         expect(hash).to eq(expected_hash)
       end
+
+      it "raise error if the object is already in the hash" do
+        hash = {:a => 'A', "VmOrTemplate::vm" => Vm.first.id}
+        expect { MiqAeEngine.set_automation_attributes_from_objects([Vm.first], hash) }.to raise_error
+      end
+
     end
 
     context ".automation_attribute_is_array?" do

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -385,20 +385,18 @@ module MiqAeEngineSpec
         MiqAeEngine.create_automation_attributes("").should == ""
       end
 
-     it "with an array of nil objects" do
-       hash = {}
-       MiqAeEngine.create_automation_attributes_from_obj_array([nil, nil], hash)
-       expect(hash).to be_empty
-     end
+      it "with an array of nil objects" do
+        hash = {}
+        MiqAeEngine.create_automation_attributes_from_obj_array([nil, nil], hash)
+        expect(hash).to be_empty
+      end
 
-     it "with an array of nil and valid objects" do
-       hash = {:a => 'A', 'b' => 'b'}
-       expected_hash = hash.merge("VmOrTemplate::vm" => Vm.first.id, "Host::host" => Host.first.id)
-       MiqAeEngine.create_automation_attributes_from_obj_array([Vm.first, nil, Host.first], hash)
-       expect(hash).to eq(expected_hash)
-     end
-
-
+      it "with an array of nil and valid objects" do
+        hash = {:a => 'A', 'b' => 'b'}
+        expected_hash = hash.merge("VmOrTemplate::vm" => Vm.first.id, "Host::host" => Host.first.id)
+        MiqAeEngine.create_automation_attributes_from_obj_array([Vm.first, nil, Host.first], hash)
+        expect(hash).to eq(expected_hash)
+      end
     end
 
     context ".automation_attribute_is_array?" do


### PR DESCRIPTION
Refactored some automate code so that we can pass in an array
of objects which get converted to the automate attribute notation
of
ClassName::variablename = object id
e.g Host::host=128
This pattern gets used in many places in

app/models/miq_provision/automate.rb