### PR TITLE
BZ1240309 - Fix javascript error on refresh of dynamic drop down with nil key

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -34,29 +34,33 @@ var dialogFieldRefresh = {
   refreshDropDownList: function(fieldName, fieldId, selectedValue) {
     miqSparkleOn();
 
-    $.post('dynamic_radio_button_refresh', {name: fieldName, checked_value: selectedValue}, function(data) {
-      var dropdownOptions = [];
-
-      $.each(data.values.refreshed_values, function(index, value) {
-        var option = '<option ';
-        option += 'value="' + value[0] + '" ';
-        if (data.values.checked_value !== null) {
-          if (data.values.checked_value.toString() === value[0].toString()) {
-            option += 'selected="selected" ';
-          }
-        } else {
-          if (index === 0) {
-            option += 'selected="selected" ';
-          }
-        }
-        option += '> ' + value[1] + '</option>';
-        dropdownOptions.push(option);
-      });
-
-      $('.dynamic-drop-down-' + fieldId).html(dropdownOptions);
-
-      miqSparkle(false);
+    $.post('dynamic_radio_button_refresh', {name: fieldName, checked_value: selectedValue}).done(function(data) {
+      dialogFieldRefresh.addOptionsToDropDownList(data, fieldId);
     });
+  },
+
+  addOptionsToDropDownList: function(data, fieldId) {
+    var dropdownOptions = [];
+
+    $.each(data.values.refreshed_values, function(index, value) {
+      var option = '<option ';
+      option += 'value="' + value[0] + '" ';
+      if (data.values.checked_value !== null) {
+        if (data.values.checked_value.toString() === value[0].toString()) {
+          option += 'selected="selected" ';
+        }
+      } else {
+        if (index === 0) {
+          option += 'selected="selected" ';
+        }
+      }
+      option += '> ' + value[1] + '</option>';
+      dropdownOptions.push(option);
+    });
+
+    $('.dynamic-drop-down-' + fieldId).html(dropdownOptions);
+
+    miqSparkle(false);
   },
 
   refreshRadioList: function(fieldName, fieldId, checkedValue, onClickString) {

--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -46,8 +46,10 @@ var dialogFieldRefresh = {
       var option = '<option ';
       option += 'value="' + value[0] + '" ';
       if (data.values.checked_value !== null) {
-        if (data.values.checked_value.toString() === value[0].toString()) {
-          option += 'selected="selected" ';
+        if (value[0] !== null) {
+          if (data.values.checked_value.toString() === value[0].toString()) {
+            option += 'selected="selected" ';
+          }
         }
       } else {
         if (index === 0) {

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -1,0 +1,60 @@
+describe('dialogFieldRefresh', function() {
+  describe('#addOptionsToDropDownList', function() {
+    var data = {};
+
+    beforeEach(function() {
+      var html = "";
+      html += '<select class="dynamic-drop-down-345">';
+      html += '</select>';
+      setFixtures(html);
+    });
+
+    context('when the refreshed values contain a checked value', function() {
+      context('when the refreshed values contain a null key', function() {
+        beforeEach(function() {
+          data = {values: {refreshed_values: [[null, 'not test'], ['123', 'is test']], checked_value: 123}};
+        });
+
+        it('it does not blow up', function() {
+          var test = function() {
+            dialogFieldRefresh.addOptionsToDropDownList(data, 345);
+          };
+          expect(test).not.toThrow();
+        });
+
+        it('selects the option that corresponds to the checked value', function() {
+          dialogFieldRefresh.addOptionsToDropDownList(data, 345);
+          expect($('.dynamic-drop-down-345').val()).toBe('123');
+        });
+      });
+    });
+
+    context('when the refreshed values do not contain a checked value', function() {
+      beforeEach(function() {
+        data = {values: {refreshed_values: [["test", "test"], ["not test", "not test"]], checked_value: null}};
+      });
+
+      it('selects the first option', function() {
+        dialogFieldRefresh.addOptionsToDropDownList(data, 345);
+        expect($('.dynamic-drop-down-345').val()).toBe('test');
+      });
+    });
+  });
+
+  describe('#refreshDropDownList', function() {
+    beforeEach(function() {
+      spyOn(dialogFieldRefresh, 'addOptionsToDropDownList');
+
+      spyOn($, 'post').and.callFake(function() {
+        var d = $.Deferred();
+        d.resolve("the data");
+        return d.promise();
+      });
+    });
+
+    it('calls addOptionsToDropDownList', function() {
+      dialogFieldRefresh.refreshDropDownList('abc', 123, 'test');
+      expect(dialogFieldRefresh.addOptionsToDropDownList).toHaveBeenCalledWith("the data", 123);
+    });
+  });
+});

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -1,0 +1,1 @@
+var context = describe;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1240309

Previously when the dynamic method of a drop down dialog would return something with a nil key, like [nil, "test"], a javascript error would be thrown. The original fix that I mentioned in the BZ was to fix when the selected value was nil, but not the actual list of values. This PR fixes that issue.

/cc @dclarizio