### PR TITLE
Cloud provider accordion and timeline links broken

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -534,7 +534,7 @@ module EmsCommon
       custom_buttons if params[:pressed] == "custom_button"
 
       return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-      return if ["#{@table_name}_tag", "#{@table_name}_protect", "#{@table_name}_tineline"].include?(params[:pressed]) &&
+      return if ["#{@table_name}_tag", "#{@table_name}_protect", "#{@table_name}_timeline"].include?(params[:pressed]) &&
                 @flash_array.nil? # Tag screen showing, so return
       check_if_button_is_implemented
     end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -518,12 +518,24 @@ module EmsCommon
       tag(model) if params[:pressed] == "#{@table_name}_tag"
       assign_policies(model) if params[:pressed] == "#{@table_name}_protect"
       edit_record if params[:pressed] == "#{@table_name}_edit"
+      if params[:pressed] == "ems_cloud_timeline"
+        @showtype = "timeline"
+        @record = find_by_id_filtered(model, params[:id])
+        @timeline = @timeline_filter = true
+        @lastaction = "show_timeline"
+        tl_build_timeline                       # Create the timeline report
+        drop_breadcrumb(:name => "Timelines", :url => show_link(@record, :refresh => "n", :display => "timeline"))
+        session[:tl_record_id] = @record.id
+        render :update do |page|
+          page.redirect_to  polymorphic_path(@record, :display => 'timeline')
+        end
+        return
+      end
       custom_buttons if params[:pressed] == "custom_button"
 
       return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-      return if ["#{@table_name}_tag", "#{@table_name}_protect"].include?(params[:pressed]) &&
+      return if ["#{@table_name}_tag", "#{@table_name}_protect", "#{@table_name}_tineline"].include?(params[:pressed]) &&
                 @flash_array.nil? # Tag screen showing, so return
-
       check_if_button_is_implemented
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -922,7 +922,11 @@ module ApplicationHelper
       check_changes = args[:check_changes] || args[:check_changes].nil?
       tag_attrs[:onclick] = 'return miqCheckForChanges()' if check_changes
       content_tag(:li) do
-        link_to(link_text, link_params, tag_attrs)
+        if args[:record] && restful_routed?(args[:record])
+          link_to(link_text, polymorphic_path(args[:record], :display => args[:display]))
+        else
+          link_to(link_text, link_params, tag_attrs)
+        end
       end
     else
       content_tag(:li, :class => "disabled") do

--- a/app/views/layouts/_taskbar.html.haml
+++ b/app/views/layouts/_taskbar.html.haml
@@ -1,7 +1,7 @@
 - if display_back_button?
   -# Only create this div if we get back a file name
   %div{:style => "float: left;"}
-    = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "summary_center_tb", :tb_yaml => "summary_center_tb"}
+    = render :partial => "layouts/dhtmlxtoolbar", :locals => {:tb => "summary_center_tb", :tb_yaml => controller.send(:restful?) ? "summary_center_restful_tb" : "summary_center_tb"}
 
 %div{:style => "float: left; padding-left: 0px;"}
   = render :partial => "layouts/center_buttons"

--- a/app/views/layouts/listnav/_ems_cloud.html.haml
+++ b/app/views/layouts/listnav/_ems_cloud.html.haml
@@ -10,12 +10,10 @@
     = miq_accordion_panel(_("Properties"), false, "ems_prop") do
       %ul.nav.nav-pills.nav-stacked
         %li
-          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, :title => _("Show Summary"))
+          = link_to_with_icon(_('Summary'), polymorphic_path(@record, :display => 'main'), :title => _("Show Summary"))
           - if @record.has_events? || @record.has_events?(:policy_events)
             %li
-              = link_to(_('Timelines'),
-                {:action => 'show', :id => @record, :display => 'timeline'},
-                :title => _("Show Timelines"))
+              = link_to(_('Timelines'), polymorphic_path( @record, :display => 'timeline'), :title => _("Show Timelines"))
           - else
             %li.disabled
               = link_to(_('Timelines'), "#")
@@ -24,40 +22,40 @@
       %ul.nav.nav-pills.nav-stacked
         - if role_allows(:feature => "availability_zone_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:availability_zones),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => 'availability_zones',
             :tables                   => 'availability_zone',
             :controller               => 'ems_cloud')
         - if role_allows(:feature => "cloud_tenant_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:cloud_tenants),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => "cloud_tenants",
             :tables                   => "cloud_tenant",
             :controller               => "ems_cloud")
         - if role_allows(:feature => "flavor_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:flavors),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => 'flavors',
             :tables                   => 'flavor',
             :controller               => 'ems_cloud')
         - if role_allows(:feature => "security_group_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:security_groups),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => 'security_groups',
             :tables                   => 'security_group',
             :controller               => 'ems_cloud')
         - if role_allows(:feature => "vm_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:vms),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => 'instances',
             :tables                   => 'instances')
         - if role_allows(:feature => "miq_template_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:miq_templates),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => 'images',
             :tables                   => 'images')
         - if role_allows(:feature => "orchestration_stack_show_list")
           = li_link_if_nonzero(:count => @record.number_of(:orchestration_stacks),
-            :record_id                => @record.id,
+            :record                   => @record,
             :display                  => 'orchestration_stacks',
             :tables                   => 'orchestration_stack')

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -4,7 +4,7 @@
   - arr.concat(%w(cloud_tenants ems_clusters flavors security_groups hosts instances images miq_templates))
   - arr.concat(%w(orchestration_stacks vms storages miq_proxies))
   - if arr.include?(@display) && @showtype != "compare"
-    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@ems.id}"}
+    = render :partial => "layouts/gtl", :locals => {:action_url => "#{@ems.id}"}
   - elsif @showtype == "compare"
     = render :partial => "layouts/compare"
   - elsif @showtype == "timeline"

