### PR TITLE
Exclude the vim wsdl mapping registry from test code coverage

### DIFF
--- a/gems/pending/spec/coverage_helper.rb
+++ b/gems/pending/spec/coverage_helper.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext/kernel/reporting'
 
 # Require all ruby files for accuracte test coverage reports
-EXCLUSIONS_LIST = %w(/bin/ /ext/ /spec/ /test/ /vendor/ appliance_console.rb bundler_setup.rb test.rb require_with_logging.rb VixDiskLibServer.rb)
+EXCLUSIONS_LIST = %w(/bin/ /ext/ /spec/ /test/ /vendor/ appliance_console.rb bundler_setup.rb test.rb require_with_logging.rb VixDiskLibServer.rb VMwareWebService/wsdl41 )
 Dir.glob(File.join(GEMS_PENDING_ROOT, "**", "*.rb")).each do |file|
   next if EXCLUSIONS_LIST.any? { |exclusion| file.include?(exclusion) }
   begin


### PR DESCRIPTION
The vim wsdl mapping registry translated to ruby will never be covered.
Their library's wsdl should be tested by them, not us.

Having it in the coverage_helper provides us no benefit since we won't
be adding code coverage in our test suite for this.