### PR TITLE
User.current_user= and User.with_user (not userid)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2134,7 +2134,7 @@ class ApplicationController < ActionController::Base
 
   def get_global_session_data
     # Set the current userid in the User class for this thread for models to use
-    User.current_userid = session[:userid]
+    User.current_user = current_user
 
     # Get/init sandbox (@sb) per controller in the session object
     session[:sandboxes] ||= HashWithIndifferentAccess.new

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -11,15 +11,15 @@ module ApplicationController::CurrentUser
   end
 
   def clear_current_user
-    User.current_userid = nil
-    session[:userid]    = nil
-    session[:group]     = nil
+    User.current_user = nil
+    session[:userid]  = nil
+    session[:group]   = nil
   end
 
   def current_user=(db_user)
-    User.current_userid = db_user.userid
-    session[:userid]    = db_user.userid
-    session[:group]     = db_user.current_group.try(:id)
+    User.current_user = db_user
+    session[:userid]  = db_user.userid
+    session[:group]   = db_user.current_group.try(:id)
   end
 
   def admin_user?

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -168,8 +168,12 @@ module MiqReport::Generator
   end
 
   def generate_table(options = {})
-    if options[:userid]
-      User.with_userid(MiqReportResult.parse_userid(options[:userid])) { _generate_table(options) }
+    if options[:user]
+      User.with_user(options[:user]) { _generate_table(options) }
+    elsif options[:userid]
+      userid = MiqReportResult.parse_userid(options[:userid])
+      user = User.find_by_userid(userid)
+      User.with_user(user, userid) { _generate_table(options) }
     else
       _generate_table(options)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -309,11 +309,18 @@ class User < ActiveRecord::Base
     Thread.current[:userid] = saved_userid
   end
 
+  # deprecated
   def self.current_userid=(userid)
     Thread.current[:user]   = nil
     Thread.current[:userid] = userid
   end
 
+  def self.current_user=(user)
+    Thread.current[:userid] = user.try(:userid)
+    Thread.current[:user] = user
+  end
+
+  # avoid using this. pass current_user where possible
   def self.current_userid
     Thread.current[:userid]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -299,20 +299,15 @@ class User < ActiveRecord::Base
   end
 
   # Save the current user from the session object as a thread variable to allow lookup from other areas of the code
-  def self.with_userid(userid)
+  def self.with_user(user, userid = nil)
     saved_user   = Thread.current[:user]
     saved_userid = Thread.current[:userid]
-    self.current_userid = userid
+    self.current_user = user
+    Thread.current[:userid] = userid if userid
     yield
   ensure
     Thread.current[:user]   = saved_user
     Thread.current[:userid] = saved_userid
-  end
-
-  # deprecated
-  def self.current_userid=(userid)
-    Thread.current[:user]   = nil
-    Thread.current[:userid] = userid
   end
 
   def self.current_user=(user)

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -53,7 +53,7 @@ describe CustomButton do
         end
 
         it "calls automate without saved User and MiqServer" do
-          User.with_userid(@user2.userid) { @button.invoke(@vm) }
+          User.with_user(@user2) { @button.invoke(@vm) }
 
           MiqQueue.count.should == 1
           q = MiqQueue.first

--- a/spec/models/dialog_field_date_time_control_spec.rb
+++ b/spec/models/dialog_field_date_time_control_spec.rb
@@ -3,9 +3,7 @@ require "spec_helper"
 describe DialogFieldDateTimeControl do
   context "legacy tests" do
     let!(:user) do
-      user = FactoryGirl.create(:user)
-      User.stub(:current_user).and_return(user)
-      user
+      User.current_user = FactoryGirl.create(:user)
     end
 
     context "with UTC timezone" do

--- a/spec/models/mixins/timezone_mixin_spec.rb
+++ b/spec/models/mixins/timezone_mixin_spec.rb
@@ -32,9 +32,7 @@ describe TimezoneMixin do
 
     context "with a user" do
       let!(:user) do