--- a/product/toolbars/ems_cloud_center_tb.yaml
+++ b/product/toolbars/ems_cloud_center_tb.yaml
@@ -54,5 +54,4 @@
       :image: timeline
       :text: 'Timelines'
       :title: 'Show Timelines for this #{ui_lookup(:table=>"ems_cloud")}'
-      :url: '/show'
       :url_parms: '?display=timeline'

--- a/product/toolbars/summary_center_restful_tb.yaml
+++ b/product/toolbars/summary_center_restful_tb.yaml
@@ -1,0 +1,13 @@
+#
+# Toolbar config file
+#
+---
+:model:
+:button_groups:
+- :name: record_summary
+  :items:
+  - :button: show_summary
+    :image: summary-blue
+    :title: 'Show #{@layout == "cim_base_storage_extent" ? @record.evm_display_name : @record.name} Summary'
+    :url: '/'
+    :url_parms: '?id=#{@record.id}'

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -209,5 +209,35 @@ describe EmsCloudController do
       show_link_actual_path = controller.send(:show_link, openstack.to_a[0])
       expect(show_link_actual_path).to eq("/ems_cloud/#{openstack.to_a[0].id}")
     end
+
+    it 'gets the restful timeline link path' do
+      MiqServer.stub(:my_zone).and_return("default")
+      session[:settings] = {:views =>{:vm_summary_cool => ""}}
+      post :create,
+           "button"           => "add",
+           "hostname"         => "host_openstack",
+           "name"             => "foo_openstack",
+           "emstype"          => "openstack",
+           "provider_region"  => "",
+           "port"             => "5000",
+           "zone"             => "default",
+           "default_userid"   => "foo",
+           "default_password" => "[FILTERED]",
+           "default_verify"   => "[FILTERED]"
+
+      expect(response.status).to eq(200)
+      openstack = ManageIQ::Providers::Openstack::CloudManager.where(:name => "foo_openstack")
+      show_link_actual_path = controller.send(:show_link, openstack.to_a[0])
+      expect(show_link_actual_path).to eq("/ems_cloud/#{openstack.to_a[0].id}")
+
+      post :show,
+           "button"           => "timeline",
+           "display"          => "timeline",
+           "id"               => openstack.to_a[0].id
+
+      expect(response.status).to eq(200)
+      show_link_actual_path = controller.send(:show_link, openstack.to_a[0], :display=>"timeline")
+      expect(show_link_actual_path).to eq("/ems_cloud/#{openstack.to_a[0].id}?display=timeline")
+    end
   end
 end

--- a/spec/views/layouts/listnav/_ems_cloud.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_ems_cloud.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe "layouts/listnav/_ems_cloud.html.haml" do
     ActionView::Base.any_instance.stub(:role_allows).and_return(true)
   end
 
-  it "Favorites links use restful path" do
+  it "Flavors link for Openstack cloud manager uses restful path" do
     record =  ManageIQ::Providers::Openstack::CloudManager.new(:name => "Test Cloud")
     assign(:record, record)
     record.stub(:flavors).and_return(5)
@@ -18,11 +18,25 @@ describe "layouts/listnav/_ems_cloud.html.haml" do
     expect(response).to include "ems_cloud?display=flavors"
   end
 
-  it "Instance links to use restful paths" do
+  it "Flavors link for Amazon cloud manager uses restful paths" do
     record = ManageIQ::Providers::Amazon::CloudManager.new(:name => "Test Cloud")
     assign(:record, record)
     record.stub(:flavors).and_return(14)
     render
     expect(response).to include "ems_cloud?display=flavors"
+  end
+  it "Availability Zones link uses restful paths" do
+    record = ManageIQ::Providers::Openstack::CloudManager.new(:name => "Test Cloud")
+    assign(:record, record)
+    record.stub(:availability_zones).and_return(14)
+    render
+    expect(response).to include "ems_cloud?display=availability_zones"
+  end
+  it "Cloud Tenants link uses restful paths" do
+    record = ManageIQ::Providers::Amazon::CloudManager.new(:name => "Test Cloud")
+    assign(:record, record)
+    record.stub(:cloud_tenants).and_return(10)
+    render
+    expect(response).to include "ems_cloud?display=cloud_tenants"
   end
 end

--- a/spec/views/layouts/listnav/_ems_cloud.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_ems_cloud.html.haml_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+include ApplicationHelper
+
+describe "layouts/listnav/_ems_cloud.html.haml" do
+  before :each do
+    set_controller_for_view("ems_cloud")
+    assign(:panels, "ems_cloud_prop" => true, "ems_cloud_rel" => true)
+    @settings = {:quadicons => {:ems => true}}
+    view.stub(:truncate_length).and_return(23)
+    ActionView::Base.any_instance.stub(:role_allows).and_return(true)
+  end
+
+  it "Favorites links use restful path" do
+    record =  ManageIQ::Providers::Openstack::CloudManager.new(:name => "Test Cloud")
+    assign(:record, record)
+    record.stub(:flavors).and_return(5)
+    render
+    expect(response).to include "ems_cloud?display=flavors"
+  end
+
+  it "Instance links to use restful paths" do
+    record = ManageIQ::Providers::Amazon::CloudManager.new(:name => "Test Cloud")
+    assign(:record, record)
+    record.stub(:flavors).and_return(14)
+    render
+    expect(response).to include "ems_cloud?display=flavors"
+  end
+end


### PR DESCRIPTION
After the conversion to restful paths the accordion links have to be updated.

https://bugzilla.redhat.com/show_bug.cgi?id=1265462
https://bugzilla.redhat.com/show_bug.cgi?id=1265404
https://bugzilla.redhat.com/show_bug.cgi?id=1268826
