### PR TITLE
Fixed Radio Buttons in the Provisioning dialog

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -468,7 +468,7 @@
             -# need to specify Checked/Disabled to check or disable a checkbox, so need separate lines for each depending upon radio button state
             - field_hash[:values].each do |f|
               - checked = options[field] && options[field][0] == f[0]
-              - current_div = "#{@edit[:new][:current_tab_key]}_div"
+              - current_div = "#{@edit[:new][:current_tab_key]}"
               - onclick = remote_function(:with => "miqSerializeField('#{current_div}', '#{field_id}')", :url => url, :loading => "miqSparkle(true);", :complete => "miqSparkle(false);")
               .radio-inline
                 %input{:type => "radio", :id => field_id, :value => f[0], :name => field_id, :checked => checked, :onclick => disabled ? "" : onclick}


### PR DESCRIPTION
Radio Buttons in the Provisioning dialog did not work before since an incorrect ```div``` name was used to retrieve their value.
The Patternfly tab names in the Provisioning dialog do not have a trailing ```_div``` anymore and therefore it should be removed.

https://bugzilla.redhat.com/show_bug.cgi?id=1268072