### PR TITLE
Deprecation mixin

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1,5 +1,3 @@
-require 'active_support/deprecation'
-
 class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   def auto_placement_enabled?
     get_value(@values[:placement_auto])
@@ -619,12 +617,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   def allowed_datastore_storage_controller(_options = {})
     {}
   end
-  deprecate :allowed_datastore_storage_controller
+  Vmdb::Deprecation.deprecate_methods(self, :allowed_datastore_storage_controller)
 
   def allowed_datastore_aggregate(_options = {})
     {}
   end
-  deprecate :allowed_datastore_aggregate
+  Vmdb::Deprecation.deprecate_methods(self, :allowed_datastore_aggregate)
 
   def get_source_vm
     get_source_and_targets[:vm]

--- a/app/models/mixins/deprecation_mixin.rb
+++ b/app/models/mixins/deprecation_mixin.rb
@@ -1,0 +1,28 @@
+module DeprecationMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    private
+
+    def deprecate_belongs_to(old_belongs_to, new_belongs_to)
+      deprecate_attribute_methods(old_belongs_to, new_belongs_to)
+      ["_id", "_id=", "_id?"].each do |suffix|
+        define_method("#{old_belongs_to}#{suffix}") do |*args|
+          args.present? ? send("#{new_belongs_to}#{suffix}", *args) : send("#{new_belongs_to}#{suffix}")
+        end
+        Vmdb::Deprecation.deprecate_methods(self, "#{old_belongs_to}#{suffix}" => "#{new_belongs_to}#{suffix}")
+      end
+      virtual_belongs_to(old_belongs_to)
+    end
+
+    def deprecate_attribute(old_attribute, new_attribute)
+      deprecate_attribute_methods(old_attribute, new_attribute)
+      virtual_column(old_attribute, :type => column_types[new_attribute.to_s].type)
+    end
+
+    def deprecate_attribute_methods(old_attribute, new_attribute)
+      alias_attribute old_attribute, new_attribute
+      ["", "=", "?"].each { |suffix| Vmdb::Deprecation.deprecate_methods(self, "#{old_attribute}#{suffix}" => "#{new_attribute}#{suffix}") }
+    end
+  end
+end

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -673,11 +673,7 @@ module RelationshipMixin
   def self.deprecate_of_type_parameter(*args)
     return args if args.empty? || args.first.kind_of?(Hash)
 
-    unless Rails.env.production?
-      msg = "[DEPRECATION] of_type parameter without hash symbol is deprecated.  Please use :of_type => 'Type' style instead.  At #{caller[1]}"
-      $log.warn msg
-      warn msg
-    end
+    Vmdb::Deprecation.deprecation_warning("of_type parameter without hash symbol", "use :of_type => 'Type' style instead") unless Rails.env.production?
 
     options = args.extract_options!
     [options.merge(:of_type => args.first)]
@@ -686,20 +682,12 @@ module RelationshipMixin
   def self.deprecate_of_type_and_rel_type_parameter(*args)
     return args if args.empty? || args.first.kind_of?(Hash)
 
-    unless Rails.env.production?
-      msg = "[DEPRECATION] of_type parameter without hash symbol is deprecated.  Please use :of_type => 'Type' style instead.  At #{caller[1]}"
-      $log.warn msg
-      warn msg
-    end
+    Vmdb::Deprecation.deprecation_warning("of_type parameter without hash symbol", "use :of_type => 'Type' style instead") unless Rails.env.production?
 
     options = args.extract_options!
 
     if args.length > 1
-      unless Rails.env.production?
-        msg = "[DEPRECATION] relationship_type parameter is deprecated.  Please use with_relationship_type method before calling instead.  At #{caller[1]}"
-        $log.warn msg
-        warn msg
-      end
+      Vmdb::Deprecation.deprecation_warning("relationship_type parameter", "use with_relationship_type method before calling instead") unless Rails.env.production?
     end
 
     [options.merge(:of_type => args.first)]
@@ -708,11 +696,7 @@ module RelationshipMixin
   def self.deprecate_start_parameter(*args)
     return args if args.empty? || args.first.kind_of?(Hash)
 
-    unless Rails.env.production?
-      msg = "[DEPRECATION] start parameter is deprecated.  At #{caller[1]}"
-      $log.warn msg
-      warn msg
-    end
+    Vmdb::Deprecation.deprecation_warning("start parameter") unless Rails.env.production?
 
     [args.extract_options!]
   end

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -1,5 +1,3 @@
-require 'active_support/deprecation'
-
 module ReportableMixin
   extend ActiveSupport::Concern
   included do
@@ -120,11 +118,11 @@ module ReportableMixin
   end
 
   def reportable_data(options = {})
-    ActiveSupport::Deprecation.warn "`reportable_data` is deprecated, use `reportable_data_with_columns` instead"
     columns, data_records = reportable_data_with_columns(options)
     self.class.aar_columns |= columns
     data_records
   end
+  Vmdb::Deprecation.deprecate_methods(self, :reportable_data => :reportable_data_with_columns)
 
   private
 

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -34,12 +34,10 @@ class ServiceOrchestration < Service
     save_option(:stack_name, stname)
   end
 
-  #
-  # deprecated
-  #
   def stack_ems_ref
     orchestration_stack.try(:ems_ref)
   end
+  Vmdb::Deprecation.deprecate_methods(ServiceOrchestration, :stack_ems_ref => "use orchestration_stack#ems_ref instead")
 
   def orchestration_stack_status
     return "check_status_failed", "stack has not been deployed" unless orchestration_stack

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,9 @@ class User < ActiveRecord::Base
 
   include ReportableMixin
 
+  include DeprecationMixin
+  deprecate_belongs_to :miq_group, :current_group
+
   @@role_ns  = "/managed/user"
   @@role_cat = "role"
 
