### PR TITLE
Invalid input [provider_foreman/edit] when a Foreman Config Manager is selected for Edit in the Grid/Tile mode

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -37,7 +37,9 @@ class ProviderForemanController < ApplicationController
     else
       assert_privileges("provider_foreman_edit_provider")
       @provider_foreman = find_by_id_filtered(ManageIQ::Providers::Foreman::ConfigurationManager,
-                                              from_cid(params[:miq_grid_checks] || params[:id]))
+                                              from_cid(params[:miq_grid_checks] ||
+                                                       params[:id] ||
+                                                       find_checked_items[0]))
       render_form
     end
   end
@@ -628,9 +630,9 @@ class ProviderForemanController < ApplicationController
   end
 
   def update_title(presenter)
-    if params[:action] == "new"
+    if action_name == "new"
       @right_cell_text = _("Add a new %s Provider") % ui_lookup(:ui_title => "foreman")
-    elsif params[:pressed] == "provider_foreman_edit_provider"
+    elsif action_name == "edit"
       @right_cell_text = _("Edit %s Provider") % ui_lookup(:ui_title => "foreman")
     end
     presenter[:right_cell_text] = @right_cell_text

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -113,6 +113,29 @@ describe ProviderForemanController do
     expect(response.status).to eq(200)
   end
 
+  context "#edit" do
+    before do
+      set_user_privileges
+    end
+
+    it "renders the edit page when the configuration manager id is supplied" do
+      post :edit, :id => @config_mgr.id
+      expect(response.status).to eq(200)
+      right_cell_text = controller.instance_variable_get(:@right_cell_text)
+      expect(right_cell_text).to eq(_("Edit Foreman Provider"))
+    end
+
+    it "renders the edit page when the configuration manager id is selected from a list view" do
+      post :edit, :miq_grid_checks => @config_mgr.id
+      expect(response.status).to eq(200)
+    end
+
+    it "renders the edit page when the configuration manager id is selected from a grid/tile" do
+      post :edit, "check_#{ActiveRecord::Base.compress_id(@config_mgr.id)}" => "1"
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "renders right cell text" do
     before do
       right_cell_text = nil


### PR DESCRIPTION
The Foreman Configuration Manager id will be retrieved in Edit with ```find_checked_items``` in the Grid/Tile mode.
Also fixed the title on the Edit page.

https://bugzilla.redhat.com/show_bug.cgi?id=1267045