### PR TITLE
MiqAeDomain is tenant aware, not the parent MiqAeNamespace.

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -9,6 +9,8 @@ class MiqAeDomain < MiqAeNamespace
   before_save :default_priority
   belongs_to :tenant
 
+  include TenancyMixin
+
   def self.enabled
     where(:enabled => true)
   end

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -2,10 +2,8 @@ class MiqAeNamespace < ActiveRecord::Base
   acts_as_tree
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
-  include TenancyMixin
 
   belongs_to :parent,        :class_name => "MiqAeNamespace",  :foreign_key => :parent_id
-  belongs_to :tenant
   has_many   :ae_namespaces, :class_name => "MiqAeNamespace",  :foreign_key => :parent_id,    :dependent => :destroy
   has_many   :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) },    :class_name => "MiqAeClass",      :foreign_key => :namespace_id, :dependent => :destroy
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -17,7 +17,6 @@ describe Rbac do
 
     klass_factory_names = [
       "ExtManagementSystem", :ems_vmware,
-      "MiqAeNamespace", :miq_ae_namespace,
       "MiqAeDomain", :miq_ae_domain,
       # "MiqRequest", :miq_request,  # MiqRequest is an abstract class that can't be instantiated currently
       "MiqRequestTask", :miq_request_task,


### PR DESCRIPTION
Introduced in #4396
https://trello.com/c/1uf5urJz

cc @mkanoor 