### PR TITLE
restore retire service datepicker in Service Details state

### DIFF
--- a/spa_ui/self_service/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/spa_ui/self_service/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -38,10 +38,14 @@
 
     vm.service = serviceDetails;
     vm.retireService = retireService;
-
+    var existingDate = new Date(vm.service.retires_on);
+    var existingUTCDate = new Date(existingDate.getTime() + existingDate.getTimezoneOffset() * 60000);
     vm.modalData = {
       action: 'retire',
-      resource: {date: vm.service.retires_on || new Date(), warn: vm.service.retirement_warn || 0}
+      resource: {
+        date: vm.service.retires_on ? existingUTCDate : new Date(),
+        warn: vm.service.retirement_warn || 0
+      }
     };
 
     vm.dateOptions = {


### PR DESCRIPTION

<img width="1920" alt="screen shot 2015-10-06 at 3 28 30 pm" src="https://cloud.githubusercontent.com/assets/6640236/10319979/f4f7dde4-6c3e-11e5-8a03-01e75e33eef8.png">
Schedule Retire Service button did not allow reconfigured date. Api returns a string rather than a date object, created date object and normalized string (UTC) which correctly selects server provided retirement date and allows user to reconfigure date.