### PR TITLE
remove warning test around ownership_mixin.rb

### DIFF
--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -16,7 +16,7 @@ module OwnershipMixin
   module ClassMethods
     def set_ownership(ids, options)
       errors = ActiveModel::Errors.new(self)
-      objects = find_all_by_id(ids)
+      objects = where(:id => ids)
       missing = ids - objects.collect(&:id)
       errors.add(:missing_ids, "Unable to find #{name.pluralize} with the following ids #{missing.inspect}") unless missing.empty?
 


### PR DESCRIPTION
```
DEPRECATION WARNING: This dynamic method is deprecated. Please use e.g. Post.where(...).all instead. (called from set_ownership at /home/travis/build/ManageIQ/manageiq/app/models/mixins/ownership_mixin.rb:19)
```