### PR TITLE
Restore parameter names that might be used by evals

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -154,7 +154,7 @@ class Condition < ActiveRecord::Base
     result
   end
 
-  def self._subst_find(rec, _inputs, expr)
+  def self._subst_find(rec, inputs, expr)
     MiqPolicy.logger.debug("MIQ(condition-_subst_find): Find Expression before substitution: [#{expr}]")
     searchexp = /<search>(.+)<\/search>/im
     expr =~ searchexp
@@ -193,6 +193,7 @@ class Condition < ActiveRecord::Base
     if checkmode == "count"
       e = check.gsub(/<count>/i, list.length.to_s)
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Check Expression after substitution: [#{e}]")
+      _ = inputs # used by eval (presumably?)
       result = !!proc { $SAFE = 3; eval(e) }.call
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Check Expression result: [#{result}]")
       return result

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -507,7 +507,7 @@ module MiqAeEngine
       end
     end
 
-    def process_assertion(f, _message, _args)
+    def process_assertion(f, message, args)
       Benchmark.current_realtime[:assertion_count] += 1
       Benchmark.realtime_block(:assertion_time) do
         assertion = get_value(f)
@@ -516,6 +516,7 @@ module MiqAeEngine
         $miq_ae_logger.info("Evaluating substituted assertion [#{assertion}]")
 
         begin
+          _, _ = message, args # used by eval (?)
           assertion_result = eval(assertion)
         rescue SyntaxError => err
           $miq_ae_logger.error("Assertion had the following Syntax Error: '#{err.message}'")


### PR DESCRIPTION
I haven't specifically seen either of these fail, but in both cases it seems fairly plausible the parameters in question are being used there.