### PR TITLE
Test create request

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
@@ -4,12 +4,12 @@ class ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow < Mi
   end
 
   def create_request(values, requester_id, auto_approve = false)
-    event_message = "Provision requested by [#{requester_id}] for Configured Systems:#{values[:src_configured_system_ids].inspect}"
+    event_message = "Configured System Provisioning requested by <#{requester_id}> for ConfiguredSystem:#{values[:src_configured_system_ids].inspect}"
     super(values, requester_id, 'ConfiguredSystem', 'configured_system_provision_request_created', event_message, auto_approve)
   end
 
   def update_request(request, values, requester_id)
-    event_message = "Provision request was successfully updated by [#{requester_id}] for Configured Systems:#{values[:src_configured_system_ids].inspect}"
+    event_message = "Configured System Provisioning request updated by <#{requester_id}> for ConfiguredSystem:#{values[:src_configured_system_ids].inspect}"
     super(request, values, requester_id, 'ConfiguredSystem', 'configured_system_provision_request_updated', event_message)
   end
 

--- a/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow < Mi
   end
 
   def update_request(request, values, requester_id)
-    event_message = "Provision request successfully updated by [#{requester_id}] for Configured Systems:#{values[:src_configured_system_ids].inspect}"
+    event_message = "Provision request was successfully updated by [#{requester_id}] for Configured Systems:#{values[:src_configured_system_ids].inspect}"
     super(request, values, requester_id, 'ConfiguredSystem', 'configured_system_provision_request_updated', event_message)
   end
 

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -20,12 +20,12 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   end
 
   def create_request(values, requester_id, auto_approve=false)
-    event_message = "Host Provision requested by [#{requester_id}] for Host:#{values[:src_host_ids].inspect}"
+    event_message = "Host Provisioning requested by <#{requester_id}> for Host:#{values[:src_host_ids].inspect}"
     super(values, requester_id, 'Host', 'host_provision_request_created', event_message, auto_approve) { update_selected_storage_names(values) }
   end
 
   def update_request(request, values, requester_id)
-    event_message = "Host Provision request was successfully updated by [#{requester_id}] for Host:#{values[:src_host_ids].inspect}"
+    event_message = "Host Provisioning request updated by <#{requester_id}> for Host:#{values[:src_host_ids].inspect}"
     super(request, values, requester_id, 'Host', 'host_provision_request_updated', event_message) { update_selected_storage_names(values) }
   end
 

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -20,12 +20,12 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   end
 
   def create_request(values, requester_id, auto_approve=false)
-    event_message = "Host Provision requested by [#{requester_id}] for Host:#{values[:src_host_id].inspect}"
+    event_message = "Host Provision requested by [#{requester_id}] for Host:#{values[:src_host_ids].inspect}"
     super(values, requester_id, 'Host', 'host_provision_request_created', event_message, auto_approve) { update_selected_storage_names(values) }
   end
 
   def update_request(request, values, requester_id)
-    event_message = "Host Provision request was successfully updated by [#{requester_id}] for Host:#{values[:src_host_id].inspect}"
+    event_message = "Host Provision request was successfully updated by [#{requester_id}] for Host:#{values[:src_host_ids].inspect}"
     super(request, values, requester_id, 'Host', 'host_provision_request_updated', event_message) { update_selected_storage_names(values) }
   end
 

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -62,6 +62,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
   def update_request(request, values, requester_id)
     event_message = "VM Provision request was successfully updated by [#{requester_id}] for VM:#{values[:src_vm_id].inspect}"
+    request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
+    request.src_vm_id = request.get_option(:src_vm_id)
     super(request, values, requester_id, 'Vm', 'vm_migrate_request_updated', event_message)
   end
 

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -55,16 +55,16 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       password_helper(values, true)
       return nil
     else
-      event_message = "VM Provision requested by [#{requester_id}] for VM:#{values[:src_vm_id].inspect}"
-      super(values, requester_id, 'Vm', 'vm_provision_request_updated', event_message, auto_approve)
+      event_message = "VM Provisioning requested by <#{requester_id}> for Vm:#{values[:src_vm_id].inspect}"
+      super(values, requester_id, 'Vm', 'vm_provision_request_created', event_message, auto_approve)
     end
   end
 
   def update_request(request, values, requester_id)
-    event_message = "VM Provision request was successfully updated by [#{requester_id}] for VM:#{values[:src_vm_id].inspect}"
+    event_message = "VM Provisioning request updated by <#{requester_id}> for Vm:#{values[:src_vm_id].inspect}"
     request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
     request.src_vm_id = request.get_option(:src_vm_id)
-    super(request, values, requester_id, 'Vm', 'vm_migrate_request_updated', event_message)
+    super(request, values, requester_id, 'Vm', 'vm_provision_request_updated', event_message)
   end
 
   def refresh_field_values(values, _requester_id)

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -66,10 +66,4 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
 
     true
   end
-
-  def update_request(request, values, requester_id, target_class, event_name, event_message)
-    request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
-    request.src_vm_id = request.get_option(:src_vm_id)
-    super
-  end
 end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -40,12 +40,12 @@ class ServiceTemplateProvisionRequest < MiqRequest
   end
 
   def self.create_request(values, requester_id, auto_approve=false)
-    event_message = "#{TASK_DESCRIPTION} requested by <#{requester_id}>"
+    event_message = "#{TASK_DESCRIPTION} requested by <#{requester_id}> for ServiceTemplate:#{values[:src_id]}"
     super(values, requester_id, auto_approve, request_types.first, SOURCE_CLASS_NAME, event_message)
   end
 
   def self.update_request(request, values, requester_id)
-    event_message = "#{TASK_DESCRIPTION} request was successfully updated by <#{requester_id}>"
+    event_message = "#{TASK_DESCRIPTION} request updated by <#{requester_id}> for ServiceTemplate:#{values[:src_id]}"
     super(request, values, requester_id, SOURCE_CLASS_NAME, event_message)
   end
 end

--- a/app/models/vm_migrate_request.rb
+++ b/app/models/vm_migrate_request.rb
@@ -1,7 +1,7 @@
 class VmMigrateRequest < MiqRequest
 
   TASK_DESCRIPTION  = 'VM Migrate'
-  SOURCE_CLASS_NAME = 'VmOrTemplate'
+  SOURCE_CLASS_NAME = 'Vm'
   ACTIVE_STATES     = %w{ migrated } + self.base_class::ACTIVE_STATES
 
   validates_inclusion_of :request_state,  :in => %w{ pending finished } + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"

--- a/app/models/vm_migrate_workflow.rb
+++ b/app/models/vm_migrate_workflow.rb
@@ -12,12 +12,12 @@ class VmMigrateWorkflow < MiqRequestWorkflow
   end
 
   def create_request(values, requester_id, auto_approve=false)
-    event_message = "VM Migrate requested by [#{requester_id}] for VM:#{values[:src_host_id].inspect}"
+    event_message = "VM Migrate requested by [#{requester_id}] for VM:#{values[:src_ids].inspect}"
     super(values, requester_id, 'Vm', 'vm_migrate_request_created', event_message, auto_approve)
   end
 
   def update_request(request, values, requester_id)
-    event_message = "VM Migrate request was successfully updated by [#{requester_id}] for VM:#{values[:src_host_id].inspect}"
+    event_message = "VM Migrate request was successfully updated by [#{requester_id}] for VM:#{values[:src_ids].inspect}"
     super(request, values, requester_id, 'Vm', 'vm_migrate_request_updated', event_message)
   end
 

--- a/app/models/vm_migrate_workflow.rb
+++ b/app/models/vm_migrate_workflow.rb
@@ -12,12 +12,12 @@ class VmMigrateWorkflow < MiqRequestWorkflow
   end
 
   def create_request(values, requester_id, auto_approve=false)
-    event_message = "VM Migrate requested by [#{requester_id}] for VM:#{values[:src_ids].inspect}"
+    event_message = "VM Migrate requested by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
     super(values, requester_id, 'Vm', 'vm_migrate_request_created', event_message, auto_approve)
   end
 
   def update_request(request, values, requester_id)
