### PR TITLE
Add GCE as a Cloud Provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,12 +74,15 @@ gem "ancestry",                       "~>2.1.0",   :require => false
 gem "aws-sdk",                        "~>1.56.0",  :require => false
 gem "dalli",                          "~>2.7.4",   :require => false
 gem "elif",                           "=0.1.0",    :require => false
+gem "google-api-client",              ">=0.8.0",   :require => false
 gem "hamlit",                         "~>1.7.2",   :require => false
 gem "inifile",                        "~>3.0",     :require => false
 gem "logging",                        "~>1.6.1",   :require => false  # Ziya depends on this
 gem "net_app_manageability",          ">=0.1.0",   :require => false
 gem "net-ping",                       "~>1.7.4",   :require => false
 gem "net-ssh",                        "~>2.9.2",   :require => false
+gem "omniauth",                       ">=1.1.0",   :require => false
+gem "omniauth-google-oauth2",         :git => "git://github.com/zquestz/omniauth-google-oauth2.git"
 gem "open4",                          "~>1.3.0",   :require => false
 gem "ovirt_metrics",                  "~>1.1.0",   :require => false
 gem "ruby_parser",                    "~>3.7",     :require => false

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -128,6 +128,8 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
        $scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid &&
        $scope.emsCommonModel.default_verify != '' && $scope.angularForm.default_verify.$valid)) {
       return true;
+    } else if($scope.emsCommonModel.emstype == "gce") {
+      return true;
     }
     else
       return false;

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -235,6 +235,15 @@ class EmsCloudController < ApplicationController
       amqp_password = params[:amqp_password] ? params[:amqp_password] : ems.authentication_password(:amqp)
       creds[:amqp] = {:userid => params[:amqp_userid], :password => amqp_password}
     end
+    if ems.supports_authentication?(:oauth) && !session[:oauth_response].blank?
+      auth = session[:oauth_response]
+      credentials = auth["credentials"]
+      creds[:oauth] = {:refresh_token => credentials["refresh_token"],
+                       :access_token  => credentials["access_token"],
+                       :expires       => credentials["expires"],
+                       :userid        => auth["info"]["name"]}
+      session[:oauth_response] = nil
+    end
     creds
   end
 

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -689,6 +689,7 @@ module EmsCommon
     @edit[:new][:hostname] = @ems.hostname
     @edit[:new][:emstype] = @ems.emstype
     @edit[:amazon_regions] = get_amazon_regions if @ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager)
+    @edit[:google_regions] = list_google_regions if @ems.kind_of?(ManageIQ::Providers::Google::CloudManager)
     @edit[:new][:port] = @ems.port
     @edit[:new][:api_version] = @ems.api_version
     @edit[:new][:provider_id] = @ems.provider_id
@@ -755,6 +756,7 @@ module EmsCommon
     end
     @ems_types = Array(model.supported_types_and_descriptions_hash.invert).sort_by(&:first)
     @amazon_regions = get_amazon_regions
+    @google_regions = list_google_regions
     @openstack_infra_providers = retrieve_openstack_infra_providers
     @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
   end
@@ -762,6 +764,14 @@ module EmsCommon
   def get_amazon_regions
     regions = {}
     ManageIQ::Providers::Amazon::Regions.all.each do |region|
+      regions[region[:name]] = region[:description]
+    end
+    regions
+  end
+
+  def list_google_regions
+    regions = {}
+    ManageIQ::Providers::Google::Regions.all.each do |region|
       regions[region[:name]] = region[:description]
     end
     regions
@@ -827,6 +837,7 @@ module EmsCommon
     @edit[:new][:host_default_vnc_port_start] = params[:host_default_vnc_port_start] if params[:host_default_vnc_port_start]
     @edit[:new][:host_default_vnc_port_end] = params[:host_default_vnc_port_end] if params[:host_default_vnc_port_end]
     @edit[:amazon_regions] = get_amazon_regions if @edit[:new][:emstype] == "ec2"
+    @edit[:google_regions] = list_google_regions if @edit[:new][:emstype] == "gce"
     @edit[:new][:security_protocol] = params[:security_protocol] if params[:security_protocol]
     @edit[:new][:realm] = nil if params[:security_protocol]
     @edit[:new][:realm] = params[:realm] if params[:realm]

