### PR TITLE
Removed SQL queries from the dashboard controller before_action chain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,10 +44,10 @@ class ApplicationController < ActionController::Base
   include_concern 'TreeSupport'
   include_concern 'SysprepAnswerFile'
 
-  before_filter :set_session_tenant, :except => [:window_sizes]
-  before_filter :get_global_session_data, :except => [:window_sizes, :authenticate]
-  before_filter :set_user_time_zone
-  before_filter :set_gettext_locale
+  before_action :set_session_tenant, :except => [:window_sizes]
+  before_action :get_global_session_data, :except => [:window_sizes, :authenticate]
+  before_action :set_user_time_zone, :except => [:window_sizes]
+  before_action :set_gettext_locale, :except => [:window_sizes]
   after_filter :set_global_session_data, :except => [:window_sizes]
 
   ensure_security_headers

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -23,15 +23,16 @@ module ApplicationController::CurrentUser
   end
 
   def admin_user?
-    current_user.admin_user?
+    current_user.try(:admin_user?)
   end
 
   def super_admin_user?
-    current_user.super_admin_user?
+    current_user.try(:super_admin_user?)
   end
 
   def current_user
-    @current_user ||= User.find_by_userid(session[:userid])
+    @current_user ||= User.find_by_userid(session[:userid]) if current_userid
+    @current_user
   end
 
   # current_user.userid

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -409,11 +409,10 @@ module ApplicationController::Explorer
       end
       return objects
     when :roles
-      user = current_user
-      if user.super_admin_user?
+      if super_admin_user?
         roles = MiqGroup.all
       else
-        roles = [user.current_group]
+        roles = [current_user.current_group]
       end
       return options[:count_only] ? roles.count : roles.sort_by { |a| a.name.downcase }
     when :schedules
@@ -439,7 +438,7 @@ module ApplicationController::Explorer
     when :savedreports
       # Saving the unique folder id's that hold reports under them, to use them in view to generate link
       @sb[:folder_ids] = Hash.new
-      g = current_user.admin_user? ? nil : session[:group]
+      g = admin_user? ? nil : session[:group]
       MiqReport.having_report_results(:miq_group => g, :select => [:id, :name]).each do |r|
         @sb[:folder_ids][r.name] = to_cid(r.id.to_i)
       end

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -763,7 +763,7 @@ module ReportController::Menus
     x_tree_init(name, type, "MiqUserRole", :open_all => true)
     tree_nodes = x_build_dynatree(x_tree(name))
 
-    if current_user.super_admin_user?
+    if super_admin_user?
       title  = "All #{ui_lookup(:models=>"MiqGroup")}"
     else
       title  = "My #{ui_lookup(:model=>"MiqGroup")}"
@@ -778,13 +778,12 @@ module ReportController::Menus
   end
 
   def get_group_roles
-    user = current_user
-    if user.super_admin_user?
+    if super_admin_user?
       roles = MiqGroup.all
       title  = "All #{ui_lookup(:models=>"MiqGroup")}"
     else
       title  = "My #{ui_lookup(:model=>"MiqGroup")}"
-      roles = [user.current_group]
+      roles = [current_user.current_group]
     end
     return roles,title
   end

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -24,7 +24,7 @@ module ReportController::SavedReports
       return
     end
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name=>"#{rr.name} - #{format_timezone(rr.created_on,Time.zone,"gt")}", :model=>"Saved Report"}
-    if current_user.admin_user? || rr.miq_group_id == session[:group]
+    if admin_user? || rr.miq_group_id == session[:group]
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime] = rr.last_run_on
       task = MiqTask.find_by_id(rr.miq_task_id)
@@ -172,7 +172,7 @@ module ReportController::SavedReports
     end
 
     # Admin users can see all saved reports
-    unless current_user.admin_user?
+    unless admin_user?
       cond[0] << " AND miq_group_id=?"
       cond.push(session[:group])
     end

--- a/app/services/privilege_checker_service.rb
+++ b/app/services/privilege_checker_service.rb
@@ -22,6 +22,6 @@ class PrivilegeCheckerService
   end
 
   def server_ready?(current_user)
-    current_user.super_admin_user? || MiqServer.my_server(true).logon_status == :ready
+    current_user.try(:super_admin_user?) || MiqServer.my_server(true).logon_status == :ready
   end
 end


### PR DESCRIPTION
It is not really necessary to go into the database to search for a user with NULL as an id.