### PR TITLE
Automate Import changes to include tenant

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -73,7 +73,7 @@ module MiqAeDatastore
     _log.info("Upload complete (size=#{File.size(filename)})")
 
     begin
-      import_yaml_zip(filename, domain_name, Tenant.current_tenant)
+      import_yaml_zip(filename, domain_name, User.current_tenant)
     ensure
       File.delete(filename)
     end

--- a/lib/miq_automation_engine/models/miq_ae_datastore/xml_yaml_converter.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore/xml_yaml_converter.rb
@@ -2,7 +2,8 @@ module MiqAeDatastore
   class XmlYamlConverter
     def self.convert(xml, domain_name, export_options)
       temp_domain = MiqAeDatastore.temp_domain.downcase
-      MiqAeDomain.create!(:name => temp_domain, :priority => 100, :enabled => false)
+      MiqAeDomain.create!(:name   => temp_domain, :priority => 100, :enabled => false,
+                          :tenant => Tenant.root_tenant)
       MiqAeDatastore::XmlImport.load_xml(xml, temp_domain)
       export_options['export_as'] = domain_name
       MiqAeExport.new(temp_domain, export_options).export

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -104,6 +104,7 @@ class MiqAeYamlImport
 
   def reset_domain_attributes(domain_yaml)
     domain_yaml.delete_path('object', 'attributes', 'enabled') unless @restore
+    domain_yaml.delete_path('object', 'attributes', 'tenant_id') unless @restore
     domain_yaml.delete_path('object', 'attributes', 'priority')
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -8,6 +8,10 @@ class MiqAeYamlImport
     @domain_name = domain
     @options     = options
     @restore     = @options.fetch('restore', false)
+    tenant_id    = @options.fetch('tenant_id', Tenant.root_tenant.try(:id))
+    tenant_obj   = Tenant.find_by!(:id => tenant_id) if tenant_id
+    @tenant      = @options.fetch('tenant', tenant_obj)
+    raise "Tenant object is needed to import automate models" unless @tenant
   end
 
   def import
@@ -71,7 +75,7 @@ class MiqAeYamlImport
     domain_name = domain_yaml.fetch_path('object', 'attributes', 'name')
     domain_obj = MiqAeDomain.find_by_fqname(domain_name, false)
     track_stats('domain', domain_obj)
-    domain_obj ||= add_domain(domain_yaml) unless @preview
+    domain_obj ||= add_domain(domain_yaml, @tenant) unless @preview
     if @options['namespace']
       import_namespace(File.join(domain_folder, @options['namespace']), domain_obj, domain_name)
     else

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -9,7 +9,7 @@ class MiqAeYamlImport
     @options     = options
     @restore     = @options.fetch('restore', false)
     tenant_id    = @options['tenant_id']
-    @tenant      = @options['tenant'] || (tenant_id ? Tenant.find_by!(tenant_id) : Tenant.root_tenant)
+    @tenant      = @options['tenant'] || (tenant_id ? Tenant.find_by!(:id => tenant_id) : Tenant.root_tenant)
     raise "Tenant object is needed to import automate models" unless @tenant
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -8,9 +8,8 @@ class MiqAeYamlImport
     @domain_name = domain
     @options     = options
     @restore     = @options.fetch('restore', false)
-    tenant_id    = @options.fetch('tenant_id', Tenant.root_tenant.try(:id))
-    tenant_obj   = Tenant.find_by!(:id => tenant_id) if tenant_id
-    @tenant      = @options.fetch('tenant', tenant_obj)
+    tenant_id    = @options['tenant_id']
+    @tenant      = @options['tenant'] || (tenant_id ? Tenant.find_by!(tenant_id) : Tenant.root_tenant)
     raise "Tenant object is needed to import automate models" unless @tenant
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -10,7 +10,6 @@ class MiqAeYamlImport
     @restore     = @options.fetch('restore', false)
     tenant_id    = @options['tenant_id']
     @tenant      = @options['tenant'] || (tenant_id ? Tenant.find_by!(:id => tenant_id) : Tenant.root_tenant)
-    raise "Tenant object is needed to import automate models" unless @tenant
   end
 
   def import

--- a/lib/miq_automation_engine/models/mixins/miq_ae_yaml_import_export_mixin.rb
+++ b/lib/miq_automation_engine/models/mixins/miq_ae_yaml_import_export_mixin.rb
@@ -22,8 +22,8 @@ module MiqAeYamlImportExportMixin
     attributes.dup.delete_if { |k, v| EXPORT_EXCLUDE_KEYS.any? { |rexp| k =~ rexp || v.blank? } }
   end
 
-  def add_domain(domain_yaml)
-    MiqAeDomain.create!(domain_yaml['object']['attributes'])
+  def add_domain(domain_yaml, tenant)
+    MiqAeDomain.create!(domain_yaml['object']['attributes'].merge(:tenant => tenant))
   end
 
   def add_namespace(fqname)