-    event_message = "VM Migrate request was successfully updated by [#{requester_id}] for VM:#{values[:src_ids].inspect}"
+    event_message = "VM Migrate request updated by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
     super(request, values, requester_id, 'Vm', 'vm_migrate_request_updated', event_message)
   end
 

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -1,7 +1,6 @@
 class VmReconfigureRequest < MiqRequest
-
   TASK_DESCRIPTION  = 'VM Reconfigure'
-  SOURCE_CLASS_NAME = 'VmOrTemplate'
+  SOURCE_CLASS_NAME = 'Vm'
   ACTIVE_STATES     = %w{ reconfigured } + self.base_class::ACTIVE_STATES
 
   validates_inclusion_of :request_state,  :in => %w{ pending finished } + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -8,12 +8,12 @@ class VmReconfigureRequest < MiqRequest
   validate               :must_have_user
 
   def self.create_request(values, requester_id, auto_approve=false)
-    event_message = "#{TASK_DESCRIPTION} requested by <#{requester_id}>"
+    event_message = "#{TASK_DESCRIPTION} requested by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
     super(values, requester_id, auto_approve, request_types.first, SOURCE_CLASS_NAME, event_message)
   end
 
   def self.update_request(request, values, requester_id)
-    event_message = "#{TASK_DESCRIPTION} request was successfully updated by <#{requester_id}>"
+    event_message = "#{TASK_DESCRIPTION} request updated by <#{requester_id}> for Vm:#{values[:src_ids].inspect}"
     super(request, values, requester_id, SOURCE_CLASS_NAME, event_message)
   end
 

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -1,11 +1,10 @@
 require "spec_helper"
 
 describe AutomationRequest do
+  let(:admin) { FactoryGirl.create(:user, :role => "admin") }
   before(:each) do
     MiqServer.stub(:my_zone).and_return("default")
     @zone        = FactoryGirl.create(:zone, :name => "fred")
-    User.any_instance.stub(:role).and_return("admin")
-    @user        = FactoryGirl.create(:user)
     @approver    = FactoryGirl.create(:user_miq_request_approver)
 
     @version     = 1
@@ -24,26 +23,26 @@ describe AutomationRequest do
 
   context ".create_from_ws" do
     it "with empty requester string" do
-      ar = AutomationRequest.create_from_ws(@version, @user.userid, @uri_parts, @parameters, "")
+      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should                           == AutomationRequest.first
       ar.request_state.should             == "pending"
       ar.status.should                    == "Ok"
       ar.approval_state.should            == "pending_approval"
-      ar.userid.should                    == @user.userid
+      ar.userid.should                    == admin.userid
       ar.options[:message].should         == @ae_message
       ar.options[:instance_name].should   == @ae_instance
-      ar.options[:user_id].should         == @user.id
+      ar.options[:user_id].should         == admin.id
       ar.options[:attrs][:var1].should    == @ae_var1
       ar.options[:attrs][:var2].should    == @ae_var2
       ar.options[:attrs][:var3].should    == @ae_var3
-      ar.options[:attrs][:userid].should  == @user.userid
+      ar.options[:attrs][:userid].should  == admin.userid
     end
 
     it "with requester string overriding userid who is NOT in the database" do
       user_name = 'oleg'
-      ar = AutomationRequest.create_from_ws(@version, @user.userid, @uri_parts, @parameters, "user_name=#{user_name}")
+      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "user_name=#{user_name}")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should                           == AutomationRequest.first
@@ -61,7 +60,7 @@ describe AutomationRequest do
     end
 
     it "with requester string overriding userid who is in the database" do
-      ar = AutomationRequest.create_from_ws(@version, @user.userid, @uri_parts, @parameters, "user_name=#{@approver.userid}")
+      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "user_name=#{@approver.userid}")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should                           == AutomationRequest.first
@@ -79,7 +78,7 @@ describe AutomationRequest do
     end
 
     it "with requester string overriding userid AND auto_approval" do
-      ar = AutomationRequest.create_from_ws(@version, @user.userid, @uri_parts, @parameters, "user_name=#{@approver.userid}|auto_approve=true")
+      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "user_name=#{@approver.userid}|auto_approve=true")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should                           == AutomationRequest.first
@@ -100,7 +99,7 @@ describe AutomationRequest do
   context "#approve" do
     context "an unapproved request with a single approver" do
       before(:each) do
-        @ar = AutomationRequest.create_from_ws(@version, @user.userid, @uri_parts, @parameters, "")
+        @ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "")
         @reason = "Why Not?"
       end
 
@@ -122,9 +121,27 @@ describe AutomationRequest do
     end
   end
 
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+    it "creates and update a request" do
+      expect(AuditEvent).not_to receive(:success)
+      values = {}
+
+      request = described_class.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(AutomationRequest)
+      expect(request.request_type).to eq("automation")
+      expect(request.description).to eq("Automation Task")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+    end
+  end
+
   context "#create_request_tasks" do
     before(:each) do
-      @ar = AutomationRequest.create_from_ws(@version, @user.userid, @uri_parts, @parameters, "")
+      @ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "")
       root = { 'ae_result' => 'ok' }
       ws = double('ws')
       ws.stub(:root => root)
@@ -143,7 +160,6 @@ describe AutomationRequest do
   end
 
   context "validate zone" do
-
     before do
       MiqRequest.any_instance.stub(:automate_event_failed?).and_return(false)
     end
@@ -185,7 +201,5 @@ describe AutomationRequest do
       deliver(nil)
       check_zone(nil)
     end
-
   end
-
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
@@ -103,8 +103,11 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
                                  :state        => 'pending',
                                  :status       => 'Ok',
                                  :options      => options)
-    MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
 
-    vm_prov.workflow.class.should eq ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow
+    workflow_class = ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow
+    workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+
+    expect(vm_prov.workflow.class).to eq workflow_class
+    expect(vm_prov.workflow_class).to eq workflow_class
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -1,274 +1,308 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
-  context "With a user" do
-    let(:admin) { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
+  include WorkflowSpecHelper
 
-    it "pass platform attributes to automate" do
-      MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
-      MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
-        name.should eq("REQUEST")
-        attrs.should have_attributes(
-          'request'                   => 'UI_PROVISION_INFO',
-          'message'                   => 'get_pre_dialog_name',
-          'dialog_input_request_type' => 'template',
-          'dialog_input_target_type'  => 'vm',
-          'platform_category'         => 'cloud',
-          'platform'                  => 'amazon'
-        )
-      end
+  let(:admin) { FactoryGirl.create(:user_with_group) }
+  let(:ems) { FactoryGirl.create(:ems_amazon) }
+  let(:template) { FactoryGirl.create(:template_amazon, :name => "template", :ext_management_system => ems) }
+  let(:workflow) do
+    stub_dialog
+    ManageIQ::Providers::CloudManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
+    wf = described_class.new({:src_vm_id => template.id}, admin.userid)
+    wf.instance_variable_set("@ems_xml_nodes", {})
+    wf
+  end
 
-      ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow.new({}, admin.userid)
+  it "pass platform attributes to automate" do
+    stub_dialog
+    assert_automate_dialog_lookup('cloud', 'amazon')
+
+    described_class.new({}, admin.userid)
+  end
+
+  context "with empty relationships" do
+    it "#allowed_availability_zones" do
+      workflow.allowed_availability_zones.should == {}
     end
 
-    context "With a Valid Template" do
-      let(:provider) { FactoryGirl.create(:ems_amazon) }
-      let(:template) { FactoryGirl.create(:template_amazon, :name => "template", :ext_management_system => provider) }
-      let(:workflow) do
-        MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-        ManageIQ::Providers::CloudManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
-        wf = ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid)
-        wf.instance_variable_set("@ems_xml_nodes", {})
-        wf
+    it "#allowed_guest_access_key_pairs" do
+      workflow.allowed_guest_access_key_pairs.should == {}
+    end
+
+    it "#allowed_security_groups" do
+      workflow.allowed_security_groups.should == {}
+    end
+  end
+
+  context "with valid relationships" do
+    it "#allowed_availability_zones" do
+      az = FactoryGirl.create(:availability_zone_amazon)
+      ems.availability_zones << az
+      workflow.allowed_availability_zones.should == {az.id => az.name}
+    end
+
+    it "#allowed_guest_access_key_pairs" do
+      kp = AuthPrivateKey.create(:name => "auth_1")
+      ems.key_pairs << kp
+      workflow.allowed_guest_access_key_pairs.should == {kp.id => kp.name}
+    end
+
+    it "#allowed_security_groups" do
+      sg = FactoryGirl.create(:security_group_amazon, :name => "sq_1")
+      ems.security_groups << sg
+      workflow.allowed_security_groups.should == {sg.id => sg.name}
+    end
+  end
+
+  context "when a template object is returned from the provider" do
+    context "with empty relationships" do
+      it "#allowed_instance_types" do
+        workflow.allowed_instance_types.should == {}
+      end
+    end
+
+    context "with valid relationships" do
+      before do
+        ems.flavors << FactoryGirl.create(:flavor, :name => "t1.micro",    :supports_32_bit => true,  :supports_64_bit => true)
+        ems.flavors << FactoryGirl.create(:flavor, :name => "m1.large",    :supports_32_bit => false, :supports_64_bit => true)
       end
 
