### PR TITLE
Fix Miq password v2 key confusion

### DIFF
--- a/gems/pending/spec/support/custom_matchers/be_decrypted.rb
+++ b/gems/pending/spec/support/custom_matchers/be_decrypted.rb
@@ -3,22 +3,18 @@
 # this matcher handles that case
 RSpec::Matchers.define :be_decrypted do |expected|
   match do |actual|
-    actual == utf8_to_ascii_bytestring(expected)
+    actual == expected
   end
 
   failure_message_for_should do |actual|
-    "expected: #{actual.inspect} to be decrypted to #{utf8_to_ascii_bytestring(expected)}"
+    "expected: #{actual.inspect} to be decrypted to #{expected}"
   end
 
   failure_message_for_should_not do |actual|
-    "expected: #{actual.inspect} to not equal #{utf8_to_ascii_bytestring(expected)}"
+    "expected: #{actual.inspect} to not equal #{expected}"
   end
 
   description do
     "expect to be decrypted from a string (fixing utf8 encoding issues)"
-  end
-
-  def utf8_to_ascii_bytestring(str)
-    str.bytes.map(&:chr).join
   end
 end

--- a/gems/pending/spec/support/custom_matchers/be_encrypted.rb
+++ b/gems/pending/spec/support/custom_matchers/be_encrypted.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :be_encrypted do |expected|
   match do |actual|
     MiqPassword.encrypted?(actual) && (
       expected.nil? ||
-      MiqPassword.decrypt(actual) == utf8_to_ascii_bytestring(expected)
+      MiqPassword.decrypt(actual) == expected
     )
   end
 
@@ -18,9 +18,5 @@ RSpec::Matchers.define :be_encrypted do |expected|
 
   description do
     "expect to be an encrypted v2 password (with optional encrypted value)"
-  end
-
-  def utf8_to_ascii_bytestring(str)
-    str.bytes.map(&:chr).join
   end
 end

--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -76,7 +76,7 @@ describe MiqPassword do
     context "with #{pass.inspect}" do
       before do
         MiqPassword.add_legacy_key("v0_key", :v0)
-        MiqPassword.add_legacy_key("v1_key")
+        MiqPassword.add_legacy_key("v1_key", :v1)
       end
 
       it(".encrypt")        { expect(MiqPassword.encrypt(pass)).to             be_encrypted(pass) }
@@ -194,7 +194,7 @@ describe MiqPassword do
     end
 
     it "with an encrypted string" do
-      MiqPassword.add_legacy_key("v1_key")
+      MiqPassword.add_legacy_key("v1_key", :v1)
       expect(MiqPassword.md5crypt("v1:{Wv/+DC0XBqnIbRCIAI+CSQ==}")).to eq("$1$miq$Ho9GNOzRsxMpJSsgwG/y01")
     end
   end
@@ -206,7 +206,7 @@ describe MiqPassword do
     end
 
     it "with an encrypted string" do
-      MiqPassword.add_legacy_key("v1_key")
+      MiqPassword.add_legacy_key("v1_key", :v1)
       expect(MiqPassword.sysprep_crypt("v1:{Wv/+DC0XBqnIbRCIAI+CSQ==}")).to eq(
         "cABhAHMAcwB3AG8AcgBkAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==")
     end
@@ -238,7 +238,7 @@ describe MiqPassword do
 
     it "clears all_keys" do
       v0 = MiqPassword.add_legacy_key("v0_key", :v0)
-      v1 = MiqPassword.add_legacy_key("v1_key")
+      v1 = MiqPassword.add_legacy_key("v1_key", :v1)
       v2 = MiqPassword.v2_key
 
       expect(MiqPassword.all_keys).to match_array([v2, v1, v0])
@@ -253,7 +253,7 @@ describe MiqPassword do
   describe ".clear_keys" do
     it "removes legacy keys from all_keys" do
       v0 = MiqPassword.add_legacy_key("v0_key", :v0)
-      v1 = MiqPassword.add_legacy_key("v1_key")
+      v1 = MiqPassword.add_legacy_key("v1_key", :v1)
       v2 = MiqPassword.v2_key
 
       expect(MiqPassword.all_keys).to match_array([v2, v1, v0])
@@ -289,7 +289,7 @@ describe MiqPassword do
 
     it "supports raw key" do
       expect(MiqPassword.all_keys.size).to eq(1)
