### PR TITLE
simplify user creation in tests

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -3,14 +3,8 @@ include UiConstants
 
 describe ApplicationController do
   before do
-    EvmSpecHelper.create_guid_miq_server_zone
-    EvmSpecHelper.seed_specific_product_features("everything")
-    feature = MiqProductFeature.find_all_by_identifier(["everything"])
-    test_user_role  = FactoryGirl.create(:miq_user_role,
-                                         :name                 => "test_user_role",
-                                         :miq_product_features => feature)
-    test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-    login_as FactoryGirl.create(:user, :userid => 'test_user', :miq_groups => [test_user_group])
+    EvmSpecHelper.local_miq_server
+    login_as FactoryGirl.create(:user, :features => "everything")
     controller.stub(:role_allows).and_return(true)
   end
 
@@ -59,9 +53,8 @@ describe ApplicationController do
   end
 
   it "Certain actions should be allowed only for a VM record" do
-    admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => MiqProductFeature.find_all_by_identifier(["everything"]))
-    admin_group = FactoryGirl.create(:miq_group, :miq_user_role => admin_role)
-    login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [admin_group])
+    feature = MiqProductFeature.find_all_by_identifier(["everything"])
+    login_as FactoryGirl.create(:user, :features => feature)
     vm = FactoryGirl.create(:vm_vmware)
     controller.instance_variable_set(:@_params, :id => vm.id)
     actions = [:vm_right_size, :vm_reconfigure]

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -8,7 +8,7 @@ describe ApplicationController do
       ur = FactoryGirl.create(:miq_user_role)
       rptmenu = {:report_menus => [["Configuration Management", ["Hosts", ["Hosts Summary", "Hosts Summary"]]]]}
       group = FactoryGirl.create(:miq_group, :miq_user_role => ur, :settings => rptmenu)
-      login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group])
+      login_as FactoryGirl.create(:user, :miq_groups => [group])
     end
 
     it "Verify Invalid input flash error message when invalid id is passed in" do
@@ -30,11 +30,7 @@ describe ApplicationController do
     before do
       EvmSpecHelper.seed_specific_product_features("host_new", "host_edit", "perf_reload")
       feature = MiqProductFeature.find_all_by_identifier(["host_new"])
-      test_user_role  = FactoryGirl.create(:miq_user_role,
-                                           :name                 => "test_user_role",
-                                           :miq_product_features => feature)
-      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+      login_as FactoryGirl.create(:user, :features => feature)
     end
 
     it "should not raise an error for feature that user has access to" do
@@ -61,11 +57,8 @@ describe ApplicationController do
     before do
       EvmSpecHelper.seed_specific_product_features("vm_infra_explorer", "host_edit")
       feature = MiqProductFeature.find_all_by_identifier("vm_infra_explorer")
-      @test_user_role  = FactoryGirl.create(:miq_user_role,
-                                            :name                 => "test_user_role",
-                                            :miq_product_features => feature)
-      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => @test_user_role)
-      login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+      user = login_as FactoryGirl.create(:user, :features => feature)
+      @test_user_role = user.current_group.miq_user_role
     end
 
     it "should return restricted view yaml for restricted user" do
@@ -163,14 +156,7 @@ describe ApplicationController do
 
   context "#prov_redirect" do
     before do
-      EvmSpecHelper.seed_specific_product_features("vm_migrate")
-      feature = MiqProductFeature.find_all_by_identifier(["vm_migrate"])
-      test_user_role  = FactoryGirl.create(:miq_user_role,
-                                           :name                 => "test_user_role",
-                                           :miq_product_features => feature)
-      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-      User.stub(:current_user => user)
+      login_as FactoryGirl.create(:user, :features => "vm_migrate")
       controller.request.parameters[:pressed] = "vm_migrate"
     end
 

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -3,22 +3,12 @@ require "spec_helper"
 describe EmsCloudController do
   describe "#create" do
     before do
-      EvmSpecHelper.seed_specific_product_features("ems_cloud_new")
-      feature = MiqProductFeature.find_all_by_identifier(["ems_cloud_new"])
       Zone.first || FactoryGirl.create(:zone)
