### PR TITLE
Disabled redefining of already defined constant in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Vmdb::Application.routes.draw do
     x_show
   )
 
-  CONTROLLER_ACTIONS = {
+  controller_routes = {
     :alert                   => {
       :get  => %w(
         index
@@ -2042,7 +2042,7 @@ Vmdb::Application.routes.draw do
   match  '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#update',  :format => 'json', :via => [:post, :put, :patch], :version => apiver_regex
   delete '/api(/:version)/:collection(/:c_id(/:subcollection(/:s_id)))' => 'api#destroy', :format => 'json', :version => apiver_regex
 
-  CONTROLLER_ACTIONS.each do |controller_name, controller_actions|
+  controller_routes.each do |controller_name, controller_actions|
 
     # Default route with no action to controller's index action
     unless controller_name == :ems_cloud


### PR DESCRIPTION
Should fix this warning from Rails console:

    /home/rblanco/devel/manageiq/config/routes.rb:120: warning: already initialized constant CONTROLLER_ACTIONS
    /home/rblanco/devel/manageiq/config/routes.rb:120: warning: previous definition of CONTROLLER_ACTIONS was here