-        user = FactoryGirl.create(:user)
-        User.stub(:current_user).and_return(user)
-        user
+        User.current_user = FactoryGirl.create(:user)
       end
 
       it "#with_current_user_timezone in GMT" do

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -50,15 +50,15 @@ describe Rbac do
         @owned_vm = FactoryGirl.create(:vm_vmware, :tenant => @owner_tenant)
       end
 
-      it ".search with User.with_userid finds user's tenant object" do
-        User.with_userid(@owner_user.userid) do
+      it ".search with User.with_user finds user's tenant object" do
+        User.with_user(@owner_user) do
           results, = Rbac.search(:class => "Vm", :results_format => :objects)
           expect(results).to eq [@owned_vm]
         end
       end
 
-      it ".search with User.with_userid filters out other tenants" do
-        User.with_userid(@other_user.userid) do
+      it ".search with User.with_user filters out other tenants" do
+        User.with_user(@other_user) do
           results, = Rbac.search(:class => "Vm", :results_format => :objects)
           expect(results).to eq []
         end
@@ -74,8 +74,8 @@ describe Rbac do
         expect(results).to eq []
       end
 
-      it ".search with User.with_userid leaving tenant" do
-        User.with_userid(@owner_user.userid) do
+      it ".search with User.with_user leaving tenant" do
+        User.with_user(@owner_user) do
           @owner_user.miq_groups = [@other_group]
           @owner_user.save
           results, = Rbac.search(:class => "Vm", :results_format => :objects)
@@ -83,8 +83,8 @@ describe Rbac do
         end
       end
 
-      it ".search with User.with_userid joining tenant" do
-        User.with_userid(@other_user.userid) do
+      it ".search with User.with_user joining tenant" do
+        User.with_user(@other_user) do
           @other_user.miq_groups = [@owner_group]
           @other_user.save
           results, = Rbac.search(:class => "Vm", :results_format => :objects)
@@ -362,7 +362,7 @@ describe Rbac do
 
         it "search on VMs and Templates should return no objects if self-service user" do
           User.any_instance.stub(:self_service? => true)
-          User.with_userid(@user.userid) do
+          User.with_user(@user) do
             results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects)
             objects = results.first
             objects.length.should == 0
@@ -553,7 +553,7 @@ describe Rbac do
           end
 
           it "works when targets are empty" do
-            User.with_userid(@user.userid) do
+            User.with_user(@user) do
               results, attrs = Rbac.search(:class => "Service", :results_format => :objects)
               results.to_a.should match_array([@service3, @service4, @service5])
             end
@@ -575,7 +575,7 @@ describe Rbac do
           end
 
           it "works when targets are empty" do
-            User.with_userid(@user.userid) do
+            User.with_user(@user) do
               results, attrs = Rbac.search(:class => "Service", :results_format => :objects)
               results.to_a.should match_array([@service3, @service5])
             end
@@ -639,14 +639,14 @@ describe Rbac do
           end
 
           it "works when targets are empty" do
-            User.with_userid(@user.userid) do
+            User.with_user(@user) do
               results, attrs = Rbac.search(:class => "Vm", :results_format => :objects)
               results.length.should == 4
             end
           end
 
           it "works when passing a named_scope" do
-            User.with_userid(@user.userid) do
+            User.with_user(@user) do
               results, attrs = Rbac.search(:class => "Vm", :results_format => :objects, :named_scope => [:group_scope, 1])
               results.length.should == 1
             end
@@ -668,14 +668,14 @@ describe Rbac do
           end
 
           it "works when targets are empty" do
-            User.with_userid(@user.userid) do
+            User.with_user(@user) do
               results, attrs = Rbac.search(:class => "Vm", :results_format => :objects)
               results.length.should == 2
             end
           end
 
           it "works when passing a named_scope" do
-            User.with_userid(@user.userid) do
+            User.with_user(@user) do
               results, attrs = Rbac.search(:class => "Vm", :results_format => :objects, :named_scope => [:group_scope, 1])
               results.length.should == 1
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -598,8 +598,7 @@ describe Tenant do
     end
 
     it "assigns current user tenant" do
