### PR TITLE
[api] Return provision workflow for service_requests

### DIFF
--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -9,7 +9,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   virtual_has_one :picture
   virtual_has_one :service_template
-  virtual_has_one :provision_workflow
+  virtual_has_one :provision_dialog
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
@@ -31,11 +31,12 @@ class ServiceTemplateProvisionRequest < MiqRequest
     ServiceTemplate.find_by_id(source_id)
   end
 
-  def provision_workflow
+  def provision_dialog
     st = service_template
     return {} if st.blank?
     ra = st.resource_actions.find_by_action("Provision")
-    ResourceActionWorkflow.new(options[:dialog], userid, ra, {})
+    dialog = ResourceActionWorkflow.new(options[:dialog], userid, ra, {}).dialog
+    DialogSerializer.new.serialize(Array[dialog]).first
   end
 
   def requested_task_idx

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -9,6 +9,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   virtual_has_one :picture
   virtual_has_one :service_template
+  virtual_has_one :provision_workflow
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
@@ -28,6 +29,13 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   def service_template
     ServiceTemplate.find_by_id(source_id)
+  end
+
+  def provision_workflow
+    st = service_template
+    return {} if st.blank?
+    ra = st.resource_actions.find_by_action("Provision")
+    ResourceActionWorkflow.new(options[:dialog], userid, ra, {})
   end
 
   def requested_task_idx

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -1,19 +1,19 @@
 #
 # Rest API Request Tests - Service Requests specs
 #
-# - Query provision_workflows from service_requests
-#     GET /api/service_requests/:id?attributes=provision_workflow
+# - Query provision_dialog from service_requests
+#     GET /api/service_requests/:id?attributes=provision_dialog
 #
 require 'spec_helper'
 
 describe ApiController do
   include Rack::Test::Methods
 
-  let(:provision_dialog)    { FactoryGirl.create(:dialog, :label => "ProvisionDialog1") }
-  let(:retirement_dialog)   { FactoryGirl.create(:dialog, :label => "RetirementDialog2") }
+  let(:provision_dialog1)    { FactoryGirl.create(:dialog, :label => "ProvisionDialog1") }
+  let(:retirement_dialog2)   { FactoryGirl.create(:dialog, :label => "RetirementDialog2") }
 
-  let(:provision_ra) { FactoryGirl.create(:resource_action, :action => "Provision",  :dialog => provision_dialog) }
-  let(:retire_ra)    { FactoryGirl.create(:resource_action, :action => "Retirement", :dialog => retirement_dialog) }
+  let(:provision_ra) { FactoryGirl.create(:resource_action, :action => "Provision",  :dialog => provision_dialog1) }
+  let(:retire_ra)    { FactoryGirl.create(:resource_action, :action => "Retirement", :dialog => retirement_dialog2) }
   let(:template)     { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
 
   let(:service_request) do
@@ -37,23 +37,15 @@ describe ApiController do
       api_basic_authorize
     end
 
-    it "can return the provision_workflow" do
-      run_get service_requests_url(service_request.id), :attributes => "provision_workflow"
+    it "can return the provision_dialog" do
+      run_get service_requests_url(service_request.id), :attributes => "provision_dialog"
 
-      expect_result_to_have_keys(%w(id href provision_workflow))
-      provision_workflow = @result["provision_workflow"]
-      provision_workflow.should be_kind_of(Hash)
-      must_have = %w(settings requester dialog)
-      expect(provision_workflow.keys & must_have).to match_array(must_have)
-
-      expect(provision_workflow["requester"]).to eq(api_config(:user))
-
-      settings = provision_workflow["settings"]
-      expect(settings["resource_action_id"]).to eq(provision_ra.id)
-      expect(settings["dialog_id"]).to eq(provision_dialog.id)
-
-      dialog = provision_workflow["dialog"]
-      expect(dialog["label"]).to eq(provision_dialog.label)
+      expect_result_to_have_keys(%w(id href provision_dialog))
+      provision_dialog = @result["provision_dialog"]
+      provision_dialog.should be_kind_of(Hash)
+      expect(provision_dialog).to have_key("label")
+      expect(provision_dialog).to have_key("dialog_tabs")
+      expect(provision_dialog["label"]).to eq(provision_dialog1.label)
     end
   end
 end

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -1,0 +1,59 @@
+#
+# Rest API Request Tests - Service Requests specs
+#
+# - Query provision_workflows from service_requests
+#     GET /api/service_requests/:id?attributes=provision_workflow
+#
+require 'spec_helper'
+
+describe ApiController do
+  include Rack::Test::Methods
+
+  let(:provision_dialog)    { FactoryGirl.create(:dialog, :label => "ProvisionDialog1") }
+  let(:retirement_dialog)   { FactoryGirl.create(:dialog, :label => "RetirementDialog2") }
+
+  let(:provision_ra) { FactoryGirl.create(:resource_action, :action => "Provision",  :dialog => provision_dialog) }
+  let(:retire_ra)    { FactoryGirl.create(:resource_action, :action => "Retirement", :dialog => retirement_dialog) }
+  let(:template)     { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
+
+  let(:service_request) do
+    FactoryGirl.create(:service_template_provision_request,
+                       :userid      => api_config(:user),
+                       :source_id   => template.id,
+                       :source_type => template.class.name)
+  end
+
+  before(:each) do
+    init_api_spec_env
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  describe "Service Requests query" do
+    before do
+      template.resource_actions = [provision_ra, retire_ra]
+      api_basic_authorize
+    end
+
+    it "can return the provision_workflow" do
+      run_get service_requests_url(service_request.id), :attributes => "provision_workflow"
+
+      expect_result_to_have_keys(%w(id href provision_workflow))
+      provision_workflow = @result["provision_workflow"]
+      provision_workflow.should be_kind_of(Hash)
+      must_have = %w(settings requester dialog)
+      expect(provision_workflow.keys & must_have).to match_array(must_have)
+
+      expect(provision_workflow["requester"]).to eq(api_config(:user))
+
+      settings = provision_workflow["settings"]
+      expect(settings["resource_action_id"]).to eq(provision_ra.id)
+      expect(settings["dialog_id"]).to eq(provision_dialog.id)
+
+      dialog = provision_workflow["dialog"]
+      expect(dialog["label"]).to eq(provision_dialog.label)
+    end
+  end
+end


### PR DESCRIPTION
- Instantiate a resource action provisioning workflow for service_request and return as virtual attribute
- Support GET /api/service_requests/:id?attribute=provision_workflow
- Adding specs

https://trello.com/c/1rg6NLwc