### PR TITLE
Fix error in retirement editor

### DIFF
--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -36,7 +36,6 @@
                       :class    => "selectpicker")
         :javascript
           miqInitSelectPicker();
-          miqSelectPickerEvent("retirementWarning", "#{url}")
   = _('* Saving a blank date will remove all retirement dates')
 
   %hr


### PR DESCRIPTION
Calling miqSelectPickerEvent() here is unnecessary and causes
the following error:

```
FATAL -- : Error caught: [NameError] undefined local variable or method
`url' for #<#<Class:0x005562dbc96ee8>:0x005562e5b9f850>
app/views/shared/views/_retire.html.haml:20:in
`_app_views_shared_views__retire_html_haml__1540916862695159464_46941624580440'
app/views/orchestration_stack/retire.html.haml:1:in
`_app_views_orchestration_stack_retire_html_haml__1216609287779258203_46941624659700'
```

Caused by c04287aab847518ca52f4cb0c3acbc7c07721724