### PR TITLE
Show Domains using visible/editable/enabled domains methods for tenants

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -670,15 +670,16 @@ class ApplicationHelper::ToolbarBuilder
       when "action_delete"
         return true unless role_allows(:feature => "action_delete")
       end
-    when "MiqAeClass", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
+    when "MiqAeClass", "MiqAeDomain", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && MiqAeDomain.any_unlocked?
+      editable_domain = User.current_tenant.editable_domains.include?(@record)
       case id
       when "miq_ae_domain_lock"
-        return true unless @record.editable?
+        return true unless editable_domain
       when "miq_ae_domain_unlock"
-        return true if @record.editable? || @record.priority.to_i == 0
+        return true if editable_domain || @record.priority.to_i == 0
       else
-        return true unless @record.editable?
+        return true unless editable_domain
       end
     when "MiqAlert"
       case id
@@ -1018,16 +1019,17 @@ class ApplicationHelper::ToolbarBuilder
         return "Default actions can not be deleted." if @record.action_type == "default"
         return "Actions assigned to Policies can not be deleted" if @record.miq_policies.length > 0
       end
-    when "MiqAeNamespace"
+    when "MiqAeDomain", "MiqAeNamespace"
+      enabled_domain = User.current_tenant.editable_domains.include?(@record)
       case id
       when "miq_ae_domain_delete"
-        return "Read Only Domain cannot be deleted." unless @record.editable?
+        return "Read Only Domain cannot be deleted." unless enabled_domain
       when "miq_ae_domain_edit"
-        return "Read Only Domain cannot be edited" unless @record.editable?
+        return "Read Only Domain cannot be edited" unless enabled_domain
       when "miq_ae_domain_lock"
-        return "Domain is Locked." unless @record.editable?
+        return "Domain is Locked." unless enabled_domain
       when "miq_ae_domain_unlock"
-        return "Domain is Unlocked." if @record.editable?
+        return "Domain is Unlocked." if enabled_domain
       end
     when "MiqAlert"
       case id

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -15,7 +15,7 @@ class TreeBuilderAeClass < TreeBuilder
     objects = if MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
                 [MiqAeDomain.find_by_id(@sb[:domain_id])] # GIT support can't use where
               else
-                filter_ae_objects(MiqAeDomain.all)
+                filter_ae_objects(User.current_tenant.visible_domains)
               end
     count_only_or_objects(options[:count_only], objects, [:priority]).reverse
   end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -186,12 +186,19 @@ class TreeNodeBuilder
 
   def node_with_display_name(image)
     text = object.display_name.blank? ? object.name : "#{object.display_name} (#{object.name})"
-    if object.kind_of?(MiqAeNamespace) && object.domain? && (!object.editable? || !object.enabled)
-      text = add_read_only_suffix(object, text)
-      miq_ae_node(object.enabled, text, image_for_node(object, image), "#{tooltip_prefix_for_node(object)}: #{text}")
-    else
-      generic_node(text, image_for_node(object, image), "#{tooltip_prefix_for_node(object)}: #{text}")
+    if object.kind_of?(MiqAeNamespace) && object.domain?
+      editable_domain = User.current_tenant.editable_domains.include?(object)
+      enabled_domain  = object.enabled
+      unless editable_domain && enabled_domain
+        text = add_read_only_suffix(text, editable_domain, enabled_domain)
+        return miq_ae_node(enabled_domain,
+                           text,
+                           image_for_node(object, image),
+                           "#{tooltip_prefix_for_node(object)}: #{text}"
+                          )
+      end
     end
+    generic_node(text, image_for_node(object, image), "#{tooltip_prefix_for_node(object)}: #{text}")
   end
 
   def miq_ae_node(enabled, text, image, tip)

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -19,7 +19,7 @@
             %td.narrow
               %i.fa.fa-2x.fa-globe
             %td
-              = record_name(record)
+              = record_name(record).html_safe
             %td
               = record.description
             %td

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -261,6 +261,7 @@ describe MiqAeClassController do
     end
 
     before do
+      login_as FactoryGirl.create(:user_with_group)
       MiqAeDomain.stub(:find_by_name).with("another_fqname").and_return(miq_ae_domain)
       MiqAeDomain.stub(:find_by_name).with("another_fqname2").and_return(miq_ae_domain2)
     end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2563,7 +2563,7 @@ describe ApplicationHelper do
   describe "#build_toolbar_hide_button_ops" do
     subject { build_toolbar_hide_button_ops(@id) }
     before do
-      @record = FactoryGirl.create(:tenant)
+      @record = FactoryGirl.create(:tenant, :parent => Tenant.seed)
       feature = EvmSpecHelper.specific_product_features(%w(ops_rbac rbac_group_add rbac_tenant_add rbac_tenant_delete))
       login_as FactoryGirl.create(:user, :features => feature)
       @sb = {:active_tree => :rbac_tree}

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -2,13 +2,15 @@ require "spec_helper"
 include AutomationSpecHelper
 
 describe TreeBuilderAeClass do
