### PR TITLE
Toolbar - hide Reconfigure service when no Reconfigure resource action or dialog

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -460,7 +460,7 @@ class ApplicationHelper::ToolbarBuilder
     case id
     when "service_reconfigure"
       ra = @record.service_template.resource_actions.find_by_action('Reconfigure') if @record.service_template
-      return true if ra.nil? || ra.fqname.blank?
+      return true if ra.nil? || ra.dialog_id.nil? || ra.fqname.blank?
     end
     false
   end
@@ -763,7 +763,7 @@ class ApplicationHelper::ToolbarBuilder
       when "server_delete", "role_start", "role_suspend", "promote_server", "demote_server"
         return true
       end
-    when "Service"
+    when "Service", "ServiceOrchestration"
       return build_toolbar_hide_button_service(id)
     when "Vm"
       case id


### PR DESCRIPTION
This makes build_toolbar_hide call build_toolbar_hide_button_service for
both Service and ServiceOrchestration

It also adds a check for resource_action.dialog_id for
service_reconfigure, since it can't do anything without a dialog.

https://bugzilla.redhat.com/show_bug.cgi?id=1255048