-      context "with empty relationships" do
-        it "#allowed_availability_zones" do
-          workflow.allowed_availability_zones.should == {}
-        end
-
-        it "#allowed_guest_access_key_pairs" do
-          workflow.allowed_guest_access_key_pairs.should == {}
-        end
-
-        it "#allowed_security_groups" do
-          workflow.allowed_security_groups.should == {}
-        end
+      it "#allowed_instance_types with 32-bit image" do
+        template.hardware = FactoryGirl.create(:hardware, :bitness => 32)
+        workflow.allowed_instance_types.length.should == 1
       end
 
-      context "with valid relationships" do
-        it "#allowed_availability_zones" do
-          az = FactoryGirl.create(:availability_zone_amazon)
-          provider.availability_zones << az
-          workflow.allowed_availability_zones.should == {az.id => az.name}
-        end
+      it "#allowed_instance_types with 64-bit image" do
+        template.hardware = FactoryGirl.create(:hardware, :bitness => 64)
+        workflow.allowed_instance_types.length.should == 2
+      end
+    end
+  end
 
-        it "#allowed_guest_access_key_pairs" do
-          kp = AuthPrivateKey.create(:name => "auth_1")
-          provider.key_pairs << kp
-          workflow.allowed_guest_access_key_pairs.should == {kp.id => kp.name}
-        end
+  context "with VPC relationships" do
+    before do
+      @az1 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => ems)
+      @az2 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => ems)
+      @az3 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => ems)
 
-        it "#allowed_security_groups" do
-          sg = FactoryGirl.create(:security_group_amazon, :name => "sq_1")
-          provider.security_groups << sg
-          workflow.allowed_security_groups.should == {sg.id => sg.name}
-        end
+      @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems)
+
+      @cs1 = FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1, :availability_zone => @az1)
+      @cs2 = FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1, :availability_zone => @az2)
+
+      @ip1 = FactoryGirl.create(:floating_ip, :cloud_network_only => true,  :ext_management_system => ems)
+      @ip2 = FactoryGirl.create(:floating_ip, :cloud_network_only => false, :ext_management_system => ems)
+
+      @sg1 = FactoryGirl.create(:security_group_amazon, :name => "sq_1", :ext_management_system => ems, :cloud_network => @cn1)
+      @sg2 = FactoryGirl.create(:security_group_amazon, :name => "sq_1", :ext_management_system => ems)
+    end
+
+    it "#allowed_cloud_networks" do
+      workflow.allowed_cloud_networks.length.should == 1
+    end
+
+    context "#allowed_availability_zones" do
+      it "with no placement options" do
+        workflow.allowed_availability_zones.should == {
+          @az1.id => @az1.name,
+          @az2.id => @az2.name,
+          @az3.id => @az3.name
+        }
       end
 
-      context "when a template object is returned from the provider" do
-        context "with empty relationships" do
-          it "#allowed_instance_types" do
-            workflow.allowed_instance_types.should == {}
-          end
-        end
-
-        context "with valid relationships" do
-          before do
-            provider.flavors << FactoryGirl.create(:flavor, :name => "t1.micro",    :supports_32_bit => true,  :supports_64_bit => true)
-            provider.flavors << FactoryGirl.create(:flavor, :name => "m1.large",    :supports_32_bit => false, :supports_64_bit => true)
-          end
-
-          it "#allowed_instance_types with 32-bit image" do
-            template.hardware = FactoryGirl.create(:hardware, :bitness => 32)
-            workflow.allowed_instance_types.length.should == 1
-          end
-
-          it "#allowed_instance_types with 64-bit image" do
-            template.hardware = FactoryGirl.create(:hardware, :bitness => 64)
-            workflow.allowed_instance_types.length.should == 2
-          end
-        end
+      it "with a cloud_network" do
+        workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
+        workflow.allowed_availability_zones.should == {
+          @az1.id => @az1.name,
+          @az2.id => @az2.name
+        }
       end
 
-      context "with VPC relationships" do
-        before do
-          @az1 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => provider)
-          @az2 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => provider)
-          @az3 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => provider)
+      it "with a cloud_network and cloud_subnet" do
+        workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
+        workflow.values[:cloud_subnet]  = [@cs2.id, @cs2.name]
+        workflow.allowed_availability_zones.should == {@az2.id => @az2.name}
+      end
+    end
 
-          @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => provider)
-
-          @cs1 = FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1, :availability_zone => @az1)
-          @cs2 = FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1, :availability_zone => @az2)
-
-          @ip1 = FactoryGirl.create(:floating_ip, :cloud_network_only => true,  :ext_management_system => provider)
-          @ip2 = FactoryGirl.create(:floating_ip, :cloud_network_only => false, :ext_management_system => provider)
-
-          @sg1 = FactoryGirl.create(:security_group_amazon, :name => "sq_1", :ext_management_system => provider, :cloud_network => @cn1)
-          @sg2 = FactoryGirl.create(:security_group_amazon, :name => "sq_1", :ext_management_system => provider)
-        end
-
-        it "#allowed_cloud_networks" do
-          workflow.allowed_cloud_networks.length.should == 1
-        end
-
-        context "#allowed_availability_zones" do
-          it "with no placement options" do
-            workflow.allowed_availability_zones.should == {
-              @az1.id => @az1.name,
-              @az2.id => @az2.name,
-              @az3.id => @az3.name
-            }
-          end
-
-          it "with a cloud_network" do
-            workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-            workflow.allowed_availability_zones.should == {
-              @az1.id => @az1.name,
-              @az2.id => @az2.name
-            }
-          end
-
-          it "with a cloud_network and cloud_subnet" do
-            workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-            workflow.values[:cloud_subnet]  = [@cs2.id, @cs2.name]
-            workflow.allowed_availability_zones.should == {@az2.id => @az2.name}
-          end
-        end
-
-        context "#allowed_cloud_subnets" do
-          it "without a cloud_network" do
-            workflow.allowed_cloud_subnets.length.should be_zero
-          end
-
-          it "with a cloud_network" do
-            workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-            workflow.allowed_cloud_subnets.length.should == 2
-          end
-
-          it "with an cloud_network and Availability Zone" do
-            workflow.values[:cloud_network]               = [@cn1.id, @cn1.name]
-            workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
-
-            workflow.allowed_cloud_subnets.length.should == 1
-          end
-        end
-
-        context "#allowed_floating_ip_addresses" do
-          it "without a cloud_network" do
-            workflow.allowed_floating_ip_addresses.should == {@ip2.id => @ip2.address}
-          end
-
-          it "with a cloud_network" do
-            workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-            workflow.allowed_floating_ip_addresses.should == {@ip1.id => @ip1.address}
-          end
-        end
-
-        context "#allowed_security_groups" do
-          it "without a cloud_network" do
-            workflow.allowed_security_groups.should == {@sg2.id => @sg2.name}
-          end
-
-          it "with a cloud_network" do
-            workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-            workflow.allowed_security_groups.should == {@sg1.id => @sg1.name}
-          end
-        end
+    context "#allowed_cloud_subnets" do
+      it "without a cloud_network" do
+        workflow.allowed_cloud_subnets.length.should be_zero
       end
 
