### PR TITLE
Add user object to Automate

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -172,6 +172,7 @@ module ApplicationController::Automate
       :message     => @resolve[:new][:object_message]
     }
     @results = MiqAeEngine.resolve_automation_object(@sb[:name],
+                                                     User.current_user,
                                                      @sb[:attrs],
                                                      options,
                                                      @resolve[:new][:readonly]).to_expanded_xml

--- a/app/models/miq_provision/automate.rb
+++ b/app/models/miq_provision/automate.rb
@@ -12,7 +12,7 @@ module MiqProvision::Automate
       attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_domains'}
       attrs[MiqAeEngine.create_automation_attribute_key(user)] = MiqAeEngine.create_automation_attribute_value(user) unless user.nil?
 
-      ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs)
+      ws = MiqAeEngine.resolve_automation_object("REQUEST", user, attrs)
       if ws.root.nil?
         _log.warn "- Automate Failed (workspace empty)"
         return nil
@@ -38,7 +38,7 @@ module MiqProvision::Automate
       'message' => 'get_placement'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
 
     {
@@ -54,7 +54,7 @@ module MiqProvision::Automate
       'message' => 'get_availability_zone'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["availability_zone"])
   end
@@ -66,7 +66,7 @@ module MiqProvision::Automate
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
 
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     host      = MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["host"])
     datastore = MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["storage"])
@@ -79,7 +79,7 @@ module MiqProvision::Automate
       'message' => 'get_cluster'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["cluster"])
   end
@@ -90,7 +90,7 @@ module MiqProvision::Automate
       'message' => 'get_host'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => self)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["host"])
   end
@@ -133,7 +133,7 @@ module MiqProvision::Automate
       'message' => 'get_networks'
     }
     attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs)
 
     if ws.root.nil?
       _log.warn "- Automate Failed (workspace empty)"

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -13,7 +13,7 @@ module MiqProvision::Naming
         prov_obj.save
         attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'}
         attrs[MiqAeEngine.create_automation_attribute_key(prov_obj.get_user)] = MiqAeEngine.create_automation_attribute_value(prov_obj.get_user) unless prov_obj.get_user.nil?
-        ws  = MiqAeEngine.resolve_automation_object("REQUEST", prov_obj.get_user, attrs, :vmdb_object => prov_obj)
+        ws = MiqAeEngine.resolve_automation_object("REQUEST", prov_obj.get_user, attrs, :vmdb_object => prov_obj)
         unresolved_vm_name = ws.root("vmname")
         prov_obj.reload
       end

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -13,7 +13,7 @@ module MiqProvision::Naming
         prov_obj.save
         attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'}
         attrs[MiqAeEngine.create_automation_attribute_key(prov_obj.get_user)] = MiqAeEngine.create_automation_attribute_value(prov_obj.get_user) unless prov_obj.get_user.nil?
-        ws  = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => prov_obj)
+        ws  = MiqAeEngine.resolve_automation_object("REQUEST", prov_obj.get_user, attrs, :vmdb_object => prov_obj)
         unresolved_vm_name = ws.root("vmname")
         prov_obj.reload
       end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -711,7 +711,7 @@ class MiqRequestWorkflow
 
     input_fields.each { |k| attrs["dialog_input_#{k.to_s.downcase}"] = send(k).to_s }
 
-    ws = MiqAeEngine.resolve_automation_object("REQUEST", attrs, :vmdb_object => @requester)
+    ws = MiqAeEngine.resolve_automation_object("REQUEST", @requester, attrs, :vmdb_object => @requester)
 
     if ws && ws.root
       dialog_option_prefix = 'dialog_option_'

--- a/app/models/service_template/filter.rb
+++ b/app/models/service_template/filter.rb
@@ -5,14 +5,15 @@ module ServiceTemplate::Filter
     def include_service_template?(parent_svc_task, service_template_id, parent_svc = nil)
       attrs = {'request' => 'SERVICE_PROVISION_INFO', 'message' => 'include_service'}
       st = ServiceTemplate.find(service_template_id)
-      obj_array = [parent_svc_task.get_user, st, parent_svc, parent_svc_task]
+      user = parent_svc_task.get_user
+      obj_array = [user, st, parent_svc, parent_svc_task]
       MiqAeEngine.set_automation_attributes_from_objects(obj_array, attrs)
       uri = MiqAeEngine.create_automation_object("REQUEST", attrs, :vmdb_object => parent_svc_task)
-      automate_result_include_service_template?(uri, st.name)
+      automate_result_include_service_template?(uri, user, st.name)
     end
 