-      MiqPassword.add_legacy_key(v1_key)
+      MiqPassword.add_legacy_key(v1_key, :v1)
       expect(MiqPassword.all_keys.size).to eq(2)
     end
 

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -159,7 +159,7 @@ EOS
     end
   end
 
-  def self.add_legacy_key(filename, type = :v1)
+  def self.add_legacy_key(filename, type = :v2)
     key = ez_load(filename, type != :v0)
     all_keys << key if key && !all_keys.include?(key)
     key

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -34,7 +34,7 @@ class MiqPassword
       key_name = (ver == "2" && legacy) ? "alt" : "v#{ver}"
 
       begin
-        self.class.keys[key_name].decrypt64(enc)
+        self.class.keys[key_name].decrypt64(enc).force_encoding('UTF-8')
       rescue
         raise MiqPasswordError, "can not decrypt v#{ver}_key encrypted string"
       end

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -294,7 +294,7 @@ namespace :evm do
     # loads the v1 key into the enviroment
     task :environmentlegacykey => :environment do
       MiqPassword.add_legacy_key('v0_key', :v0)
-      MiqPassword.add_legacy_key('v1_key')
+      MiqPassword.add_legacy_key('v1_key', :v1)
     end
   end
 end

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -13,7 +13,7 @@ describe FixAuth::AuthConfigModel do
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
 
   before do
-    MiqPassword.add_legacy_key(v1_key)
+    MiqPassword.add_legacy_key(v1_key, :v1)
   end
 
   after do

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -17,7 +17,7 @@ describe FixAuth::AuthModel do
 
   before do
     MiqPassword.add_legacy_key(v0_key, :v0)
-    MiqPassword.add_legacy_key(v1_key)
+    MiqPassword.add_legacy_key(v1_key, :v1)
   end
 
   after do

--- a/spec/tools/fix_auth/cli_spec.rb
+++ b/spec/tools/fix_auth/cli_spec.rb
@@ -66,15 +66,15 @@ describe FixAuth::Cli do
     end
 
     it "parses legacy_keys" do
-      opts = described_class.new.parse(%w(--legacy-key v2.bak -K v2.bakbak))
+      opts = described_class.new.parse(%w(--legacy-key v2.bak))
              .options.slice(:legacy_key)
-      expect(opts).to eq(:legacy_key => %w(v2.bak v2.bakbak))
+      expect(opts).to eq(:legacy_key => "v2.bak")
     end
 
     it "parses without legacy_keys specified" do
       opts = described_class.new.parse(%w())
              .options.slice(:legacy_key)
-      expect(opts[:legacy_key] || []).to eq([])
+      expect(opts[:legacy_key]).not_to be
     end
 
     describe "v2" do

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -23,7 +23,7 @@ module FixAuth
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w(.. ..))))
         opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false
         opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
-        opt :legacy_key, "Legacy Key",      :type => :string, :short => "K", :multi => true
+        opt :legacy_key, "Legacy Key",      :type => :string, :short => "K"
       end
 
       options[:databases] = args.presence || %w(vmdb_production)

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -79,10 +79,8 @@ module FixAuth
       MiqPassword.key_root = cert_dir if cert_dir
       MiqPassword.add_legacy_key("v0_key", :v0)
       MiqPassword.add_legacy_key("v1_key", :v1)
-      (options[:legacy_key] || []).each do |k|
-        unless MiqPassword.add_legacy_key(k)
-          puts "WARNING: key #{k} not found"
-        end
+      if options[:legacy_key] && !MiqPassword.add_legacy_key(options[:legacy_key])
+        puts "WARNING: key #{k} not found"
       end
     end
 


### PR DESCRIPTION
2 things:

---
In some cases, a bad key can look like it decrypts a string, but it produces a bogus string.
Since we are generating random keys, this failure is random.
To fix this issue, I dropped supporting multiple legacy keys. It is not necessary and added unneeded complexity.

---

When decrypting some strings, it looses the UTF-8 encoding. We used to need special encryption comparison code it handle this. Now, it is setting the encoding, so a string just works out of the box.

There are enough tests around international characters that this feels pretty solid. Also the special comparison code always concerned me. Not sure why the providers worked with us possibly sending strings with possibly bad encodings. But I guess most people use standard 7bit ascii, so it wouldn't have been a common problem.

---


/cc @jrafanie @Fryguy @matthewd this tweaks the code we just added