-      context "#display_name_for_name_description" do
-        let(:flavor)   { FactoryGirl.create(:flavor_amazon, :name => "test_flavor") }
-
-        it "with name only" do
-          workflow.display_name_for_name_description(flavor).should == "test_flavor"
-        end
-
-        it "with name and description" do
-          flavor.description = "Small"
-          workflow.display_name_for_name_description(flavor).should == "test_flavor: Small"
-        end
+      it "with a cloud_network" do
+        workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
+        workflow.allowed_cloud_subnets.length.should == 2
       end
 
-      context "with virtualization type" do
-        before do
-          @instance_types_32 = ['t2.micro']
-          @instance_types_64 = ['m1.medium', 'm1.large']
-          provider.flavors << FactoryGirl.create(:flavor_amazon,
-                                                 :name                 => "t2.micro",
-                                                 :supports_32_bit      => true,
-                                                 :supports_64_bit      => true,
-                                                 :supports_paravirtual => false,
-                                                 :supports_hvm         => true)
-          provider.flavors << FactoryGirl.create(:flavor_amazon,
-                                                 :name                 => "m1.large",
-                                                 :supports_32_bit      => false,
-                                                 :supports_64_bit      => true,
-                                                 :supports_paravirtual => true,
-                                                 :supports_hvm         => false)
-          provider.flavors << FactoryGirl.create(:flavor_amazon,
-                                                 :name                 => "m1.medium",
-                                                 :supports_32_bit      => true,
-                                                 :supports_64_bit      => true,
-                                                 :supports_paravirtual => true,
-                                                 :supports_hvm         => false)
-        end
+      it "with an cloud_network and Availability Zone" do
+        workflow.values[:cloud_network]               = [@cn1.id, @cn1.name]
+        workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
 
-        it "#allowed_instance_types with 32-bit and hvm image" do
-          template.hardware = FactoryGirl.create(:hardware, :bitness => 32, :virtualization_type => 'hvm')
-          workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_32)
-        end
+        workflow.allowed_cloud_subnets.length.should == 1
+      end
+    end
 
-        it "#allowed_instance_types with 64-bit and pv image" do
-          template.hardware = FactoryGirl.create(:hardware, :bitness => 64, :virtualization_type => 'paravirtual')
-          workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_64)
-        end
+    context "#allowed_floating_ip_addresses" do
+      it "without a cloud_network" do
+        workflow.allowed_floating_ip_addresses.should == {@ip2.id => @ip2.address}
       end
 
-      context "with root device type" do
-        before do
-          @instance_types_64 = ['t1.micro', 'm1.large']
-          provider.flavors << FactoryGirl.create(:flavor_amazon,
-                                                 :name                     => "t1.micro",
-                                                 :supports_32_bit          => true,
-                                                 :supports_64_bit          => true,
-                                                 :supports_paravirtual     => true,
-                                                 :supports_hvm             => false,
-                                                 :block_storage_based_only => true)
-          provider.flavors << FactoryGirl.create(:flavor_amazon,
-                                                 :name                     => "m1.large",
-                                                 :supports_32_bit          => false,
-                                                 :supports_64_bit          => true,
-                                                 :supports_paravirtual     => true,
-                                                 :supports_hvm             => false,
-                                                 :block_storage_based_only => false)
-          provider.flavors << FactoryGirl.create(:flavor_amazon,
-                                                 :name                     => "t2.medium",
-                                                 :supports_32_bit          => false,
-                                                 :supports_64_bit          => true,
-                                                 :supports_paravirtual     => false,
-                                                 :supports_hvm             => true,
-                                                 :block_storage_based_only => true)
-        end
-
-        it "#allowed_instance_types with 32-bit, pv and instance_store" do
-          template.hardware = FactoryGirl.create(:hardware,
-                                                 :bitness             => 32,
-                                                 :virtualization_type => 'paravirtual',
-                                                 :root_device_type    => 'instance_store')
-          workflow.allowed_instance_types.collect { |_, v| v }.should be_empty
-        end
-
-        it "#allowed_instance_types with 64-bit, pv and ebs" do
-          template.hardware = FactoryGirl.create(:hardware,
-                                                 :bitness             => 64,
-                                                 :virtualization_type => 'paravirtual',
-                                                 :root_device_type    => 'ebs')
-          workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_64)
-        end
+      it "with a cloud_network" do
+        workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
+        workflow.allowed_floating_ip_addresses.should == {@ip1.id => @ip1.address}
       end
+    end
+
+    context "#allowed_security_groups" do
+      it "without a cloud_network" do
+        workflow.allowed_security_groups.should == {@sg2.id => @sg2.name}
+      end
+
+      it "with a cloud_network" do
+        workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
+        workflow.allowed_security_groups.should == {@sg1.id => @sg1.name}
+      end
+    end
+  end
+
+  context "#display_name_for_name_description" do
+    let(:flavor) { FactoryGirl.create(:flavor_amazon, :name => "test_flavor") }
+
+    it "with name only" do
+      workflow.display_name_for_name_description(flavor).should == "test_flavor"
+    end
+
+    it "with name and description" do
+      flavor.description = "Small"
+      workflow.display_name_for_name_description(flavor).should == "test_flavor: Small"
+    end
+  end
+
+  context "with virtualization type" do
+    before do
+      @instance_types_32 = ['t2.micro']
+      @instance_types_64 = ['m1.medium', 'm1.large']
+      ems.flavors << FactoryGirl.create(:flavor_amazon,
+                                        :name                 => "t2.micro",
+                                        :supports_32_bit      => true,
+                                        :supports_64_bit      => true,
+                                        :supports_paravirtual => false,
+                                        :supports_hvm         => true)
+      ems.flavors << FactoryGirl.create(:flavor_amazon,
+                                        :name                 => "m1.large",
+                                        :supports_32_bit      => false,
+                                        :supports_64_bit      => true,
+                                        :supports_paravirtual => true,
+                                        :supports_hvm         => false)
+      ems.flavors << FactoryGirl.create(:flavor_amazon,
+                                        :name                 => "m1.medium",
+                                        :supports_32_bit      => true,
+                                        :supports_64_bit      => true,
+                                        :supports_paravirtual => true,
+                                        :supports_hvm         => false)
+    end
+
+    it "#allowed_instance_types with 32-bit and hvm image" do
+      template.hardware = FactoryGirl.create(:hardware, :bitness => 32, :virtualization_type => 'hvm')
+      workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_32)
+    end
+
+    it "#allowed_instance_types with 64-bit and pv image" do
+      template.hardware = FactoryGirl.create(:hardware, :bitness => 64, :virtualization_type => 'paravirtual')
+      workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_64)
+    end
+  end
+
+  context "with root device type" do
+    before do
+      @instance_types_64 = ['t1.micro', 'm1.large']
+      ems.flavors << FactoryGirl.create(:flavor_amazon,
+                                        :name                     => "t1.micro",
+                                        :supports_32_bit          => true,
+                                        :supports_64_bit          => true,
+                                        :supports_paravirtual     => true,
+                                        :supports_hvm             => false,
+                                        :block_storage_based_only => true)
+      ems.flavors << FactoryGirl.create(:flavor_amazon,
+                                        :name                     => "m1.large",
+                                        :supports_32_bit          => false,
+                                        :supports_64_bit          => true,
+                                        :supports_paravirtual     => true,
+                                        :supports_hvm             => false,
+                                        :block_storage_based_only => false)
+      ems.flavors << FactoryGirl.create(:flavor_amazon,
+                                        :name                     => "t2.medium",
+                                        :supports_32_bit          => false,
+                                        :supports_64_bit          => true,
+                                        :supports_paravirtual     => false,
+                                        :supports_hvm             => true,
+                                        :block_storage_based_only => true)
+    end
+
+    it "#allowed_instance_types with 32-bit, pv and instance_store" do
+      template.hardware = FactoryGirl.create(:hardware,
+                                             :bitness             => 32,
+                                             :virtualization_type => 'paravirtual',
+                                             :root_device_type    => 'instance_store')
+      workflow.allowed_instance_types.collect { |_, v| v }.should be_empty
+    end
+
+    it "#allowed_instance_types with 64-bit, pv and ebs" do
+      template.hardware = FactoryGirl.create(:hardware,
+                                             :bitness             => 64,
+                                             :virtualization_type => 'paravirtual',
+                                             :root_device_type    => 'ebs')
+      workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_64)
+    end
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+    it "creates and update a request" do
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_updated",
+        :target_class => "Vm",
+        :userid       => admin.userid,
+        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+      )
+
+      # creates a request
+      stub_get_next_vm_name
+
+      # the dialogs populate this
+      values.merge!(:src_vm_id => template.id, :vm_tags => [])
+
+      request = workflow.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqProvisionRequest)
+      expect(request.request_type).to eq("template")
+      expect(request.description).to eq("Provision from [#{template.name}] to [New VM]")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      stub_get_next_vm_name
+
+      workflow = described_class.new(values, alt_user.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_migrate_request_updated",
+        :target_class => "Vm",
+        :userid       => alt_user.userid,
+        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+      )
+      workflow.make_request(request, values, alt_user.userid)
     end
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -268,10 +268,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
       workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_provision_request_updated",