-    def automate_result_include_service_template?(uri, name)
-      ws  = MiqAeEngine.resolve_automation_object(uri)
+    def automate_result_include_service_template?(uri, user, name)
+      ws  = MiqAeEngine.resolve_automation_object(uri, user)
       result = ws.root['include_service'].nil? ? true : ws.root['include_service']
       _log.info("Include Service Template <#{name}> : <#{result}>")
       result

--- a/app/models/service_template/filter.rb
+++ b/app/models/service_template/filter.rb
@@ -13,7 +13,7 @@ module ServiceTemplate::Filter
     end
 
     def automate_result_include_service_template?(uri, user, name)
-      ws  = MiqAeEngine.resolve_automation_object(uri, user)
+      ws = MiqAeEngine.resolve_automation_object(uri, user)
       result = ws.root['include_service'].nil? ? true : ws.root['include_service']
       _log.info("Include Service Template <#{name}> : <#{result}>")
       result

--- a/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
@@ -1,10 +1,13 @@
 module MiqAeEngine
   class MiqAeDomainSearch
     def initialize
-      @sorted_domains      = MiqAeDomain.enabled.order("priority DESC").pluck(:name)
       @fqns_id_cache       = {}
       @fqns_id_class_cache = {}
       @partial_ns          = []
+    end
+
+    def ae_user=(obj)
+      @sorted_domains ||= obj.current_tenant.enabled_domains.collect(&:name)
     end
 
     def get_alternate_domain(scheme, uri, ns, klass, instance)

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -74,7 +74,7 @@ module MiqAeEngine
 
     options[:instance_name] ||= 'AUTOMATION'
     options[:attrs] ||= {}
-    options[:tenant_id] ||= Tenant.root_tenant.try(:id)
+    user_obj = ae_user_object(options)
 
     object_type      = options[:object_type]
     object_id        = options[:object_id]
@@ -87,7 +87,6 @@ module MiqAeEngine
     ae_state_previous = options[:ae_state_previous]
     vmdb_object      = nil
     ae_result        = 'error'
-    tenant_id        = options[:tenant_id]
 
     begin
       object_name = "#{object_type}.#{object_id}"
@@ -106,7 +105,6 @@ module MiqAeEngine
       automate_attrs[:ae_state_retries] = ae_state_retries   unless ae_state_retries.nil?
       automate_attrs['ae_state_data']   = ae_state_data      unless ae_state_data.nil?
       automate_attrs['ae_state_previous'] = ae_state_previous  unless ae_state_previous.nil?
-      automate_attrs['Tenant::tenant']    = tenant_id          unless tenant_id.nil?
 
       create_automation_object_options = {}
       create_automation_object_options[:vmdb_object] = vmdb_object                unless vmdb_object.nil?
@@ -115,7 +113,7 @@ module MiqAeEngine
       create_automation_object_options[:fqclass]     = options[:fqclass_name]     unless options[:fqclass_name].nil?
       create_automation_object_options[:message]     = options[:automate_message] unless options[:automate_message].nil?
       uri = create_automation_object(options[:instance_name], automate_attrs, create_automation_object_options)
-      ws  = resolve_automation_object(uri)
+      ws  = resolve_automation_object(uri, user_obj)
 
       if ws.nil? || ws.root.nil?
         message = "Error delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate: Empty Workspace"
@@ -292,7 +290,6 @@ module MiqAeEngine
   def self.create_ae_attrs(attrs, name, vmdb_object, objects = [MiqServer.my_server, User.current_user])
     ae_attrs  = attrs.dup
     ae_attrs['object_name'] = name
-    ae_attrs['tenant_id'] ||= Tenant.root_tenant.try(:id)
 
     # Prepare for conversion to Automate MiqAeService objects (process vmdb_object first in case it is a User or MiqServer)
     ([vmdb_object] + objects).each do |object|
@@ -310,18 +307,25 @@ module MiqAeEngine
     array_objects.each do |o|
       ae_attrs[o] = ae_attrs[o].first   if ae_attrs[o].kind_of?(Array)
     end
-    tenant_id = ae_attrs.delete('tenant_id')
-    ae_attrs['Tenant::tenant'] = tenant_id if tenant_id
     ae_attrs
   end
 
   # side effect in options, :uri is set
   # returns workspace
-  def self.resolve_automation_object(uri, attr = nil, options = {}, readonly = false)
+  def self.resolve_automation_object(uri, user_obj, attr = nil, options = {}, readonly = false)
+    raise "User object not passed in" unless user_obj.kind_of?(User)
     uri = create_automation_object(uri, attr, options) if attr
     options[:uri] = uri
