### PR TITLE
Use LinuxAdmin::Hosts for hostname operations in appliance console

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -1,4 +1,6 @@
 require 'miq_apache'
+require 'linux_admin'
+
 module MiqServer::EnvironmentManagement
   extend ActiveSupport::Concern
 
@@ -49,7 +51,7 @@ module MiqServer::EnvironmentManagement
       begin
         if MiqEnvironment::Command.is_linux? && File.exist?('/bin/miqnet.sh')
           ipaddr      = `/bin/miqnet.sh -GET IP`.chomp
-          hostname    = `/bin/miqnet.sh -GET HOST`.chomp
+          hostname    = LinuxAdmin::Hosts.new.hostname
           mac_address = `/bin/miqnet.sh -GET MAC`.chomp
         else
           require 'MiqSockUtil'

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -24,7 +24,7 @@ gem "fog",                     "~>2.0.0.pre.0",     :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "kubeclient",              "=0.5.1",            :require => false
-gem "linux_admin",             "~>0.11.0",          :require => false
+gem "linux_admin",             "~>0.11.1",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.11.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -133,7 +133,7 @@ module ApplianceConsole
 
     loop do
       begin
-        host     = Env["HOST"]
+        host     = LinuxAdmin::Hosts.new.hostname
         ip       = Env["IP"]
         mac      = Env["MAC"]
         mask     = Env["MASK"]
@@ -233,7 +233,7 @@ Static Network Configuration
 
           if new_host != host
             say("Applying new hostname...")
-            Env['HOST'] = new_host
+            LinuxAdmin::Hosts.new.hostname = new_host
           end
 
         when I18n.t("advanced_settings.datetime")

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -233,7 +233,11 @@ Static Network Configuration
 
           if new_host != host
             say("Applying new hostname...")
-            LinuxAdmin::Hosts.new.hostname = new_host
+            system_hosts = LinuxAdmin::Hosts.new
+            system_hosts.hostname = new_host
+            system_hosts.update_entry(ip, new_host)
+            system_hosts.save
+            LinuxAdmin::Service.new("network").restart
           end
 
         when I18n.t("advanced_settings.datetime")

--- a/gems/pending/appliance_console/cli.rb
+++ b/gems/pending/appliance_console/cli.rb
@@ -125,7 +125,13 @@ module ApplianceConsole
 
     def run
       Trollop.educate unless set_host? || key? || database? || tmp_disk? || uninstall_ipa? || install_ipa? || certs?
-      LinuxAdmin::Hosts.new.hostname = options[:host] if set_host?
+      if set_host?
+        system_hosts = LinuxAdmin::Hosts.new
+        system_hosts.hostname = options[:host]
+        system_hosts.update_entry(Env["IP"], options[:host])
+        system_hosts.save
+        LinuxAdmin::Service.new("network").restart
+      end
       create_key if key?
       set_db if database?
       config_tmp_disk if tmp_disk?

--- a/gems/pending/appliance_console/cli.rb
+++ b/gems/pending/appliance_console/cli.rb
@@ -27,7 +27,7 @@ module ApplianceConsole
 
     # machine host
     def host
-      options[:host] || Env["host"]
+      options[:host] || LinuxAdmin::Hosts.new.hostname
     end
 
     # database hostname
@@ -125,7 +125,7 @@ module ApplianceConsole
 
     def run
       Trollop.educate unless set_host? || key? || database? || tmp_disk? || uninstall_ipa? || install_ipa? || certs?
-      Env[:host] = options[:host] if set_host?
+      LinuxAdmin::Hosts.new.hostname = options[:host] if set_host?
       create_key if key?
       set_db if database?
       config_tmp_disk if tmp_disk?

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -6,13 +6,13 @@ describe ApplianceConsole::Cli do
   subject { described_class.new }
 
   it "should set hostname if defined" do
-    ApplianceConsole::Env.should_receive(:[]=).with(:host, 'host1')
+    expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with('host1')
 
     subject.parse(%w(--host host1)).run
   end
 
   it "should not set hostname if none specified" do
-    ApplianceConsole::Env.should_not_receive(:[]=).with(:host, anything)
+    expect_any_instance_of(LinuxAdmin::Hosts).to_not receive(:hostname=)
 
     subject.stub(:create_key) # just give it something to do
     subject.parse(%w(--key)).run
