### PR TITLE
Fixed buttons indentation in the settings details tab

### DIFF
--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -17,11 +17,11 @@
                             :class             => "form-control",
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             = javascript_tag(javascript_focus('region_description'))
-    = render(:partial => '/layouts/edit_form_buttons',
-              :locals => {:record_id => region.id,
-              :action_url => 'region_edit',
-              :force_cancel_button => true,
-              :ajax_buttons => true})
+      = render(:partial => '/layouts/edit_form_buttons',
+                :locals => {:record_id => region.id,
+                :action_url => 'region_edit',
+                :force_cancel_button => true,
+                :ajax_buttons => true})
 
     .spacer
 


### PR DESCRIPTION
If we remove DHTMLX without this PR merged, the buttons would be before the table like this:
![screenshot from 2015-09-30 16-18-37](https://cloud.githubusercontent.com/assets/649130/10195636/ed285102-678e-11e5-8232-9d10c4b63de7.png)
