### PR TITLE
Adds confirmation directive modal to self-service ui

### DIFF
--- a/spa_ui/self_service/client/app/components/_components.sass
+++ b/spa_ui/self_service/client/app/components/_components.sass
@@ -8,3 +8,4 @@
 @import 'ss-card/ss-card'
 @import 'toasts/toasts'
 @import 'retire-service-modal/retire-service-modal'
+@import 'confirmation/confirmation'

--- a/spa_ui/self_service/client/app/components/confirmation/_confirmation.sass
+++ b/spa_ui/self_service/client/app/components/confirmation/_confirmation.sass
@@ -1,0 +1,19 @@
++block(confirmation)
+
+  +element(dialog)
+    width: 300px
+    margin: 0
+    position: absolute
+
+  +element(body)
+    padding: 16px
+    text-align: center
+
+  +element(message)
+
+  +element(buttons)
+    text-align: center
+
+  +element(button)
+    margin: 5px
+    min-width: 120px

--- a/spa_ui/self_service/client/app/components/confirmation/confirmation.directive.js
+++ b/spa_ui/self_service/client/app/components/confirmation/confirmation.directive.js
@@ -1,0 +1,203 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .directive('confirmation', ConfirmationDirective);
+
+  /** @ngInject */
+  function ConfirmationDirective($position, $window) {
+    var directive = {
+      restrict: 'AE',
+      scope: {
+        position: '@?confirmationPosition',
+        title: '@?confirmationTitle',
+        message: '@?confirmationMessage',
+        trigger: '@?confirmationTrigger',
+        ok: '@?confirmationOkText',
+        cancel: '@?confirmationCancelText',
+        onOk: '&confirmationOnOk',
+        onCancel: '&?confirmationOnCancel',
+        okStyle: '@?confirmationOkStyle',
+        confirmIf: '=?confirmationIf',
+        showCancel: '=?confirmationShowCancel'
+      },
+      link: link,
+      controller: ConfirmationController,
+      controllerAs: 'vm',
+      bindToController: true
+    };
+
+    return directive;
+
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate({
+        getOffset: getOffset,
+        getPosition: getPosition,
+        size: getSizeOfConfirmation()
+      });
+
+      element.on(attrs.confirmationTrigger || 'click', vm.onTrigger);
+
+      function getOffset() {
+        return $window.pageYOffset;
+      }
+
+      function getPosition() {
+        return $position.offset(element);
+      }
+
+      // Private
+
+      function getSizeOfConfirmation() {
+        var height;
+        var width;
+        var sizerMessage = attrs.confirmationMessage || 'For Sizing';
+        var sizer = angular.element('<div class="confirmation__dialog"><div class="confirmation__content">' +
+          '<div class="confirmation__body"><p class="confirmation_message">' + sizerMessage +
+          '</p><div class="confirmation_buttons">' +
+          '<button type="button" class="confirmation__button btn-rounded">For Sizing</button>' +
+          '</div></div></div></div>');
+
+        sizer.css('visibility', 'hidden');
+        element.parent().append(sizer);
+        height = sizer.prop('offsetHeight');
+        width = sizer.prop('offsetWidth');
+        sizer.detach();
+
+        return {
+          height: height,
+          width: width
+        };
+      }
+    }
+
+    /** @ngInject */
+    function ConfirmationController($scope, $modal) {
+      var vm = this;
+
+      var modalOptions = {
+        templateUrl: 'app/components/confirmation/confirmation.html',
+        scope: $scope
+      };
+
+      vm.top = 0;
+      vm.left = 0;
+
+      vm.activate = activate;
+      vm.onTrigger = onTrigger;
+
+      function activate(api) {
+        angular.extend(vm, api);
+        vm.position = angular.isDefined(vm.position) ? vm.position : 'top-center';
+        vm.title = angular.isDefined(vm.title) ? vm.title : false;
+        vm.message = angular.isDefined(vm.message) ? vm.message : 'Are you sure you wish to proceed?';
+        vm.ok = angular.isDefined(vm.ok) ? vm.ok : 'Ok';
+        vm.cancel = angular.isDefined(vm.cancel) ? vm.cancel : 'Cancel';
+        vm.onCancel = angular.isDefined(vm.onCancel) ? vm.onCancel : angular.noop;
+        vm.okClass = angular.isDefined(vm.okStyle) ? 'btn-' + vm.okStyle : '';
+        vm.confirmIf = angular.isDefined(vm.confirmIf) ? vm.confirmIf : true;
+        vm.showCancel = angular.isDefined(vm.showCancel) ? vm.showCancel : true;
+      }
+
+      function onTrigger() {
+        var position = getModalPosition();
+        var modal;
+
+        if (vm.confirmIf) {
+          vm.left = position.left;
+          vm.top = position.top - vm.getOffset();
+
+          modal = $modal.open(modalOptions);
+          modal.result.then(onOk, onCancel);
+        } else {
+          vm.onOk();
+        }
+
+        function onOk() {
+          vm.onOk();
+        }
+
+        function onCancel() {
+          vm.onCancel();
+        }
+      }
+
+      // Grafted in from ui.bootstraps $position.positionElements()
+      function getModalPosition() {
+        var posParts = vm.position.split('-');
+        var pos0 = posParts[0];
+        var pos1 = posParts[1] || 'center';
+        var hostElPos = vm.getPosition();
+        var targetElPos = {};
+
+        var targetElWidth = vm.size.width;
+        var targetElHeight = vm.size.height;
+
+        var shiftWidth = {
+          center: widthCenter,
+          left: widthLeft,
+          right: widthRight
+        };
+
+        var shiftHeight = {
+          center: heightCenter,
+          top: heightTop,
+          bottom: heightBottom
+        };
+
+        switch (pos0) {
+          case 'right':
+            targetElPos = {
+              top: shiftHeight[pos1](),
+              left: shiftWidth[pos0]()
+            };
+            break;
+          case 'left':
+            targetElPos = {
+              top: shiftHeight[pos1](),
+              left: hostElPos.left - targetElWidth
+            };
+            break;
+          case 'bottom':
+            targetElPos = {
+              top: shiftHeight[pos0](),
+              left: shiftWidth[pos1]()
+            };
+            break;
+          default:
+            targetElPos = {
+              top: hostElPos.top - targetElHeight,
+              left: shiftWidth[pos1]()
+            };
+            break;
+        }
+
+        return targetElPos;
+
+        function widthRight() {
+          return hostElPos.left + hostElPos.width;
+        }
+
+        function widthLeft() {
+          return hostElPos.left;
+        }
+
+        function widthCenter() {
+          return hostElPos.left + hostElPos.width / 2 - targetElWidth / 2;
+        }
+
+        function heightBottom() {
+          return hostElPos.top + hostElPos.height;
+        }
+
+        function heightTop() {
+          return hostElPos.top;
+        }
+
+        function heightCenter() {
+          return hostElPos.top + hostElPos.height / 2 - targetElHeight / 2;
+        }
+      }
+    }
+  }
+})();

