### PR TITLE
Drop some seed query counts by fixing some N + 1 queries

### DIFF
--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -41,7 +41,7 @@ module VmdbDatabase::Seeding
   end
 
   def seed
-    mine = evm_tables.index_by(&:name)
+    mine = evm_tables.includes(:text_tables, :vmdb_indexes).index_by(&:name)
 
     self.class.connection.tables.sort.each do |table_name|
       table = mine.delete(table_name)

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -18,7 +18,8 @@ class MiqAeNamespace < ActiveRecord::Base
     fqname   = fqname.downcase
     last     = fqname.split('/').last
     low_name = arel_table[:name].lower
-    query = include_classes ? includes(:parent, :ae_classes) : all
+    query    = includes(:parent)
+    query    = query.includes(:ae_classes) if include_classes
     query.where(low_name.eq(last)).detect { |namespace| namespace.fqname.downcase == fqname }
   end
 


### PR DESCRIPTION
Most significantly, `VmdbDatabase.seed` does roughly 25% less queries on a previously seeded database with the expense of a small increase in queries on the initial seed.
`1981 -> 1483`

That is if the numbers are correct

Look at the commits for more information.