-    MiqAeWorkspaceRuntime.instantiate(uri, :readonly => readonly).tap do
+    MiqAeWorkspaceRuntime.instantiate(uri, user_obj, :readonly => readonly).tap do
       $miq_ae_logger.debug { ws.to_expanded_xml }
+    end
+  end
+
+  def self.ae_user_object(options = {})
+    raise "user_id not specified in Automation request" if options[:user_id].blank?
+    # raise "group_id not specified in Automation request" if options[:group_id].blank?
+    User.find_by!(:id => options[:user_id]).tap do |obj|
+      # obj.current_group = MiqGroup.find_by!(:id => options[:group_id])
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -323,9 +323,9 @@ module MiqAeEngine
 
   def self.ae_user_object(options = {})
     raise "user_id not specified in Automation request" if options[:user_id].blank?
-    # raise "group_id not specified in Automation request" if options[:group_id].blank?
+    # raise "group_id not specified in Automation request" if options[:miq_group_id].blank?
     User.find_by!(:id => options[:user_id]).tap do |obj|
-      # obj.current_group = MiqGroup.find_by!(:id => options[:group_id])
+      # obj.current_group = MiqGroup.find_by!(:id => options[:miq_group_id])
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -121,7 +121,7 @@ module MiqAeEvent
   end
 
   def self.automate_user
-    #TODO: Get the real userid to pass into Automate
+    # TODO: Get the real userid to pass into Automate
     user = User.where(:userid => "admin").first
     raise "Admin user needed to raise events" unless user
     user

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -555,12 +555,12 @@ module MiqAeEngine
         rels = []
         wildcard_expand(relationship).each do|r|
           Benchmark.current_realtime[:relationship_followed_count] += 1
-          rels << @workspace.instantiate(r, self)
+          rels << @workspace.instantiate(r, @workspace.ae_user, self)
         end
         process_collects(collect, rels)
       else
         Benchmark.current_realtime[:relationship_followed_count] += 1
-        rels = @workspace.instantiate(relationship, self)
+        rels = @workspace.instantiate(relationship, @workspace.ae_user, self)
         process_collects(collect, rels)
       end
       @rels[name] = rels

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -125,7 +125,7 @@ module MiqAeMethodService
     end
 
     def instantiate(uri)
-      obj = @workspace.instantiate(uri, @workspace.current_object)
+      obj = @workspace.instantiate(uri, @workspace.ae_user, @workspace.current_object)
       return nil if obj.nil?
       drb_return(MiqAeServiceObject.new(obj, self))
     rescue => e

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -37,6 +37,7 @@ module MiqAeEngine
   class MiqAeWorkspaceRuntime
     attr_accessor :graph, :num_drb_methods, :class_methods
     attr_accessor :datastore_cache, :persist_state_hash, :current_state_info
+    attr_accessor :ae_user
     include MiqAeStateInfo
 
     attr_reader :nodes
@@ -52,15 +53,16 @@ module MiqAeEngine
       @persist_state_hash = HashWithIndifferentAccess.new
       @current_state_info = {}
       @state_machine_objects = []
+      @ae_user            = nil
     end
 
     def readonly?
       @readonly
     end
 
-    def self.instantiate(uri, attrs = {})
+    def self.instantiate(uri, user, attrs = {})
       workspace = MiqAeWorkspaceRuntime.new(attrs)
-      workspace.instantiate(uri, nil)
+      workspace.instantiate(uri, user, nil)
       workspace
     rescue MiqAeException
     end
@@ -93,9 +95,10 @@ module MiqAeEngine
       false
     end
 
-    def instantiate(uri, root = nil)
+    def instantiate(uri, user, root = nil)
       $miq_ae_logger.info("Instantiating [#{uri}]") if root.nil?
-
+      @ae_user = user
+      @dom_search.ae_user = user
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(uri, "miqaedb")
       raise "Unsupported Scheme [#{scheme}]" unless MiqAeUri.scheme_supported?(scheme)
       raise "Invalid URI <#{uri}>" if path.nil?

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -53,7 +53,7 @@ module MiqAeEngine
       @persist_state_hash = HashWithIndifferentAccess.new
       @current_state_info = {}
       @state_machine_objects = []
-      @ae_user            = nil
+      @ae_user = nil
     end
 
     def readonly?

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -10,7 +10,10 @@ module EvmAutomate
   end
 
   def self.simulate(domain, namespace, class_name, instance_name)
