### PR TITLE
Reset session on protect_from_forgery check failure.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   include Vmdb::Logging
 
   if Vmdb::Application.config.action_controller.allow_forgery_protection
-    protect_from_forgery :secret => MiqDatabase.first.csrf_secret_token, :except => :csp_report
+    protect_from_forgery :with => :reset_session, :secret => MiqDatabase.first.csrf_secret_token, :except => :csp_report
   end
 
   helper ChartingHelper


### PR DESCRIPTION
@kbrock, ping

http://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/

I'd go this way as it it suggested in literature to take every change to make hacking your app a frustrating experience. Resetting session on errors is one way to frustrate the attacker.