### PR TITLE
test changes: explicitly login_as a user

### DIFF
--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -133,7 +133,7 @@ describe DashboardController do
     }
     main_tabs.each do |tab, feature|
       it "for tab ':#{tab}'" do
-        seed_specific_product_features(feature)
+        login_as FactoryGirl.create(:user, :features => feature)
         session[:tab_url] = {}
         post :maintab, :tab => tab
         url_controller = Menu::Manager.tab_features_by_id(tab).find { |f| f.ends_with?("_explorer") }
@@ -149,7 +149,7 @@ describe DashboardController do
     end
 
     it "retuns start page url that user has set as startpage in settings" do
-      seed_specific_product_features(%(everything))
+      login_as FactoryGirl.create(:user, :features => "everything")
       controller.instance_variable_set(:@settings, :display => {:startpage => "/dashboard/show"})
 
       controller.stub(:role_allows).and_return(true)
@@ -158,7 +158,7 @@ describe DashboardController do
     end
 
     it "returns first url that user has access to as start page when user doesn't have access to startpage set in settings" do
-      seed_specific_product_features("vm_cloud_explorer")
+      login_as FactoryGirl.create(:user, :features => "vm_cloud_explorer")
       controller.instance_variable_set(:@settings, :display => {:startpage => "/dashboard/show"})
       url = controller.send(:start_url_for_user, nil)
       url.should eq("/vm_cloud/explorer?accordion=instances")

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -6,9 +6,8 @@ describe MiqAeCustomizationController do
     context "#dialog_delete" do
       before do
         FactoryGirl.create(:vmdb_database)
-        EvmSpecHelper.create_guid_miq_server_zone
-        seed_specific_product_features("dialog_delete")
-        described_class.any_instance.stub(:set_user_time_zone)
+        EvmSpecHelper.local_miq_server
+        login_as FactoryGirl.create(:user, :features => "dialog_delete")
         controller.stub(:check_privileges).and_return(true)
       end
 
@@ -52,7 +51,7 @@ describe MiqAeCustomizationController do
 
     context "#dialog_edit" do
       before do
-        seed_specific_product_features("dialog_edit")
+        login_as FactoryGirl.create(:user, :features => "dialog_edit")
         @dialog = FactoryGirl.create(:dialog,
                                      :label       => "Test Label",
                                      :description => "Test Description"

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -4,7 +4,7 @@ include UiConstants
 describe MiqPolicyController do
   context "::AlertProfiles" do
     before do
-      seed_specific_product_features("alert_profile_assign")
+      login_as FactoryGirl.create(:user, :features => "alert_profile_assign")
     end
 
     context "#alert_profile_assign" do

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -3,10 +3,11 @@ require "spec_helper"
 describe ReportController do
   context "::Dashboards" do
     context "#db_edit" do
+      let(:user) { FactoryGirl.create(:user, :features => "db_edit") }
       before :each do
-        seed_specific_product_features("db_edit")
+        login_as user
         @db = FactoryGirl.create(:miq_widget_set,
-                                 :owner    => User.current_user.current_group,
+                                 :owner    => user.current_group,
                                  :set_data => {:col1 => [], :col2 => [], :col3 => []})
       end
 
@@ -14,9 +15,9 @@ describe ReportController do
         controller.stub(:db_fields_validation)
         controller.stub(:replace_right_cell)
         owner = @db.owner
-        new = {:name => "New Name", :description => "New Description", :col1 => [1], :col2 => [], :col3 => []}
+        new_hash = {:name => "New Name", :description => "New Description", :col1 => [1], :col2 => [], :col3 => []}
         current = {:name => "New Name", :description => "New Description", :col1 => [], :col2 => [], :col3 => []}
-        controller.instance_variable_set(:@edit, {:new => new, :db_id => @db.id, :current => current})
+        controller.instance_variable_set(:@edit, {:new => new_hash, :db_id => @db.id, :current => current})
         controller.instance_variable_set(:@_params, {:id => @db.id, :button => "save"})
         controller.db_edit
         @db.owner.id.should == owner.id

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -2,8 +2,9 @@ require "spec_helper"
 
 describe OpsController do
   context "OpsSettings::Schedules" do
+    let(:user) { FactoryGirl.create(:user, :features => %w(schedule_enable schedule_disable)) }
     before do
-      seed_specific_product_features("schedule_enable", "schedule_disable")
+      login_as user
     end
 
     context "no schedules selected" do
@@ -93,7 +94,7 @@ describe OpsController do
       before(:each) do
         EvmSpecHelper.create_guid_miq_server_zone
         controller.should_receive(:render)
-        @schedule = FactoryGirl.create(:miq_schedule, :userid => "test", :towhat => "Vm")
+        @schedule = FactoryGirl.create(:miq_schedule, :userid => user.userid, :towhat => "Vm")
         @params = {
           :action      => "schedule_edit",
           :button      => "add",
@@ -127,7 +128,7 @@ describe OpsController do
         @params[:id] = @schedule.id
         @params[:name] = "schedule01"
         controller.instance_variable_set(:@_params, @params)
-        FactoryGirl.create(:miq_schedule, :name => @params[:name], :userid => "test", :towhat => "Vm")
+        FactoryGirl.create(:miq_schedule, :name => @params[:name], :userid => user.userid, :towhat => "Vm")
         controller.send(:schedule_edit)
         controller.send(:flash_errors?).should be_true
         assigns(:flash_array).first[:message].should include("Name has already been taken")

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -754,7 +754,7 @@ describe ReportController do
 
   context "ReportController::Schedules" do
     before do
-      seed_specific_product_features("miq_report_schedule_enable", "miq_report_schedule_disable")
+      login_as FactoryGirl.create(:user, :features => %w(miq_report_schedule_enable miq_report_schedule_disable))
     end
 
     context "no schedules selected" do

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -70,7 +70,7 @@ describe StorageController do
       "host_reset"    => "Reset"
     }.each do |button, description|
       it "when Host #{description} button is pressed" do
-        seed_specific_product_features(button)
+        login_as FactoryGirl.create(:user, :features => button)
 
         host = FactoryGirl.create(:host)
         controller.instance_variable_set(:@_params, {:pressed => button, :miq_grid_checks => "#{host.id}"})

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -17,17 +17,6 @@ module ControllerSpecHelper
     User.any_instance.stub(:role_allows?).and_return(true)
   end
 
-  def seed_specific_product_features(*features)
-    @test_user = login_as FactoryGirl.create(:user,
-                                             :userid   => "test",
-                                             :name     => 'test_user',
-                                             :features => specific_product_features(*features))
-  end
-
-  def specific_product_features(*features)
-    EvmSpecHelper.specific_product_features(features)
-  end
-
   shared_context "valid session" do
     let(:privilege_checker_service) { auto_loaded_instance_double("PrivilegeCheckerService", :valid_session?  => true) }
     let(:request_referer_service)   { auto_loaded_instance_double("RequestRefererService",   :allowed_access? => true) }


### PR DESCRIPTION
This is test changes only.

the `seed_specific_product_features` hides what actually happens. This replaces it with explicitly logging the user in using `login_as`. 

don't:
- hide when a user is logging in
- hardcode the userid
- set class variable in helpers

/cc @chessbyte @dclarizio @matthewd just your typical refactor