+    user = User.where(:userid => 'admin').first
+    raise "Need a admin user to run simulation" unless user
     MiqAeEngine.resolve_automation_object(instance_name,
+                                          user,
                                           {},
                                           :fqclass => "#{domain}/#{namespace}/#{class_name}")
   end

--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_multi_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_multi_spec.rb
@@ -19,6 +19,7 @@ describe "MultipleStateMachineSteps" do
     @state_class3        = 'SM3'
     @state_instance      = 'MY_STATE_INSTANCE'
     @fqname              = '/SPEC_DOMAIN/NS1/SM1/MY_STATE_INSTANCE'
+    @user                = FactoryGirl.create(:user_with_group)
     @method_params       = {'ae_result'     => {:datatype => 'string', 'default_value' => 'ok'},
                             'ae_next_state' => {:datatype => 'string'},
                             'raise'         => {:datatype => 'string'}
@@ -26,6 +27,7 @@ describe "MultipleStateMachineSteps" do
     @automate_args   = {:namespace        => "#{@domain}/#{@namespace}",
                         :class_name       => @state_class1,
                         :instance_name    => @state_instance,
+                        :user_id          => @user.id,
                         :automate_message => 'create'}
     MiqServer.stub(:my_zone).and_return('default')
     clear_domain

--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -13,9 +13,11 @@ describe "MiqAeStateMachineRetry" do
     @max_time        = 2
     @root_class      = "TOP_OF_THE_WORLD"
     @root_instance   = "EVEREST"
+    @user            = FactoryGirl.create(:user_with_group)
     @automate_args   = {:namespace        => @namespace,
                         :class_name       => @root_class,
                         :instance_name    => @root_instance,
+                        :user_id          => @user.id,
                         :automate_message => 'create'}
     MiqServer.stub(:my_zone).and_return('default')
     clear_domain

--- a/spec/lib/miq_automation_engine/miq_ae_discovery_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_discovery_spec.rb
@@ -8,6 +8,8 @@ module MiqAeDiscoverySpec
       @event  = FactoryGirl.create(:ems_event, :event_type => "CreateVM_Task_Complete",
                                   :source => "VC", :ems_id => 1, :vm_or_template_id => @vm.id)
       @domain = "SPEC_DOMAIN"
+      # admin user is needed to process Events
+      FactoryGirl.create(:user_with_group, :userid => "admin", :name => "Administrator")
       @model_data_dir = File.join(File.dirname(__FILE__), "data")
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "discovery"), @domain)
     end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -41,7 +41,9 @@ module MiqAeEngineSpec
           :attrs            => {"request" => "InspectMe"},
           :object_type      => @vm.class.name,
           :object_id        => @vm.id,
-          :user_id          => @user.id
+          :user_id          => @user.id,
+          :miq_group_id     => @user.current_group.id,
+          :tenant_id        => @user.current_tenant.id
         }
 
         q = MiqQueue.put(
@@ -68,7 +70,7 @@ module MiqAeEngineSpec
           object_type = @cluster.class.name
           object_id   = @cluster.id
           automate_attrs = {"#{object_type}::#{object_type.underscore}" => object_id,
-                            "User::user" => @user.id}
+                            "User::user"                                => @user.id}
           MiqAeEngine.should_receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @cluster}).and_return('uri')
           MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should be_nil
         end
@@ -78,7 +80,7 @@ module MiqAeEngineSpec
           object_type = @ems.class.name
           object_id   = @ems.id
           automate_attrs = {"#{base_name}::#{base_name.underscore}" => object_id,
-                            "User::user" => @user.id}
+                            "User::user"                            => @user.id}
           MiqAeEngine.should_receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @ems}).and_return('uri')
           MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should be_nil
         end
@@ -120,7 +122,7 @@ module MiqAeEngineSpec
             args[:instance_name]    = "DEFAULT"
             args[:fqclass_name] = "Factory/StateMachines/ServiceProvision_template"
             args[:user_id] = @user.id
-            MiqAeEngine.should_receive(:create_automation_object).with("DEFAULT", attrs, {:fqclass => "Factory/StateMachines/ServiceProvision_template"}).and_return('uri')
+            MiqAeEngine.should_receive(:create_automation_object).with("DEFAULT", attrs, :fqclass => "Factory/StateMachines/ServiceProvision_template").and_return('uri')
             MiqAeEngine.deliver(args).should == @ws
           end
         end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -6,6 +6,7 @@ module MiqAeEngineSpec
     before(:each) do
       MiqAeDatastore.reset
       EvmSpecHelper.local_guid_miq_server_zone