@@ -98,7 +98,7 @@ describe ApplianceConsole::Cli do
     end
 
     it "should install ipa" do
-      ApplianceConsole::Env.should_receive(:[]).with("host").and_return('client.domain.com')
+      expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname).and_return('client.domain.com')
       ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
       ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
           .with('client.domain.com',
@@ -111,8 +111,8 @@ describe ApplianceConsole::Cli do
     end
 
     it "should not post_activate install ipa (aside: testing passing in host" do
-      ApplianceConsole::Env.should_receive(:[]=).with(:host, "client.domain.com")
-      ApplianceConsole::Env.should_not_receive(:[]).with(:host)
+      expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with("client.domain.com")
+      expect_any_instance_of(LinuxAdmin::Hosts).to_not receive(:hostname)
       ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
       ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
           .with('client.domain.com',
@@ -135,7 +135,7 @@ describe ApplianceConsole::Cli do
   context "#install_certs" do
     it "should basic install completed (default ca_name, non verbose)" do
       subject.should_receive(:say).with(/creating/)
-      ApplianceConsole::Env.should_receive(:[]).with("host").and_return('client.domain.com')
+      expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname).and_return('client.domain.com')
       subject.should_receive(:say).with(/certificate result/)
       subject.should_not_receive(:say).with(/rerun/)
       ApplianceConsole::CertificateAuthority.should_receive(:new)
@@ -154,7 +154,7 @@ describe ApplianceConsole::Cli do
 
     it "should basic install waiting (manual ca_name, verbose)" do
       subject.should_receive(:say).with(/creating/)
-      ApplianceConsole::Env.should_receive(:[]).with("host").and_return('client.domain.com')
+      expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname).and_return('client.domain.com')
       subject.should_receive(:say).with(/certificate result/)
       subject.should_receive(:say).with(/rerun/)
       ApplianceConsole::CertificateAuthority.should_receive(:new)

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -7,6 +7,8 @@ describe ApplianceConsole::Cli do
 
   it "should set hostname if defined" do
     expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with('host1')
+    expect_any_instance_of(LinuxAdmin::Hosts).to receive(:save).and_return(true)
+    expect_any_instance_of(LinuxAdmin::Service.new("test").class).to receive(:restart).and_return(true)
 
     subject.parse(%w(--host host1)).run
   end
@@ -112,6 +114,8 @@ describe ApplianceConsole::Cli do
 
     it "should not post_activate install ipa (aside: testing passing in host" do
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with("client.domain.com")
+      expect_any_instance_of(LinuxAdmin::Hosts).to receive(:save).and_return(true)
+      expect_any_instance_of(LinuxAdmin::Service.new("test").class).to receive(:restart).and_return(true)
       expect_any_instance_of(LinuxAdmin::Hosts).to_not receive(:hostname)
       ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
       ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -1,3 +1,5 @@
+require 'linux_admin'
+
 module Vmdb
   module Appliance
     def self.VERSION
@@ -125,18 +127,20 @@ module Vmdb
 
     def self.get_network
       retVal = {}
+      retVal[:hostname] = LinuxAdmin::Hosts.new.hostname
+
       miqnet = "/bin/miqnet.sh"
 
       if File.exist?(miqnet)
         # Make a call to the virtual appliance to get the network information
         cmd     = "#{miqnet} -GET"
-        netinfo = `#{cmd}`
-        raise "Unable to execute command: #{cmd}" if netinfo.nil?
-        netinfo = netinfo.split
 
-        [:hostname, :macaddress, :ipaddress, :netmask, :gateway, :primary_dns, :secondary_dns].each do |type|
-          retVal[type] = netinfo.shift
-        end
+        retVal[:macaddress]    = `#{cmd} MAC`
+        retVal[:ipaddress]     = `#{cmd} IP`
+        retVal[:netmask]       = `#{cmd} MASK`
+        retVal[:gateway]       = `#{cmd} GW`
+        retVal[:primary_dns]   = `#{cmd} DNS1`
+        retVal[:secondary_dns] = `#{cmd} DNS2`
       end
 
       retVal


### PR DESCRIPTION
Requires https://github.com/ManageIQ/linux_admin/pull/123

@Fryguy @kbrock @jrafanie 