### PR TITLE
Inline cursor style for disabled buttons for a standardized bootstrap UI

### DIFF
--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -12,6 +12,7 @@
                  :class     => "btn btn-primary btn-xs btn-disabled",
                  :alt       => "Validate",
                  :title     => "Validate",
+                 :style     => "cursor:not-allowed",
                  "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()",
                  "ng-click" => "disabledClick($event)")
   = button_tag("Validate",

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -4,6 +4,7 @@
                :alt          => "Add",
                :title        => "Add",
                "ng-click"    => "disabledClick($event)",
+               :style        => "cursor:not-allowed",
                "ng-show"     => "newRecord && !saveable(angularForm)")
 
   = button_tag("Add",
@@ -18,6 +19,7 @@
                :alt          => "Save changes",
                :title        => "Save changes",
                "ng-click"    => "disabledClick($event)",
+               :style        => "cursor:not-allowed",
                "ng-show"     => "!newRecord && !saveable(angularForm)")
 
   = button_tag("Save",


### PR DESCRIPTION
This turns on the ```no-entry``` cursor also known as the ```not-allowed```mouse cursor for disabled buttons.