### PR TITLE
Converted XML model to use factories for specs

### DIFF
--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
@@ -1,28 +1,14 @@
 require "spec_helper"
 
+include AutomationSpecHelper
 module MiqAeServiceServiceReconfigureRequestSpec
   describe MiqAeMethodService::MiqAeServiceServiceReconfigureRequest do
     before(:each) do
-      xml = <<-XML
-      <MiqAeDatastore version='1.0'>
-        <MiqAeClass name="AUTOMATE" namespace="EVM">
-          <MiqAeSchema>
-            <MiqAeField name="method1"  aetype="method"/>
-          </MiqAeSchema>
-          <MiqAeMethod name="test" language="ruby" location="inline" scope="instance">
-          <![CDATA[
-          ]]>
-          </MiqAeMethod>
-          <MiqAeInstance name="test1">
-            <MiqAeField name="method1">test</MiqAeField>
-          </MiqAeInstance>
-        </MiqAeClass>
-      </MiqAeDatastore>
-      XML
+      method_script   = "$evm.root['ci_type'] = $evm.root['request'].ci_type"
+      create_ae_model_with_method(:method_script => method_script, :ae_class => 'AUTOMATE',
+                                  :ae_namespace  => 'EVM', :instance_name => 'test1',
+                                  :method_name   => 'test', :name => 'TEST_DOMAIN')
 
-      # hide deprecation warning
-      expect(MiqAeDatastore).to receive(:xml_deprecated_warning)
-      MiqAeDatastore::Import.load_xml(xml)
     end
 
     let(:ae_method)     { ::MiqAeMethod.first }
@@ -34,8 +20,6 @@ module MiqAeServiceServiceReconfigureRequestSpec
     end
 
     it "returns 'service' for ci_type" do
-      method   = "$evm.root['ci_type'] = $evm.root['request'].ci_type"
-      ae_method.update_attributes(:data => method)
       invoke_ae.root('ci_type').should == 'service'
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
@@ -1,28 +1,13 @@
 require "spec_helper"
-
+include AutomationSpecHelper
 module MiqAeServiceServiceReconfigureTaskSpec
   describe MiqAeMethodService::MiqAeServiceServiceReconfigureTask do
     before(:each) do
-      xml = <<-XML
-      <MiqAeDatastore version='1.0'>
-        <MiqAeClass name="AUTOMATE" namespace="EVM">
-          <MiqAeSchema>
-            <MiqAeField name="method1"  aetype="method"/>
-          </MiqAeSchema>
-          <MiqAeMethod name="test" language="ruby" location="inline" scope="instance">
-          <![CDATA[
-          ]]>
-          </MiqAeMethod>
-          <MiqAeInstance name="test1">
-            <MiqAeField name="method1">test</MiqAeField>
-          </MiqAeInstance>
-        </MiqAeClass>
-      </MiqAeDatastore>
-      XML
+      method_script   = "$evm.root['result'] = $evm.root['service_reconfigure_task'].status"
+      create_ae_model_with_method(:method_script => method_script, :ae_class => 'AUTOMATE',
+                                  :ae_namespace  => 'EVM', :instance_name => 'test1',
+                                  :method_name   => 'test', :name => 'TEST_DOMAIN')
 
-      # hide deprecation warning
-      expect(MiqAeDatastore).to receive(:xml_deprecated_warning)
-      MiqAeDatastore::Import.load_xml(xml)
     end
 
     let(:ae_method) { ::MiqAeMethod.first }
@@ -42,16 +27,12 @@ module MiqAeServiceServiceReconfigureTaskSpec
     context "#status" do
       it "returns 'ok' when state is finished" do
         task.update_attributes(:state => "finished")
-        method   = "$evm.root['result'] = $evm.root['service_reconfigure_task'].status"
-        ae_method.update_attributes!(:data => method)
 
         invoke_ae.root('result').should == 'ok'
       end
 
       it "returns 'retry' when state is pending" do
         task.update_attributes(:state => "pending")
-        method   = "$evm.root['result'] = $evm.root['service_reconfigure_task'].status"
-        ae_method.update_attributes!(:data => method)
 
         invoke_ae.root('result').should == 'retry'
       end

--- a/spec/support/automation_spec_helper.rb
+++ b/spec/support/automation_spec_helper.rb
@@ -47,6 +47,24 @@ module AutomationSpecHelper
                        attrs.merge('ae_fields' => ae_fields, 'ae_instances' => ae_instances))
   end
 
+  def create_ae_model_with_method(attrs = {})
+    attrs = default_ae_model_attributes(attrs)
+    method_script = attrs.delete(:method_script)
+    method_params = attrs.delete(:method_params) || {}
+    instance_name = attrs.delete(:instance_name)
+    method_name = attrs.delete(:method_name)
+    ae_fields = {'execute' => {:aetype => 'method', :datatype => 'string'}}
+    ae_instances = {instance_name => {'execute' => {:value => method_name}}}
+    ae_methods = {method_name => {:scope => 'instance', :location => 'inline',
+                                  :data => method_script,
+                                  :language => 'ruby', 'params' => method_params}}
+
+    FactoryGirl.create(:miq_ae_domain, :with_small_model, :with_instances, :with_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_instances' => ae_instances,
+                                   'ae_methods'   => ae_methods))
+  end
+
   def default_ae_model_attributes(attrs = {})
     attrs.reverse_merge!(
       :ae_class      => 'CLASS1',


### PR DESCRIPTION
We had 2 specs that were using the legacy XML format for
importing models, switched them to use the Factory to build
a small model.