-      test_user_role  = FactoryGirl.create(:miq_user_role,
-                                           :name                 => "test_user_role",
-                                           :miq_product_features => feature)
-      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
-
-      allow(user).to receive(:server_timezone).and_return("UTC")
-      described_class.any_instance.stub(:set_user_time_zone)
       controller.stub(:check_privileges).and_return(true)
       controller.stub(:assert_privileges).and_return(true)
       FactoryGirl.create(:vmdb_database)
-      EvmSpecHelper.create_guid_miq_server_zone
-      login_as user
+      EvmSpecHelper.local_miq_server
+      login_as FactoryGirl.create(:user, :features => "ems_cloud_new")
     end
 
     it "adds a new provider" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -75,13 +75,7 @@ describe EmsInfraController do
 
   describe "#create" do
     before do
-      EvmSpecHelper.seed_specific_product_features("ems_infra_new")
-      feature = MiqProductFeature.find_all_by_identifier(["ems_infra_new"])
-      test_user_role  = FactoryGirl.create(:miq_user_role,
-                                           :name                 => "test_user_role",
-                                           :miq_product_features => feature)
-      test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-      user = FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+      user = FactoryGirl.create(:user, :features => "ems_infra_new")
 
       allow(user).to receive(:server_timezone).and_return("UTC")
       described_class.any_instance.stub(:set_user_time_zone)

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -245,13 +245,7 @@ describe OpsController do
   before do
     MiqRegion.seed
     EvmSpecHelper.local_miq_server
-    EvmSpecHelper.seed_specific_product_features("ops_rbac")
-    feature = MiqProductFeature.find_all_by_identifier("ops_rbac")
-    @test_user_role  = FactoryGirl.create(:miq_user_role,
-                                          :name                 => "test_user_role",
-                                          :miq_product_features => feature)
-    test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => @test_user_role)
-    login_as FactoryGirl.create(:user, :name => 'test_user', :miq_groups => [test_user_group])
+    login_as FactoryGirl.create(:user, :features => "ops_rbac")
     controller.stub(:get_vmdb_config).and_return(:product => {})
   end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe ProviderForemanController do
   render_views
   before(:each) do
-    _, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    @zone = EvmSpecHelper.local_miq_server.zone
 
     @provider = ManageIQ::Providers::Foreman::Provider.create(:name => "test", :url => "10.8.96.102", :zone => @zone)
     @config_mgr = ManageIQ::Providers::Foreman::ConfigurationManager.find_by_provider_id(@provider.id)
@@ -320,13 +320,8 @@ describe ProviderForemanController do
   end
 
   def user_with_feature(features)
-    EvmSpecHelper.seed_specific_product_features(*features)
-    feature = MiqProductFeature.find_all_by_identifier(features)
-    test_user_role  = FactoryGirl.create(:miq_user_role,
-                                         :name                 => "test_user_role",
-                                         :miq_product_features => feature)
-    test_user_group = FactoryGirl.create(:miq_group, :miq_user_role => test_user_role)
-    FactoryGirl.create(:user, :userid => 'test_user', :name => 'test_user', :miq_groups => [test_user_group])
+    features = EvmSpecHelper.specific_product_features(*features)
+    FactoryGirl.create(:user, :features => features)
   end
 
   def set_view_10_per_page

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -56,9 +56,7 @@ describe ApplicationHelper do
     before(:each) do
       EvmSpecHelper.seed_specific_product_features("miq_report", "service")
 
-      @admin_role  = FactoryGirl.create(:miq_user_role, :name => "admin", :miq_product_features => features)
-      @admin_group = FactoryGirl.create(:miq_group, :miq_user_role => @admin_role)
-      @user        = FactoryGirl.create(:user, :name => 'wilma', :miq_groups => [@admin_group])
+      @user        = FactoryGirl.create(:user, :features => features)
       login_as  @user
     end
 

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -4,13 +4,12 @@ describe MiqReportResult do
   before(:each) do
     EvmSpecHelper.local_miq_server
 
-    @group = FactoryGirl.create(:miq_group)
-    @user  = FactoryGirl.create(:user, :miq_groups => [@group])
+    user = FactoryGirl.create(:user_with_group)
 
     5.times do |i|
       vm = FactoryGirl.build(:vm_vmware)
-      vm.evm_owner_id = @user.id           if i > 2
-      vm.miq_group_id = @user.current_group.id if vm.evm_owner_id || (i > 1)
+      vm.evm_owner_id = user.id               if i > 2
+      vm.miq_group_id = user.current_group.id if vm.evm_owner_id || (i > 1)
       vm.save
     end
 

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -68,7 +68,6 @@ describe MiqReport do
         5  => "/managed/service_level/silver"
       }
 
