### PR TITLE
Do not allow deletion of assigned Chargeback Rates

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -299,22 +299,17 @@ class ChargebackController < ApplicationController
 
       # Do not delete assigned rates
       rates_to_delete = []
-      rates.each do |cb_rate_id|
-        cb_rate = ChargebackRate.find_by_id(cb_rate_id)
-        if cb_rate.assigned?
-          rate_descr = cb_rate.description
-          add_flash(_("Selected %{model} %{rate} is assigned and cannot be deleted") % {:model => "ChargebackRate", :rate  => rate_descr}, :error)
+      selected_rates = ChargebackRate.find(rates)
+      selected_rates.each do |rate|
+        if rate.assigned?
+          add_flash(_("Selected %{model} %{rate} is assigned and cannot be deleted") % {:model => "ChargebackRate", :rate  => rate.description}, :error)
         else
-          rates_to_delete << cb_rate_id
+          rates_to_delete << rate.id
         end
       end
 
       process_cb_rates(rates_to_delete, "destroy")  unless rates_to_delete.empty?
-      if rates_to_delete.size > 1
-        add_flash(_("The selected %s were deleted") % ui_lookup(:models => "ChargebackRate"), :info, true) unless flash_errors?
-      else
-        add_flash(_("The selected %s was deleted") % ui_lookup(:model => "ChargebackRate"), :info, true) unless flash_errors?
-      end
+      add_flash(_("Selected %{typ} successfully deleted") % {:typ => "Chargeback Rate".pluralize(rates.length)}, :info, true) unless flash_errors?
 
       cb_rates_list
       @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
@@ -340,7 +335,7 @@ class ChargebackController < ApplicationController
         tree_select
       else
         process_cb_rates(rates, "destroy")  unless rates.empty?
-        add_flash(_("The selected %s was deleted") % ui_lookup(:model => "ChargebackRate"), :info, true) unless flash_errors?
+        add_flash(_("Selected %{typ} successfully deleted") % {:typ => "Chargeback Rate"}, :info, true) unless flash_errors?
 
         self.x_node = "xx-#{@record.rate_type}"
         cb_rates_list

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -7,6 +7,8 @@ class ChargebackRate < ActiveRecord::Base
 
   has_many :chargeback_rate_details, :dependent => :destroy
 
+  virtual_column :assigned?, :type => :boolean
+
   validates_presence_of     :description, :guid
   validates_uniqueness_of   :guid
   validates_uniqueness_of   :description, :scope => :rate_type
@@ -70,4 +72,10 @@ class ChargebackRate < ActiveRecord::Base
       end
     end
   end
+
+  def assigned?
+    assigned_tos = get_assigned_tos
+    assigned_tos == {:objects=>[], :tags=>[]} ? false : true
+  end
+
 end

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -74,8 +74,7 @@ class ChargebackRate < ActiveRecord::Base
   end
 
   def assigned?
-    assigned_tos = get_assigned_tos
-    assigned_tos == {:objects=>[], :tags=>[]} ? false : true
+    get_assigned_tos != {:objects=>[], :tags=>[]}
   end
 
 end


### PR DESCRIPTION

![multi-delete from a list](https://cloud.githubusercontent.com/assets/552686/10321838/b0267ca2-6c2f-11e5-8fd3-69aa8c921159.png)
![single delete from accordion](https://cloud.githubusercontent.com/assets/552686/10321843/b9595d62-6c2f-11e5-8029-5b95012f9e52.png)

This will still allow Default rates to be deleted and then restored via .seed

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1206285