### PR TITLE
remove thread local var for user filters

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -341,18 +341,15 @@ class User < ActiveRecord::Base
   def self.with_userid(userid)
     saved_user   = Thread.current[:user]
     saved_userid = Thread.current[:userid]
-    saved_filters = Thread.current[:user_has_filters]
     self.current_userid = userid
     yield
   ensure
     Thread.current[:user]   = saved_user
     Thread.current[:userid] = saved_userid
-    Thread.current[:user_has_filters] = saved_filters
   end
 
   def self.current_userid=(userid)
     Thread.current[:user]   = nil
-    Thread.current[:user_has_filters] = nil
     Thread.current[:userid] = userid
   end
 
@@ -363,15 +360,4 @@ class User < ActiveRecord::Base
   def self.current_user
     Thread.current[:user] ||= self.find_by_userid(self.current_userid)
   end
-
-  def self.current_user_has_filters?
-    if Thread.current[:user_has_filters].nil?
-      Thread.current[:user_has_filters] =
-        current_user.current_group.filters &&
-        !(current_user.current_group.filters["managed"].blank? &&
-          current_user.current_group.filters["belongs_to"].blank?)
-    end
-    return Thread.current[:user_has_filters]
-  end
-  #
 end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -409,7 +409,7 @@ class TreeBuilder
     results = Rbac.filtered(objects, options)
 
     # If we are processing :match_via_descendants and user is filtered (i.e. not like admin/super-admin)
-    if check_vm_descendants && User.current_user_has_filters?
+    if check_vm_descendants && User.current_user.has_filters?
       filtered_objects = objects - results
       results = objects.select do |o|
         if o.is_a?(EmsFolder) || filtered_objects.include?(o)


### PR DESCRIPTION
background: I'm working on setting the `current_user` and keeping the `current_group` / `current_tenant`.

Here:

User already defined `has_filter?`

Use that instead of caching the value in a thread local.

There are already a simple test for `User#has_filter?`

/cc @jrafanie @matthewd 