### PR TITLE
Fix and speed up Product feature seed and tests

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -6,9 +6,7 @@ class MiqProductFeature < ActiveRecord::Base
   validates_presence_of   :identifier
   validates_uniqueness_of :identifier
 
-  FIXTURE_DIR  = File.join(Rails.root, "db/fixtures")
-  FIXTURE_PATH = File.join(FIXTURE_DIR, table_name)
-  FIXTURE_YAML = "#{FIXTURE_PATH}.yml"
+  FIXTURE_PATH = Rails.root.join(*["db", "fixtures", table_name])
 
   DETAIL_ATTRS = [
     :name,
@@ -19,6 +17,10 @@ class MiqProductFeature < ActiveRecord::Base
   ]
 
   FEATURE_TYPE_ORDER = ["view", "control", "admin", "node"]
+
+  def self.feature_yaml(path = FIXTURE_PATH)
+    "#{path}.yml".freeze
+  end
 
   def self.feature_root
     features.keys.detect { |k| feature_parent(k).nil? }
@@ -76,12 +78,14 @@ class MiqProductFeature < ActiveRecord::Base
     seed_features
   end
 
-  def self.seed_features
+  def self.seed_features(path = FIXTURE_PATH)
+    fixture_yaml = feature_yaml(path)
+
     features = all.to_a.index_by(&:identifier)
-    seen     = seed_from_hash(YAML.load_file(FIXTURE_YAML), seen, nil, features)
+    seen     = seed_from_hash(YAML.load_file(fixture_yaml), seen, nil, features)
 
     root_feature = MiqProductFeature.find_by(:identifier => 'everything')
-    Dir.glob(File.join(FIXTURE_PATH, "*.yml")).each do |fixture|
+    Dir.glob(path.join("*.yml")).each do |fixture|
       seed_from_hash(YAML.load_file(fixture), seen, root_feature)
     end
 

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -129,7 +129,7 @@ class MiqProductFeature < ActiveRecord::Base
   def seed_vm_explorer_for_custom_roles
     return unless identifier == "vm_explorer"
 
-    MiqUserRole.all.select { |r| r.feature_identifiers.include?("vm") && !r.feature_identifiers.include?("vm_explorer") }.each do |role|
+    MiqUserRole.includes(:miq_product_features).select { |r| r.feature_identifiers.include?("vm") && !r.feature_identifiers.include?("vm_explorer") }.each do |role|
       role.miq_product_features << self
       role.save!
     end

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -77,8 +77,8 @@ class MiqProductFeature < ActiveRecord::Base
   end
 
   def self.seed_features
-    seen = Hash.new([])
-    seed_from_hash(YAML.load_file(FIXTURE_YAML), seen)
+    features = all.to_a.index_by(&:identifier)
+    seen     = seed_from_hash(YAML.load_file(FIXTURE_YAML), seen, nil, features)
 
     root_feature = MiqProductFeature.find_by(:identifier => 'everything')
     Dir.glob(File.join(FIXTURE_PATH, "*.yml")).each do |fixture|
@@ -90,23 +90,26 @@ class MiqProductFeature < ActiveRecord::Base
     seen
   end
 
-  def self.seed_from_hash(hash, seen = {}, parent = nil)
+  def self.seed_from_hash(hash, seen = nil, parent = nil, features = nil)
+    seen ||= Hash.new { |h, k| h[k] = [] }
+
     children = hash.delete(:children) || []
     hash.delete(:parent_identifier)
 
-    hash[:parent] = parent
-    feature, status = seed_feature(hash)
-    seen[status] = [] unless seen.key?(status)
+    hash[:parent]   = parent
+    feature, status = seed_feature(hash, features)
     seen[status] << hash[:identifier]
 
     children.each do |child|
-      self.seed_from_hash(child, seen, feature)
+      seed_from_hash(child, seen, feature, features)
     end
+    seen
   end
 
-  def self.seed_feature(hash)
+  def self.seed_feature(hash, features)
+    feature = features ? features[hash[:identifier]] : find_by(:identifier => hash[:identifier])
+
     status = :unchanged
-    feature = find_by_identifier(hash[:identifier])
     if feature
       feature.attributes = hash
       if feature.changed?

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -87,6 +87,7 @@ class MiqProductFeature < ActiveRecord::Base
 
     deletes = where.not(:identifier => idents_from_hash).destroy_all
     _log.info("Deleting product features: #{deletes.collect(&:identifier).inspect}") unless deletes.empty?
+    idents_from_hash
   end
 
   def self.seed_from_hash(hash, seen = [], parent = nil)

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -98,6 +98,15 @@ class MiqProductFeature < ActiveRecord::Base
     hash.delete(:parent_identifier)
 
     hash[:parent] = parent
