### PR TITLE
don't create zones with possible duplicate names

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -44,10 +44,8 @@ class Zone < ActiveRecord::Base
   end
 
   def self.seed
-    unless exists?(:name => 'default')
+    create_with(:description => "Default Zone").find_or_create_by!(:name => 'default') do |_z|
       _log.info("Creating default zone...")
-      create(:name => "default", :description => "Default Zone")
-      _log.info("Creating default zone... Complete")
     end
   end
 

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -3,11 +3,10 @@ require "spec_helper"
 describe EmsCloudController do
   describe "#create" do
     before do
-      Zone.first || FactoryGirl.create(:zone)
       controller.stub(:check_privileges).and_return(true)
       controller.stub(:assert_privileges).and_return(true)
       FactoryGirl.create(:vmdb_database)
-      EvmSpecHelper.local_miq_server
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
       login_as FactoryGirl.create(:user, :features => "ems_cloud_new")
     end
 
@@ -22,7 +21,7 @@ describe EmsCloudController do
 
     it 'shows the edit page' do
       expect(MiqServer.my_server).to be
-      FactoryGirl.create(:ems_amazon, :zone => Zone.first)
+      FactoryGirl.create(:ems_amazon, :zone => Zone.seed)
       ems = ManageIQ::Providers::Amazon::CloudManager.first
       get :edit, :id => ems.id
       expect(response.status).to eq(200)
@@ -159,7 +158,7 @@ describe EmsCloudController do
 
   describe "#ems_cloud_form_fields" do
     before do
-      Zone.first || FactoryGirl.create(:zone)
+      Zone.seed
       described_class.any_instance.stub(:set_user_time_zone)
       controller.stub(:check_privileges).and_return(true)
       controller.stub(:assert_privileges).and_return(true)
@@ -188,7 +187,7 @@ describe EmsCloudController do
 
   describe "#show_link" do
     before do
-      Zone.first || FactoryGirl.create(:zone)
+      Zone.seed
       described_class.any_instance.stub(:set_user_time_zone)
       controller.stub(:check_privileges).and_return(true)
       controller.stub(:assert_privileges).and_return(true)

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -130,7 +130,7 @@ FactoryGirl.define do
   end
 
   factory :ems_azure, :aliases => ["manageiq/providers/azure/cloud_manager"], :class => "ManageIQ::Providers::Azure::CloudManager", :parent => :ems_cloud do
-    zone {  Zone.first || FactoryGirl.create(:zone) }
+    zone { Zone.seed }
   end
 
   factory :ems_azure_with_authentication, :parent => :ems_azure do

--- a/spec/factories/zone.rb
+++ b/spec/factories/zone.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :zone do
-    sequence(:name)        { |n| Zone.exists? ? "Zone #{n}" : "default" }
-    sequence(:description) { |n| Zone.exists? ? "Zone #{n}" : "Default Zone" }
+    sequence(:name)        { |n| "Zone #{n}" }
+    sequence(:description) { |n| "Zone #{n}" }
   end
 end

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -14,8 +14,8 @@ describe EmsCloudHelper do
     it "sets restful path for instances in summary for restful controllers" do
       controller.stub(:restful?).and_return(true)
       controller.stub(:controller_name).and_return("ems_cloud")
-      Zone.first || FactoryGirl.create(:zone)
-      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
+
+      FactoryGirl.create(:ems_openstack, :zone => Zone.seed)
       FactoryGirl.create(:vm_openstack)
       @ems = ManageIQ::Providers::Openstack::CloudManager.first
       vms = ManageIQ::Providers::Openstack::CloudManager::Vm.first
@@ -33,8 +33,7 @@ describe EmsCloudHelper do
     it "sets restful path for images in summary for restful controllers" do
       controller.stub(:restful?).and_return(true)
       controller.stub(:controller_name).and_return("ems_cloud")
