### PR TITLE
Unable to export automate methods with nil data

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_yaml_export.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_export.rb
@@ -182,8 +182,10 @@ class MiqAeYamlExport
   def write_method_file(method_obj, export_file_hash)
     @counts['method_files'] += 1
     export_file_hash['output_filename'] = get_method_filename(method_obj)
-    method_obj.data += NEW_LINE unless method_obj.data.end_with?(NEW_LINE)
-    export_file_hash['export_data'] = method_obj.data
+    if method_obj.data
+      method_obj.data += NEW_LINE unless method_obj.data.end_with?(NEW_LINE)
+    end
+    export_file_hash['export_data'] = method_obj.data || ""
     write_export_file(export_file_hash)
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -667,7 +667,7 @@ describe MiqAeDatastore do
                                   :name     => 'test1',
                                   :scope    => "instance",
                                   :language => "ruby",
-                                  :data     => "puts 1",
+                                  # Method with no data
                                   :location => "inline")
     FactoryGirl.create(:miq_ae_instance,  :name => "#{domain_name}_test_instance1", :class_id => n1_1_c1.id)
     FactoryGirl.create(:miq_ae_method,


### PR DESCRIPTION
Fixes #4619

Automate export fails when it encounters a method with nil data.