--- a/lib/miq_automation_engine/models/mixins/miq_ae_yaml_import_export_mixin.rb
+++ b/lib/miq_automation_engine/models/mixins/miq_ae_yaml_import_export_mixin.rb
@@ -12,7 +12,7 @@ module MiqAeYamlImportExportMixin
   ALL_DOMAINS             = '*'
   VERSION                 = 1.0
 
-  EXPORT_EXCLUDE_KEYS     = [/^id$/, /_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/]
+  EXPORT_EXCLUDE_KEYS     = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/]
 
   def export_attributes
     attributes.dup.delete_if { |k, _| EXPORT_EXCLUDE_KEYS.any? { |rexp| k =~ rexp } }

--- a/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
@@ -2,15 +2,16 @@ require "spec_helper"
 include AutomationSpecHelper
 
 describe MiqAeDomain do
+  let(:root_tenant) { Tenant.seed }
   before do
     EvmSpecHelper.local_miq_server
-    @root_tenant = Tenant.seed
+    root_tenant
     setup_model
   end
 
   def setup_model
     yaml_file = File.join(File.dirname(__FILE__), 'data', 'domain_test.yaml')
-    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*', 'tenant_id' => @root_tenant.id}
+    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*', 'tenant_id' => root_tenant.id}
     MiqAeImport.new('*', import_options).import
     update_domain_attributes('root', :priority => 10, :system => true, :enabled => true)
     update_domain_attributes('user', :priority => 20, :enabled => true)
@@ -28,13 +29,13 @@ describe MiqAeDomain do
 
   context 'Domain Checks' do
     it 'cannot set parent_id in a domain object' do
