### PR TITLE
workflow and request accept user

### DIFF
--- a/app/models/miq_approval.rb
+++ b/app/models/miq_approval.rb
@@ -13,12 +13,12 @@ class MiqApproval < ActiveRecord::Base
   end
 
   def approve(userid, reason)
-    user = User.find_by_userid(userid)
-    raise "not authorized" unless self.authorized?(user)
+    user = userid.kind_of?(User) ? userid : User.find_by_userid(userid)
+    raise "not authorized" unless authorized?(user)
     update_attributes(:state => "approved", :reason => reason, :stamper => user, :stamper_name => user.name, :stamped_on => Time.now.utc)
 
     # execute parent now that request is approved
-    _log.info("Request: [#{miq_request.description}] has been approved by [#{userid}]")
+    _log.info("Request: [#{miq_request.description}] has been approved by [#{user.userid}]")
     begin
       miq_request.approval_approved
     rescue => err
@@ -27,8 +27,8 @@ class MiqApproval < ActiveRecord::Base
   end
 
   def deny(userid, reason)
-    user = User.find_by_userid(userid)
-    raise "not authorized" unless self.authorized?(user)
+    user = userid.kind_of?(User) ? userid : User.find_by_userid(userid)
+    raise "not authorized" unless authorized?(user)
     update_attributes(:state => "denied", :reason => reason, :stamper => user, :stamper_name => user.name, :stamped_on => Time.now.utc)
     miq_request.approval_denied
   end

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -413,6 +413,7 @@ class MiqRequest < ActiveRecord::Base
   end
 
   def self.create_request(values, requester_id, auto_approve = false, request_type = request_types.first)
+    requester = requester_id.kind_of?(User) ? requester_id : User.find_by_userid(requester_id)
     values[:src_ids] = values[:src_ids].to_miq_a unless values[:src_ids].nil?
     request          = create(:options => values, :userid => requester_id, :request_type => request_type)
     request.save!  # Force validation errors to raise now
@@ -423,7 +424,7 @@ class MiqRequest < ActiveRecord::Base
     request.log_request_success(requester_id, :created)
 
     request.call_automate_event_queue("request_created")
-    request.approve(requester_id, "Auto-Approved") if auto_approve
+    request.approve(requester, "Auto-Approved") if auto_approve
     request.reload if auto_approve
     request
   end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -88,10 +88,10 @@ class MiqRequestWorkflow
     request.set_description
     request.create_request
 
-    request.log_request_success(@requester.userid, :created)
+    request.log_request_success(@requester, :created)
 
     request.call_automate_event_queue("request_created")
-    request.approve(@requester.userid, "Auto-Approved") if auto_approve == true
+    request.approve(@requester, "Auto-Approved") if auto_approve == true
     request.reload if auto_approve
     request
   end

--- a/spec/models/miq_approval_spec.rb
+++ b/spec/models/miq_approval_spec.rb
@@ -47,6 +47,15 @@ describe MiqApproval do
 
       expect { approval.approve(user.userid, 'Why Not') }.to_not raise_error
     end
+
+    it "with an approver's object'" do
+      vm_template = FactoryGirl.create(:template_vmware)
+      user        = FactoryGirl.create(:user_miq_request_approver)
+      request     = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => vm_template.id, :userid => user.userid)
+      approval    = FactoryGirl.create(:miq_approval, :miq_request => request)
+
+      expect { approval.approve(user, 'Why Not') }.to_not raise_error
+    end
   end
 
   it "#deny" do


### PR DESCRIPTION
Workflow and request take user.

While we are at it, don't lookup the user again for approvals (we want to have the correct `user.current_group`)

/cc @gmcculloug 