### PR TITLE
Set root_tenant when creating miq_group for user factory

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
   end
 
   factory :user_with_group, :parent => :user do
-    miq_groups { FactoryGirl.create_list(:miq_group, 1) }
+    miq_groups { FactoryGirl.create_list(:miq_group, 1, :tenant => Tenant.seed) }
   end
 
   factory :user_admin, :parent => :user do


### PR DESCRIPTION
When calling :user_with_group pass in the root tenant