+        :event        => "vm_provision_request_created",
         :target_class => "Vm",
         :userid       => admin.userid,
-        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
       )
 
       # creates a request
@@ -297,10 +297,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
       workflow = described_class.new(values, alt_user.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_migrate_request_updated",
+        :event        => "vm_provision_request_updated",
         :target_class => "Vm",
         :userid       => alt_user.userid,
-        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 
 describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow do
+  include WorkflowSpecHelper
+
+  let(:admin) { FactoryGirl.create(:user_with_group) }
+  let(:system) do
+    FactoryGirl.create(:configured_system_foreman,
+                       :hostname              => 'host',
+                       :configuration_manager => FactoryGirl.create(:configuration_manager_foreman))
+  end
+
   it "#allowed_configuration_profiles" do
     cp       = FactoryGirl.build(:configuration_profile, :name => "test profile")
     cs       = FactoryGirl.build(:configured_system_foreman)
@@ -10,5 +19,50 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
     ConfiguredSystem.should_receive(:common_configuration_profiles_for_selected_configured_systems).with([cs.id]).and_return([cp])
 
     expect(workflow.allowed_configuration_profiles).to eq(cp.id => cp.name)
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "configured_system_provision_request_created",
+        :target_class => "ConfiguredSystem",
+        :userid       => admin.userid,
+        :message      => "Provision requested by [#{admin.userid}] for Configured Systems:#{[system.id].inspect}"
+      )
+
+      # creates a request
+
+      # the dialogs populate this
+      values.merge!(:src_configured_system_ids => [system.id], :vm_tags => [])
+
+      request = workflow.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqProvisionConfiguredSystemRequest)
+      expect(request.request_type).to eq("provision_via_foreman")
+      expect(request.description).to eq("Foreman install on [host]")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+      workflow = described_class.new(values, alt_user.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "configured_system_provision_request_updated",
+        :target_class => "ConfiguredSystem",
+        :userid       => alt_user.userid,
+        :message      => "Provision request was successfully updated by [#{alt_user.userid}] for Configured Systems:#{[system.id].inspect}"
+      )
+      workflow.make_request(request, values, alt_user.userid)
+    end
   end
 end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -35,7 +35,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
         :event        => "configured_system_provision_request_created",
         :target_class => "ConfiguredSystem",
         :userid       => admin.userid,
-        :message      => "Provision requested by [#{admin.userid}] for Configured Systems:#{[system.id].inspect}"
+        :message      => "Configured System Provisioning requested by <#{admin.userid}> for ConfiguredSystem:#{[system.id].inspect}"
       )
 
       # creates a request
@@ -60,7 +60,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
         :event        => "configured_system_provision_request_updated",
         :target_class => "ConfiguredSystem",
         :userid       => alt_user.userid,
-        :message      => "Provision request was successfully updated by [#{alt_user.userid}] for Configured Systems:#{[system.id].inspect}"
+        :message      => "Configured System Provisioning request updated by <#{alt_user.userid}> for ConfiguredSystem:#{[system.id].inspect}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
@@ -43,8 +43,11 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
 
     context "SCVMM provisioning" do
       it "#workflow" do
-        ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-        vm_prov.workflow.class.should eq ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow
+        workflow_class = ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow
+        workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+
+        expect(vm_prov.workflow.class).to eq workflow_class
+        expect(vm_prov.workflow_class).to eq workflow_class
       end
     end
 

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
@@ -1,31 +1,69 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
-  context "With a Valid Template," do
-    let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
-    let(:provider) { FactoryGirl.create(:ems_microsoft) }
-    let(:template) { FactoryGirl.create(:template_microsoft, :name => "template", :ext_management_system => provider) }
+  include WorkflowSpecHelper
 
-    before do
-      ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-      ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
-    end
+  let(:admin)    { FactoryGirl.create(:user_with_group) }
+  let(:ems)      { FactoryGirl.create(:ems_microsoft) }
+  let(:template) { FactoryGirl.create(:template_microsoft, :name => "template", :ext_management_system => ems) }
 
-    it "pass platform attributes to automate" do
-      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
-      MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
-        name.should eq("REQUEST")
-        attrs.should have_attributes(
-          'request'                   => 'UI_PROVISION_INFO',
-          'message'                   => 'get_pre_dialog_name',
-          'dialog_input_request_type' => 'template',
-          'dialog_input_target_type'  => 'vm',
-          'platform_category'         => 'infra',
-          'platform'                  => 'microsoft'
-        )
-      end
+  before do
+    described_class.any_instance.stub(:update_field_visibility)
+  end
 
-      ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow.new({}, admin.userid)
+  it "pass platform attributes to automate" do
+    stub_dialog
+    assert_automate_dialog_lookup('infra', 'microsoft')
+
+    described_class.new({}, admin.userid)
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_updated",
+        :target_class => "Vm",
+        :userid       => admin.userid,
+        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+      )
+
+      # creates a request
+      stub_get_next_vm_name
+
+      # the dialogs populate this
+      values.merge!(:src_vm_id => template.id, :vm_tags => [])
+
+      request = workflow.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqProvisionRequest)
+      expect(request.request_type).to eq("template")
+      expect(request.description).to eq("Provision from [#{template.name}] to [New VM]")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      stub_get_next_vm_name
+
+      workflow = described_class.new(values, alt_user.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_migrate_request_updated",
+        :target_class => "Vm",
+        :userid       => alt_user.userid,
+        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+      )
+      workflow.make_request(request, values, alt_user.userid)
     end
   end
 end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
@@ -29,10 +29,10 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
       workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_provision_request_updated",
+        :event        => "vm_provision_request_created",
         :target_class => "Vm",
         :userid       => admin.userid,
-        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
       )
 
       # creates a request
@@ -58,10 +58,10 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
       workflow = described_class.new(values, alt_user.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_migrate_request_updated",
+        :event        => "vm_provision_request_updated",
         :target_class => "Vm",
         :userid       => alt_user.userid,
-        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_spec.rb
@@ -93,8 +93,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision do
   end
 
   it "#workflow" do
-    ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow.any_instance.stub(:get_dialogs => {:dialogs => {}})
+    workflow_class = ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow
+    workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
 
-    expect(vm_prov.workflow).to be_kind_of(ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow)
+    expect(vm_prov.workflow.class).to eq workflow_class
+    expect(vm_prov.workflow_class).to eq workflow_class
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -177,10 +177,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_provision_request_updated",
+        :event        => "vm_provision_request_created",
         :target_class => "Vm",
         :userid       => admin.userid,
-        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
       )
 
       # creates a request
