### PR TITLE
Updated missing selectpickers style to Patternfly

### DIFF
--- a/app/views/catalog/_ot_add.html.haml
+++ b/app/views/catalog/_ot_add.html.haml
@@ -33,9 +33,13 @@
         .col-md-8
           = select_tag("type",
                        options_for_select({"Amazon CloudFormation" => "OrchestrationTemplateCfn",
-                       "OpenStack Heat" => "OrchestrationTemplateHot"}, @edit[:new][:type]),
-                       "data-miq_sparkle_on" => true,
-                       "data-miq_observe"    => {:url => url}.to_json)
+                                           "OpenStack Heat" => "OrchestrationTemplateHot"},
+                                          @edit[:new][:type]),
+                       :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('type', '#{url}', {beforeSend: true})
+
       .form-group
         %label.col-md-2.control-label
           = _('Draft')


### PR DESCRIPTION
Before: ![screencapture-localhost-3000-catalog-explorer-1443694630088](https://cloud.githubusercontent.com/assets/1187051/10218423/089b012a-6837-11e5-8fa9-dfef36ffdc2f.png)
After: ![screencapture-localhost-3000-catalog-explorer-1443694798701](https://cloud.githubusercontent.com/assets/1187051/10218426/09c82d66-6837-11e5-8bda-952bcbd0f11e.png)

@epwinchell