### PR TITLE
Add Tenant to legacy XML Import

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
@@ -156,8 +156,7 @@ module MiqAeDatastore
 
     def self.create_domain(domain)
       MiqAeDomain.find_by_fqname(domain) ||
-      MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant,
-                          :name => domain)
+      MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant, :name => domain)
     end
 
     def self.load_xml_file(filename, domain)

--- a/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
@@ -155,8 +155,9 @@ module MiqAeDatastore
     end
 
     def self.create_domain(domain)
-      MiqAeDomain.find_or_create_by!(:name     => domain, :enabled => true,
-                                     :priority => 100,    :tenant  => Tenant.root_tenant)
+      dom = MiqAeDomain.find_by_fqname(domain)
+      MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant,
+                          :name => domain) unless dom
     end
 
     def self.load_xml_file(filename, domain)

--- a/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
@@ -155,8 +155,8 @@ module MiqAeDatastore
     end
 
     def self.create_domain(domain)
-      ns = MiqAeNamespace.find_by_fqname(domain)
-      MiqAeNamespace.create!(:name => domain, :enabled => true, :priority => 100) unless ns
+      ns = MiqAeDomain.where(:name => domain).first
+      MiqAeDomain.create!(:name => domain, :enabled => true, :priority => 100, :tenant => Tenant.seed) unless ns
     end
 
     def self.load_xml_file(filename, domain)

--- a/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
@@ -155,8 +155,8 @@ module MiqAeDatastore
     end
 
     def self.create_domain(domain)
-      ns = MiqAeDomain.where(:name => domain).first
-      MiqAeDomain.create!(:name => domain, :enabled => true, :priority => 100, :tenant => Tenant.seed) unless ns
+      MiqAeDomain.find_or_create_by!(:name     => domain, :enabled => true,
+                                     :priority => 100,    :tenant  => Tenant.root_tenant)
     end
 
     def self.load_xml_file(filename, domain)

--- a/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore/xml_import.rb
@@ -155,9 +155,9 @@ module MiqAeDatastore
     end
 
     def self.create_domain(domain)
-      dom = MiqAeDomain.find_by_fqname(domain)
+      MiqAeDomain.find_by_fqname(domain) ||
       MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant,
-                          :name => domain) unless dom
+                          :name => domain)
     end
 
     def self.load_xml_file(filename, domain)

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore/legacy_xml_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore/legacy_xml_import_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe "LegacyXMLImport" do
+  before(:each) do
+    xml = <<-XML
+    <MiqAeDatastore version='1.0'>
+      <MiqAeClass name="AUTOMATE" namespace="EVM">
+        <MiqAeSchema>
+          <MiqAeField name="method1"  aetype="method"/>
+        </MiqAeSchema>
+        <MiqAeMethod name="test" language="ruby" location="inline" scope="instance">
+         <![CDATA[
+          ]]>
+         </MiqAeMethod>
+         <MiqAeInstance name="test1">
+           <MiqAeField name="method1">test</MiqAeField>
+         </MiqAeInstance>
+       </MiqAeClass>
+    </MiqAeDatastore>
+    XML
+    Tenant.seed
+    # hide deprecation warning
+    expect(MiqAeDatastore).to receive(:xml_deprecated_warning)
+    MiqAeDatastore::Import.load_xml(xml)
+  end
+
+  it "Check the tenant" do
+    expect(MiqAeDomain.first.tenant_id).to eql(Tenant.root_tenant.id)
+  end
+end

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore/legacy_xml_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore/legacy_xml_import_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe "LegacyXMLImport" do
-  before(:each) do
-    xml = <<-XML
+  let(:xml) do
+    %(
     <MiqAeDatastore version='1.0'>
       <MiqAeClass name="AUTOMATE" namespace="EVM">
         <MiqAeSchema>
@@ -17,7 +17,9 @@ describe "LegacyXMLImport" do
          </MiqAeInstance>
        </MiqAeClass>
     </MiqAeDatastore>
-    XML
+    )
+  end
+  before(:each) do
     Tenant.seed
     # hide deprecation warning
     expect(MiqAeDatastore).to receive(:xml_deprecated_warning)


### PR DESCRIPTION
We still have some specs that use XML for importing Automate
Data, they were not setting the Tenant ID on the temporary domains
that the XML Import creates.