### PR TITLE
Add handling of MigEVMLoginError exception

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -262,6 +262,8 @@ module AuthenticationMixin
           [:unreachable, err]
         rescue MiqException::MiqInvalidCredentialsError => err
           [:invalid, err]
+        rescue MiqException::MiqEVMLoginError
+          [:invalid, "Login failed due to a bad username or password."]
         rescue => err
           [:error, err]
         end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -401,6 +401,11 @@ describe AuthenticationMixin do
           @host.authentication_check.should == [false, "MiqException::MiqInvalidCredentialsError"]
         end
 
+        it "verify_credentials raising login error" do
+          @host.stub(:verify_credentials).and_raise(MiqException::MiqEVMLoginError)
+          @host.authentication_check.should == [false, "Login failed due to a bad username or password."]
+        end
+
         it "verify_credentials raising an unexpected error" do
           @host.stub(:verify_credentials).and_raise(RuntimeError)
           @host.authentication_check.should == [false, "RuntimeError"]


### PR DESCRIPTION
This exception is raised when user uses invalid credentials for RHEVM.