### PR TITLE
find_by_id only accepts ids

### DIFF
--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -169,9 +169,7 @@ class ActsAsArModel
   end
 
   def self.find_by_id(*id)
-    options = id.extract_options!
-    options.merge!(:conditions => {:id => id.first})
-    first(options)
+    find_by(:id => id.flatten.first)
   end
 
   def self.find_all_by_id(*ids)

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -373,10 +373,6 @@ EOF
       it "without options" do
         VmdbTable.find_by_id(1).name.should == VmdbTable.vmdb_table_names.first
       end
-
-      it "with options" do
-        VmdbTable.find_by_id(1, :include => {}).name.should == VmdbTable.vmdb_table_names.first
-      end
     end
 
     context ".find_all_by_id" do


### PR DESCRIPTION
this will remove some potential warnings

Not sure if this is a good idea.
Alternative is to just remove our definition of this method. (We use it in a bunch of places)

/cc @matthewd thoughts?