### PR TITLE
Change cloud tenants description to text

### DIFF
--- a/db/migrate/20150930201117_change_cloud_tenant_description_to_text.rb
+++ b/db/migrate/20150930201117_change_cloud_tenant_description_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeCloudTenantDescriptionToText < ActiveRecord::Migration
+  def up
+    change_column :cloud_tenants, :description, :text
+  end
+
+  def down
+    change_column :cloud_tenants, :description, :string
+  end
+end


### PR DESCRIPTION
The 255 character limit on the `CloudTenant` `description` field causes inventory
collection to irreparably fail with the error:

> PGError: ERROR:  value too long for type character varying(255)

Since OpenStack allows a tenant description value larger than 255 characters,
openstack inventory collection must support tenant descriptions larger than 255
characters.

https://bugzilla.redhat.com/show_bug.cgi?id=1263744