-      Zone.first || FactoryGirl.create(:zone)
-      FactoryGirl.create(:ems_openstack, :zone => Zone.first)
+      FactoryGirl.create(:ems_openstack, :zone => Zone.seed)
       FactoryGirl.create(:template_cloud)
       @ems = ManageIQ::Providers::Openstack::CloudManager.first
       template = MiqTemplate.first

--- a/spec/lib/extensions/ar_nested_count_by_spec.rb
+++ b/spec/lib/extensions/ar_nested_count_by_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "AR Nested Count By extension" do
   context "miq_queue with messages" do
     before(:each) do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @zone = EvmSpecHelper.local_miq_server.zone
 
       FactoryGirl.create(:miq_queue, :zone => @zone.name, :state => MiqQueue::STATE_DEQUEUE,  :role => "role1", :priority => 20)
       FactoryGirl.create(:miq_queue, :zone => @zone.name, :state => MiqQueue::STATE_DEQUEUE,  :role => "role1", :priority => 20)
@@ -22,19 +22,19 @@ describe "AR Nested Count By extension" do
     it "should count by state, zone and role" do
       expect(MiqQueue.nested_count_by(%w(state zone role))).to eq(
         MiqQueue::STATE_READY => {
-          "default" => { "role1" => 3 },
-          "west"    => { "role3" => 1 },
+          @zone.name => {"role1" => 3},
+          "west"     => {"role3" => 1},
         },
         MiqQueue::STATE_DEQUEUE => {
-          "default" => { "role1" => 2, "role2" => 1 },
-          "east"    => { "role1" => 2 },
+          @zone.name => {"role1" => 2, "role2" => 1},
+          "east"     => {"role1" => 2},
         },
         MiqQueue::STATE_WARN => {
-          "default" => { "role3" => 1 },
+          @zone.name => {"role3" => 1},
         },
         MiqQueue::STATE_ERROR => {
-          "default" => { "role1" => 1 },
-          "west"    => { "role2" => 1 },
+          @zone.name => {"role1" => 1},
+          "west"     => {"role2" => 1},
         }
       )
     end

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe AutomationRequest do
   before(:each) do
-    MiqServer.stub(:my_zone).and_return("default")
+    MiqServer.stub(:my_zone).and_return(Zone.seed.name)
     @zone        = FactoryGirl.create(:zone, :name => "fred")
     User.any_instance.stub(:role).and_return("admin")
     @user        = FactoryGirl.create(:user)

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe CustomButton do
   context "with no buttons" do
     before(:each) do
-      @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
+      @miq_server = EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
 
       User.any_instance.stub(:role).and_return("admin")
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -148,7 +148,7 @@ describe ExtManagementSystem do
         @same_host_name      = "us-east-1"
         @different_host_name = "us-west-1"
         @ems = FactoryGirl.create(:ems_vmware, :hostname => @same_host_name)
-        @zone = Zone.first || FactoryGirl.create(:zone)
+        @zone = Zone.seed
       end
 
       it "duplicate name" do

--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -18,7 +18,7 @@ describe ManageIQ::Providers::Amazon::CloudManager do
 
   context ".discover" do
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
       @ec2_user = "0123456789ABCDEFGHIJ"
       @ec2_pass = "ABCDEFGHIJKLMNO1234567890abcdefghijklmno"
       @ec2_user2 = "testuser"

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -12,7 +12,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
 
   context "SmartState Analysis Methods" do
     before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
       @ems = FactoryGirl.create(
         :ems_kubernetes,
         :hostname        => 'hostname',

--- a/spec/models/miq_host_provision_request_spec.rb
+++ b/spec/models/miq_host_provision_request_spec.rb
@@ -39,7 +39,7 @@ describe MiqHostProvisionRequest do
 
     context "when calling call_automate_event_queue" do
       before(:each) do
-        EvmSpecHelper.local_miq_server
+        EvmSpecHelper.local_miq_server(:zone => Zone.seed)
         @pr.miq_request.call_automate_event_queue("request_created")
       end
 


### PR DESCRIPTION
there are sporadic errors around duplicate zone names.
For the `"default"` zone, use `Zone.seed`

/cc @mkanoor 
