### PR TITLE
Addressed Brakeman's Remote Code Execution warning in CimInstanceController

### DIFF
--- a/app/controllers/cim_instance_controller.rb
+++ b/app/controllers/cim_instance_controller.rb
@@ -147,7 +147,7 @@ class CimInstanceController < ApplicationController
     else
       whitelisted_key = associations.keys.find { |key| key == @display }
       if whitelisted_key.present?
-        model_name = whitelisted_key.singularize.classify.constantize
+        model_name = whitelisted_key.singularize.classify
         drop_breadcrumb( {:name=>@record.evm_display_name+" (All #{ui_lookup(:tables => @display.singularize)})", :url=>"/#{self.class.table_name}/show/#{@record.id}?display=#{@display}"} )
         @view, @pages = get_view(model_name, :parent=>@record, :parent_method => associations[@display])  # Get the records (into a view) and the paginator
         @showtype = @display

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -98,25 +98,6 @@
     {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
-      "fingerprint": "5f71c7d78b272c9c25e8892a2531396be07a770d904ed8e5c54b5e48096f2a3b",
-      "message": "Unsafe reflection method constantize called with parameter value",
-      "file": "app/controllers/cim_instance_controller.rb",
-      "line": 164,
-      "link": "http://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "associations.keys.find do\n (key == (session[\"#{self.class.session_key_prefix}_display\".to_sym] or (params[:display] or \"main\")))\n end.singularize.classify.constantize",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CimInstanceController",
-        "method": "process_show"
-      },
-      "user_input": "params[:display]",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
       "fingerprint": "ed8ad3c654ab94304d6536d62f89f18b40798ef0cec3527ac2d51351d901bfe6",
       "message": "Unsafe reflection method constantize called with parameter value",
       "file": "app/controllers/miq_ae_class_controller.rb",


### PR DESCRIPTION
There is no need to constantize the model name.  It is ONLY used as a parameter to `ApplicationController#get_view`.
The first thing that `ApplicationController#get_view` does with that parameter (`db`) is convert it (back) to a string.  See [code](https://github.com/ManageIQ/manageiq/blob/master/app/controllers/application_controller.rb#L1732-L1733)