### PR TITLE
[api] Be consistent about types for rates

### DIFF
--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can fetch an individual chargeback rate detail" do
-    chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => 5)
+    chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "5")
     chargeback_rate = FactoryGirl.create(:chargeback_rate,
                                          :chargeback_rate_details => [chargeback_rate_detail])
 
@@ -76,7 +76,7 @@ RSpec.describe "chargebacks API" do
     it "can create a new chargeback rate detail" do
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
 
-      expect { run_post rates_url, :rate => 0, :enabled => true }.to change(ChargebackRateDetail, :count).by(1)
+      expect { run_post rates_url, :rate => "0", :enabled => true }.to change(ChargebackRateDetail, :count).by(1)
       actual = @result["results"].first
       expect(actual["rate"]).to eq("0")
       expect(actual["enabled"]).to be true
@@ -84,10 +84,10 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can edit a chargeback rate detail through POST" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => 0)
+      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "0")
 
       api_basic_authorize action_identifier(:rates, :edit)
-      run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => 0.02)
+      run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => "0.02")
 
       expect(@result["rate"]).to eq("0.02")
       expect_request_success
@@ -95,10 +95,10 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can edit a chargeback rate detail through PATCH" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => 0)
+      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "0")
 
       api_basic_authorize action_identifier(:rates, :edit)
-      run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "rate", :value => 0.02}]
+      run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "rate", :value => "0.02"}]
 
       expect(@result["rate"]).to eq("0.02")
       expect_request_success
@@ -132,17 +132,17 @@ RSpec.describe "chargebacks API" do
     it "cannot create a chargeback rate detail" do
       api_basic_authorize
 
-      expect { run_post rates_url, :rate => 0, :enabled => true }.not_to change(ChargebackRateDetail, :count)
+      expect { run_post rates_url, :rate => "0", :enabled => true }.not_to change(ChargebackRateDetail, :count)
       expect_request_forbidden
     end
 
     it "cannot edit a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => 0)
+      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "0")
 
       api_basic_authorize
 
       expect do
-        run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => 0.02)
+        run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => "0.02")
       end.not_to change { chargeback_rate_detail.reload.rate }
       expect_request_forbidden
     end


### PR DESCRIPTION
Rates are saved as strings and returned as strings in the API. This
change ensures that the request represents these values as strings
too. While there is no apparent change in the outcome here, when
backporting some of these tests failed because they were returning an
unexpected type, so it seems best to go for consistency here.

@abellotti please review