+      @user   = FactoryGirl.create(:user_with_group)
       @domain = 'SPEC_DOMAIN'
       @model_data_dir = File.join(File.dirname(__FILE__), "data")
       @root_tenant_id = Tenant.root_tenant.id
@@ -39,7 +40,8 @@ module MiqAeEngineSpec
           :automate_message => "create",
           :attrs            => {"request" => "InspectMe"},
           :object_type      => @vm.class.name,
-          :object_id        => @vm.id
+          :object_id        => @vm.id,
+          :user_id          => @user.id
         }
 
         q = MiqQueue.put(
@@ -66,9 +68,9 @@ module MiqAeEngineSpec
           object_type = @cluster.class.name
           object_id   = @cluster.id
           automate_attrs = {"#{object_type}::#{object_type.underscore}" => object_id,
-                            "Tenant::tenant"                            => @root_tenant_id}
+                            "User::user" => @user.id}
           MiqAeEngine.should_receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @cluster}).and_return('uri')
-          MiqAeEngine.deliver(object_type, object_id).should be_nil
+          MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should be_nil
         end
 
         it "with defaults and STI object" do
@@ -76,9 +78,9 @@ module MiqAeEngineSpec
           object_type = @ems.class.name
           object_id   = @ems.id
           automate_attrs = {"#{base_name}::#{base_name.underscore}" => object_id,
-                            "Tenant::tenant"                        => @root_tenant_id}
+                            "User::user" => @user.id}
           MiqAeEngine.should_receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @ems}).and_return('uri')
-          MiqAeEngine.deliver(object_type, object_id).should be_nil
+          MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should be_nil
         end
       end
 
@@ -94,7 +96,7 @@ module MiqAeEngineSpec
           it "with defaults" do
             object_type = @ems.class.name
             object_id   = @ems.id
-            MiqAeEngine.deliver(object_type, object_id).should == @ws
+            MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should == @ws
           end
         end
 
@@ -109,15 +111,16 @@ module MiqAeEngineSpec
           it "with defaults" do
             object_type = @ems.class.name
             object_id   = @ems.id
-            MiqAeEngine.deliver(object_type, object_id).should == @ws
+            MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should == @ws
           end
 
           it "with a starting point instead of /SYSTEM/PROCESS" do
             args = {}
-            automate_attrs =  {"Tenant::tenant" => @root_tenant_id}
+            attrs = {'User::user' => @user.id}
             args[:instance_name]    = "DEFAULT"
             args[:fqclass_name] = "Factory/StateMachines/ServiceProvision_template"
-            MiqAeEngine.should_receive(:create_automation_object).with("DEFAULT", automate_attrs, {:fqclass => "Factory/StateMachines/ServiceProvision_template"}).and_return('uri')
+            args[:user_id] = @user.id
+            MiqAeEngine.should_receive(:create_automation_object).with("DEFAULT", attrs, {:fqclass => "Factory/StateMachines/ServiceProvision_template"}).and_return('uri')
             MiqAeEngine.deliver(args).should == @ws
           end
         end
@@ -135,7 +138,7 @@ module MiqAeEngineSpec
           it "with defaults" do
             object_type = @ems.class.name
             object_id   = @ems.id
-            MiqAeEngine.deliver(object_type, object_id).should == @ws
+            MiqAeEngine.deliver(object_type, object_id, nil, nil, @user.id).should == @ws
 
             MiqQueue.count.should == 1
 
@@ -151,13 +154,12 @@ module MiqAeEngineSpec
               :object_id        => object_id,
               :attrs            => @attrs,
               :instance_name    => @instance_name,
-              :user_id          => @user_id,
+              :user_id          => @user.id,
               :state            => @state,
               :automate_message => @automate_message,
               :ae_fsm_started   => @ae_fsm_started,
               :ae_state_started => @ae_state_started,
               :ae_state_retries => @ae_state_retries,
-              :tenant_id        => @root_tenant_id
             }
             q.args.first.should == args
           end
@@ -167,7 +169,7 @@ module MiqAeEngineSpec
 
     context ".create_automation_object" do
       it "with various URIs" do