--- a/spa_ui/self_service/client/app/components/confirmation/confirmation.html
+++ b/spa_ui/self_service/client/app/components/confirmation/confirmation.html
@@ -1,0 +1,20 @@
+<div class="modal-header" ng-if="::vm.title">
+  <button type="button" class="close" ng-click="$dismiss()" aria-hidden="true">
+    <span class="pficon pficon-close"></span>
+  </button>
+  <h4 class="modal-title" id="myModalLabel"> {{ ::vm.title }}</h4>
+</div>
+<div class="modal-body">
+  <p class="confirmation__message">{{ ::vm.message }}</p>
+</div>
+<div class="modal-footer">
+  <div class="confirmation__buttons">
+    <button ng-if="vm.showCancel" type="button" class="confirmation__button btn-default" ng-click="$dismiss()">
+      {{ ::vm.cancel }}
+    </button>
+    <button type="button" class="confirmation__button btn-rounded" ng-class="::vm.okClass" ng-click="$close()">
+      {{ ::vm.ok }}
+    </button>
+  </div>
+</div>
+

--- a/spa_ui/self_service/client/app/states/services/details/details.html
+++ b/spa_ui/self_service/client/app/states/services/details/details.html
@@ -61,36 +61,48 @@
               </div>
             </div>
           </div>