@@ -206,10 +206,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       workflow = described_class.new(values, alt_user.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_migrate_request_updated",
+        :event        => "vm_provision_request_updated",
         :target_class => "Vm",
         :userid       => alt_user.userid,
-        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -1,34 +1,25 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
+  include WorkflowSpecHelper
+
+  let(:admin)    { FactoryGirl.create(:user_with_group) }
+  let(:provider) { FactoryGirl.create(:ems_openstack) }
+  let(:template) { FactoryGirl.create(:template_openstack, :name => "template", :ext_management_system => provider) }
+
   context "With a user" do
-    let(:admin) { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
-
     it "pass platform attributes to automate" do
-      ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
-      MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
-        name.should eq("REQUEST")
-        attrs.should have_attributes(
-          'request'                   => 'UI_PROVISION_INFO',
-          'message'                   => 'get_pre_dialog_name',
-          'dialog_input_request_type' => 'template',
-          'dialog_input_target_type'  => 'vm',
-          'platform_category'         => 'cloud',
-          'platform'                  => 'openstack'
-        )
-      end
+      stub_dialog
+      assert_automate_dialog_lookup('cloud', 'openstack')
 
-      ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow.new({}, admin.userid)
+      described_class.new({}, admin.userid)
     end
 
     context "With a Valid Template" do
-      let(:provider) { FactoryGirl.create(:ems_openstack) }
-      let(:template) { FactoryGirl.create(:template_openstack, :name => "template", :ext_management_system => provider) }
       let(:workflow) do
-        ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-        ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
-        ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid)
+        stub_dialog
+        described_class.any_instance.stub(:update_field_visibility)
+        described_class.new({:src_vm_id => template.id}, admin.userid)
       end
 
       context "with empty relationships" do
@@ -171,6 +162,56 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           end
         end
       end
+    end
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_updated",
+        :target_class => "Vm",
+        :userid       => admin.userid,
+        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+      )
+
+      # creates a request
+      stub_get_next_vm_name
+
+      # the dialogs populate this
+      values.merge!(:src_vm_id => template.id, :vm_tags => [])
+
+      request = workflow.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqProvisionRequest)
+      expect(request.request_type).to eq("template")
+      expect(request.description).to eq("Provision from [#{template.name}] to [New VM]")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      stub_get_next_vm_name
+
+      workflow = described_class.new(values, alt_user.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_migrate_request_updated",
+        :target_class => "Vm",
+        :userid       => alt_user.userid,
+        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+      )
+      workflow.make_request(request, values, alt_user.userid)
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -28,9 +28,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       end
 
       it "#workflow" do
-        MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+        workflow_class = ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow
+        workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
 
-        @vm_prov.workflow.class.should eq ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow
+        expect(@vm_prov.workflow.class).to eq workflow_class
+        expect(@vm_prov.workflow_class).to eq workflow_class
       end
 
       it "disable_customization_spec" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -109,10 +109,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
       workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_provision_request_updated",
+        :event        => "vm_provision_request_created",
         :target_class => "Vm",
         :userid       => admin.userid,
-        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
       )
 
       # creates a request
@@ -138,10 +138,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
       workflow = described_class.new(values, alt_user.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_migrate_request_updated",
+        :event        => "vm_provision_request_updated",
         :target_class => "Vm",
         :userid       => alt_user.userid,
-        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -1,111 +1,109 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
-  context "With a Valid Template," do
-    let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
-    let(:provider) { FactoryGirl.create(:ems_redhat) }
-    let(:template) { FactoryGirl.create(:template_redhat, :name => "template", :ext_management_system => provider) }
+  let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
+  let(:provider) { FactoryGirl.create(:ems_redhat) }
+  let(:template) { FactoryGirl.create(:template_redhat, :name => "template", :ext_management_system => provider) }
+
+  before do
+    MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+    ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
+  end
+
+  it "pass platform attributes to automate" do
+    MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
+    MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
+      name.should eq("REQUEST")
+      attrs.should have_attributes(
+        'request'                   => 'UI_PROVISION_INFO',
+        'message'                   => 'get_pre_dialog_name',
+        'dialog_input_request_type' => 'template',
+        'dialog_input_target_type'  => 'vm',
+        'platform_category'         => 'infra',
+        'platform'                  => 'redhat'
+      )
+    end
+
+    ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({}, admin.userid)
+  end
+
+  context "#allowed_storages" do
+    let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid) }
+    let(:host)     { FactoryGirl.create(:host, :ext_management_system => provider) }
 
     before do
-      MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
-      ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
-    end
-
-    it "pass platform attributes to automate" do
-      MiqAeEngine::MiqAeWorkspaceRuntime.should_receive(:instantiate)
-      MiqAeEngine.should_receive(:create_automation_object) do |name, attrs, _options|
-        name.should eq("REQUEST")
-        attrs.should have_attributes(
-          'request'                   => 'UI_PROVISION_INFO',
-          'message'                   => 'get_pre_dialog_name',
-          'dialog_input_request_type' => 'template',
-          'dialog_input_target_type'  => 'vm',
-          'platform_category'         => 'infra',
-          'platform'                  => 'redhat'
-        )
+      %w(iso data export data).each do |domain_type|
+        host.storages << FactoryGirl.create(:storage, :storage_domain_type => domain_type)
       end
-
-      ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({}, admin.userid)
+      host.reload
+      workflow.stub(:process_filter).and_return(host.storages.to_a)
+      workflow.stub(:allowed_hosts_obj).and_return([host])
     end
 
-    context "#allowed_storages" do
-      let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid) }
-      let(:host)     { FactoryGirl.create(:host, :ext_management_system => provider) }
+    it "for ISO and PXE provisioning" do
+      result = workflow.allowed_storages
+      result.length.should == 2
+      result.each { |storage| storage.should be_kind_of(MiqHashStruct) }
+      result.each { |storage| storage.storage_domain_type.should == "data" }
+    end
 
-      before do
-        %w(iso data export data).each do |domain_type|
-          host.storages << FactoryGirl.create(:storage, :storage_domain_type => domain_type)
+    it "for linked-clone provisioning" do
+      workflow.stub(:supports_linked_clone?).and_return(true)
+      template.storage = Storage.where(:storage_domain_type => "data").first
+      template.save
+
+      result = workflow.allowed_storages
+      result.length.should == 1
+      result.each { |storage| storage.should be_kind_of(MiqHashStruct) }
+      result.each { |storage| storage.storage_domain_type.should == "data" }
+    end
+  end
+
+  context "supports_linked_clone?" do
+    let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id, :linked_clone => true}, admin.userid) }
+
+    it "when supports_native_clone? is true" do
+      workflow.stub(:supports_native_clone?).and_return(true)
+      workflow.supports_linked_clone?.should be_true
+    end
+
+    it "when supports_native_clone? is false " do
+      workflow.stub(:supports_native_clone?).and_return(false)
+      workflow.supports_linked_clone?.should be_false
+    end
+  end
+
+  context "#supports_cloud_init?" do
+    let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid) }
+
+    it "should support cloud-init" do
+      workflow.supports_cloud_init?.should == true
+    end
+  end
+
+  context "#allowed_customization_templates" do
+    let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid) }
+
+    it "should retrieve cloud-init templates when cloning" do
+      options = {'key' => 'value'}
+      workflow.stub(:supports_native_clone?).and_return(true)
+      workflow.should_receive(:allowed_cloud_init_customization_templates).with(options)
+      workflow.allowed_customization_templates(options)
+    end
+
+    it "should retrieve ISO/PXE templates when not cloning" do
+      # Intercept the call to super
+      module SuperAllowedCustomizationTemplates
+        def allowed_customization_templates(options)
+          super_allowed_customization_templates(options)
         end
-        host.reload
-        workflow.stub(:process_filter).and_return(host.storages.to_a)
-        workflow.stub(:allowed_hosts_obj).and_return([host])
       end
+      workflow.extend(SuperAllowedCustomizationTemplates)
 