-        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         env = 'dev'
         {
           "/System/Process/REQUEST?#{extras}&environment=#{env}&message=get_container_info&object_name=REQUEST&request=UI_PROVISION_INFO"  => {'request' => 'UI_PROVISION_INFO', 'message' => 'get_container_info',  'environment' => env},
@@ -200,7 +202,7 @@ module MiqAeEngineSpec
 
       it "with a Vm (special case)" do
         vm = FactoryGirl.create(:vm_vmware)
-        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         uri = "/System/Process/AUTOMATION?#{extras}&VmOrTemplate%3A%3Avm=#{vm.id}&object_name=AUTOMATION&vmdb_object_type=vm"
         MiqAeEngine.create_automation_object("AUTOMATION", {}, :vmdb_object => vm).should == uri
       end
@@ -209,7 +211,7 @@ module MiqAeEngineSpec
         vm = FactoryGirl.create(:vm_vmware)
         fqclass = "Factory/StateMachines/ServiceProvision_template"
         uri = MiqAeEngine.create_automation_object("DEFAULT", {}, :vmdb_object => vm, :fqclass => fqclass)
-        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         expected_uri = "/#{fqclass}/DEFAULT?#{extras}&VmOrTemplate%3A%3Avm=#{vm.id}&object_name=DEFAULT&vmdb_object_type=vm"
         uri.should == expected_uri
       end
@@ -217,7 +219,7 @@ module MiqAeEngineSpec
       it "will not override values in attrs" do
         host  = FactoryGirl.create(:host)
         attrs = {"Host::host" => host.id, "MiqServer::miq_server" => "12"}
-        extras = "MiqServer%3A%3Amiq_server=12&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=12"
         uri = "/System/Process/AUTOMATION?Host%3A%3Ahost=#{host.id}&#{extras}&object_name=AUTOMATION&vmdb_object_type=host"
         MiqAeEngine.create_automation_object("AUTOMATION", attrs, :vmdb_object => host).should == uri
       end
@@ -227,7 +229,7 @@ module MiqAeEngineSpec
         hash       = {"hosts" => Host.all}
         attrs      = {"Array::my_hosts" => hash["hosts"].collect { |h| "Host::#{h.id}" }}
         result_str = "Array%3A%3Amy_hosts=" + hash["hosts"].collect { |h| "Host%3A%3A#{h.id}" }.join(",")
-        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         uri = "/System/Process/AUTOMATION?#{result_str}&#{extras}&object_name=AUTOMATION"
         MiqAeEngine.create_automation_object("AUTOMATION", attrs).should == uri
       end
@@ -235,13 +237,13 @@ module MiqAeEngineSpec
       it "will process an empty array" do
         attrs      = {"Array::my_hosts" => ""}
         result_str = "Array%3A%3Amy_hosts="""
-        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         uri = "/System/Process/AUTOMATION?#{result_str}&#{extras}&object_name=AUTOMATION"
         MiqAeEngine.create_automation_object("AUTOMATION", attrs).should == uri
       end
 
       it "will process an array of objects with a server and user" do
-        extras = "MiqServer%3A%3Amiq_server=12&Tenant%3A%3Atenant=#{@root_tenant_id}"
+        extras = "MiqServer%3A%3Amiq_server=12"
         FactoryGirl.create(:small_environment)
         attrs = {"MiqServer::miq_server" => "12", "array::tag" => "Classification::1,Classification::2"}
         result_str = "array%3A%3Atag=Classification%3A%3A1%2CClassification%3A%3A2"
@@ -422,7 +424,7 @@ module MiqAeEngineSpec
     it "a namespace containing a slash is parsed correctly " do
       start   = "namespace/more_namespace/my_favorite_class"
       msg_attrs = "message=testmessage&object_name=REQUEST&request=NOT_THERE"
-      extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+      extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
       uri =  "/namespace/more_namespace/my_favorite_class/REQUEST?#{extras}&#{msg_attrs}"
       attrs  = {'request' => 'NOT_THERE', 'message' => 'testmessage'}
       MiqAeEngine.create_automation_object('REQUEST', attrs, :fqclass => start).should == uri
@@ -431,7 +433,7 @@ module MiqAeEngineSpec
     it "a namespace not containing a slash is parsed correctly " do
       start   = "namespace/my_favorite_class"
       msg_attrs = "message=testmessage&object_name=REQUEST&request=NOT_THERE"
-      extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}&Tenant%3A%3Atenant=#{@root_tenant_id}"
+      extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
       uri =  "/namespace/my_favorite_class/REQUEST?#{extras}&#{msg_attrs}"
       attrs  = {'request' => 'NOT_THERE', 'message' => 'testmessage'}
       MiqAeEngine.create_automation_object('REQUEST', attrs, :fqclass => start).should == uri
@@ -448,15 +450,15 @@ module MiqAeEngineSpec
       roots.length.should == 1
       roots.first.attributes["attr1"].should == "Gregg TEST2 Oleg"
 
-      ws.instantiate("/EVM/AUTOMATE/test2")
+      ws.instantiate("/EVM/AUTOMATE/test2", @user)
       ws.roots.length.should == 2
       ws.roots[1].attributes["attr1"].should == "TEST2"
 
