### PR TITLE
appliance console: don't hardcode key_root

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -100,6 +100,9 @@ TZ_AREAS_MAP     = Hash.new { |_h, k| k }.merge!(
 )
 TZ_AREAS_MAP_REV = Hash.new { |_h, k| k }.merge!(TZ_AREAS_MAP.invert)
 
+require 'util/miq-password'
+MiqPassword.key_root = "#{RAILS_ROOT}/certs"
+
 # Load appliance_console libraries
 require 'appliance_console/utilities'
 require 'appliance_console/logging'

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -11,8 +11,6 @@ require 'appliance_console/logging'
 RAILS_ROOT ||= Pathname.new(__dir__).join("../../..")
 
 module ApplianceConsole
-  MiqPassword.key_root = "#{RAILS_ROOT}/certs"
-
   class DatabaseConfiguration
     attr_accessor :adapter, :host, :username, :database, :password, :port, :region
 


### PR DESCRIPTION
Just including the `database_configuration` module or specs was changing the `MiqPassword.key_root`.

Instead, this sets the module at app startup (`appliance_console`) instead of module inclusion

/cc @carbonin @gtanzillo 