### PR TITLE
Self service UI: API call fix for service dialogs

### DIFF
--- a/spa_ui/self_service/client/app/states/marketplace/details/details.state.js
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.state.js
@@ -34,7 +34,7 @@
 
   /** @ngInject */
   function resolveDialogs($stateParams, CollectionsApi) {
-    var options = {expand: true, attributes: 'content'};
+    var options = {expand: 'resources', attributes: 'content'};
 
     return CollectionsApi.query('service_templates/' + $stateParams.serviceTemplateId + '/service_dialogs', options);
   }

--- a/spa_ui/self_service/client/app/states/marketplace/details/details.state.spec.js
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.state.spec.js
@@ -1,0 +1,21 @@
+/* jshint -W117, -W030 */
+describe('Marketplace.details', function() {
+  beforeEach(function() {
+    module('app.states', 'app.config', bard.fakeToastr);
+  });
+
+  describe('#resolveDialogs', function() {
+    beforeEach(function() {
+      bard.inject('$state', '$stateParams', 'CollectionsApi');
+
+      $stateParams.serviceTemplateId = 123;
+      collectionsApiSpy = sinon.spy(CollectionsApi, 'query');
+    });
+
+    it('should query the API with the correct template id and options', function() {
+      var options = {expand: 'resources', attributes: 'content'};
+      $state.get('marketplace.details').resolve.dialogs($stateParams, CollectionsApi);
+      expect(collectionsApiSpy).to.have.been.calledWith('service_templates/123/service_dialogs', options);
+    });
+  });
+});


### PR DESCRIPTION
Noticed that the API wasn't returning the expanded resources that it was previously, and it turns out that a `true` needed to be replaced with a `'resources'`.

I also added a spec for this.

/cc @dclarizio 