### PR TITLE
Collect cloud provider flavor disk data

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -179,8 +179,8 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :supports_paravirtual     => flavor[:virtualization_type].include?(:paravirtual),
       :block_storage_based_only => flavor[:ebs_only],
       :cloud_subnet_required    => flavor[:vpc_only],
-      :disk_size                => flavor[:instance_store_size],
-      :disk_count               => flavor[:instance_store_volumes]
+      :ephemeral_disk_size      => flavor[:instance_store_size],
+      :ephemeral_disk_count     => flavor[:instance_store_volumes]
     }
 
     return uid, new_result
@@ -364,7 +364,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
         :cores_per_socket    => 1,
         :logical_cpus        => flavor[:cpus],
         :memory_cpu          => flavor[:memory] / (1024 * 1024), # memory_cpu is in megabytes
-        :disk_capacity       => flavor[:disk_size],
+        :disk_capacity       => flavor[:ephemeral_disk_size],
         :disks               => [], # Filled in later conditionally on flavor
         :networks            => [], # Filled in later conditionally on what's available
       },
@@ -386,10 +386,10 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       new_result.store_path(:hardware, :guest_os, parent_image.fetch_path(:hardware, :guest_os))
     end
 
-    if flavor[:disk_count] > 0
+    if flavor[:ephemeral_disk_count] > 0
       disks = new_result[:hardware][:disks]
-      single_disk_size = flavor[:disk_size] / flavor[:disk_count]
-      flavor[:disk_count].times do |i|
+      single_disk_size = flavor[:ephemeral_disk_size] / flavor[:ephemeral_disk_count]
+      flavor[:ephemeral_disk_count].times do |i|
         add_instance_disk(disks, single_disk_size, i, "Disk #{i}")
       end
     end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -80,7 +80,7 @@ module ManageIQ::Providers
           :cpu_cores      => s['numberOfCores'],
           :memory         => s['memoryInMB'].to_f,
           :root_disk_size => s['osDiskSizeInMB'] * 1024,
-          :swap_disk_size => s['resourceDiskSizeInMB']
+          :swap_disk_size => s['resourceDiskSizeInMB'] * 1024
         }
         return uid, new_result
       end

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -493,9 +493,9 @@ module ManageIQ::Providers
       end
       add_instance_disk(disks, sz, dev.dup, "Root disk")
       sz = flavor[:ephemeral_disk_size]
-      add_instance_disk(disks, sz, dev.succ!.dup, "Ephemeral disk") unless sz.zero?
+      add_instance_disk(disks, sz, dev.succ!.dup, "Ephemeral disk")
       sz = flavor[:swap_disk_size]
-      add_instance_disk(disks, sz, dev.succ!.dup, "Swap disk") unless sz.zero?
+      add_instance_disk(disks, sz, dev.succ!.dup, "Swap disk")
 
       return uid, new_result
     end

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -205,8 +205,14 @@ module ManageIQ::Providers
         :memory               => flavor.ram.megabytes,
         :root_disk_size       => flavor.disk.to_i.gigabytes,
         :swap_disk_size       => flavor.swap.to_i.megabytes,
-        :ephemeral_disk_size  => flavor.ephemeral.to_i.gigabytes,
-        :ephemeral_disk_count => flavor.ephemeral.to_i.gigabytes > 0 ? 1 : 0
+        :ephemeral_disk_size  => flavor.ephemeral.nil? ? nil : flavor.ephemeral.to_i.gigabytes,
+        :ephemeral_disk_count => if flavor.ephemeral.nil?
+                                   nil
+                                 elsif flavor.ephemeral.to_i > 0
+                                   1
+                                 else
+                                   0
+                                 end
       }
 
       return uid, new_result

--- a/db/migrate/20150924195523_enhance_flavors_for_cloud_disk_info.rb
+++ b/db/migrate/20150924195523_enhance_flavors_for_cloud_disk_info.rb
@@ -1,0 +1,8 @@
+class EnhanceFlavorsForCloudDiskInfo < ActiveRecord::Migration
+  def change
+    add_column :flavors, :root_disk_size, :bigint
+    add_column :flavors, :swap_disk_size, :bigint
+    rename_column :flavors, :disk_size, :ephemeral_disk_size
+    rename_column :flavors, :disk_count, :ephemeral_disk_count
+  end
+end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -104,8 +104,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :supports_hvm             => false,
       :supports_paravirtual     => true,
       :block_storage_based_only => true,
-      :disk_size                => 0,
-      :disk_count               => 0
+      :ephemeral_disk_size      => 0,
+      :ephemeral_disk_count     => 0
     )
 
     @flavor.ext_management_system.should == @ems

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -78,8 +78,8 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :supports_hvm             => nil,
       :supports_paravirtual     => nil,
       :block_storage_based_only => nil,