-  before do
-    create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace  => 'A/B/C')
-    create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
-    @sb = {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
-  end
-
   context "initialize" do
+    before do
+      user = FactoryGirl.create(:user_with_group)
+      login_as user
+      create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
+      create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
+      @sb = {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
+    end
+
     it "a tree with filter" do
       @sb[:cached_waypoint_ids] =  MiqAeClass.waypoint_ids_for_state_machines
       tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
@@ -20,6 +22,24 @@ describe TreeBuilderAeClass do
       tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
       domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
       domains.should match_array %w(LUIGI MARIO)
+    end
+  end
+
+  context "#x_get_tree_roots" do
+    before do
+      user = FactoryGirl.create(:user_with_group)
+      login_as user
+      tenant1 = user.current_tenant
+      tenant2 = FactoryGirl.create(:tenant, :parent => tenant1)
+      FactoryGirl.create(:miq_ae_domain, :name => "test1", :tenant => tenant1)
+      FactoryGirl.create(:miq_ae_domain, :name => "test2", :tenant => tenant2)
+    end
+
+    it "should only return domains in a user's current tenant" do
+      tree = TreeBuilderAeClass.new("ae_tree", "ae", {})
+      domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      domains.should match_array %w(test1)
+      domains.should_not include %w(test2)
     end
   end
 end

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -131,6 +131,8 @@ describe TreeNodeBuilder do
     end
 
     it 'MiqAeNamespace node' do
+      login_as FactoryGirl.create(:user_with_group)
+
       namespace = FactoryGirl.build(:miq_ae_namespace)
       node = TreeNodeBuilder.build(namespace, nil, {})
       node.should_not be_nil
@@ -336,6 +338,42 @@ describe TreeNodeBuilder do
       tenant = FactoryGirl.build(:tenant)
       node = TreeNodeBuilder.build(tenant, "root", :expand => true, :open_all => true)
       node[:expand].should eq(true)
+    end
+  end
+
+  context "#node_with_display_name" do
+    before do
+      login_as FactoryGirl.create(:user_with_group)
+    end
+    it "should return node text with Disabled in the text for Disabled domain" do
+      domain = FactoryGirl.create(:miq_ae_domain,
+                                  :name    => "test1",
+                                  :enabled => false)
+      node = TreeNodeBuilder.build(domain, nil, {})
+      node[:title].should eq('test1 (Disabled)')
+    end
+
+    it "should return node text with Locked in the text for Locked domain" do
+      domain = FactoryGirl.create(:miq_ae_domain,
+                                  :name   => "test1",
+                                  :system => true)
+      node = TreeNodeBuilder.build(domain, nil, {})
+      node[:title].should eq('test1 (Locked)')
+    end
+
+    it "should return node text with Locked & Disabled in the text for Locked & Disabled domain" do
+      domain = FactoryGirl.create(:miq_ae_domain,
+                                  :name    => "test1",
+                                  :enabled => false,
+                                  :system  => true)
+      node = TreeNodeBuilder.build(domain, nil, {})
+      node[:title].should eq('test1 (Locked & Disabled)')
+    end
+
+    it "should return node text with no suffix when Domain is not Locked or Disabled" do
+      domain = FactoryGirl.create(:miq_ae_domain, :name => "test1")
+      node = TreeNodeBuilder.build(domain, nil, {})
+      node[:title].should eq('test1')
     end
   end
 end


### PR DESCRIPTION
- Changed tree building, controller & toolbar builder code to use new visible/editable/enabled domains methods for tenants.
- Added specs to verify that only Domains in user's current_tenant are being displayed in the tree
- Added spec to verify the node text of nodes have appropriate suffix to show whether they are Locked or Disabled domains.

@dclarizio please review.

Before:
test user showing all domains:
![test_user_domain_lists_before](https://cloud.githubusercontent.com/assets/3450808/10199422/a74c2ed0-676e-11e5-8488-92c9f6a1b883.png)

test2 user showing all domains:
![test2_user_domains_list_before](https://cloud.githubusercontent.com/assets/3450808/10199424/aad5cf70-676e-11e5-87d1-3748655d2e7d.png)

Domain Priority order form for test_user:
![domain_pri_order_test_user_before](https://cloud.githubusercontent.com/assets/3450808/10224671/10d3147c-682d-11e5-98b7-8bb28a3271ad.png)


After:
test user showing their current_tenant domains:
![test_user_domains_list](https://cloud.githubusercontent.com/assets/3450808/10199435/b5b8bfb0-676e-11e5-97af-19af589f5d2e.png)

test2 user showing their current_tenant domains:
![test2_user_domains_list](https://cloud.githubusercontent.com/assets/3450808/10199439/bdaecc82-676e-11e5-813c-9672a21bf520.png)

Domain Priority order form for test_user:
![domain_pri_order_test_user_after](https://cloud.githubusercontent.com/assets/3450808/10225134/4b3f12e4-682f-11e5-8ebf-53fcfae927e5.png)