-      User.any_instance.stub(:validate => true)
       @group = FactoryGirl.create(:miq_group)
       @user  = FactoryGirl.create(:user, :miq_groups => [@group])
     end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe MiqWidgetSet do
-  let(:group) { FactoryGirl.create(:miq_group, :description => 'dev group') }
-  let(:user)  { FactoryGirl.create(:user, :name => 'cloud', :userid => 'cloud', :miq_groups => [group]) }
+  let(:group) { user.current_group }
+  let(:user)  { FactoryGirl.create(:user_with_group) }
   before do
     @ws_group = FactoryGirl.create(:miq_widget_set, :name => 'Home', :owner => group)
   end

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -10,14 +10,13 @@ describe MiqWidget do
       MiqReport.seed_report("Vendor and Guest OS")
 
       feature1 = MiqProductFeature.find_all_by_identifier("dashboard_admin")
-      @role1   = FactoryGirl.create(:miq_user_role, :name => "Role1", :miq_product_features => feature1)
-      @group1  = FactoryGirl.create(:miq_group, :miq_user_role => @role1)
-      @user1   = FactoryGirl.create(:user, :miq_groups => [@group1], :name => "Administrator", :userid => "admin")
+      @user1   = FactoryGirl.create(:user, :role => "role1", :features => feature1)
+      @group1  = @user1.current_group
 
       feature2 = MiqProductFeature.find_all_by_identifier("everything")
-      @role2   = FactoryGirl.create(:miq_user_role, :name => "Role2", :miq_product_features => feature2)
+      @role2   = FactoryGirl.create(:miq_user_role, :name => "Role2", :features => feature2)
       @group2  = FactoryGirl.create(:miq_group, :description => "Group2", :miq_user_role => @role2)