-      :root_disk_size           => 1_072_693_248,
-      :swap_disk_size           => 71_680
+      :root_disk_size           => 1023.megabytes,
+      :swap_disk_size           => 70.megabytes
     )
 
     @flavor.ext_management_system.should == @ems
@@ -137,7 +137,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :annotation          => nil,
       :numvcpus            => 1,
       :memory_cpu          => 1792, # MB
-      :disk_capacity       => 1_072_764_928,
+      :disk_capacity       => 1093.megabytes,
       :bitness             => nil,
       :virtualization_type => nil
     )
@@ -217,7 +217,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :annotation         => nil,
       :numvcpus           => 1,
       :memory_cpu         => 768, # MB
-      :disk_capacity      => 1_072_713_728,
+      :disk_capacity      => 1043.megabytes,
       :bitness            => nil
     )
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -78,6 +78,8 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :supports_hvm             => nil,
       :supports_paravirtual     => nil,
       :block_storage_based_only => nil,
+      :root_disk_size           => 1_072_693_248,
+      :swap_disk_size           => 71_680
     )
 
     @flavor.ext_management_system.should == @ems

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -220,11 +220,13 @@ module Openstack
       ManageIQ::Providers::Openstack::CloudManager::Flavor.all.each do |flavor|
         expect(flavor.ext_management_system).to eq @ems
         # TODO(lsmola) expose below to Builder's data
-        expect(flavor.enabled).to               eq true
-        expect(flavor.cpu_cores).to             eq nil
-        expect(flavor.description).to           eq nil
-        expect(flavor.disk_size).to_not         be_nil
-        expect(flavor.disk_count).to            eq flavor.disk_size == 0 ? 0 : 1
+        expect(flavor.enabled).to                 eq true
+        expect(flavor.cpu_cores).to               eq nil
+        expect(flavor.description).to             eq nil
+        expect(flavor.root_disk_size).to_not      be_nil
+        expect(flavor.swap_disk_size).to_not      be_nil
+        expect(flavor.ephemeral_disk_size).to_not be_nil
+        expect(flavor.ephemeral_disk_count).to    eq flavor.ephemeral_disk_size == 0 ? 0 : 1
       end
     end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_grizzly_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_grizzly_spec.rb
@@ -4,6 +4,10 @@ require_relative "refresh_spec_common"
 describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   include Openstack::RefreshSpecCommon
 
+  def root_disk_size_by_flavor(flavor_name)
+    flavor_name == "m1.tiny" ? 0 : Openstack::RefreshSpecCommon::ROOT_DISK_SIZE_HASH[flavor_name]
+  end
+
   before(:each) do
     setup_ems('1.2.3.4', 'password_2WpEraURh')
     @environment = :grizzly

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_spec.rb
@@ -4,6 +4,10 @@ require_relative "refresh_spec_common"
 describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   include Openstack::RefreshSpecCommon
 
+  def root_disk_size_by_flavor(flavor_name)
+    flavor_name == "m1.tiny" ? 1.gigabytes : Openstack::RefreshSpecCommon::ROOT_DISK_SIZE_HASH[flavor_name]
+  end
+
   before(:each) do
     setup_ems('1.2.3.4', 'password_2WpEraURh')
     @environment = :havana

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_kilo_keystone_v3_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_kilo_keystone_v3_spec.rb
@@ -4,6 +4,10 @@ require_relative "refresh_spec_common"
 describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   include Openstack::RefreshSpecCommon
 
+  def root_disk_size_by_flavor(flavor_name)
+    flavor_name == "m1.tiny" ? 1.gigabytes : Openstack::RefreshSpecCommon::ROOT_DISK_SIZE_HASH[flavor_name]
+  end
+
   before(:each) do
     setup_ems('1.2.3.4', 'password_2WpEraURh', 5000, "cloud_admin", "v3")
     @environment = :kilo_keystone_v3


### PR DESCRIPTION
This PR will populate the appropriate DB column for flavor disk information
as described in the below table by Cloud Provider

(Azure uses the term to *Series* for *Flavor*)

MiQ DB column             |    Amazon                            | OpenStack               | Azure
--------------------------------|--------------------------------------|----------------------------|-----------------------
root_disk_size                | NA                                       | disk                           | OS disk 
swap_disk_size              | NA                                        | swap                        | swap
ephemeral_disk_size     | instance_store_size             | ephemeral               | NA
ephemeral_disk_count   | instance_store_volumes     | 1 if ephemeral > 0    | NA



Fixes #4427 