+    feature = seed_feature(hash)
+    seen << hash[:identifier]
+
+    children.each do |child|
+      self.seed_from_hash(child, seen, feature)
+    end
+  end
+
+  def self.seed_feature(hash)
     feature = find_by_identifier(hash[:identifier])
     if feature
       feature.attributes = hash
@@ -110,11 +119,7 @@ class MiqProductFeature < ActiveRecord::Base
       feature = create(hash.except(:id))
       feature.seed_vm_explorer_for_custom_roles
     end
-    seen << hash[:identifier]
-
-    children.each do |child|
-      seed_from_hash(child, seen, feature)
-    end
+    feature
   end
 
   def seed_vm_explorer_for_custom_roles

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -85,12 +85,8 @@ class MiqProductFeature < ActiveRecord::Base
       seed_from_hash(YAML.load_file(fixture), idents_from_hash, root_feature)
     end
 
-    idents_from_db = all.collect(&:identifier)
-    deletes = idents_from_db - (idents_from_db & idents_from_hash)
-    unless deletes.empty?
-      _log.info("Deleting product features: #{deletes.inspect}")
-      destroy_all(:identifier => deletes)
-    end
+    deletes = where.not(:identifier => idents_from_hash).destroy_all
+    _log.info("Deleting product features: #{deletes.collect(&:identifier).inspect}") unless deletes.empty?
   end
 
   def self.seed_from_hash(hash, seen = [], parent = nil)

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -168,34 +168,10 @@
         :description: Add Atomic Catalog Item
         :feature_type: admin
         :identifier: atomic_catalogitem_new
-      - :name: Add a new Button Group
-        :description: Add a new Button Group
-        :feature_type: admin
-        :identifier: ab_group_new
-      - :name: Edit Button Group
-        :description: Edit Button Group
-        :feature_type: admin
-        :identifier: ab_group_edit
-      - :name: Remove Button Group
-        :description: Remove Button Group
-        :feature_type: admin
-        :identifier: ab_group_delete
-      - :name: Add a new Button
-        :description: Add a new Button
-        :feature_type: admin
-        :identifier: ab_button_new
       - :name: Edit Button
         :description: Edit Button
         :feature_type: admin
         :identifier: ab_button_edit
-      - :name: Remove Button
-        :description: Remove Button
-        :feature_type: admin
-        :identifier: ab_button_delete
-      - :name: Reorder Buttons and Groups
-        :description: Reorder Buttons and Groups
-        :feature_type: admin
-        :identifier: ab_group_reorder
     - :name: Operate
       :description: Perform Operations on Catalog Items
       :feature_type: control
@@ -1799,16 +1775,6 @@
           :feature_type: admin
           :hidden: true
           :identifier: ab_group_new
-        - :name: Add Button
-          :description: Add Buttons
-          :feature_type: admin
-          :hidden: true
-          :identifier: ab_button_new
-        - :name: Edit
-          :description: Edit Buttons
-          :feature_type: admin
-          :hidden: true
-          :identifier: ab_group_edit
         - :name: Delete
           :description: Delete Buttons
           :feature_type: admin

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -6,9 +6,10 @@ describe MiqProductFeature do
   end
 
   context ".seed" do
-    it "empty table" do
-      MiqProductFeature.seed
-      MiqProductFeature.count.should eq(@expected_feature_count)
+    it "expected feature count with no duplicate identifiers" do
+      seeded_identifiers = MiqProductFeature.seed
+      expect(MiqProductFeature.count).to eq(@expected_feature_count)
+      expect(seeded_identifiers).to match_array seeded_identifiers.uniq
     end
 
     it "run twice" do

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -6,16 +6,18 @@ describe MiqProductFeature do
   end
 
   context ".seed" do
-    it "expected feature count with no duplicate identifiers" do
-      seeded_identifiers = MiqProductFeature.seed
+    it "creates feature identifiers once on first seed, changes nothing on second seed" do
+      status_seed1 = MiqProductFeature.seed
       expect(MiqProductFeature.count).to eq(@expected_feature_count)
-      expect(seeded_identifiers).to match_array seeded_identifiers.uniq
-    end
+      expect(status_seed1[:created]).to match_array status_seed1[:created].uniq
+      expect(status_seed1[:updated]).to match_array []
+      expect(status_seed1[:unchanged]).to match_array []
 
-    it "run twice" do
-      MiqProductFeature.seed
-      MiqProductFeature.seed
+      status_seed2 = MiqProductFeature.seed
       MiqProductFeature.count.should eq(@expected_feature_count)
+      expect(status_seed2[:created]).to match_array []
+      expect(status_seed2[:updated]).to match_array []
+      expect(status_seed2[:unchanged]).to match_array status_seed1[:created]
     end
 
     it "with existing records" do

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -21,45 +21,47 @@ describe MiqProductFeature do
       expect(status_seed2[:updated]).to match_array []
       expect(status_seed2[:unchanged]).to match_array status_seed1[:created]
     end