-      @user2   = FactoryGirl.create(:user, :userid => "user2", :miq_groups => [@group2])
+      @user2   = FactoryGirl.create(:user, :miq_groups => [@group2])
 
       @widget_report_vendor_and_guest_os = MiqWidget.sync_from_hash(YAML.load('
         description: report_vendor_and_guest_os
@@ -77,7 +76,7 @@ describe MiqWidget do
 
       it "with a task" do
         @widget.miq_task = MiqTask.new
-        @widget.queue_generate_content_for_users_or_group("admin")
+        @widget.queue_generate_content_for_users_or_group(@user1.userid)
         MiqQueue.exists?({:method_name => "generate_content"}.merge(@queue_conditions)).should be_true
       end
     end
@@ -102,7 +101,7 @@ describe MiqWidget do
         end
 
         it "returns non-empty array when widget has subscribers" do
-          user_temp = add_user("test", @group1)
+          user_temp = add_user(@group1)
           ws_temp   = add_dashboard_for_user("Home", user_temp.userid, @group1.id)
           @widget_report_vendor_and_guest_os.make_memberof(ws_temp)
           result = @widget_report_vendor_and_guest_os.grouped_subscribers
@@ -114,7 +113,7 @@ describe MiqWidget do
         it "with multiple groups and users" do
           users = []
           (1..3).each do |i|
-            user_i = add_user("user_#{i}", @group2)
+            user_i = add_user(@group2)
             ws_i   = add_dashboard_for_user("Home", user_i.userid, @group2.id)
             @widget_report_vendor_and_guest_os.make_memberof(ws_i)
             users << user_i
@@ -128,7 +127,7 @@ describe MiqWidget do
         end
 
         it 'ignores the user that does not exist any more' do
-          user_temp = add_user("test", @group1)
+          user_temp = add_user(@group1)
           ws_temp   = add_dashboard_for_user("Home", user_temp.userid, @group1.id)
           @widget_report_vendor_and_guest_os.make_memberof(ws_temp)
 
@@ -147,8 +146,8 @@ describe MiqWidget do
         end
       end
 
-      def add_user(userid, group)
-        FactoryGirl.create(:user, :miq_groups => [group], :name => userid, :userid => userid)
+      def add_user(group)
+        FactoryGirl.create(:user, :miq_groups => [group])
       end
 
       def add_dashboard_for_user(db_name, userid, group)
@@ -207,13 +206,13 @@ describe MiqWidget do
       subject { MiqWidget.available_for_user(@user) }
 
       it "by role" do
-        @widget_report_vendor_and_guest_os.update_attributes(:visibility => {:roles => "Role2"})
+        @widget_report_vendor_and_guest_os.update_attributes(:visibility => {:roles => @group2.miq_user_role.name})
         expect(MiqWidget.available_for_user(@user1).count).to eq(1)
         expect(MiqWidget.available_for_user(@user2).count).to eq(2)
       end
 
       it "by group" do
-        @widget_report_vendor_and_guest_os.update_attributes(:visibility => {:groups => "Group2"})
+        @widget_report_vendor_and_guest_os.update_attributes(:visibility => {:groups => @group2.description })
         expect(MiqWidget.available_for_user(@user1).count).to eq(1)
         expect(MiqWidget.available_for_user(@user2).count).to eq(2)
       end
@@ -257,8 +256,8 @@ describe MiqWidget do
         read_only: true
       ')
 
-      ws1 = FactoryGirl.create(:miq_widget_set, :name => "default", :userid => "user1", :group_id => group1.id)
-      ws2 = FactoryGirl.create(:miq_widget_set, :name => "default", :userid => "admin", :group_id => @group2.id)
+      ws1 = FactoryGirl.create(:miq_widget_set, :name => "default", :userid => user1.userid, :group_id => group1.id)
+      ws2 = FactoryGirl.create(:miq_widget_set, :name => "default", :userid => @user2.userid, :group_id => @group2.id)
       @widget = MiqWidget.sync_from_hash(attrs)
       ws1.add_member(@widget)
       ws2.add_member(@widget)
@@ -372,8 +371,7 @@ describe MiqWidget do
       task.pct_complete.should eq(100)
 
       @widget.visibility[:roles] = "_ALL_"
-      new_group = FactoryGirl.create(:miq_group, :miq_user_role => FactoryGirl.create(:miq_user_role))
-      new_user  = FactoryGirl.create(:user, :userid => "test task", :miq_groups => [new_group])
+      new_user  = FactoryGirl.create(:user, :userid => "test task", :role => "random")
 
       @widget.create_initial_content_for_user(new_user)
       q = MiqQueue.first
@@ -431,19 +429,17 @@ describe MiqWidget do
 
       it "multiple" do
         @widget.visibility[:roles] = "_ALL_"
-        new_role1 = FactoryGirl.create(:miq_user_role, :name => 'EvmRole-Operator')
-        new_group1 = FactoryGirl.create(:miq_group, :description => "EvmGroup-operator", :miq_user_role => new_role1)
+        new_group1 = FactoryGirl.create(:miq_group, :role => "operator")
         new_ws1 = FactoryGirl.create(:miq_widget_set,
                                      :name     => "default",
-                                     :userid   => "admin",
+                                     :userid   => @user2.userid,
                                      :group_id => new_group1.id)
         new_ws1.add_member(@widget)
 
-        new_role2 = FactoryGirl.create(:miq_user_role, :name => 'EvmRole-Approver')
-        new_group2 = FactoryGirl.create(:miq_group, :description => "EvmGroup-approver", :miq_user_role => new_role2)
+        new_group2 = FactoryGirl.create(:miq_group, :role => "approver")
         new_ws2 = FactoryGirl.create(:miq_widget_set,
                                      :name     => "default",
-                                     :userid   => "admin",
+                                     :userid   => @user2.userid,
                                      :group_id => new_group2.id)
         new_ws2.add_member(@widget)
 
@@ -556,11 +552,9 @@ describe MiqWidget do
       @role   = FactoryGirl.create(:miq_user_role)
       @group  = FactoryGirl.create(:miq_group, :miq_user_role => @role)
       @user1  = FactoryGirl.create(:user,
-                                   :userid     => "user1",
                                    :settings   => {:display => {:timezone => "Eastern Time (US & Canada)"}},
                                    :miq_groups => [@group])
       @user2  = FactoryGirl.create(:user,
-                                   :userid     => "user2",
                                    :settings   => {:display => {:timezone => "Pacific Time (US & Canada)"}},
                                    :miq_groups => [@group])
 


### PR DESCRIPTION
remove unneeded hardcoded user names from factories
just use single line for creating users with features / groups / and roles