### PR TITLE
fix kubernetes inventory refresh failure when pod has no volumes

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -504,7 +504,7 @@ module ManageIQ::Providers::Kubernetes
     end
 
     def parse_volumes(volumes)
-      volumes.collect do |volume|
+      volumes.to_a.collect do |volume|
         {
           :type                    => 'ContainerVolumeKubernetes',
           :name                    => volume.name,


### PR DESCRIPTION
the exception was: "undefined method `collect' for nil:NilClass"