@@ -90,26 +93,6 @@ class User < ActiveRecord::Base
   before_validation :nil_email_field_if_blank
   before_validation :dummy_password_for_external_auth
   before_destroy :destroy_subscribed_widget_sets
-
-  def miq_group
-    unless Rails.env.production?
-      msg = "[DEPRECATION] miq_group accessor is deprecated.  Please use current_group instead.  At #{caller[0]}"
-      $log.warn msg
-      warn msg
-    end
-
-    current_group
-  end
-
-  def miq_group=(group)
-    unless Rails.env.production?
-      msg = "[DEPRECATION] miq_group= accessor is deprecated.  Please use current_group= instead.  At #{caller[0]}"
-      $log.warn msg
-      warn msg
-    end
-
-    self.current_group = group
-  end
 
   def miq_group_description=(group_description)
     if group_description

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -25,7 +25,7 @@ class VimPerformanceDaily < MetricRollup
   def self.find(cnt, *args)
     raise "Unsupported finder value #{cnt}" unless cnt == :all
 
-    ActiveSupport::Deprecation.warn "VimPerformanceDaily#find(:all) is deprecated; please use #find_entries instead", caller
+    Vmdb::Deprecation.deprecated_method_warning(:find, :find_entries)
 
     options = args.last.kind_of?(Hash) ? args.last : {}
     ext_options = options.delete(:ext_options) || {}

--- a/lib/extensions/as_deprecation_custom_deprecator.rb
+++ b/lib/extensions/as_deprecation_custom_deprecator.rb
@@ -1,0 +1,11 @@
+# Fixed by https://github.com/rails/rails/pull/21953
+raise "Delete this patch in #{__FILE__}" if Gem::Version.new(Rails.version) >= Gem::Version.new("5.0")
+
+deprecate_methods_fix = Module.new do
+  def deprecate_methods(target_module, *method_names)
+    options = method_names.extract_options!
+    options.reverse_merge!(:deprecator => self)
+    super(target_module, *method_names.push(options))
+  end
+end
+ActiveSupport::Deprecation.prepend(deprecate_methods_fix)

--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -1,0 +1,5 @@
+Vmdb::Deprecation ||= begin
+  deprecator = ActiveSupport::Deprecation.new("D-release", "ManageIQ")
+  deprecator.behavior = [:stderr, :log]
+  deprecator
+end


### PR DESCRIPTION
Create a DeprecationMixin for consistency

```
irb(main):001:0> u = User.first
  User Load (1.4ms)  SELECT  "users".* FROM "users"  ORDER BY "users"."id" ASC LIMIT 1
  User Inst Including Associations (12.3ms - 1rows)
=> #<User id: 1, name: "Administrator", email: nil, icon: nil, created_on: "2015-07-21 21:09:51", updated_on: "2015-09-14 20:00:18", userid: "admin", settings: {}, filters: nil, lastlogon: "2015-09-14 20:00:18", lastlogoff: nil, region: 0, current_group_id: 1, first_name: nil, last_name: nil, password_digest: "$2a$10$Tu1FN9WQ0giI9FORkKyJnOE/DBRTTNOnp6hNLxVpbQX...">

irb(main):002:0> u.miq_group
[DEPRECATION] miq_group is deprecated.  Please use current_group instead.  At (irb):2:in `irb_binding'
  MiqGroup Load (0.6ms)  SELECT  "miq_groups".* FROM "miq_groups" WHERE ("miq_groups".id >= 0 AND "miq_groups".id <= 999999999999) AND "miq_groups"."id" = $1 LIMIT 1  [["id", 1]]
  MiqGroup Inst Including Associations (11.0ms - 1rows)
=> #<MiqGroup id: 1, guid: "d38ab926-2fec-11e5-b357-56847afe9799", description: "EvmGroup-super_administrator", group_type: "system", sequence: 1, resource_type: nil, resource_id: nil, filters: nil, created_on: "2015-07-21 21:09:51", updated_on: "2015-07-21 21:09:51", miq_user_role_id: 1, settings: nil, tenant_id: 1>

irb(main):003:0> u.miq_group = MiqGroup.last
  MiqGroup Load (1.1ms)  SELECT  "miq_groups".* FROM "miq_groups" WHERE ("miq_groups".id >= 0 AND "miq_groups".id <= 999999999999)  ORDER BY "miq_groups"."id" DESC LIMIT 1
  MiqGroup Inst Including Associations (0.2ms - 1rows)
[DEPRECATION] miq_group= is deprecated.  Please use current_group= instead.  At (irb):3:in `irb_binding'
  MiqUserRole Load (0.6ms)  SELECT  "miq_user_roles".* FROM "miq_user_roles" WHERE "miq_user_roles"."id" = $1 LIMIT 1  [["id", 10]]
  MiqUserRole Inst Including Associations (6.0ms - 1rows)
=> #<MiqGroup id: 12, guid: "d3951358-2fec-11e5-b357-56847afe9799", description: "EvmGroup-user_limited_self_service", group_type: "system", sequence: 12, resource_type: nil, resource_id: nil, filters: nil, created_on: "2015-07-21 21:09:51", updated_on: "2015-07-21 21:09:51", miq_user_role_id: 10, settings: nil, tenant_id: 1>

irb(main):004:0> u.current_group
=> #<MiqGroup id: 12, guid: "d3951358-2fec-11e5-b357-56847afe9799", description: "EvmGroup-user_limited_self_service", group_type: "system", sequence: 12, resource_type: nil, resource_id: nil, filters: nil, created_on: "2015-07-21 21:09:51", updated_on: "2015-07-21 21:09:51", miq_user_role_id: 10, settings: nil, tenant_id: 1>
```