### PR TITLE
Bump apipie-bindings to remove awesome_print runtime dependency.

### DIFF
--- a/gems/manageiq_foreman/lib/manageiq_foreman/version.rb
+++ b/gems/manageiq_foreman/lib/manageiq_foreman/version.rb
@@ -1,3 +1,3 @@
 module ManageiqForeman
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/gems/manageiq_foreman/manageiq_foreman.gemspec
+++ b/gems/manageiq_foreman/manageiq_foreman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "apipie-bindings", "~> 0.0.12"
+  spec.add_runtime_dependency "apipie-bindings", "~> 0.0.15"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
AwesomePrint was used only for debug logging in the api in apipie-bindings
but when it is required, it globally monkey patches core ruby and rails classes.

An issue was opened in apipie-bindings to make this dependency opt-in
by requiring a developer to manually add awesome_print to their Gemfile
so it is required before it hits the apipie-bindings code.

See:
https://github.com/Apipie/apipie-bindings/issues/29

It was subsequently fixed here:
https://github.com/Apipie/apipie-bindings/pull/30