### PR TITLE
Reduce automate callers

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -41,13 +41,9 @@ module MiqAeEngine
     include MiqAeStateInfo
 
     attr_reader :nodes
-    DEFAULTS = {
-      :readonly => false
-    }
 
     def initialize(options = {})
-      options            = DEFAULTS.merge(options)
-      @readonly          = options[:readonly]
+      @readonly          = options[:readonly] || false
       @nodes             = []
       @current           = Array.new
       @num_drb_methods   = 0
@@ -63,23 +59,11 @@ module MiqAeEngine
       @readonly
     end
 
-    def self.instantiate_readonly(uri, workspace = nil, root = nil)
-      workspace ||= MiqAeWorkspaceRuntime.new(:readonly => true)
-      self._instantiate(uri, workspace, root)
-    end
-
-    def self.instantiate(uri, workspace = nil, root = nil)
-      workspace ||= MiqAeWorkspaceRuntime.new
-      self._instantiate(uri, workspace, root)
-    end
-
-    def self._instantiate(uri, workspace, root)
-      begin
-        workspace.instantiate(uri, root)
-      rescue MiqAeException
-        return nil
-      end
-      return workspace
+    def self.instantiate(uri, attrs = {})
+      workspace = MiqAeWorkspaceRuntime.new(attrs)
+      workspace.instantiate(uri, nil)
+      workspace
+    rescue MiqAeException
     end
 
     DATASTORE_CACHE = true

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -10,11 +10,9 @@ module EvmAutomate
   end
 
   def self.simulate(domain, namespace, class_name, instance_name)
-    automate_attrs = {}
-    uri = MiqAeEngine.create_automation_object(instance_name,
-                                               automate_attrs,
-                                               :fqclass => "#{domain}/#{namespace}/#{class_name}")
-    MiqAeEngine.resolve_automation_object(uri)
+    MiqAeEngine.resolve_automation_object(instance_name,
+                                          {},
+                                          :fqclass => "#{domain}/#{namespace}/#{class_name}")
   end
 
   def self.write_method_data(class_fqpath, method_name, content)


### PR DESCRIPTION
Goal: reduce calls into automate so we can more easily stub it out when we are working through various scenarios like provisioning, where it is not practical to use automate for all the callback functionality.


/cc @gmcculloug low hanging fruit