### PR TITLE
resource_action_workflow#create_request call

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -22,7 +22,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     dialog
   end
 
-  def submit_request(requester_id, auto_approve = false)
+  def submit_request(_requester_id = nil)
     result = {}
 
     result[:errors] = @dialog.validate
@@ -32,9 +32,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     values[:src_id] = @target.id
 
     if create_request?(values)
-      event_message = "Request by [#{requester_id}] for #{@target.class.name}:#{@target.id}"
-      result[:request] = create_request(values, requester_id, @target.class.name,
-                                        'resource_action_request_created', event_message, auto_approve)
+      create_request(values, @requester.userid)
     else
       ra = load_resource_action(values)
       ra.deliver_to_automate_from_dialog(values, @target)


### PR DESCRIPTION
I fixed resource_action_workflow so it properly calls create_request

as a side effect, the logging now displays the actual event instead of a generic was: `"resource_action_request_created"`, now: `"service_reconfigure_request_created"`. I can change to the old value, but this seems to work better.

/cc @gmcculloug this is the bug we found today. Updated spec to be more thorough, and to detect this error as well.