-      it "for ISO and PXE provisioning" do
-        result = workflow.allowed_storages
-        result.length.should == 2
-        result.each { |storage| storage.should be_kind_of(MiqHashStruct) }
-        result.each { |storage| storage.storage_domain_type.should == "data" }
-      end
-
-      it "for linked-clone provisioning" do
-        workflow.stub(:supports_linked_clone?).and_return(true)
-        template.storage = Storage.where(:storage_domain_type => "data").first
-        template.save
-
-        result = workflow.allowed_storages
-        result.length.should == 1
-        result.each { |storage| storage.should be_kind_of(MiqHashStruct) }
-        result.each { |storage| storage.storage_domain_type.should == "data" }
-      end
-    end
-
-    context "supports_linked_clone?" do
-      let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id, :linked_clone => true}, admin.userid) }
-
-      it "when supports_native_clone? is true" do
-        workflow.stub(:supports_native_clone?).and_return(true)
-        workflow.supports_linked_clone?.should be_true
-      end
-
-      it "when supports_native_clone? is false " do
-        workflow.stub(:supports_native_clone?).and_return(false)
-        workflow.supports_linked_clone?.should be_false
-      end
-    end
-
-    context "#supports_cloud_init?" do
-      let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid) }
-
-      it "should support cloud-init" do
-        workflow.supports_cloud_init?.should == true
-      end
-    end
-
-    context "#allowed_customization_templates" do
-      let(:workflow) { ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new({:src_vm_id => template.id}, admin.userid) }
-
-      it "should retrieve cloud-init templates when cloning" do
-        options = {'key' => 'value'}
-        workflow.stub(:supports_native_clone?).and_return(true)
-        workflow.should_receive(:allowed_cloud_init_customization_templates).with(options)
-        workflow.allowed_customization_templates(options)
-      end
-
-      it "should retrieve ISO/PXE templates when not cloning" do
-        # Intercept the call to super
-        module SuperAllowedCustomizationTemplates
-          def allowed_customization_templates(options)
-            super_allowed_customization_templates(options)
-          end
-        end
-        workflow.extend(SuperAllowedCustomizationTemplates)
-
-        options = {'key' => 'value'}
-        workflow.stub(:supports_native_clone?).and_return(false)
-        workflow.should_receive(:super_allowed_customization_templates).with(options)
-        workflow.allowed_customization_templates(options)
-      end
+      options = {'key' => 'value'}
+      workflow.stub(:supports_native_clone?).and_return(false)
+      workflow.should_receive(:super_allowed_customization_templates).with(options)
+      workflow.allowed_customization_templates(options)
     end
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -26,9 +26,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
       end
 
       it "#workflow" do
-        MiqProvisionWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+        workflow_class = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow
+        workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
 
-        @vm_prov.workflow.class.should eq ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow
+        expect(@vm_prov.workflow.class).to eq workflow_class
+        expect(@vm_prov.workflow_class).to eq workflow_class
       end
 
       it "should return a config spec" do

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -40,10 +40,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_provision_request_updated",
+        :event        => "vm_provision_request_created",
         :target_class => "Vm",
         :userid       => admin.userid,
-        :message      => "VM Provision requested by [#{admin.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
       )
 
       # creates a request
@@ -69,10 +69,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       workflow = described_class.new(values, alt_user.userid)
 
       expect(AuditEvent).to receive(:success).with(
-        :event        => "vm_migrate_request_updated",
+        :event        => "vm_provision_request_updated",
         :target_class => "Vm",
         :userid       => alt_user.userid,
-        :message      => "VM Provision request was successfully updated by [#{alt_user.userid}] for VM:#{template.id}"
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 silence_warnings { MiqHostProvisionWorkflow.const_set("DIALOGS_VIA_AUTOMATE", false) }
 
 describe MiqHostProvisionWorkflow do
-
+  include WorkflowSpecHelper
   context "seeded" do
     context "After setup," do
       before(:each) do
@@ -43,6 +43,54 @@ describe MiqHostProvisionWorkflow do
           opt = request.options
         end
       end
+    end
+  end
+
+  describe "#make_request" do
+    let(:host)  { FactoryGirl.create(:host) }
+    let(:admin) { FactoryGirl.create(:user_with_group) }
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "host_provision_request_created",
+        :target_class => "Host",
+        :userid       => admin.userid,
+        :message      => "Host Provision requested by [#{admin.userid}] for Host:#{[host.id].inspect}"
+      )
+
+      # creates a request
+
+      # the dialogs populate this
+      values.merge!(:src_host_ids => [host.id], :vm_tags => [])
+
+      request = workflow.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqHostProvisionRequest)
+      expect(request.request_type).to eq("host_pxe_install")
+      expect(request.description).to eq("PXE install on [#{host.name}] from image []")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      workflow = described_class.new(values, alt_user.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "host_provision_request_updated",
+        :target_class => "Host",
+        :userid       => alt_user.userid,
+        :message      => "Host Provision request was successfully updated by [#{alt_user.userid}] for Host:#{[host.id].inspect}"
+      )
+      workflow.make_request(request, values, alt_user.userid)
     end
   end
 end

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -62,7 +62,7 @@ describe MiqHostProvisionWorkflow do
         :event        => "host_provision_request_created",
         :target_class => "Host",
         :userid       => admin.userid,
-        :message      => "Host Provision requested by [#{admin.userid}] for Host:#{[host.id].inspect}"
+        :message      => "Host Provisioning requested by <#{admin.userid}> for Host:#{[host.id].inspect}"
       )
 
       # creates a request
@@ -88,7 +88,7 @@ describe MiqHostProvisionWorkflow do
         :event        => "host_provision_request_updated",
         :target_class => "Host",
         :userid       => alt_user.userid,
-        :message      => "Host Provision request was successfully updated by [#{alt_user.userid}] for Host:#{[host.id].inspect}"
+        :message      => "Host Provisioning request updated by <#{alt_user.userid}> for Host:#{[host.id].inspect}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -119,7 +119,7 @@ describe ServiceTemplateProvisionRequest do
         :event        => "service_template_provision_request_created",
         :target_class => "ServiceTemplate",
         :userid       => admin.userid,
-        :message      => "Service_Template_Provisioning requested by <#{admin.userid}>"
+        :message      => "Service_Template_Provisioning requested by <#{admin.userid}> for ServiceTemplate:#{service_template.id}"
       )
 
       # creates a request
@@ -143,7 +143,7 @@ describe ServiceTemplateProvisionRequest do
         :event        => "service_template_provision_request_updated",
         :target_class => "ServiceTemplate",
         :userid       => alt_user.userid,
-        :message      => "Service_Template_Provisioning request was successfully updated by <#{alt_user.userid}>"
+        :message      => "Service_Template_Provisioning request updated by <#{alt_user.userid}> for ServiceTemplate:#{service_template.id}"
       )
       described_class.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/vm_migrate_workflow_spec.rb
+++ b/spec/models/vm_migrate_workflow_spec.rb
@@ -1,32 +1,76 @@
 require "spec_helper"
 
 describe VmMigrateWorkflow do
+  include WorkflowSpecHelper
+  let(:admin) { FactoryGirl.create(:user_with_group) }
+  let(:ems) { FactoryGirl.create(:ems_vmware) }
+  let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'My VM', :ext_management_system => ems) }
+
   context "With a Valid Template," do
-    let(:admin)    { FactoryGirl.create(:user, :name => 'admin', :userid => 'admin') }
-    let(:provider) { FactoryGirl.create(:ems_vmware) }
-    let(:vm) { FactoryGirl.create(:vm_vmware, :ext_management_system => provider) }
-
-    before do
-      VmMigrateWorkflow.any_instance.stub(:get_dialogs).and_return( {:dialogs => {}} )
-      VmMigrateWorkflow.any_instance.stub(:update_field_visibility)
-    end
-
     context "#allowed_hosts" do
       let(:workflow) { VmMigrateWorkflow.new({:src_ids => [vm.id]}, admin.userid) }
 
       context "#allowed_hosts" do
         it "with no hosts" do
+          stub_dialog
           workflow.allowed_hosts.should == []
         end
 
         it "with a host" do
-          host = FactoryGirl.create(:host_vmware, :ext_management_system => provider)
-          host.set_parent(provider)
+          stub_dialog
+          host = FactoryGirl.create(:host_vmware, :ext_management_system => ems)
+          host.set_parent(ems)
           workflow.stub(:process_filter).and_return([host])
 
           workflow.allowed_hosts.should == [workflow.ci_to_hash_struct(host)]
         end
       end
