### PR TITLE
added .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ private_test
 REGION
 SyntaxCheck
 xfer_*.xml
+.ruby-version
 
 # app/controllers/
 app/controllers/new_module.rb

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .loadpath
 .project
 .redcar/
+.ruby-version
 .sass-cache/
 .tags
 /data/
@@ -29,7 +30,6 @@ private_test
 REGION
 SyntaxCheck
 xfer_*.xml
-.ruby-version
 
 # app/controllers/
 app/controllers/new_module.rb


### PR DESCRIPTION
Added .ruby-version to .gitignore so it is not included in version management.

Now, you can use any .ruby-version file to manage your environment ruby version without conflict.