### PR TITLE
Update resource_group method for Azure VM

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
 
   # The resource group is stored as part of the uid_ems. This splits it out.
   def resource_group
-    uid_ems.split('\\').first
+    uid_ems.split('\\')[1]
   end
 
   #

--- a/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
@@ -10,6 +10,12 @@ describe ManageIQ::Providers::Azure::CloudManager::Vm do
     let(:power_state_off) { "VM stopped" }
     let(:power_state_suspended) { "VM stopping" }
 
+    it "defines a resource_group method that returns the expected value based on uid_ems" do
+      vm.uid_ems = "aaa\\bbb\\ccc\\ddd"
+      expect(vm).to respond_to(:resource_group)
+      expect(vm.resource_group).to eq("bbb")
+    end
+
     context("with :start") do
       let(:state) { :start }
       include_examples "Vm operation is available when not powered on"


### PR DESCRIPTION
There was a change in the way the uid_ems is set, and that broke the resource_group method. This fixes it, and adds a couple basic specs to check for it in the future.