-      domain = MiqAeDomain.create!(:name => 'Fred', :tenant => @root_tenant)
+      domain = MiqAeDomain.create!(:name => 'Fred', :tenant => root_tenant)
       ns = MiqAeNamespace.create!(:name => 'NS1')
       expect { domain.update_attributes!(:parent_id => ns.id) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'can set other attributes in a domain object' do
-      domain = MiqAeDomain.create!(:name => 'Fred', :tenant => @root_tenant)
+      domain = MiqAeDomain.create!(:name => 'Fred', :tenant => root_tenant)
       domain.update_attributes!(:priority => 10, :system => false).should be_true
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
@@ -3,8 +3,8 @@ include AutomationSpecHelper
 
 describe MiqAeDomain do
   before do
-    EvmSpecHelper.local_guid_miq_server_zone
-    @root_tenant = Tenant.root_tenant
+    EvmSpecHelper.local_miq_server
+    @root_tenant = Tenant.seed
     setup_model
   end
 

--- a/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
@@ -3,12 +3,14 @@ include AutomationSpecHelper
 
 describe MiqAeDomain do
   before do
+    EvmSpecHelper.local_guid_miq_server_zone
+    @root_tenant = Tenant.root_tenant
     setup_model
   end
 
   def setup_model
     yaml_file = File.join(File.dirname(__FILE__), 'data', 'domain_test.yaml')
-    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*'}
+    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*', 'tenant_id' => @root_tenant.id}
     MiqAeImport.new('*', import_options).import
     update_domain_attributes('root', :priority => 10, :system => true, :enabled => true)
     update_domain_attributes('user', :priority => 20, :enabled => true)
@@ -26,13 +28,13 @@ describe MiqAeDomain do
 
   context 'Domain Checks' do
     it 'cannot set parent_id in a domain object' do
-      domain = MiqAeDomain.create!(:name => 'Fred')
+      domain = MiqAeDomain.create!(:name => 'Fred', :tenant => @root_tenant)
       ns = MiqAeNamespace.create!(:name => 'NS1')
       expect { domain.update_attributes!(:parent_id => ns.id) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'can set other attributes in a domain object' do
-      domain = MiqAeDomain.create!(:name => 'Fred')
+      domain = MiqAeDomain.create!(:name => 'Fred', :tenant => @root_tenant)
       domain.update_attributes!(:priority => 10, :system => false).should be_true
     end
   end

--- a/spec/lib/miq_automation_engine/miq_method_override_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_method_override_spec.rb
@@ -3,8 +3,10 @@ include AutomationSpecHelper
 
 describe MiqAeDomain do
   before do
+    EvmSpecHelper.local_guid_miq_server_zone
     yaml_file = File.join(File.dirname(__FILE__), 'data', 'method_override.yaml')
-    import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*'}
+    import_options = {'yaml_file' => yaml_file, 'preview' => false,
+                      'domain'    => '*',       'tenant'  => Tenant.root_tenant}
     MiqAeImport.new('*', import_options).import
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -82,7 +82,7 @@ describe MiqAeDatastore do
   it ".upload" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
-    MiqAeDatastore.should_receive(:import_yaml_zip).with(import_file, "*").once
+    MiqAeDatastore.should_receive(:import_yaml_zip).with(import_file, "*", nil).once
 
     MiqAeDatastore.upload(fd, "dummy.zip")
   end
@@ -105,7 +105,7 @@ describe MiqAeDatastore do
   it "temporary file cleanup for successful import" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
-    MiqAeDatastore.should_receive(:import_yaml_zip).with(import_file, "*").once
+    MiqAeDatastore.should_receive(:import_yaml_zip).with(import_file, "*", nil).once
     MiqAeDatastore.upload(fd, "dummy.zip")
     File.exist?(import_file).should be_false
   end

--- a/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
@@ -5,6 +5,7 @@ module MiqAeDatastoreConverter
   describe "XML2YAML Converter" do
     before(:each) do
       MiqAeDatastore.reset
+      EvmSpecHelper.local_guid_miq_server_zone
     end
 
     after(:each) do

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -12,6 +12,8 @@ describe MiqAeDatastore do
     @clear_default_password = 'little_secret'
     @clear_password = 'secret'
     @relations_value = "bedrock relations"
+    EvmSpecHelper.local_guid_miq_server_zone
+    @tenant = Tenant.root_tenant
     create_factory_data("manageiq", 0)
     setup_export_dir
     set_manageiq_values
@@ -564,6 +566,7 @@ describe MiqAeDatastore do
       [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| k.count.should == 0 }
     end
     import_options = {'preview' => true,
+                      'tenant'  => @tenant,
                       'mode'    => 'add'}.merge(options)
     MiqAeImport.new(domain, import_options).import
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -12,8 +12,8 @@ describe MiqAeDatastore do
     @clear_default_password = 'little_secret'
     @clear_password = 'secret'
     @relations_value = "bedrock relations"
-    EvmSpecHelper.local_guid_miq_server_zone
-    @tenant = Tenant.root_tenant
+    EvmSpecHelper.local_miq_server
+    @tenant = Tenant.seed
     create_factory_data("manageiq", 0)
     setup_export_dir
     set_manageiq_values
@@ -156,6 +156,15 @@ describe MiqAeDatastore do
     def assert_import_failure_with_missing_file(import_options)
       expect { MiqAeImport.new("fred", import_options).import }
         .to raise_error(MiqAeException::FileNotFound)
+    end
+  end
+
+  context "tenant id" do
+    it "validate export data" do
+      export_model(@manageiq_domain.name)
+      domain_file = File.join(@export_dir, @manageiq_domain.name, '__domain__.yaml')
+      data = YAML.load_file(domain_file)
+      expect(data.fetch_path('object', 'attributes', 'tenant_id')).to eq(@tenant.id)
     end
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_spec.rb
@@ -5,9 +5,13 @@ describe MiqAeYamlImport do
   let(:options) { {} }
   let(:miq_ae_yaml_import) { described_class.new(domain, options) }
 
+  before do
+    EvmSpecHelper.local_guid_miq_server_zone
+  end
+
   describe "#new_domain_name_valid?" do
     context "when the options hash overwrite is true" do
-      let(:options) { {"overwrite" => true} }
+      let(:options) { {"overwrite" => true, "tenant" => Tenant.root_tenant} }
 
       it "returns true" do
         expect(miq_ae_yaml_import.new_domain_name_valid?).to be_true

--- a/spec/support/automation_example_group.rb
+++ b/spec/support/automation_example_group.rb
@@ -12,6 +12,7 @@ module AutomationExampleGroup
       RSpec.configure do |config|
         config.before(:suite) do
           puts "** Resetting ManageIQ domain"
+          Tenant.seed
           MiqAeDatastore.reset
           MiqAeDatastore.reset_manageiq_domain
         end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -139,7 +139,7 @@ module EvmSpecHelper
   end
 
   def self.yaml_import(domain, options, attrs = {})
-    create_root_tenant
+    Tenant.seed
     MiqAeImport.new(domain, options.merge('tenant' => Tenant.root_tenant)).import
     dom = MiqAeNamespace.find_by_fqname(domain)
     dom.update_attributes!(attrs.reverse_merge(:enabled => true)) if dom

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -139,7 +139,8 @@ module EvmSpecHelper
   end
 
   def self.yaml_import(domain, options, attrs = {})
-    MiqAeImport.new(domain, options).import
+    create_root_tenant
+    MiqAeImport.new(domain, options.merge('tenant' => Tenant.root_tenant)).import
     dom = MiqAeNamespace.find_by_fqname(domain)
     dom.update_attributes!(attrs.reverse_merge(:enabled => true)) if dom
   end


### PR DESCRIPTION
The Automate import function take either a tenant_object
or a tenant_id, which is used when adding a domain.
The tenant_id is used when called from the command line.