### PR TITLE
Compact the timestamps array before sort

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb
@@ -133,7 +133,7 @@ class ManageIQ::Providers::Amazon::CloudManager::MetricsCapture < ManageIQ::Prov
     COUNTER_INFO.each do |i|
       timestamps = i[:amazon_counters].collect do |c|
         metrics_by_counter_name[c].keys unless metrics_by_counter_name[c].nil?
-      end.flatten.uniq.sort.compact
+      end.flatten.uniq.compact.sort
 
       # If we are unable to determine if a datapoint is a 1-minute (detailed)
       #   or 5-minute (basic) interval, we will throw it away.  This includes
@@ -146,8 +146,8 @@ class ManageIQ::Providers::Amazon::CloudManager::MetricsCapture < ManageIQ::Prov
         value   = i[:calculation].call(*metrics, interval)
 
         # For (temporary) symmetry with VIM API we create 20-second intervals.
-        (last_ts + 20.seconds..ts).step_value(20.seconds).each do |ts|
-          counter_values_by_ts.store_path(ts.iso8601, i[:vim_style_counter_key], value)
+        (last_ts + 20.seconds..ts).step_value(20.seconds).each do |inner_ts|
+          counter_values_by_ts.store_path(inner_ts.iso8601, i[:vim_style_counter_key], value)
         end
       end
     end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
@@ -28,5 +28,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
       expect(@vm.perf_collect_metrics('realtime')).to eq([{"amazon-perf-vm" => described_class::VIM_STYLE_COUNTERS},
                                                           {"amazon-perf-vm" => {}}])
     end
+
+    it "handles when metrixs are collected for only one counter" do
+      @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => @ems_amazon)
+      mc = described_class.new(@vm)
+
+      filter_double = (double(:name => "NetworkIn", :statistics => [{:timestamp => Time.new(1999).utc, :average => 1}]))
+      ems_double = double(:metrics => double(:filter => [filter_double]))
+
+      expect(@vm.ext_management_system).to receive(:connect).and_return(ems_double)
+      expect(@vm).to receive(:perf_capture_object).and_return(mc)
+
+      expect(@vm.perf_collect_metrics('realtime')).to eq([{"amazon-perf-vm" => described_class::VIM_STYLE_COUNTERS},
+                                                          {"amazon-perf-vm" => {}}])
+    end
   end
 end


### PR DESCRIPTION
Compact the timestamps array before sort

Also fix a one line rubocop failure.

This bug was discoverd in issue 4634 after it was merged.
So a new issue was created to track this fix.

Fixes  #4716