--- a/app/controllers/oauth_sessions_controller.rb
+++ b/app/controllers/oauth_sessions_controller.rb
@@ -1,0 +1,6 @@
+class OAuthSessionsController < ApplicationController
+  def create
+    session[:oauth_response] = request.env["omniauth.auth"]
+    render :text => "Authenticated, please close tab to return to ManageIQ."
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -1,0 +1,48 @@
+class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudManager
+  require_nested :Refresher
+
+  def self.ems_type
+    @ems_type ||= "gce".freeze
+  end
+
+  def self.description
+    @description ||= "Google Compute Engine".freeze
+  end
+
+  def self.hostname_required?
+    false
+  end
+
+  def self.region_required?
+    false
+  end
+
+  def supported_auth_types
+    %w(oauth)
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
+  validates :provider_region, :inclusion => {:in => ManageIQ::Providers::Google::Regions.names}
+
+  def description
+    ManageIQ::Providers::Google::Regions.find_by_name(provider_region)[:description]
+  end
+
+  def verify_credentials(_auth_type = nil, _options = {})
+    true
+  end
+
+  #
+  # Connections
+  #
+
+  def connect(_options = {})
+  end
+
+  def gce
+    @gce ||= connect(:service => "GCE")
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresher.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Google::CloudManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+  include ::EmsRefresh::Refreshers::EmsRefresherMixin
+
+  def parse_inventory(ems, _targets)
+    ::ManageIQ::Providers::Google::CloudManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+  end
+
+  def post_process_refresh_classes
+    [::Vm]
+  end
+end

--- a/app/models/manageiq/providers/google/regions.rb
+++ b/app/models/manageiq/providers/google/regions.rb
@@ -1,0 +1,50 @@
+module ManageIQ
+  module Providers::Google
+    module Regions
+      # From https://cloud.google.com/compute/docs/zones
+      REGIONS = {
+        "us-central1"  => {
+          :name        => "us-central1",
+          :hostname    => "us-central1",
+          :description => "Central US",
+        },
+        "europe-west1" => {
+          :name        => "europe-west1",
+          :hostname    => "europe-west1",
+          :description => "Western Europe",
+        },
+        "asia-east1"   => {
+          :name        => "asia-east1",
+          :hostname    => "asia-east1",
+          :description => "East Asia",
+        },
+      }
+
+      # TODO(lwander): hack to make GCE more compatible with other providers
+      REGIONS_BY_HOSTNAME =
+        REGIONS.values.each_with_object({}) do |v, h|
+          h[v[:hostname]] = v
+        end
+
+      def self.all
+        REGIONS.values
+      end
+
+      def self.names
+        REGIONS.keys
+      end
+
+      def self.hostnames
+        REGIONS_BY_HOSTNAME.keys
+      end
+
+      def self.find_by_name(name)
+        REGIONS[name]
+      end
+
+      def self.find_by_hostname(hostname)
+        REGIONS_BY_HOSTNAME[hostname]
+      end
+    end
+  end
+end

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -42,6 +42,11 @@
                                               :prefix                 => "default",
                                               :verify_title_off       => _("Access Key ID and matching Secret Access Key fields are needed to perform verification of credentials"),
                                               :basic_info_needed      => true}
+        .col-md-12{"ng-if" => "#{ng_model}" != "emsCommonModel" || "#{ng_model}.emstype == 'gce'"}
+          = render :partial => "layouts/angular/oauth_button_angular", 
+                   :locals  => {:ng_show           => true,
+                                :title             => "Google OAuth 2.0",
+                                :auth_url          => "google_oauth2"}
         .col-md-12{"ng-if" => "#{ng_model}" != "emsCommonModel" || "#{ng_model}.emstype != 'ec2'"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show           => true,
@@ -161,6 +166,13 @@
   :javascript
     $('#auth_tabs').hide();
 %div{"ng-if" => "emsCommonModel.emstype == 'ec2'"}
+  :javascript
+    miq_tabs_show_hide("#amqp_tab", false);
+    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_init('#auth_tabs');
+    $('#auth_tabs').show();
+%div{"ng-if" => "emsCommonModel.emstype == 'gce'"}
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);

--- a/app/views/layouts/angular/_oauth_button_angular.html.haml
+++ b/app/views/layouts/angular/_oauth_button_angular.html.haml
@@ -1,0 +1,6 @@
+%div{'ng-show' => ng_show}
+  %a.btn.btn-primar.btn-s{:href   => "/auth/#{auth_url}",
+                          :target => "_blank",
+                          :type   => "button"}
+    #{title}
+  %br

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,8 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
+           :scope => 'https://www.googleapis.com/auth/compute,' \
+             'https://www.googleapis.com/auth/devstorage.read_only,' \
+             'https://www.googleapis.com/auth/logging.write,' \
+             'https://www.googleapis.com/auth/cloud-platform,' \
+             'email,profile'
+end

--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -20,3 +20,4 @@
 - ems-type:openshift
 - ems-type:atomic
 - ems-type:foreman_provisioning
+- ems-type:gce

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2061,4 +2061,5 @@ Vmdb::Application.routes.draw do
   get '/static/*id' => 'static#show', :format => false
 
   resources :ems_cloud, :as => :ems_clouds
+  match "/auth/:provider/callback" => "sessions#create", :via => :get
 end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -248,6 +248,7 @@ describe EmsCloudController do
                                        :default_password => "default_password2")
       creds = {:userid => "default_userid", :password => "default_password2"}
       mocked_ems.should_receive(:supports_authentication?).with(:amqp)
+      mocked_ems.should_receive(:supports_authentication?).with(:oauth)
       expect(controller.send(:build_credentials, mocked_ems)).to include(:default => creds)
     end
 
