### PR TITLE
Set up rubocop so we can trust its autocorrect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,8 @@ SingleLineMethods:
   AllowIfMethodIsEmpty: false
 SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+TrivialAccessors:
+  AllowPredicates: true
 #
 # Enabled/Disabled
 #
@@ -64,18 +66,38 @@ AllCops:
   RunRailsCops: true
 ClassAndModuleChildren:
   Enabled: false
+DefEndAlignment:
+  AutoCorrect: true
 Documentation:
   Enabled: false
 Encoding:
+  Enabled: false
+EndAlignment:
+  AutoCorrect: true
+ExtraSpacing:
+  AutoCorrect: false # https://github.com/bbatsov/rubocop/issues/2280
+FindEach:
   Enabled: false
 GuardClause:
   Enabled: false
 IfUnlessModifier:
   Enabled: false
+NumericLiterals:
+  AutoCorrect: false
+ParallelAssignment:
+  Enabled: false
+PerlBackrefs:
+  Enabled: false
+ReadWriteAttribute:
+  AutoCorrect: false
+RescueModifier:
+  AutoCorrect: false
 SingleLineBlockParams:
   Enabled: false
 SingleSpaceBeforeFirstArg:
   Enabled: false
+SpecialGlobalVars:
+  AutoCorrect: false
 StringLiterals:
   Enabled: false
 StringLiteralsInInterpolation:
@@ -84,6 +106,8 @@ TrailingComma:
   Enabled: false
 WhileUntilModifier:
   Enabled: false
+WordArray:
+  AutoCorrect: false
 
 ClassAndModuleCamelCase:
   Exclude:

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -521,7 +521,7 @@ module VmCommon
       srow.add_element("cell", {"image" => "blank.gif", "title" => "Disk #{idx}"}).text = calculate_disk_name(disk)
       srow.add_element("cell", {"image" => "blank.gif", "title" => "#{disk.disk_type}"}).text = disk.disk_type
       srow.add_element("cell", {"image" => "blank.gif", "title" => "#{disk.mode}"}).text = disk.mode
-      srow.add_element("cell", {"image" => "blank.gif", "title" => "#{disk.partitions_aligned}",}).text = disk.partitions_aligned
+      srow.add_element("cell", {"image" => "blank.gif", "title" => "#{disk.partitions_aligned}"}).text = disk.partitions_aligned
       srow.add_element("cell", {"image" => "blank.gif", "title" => "#{calculate_size(disk.size)}"}).text = calculate_size(disk.size)
       srow.add_element("cell", {"image" => "blank.gif", "title" => "#{calculate_size(disk.size_on_disk)}"}).text = calculate_size(disk.size_on_disk)
       srow.add_element("cell", {"image" => "blank.gif", "title" => "#{disk.used_percent_of_provisioned}"}).text = disk.used_percent_of_provisioned

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -216,7 +216,7 @@ class Classification < ActiveRecord::Base
   def self.tag_name_split(tag_name)
     parts = tag_name.split("/")
     parts.shift
-    return *parts
+    return parts
   end
 
   # Splits a fully qualified tag into the namespace, category object, and entry object

--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
@@ -39,7 +39,7 @@ class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Prov
         when Vm;   OvirtMetrics.vm_realtime(target.uid_ems, start_time, end_time)
         end
       end
-      return *counters
+      return counters
     rescue Exception => err
       _log.error("#{log_header} Unhandled exception during perf data collection: [#{err}], class: [#{err.class}]")
       _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
@@ -289,7 +289,7 @@ module RefreshParser::Filter
   def vm_parent_rp(vm_mor, data_source)
     parent = data_source[:rp].find { |mor, data| get_mors(data, 'vm').include?(vm_mor) }
     return nil, nil if parent.nil?
-    return *parent
+    return parent
   end
 
   def ems_metadata_inv_by_host_mor(host_mor, data_source)

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -8,7 +8,7 @@ class ScanItem < ActiveRecord::Base
   YAML_DIR = File.expand_path(File.join(Rails.root, "product/scan_items"))
   Dir.mkdir YAML_DIR unless File.exist?(YAML_DIR)
 
-  SAMPLE_VM_PROFILE    = {:name => "sample",       :description => "VM Sample",       :mode => 'Vm',   :read_only => true, }.freeze
+  SAMPLE_VM_PROFILE    = {:name => "sample",       :description => "VM Sample",    :mode => 'Vm',   :read_only => true}.freeze
   SAMPLE_HOST_PROFILE  = {:name => "host sample",  :description => "Host Sample",  :mode => 'Host', :read_only => true}.freeze
   DEFAULT_HOST_PROFILE = {:name => "host default", :description => "Host Default", :mode => 'Host'}.freeze
 

--- a/spec/migrations/data/20131125153220_import_provision_dialogs_spec/miq_provision_dialogs.rb
+++ b/spec/migrations/data/20131125153220_import_provision_dialogs_spec/miq_provision_dialogs.rb
@@ -85,7 +85,7 @@ module MiqProvisionDialogs
           :display     => :show,
           :fields      => {
       :number_of_cpus     => {:data_type => :integer, :display => :edit, :required =>false, :description => "Number of CPUs",:default => 1,:values  => {1    => "1",2		=> "2",4		=> "4",8    => "8"}},
-      :vm_memory          => {:data_type => :string, :display => :edit, :required => false, :description => "Memory (MB)",:default => "1024",:values  => {"1024"  => "1024","2048"  => "2048","4096"  => "4096",}},
+      :vm_memory          => {:data_type => :string, :display => :edit, :required => false, :description => "Memory (MB)",:default => "1024",:values  => {"1024"  => "1024","2048"  => "2048","4096"  => "4096"}},
       :network_adapters   => {:data_type => :integer, :display => :hide, :required => false, :description => "Network Adapters",:default => 1,:values  => {1    => "1",2		=> "2",3		=> "3",4		=> "4"}},
       :disk_format        => {:data_type => :string, :display => :edit, :required => false, :description => "Disk Format",:default => "unchanged",:values  => {"unchanged"    => "Default","thin"		=> "Thin","thick"		=> "Thick"}},
       :cpu_limit          => {:data_type => :integer, :display => :edit, :required => false, :description => "CPU (MHz)", :notes=>"(-1 = Unlimited)", :notes_display=>:show},

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -303,7 +303,7 @@ describe Chargeback do
 
         @options = { :interval_size => 4,
                      :owner         => @user.userid,
-                     :ext_options   => { :tz => "Eastern Time (US & Canada)", }
+                     :ext_options   => {:tz => "Eastern Time (US & Canada)"},
                    }
       end
 


### PR DESCRIPTION
1. Remove a couple of meaningless eccentricities that it's tripping over
2. Turn off rules we aren't really obeying (and that I don't think we should :wink:)
3. Toggle some autocorrects that can do weird-looking things -- we might revisit them later, once we're not being overwhelmed by the trivial cleanups

@Fryguy I think there are a few Actual Opinions in here, so you'll probably want to go through them