-      ws.instantiate("/EVM/AUTOMATE/test1")
+      ws.instantiate("/EVM/AUTOMATE/test1", @user)
       ws.roots.length.should == 3
       ws.roots[2].attributes["attr1"].should == "frank"
 
-      ws.instantiate("/EVM/AUTOMATE/test4")
+      ws.instantiate("/EVM/AUTOMATE/test4", @user)
       ws.roots.length.should == 4
       ws.roots[3].attributes["attr1"].should == "frank"
 

--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -15,6 +15,8 @@ describe "MiqAeMethodDispatch" do
                         :class_name       => @root_class,
                         :instance_name    => @root_instance,
                         :user_id          => @user.id,
+                        :miq_group_id     => @user.current_group.id,
+                        :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
     MiqServer.stub(:my_zone).and_return('default')
     @pidfile = File.join(Dir.mktmpdir, "rip_van_winkle.pid")

--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -10,9 +10,11 @@ describe "MiqAeMethodDispatch" do
     @namespace       = 'NS1'
     @root_class      = "TOP_OF_THE_WORLD"
     @root_instance   = "EVEREST"
+    @user            = FactoryGirl.create(:user_with_group)
     @automate_args   = {:namespace        => @namespace,
                         :class_name       => @root_class,
                         :instance_name    => @root_instance,
+                        :user_id          => @user.id,
                         :automate_message => 'create'}
     MiqServer.stub(:my_zone).and_return('default')
     @pidfile = File.join(Dir.mktmpdir, "rip_van_winkle.pid")

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -16,7 +16,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
   it "pass platform attributes to automate" do
     stub_dialog
-    assert_automate_dialog_lookup('cloud', 'amazon')
+    assert_automate_dialog_lookup(admin, 'cloud', 'amazon')
 
     described_class.new({}, admin.userid)
   end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
 
   it "pass platform attributes to automate" do
     stub_dialog
-    assert_automate_dialog_lookup('infra', 'microsoft')
+    assert_automate_dialog_lookup(admin, 'infra', 'microsoft')
 
     described_class.new({}, admin.userid)
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
   context "With a user" do
     it "pass platform attributes to automate" do
       stub_dialog
-      assert_automate_dialog_lookup('cloud', 'openstack')
+      assert_automate_dialog_lookup(admin, 'cloud', 'openstack')
 
       described_class.new({}, admin.userid)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
   end
 
   it "pass platform attributes to automate" do
-    assert_automate_dialog_lookup("infra", "redhat", "get_pre_dialog_name", nil)
+    assert_automate_dialog_lookup(admin, "infra", "redhat", "get_pre_dialog_name", nil)
 
     described_class.new({}, admin.userid)
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -15,7 +15,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
   describe "#new" do
     it "pass platform attributes to automate" do
       stub_dialog(:get_dialogs)
-      assert_automate_dialog_lookup("infra", "vmware", "get_pre_dialog_name", nil)
+      assert_automate_dialog_lookup(admin, "infra", "vmware", "get_pre_dialog_name", nil)
 
       described_class.new({}, admin.userid)
     end

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -4,7 +4,7 @@ describe MiqProvision do
   context "A new provision request," do
     before(:each) do
       @os = OperatingSystem.new(:product_name => 'Microsoft Windows')