-
-    it "with existing records" do
-      deleted   = FactoryGirl.create(:miq_product_feature, :identifier => "xxx")
-      changed   = FactoryGirl.create(:miq_product_feature, :identifier => "about", :name => "XXX")
-      unchanged = FactoryGirl.create(:miq_product_feature_everything)
-      unchanged_orig_updated_at = unchanged.updated_at
-
-      MiqProductFeature.seed
-      MiqProductFeature.count.should eq(@expected_feature_count)
-      expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      changed.reload.name.should == "About"
-      unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at
-    end
   end
 
   context ".seed_features" do
     let(:feature_path) { Pathname.new(Dir.tmpdir).join(rand(1000).to_s) }
-
-    before do
-      FileUtils.mkdir_p(feature_path)
-    end
-
-    after do
-      FileUtils.rm_rf(feature_path)
-    end
-
-    it "additional yaml feature" do
-      base = {
+    let(:base) do
+      {
         :feature_type => "node",
         :identifier   => "everything",
         :children     => [
           {
             :feature_type => "node",
             :identifier   => "one",
+            :name         => "One",
             :children     => []
           }
         ]
       }
+    end
 
+    before do
+      FileUtils.mkdir_p(feature_path)
+      File.write("#{feature_path}.yml", YAML.dump(base))
+    end
+
+    after do
+      FileUtils.rm_rf(feature_path)
+    end
+
+    it "existing records" do
+      deleted   = FactoryGirl.create(:miq_product_feature, :identifier => "xxx")
+      changed   = FactoryGirl.create(:miq_product_feature, :identifier => "one", :name => "XXX")
+      unchanged = FactoryGirl.create(:miq_product_feature_everything)
+      unchanged_orig_updated_at = unchanged.updated_at
+
+      MiqProductFeature.seed_features(feature_path)
+      expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      changed.reload.name.should == "One"
+      unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at
+    end
+
+    it "additional yaml feature" do
       additional = {
         :feature_type => "node",
         :identifier   => "two",
@@ -67,7 +69,6 @@ describe MiqProductFeature do
       }
 
       additional_file = feature_path.join("additional.yml")
-      File.write("#{feature_path}.yml", YAML.dump(base))
       File.write(additional_file, YAML.dump(additional))
 
       status_seed = MiqProductFeature.seed_features(feature_path)

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -1,4 +1,6 @@
 require "spec_helper"
+require 'tmpdir'
+require 'pathname'
 
 describe MiqProductFeature do
   before do
@@ -31,6 +33,46 @@ describe MiqProductFeature do
       expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
       changed.reload.name.should == "About"
       unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at
+    end
+  end
+
+  context ".seed_features" do
+    let(:feature_path) { Pathname.new(Dir.tmpdir).join(rand(1000).to_s) }
+
+    before do
+      FileUtils.mkdir_p(feature_path)
+    end
+
+    after do
+      FileUtils.rm_rf(feature_path)
+    end
+
+    it "additional yaml feature" do
+      base = {
+        :feature_type => "node",
+        :identifier   => "everything",
+        :children     => [
+          {
+            :feature_type => "node",
+            :identifier   => "one",
+            :children     => []
+          }
+        ]
+      }
+
+      additional = {
+        :feature_type => "node",
+        :identifier   => "two",
+        :children     => []
+      }
+
+      additional_file = feature_path.join("additional.yml")
+      File.write("#{feature_path}.yml", YAML.dump(base))
+      File.write(additional_file, YAML.dump(additional))
+
+      status_seed = MiqProductFeature.seed_features(feature_path)
+      MiqProductFeature.count.should eq(3)
+      expect(status_seed[:created]).to match_array %w(everything one two)
     end
   end
 end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -74,7 +74,7 @@ module EvmSpecHelper
 
   def self.seed_specific_product_features(*features)
     features.flatten!
-    hashes   = YAML.load_file(MiqProductFeature::FIXTURE_YAML)
+    hashes   = YAML.load_file(MiqProductFeature.feature_yaml)
     filtered = filter_specific_features([hashes], features).first
     MiqProductFeature.seed_from_hash(filtered)
   end


### PR DESCRIPTION
We have several duplicated identifiers in the `db/fixtures/miq_product_features.yml` when they must be unique.  The seed method will create on the first instance and update on each subsequent instance and the last one in the file always wins.  Since only the last one survives, I chose to delete these "all but last duplicates" cc @h-kataria @dclarizio 

Added a missing test for "providing additional product features used by the UI plugins" (from #1680)

Changed the tests to not run the seed against the enormous miq_product_features.yml file except when we try to detect duplicate identifiers in changes to this file.

Tests before:
`Finished in 10.4 seconds`

Tests after:
`Finished in 3.25 seconds`

MiqProductFeature.seed is also a little faster:
Initial seed:            3 s -> 2.3 s
Subsequent seed:  0.8 s -> 0.2 s