### PR TITLE
Use LinuxAdmin dns class

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -114,20 +114,20 @@ module ApplianceConsole
 
   loop do
     begin
+      dns = LinuxAdmin::Dns.new
       eth0.reload
       eth0.parse_conf
 
-      host     = LinuxAdmin::Hosts.new.hostname
-      ip       = eth0.address
-      mac      = eth0.mac_address
-      mask     = eth0.netmask
-      gw       = eth0.gateway
-      dns1     = Env["DNS1"]
-      dns2     = Env["DNS2"]
-      order    = Env["SEARCHORDER"]
-      timezone = LinuxAdmin::TimeDate.system_timezone
-      region   = File.read(REGION_FILE).chomp  if File.exist?(REGION_FILE)
-      version  = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
+      host       = LinuxAdmin::Hosts.new.hostname
+      ip         = eth0.address
+      mac        = eth0.mac_address
+      mask       = eth0.netmask
+      gw         = eth0.gateway
+      dns1, dns2 = dns.nameservers
+      order      = dns.search_order.join(' ')
+      timezone   = LinuxAdmin::TimeDate.system_timezone
+      region     = File.read(REGION_FILE).chomp  if File.exist?(REGION_FILE)
+      version    = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
       configured = ApplianceConsole::DatabaseConfiguration.configured?
 
       summary_attributes = [

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -133,16 +133,7 @@ module Vmdb
       retVal[:ipaddress]  = eth0.address
       retVal[:netmask]    = eth0.netmask
       retVal[:gateway]    = eth0.gateway
-
-      miqnet = "/bin/miqnet.sh"
-
-      if File.exist?(miqnet)
-        # Make a call to the virtual appliance to get the network information
-        cmd     = "#{miqnet} -GET"
-
-        retVal[:primary_dns]   = `#{cmd} DNS1`
-        retVal[:secondary_dns] = `#{cmd} DNS2`
-      end
+      retVal[:primary_dns], retVal[:secondary_dns] = LinuxAdmin::Dns.new.nameservers
 
       retVal
     end


### PR DESCRIPTION
Using `LinuxAdmin::Dns` for getting the nameserver and search order info rather than `miqnet.sh`

Requires https://github.com/ManageIQ/linux_admin/pull/127

https://trello.com/c/rWKh4KQs