### PR TITLE
User delegate filter

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -132,11 +132,15 @@ class MiqGroup < ActiveRecord::Base
   end
 
   def get_filters(type = nil)
-    f = self.filters
-    return f if type.nil?
+    if type
+      (filters.respond_to?(:key?) && filters[type.to_s]) || []
+    else
+      filters || {"managed" => [], "belongsto" => []}
+    end
+  end
 
-    type = type.to_s
-    return (f.respond_to?(:key) && f.key?(type)) ? f[type] : []
+  def has_filters?
+    get_managed_filters.present? || get_belongsto_filters.present?
   end
 
   def get_managed_filters

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -309,9 +309,7 @@ module Rbac
       user.current_group = miq_group if user.miq_groups.include?(miq_group)
     end
     tz                        = user.get_timezone if user
-    user_filters              = miq_group.get_filters  if miq_group
-    user_filters              = user.get_filters       if user
-    user_filters            ||= {}
+    user_filters = user.try(:get_filters) || miq_group.try(:get_filters) || {}
     user_filters["managed"] ||= []
 
     return user, miq_group, user_filters, tz

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,8 @@ class User < ActiveRecord::Base
 
   virtual_has_many :active_vms, :class_name => "VmOrTemplate"
 
-  delegate   :miq_user_role,  :to => :current_group, :allow_nil => true
-  delegate   :current_tenant, :to => :current_group, :allow_nil => true
+  delegate   :miq_user_role, :current_tenant, :get_filters, :has_filters?, :get_managed_filters, :get_belongsto_filters,
+             :to => :current_group, :allow_nil => true
   delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?,
              :to => :miq_user_role, :allow_nil => true
 
@@ -132,23 +132,6 @@ class User < ActiveRecord::Base
 
     self.password = newpwd
     self.save!
-  end
-
-  def get_filters
-    filters = self.current_group.get_filters if self.current_group
-    filters || {"managed" => [], "belongsto" => []}
-  end
-
-  def has_filters?
-    !(self.get_managed_filters.blank? && self.get_belongsto_filters.blank?)
-  end
-
-  def get_managed_filters
-    self.get_filters["managed"]
-  end
-
-  def get_belongsto_filters
-    self.get_filters["belongsto"]
   end
 
   def ldap_group

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -16,12 +16,34 @@ describe MiqGroup do
 
       it "when nil" do
         @miq_group.filters = nil
-        @miq_group.get_filters.should be_nil
+        expect(@miq_group.get_filters).to eq("managed" => [], "belongsto" => [])
       end
 
       it "when {}" do
         @miq_group.filters = {}
         @miq_group.get_filters.should == {}
+      end
+    end
+
+    context "#has_filters?" do
+      it "normal" do
+        @miq_group.filters = {"managed" => %w(a)}
+        expect(@miq_group).to be_has_filter
+      end
+
+      it "when other" do
+        @miq_group.filters = {"other" => %(x)}
+        expect(@miq_group).not_to be_has_filter
+      end
+
+      it "when nil" do
+        @miq_group.filters = nil
+        expect(@miq_group).not_to be_has_filter
+      end
+
+      it "when {}" do
+        @miq_group.filters = {}
+        expect(@miq_group).not_to be_has_filter
       end
     end
 


### PR DESCRIPTION
There is no reason to duplicate the filter logic in both `group` and `user`.

Do keep in mind that `user` can not login to the system without a `group`. Although, specs seem to have them.

/cc @gtanzillo @jrafanie @matthewd 