### PR TITLE
Fixed IE9 4095 CSS rule limit by splitting the application.css

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "jquery-rails",                   "~>4.0.4"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "https://github.com/amatsuda/jquery-rjs.git"
 gem "lodash-rails",                   "~>3.10.0"
 gem "patternfly-sass",                "~>2.2.0"
+gem "css_splitter"
 gem "sass-rails"
 
 # Vendored and required

--- a/app/assets/stylesheets/application_split2.css
+++ b/app/assets/stylesheets/application_split2.css
@@ -1,0 +1,3 @@
+/*
+ * = require application
+ */

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
     %head
       %title CloudForms Management Engine: #{@layout.titleize}
       = stylesheet_link_tag 'template'
-      = stylesheet_link_tag 'application'
+      = split_stylesheet_link_tag 'application'
       = javascript_include_tag 'application'
       - if Rails.env.development?
         = javascript_include_tag 'miq_debug'
@@ -22,7 +22,7 @@
       %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
 
       = tag :link, :rel => "shortcut icon", :href => image_path("favicon.ico")
-      = stylesheet_link_tag 'application'
+      = split_stylesheet_link_tag 'application'
       = stylesheet_link_tag 'template'
       = stylesheet_link_tag 'jquery/miq/jquery-ui-1.9.2.custom'
       = render :partial => "stylesheets/template50"

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -5,7 +5,7 @@
     %title
       = h(title_from_layout(@layout))
     = tag :link, :rel => "shortcut icon", :href => image_path("favicon.ico")
-    = stylesheet_link_tag 'application'
+    = split_stylesheet_link_tag 'application'
     = stylesheet_link_tag 'template'
     = javascript_include_tag 'application'
     - if Rails.env.development?

--- a/app/views/vm_common/console_spice.html.haml
+++ b/app/views/vm_common/console_spice.html.haml
@@ -4,7 +4,7 @@
   %head
     %title
       = _('SPICE Console')
-    = stylesheet_link_tag 'application'
+    = split_stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'spiceHTML5/enums', 'spiceHTML5/atKeynames', 'spiceHTML5/utils',
     'spiceHTML5/png', 'spiceHTML5/lz', 'spiceHTML5/quic', 'spiceHTML5/bitmap',
     'spiceHTML5/spicedataview', 'spiceHTML5/spicetype', 'spiceHTML5/spicemsg', 'spiceHTML5/wire',

--- a/app/views/vm_common/console_vnc.html.haml
+++ b/app/views/vm_common/console_vnc.html.haml
@@ -3,7 +3,7 @@
   %head
     %title
       = _('VNC Console')
-    = stylesheet_link_tag 'application'
+    = split_stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'novnc-rails', 'miq_novnc'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,9 @@ module Vmdb
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
+    # Fix 4095 CSS rule limit by using the css_splitter gem on the application.css
+    config.assets.precompile += %w(application_split2.css)
+
     # Customize any additional options below...
 
     # HACK: By default, Rails.configuration.eager_load_paths contains all of the directories


### PR DESCRIPTION
**Before:**
![screenshot from 2015-10-06 09-41-42](https://cloud.githubusercontent.com/assets/649130/10302719/d4296e96-6c0e-11e5-815d-74b651ceb376.png)
**After:**
![screenshot from 2015-10-06 09-43-41](https://cloud.githubusercontent.com/assets/649130/10302721/dd6542a0-6c0e-11e5-8a5c-2b3f4e3498d9.png)
