### PR TITLE
Call domain factory instead of namespace factory

### DIFF
--- a/spec/support/miq_automate_helper.rb
+++ b/spec/support/miq_automate_helper.rb
@@ -1,7 +1,7 @@
 module MiqAutomateHelper
   def self.create_dummy_method(identifiers, field_array)
     MiqAeDatastore.reset
-    @aed = FactoryGirl.create(:miq_ae_namespace, :name => identifiers[:domain],
+    @aed = FactoryGirl.create(:miq_ae_domain, :name => identifiers[:domain],
                               :priority => 10, :enabled => true)
     @aen1 = FactoryGirl.create(:miq_ae_namespace, :name      => identifiers[:namespace],
                                                   :parent_id => @aed.id)


### PR DESCRIPTION
Tenancy requires the presence of tenant object when creating a
domain. The factory for domain provides a default tenant object.