### PR TITLE
escape selected value in bootstrap selects before sending them to server

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1252,7 +1252,8 @@ function miqSelectPickerEvent(element, url, options){
   $('#' + element).on('change', function(){
     var selected = $('#' + element).val();
     options =  typeof options !== 'undefined' ? options : {}
-    miqJqueryRequest(url + '?' + element + '=' + selected, options);
+    options['no_encoding'] = true;
+    miqJqueryRequest(url + '?' + element + '=' + escape(selected), options);
     return true;
   });
 }


### PR DESCRIPTION
No need to escape drop down values and encodeURI before sending up to server.

https://bugzilla.redhat.com/show_bug.cgi?id=1264218

@dclarizio please review, didn't know how to mimic the issue in JS spec tests so attached before/after screenshots. This issue is caused by bootstrap select replacing special characters in the drop down values, have to make sure to escape them and not to encodeURI beofre sending them up to server to fix the issue. this is the link to bootstrap select code that replaces special characters in the values: https://github.com/silviomoreto/bootstrap-select/blob/d258b8debd3099823d2c9186c1fa2db055a0f30f/dist/js/bootstrap-select.js#L238

before:
![before](https://cloud.githubusercontent.com/assets/3450808/10201476/47415c02-677a-11e5-81e1-044d41103bdf.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/10201487/4d46f1e8-677a-11e5-80fd-c12ac399a6d3.png)