+    end
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+      stub_dialog
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_migrate_request_created",
+        :target_class => "Vm",
+        :userid       => admin.userid,
+        :message      => "VM Migrate requested by [#{admin.userid}] for VM:#{[vm.id].inspect}"
+      )
+
+      # creates a request
+
+      # the dialogs populate this
+      values.merge!(:src_ids => [vm.id], :vm_tags => [])
+
+      request = workflow.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(VmMigrateRequest)
+      expect(request.request_type).to eq("vm_migrate")
+      expect(request.description).to eq("VM Migrate for: #{vm.name} - ")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      workflow = described_class.new(values, alt_user.userid)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_migrate_request_updated",
+        :target_class => "Vm",
+        :userid       => alt_user.userid,
+        :message      => "VM Migrate request was successfully updated by [#{alt_user.userid}] for VM:#{[vm.id].inspect}"
+      )
+      workflow.make_request(request, values, alt_user.userid)
     end
   end
 end

--- a/spec/models/vm_migrate_workflow_spec.rb
+++ b/spec/models/vm_migrate_workflow_spec.rb
@@ -42,7 +42,7 @@ describe VmMigrateWorkflow do
         :event        => "vm_migrate_request_created",
         :target_class => "Vm",
         :userid       => admin.userid,
-        :message      => "VM Migrate requested by [#{admin.userid}] for VM:#{[vm.id].inspect}"
+        :message      => "VM Migrate requested by <#{admin.userid}> for Vm:#{[vm.id].inspect}"
       )
 
       # creates a request
@@ -68,7 +68,7 @@ describe VmMigrateWorkflow do
         :event        => "vm_migrate_request_updated",
         :target_class => "Vm",
         :userid       => alt_user.userid,
-        :message      => "VM Migrate request was successfully updated by [#{alt_user.userid}] for VM:#{[vm.id].inspect}"
+        :message      => "VM Migrate request updated by <#{alt_user.userid}> for Vm:#{[vm.id].inspect}"
       )
       workflow.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -50,7 +50,7 @@ describe VmReconfigureRequest do
         :event        => "vm_reconfigure_request_created",
         :target_class => "VmOrTemplate",
         :userid       => admin.userid,
-        :message      => "VM Reconfigure requested by <#{admin.userid}>"
+        :message      => "VM Reconfigure requested by <#{admin.userid}> for Vm:#{[@vm.id].inspect}"
       )
 
       # creates a request
@@ -75,7 +75,7 @@ describe VmReconfigureRequest do
         :event        => "vm_reconfigure_request_updated",
         :target_class => "VmOrTemplate",
         :userid       => alt_user.userid,
-        :message      => "VM Reconfigure request was successfully updated by <#{alt_user.userid}>"
+        :message      => "VM Reconfigure request updated by <#{alt_user.userid}> for Vm:#{[@vm.id].inspect}"
       )
       described_class.make_request(request, values, alt_user.userid)
     end

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -1,14 +1,15 @@
 require "spec_helper"
 
 describe VmReconfigureRequest do
+  let(:admin) { FactoryGirl.create(:user, :userid => "tester") }
   before do
     server = FactoryGirl.create(:miq_server, :is_master => true)
-    @request = FactoryGirl.create(:vm_reconfigure_request, :userid => FactoryGirl.create(:user, :userid => "tester").userid)
+    @request = FactoryGirl.create(:vm_reconfigure_request, :userid => admin.userid)
     @guid1 = server.guid
     @zone1 = server.zone
 
     zone2  = FactoryGirl.create(:zone, :name => "zone_2")
-    FactoryGirl.create(:miq_server, :zone => zone2, :guid => MiqUUID.new_guid)
+    FactoryGirl.create(:miq_server, :zone => zone2)
     @vm = FactoryGirl.create(:vm_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware, :zone => zone2))
   end
 
@@ -38,5 +39,49 @@ describe VmReconfigureRequest do
         @request.my_zone.should eq(@zone1.name)
       end
     end
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+    it "creates and update a request" do
+      EvmSpecHelper.local_miq_server
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_reconfigure_request_created",
+        :target_class => "VmOrTemplate",
+        :userid       => admin.userid,
+        :message      => "VM Reconfigure requested by <#{admin.userid}>"
+      )
+
+      # creates a request
+      stub_get_next_vm_name
+
+      # the dialogs populate this
+      values = {:src_ids => [@vm.id]}
+
+      request = described_class.make_request(nil, values, admin.userid) # TODO: nil
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(described_class)
+      expect(request.request_type).to eq("vm_reconfigure")
+      expect(request.description).to eq("VM Reconfigure for: #{@vm.name} - ")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_reconfigure_request_updated",
+        :target_class => "VmOrTemplate",
+        :userid       => alt_user.userid,
+        :message      => "VM Reconfigure request was successfully updated by <#{alt_user.userid}>"
+      )
+      described_class.make_request(request, values, alt_user.userid)
+    end
+  end
+
+  def stub_get_next_vm_name(vm_name = "New VM")
+    allow(MiqProvision).to receive(:get_next_vm_name).and_return(vm_name)
   end
 end

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -48,7 +48,7 @@ describe VmReconfigureRequest do
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_reconfigure_request_created",
-        :target_class => "VmOrTemplate",
+        :target_class => "Vm",
         :userid       => admin.userid,
         :message      => "VM Reconfigure requested by <#{admin.userid}> for Vm:#{[@vm.id].inspect}"
       )
@@ -73,7 +73,7 @@ describe VmReconfigureRequest do
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_reconfigure_request_updated",
-        :target_class => "VmOrTemplate",
+        :target_class => "Vm",
         :userid       => alt_user.userid,
         :message      => "VM Reconfigure request updated by <#{alt_user.userid}> for Vm:#{[@vm.id].inspect}"
       )

--- a/spec/support/workflow_spec_helper.rb
+++ b/spec/support/workflow_spec_helper.rb
@@ -1,0 +1,46 @@
+module WorkflowSpecHelper
+  def stub_dialog(method = :get_dialogs)
+    allow_any_instance_of(described_class).to receive(method).and_return(:dialogs => {})
+  end  
+
+  def stub_get_next_vm_name(vm_name = "New VM")
+    allow(MiqProvision).to receive(:get_next_vm_name).and_return(vm_name)
+  end
+
+  def assert_automate_dialog_lookup(category, platform, method = 'get_pre_dialog_name', dialog_name = nil)
+    no_attrs = double(:attributes => [])
+    stub_automate_workspace(dialog_name, no_attrs, no_attrs, dialog_name)
+
+    expect(MiqAeEngine).to receive(:create_automation_object).with(
+      "REQUEST",
+      hash_including(
+        'request'                   => 'UI_PROVISION_INFO',
+        'message'                   => method,
+        'dialog_input_request_type' => 'template',
+        'dialog_input_target_type'  => 'vm',
+        'platform_category'         => category,
+        'platform'                  => platform,
+      ),
+      anything).and_return(dialog_name)
+  end
+
+  def assert_automate_vm_name_lookup(user, vm_name = 'vm_name')
+    stub_automate_workspace("get_vmname_url", vm_name)
+
+    MiqAeEngine.should_receive(:create_automation_object).with(
+      "REQUEST",
+      hash_including(
+        'request'    => 'UI_PROVISION_INFO',
+        'message'    => 'get_vmname',
+        'User::user' => user.id
+      ),
+      anything).and_return("get_vmname_url")
+  end
+
+  def stub_automate_workspace(url, *result)
+    workspace_stub = double
+    expect(workspace_stub).to receive(:instantiate).with(url, nil)
+    expect(workspace_stub).to receive(:root).and_return(*result)
+    expect(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:new).and_return(workspace_stub)
+  end
+end


### PR DESCRIPTION
I want to consolidate `create_request` methods, so I can pass the `tenant` around when creating a `workspace`, `request`, and `task`.

But before I do this, I want to make sure I don't introduce regressions, so this PR adds tests around `MiqRequest.create_request` and `MiqRequestWorkflow#create_request`, which are `MiqRequest` factory method.

**NOTE:** If you notice, a few of these I did change the `request` / `workspace` code because it looked to be erroneously reading the wrong key.

Please let me know if I missed any `create_request` factory calls or if it looks like I'm passing in the wrong key. Of note, these things easily blew up if we don't pass the right keys around.

/cc @gmcculloug yay!