### PR TITLE
Fix for submenu not getting rendered in miq_request/show_list after Foreman provisioning

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -494,7 +494,6 @@ module ApplicationController::MiqRequestMethods
   def layout_from_tab_name(tab_name)
     case tab_name
     when "ae"                then "miq_request_ae"
-    when "configured_system" then "miq_request_configured_system"
     when "host"              then "miq_request_host"
     else                          "miq_request_vm"  # Includes "vm"
     end

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -143,4 +143,21 @@ describe MiqRequestController do
       expect(response.body).to_not be_empty
     end
   end
+
+  context "#layout_from_tab_name" do
+    before do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+      session[:settings] = {:display   => {:quad_truncate => 'f'},
+                            :quadicons => {:host => 'foo'},
+                            :views     => {:miq_request => 'grid'}}
+    end
+
+    it "miq_request/show_list sets @layout='miq_request_vm' when redirected via foreman provisioning" do
+      post :show_list, :typ => "configured_systems"
+      layout = controller.instance_variable_get(:@layout)
+      expect(layout).to eq("miq_request_vm")
+    end
+  end
 end


### PR DESCRIPTION
```layout_from_tab_name``` was not returning the correct layout value causing ```@layout``` to have an incorrect value, due to which the submenu under ```Services``` was not getting rendered.

https://bugzilla.redhat.com/show_bug.cgi?id=1218604