-          <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
-            <div class="form-horizontal">
-              <div class="form-group">
-                <label class="control-label col-sm-4">Service Approval State</label>
-                <div class="col-sm-8">
-                  <input class="form-control" disabled value="{{ ::vm.service.approval_state }}"/>
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="control-label col-sm-4">Service Adjudicator</label>
-                <div class="col-sm-8">
-                  <input class="form-control" disabled value="N/A" />
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="control-label col-sm-4">Last Message</label>
-                <div class="col-sm-8">
-                  <input class="form-control" disabled value="{{ ::vm.service.message}}" />
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="control-label col-sm-4">Last Updated</label>
-                <div class="col-sm-8">
-                  <input class="form-control" disabled value="Service Updated On {{ ::vm.service.updated_at | date}}" />
-                </div>
-              </div>
+          <div class="col-lg-5 col-md-5 col-sm-5 col-xs-5">
+            <dl class="dl-horizontal text-capitalize">
+              <dt>Service Approval State</dt>
+              <dd>{{ ::vm.service.approval_state }}</dd>
+              <dt>Service Adjudicator</dt>
+              <dd>N/A</dd>
+              <dt>Last Message</dt>
+              <dd>{{ ::vm.service.message}}</dd>
+              <dt>Last Updated</dt>
+              <dd>Service Updated On {{ ::vm.service.updated_at | date}}</dd>
+              <dt>Service Type</dt>
+              <dd>{{ ::vm.service.service_type }}</dd>
+            </dl>
+          </div>
+          <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
+            <p>
+              <button class="btn btn-danger" type="button" ng-click="vm.removeService()">Remove Service</button>
+            </p>
+            <p>
+            <div class="btn-group">
+            <button class="btn btn-primary"
+                    type="button"
+                    confirmation
+                    confirmation-if="true"
+                    confirmation-title="Retire Service Now"
+                    confirmation-message="Confirm, would you like to retire this service?"
+                    confirmation-ok-text="Yes, Retire Service Now"
+                    confirmation-on-ok="vm.retireServiceNow()"
+                    confirmation-ok-style="primary"
+                    confirmation-show-cancel="true">
+              Retire
+            </button>
+            <button class="btn btn-primary" type="button" ng-click="vm.retireServiceLater()">Schedule</button>
             </div>
           </div>
           </div>
         </div>
+            <dl>
+              <dt>Description</dt>
+              <dd>{{ ::vm.service.long_description || vm.service.description }}</dd>
+            </dl>
+
     </section>
   </div>
 </div>

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -95,6 +95,7 @@
   <script src="/client/app/blocks/pub-sub/pub-sub.factory.js"></script>
   <script src="/client/app/blocks/recursion/recursion-helper.factory.js"></script>
   <script src="/client/app/blocks/router/router-helper.provider.js"></script>
+  <script src="/client/app/components/confirmation/confirmation.directive.js"></script>
   <script src="/client/app/components/edit-service-modal/edit-service-modal-service.factory.js"></script>
   <script src="/client/app/components/footer/footer-content.directive.js"></script>
   <script src="/client/app/components/main-content/main-content.directive.js"></script>


### PR DESCRIPTION

<img width="1920" alt="691f743c-6386-11e5-8d15-4a2a507ed77b" src="https://cloud.githubusercontent.com/assets/6640236/10163546/a855707c-6681-11e5-98e9-8e78988e1561.png">
Employed by the retire (now) service button on the Service Details State, this directive can be used anywhere action confirmation is required.