@@ -256,6 +257,7 @@ describe EmsCloudController do
       mocked_ems.should_receive(:authentication_password).and_return('default_password')
       creds = {:userid => "default_userid", :password => "default_password"}
       mocked_ems.should_receive(:supports_authentication?).with(:amqp)
+      mocked_ems.should_receive(:supports_authentication?).with(:oauth)
       expect(controller.send(:build_credentials, mocked_ems)).to include(:default => creds)
     end
 
@@ -268,6 +270,7 @@ describe EmsCloudController do
       default_creds = {:userid => "default_userid", :password => "default_password2"}
       amqp_creds = {:userid => "amqp_userid", :password => "amqp_password2"}
       mocked_ems.should_receive(:supports_authentication?).with(:amqp).and_return(true)
+      mocked_ems.should_receive(:supports_authentication?).with(:oauth)
       expect(controller.send(:build_credentials, mocked_ems)).to include(:default => default_creds,
                                                                          :amqp    => amqp_creds)
     end
@@ -281,6 +284,7 @@ describe EmsCloudController do
       default_creds = {:userid => "default_userid", :password => "default_password"}
       amqp_creds = {:userid => "amqp_userid", :password => "amqp_password"}
       mocked_ems.should_receive(:supports_authentication?).with(:amqp).and_return(true)
+      mocked_ems.should_receive(:supports_authentication?).with(:oauth)
       expect(controller.send(:build_credentials, mocked_ems)).to include(:default => default_creds,
                                                                          :amqp    => amqp_creds)
     end
@@ -294,6 +298,7 @@ describe EmsCloudController do
       default_creds = {:userid => "default_userid", :password => "default_password2"}
       amqp_creds = {:userid => "amqp_userid", :password => "amqp_password"}
       mocked_ems.should_receive(:supports_authentication?).with(:amqp).and_return(true)
+      mocked_ems.should_receive(:supports_authentication?).with(:oauth)
       expect(controller.send(:build_credentials, mocked_ems)).to include(:default => default_creds,
                                                                          :amqp    => amqp_creds)
     end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -99,6 +99,11 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_google, :aliases => ["manageiq/providers/google/cloud_manager"],
+    :class => "ManageIQ::Providers::Google::CloudManager", :parent => :ems_cloud do
+    provider_region "us-central1"
+  end
+
   # Leaf classes for ems_container
 
   factory :ems_kubernetes, :aliases => ["manageiq/providers/kubernetes/container_manager"], :class => "ManageIQ::Providers::Kubernetes::ContainerManager", :parent => :ems_container do

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -13,6 +13,7 @@ describe ExtManagementSystem do
       ec2
       foreman_configuration
       foreman_provisioning
+      gce
       kubernetes
       openshift
       atomic

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -2,17 +2,26 @@ require "spec_helper"
 
 describe EmsCloud do
   it ".types" do
-    expected_types = [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Azure::CloudManager, ManageIQ::Providers::Openstack::CloudManager].collect(&:ems_type)
+    expected_types = [ManageIQ::Providers::Amazon::CloudManager,
+                      ManageIQ::Providers::Azure::CloudManager,
+                      ManageIQ::Providers::Openstack::CloudManager,
+                      ManageIQ::Providers::Google::CloudManager].collect(&:ems_type)
     described_class.types.should match_array(expected_types)
   end
 
   it ".supported_subclasses" do
-    expected_subclasses = [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Azure::CloudManager, ManageIQ::Providers::Openstack::CloudManager]
+    expected_subclasses = [ManageIQ::Providers::Amazon::CloudManager,
+                           ManageIQ::Providers::Azure::CloudManager,
+                           ManageIQ::Providers::Openstack::CloudManager,
+                           ManageIQ::Providers::Google::CloudManager]
     described_class.supported_subclasses.should match_array(expected_subclasses)
   end
 
   it ".supported_types" do
-    expected_types = [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Azure::CloudManager, ManageIQ::Providers::Openstack::CloudManager].collect(&:ems_type)
+    expected_types = [ManageIQ::Providers::Amazon::CloudManager,
+                      ManageIQ::Providers::Azure::CloudManager,
+                      ManageIQ::Providers::Openstack::CloudManager,
+                      ManageIQ::Providers::Google::CloudManager].collect(&:ems_type)
     described_class.supported_types.should match_array(expected_types)
   end
 end


### PR DESCRIPTION
This is a small step in adding GCE as a Cloud Provider. So far, it allows users to authenticate using OAuth. The authentication starts like this:

![oauth1](https://cloud.githubusercontent.com/assets/4874941/10080552/41c12a3e-62be-11e5-95f3-5b8056540e12.png)

Next, I plan to allow authentication using service accounts, and the creation of VMs from default images. I am not entirely familiar with the naming inside ManageIQ, so I am wondering if it makes sense to allow GCE to act as a Infrastructure Provider as well as a Cloud Provider, since I don't know what the difference is between the two in this context. 

As a disclaimer, this is my first time using Ruby, Rails, Angular, etc, so please don't hold back when providing feedback and corrections since I want to get up speed quickly.