### PR TITLE
Fix virtual associations

### DIFF
--- a/app/models/metric/finders.rb
+++ b/app/models/metric/finders.rb
@@ -31,7 +31,7 @@ module Metric::Finders
 
     klass, meth = Metric::Helper.class_and_association_for_interval_name(interval_name)
 
-    return resource.send(meth).where(cond) unless resource.kind_of?(Array)
+    return resource.send(meth).where(cond) unless resource.kind_of?(Array) || resource.kind_of?(ActiveRecord::Relation)
 
     # Group the resources by type to find the ids on which to query
     res_cond = []

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -162,6 +162,11 @@ module VirtualFields
     uses = options.delete :uses
     reflection = ActiveRecord::Associations::Builder::HasMany.build(self, name, nil, options)
     add_virtual_reflection(reflection, name, uses, options)
+    define_method("#{name.to_s.singularize}_ids") do
+      _log.info("DJM: Entering #{name.to_s.singularize}_ids")
+      records = send(name)
+      records.respond_to?(:ids) ? records.ids : records.collect(&:id)
+    end
   end
 
   def virtual_belongs_to(name, options = {})

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -159,13 +159,13 @@ module VirtualFields
   end
 
   def virtual_has_many(name, options = {})
-    uses = options.delete :uses
-    reflection = ActiveRecord::Associations::Builder::HasMany.build(self, name, nil, options)
-    add_virtual_reflection(reflection, name, uses, options)
     define_method("#{name.to_s.singularize}_ids") do
       records = send(name)
       records.respond_to?(:ids) ? records.ids : records.collect(&:id)
     end
+    uses = options.delete :uses
+    reflection = ActiveRecord::Associations::Builder::HasMany.build(self, name, nil, options)
+    add_virtual_reflection(reflection, name, uses, options)
   end
 
   def virtual_belongs_to(name, options = {})

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -163,7 +163,6 @@ module VirtualFields
     reflection = ActiveRecord::Associations::Builder::HasMany.build(self, name, nil, options)
     add_virtual_reflection(reflection, name, uses, options)
     define_method("#{name.to_s.singularize}_ids") do
-      _log.info("DJM: Entering #{name.to_s.singularize}_ids")
       records = send(name)
       records.respond_to?(:ids) ? records.ids : records.collect(&:id)
     end

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -450,6 +450,13 @@ describe VirtualFields do
       end
     end
 
+    describe ".virtual_has_many" do
+      it "defines _ids method" do
+        c = TestClass.send(:virtual_has_many, :vref1)
+        expect(c.public_methods).to include(:vref1_ids)
+      end
+    end
+
     context "virtual_reflection assignment" do
       it "" do
         {

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -450,13 +450,6 @@ describe VirtualFields do
       end
     end
 
-    describe ".virtual_has_many" do
-      it "defines _ids method" do
-        c = TestClass.send(:virtual_has_many, :vref1)
-        expect(c.public_methods).to include(:vref1_ids)
-      end
-    end
-
     context "virtual_reflection assignment" do
       it "" do
         {


### PR DESCRIPTION
Added virtual association support for *_ids. Metrics rollup for region was blowing up looking for host_ids which was not defined. This change dynamically creates the *_ids method definitions in virtual_has_many.