### PR TITLE
Root tenant RBAC

### DIFF
--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -13,6 +13,7 @@ module TenancyMixin
     def accessible_tenant_ids(user_or_group, strategy)
       tenant = user_or_group.try(:current_tenant)
       return [] unless tenant
+      return [] if tenant == Tenant.root_tenant
 
       tenant.accessible_tenant_ids(strategy)
     end


### PR DESCRIPTION
- Added logic to bypass tenant scoping if the current tenant is the root tenant (Tenant 0).
- Tenant 0 can see resources owned by any tenant.

https://trello.com/c/Yhly16Sl