-      user = FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group])
-      User.stub(:current_user => user)
+      User.current_user = FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group])
       vm = FactoryGirl.create(:vm_vmware)
 
       expect(vm.tenant).to eql tenant

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -567,4 +567,55 @@ describe User do
       expect(User.find_by_lower_email(u.email.upcase)).to eq(u)
     end
   end
+
+  describe "#current_tenant" do
+    let(:user1) { FactoryGirl.create(:user_with_group) }
+
+    it "sets the tenant" do
+      User.with_user(user1) do
+        expect(User.current_tenant).to be
+        expect(User.current_tenant).to eq(user1.current_tenant)
+      end
+    end
+  end
+
+  describe "#current_user=" do
+    let(:user1) { FactoryGirl.create(:user) }
+
+    it "sets the user" do
+      User.current_user = user1
+      expect(User.current_userid).to eq(user1.userid)
+      expect(User.current_user).to eq(user1)
+    end
+  end
+
+  describe "#with_user" do
+    let(:user1) { FactoryGirl.create(:user) }
+    let(:user2) { FactoryGirl.create(:user) }
+
+    it "sets the user" do
+      User.with_user(user1) do
+        expect(User.current_userid).to eq(user1.userid)
+        expect(User.current_user).to eq(user1)
+        User.with_user(user2) do
+          expect(User.current_userid).to eq(user2.userid)
+          expect(User.current_user).to eq(user2)
+        end
+        expect(User.current_userid).to eq(user1.userid)
+        expect(User.current_user).to eq(user1)
+      end
+    end
+
+    # sorry. please help me delete this use case / parameter
+    it "supports a userid with a nil user" do
+      User.with_user(user1) do
+        User.with_user(nil, "oleg") do
+          expect(User.current_userid).to eq("oleg")
+          expect(User.current_user).not_to be
+        end
+        expect(User.current_userid).to eq(user1.userid)
+        expect(User.current_user).to eq(user1)
+      end
+    end
+  end
 end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -4,10 +4,9 @@ module AuthHelper
   end
 
   def login_as(user)
-    User.stub(:current_user => user)
-    User.stub(:current_userid => user.userid)
-    session[:userid]   = user.userid
-    session[:group]    = user.current_group.try(:id)
+    User.current_user = user
+    session[:userid]  = user.userid
+    session[:group]   = user.current_group.try(:id)
     user
   end
 end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -19,7 +19,7 @@ module EvmSpecHelper
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
 
     # Clear the thread local variable to prevent test contamination
-    User.current_userid = nil if defined?(User) && User.respond_to?(:current_userid=)
+    User.current_user = nil if defined?(User) && User.respond_to?(:current_user=)
 
     # Clear configuration caches
     VMDB::Config.invalidate_all

--- a/spec/support/presenter_spec_helper.rb
+++ b/spec/support/presenter_spec_helper.rb
@@ -2,8 +2,7 @@ module PresenterSpecHelper
   include ActionView::Helpers::JavaScriptHelper
 
   def login_as(user)
-    User.stub(:current_user => user)
-    User.stub(:current_userid => user.userid)
+    User.current_user = user
     ActionController::TestSession.any_instance.stub(:userid).and_return(user.userid)
     ActionController::TestSession.any_instance.stub(:group).and_return(user.current_group.try(:id))
   end


### PR DESCRIPTION
**back story:**
In automate and other areas of the code, the `user` object may have a different `tenant` or `group` than what is stored in the database (`users.current_group_id`).

So I want to start phase out passing around `userid`, and pass around `user` objects instead.
For automate, when saving to the queue and database (e.g. `miq_request`) we're actually serializing all 3.

**this pr:**

This change allows the code to set the full user object, with the correct group and tenant (rather than looking it up again in the database and possibly getting a different answer)

Currently, we allow the userid to represent a user that is not stored in the database. This code is not making a stance against that. But is paving the way to ensure that the userid is valid and the group/tenant are correct.



/cc @Fryguy @jrafanie Does this look good?
/cc @abellotti fyi