### PR TITLE
Removed creation of second miq_server

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -18,7 +18,6 @@ module MiqAeEngineSpec
 
     context ".deliver" do
       before(:each) do
-        MiqServer.stub(:my_zone).and_return("default")
         @ems              = FactoryGirl.create(:ems_vmware)
         @cluster          = FactoryGirl.create(:ems_cluster)
         @vm               = FactoryGirl.create(:vm_vmware)


### PR DESCRIPTION
The EvmSpecHelper.local_guid_miq_server_zone call creates a
miq_server so the second call is not needed. This was leading to
sporadic test failures.