### PR TITLE
no longer require vm to login

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -800,5 +800,4 @@ class DashboardController < ApplicationController
     session[:layout]          = @layout
     session[:vm_current_page] = @current_page
   end
-
 end

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -45,12 +45,6 @@ class UserValidationService
 
     session_init(db_user)
 
-    # Don't allow logins until there's some content in the system
-    return ValidateResult.new(
-      :fail,
-      "Logins not allowed, no providers are being managed yet. Please contact the administrator"
-    ) unless db_user.super_admin_user? || data_ready?
-
     return validate_user_handle_not_ready(db_user) unless server_ready?
 
     # Start super admin at the main db if the main db has no records yet
@@ -145,10 +139,6 @@ class UserValidationService
     return ValidateResult.new(:fail, "Error: New password is the same as existing password") if
       user[:new_password].present? && user[:password] == user[:new_password]
     nil
-  end
-
-  def data_ready?
-    Vm.first || Host.first
   end
 
   def server_ready?

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -43,15 +43,10 @@ describe DashboardController do
       expect_failed_login('Role')
     end
 
-    it "requires VMs" do
+    it "allow users in with no vms" do
+      skip_data_checks
       post :authenticate, :user_name => user_with_role.userid, :user_password => "dummy"
-      expect_failed_login('no providers')
-    end
-
-    it "allows super admin with no vms" do
-      user = FactoryGirl.create(:user_admin)
-      post :authenticate, :user_name => user.userid, :user_password => "dummy"
-      expect_successful_login(user)
+      expect_successful_login(user_with_role)
     end
 
     it "redirects to a proper start page" do
@@ -180,7 +175,6 @@ describe DashboardController do
   end
 
   def skip_data_checks(url = '/')
-    UserValidationService.any_instance.stub(:data_ready?).and_return(true)
     UserValidationService.any_instance.stub(:server_ready?).and_return(true)
     controller.stub(:start_url_for_user).and_return(url)
   end


### PR DESCRIPTION
Allow users to login whether there are vms/ems or not.

This is a place holder for a (tenancy) discussion

/cc @dclarizio @gmcculloug @gtanzillo per discussion