### PR TITLE
quote headers

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,11 +11,11 @@ SecureHeaders::Configuration.configure do |config|
   }
   config.csp = {
     :enforce     => true,
-    :default_src => 'self',
-    :frame_src   => 'self',
-    :connect_src => 'self',
-    :style_src   => 'inline self',
-    :script_src  => 'eval inline self',
-    :report_uri  => '/dashboard/csp_report'
+    :default_src => "'self'",
+    :frame_src   => "'self'",
+    :connect_src => "'self'",
+    :style_src   => "'unsafe-inline' 'self'",
+    :script_src  => "'unsafe-eval' 'unsafe-inline' 'self'",
+    :report_uri  => "/dashboard/csp_report"
   }
 end


### PR DESCRIPTION
Remove the following deprecation warnings:

```
[DEPRECATION] using self/none may not be supported in the future. Instead use 'self'/'none' instead.
[DEPRECATION] using inline/eval may not be supported in the future. Instead use 'unsafe-inline'/'unsafe-eval' instead.
```

/cc @martinpovolny @matthewd does this work for you?

which came from [secure_headers]( https://github.com/twitter/secureheaders/commit/ddf75e81e1c9b749092e16d4cf6f2a75c362acdf)