-      @admin = FactoryGirl.create(:user_admin)
+      @admin = FactoryGirl.create(:user_with_group, :role => "admin")
       @target_vm_name = 'clone test'
       @options = {
         :pass          => 1,

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe MiqRequest do
-  let(:fred)   { FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred',   :email => "fred@example.com") }
-  let(:barney) { FactoryGirl.create(:user, :name => 'Barney Rubble',   :userid => 'barney', :email => "barney@example.com") }
+  let(:fred)   { FactoryGirl.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred',   :email => "fred@example.com") }
+  let(:barney) { FactoryGirl.create(:user_with_group, :name => 'Barney Rubble',   :userid => 'barney', :email => "barney@example.com") }
 
   context "CONSTANTS" do
     it "REQUEST_TYPES" do

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -65,7 +65,7 @@ describe "Service Filter" do
       let(:options) { {'include_service' => true} }
       it "check true value" do
         MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
-        expect(test_class.automate_result_include_service_template?('a', 'b')).to be_true
+        expect(test_class.automate_result_include_service_template?('a', @user, 'b')).to be_true
       end
     end
 
@@ -73,7 +73,7 @@ describe "Service Filter" do
       let(:options) { {'include_service' => false} }
       it "check false value" do
         MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
-        expect(test_class.automate_result_include_service_template?('a', 'b')).to be_false
+        expect(test_class.automate_result_include_service_template?('a', @user, 'b')).to be_false
       end
     end
 
@@ -81,7 +81,7 @@ describe "Service Filter" do
       let(:options) { {} }
       it "check nil value" do
         MiqAeEngine.stub(:resolve_automation_object).and_return(workspace)
-        expect(test_class.automate_result_include_service_template?('a', 'b')).to be_true
+        expect(test_class.automate_result_include_service_template?('a', @user, 'b')).to be_true
       end
     end
   end

--- a/spec/support/miq_ae_engine_monkeypatch.rb
+++ b/spec/support/miq_ae_engine_monkeypatch.rb
@@ -1,6 +1,6 @@
 module MiqAeEngine
   def self.instantiate(uri)
-    EvmSpecHelper.create_root_tenant
+    Tenant.seed
     user = FactoryGirl.create(:user_with_group)
     MiqAeWorkspaceRuntime.instantiate(uri, user)
   end

--- a/spec/support/miq_ae_engine_monkeypatch.rb
+++ b/spec/support/miq_ae_engine_monkeypatch.rb
@@ -1,0 +1,7 @@
+module MiqAeEngine
+  def self.instantiate(uri)
+    EvmSpecHelper.create_root_tenant
+    user = FactoryGirl.create(:user_with_group)
+    MiqAeWorkspaceRuntime.instantiate(uri, user)
+  end
+end

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -87,6 +87,6 @@ module ServiceTemplateHelper
 
   def user_helper
     User.any_instance.stub(:role).and_return("admin")
-    @user        = FactoryGirl.create(:user_with_group, :name => 'Wilma',  :userid => 'wilma')
+    @user = FactoryGirl.create(:user_with_group, :name => 'Wilma', :userid => 'wilma')
   end
 end

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -80,13 +80,13 @@ module ServiceTemplateHelper
   end
 
   def service_template_stubs
-    ServiceTemplate.stub(:automate_result_include_service_template?) do |_uri, name|
+    ServiceTemplate.stub(:automate_result_include_service_template?) do |_uri, _user, name|
       @allowed_service_templates.include?(name)
     end
   end
 
   def user_helper
     User.any_instance.stub(:role).and_return("admin")
-    @user        = FactoryGirl.create(:user, :name => 'Wilma',  :userid => 'wilma')
+    @user        = FactoryGirl.create(:user_with_group, :name => 'Wilma',  :userid => 'wilma')
   end
 end

--- a/spec/support/workflow_spec_helper.rb
+++ b/spec/support/workflow_spec_helper.rb
@@ -7,9 +7,9 @@ module WorkflowSpecHelper
     allow(MiqProvision).to receive(:get_next_vm_name).and_return(vm_name)
   end
 
-  def assert_automate_dialog_lookup(category, platform, method = 'get_pre_dialog_name', dialog_name = nil)
+  def assert_automate_dialog_lookup(user, category, platform, method = 'get_pre_dialog_name', dialog_name = nil)
     no_attrs = double(:attributes => [])
-    stub_automate_workspace(dialog_name, no_attrs, no_attrs, dialog_name)
+    stub_automate_workspace(dialog_name, user, no_attrs, no_attrs, dialog_name)
 
     expect(MiqAeEngine).to receive(:create_automation_object).with(
       "REQUEST",
@@ -25,7 +25,7 @@ module WorkflowSpecHelper
   end
 
   def assert_automate_vm_name_lookup(user, vm_name = 'vm_name')
-    stub_automate_workspace("get_vmname_url", vm_name)
+    stub_automate_workspace("get_vmname_url", user, vm_name)
 
     MiqAeEngine.should_receive(:create_automation_object).with(
       "REQUEST",
@@ -37,9 +37,9 @@ module WorkflowSpecHelper
       anything).and_return("get_vmname_url")
   end
 
-  def stub_automate_workspace(url, *result)
+  def stub_automate_workspace(url, user, *result)
     workspace_stub = double
-    expect(workspace_stub).to receive(:instantiate).with(url, nil)
+    expect(workspace_stub).to receive(:instantiate).with(url, user, nil)
     expect(workspace_stub).to receive(:root).and_return(*result)
     expect(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:new).and_return(workspace_stub)
   end


### PR DESCRIPTION
Pass User object into Automate
    
    The model, workflow and specs have been modified to pass in the User
    object or the user id.
    When calling automate via the MiqQueue we need the user id.
    When calling direct within the same thread we need the user object.