### PR TITLE
Use PG utility to create the postgres role

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ gem "net-ping",                       "~>1.7.4",   :require => false
 gem "net-ssh",                        "~>2.9.2",   :require => false
 gem "open4",                          "~>1.3.0",   :require => false
 gem "ovirt_metrics",                  "~>1.1.0",   :require => false
-gem "pg",                             "~>0.18.2",  :require => false
 gem "ruby_parser",                    "~>3.7",     :require => false
 gem "ruby-progressbar",               "~>1.7.0",   :require => false
 gem "rufus-scheduler",                "~>3.1.3",   :require => false

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -34,6 +34,7 @@ gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=0.1.0",            :require => false
 gem "ovirt",                   "~>0.6.0",           :require => false
 gem "parallel",                "~>0.5.21",          :require => false
+gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false
 gem "rubyzip",                 "=0.9.5",            :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -2,6 +2,7 @@ require "appliance_console/database_configuration"
 require "appliance_console/service_group"
 require "pathname"
 require "util/postgres_admin"
+require "pg"
 
 RAILS_ROOT ||= Pathname.new(__dir__).join("../../../")
 
@@ -171,7 +172,9 @@ module ApplianceConsole
     end
 
     def create_postgres_root_user
-      run_as_postgres("psql -c 'CREATE ROLE #{username} WITH LOGIN CREATEDB SUPERUSER PASSWORD '\\'#{password}\\';")
+      conn = PG.connect(:user => "postgres", :dbname => "postgres")
+      esc_pass = conn.escape_string(password)
+      conn.exec("CREATE ROLE #{username} WITH LOGIN CREATEDB SUPERUSER PASSWORD '#{esc_pass}'")
     end
 
     def create_postgres_database


### PR DESCRIPTION
This allows us to avoid nasty quoting and escaping issues
associated with shelling out to run commands using psql.
This also allow us to use PG's built in string escape method
so passwords can now contain all manner of special characters.

https://bugzilla.redhat.com/show_bug.cgi?id=1267698