### PR TITLE
We assert root_disk_size_by_flavor commonly so define it there

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -27,6 +27,10 @@ module Openstack
       end
     end
 
+    def root_disk_size_by_flavor(flavor_name)
+      flavor_name == "m1.tiny" ? 1.gigabytes : ROOT_DISK_SIZE_HASH[flavor_name]
+    end
+
     def assert_with_skips
       # skips configured modules
       expect(CloudVolume.count).to eq 0

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_spec.rb
@@ -4,10 +4,6 @@ require_relative "refresh_spec_common"
 describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   include Openstack::RefreshSpecCommon
 
-  def root_disk_size_by_flavor(flavor_name)
-    flavor_name == "m1.tiny" ? 1.gigabytes : Openstack::RefreshSpecCommon::ROOT_DISK_SIZE_HASH[flavor_name]
-  end
-
   before(:each) do
     setup_ems('1.2.3.4', 'password_2WpEraURh')
     @environment = :havana

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_kilo_keystone_v3_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_kilo_keystone_v3_spec.rb
@@ -4,10 +4,6 @@ require_relative "refresh_spec_common"
 describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   include Openstack::RefreshSpecCommon
 
-  def root_disk_size_by_flavor(flavor_name)
-    flavor_name == "m1.tiny" ? 1.gigabytes : Openstack::RefreshSpecCommon::ROOT_DISK_SIZE_HASH[flavor_name]
-  end
-
   before(:each) do
     setup_ems('1.2.3.4', 'password_2WpEraURh', 5000, "cloud_admin", "v3")
     @environment = :kilo_keystone_v3


### PR DESCRIPTION
See 66317eb26b and f148a0cab1

Fixes a few openstack test failures such as:

```
  1) ManageIQ::Providers::Openstack::CloudManager::Refresher will perform a full refresh against RHOS
     Failure/Error: assert_common
     NoMethodError:
       undefined method `root_disk_size_by_flavor' for #<RSpec::Core::ExampleGroup::Nested_1:0x007fdc0772b650>
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb:241:in `block in assert_flavors'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb:226:in `assert_flavors'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb:43:in `assert_common'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_icehouse_spec.rb:18:in `block (3 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_icehouse_spec.rb:13:in `times'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_icehouse_spec.rb:13:in `block (2 levels) in <top (required)>'
```