### PR TITLE
Update translation catalogs

### DIFF
--- a/config/locales/en/manageiq.po
+++ b/config/locales/en/manageiq.po
@@ -40,6 +40,9 @@ msgstr ""
 msgid " Selected Alerts:"
 msgstr ""
 
+msgid " Valid numeric quota value required "
+msgstr ""
+
 msgid " that match the entered search string"
 msgstr ""
 
@@ -70,6 +73,12 @@ msgstr ""
 msgid "\"%{record}\": %{task} successfully initiated"
 msgstr ""
 
+msgid "\"%{record}\": Analysis successfully initiated"
+msgstr ""
+
+msgid "\"Unable to initiate scaling, obtaining of status failed: #{ex}\""
+msgstr ""
+
 msgid "% Savings"
 msgstr ""
 
@@ -85,16 +94,19 @@ msgstr ""
 msgid "%s  Ending with"
 msgstr ""
 
-msgid "%s & %s"
+msgid "%s (%s)"
 msgstr ""
 
-msgid "%s (%s)"
+msgid "%s (0)"
 msgstr ""
 
 msgid "%s (All %s)"
 msgstr ""
 
 msgid "%s (All cloud tenants present on this host)"
+msgstr ""
+
+msgid "%s Alert Profiles"
 msgstr ""
 
 msgid "%s Being Tagged"
@@ -111,11 +123,6 @@ msgstr ""
 
 msgid "%s Credentials validated successfully"
 msgstr ""
-
-msgid "%s Day"
-msgid_plural "%s Days"
-msgstr[0] ""
-msgstr[1] ""
 
 msgid "%s Days Ago"
 msgstr ""
@@ -166,9 +173,6 @@ msgstr ""
 msgid "%s Summary"
 msgstr ""
 
-msgid "%s Tags"
-msgstr ""
-
 msgid "%s Utilization"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "%s has no network adapters"
 msgstr ""
 
-msgid "%s has no snapshots."
+msgid "%s has no snapshots"
 msgstr ""
 
 msgid "%s is currently being used in the Display Filter"
@@ -246,6 +250,9 @@ msgstr ""
 msgid "%s record no longer exists"
 msgstr ""
 
+msgid "%s requests cannot be deleted"
+msgstr ""
+
 msgid "%s saved"
 msgstr ""
 
@@ -265,11 +272,6 @@ msgid "%s tab is not available unless at least 1 time field has been selected"
 msgstr ""
 
 msgid "%s tab is not available until at least 1 field has been selected"
-msgstr ""
-
-msgid ""
-"%s to validate against, Username and matching password fields are needed to pe"
-"rform verification of credentials"
 msgstr ""
 
 msgid "%s was cancelled by the user"
@@ -297,6 +299,9 @@ msgid "%{field} Value Error: %{msg}"
 msgstr ""
 
 msgid "%{field} cannot contain \"%{character}\""
+msgstr ""
+
+msgid "%{model}"
 msgstr ""
 
 msgid "%{model} \"%{name}\""
@@ -330,6 +335,9 @@ msgid "%{model} \"%{name}\": Delete successful"
 msgstr ""
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
+msgstr ""
+
+msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
 msgid "%{model} for \"%{name}\""
@@ -371,13 +379,22 @@ msgstr ""
 msgid "%{task} does not apply because you selected at least one %{model}"
 msgstr ""
 
+msgid "%{task} does not apply because you selected at least one un-reconfigurable VM"
+msgstr ""
+
+msgid "%{task} does not apply to at least one of the selected %{model}"
+msgstr ""
+
 msgid "%{task} does not apply to selected %{model}"
 msgstr ""
 
-msgid "%{task} initiated for %{count_model} (Foreman) from the CFME Database"
+msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
 msgstr ""
 
 msgid "%{task} initiated for %{count_model} from the CFME Database"
+msgstr ""
+
+msgid "%{task} initiated for %{model} from the CFME Database"
 msgstr ""
 
 msgid "%{typ} %{model}"
@@ -441,9 +458,6 @@ msgid "(Look Up LDAP Groups)"
 msgstr ""
 
 msgid "(MB) memory"
-msgstr ""
-
-msgid "(NS/Cls/Inst)"
 msgstr ""
 
 msgid "(Row %{start_number} of %{pages})"
@@ -597,6 +611,9 @@ msgstr ""
 msgid "* Style \"If\" conditions are evaluated top to bottom for each column"
 msgstr ""
 
+msgid "-- OR --"
+msgstr ""
+
 msgid "1 - Select a Reference VM."
 msgstr ""
 
@@ -617,7 +634,7 @@ msgstr ""
 msgid "2 Weeks before retirement"
 msgstr ""
 
-msgid "24 Hour Time Period:"
+msgid "24 Hour Time Period"
 msgstr ""
 
 msgid "3 - Specify Target Options to qualify target %s or %s."
@@ -630,6 +647,9 @@ msgid "4 - Change the Trend Options used to calculate the daily trends, if desir
 msgstr ""
 
 msgid "5 - Press the Submit button."
+msgstr ""
+
+msgid "<Archived>"
 msgstr ""
 
 msgid "<Choose a Group>"
@@ -657,6 +677,15 @@ msgid "<New LDAP Server>"
 msgstr ""
 
 msgid "<No Depot>"
+msgstr ""
+
+msgid "<No chart>"
+msgstr ""
+
+msgid "<Orphaned>"
+msgstr ""
+
+msgid "<Unnamed>"
 msgstr ""
 
 msgid "A %s must be chosen to commit this expression element"
@@ -695,13 +724,13 @@ msgstr ""
 msgid "AMQP"
 msgstr ""
 
-msgid "AMQP Messaging"
-msgstr ""
-
 msgid "AND with a new expression element"
 msgstr ""
 
 msgid "API Port"
+msgstr ""
+
+msgid "API Version"
 msgstr ""
 
 msgid "About"
@@ -711,6 +740,9 @@ msgid "Access Key"
 msgstr ""
 
 msgid "Access Key ID"
+msgstr ""
+
+msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
 msgid "Access URL"
@@ -799,6 +831,9 @@ msgstr ""
 msgid "Add a new %s Provider"
 msgstr ""
 
+msgid "Add of %{model} was cancelled by the user"
+msgstr ""
+
 msgid "Add of new %s was cancelled by the user"
 msgstr ""
 
@@ -806,9 +841,6 @@ msgid "Add subfolder to selected folder"
 msgstr ""
 
 msgid "Add this %s"
-msgstr ""
-
-msgid "Add this Host"
 msgstr ""
 
 msgid "Add this LDAP Server"
@@ -934,12 +966,78 @@ msgstr ""
 msgid "All (%s)"
 msgstr ""
 
+msgid "All Actions"
+msgstr ""
+
+msgid "All Alert Profiles"
+msgstr ""
+
+msgid "All Alerts"
+msgstr ""
+
+msgid "All Catalog Items"
+msgstr ""
+
+msgid "All Catalogs"
+msgstr ""
+
+msgid "All Conditions"
+msgstr ""
+
+msgid "All Containers"
+msgstr ""
+
 msgid ""
 "All Datastore customizations will be lost. Are you sure you want to reset all "
 "classes and instances to default?"
 msgstr ""
 
+msgid "All Dialogs"
+msgstr ""
+
+msgid "All Events"
+msgstr ""
+
 msgid "All Files"
+msgstr ""
+
+msgid "All ISO Datastores"
+msgstr ""
+
+msgid "All Images"
+msgstr ""
+
+msgid "All Images by Provider that I can see"
+msgstr ""
+
+msgid "All Instances"
+msgstr ""
+
+msgid "All Instances by Provider that I can see"
+msgstr ""
+
+msgid "All Orchestration Templates"
+msgstr ""
+
+msgid "All PXE Servers"
+msgstr ""
+
+msgid "All Policies"
+msgstr ""
+
+msgid "All Policy Profiles"
+msgstr ""
+
+msgid "All Services"
+msgstr ""
+
+msgid "All System Image Types"
+msgstr ""
+
+msgid "All Templates"
+msgstr ""
+
+msgid "All Templates & Images"
 msgstr ""
 
 msgid "All Templates: %s"
@@ -951,7 +1049,19 @@ msgstr ""
 msgid "All Users"
 msgstr ""
 
+msgid "All VM and Instance Conditions"
+msgstr ""
+
 msgid "All VMs"
+msgstr ""
+
+msgid "All VMs & Instances"
+msgstr ""
+
+msgid "All VMs & Templates"
+msgstr ""
+
+msgid "All VMs & Templates that I can see"
 msgstr ""
 
 msgid "All VMs (Tree View): %s"
@@ -976,6 +1086,24 @@ msgid "All custom classes and instances have been reset to default"
 msgstr ""
 
 msgid "All fields are needed to perform verification of Database Settings"
+msgstr ""
+
+msgid "All of the Images that I can see"
+msgstr ""
+
+msgid "All of the Instances that I can see"
+msgstr ""
+
+msgid "All of the Templates & Images that I can see"
+msgstr ""
+
+msgid "All of the Templates that I can see"
+msgstr ""
+
+msgid "All of the VMs & Instances that I can see"
+msgstr ""
+
+msgid "All of the VMs that I can see"
 msgstr ""
 
 msgid "All selected %s are not in the current region"
@@ -1003,6 +1131,9 @@ msgid "An internal system error."
 msgstr ""
 
 msgid "Analysis"
+msgstr ""
+
+msgid "Analysis Affinity was saved"
 msgstr ""
 
 msgid "Analysis History (%s)"
@@ -1077,16 +1208,22 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
+msgid "Arch"
+msgstr ""
+
 msgid "Architecture"
+msgstr ""
+
+msgid "Archived Instances"
+msgstr ""
+
+msgid "Archived VMs and Templates"
 msgstr ""
 
 msgid "Are you sure you want to Run Database Garbage Collection Now?"
 msgstr ""
 
 msgid "Are you sure you want to Run a Database Backup Now?"
-msgstr ""
-
-msgid "Are you sure you want to delete build %s?"
 msgstr ""
 
 msgid "Are you sure you want to delete category '%s'?"
@@ -1286,6 +1423,18 @@ msgstr ""
 msgid "Authorization Error"
 msgstr ""
 
+msgid "Auto Refresh other fields when modified"
+msgstr ""
+
+msgid "Auto refresh"
+msgstr ""
+
+msgid "Automate"
+msgstr ""
+
+msgid "Automate Workers"
+msgstr ""
+
 msgid "Automate button %s has been cleared"
 msgstr ""
 
@@ -1319,7 +1468,7 @@ msgstr ""
 msgid "Available %s Conditions:"
 msgstr ""
 
-msgid "Available %s:"
+msgid "Available %{title}:"
 msgstr ""
 
 msgid "Available Actions:"
@@ -1440,6 +1589,21 @@ msgid "Bind DN"
 msgstr ""
 
 msgid "Bind Password"
+msgstr ""
+
+msgid "Blacklisted event"
+msgstr ""
+
+msgid "BlacklistedEvent|Enabled"
+msgstr ""
+
+msgid "BlacklistedEvent|Event name"
+msgstr ""
+
+msgid "BlacklistedEvent|Provider model"
+msgstr ""
+
+msgid "BlacklistedEvent|System"
 msgstr ""
 
 msgid "Bottleneck Event Details"
@@ -1707,13 +1871,22 @@ msgstr ""
 msgid "Change %s value to submit reconfigure request"
 msgstr ""
 
-msgid "Change Password / Confirm Password"
+msgid "Change Group:"
+msgstr ""
+
+msgid "Change Password"
 msgstr ""
 
 msgid "Changes"
 msgstr ""
 
 msgid "Changing the UI Workers Count will immediately restart the webserver"
+msgstr ""
+
+msgid "Channel Name(s)"
+msgstr ""
+
+msgid "Channel Name(s):"
 msgstr ""
 
 msgid "Chargeback"
@@ -1797,6 +1970,9 @@ msgstr ""
 msgid "Chart Theme"
 msgstr ""
 
+msgid "Chart mode"
+msgstr ""
+
 msgid "Chart no longer exists"
 msgstr ""
 
@@ -1816,6 +1992,9 @@ msgid "Check for updates"
 msgstr ""
 
 msgid "Checked default filters will be visible."
+msgstr ""
+
+msgid "Child Tenants"
 msgstr ""
 
 msgid "Child VM Selection"
@@ -1929,6 +2108,12 @@ msgstr ""
 msgid "Click on this row to create a new entry"
 msgstr ""
 
+msgid "Click to Logout"
+msgstr ""
+
+msgid "Click to add a new category"
+msgstr ""
+
 msgid "Click to add a new entry"
 msgstr ""
 
@@ -1950,9 +2135,6 @@ msgstr ""
 msgid "Click to delete this LDAP Server"
 msgstr ""
 
-msgid "Click to delete this build"
-msgstr ""
-
 msgid "Click to delete this category"
 msgstr ""
 
@@ -1968,10 +2150,19 @@ msgstr ""
 msgid "Click to delete this input field from method"
 msgstr ""
 
+msgid "Click to edit this category"
+msgstr ""
+
 msgid "Click to edit this forest"
 msgstr ""
 
 msgid "Click to go to this location"
+msgstr ""
+
+msgid "Click to open"
+msgstr ""
+
+msgid "Click to remove message"
 msgstr ""
 
 msgid "Click to remove messages"
@@ -2013,6 +2204,12 @@ msgstr ""
 msgid "Click to view Time Profile"
 msgstr ""
 
+msgid "Click to view child Tenant"
+msgstr ""
+
+msgid "Click to view child TenantProject"
+msgstr ""
+
 msgid "Click to view details"
 msgstr ""
 
@@ -2040,7 +2237,19 @@ msgstr ""
 msgid "Client Connections"
 msgstr ""
 
+msgid "Client ID"
+msgstr ""
+
+msgid "Client Key"
+msgstr ""
+
+msgid "Client Keys do not match"
+msgstr ""
+
 msgid "Close any duplicate browser sessions, then select a menu option above."
+msgstr ""
+
+msgid "Cloud Intelligence"
 msgstr ""
 
 msgid "Cloud Networks (%s)"
@@ -2076,6 +2285,9 @@ msgstr ""
 msgid "Cloud volume snapshot"
 msgstr ""
 
+msgid "CloudInit"
+msgstr ""
+
 msgid "CloudNetwork|Cidr"
 msgstr ""
 
@@ -2089,6 +2301,9 @@ msgid "CloudNetwork|External facing"
 msgstr ""
 
 msgid "CloudNetwork|Name"
+msgstr ""
+
+msgid "CloudNetwork|Shared"
 msgstr ""
 
 msgid "CloudNetwork|Status"
@@ -2246,6 +2461,9 @@ msgstr ""
 msgid "Collection Options"
 msgstr ""
 
+msgid "Column"
+msgstr ""
+
 msgid "Column %s"
 msgstr ""
 
@@ -2262,9 +2480,6 @@ msgid "Column 4"
 msgstr ""
 
 msgid "Column Name"
-msgstr ""
-
-msgid "Column:"
 msgstr ""
 
 msgid "Commit"
@@ -2307,6 +2522,9 @@ msgid "Compliance"
 msgstr ""
 
 msgid "Compliance Check"
+msgstr ""
+
+msgid "Compliance Policies"
 msgstr ""
 
 msgid "Compliance detail"
@@ -2464,6 +2682,12 @@ msgstr ""
 msgid "Configuration Management"
 msgstr ""
 
+msgid "Configuration Management Configured Systems"
+msgstr ""
+
+msgid "Configuration Management Providers"
+msgstr ""
+
 msgid "Configuration Organization"
 msgstr ""
 
@@ -2542,6 +2766,9 @@ msgstr ""
 msgid "Configuration|Updated on"
 msgstr ""
 
+msgid "Configure"
+msgstr ""
+
 msgid "Configure Report Columns"
 msgstr ""
 
@@ -2577,6 +2804,9 @@ msgstr ""
 msgid "ConfiguredSystem|Puppet status"
 msgstr ""
 
+msgid "Confirm Password"
+msgstr ""
+
 msgid "Connecting (unencrypted) to: %s"
 msgstr ""
 
@@ -2601,10 +2831,31 @@ msgstr ""
 msgid "Container"
 msgstr ""
 
+msgid "Container Images"
+msgstr ""
+
+msgid "Container Nodes"
+msgstr ""
+
 msgid "Container Nodes (%s)"
 msgstr ""
 
 msgid "Container Nodes (0)"
+msgstr ""
+
+msgid "Container Projects (%s)"
+msgstr ""
+
+msgid "Container Projects (0)"
+msgstr ""
+
+msgid "Container Routes (%s)"
+msgstr ""
+
+msgid "Container Routes (0)"
+msgstr ""
+
+msgid "Container Services"
 msgstr ""
 
 msgid "Container Services (%s)"
@@ -2613,7 +2864,22 @@ msgstr ""
 msgid "Container Services (0)"
 msgstr ""
 
+msgid "Container condition"
+msgstr ""
+
 msgid "Container definition"
+msgstr ""
+
+msgid "Container env var"
+msgstr ""
+
+msgid "Container group"
+msgstr ""
+
+msgid "Container image"
+msgstr ""
+
+msgid "Container image registry"
 msgstr ""
 
 msgid "Container node"
@@ -2622,10 +2888,40 @@ msgstr ""
 msgid "Container port config"
 msgstr ""
 
-msgid "Container replication controller"
+msgid "Container project"
+msgstr ""
+
+msgid "Container replicator"
+msgstr ""
+
+msgid "Container route"
 msgstr ""
 
 msgid "Container service"
+msgstr ""
+
+msgid "Container service port config"
+msgstr ""
+
+msgid "ContainerCondition|Container entity type"
+msgstr ""
+
+msgid "ContainerCondition|Last heartbeat time"
+msgstr ""
+
+msgid "ContainerCondition|Last transition time"
+msgstr ""
+
+msgid "ContainerCondition|Message"
+msgstr ""
+
+msgid "ContainerCondition|Name"
+msgstr ""
+
+msgid "ContainerCondition|Reason"
+msgstr ""
+
+msgid "ContainerCondition|Status"
 msgstr ""
 
 msgid "ContainerDefinition|Cpu cores"
@@ -2646,6 +2942,68 @@ msgstr ""
 msgid "ContainerDefinition|Name"
 msgstr ""
 
+msgid "ContainerEnvVar|Field path"
+msgstr ""
+
+msgid "ContainerEnvVar|Name"
+msgstr ""
+
+msgid "ContainerEnvVar|Value"
+msgstr ""
+
+msgid "ContainerGroup|Creation timestamp"
+msgstr ""
+
+msgid "ContainerGroup|Dns policy"
+msgstr ""
+
+msgid "ContainerGroup|Ems ref"
+msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "ContainerGroup|Ipaddress"
+msgstr "IP Address"
+
+msgid "ContainerGroup|Message"
+msgstr ""
+
+msgid "ContainerGroup|Name"
+msgstr ""
+
+msgid "ContainerGroup|Phase"
+msgstr ""
+
+msgid "ContainerGroup|Reason"
+msgstr ""
+
+msgid "ContainerGroup|Resource version"
+msgstr ""
+
+msgid "ContainerGroup|Restart policy"
+msgstr ""
+
+msgid "ContainerImageRegistry|Host"
+msgstr ""
+
+msgid "ContainerImageRegistry|Name"
+msgstr ""
+
+msgid "ContainerImageRegistry|Port"
+msgstr ""
+
+msgid "ContainerImage|Image ref"
+msgstr ""
+
+msgid "ContainerImage|Name"
+msgstr ""
+
+msgid "ContainerImage|Tag"
+msgstr ""
+
+msgid "ContainerNode|Container runtime version"
+msgstr ""
+
 msgid "ContainerNode|Creation timestamp"
 msgstr ""
 
@@ -2661,7 +3019,16 @@ msgstr ""
 msgid "ContainerNode|Identity system"
 msgstr ""
 
+msgid "ContainerNode|Kubernetes kubelet version"
+msgstr ""
+
+msgid "ContainerNode|Kubernetes proxy version"
+msgstr ""
+
 msgid "ContainerNode|Lives on type"
+msgstr ""
+
+msgid "ContainerNode|Max container groups"
 msgstr ""
 
 msgid "ContainerNode|Name"
@@ -2685,28 +3052,72 @@ msgstr ""
 msgid "ContainerPortConfig|Protocol"
 msgstr ""
 
-msgid "ContainerReplicationController|Creation timestamp"
+msgid "ContainerProject|Creation timestamp"
 msgstr ""
 
-msgid "ContainerReplicationController|Current replicas"
+msgid "ContainerProject|Display name"
 msgstr ""
 
-msgid "ContainerReplicationController|Ems ref"
+msgid "ContainerProject|Ems ref"
 msgstr ""
 
-msgid "ContainerReplicationController|Name"
+msgid "ContainerProject|Name"
 msgstr ""
 
-msgid "ContainerReplicationController|Namespace"
+msgid "ContainerProject|Resource version"
 msgstr ""
 
-msgid "ContainerReplicationController|Replicas"
+msgid "ContainerReplicator|Creation timestamp"
 msgstr ""
 
-msgid "ContainerReplicationController|Resource version"
+msgid "ContainerReplicator|Current replicas"
 msgstr ""
 
-msgid "ContainerService|Container port"
+msgid "ContainerReplicator|Ems ref"
+msgstr ""
+
+msgid "ContainerReplicator|Name"
+msgstr ""
+
+msgid "ContainerReplicator|Replicas"
+msgstr ""
+
+msgid "ContainerReplicator|Resource version"
+msgstr ""
+
+msgid "ContainerRoute|Creation timestamp"
+msgstr ""
+
+msgid "ContainerRoute|Ems ref"
+msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "ContainerRoute|Host name"
+msgstr "Host Name"
+
+msgid "ContainerRoute|Name"
+msgstr ""
+
+msgid "ContainerRoute|Path"
+msgstr ""
+
+msgid "ContainerRoute|Resource version"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Ems ref"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Name"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Port"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Protocol"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Target port"
 msgstr ""
 
 msgid "ContainerService|Creation timestamp"
@@ -2718,16 +3129,7 @@ msgstr ""
 msgid "ContainerService|Name"
 msgstr ""
 
-msgid "ContainerService|Namespace"
-msgstr ""
-
-msgid "ContainerService|Port"
-msgstr ""
-
 msgid "ContainerService|Portal ip"
-msgstr ""
-
-msgid "ContainerService|Protocol"
 msgstr ""
 
 msgid "ContainerService|Resource version"
@@ -2739,13 +3141,16 @@ msgstr ""
 msgid "Containers"
 msgstr ""
 
+msgid "Containers (%s)"
+msgstr ""
+
+msgid "Containers (0)"
+msgstr ""
+
 msgid "Container|Backing ref"
 msgstr ""
 
 msgid "Container|Ems ref"
-msgstr ""
-
-msgid "Container|Image"
 msgstr ""
 
 msgid "Container|Name"
@@ -2772,6 +3177,9 @@ msgstr ""
 msgid "Control"
 msgstr ""
 
+msgid "Control Policies"
+msgstr ""
+
 msgid "Copy"
 msgstr ""
 
@@ -2788,6 +3196,9 @@ msgid "Copy to same path"
 msgstr ""
 
 msgid "Copying %s"
+msgstr ""
+
+msgid "Cores Per socket"
 msgstr ""
 
 msgid "Count"
@@ -2842,6 +3253,9 @@ msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
 msgid "Current Backlog"
+msgstr ""
+
+msgid "Current Group"
 msgstr ""
 
 msgid "Current Rates"
@@ -3090,6 +3504,12 @@ msgstr ""
 msgid "Data Type:"
 msgstr ""
 
+msgid "Data column"
+msgstr ""
+
+msgid "Data type: %s"
+msgstr ""
+
 msgid "Data validated successfully"
 msgstr ""
 
@@ -3169,6 +3589,9 @@ msgstr ""
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
+msgid "Default Filters"
+msgstr ""
+
 msgid "Default Filters saved successfully"
 msgstr ""
 
@@ -3188,6 +3611,15 @@ msgid "Default Repository SmartProxy"
 msgstr ""
 
 msgid "Default Value"
+msgstr ""
+
+msgid "Default Views"
+msgstr ""
+
+msgid "Default dialogs cannot be edited"
+msgstr ""
+
+msgid "Default dialogs cannot be removed from the VMDB"
 msgstr ""
 
 msgid "Delay (mins)"
@@ -3250,10 +3682,10 @@ msgstr ""
 msgid "Details Mode"
 msgstr ""
 
-msgid "Details View"
+msgid "Determine at Run Time"
 msgstr ""
 
-msgid "Determine at Run Time"
+msgid "Device Type"
 msgstr ""
 
 msgid "Devices"
@@ -3281,6 +3713,9 @@ msgid "Dialog has to be set if Display in Catalog is chosen"
 msgstr ""
 
 msgid "Dialog tab"
+msgstr ""
+
+msgid "DialogField|Auto refresh"
 msgstr ""
 
 msgid "DialogField|Data type"
@@ -3341,6 +3776,9 @@ msgid "DialogField|Required method options"
 msgstr ""
 
 msgid "DialogField|Show refresh button"
+msgstr ""
+
+msgid "DialogField|Trigger auto refresh"
 msgstr ""
 
 msgid "DialogField|Validator rule"
@@ -3583,6 +4021,9 @@ msgstr ""
 msgid "Driving Event"
 msgstr ""
 
+msgid "Dropdown elements require some entries"
+msgstr ""
+
 msgid "Dynamic"
 msgstr ""
 
@@ -3620,6 +4061,9 @@ msgid "Edit Compute Rate Assignments"
 msgstr ""
 
 msgid "Edit Log Depot settings was cancelled by the user"
+msgstr ""
+
+msgid "Edit Registration"
 msgstr ""
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
@@ -3715,9 +4159,6 @@ msgstr ""
 msgid "Ems cluster"
 msgstr ""
 
-msgid "Ems event"
-msgstr ""
-
 msgid "Ems folder"
 msgstr ""
 
@@ -3766,60 +4207,6 @@ msgstr ""
 msgid "EmsCluster|Updated on"
 msgstr ""
 
-msgid "EmsEvent|Created on"
-msgstr ""
-
-msgid "EmsEvent|Dest ems cluster name"
-msgstr ""
-
-msgid "EmsEvent|Dest ems cluster uid"
-msgstr ""
-
-msgid "EmsEvent|Dest host name"
-msgstr ""
-
-msgid "EmsEvent|Dest vm location"
-msgstr ""
-
-msgid "EmsEvent|Dest vm name"
-msgstr ""
-
-msgid "EmsEvent|Ems cluster name"
-msgstr ""
-
-msgid "EmsEvent|Ems cluster uid"
-msgstr ""
-
-msgid "EmsEvent|Event type"
-msgstr ""
-
-msgid "EmsEvent|Full data"
-msgstr ""
-
-msgid "EmsEvent|Host name"
-msgstr ""
-
-msgid "EmsEvent|Is task"
-msgstr ""
-
-msgid "EmsEvent|Message"
-msgstr ""
-
-msgid "EmsEvent|Source"
-msgstr ""
-
-msgid "EmsEvent|Timestamp"
-msgstr ""
-
-msgid "EmsEvent|Username"
-msgstr ""
-
-msgid "EmsEvent|Vm location"
-msgstr ""
-
-msgid "EmsEvent|Vm name"
-msgstr ""
-
 msgid "EmsFolder|Created on"
 msgstr ""
 
@@ -3862,10 +4249,16 @@ msgstr ""
 msgid "End Port"
 msgstr ""
 
+msgid "Enforced"
+msgstr ""
+
 msgid "Enter Automation Simulation options on the left and press Submit."
 msgstr ""
 
 msgid "Enter URL Manually"
+msgstr ""
+
+msgid "Enterprise"
 msgstr ""
 
 msgid "Entity:"
@@ -3947,7 +4340,16 @@ msgstr ""
 msgid "Error when adding a new schedule: "
 msgstr ""
 
+msgid "Error when adding a new tenant: "
+msgstr ""
+
 msgid "Error when creating a Service Dialog from Orchestration Template: "
+msgstr ""
+
+msgid "Error when saving new server name: "
+msgstr ""
+
+msgid "Error when saving tenant quota: "
 msgstr ""
 
 msgid "Error: Datastore import file upload expired"
@@ -4010,7 +4412,10 @@ msgstr ""
 msgid "Event log"
 msgstr ""
 
-msgid "Event to position at:"
+msgid "Event stream"
+msgstr ""
+
+msgid "Event to position at"
 msgstr ""
 
 msgid "Event:"
@@ -4040,13 +4445,76 @@ msgstr ""
 msgid "EventLog|Uid"
 msgstr ""
 
+msgid "EventStream|Container group name"
+msgstr ""
+
+msgid "EventStream|Container namespace"
+msgstr ""
+
+msgid "EventStream|Container node name"
+msgstr ""
+
+msgid "EventStream|Created on"
+msgstr ""
+
+msgid "EventStream|Dest ems cluster name"
+msgstr ""
+
+msgid "EventStream|Dest ems cluster uid"
+msgstr ""
+
+msgid "EventStream|Dest host name"
+msgstr ""
+
+msgid "EventStream|Dest vm location"
+msgstr ""
+
+msgid "EventStream|Dest vm name"
+msgstr ""
+
+msgid "EventStream|Ems cluster name"
+msgstr ""
+
+msgid "EventStream|Ems cluster uid"
+msgstr ""
+
+msgid "EventStream|Event type"
+msgstr ""
+
+msgid "EventStream|Full data"
+msgstr ""
+
+msgid "EventStream|Host name"
+msgstr ""
+
+msgid "EventStream|Is task"
+msgstr ""
+
+msgid "EventStream|Message"
+msgstr ""
+
+msgid "EventStream|Source"
+msgstr ""
+
+msgid "EventStream|Target type"
+msgstr ""
+
+msgid "EventStream|Timestamp"
+msgstr ""
+
+msgid "EventStream|Username"
+msgstr ""
+
+msgid "EventStream|Vm location"
+msgstr ""
+
+msgid "EventStream|Vm name"
+msgstr ""
+
 msgid "Events"
 msgstr ""
 
 msgid "Execute Methods"
-msgstr ""
-
-msgid "Exist Mode"
 msgstr ""
 
 msgid "Exists Mode"
@@ -4153,6 +4621,9 @@ msgid "External Authentication (httpd) Settings"
 msgstr ""
 
 msgid "External RSS Feed/URL"
+msgstr ""
+
+msgid "FS Type"
 msgstr ""
 
 msgid "Failed"
@@ -4358,7 +4829,7 @@ msgstr ""
 msgid "First %s"
 msgstr ""
 
-msgid "First band unit:"
+msgid "First band unit"
 msgstr ""
 
 msgid "Flavor"
@@ -4368,6 +4839,9 @@ msgid "Flavors"
 msgstr ""
 
 msgid "Flavor|Block storage based only"
+msgstr ""
+
+msgid "Flavor|Cloud subnet required"
 msgstr ""
 
 msgid "Flavor|Cpu cores"
@@ -4460,6 +4934,9 @@ msgstr ""
 msgid "GB"
 msgstr ""
 
+msgid "GCE PD Resource"
+msgstr ""
+
 msgid "Genealogy"
 msgstr ""
 
@@ -4487,13 +4964,28 @@ msgstr ""
 msgid "Get User Groups from LDAP"
 msgstr ""
 
+msgid "Git Repository"
+msgstr ""
+
+msgid "Git Revision"
+msgstr ""
+
 msgid "Global Default"
+msgstr ""
+
+msgid "Global Filters"
+msgstr ""
+
+msgid "Global Shared Filters"
 msgstr ""
 
 msgid "Global Time Profile cannot be edited"
 msgstr ""
 
 msgid "Global search:"
+msgstr ""
+
+msgid "Glusterfs Endpoint Name"
 msgstr ""
 
 msgid "Grid View"
@@ -4631,6 +5123,12 @@ msgstr ""
 msgid "HKLM"
 msgstr ""
 
+msgid "HTTP Proxy Address"
+msgstr ""
+
+msgid "HTTP Proxy:"
+msgstr ""
+
 msgid "Hardware"
 msgstr ""
 
@@ -4736,13 +5234,25 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
+msgid "Host Compliance Policies"
+msgstr ""
+
+msgid "Host Conditions"
+msgstr ""
+
+msgid "Host Control Policies"
+msgstr ""
+
+msgid "Host Default VNC End Port"
+msgstr ""
+
 msgid "Host Default VNC Port Range"
 msgstr ""
 
-msgid "Host Name"
+msgid "Host Default VNC Start Port"
 msgstr ""
 
-msgid "Host Name (or IPv4 or IPv6 address)"
+msgid "Host Policies"
 msgstr ""
 
 msgid "Host Protocol"
@@ -4758,6 +5268,15 @@ msgid "HostServiceGroup|Name"
 msgstr ""
 
 msgid "Hostname"
+msgstr ""
+
+msgid "Hostname (or IPv4 or IPv6 address)"
+msgstr ""
+
+msgid "Hostname or IP address"
+msgstr ""
+
+msgid "Hostname or IPv4/IPv6 address"
 msgstr ""
 
 msgid "Hosts"
@@ -4886,10 +5405,22 @@ msgstr ""
 msgid "IPMI"
 msgstr ""
 
+msgid "IPMI Credentials"
+msgstr ""
+
 msgid "IPMI IP Address"
 msgstr ""
 
 msgid "IPMI Present"
+msgstr ""
+
+msgid "ISCSI Target Lun Number"
+msgstr ""
+
+msgid "ISCSI Target Portal"
+msgstr ""
+
+msgid "ISCSI Target Qualified Name"
 msgstr ""
 
 msgid "ISO"
@@ -4912,6 +5443,12 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
+msgid "Image Registries (%s)"
+msgstr ""
+
+msgid "Image Registries (0)"
+msgstr ""
+
 msgid "Image Type"
 msgstr ""
 
@@ -4922,6 +5459,12 @@ msgid "Images"
 msgstr ""
 
 msgid "Images (%s)"
+msgstr ""
+
+msgid "Images (0)"
+msgstr ""
+
+msgid "Images by Provider"
 msgstr ""
 
 msgid "Import"
@@ -4996,10 +5539,10 @@ msgstr ""
 msgid "Init Processes (%s)"
 msgstr ""
 
-msgid "Input Parameters"
+msgid "Input Name"
 msgstr ""
 
-msgid "Insight"
+msgid "Input Parameters"
 msgstr ""
 
 msgid "Instance Type:"
@@ -5011,10 +5554,10 @@ msgstr ""
 msgid "Instances (%s)"
 msgstr ""
 
-msgid "Integer"
+msgid "Instances by Provider"
 msgstr ""
 
-msgid "Integration Services"
+msgid "Integer"
 msgstr ""
 
 msgid "Internal"
@@ -5130,6 +5673,9 @@ msgstr ""
 msgid "Key:"
 msgstr ""
 
+msgid "Kickstart"
+msgstr ""
+
 msgid "LDAP"
 msgstr ""
 
@@ -5145,15 +5691,15 @@ msgstr ""
 msgid "LDAP Groups for User"
 msgstr ""
 
-msgid "LDAP Host Name"
+msgid "LDAP Host Names"
+msgstr ""
+
+msgid "LDAP Hostname"
 msgstr ""
 
 msgid ""
-"LDAP Host Name and Port fields are needed to perform verification of LDAP Sett"
-"ings"
-msgstr ""
-
-msgid "LDAP Host Names"
+"LDAP Hostname and Port fields are needed to perform verification of LDAP Setti"
+"ngs"
 msgstr ""
 
 msgid "LDAP Port"
@@ -5178,6 +5724,9 @@ msgid "Label"
 msgstr ""
 
 msgid "Label on Summary Row"
+msgstr ""
+
+msgid "Labels"
 msgstr ""
 
 msgid "Lan"
@@ -5241,6 +5790,9 @@ msgid "Last Message"
 msgstr ""
 
 msgid "Last Run Time"
+msgstr ""
+
+msgid "Last Transition Time"
 msgstr ""
 
 msgid "Last Update"
@@ -5419,9 +5971,6 @@ msgstr ""
 msgid "Lifecycle"
 msgstr ""
 
-msgid "Lifecycle and Automation"
-msgstr ""
-
 msgid "Lifecycle event"
 msgstr ""
 
@@ -5545,10 +6094,16 @@ msgstr ""
 msgid "Logging"
 msgstr ""
 
+msgid "Logging into"
+msgstr ""
+
 msgid "Login"
 msgstr ""
 
 msgid "Login not allowed, User's %s is missing. Please contact the administrator"
+msgstr ""
+
+msgid "Logout"
 msgstr ""
 
 msgid "Logs for this CFME Server are not available for viewing"
@@ -5584,10 +6139,19 @@ msgstr ""
 msgid "Manage Reports"
 msgstr ""
 
+msgid "Manage quotas for %{model} \"%{name}\""
+msgstr ""
+
+msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
+msgstr ""
+
 msgid "Management Event"
 msgstr ""
 
 msgid "Manager"
+msgstr ""
+
+msgid "Matching password fields are needed to perform verification of credentials"
 msgstr ""
 
 msgid "Max"
@@ -5606,6 +6170,9 @@ msgid "Max Time"
 msgstr ""
 
 msgid "Max VMs"
+msgstr ""
+
+msgid "Max active VM Scans"
 msgstr ""
 
 msgid "Medium"
@@ -6061,25 +6628,7 @@ msgstr ""
 msgid "Miq action set"
 msgstr ""
 
-msgid "Miq ae class"
-msgstr ""
-
 msgid "Miq ae engine/miq ae workspace"
-msgstr ""
-
-msgid "Miq ae field"
-msgstr ""
-
-msgid "Miq ae instance"
-msgstr ""
-
-msgid "Miq ae method"
-msgstr ""
-
-msgid "Miq ae namespace"
-msgstr ""
-
-msgid "Miq ae value"
 msgstr ""
 
 msgid "Miq alert"
@@ -6112,10 +6661,10 @@ msgstr ""
 msgid "Miq enterprise"
 msgstr ""
 
-msgid "Miq event"
+msgid "Miq event definition"
 msgstr ""
 
-msgid "Miq event set"
+msgid "Miq event definition set"
 msgstr ""
 
 msgid "Miq group"
@@ -6250,33 +6799,6 @@ msgstr ""
 msgid "MiqAction|Updated on"
 msgstr ""
 
-msgid "MiqAeClass|Created on"
-msgstr ""
-
-msgid "MiqAeClass|Description"
-msgstr ""
-
-msgid "MiqAeClass|Display name"
-msgstr ""
-
-msgid "MiqAeClass|Inherits"
-msgstr ""
-
-msgid "MiqAeClass|Name"
-msgstr ""
-
-msgid "MiqAeClass|Owner"
-msgstr ""
-
-msgid "MiqAeClass|Updated by"
-msgstr ""
-
-msgid "MiqAeClass|Updated on"
-msgstr ""
-
-msgid "MiqAeClass|Visibility"
-msgstr ""
-
 msgid "MiqAeEngine::MiqAeWorkspace|Created on"
 msgstr ""
 
@@ -6293,186 +6815,6 @@ msgid "MiqAeEngine::MiqAeWorkspace|Uri"
 msgstr ""
 
 msgid "MiqAeEngine::MiqAeWorkspace|Workspace"
-msgstr ""
-
-msgid "MiqAeField|Aetype"
-msgstr ""
-
-msgid "MiqAeField|Collect"
-msgstr ""
-
-msgid "MiqAeField|Condition"
-msgstr ""
-
-msgid "MiqAeField|Created on"
-msgstr ""
-
-msgid "MiqAeField|Datatype"
-msgstr ""
-
-msgid "MiqAeField|Default value"
-msgstr ""
-
-msgid "MiqAeField|Description"
-msgstr ""
-
-msgid "MiqAeField|Display name"
-msgstr ""
-
-msgid "MiqAeField|Max retries"
-msgstr ""
-
-msgid "MiqAeField|Max time"
-msgstr ""
-
-msgid "MiqAeField|Message"
-msgstr ""
-
-msgid "MiqAeField|Name"
-msgstr ""
-
-msgid "MiqAeField|On entry"
-msgstr ""
-
-msgid "MiqAeField|On error"
-msgstr ""
-
-msgid "MiqAeField|On exit"
-msgstr ""
-
-msgid "MiqAeField|Owner"
-msgstr ""
-
-msgid "MiqAeField|Priority"
-msgstr ""
-
-msgid "MiqAeField|Scope"
-msgstr ""
-
-msgid "MiqAeField|Substitute"
-msgstr ""
-
-msgid "MiqAeField|Updated by"
-msgstr ""
-
-msgid "MiqAeField|Updated on"
-msgstr ""
-
-msgid "MiqAeField|Visibility"
-msgstr ""
-
-msgid "MiqAeInstance|Created on"
-msgstr ""
-
-msgid "MiqAeInstance|Description"
-msgstr ""
-
-msgid "MiqAeInstance|Display name"
-msgstr ""
-
-msgid "MiqAeInstance|Inherits"
-msgstr ""
-
-msgid "MiqAeInstance|Name"
-msgstr ""
-
-msgid "MiqAeInstance|Updated by"
-msgstr ""
-
-msgid "MiqAeInstance|Updated on"
-msgstr ""
-
-msgid "MiqAeMethod|Created on"
-msgstr ""
-
-msgid "MiqAeMethod|Data"
-msgstr ""
-
-msgid "MiqAeMethod|Description"
-msgstr ""
-
-msgid "MiqAeMethod|Display name"
-msgstr ""
-
-msgid "MiqAeMethod|Language"
-msgstr ""
-
-msgid "MiqAeMethod|Location"
-msgstr ""
-
-msgid "MiqAeMethod|Name"
-msgstr ""
-
-msgid "MiqAeMethod|Scope"
-msgstr ""
-
-msgid "MiqAeMethod|Updated by"
-msgstr ""
-
-msgid "MiqAeMethod|Updated on"
-msgstr ""
-
-msgid "MiqAeNamespace|Created on"
-msgstr ""
-
-msgid "MiqAeNamespace|Description"
-msgstr ""
-
-msgid "MiqAeNamespace|Display name"
-msgstr ""
-
-msgid "MiqAeNamespace|Enabled"
-msgstr ""
-
-msgid "MiqAeNamespace|Name"
-msgstr ""
-
-msgid "MiqAeNamespace|Priority"
-msgstr ""
-
-msgid "MiqAeNamespace|System"
-msgstr ""
-
-msgid "MiqAeNamespace|Updated by"
-msgstr ""
-
-msgid "MiqAeNamespace|Updated on"
-msgstr ""
-
-msgid "MiqAeValue|Collect"
-msgstr ""
-
-msgid "MiqAeValue|Condition"
-msgstr ""
-
-msgid "MiqAeValue|Created on"
-msgstr ""
-
-msgid "MiqAeValue|Display name"
-msgstr ""
-
-msgid "MiqAeValue|Max retries"
-msgstr ""
-
-msgid "MiqAeValue|Max time"
-msgstr ""
-
-msgid "MiqAeValue|On entry"
-msgstr ""
-
-msgid "MiqAeValue|On error"
-msgstr ""
-
-msgid "MiqAeValue|On exit"
-msgstr ""
-
-msgid "MiqAeValue|Updated by"
-msgstr ""
-
-msgid "MiqAeValue|Updated on"
-msgstr ""
-
-msgid "MiqAeValue|Value"
 msgstr ""
 
 msgid "MiqAlertSet|Created on"
@@ -6754,64 +7096,64 @@ msgstr ""
 msgid "MiqEnterprise|Updated on"
 msgstr ""
 
-msgid "MiqEventSet|Created on"
+msgid "MiqEventDefinitionSet|Created on"
 msgstr ""
 
-msgid "MiqEventSet|Description"
+msgid "MiqEventDefinitionSet|Description"
 msgstr ""
 
-msgid "MiqEventSet|Guid"
+msgid "MiqEventDefinitionSet|Guid"
 msgstr ""
 
-msgid "MiqEventSet|Mode"
+msgid "MiqEventDefinitionSet|Mode"
 msgstr ""
 
-msgid "MiqEventSet|Name"
+msgid "MiqEventDefinitionSet|Name"
 msgstr ""
 
-msgid "MiqEventSet|Owner type"
+msgid "MiqEventDefinitionSet|Owner type"
 msgstr ""
 
-msgid "MiqEventSet|Read only"
+msgid "MiqEventDefinitionSet|Read only"
 msgstr ""
 
-msgid "MiqEventSet|Set data"
+msgid "MiqEventDefinitionSet|Set data"
 msgstr ""
 
-msgid "MiqEventSet|Set type"
+msgid "MiqEventDefinitionSet|Set type"
 msgstr ""
 
-msgid "MiqEventSet|Updated on"
+msgid "MiqEventDefinitionSet|Updated on"
 msgstr ""
 
-msgid "MiqEventSet|Userid"
+msgid "MiqEventDefinitionSet|Userid"
 msgstr ""
 
-msgid "MiqEvent|Created on"
+msgid "MiqEventDefinition|Created on"
 msgstr ""
 
-msgid "MiqEvent|Default"
+msgid "MiqEventDefinition|Default"
 msgstr ""
 
-msgid "MiqEvent|Definition"
+msgid "MiqEventDefinition|Definition"
 msgstr ""
 
-msgid "MiqEvent|Description"
+msgid "MiqEventDefinition|Description"
 msgstr ""
 
-msgid "MiqEvent|Enabled"
+msgid "MiqEventDefinition|Enabled"
 msgstr ""
 
-msgid "MiqEvent|Event type"
+msgid "MiqEventDefinition|Event type"
 msgstr ""
 
-msgid "MiqEvent|Guid"
+msgid "MiqEventDefinition|Guid"
 msgstr ""
 
-msgid "MiqEvent|Name"
+msgid "MiqEventDefinition|Name"
 msgstr ""
 
-msgid "MiqEvent|Updated on"
+msgid "MiqEventDefinition|Updated on"
 msgstr ""
 
 msgid "MiqGroup|Created on"
@@ -7720,13 +8062,22 @@ msgstr ""
 msgid "My Filters"
 msgstr ""
 
+msgid "My Personal Filters"
+msgstr ""
+
 msgid "My Services"
 msgstr ""
 
 msgid "My Settings"
 msgstr ""
 
+msgid "MyTags"
+msgstr ""
+
 msgid "N/A"
+msgstr ""
+
+msgid "NFS Server"
 msgstr ""
 
 msgid "NONE"
@@ -7747,10 +8098,10 @@ msgstr ""
 msgid "Name: %s | %s Type: %s"
 msgstr ""
 
-msgid "Name: %s | Host Name: %s"
+msgid "Name: %s | Hostname: %s"
 msgstr ""
 
-msgid "Name: %s | Host Name: %s | Refresh Status: %s"
+msgid "Name: %s | Hostname: %s | Refresh Status: %s"
 msgstr ""
 
 msgid "Name: %s | Path: %s"
@@ -7828,9 +8179,6 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-msgid "New Catalog Item"
-msgstr ""
-
 msgid "New Entry"
 msgstr ""
 
@@ -7846,8 +8194,13 @@ msgstr ""
 msgid "New Parameter"
 msgstr ""
 
-msgid "New setting will affect %s"
+msgid "New Password"
 msgstr ""
+
+msgid "New setting will affect Orchestration Stack"
+msgid_plural "New setting will affect Orchestration Stacks"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "New setting will affect Service"
 msgid_plural "New setting will affect Services"
@@ -7874,10 +8227,10 @@ msgstr ""
 msgid "No %s %s Policies are defined %s."
 msgstr ""
 
-msgid "No %s Alert Profiles are defined%s."
+msgid "No %s Alert Profiles are defined %s."
 msgstr ""
 
-msgid "No %s Conditions are defined%s."
+msgid "No %s Conditions are defined %s."
 msgstr ""
 
 msgid "No %s Policy Profiles are defined%s."
@@ -7985,7 +8338,7 @@ msgstr ""
 msgid "No Choices Available"
 msgstr ""
 
-msgid "No Class found for explorer tree node type '%s'"
+msgid "No Class found for explorer tree node id '%s'"
 msgstr ""
 
 msgid "No Dashboards are defined for this group. Default dashboard will be shown."
@@ -8006,6 +8359,11 @@ msgid "No Display Filter defined."
 msgstr ""
 
 msgid "No Group"
+msgstr ""
+
+msgid ""
+"No Hourly or Daily data is available, real time data from the Most Recent Hour"
+" is being displayed"
 msgstr ""
 
 msgid "No Indexes found for this table."
@@ -8138,9 +8496,6 @@ msgstr ""
 msgid "No events available for this timeline."
 msgstr ""
 
-msgid "No explorer tree node type found for '%s'"
-msgstr ""
-
 msgid "No expression defined, a condition must contain a valid expression."
 msgstr ""
 
@@ -8195,6 +8550,12 @@ msgstr ""
 msgid "No variables configured."
 msgstr ""
 
+msgid "Node Port"
+msgstr ""
+
+msgid "Node Selector"
+msgstr ""
+
 msgid "Nodes"
 msgstr ""
 
@@ -8242,6 +8603,9 @@ msgstr ""
 msgid "Note: Only Time Profiles with 'Roll Up Performance' set are shown."
 msgstr ""
 
+msgid "Note: Username must be in the format: name@realm"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -8267,6 +8631,9 @@ msgid "Number of VMs"
 msgstr ""
 
 msgid "OR with a new expression element"
+msgstr ""
+
+msgid "OS"
 msgstr ""
 
 msgid "OS %s"
@@ -9601,6 +9968,9 @@ msgstr ""
 msgid "OpenStack Status"
 msgstr ""
 
+msgid "Openstack Infra Provider"
+msgstr ""
+
 msgid "Openstack Infra provider"
 msgstr ""
 
@@ -9629,6 +9999,9 @@ msgid "OperatingSystem|Build number"
 msgstr ""
 
 msgid "OperatingSystem|Distribution"
+msgstr ""
+
+msgid "OperatingSystem|Kernel version"
 msgstr ""
 
 msgid "OperatingSystem|Lockout duration"
@@ -9685,6 +10058,9 @@ msgstr ""
 msgid "OperatingSystem|Version"
 msgstr ""
 
+msgid "Optimize"
+msgstr ""
+
 msgid "Option 1"
 msgstr ""
 
@@ -9707,9 +10083,6 @@ msgid "Orchestration Template"
 msgstr ""
 
 msgid "Orchestration Template \"%s\" was deleted."
-msgstr ""
-
-msgid "Orchestration Template Information"
 msgstr ""
 
 msgid "Orchestration Templates"
@@ -9817,6 +10190,9 @@ msgstr ""
 msgid "OrchestrationStack|Status"
 msgstr ""
 
+msgid "OrchestrationStack|Status reason"
+msgstr ""
+
 msgid "OrchestrationTemplate|Content"
 msgstr ""
 
@@ -9847,13 +10223,22 @@ msgstr ""
 msgid "Organization"
 msgstr ""
 
+msgid "Organization ID"
+msgstr ""
+
 msgid "Original Value"
 msgstr ""
 
 msgid "Orphaned Data"
 msgstr ""
 
+msgid "Orphaned Instances"
+msgstr ""
+
 msgid "Orphaned Records for userid %s were successfully deleted"
+msgstr ""
+
+msgid "Orphaned VMs and Templates"
 msgstr ""
 
 msgid "Os process"
@@ -9901,6 +10286,9 @@ msgstr ""
 msgid "Outputs (%s)"
 msgstr ""
 
+msgid "Overview"
+msgstr ""
+
 msgid "Overwrite existing reports?"
 msgstr ""
 
@@ -9931,6 +10319,9 @@ msgstr ""
 msgid "PXE Images"
 msgstr ""
 
+msgid "Packages"
+msgstr ""
+
 msgid "Packages (%s)"
 msgstr ""
 
@@ -9944,6 +10335,9 @@ msgid "Parameters"
 msgstr ""
 
 msgid "Parameters (%s)"
+msgstr ""
+
+msgid "Parent"
 msgstr ""
 
 msgid "Parent %s: %s"
@@ -9974,6 +10368,9 @@ msgid "Partition"
 msgstr ""
 
 msgid "Partition Table"
+msgstr ""
+
+msgid "Partitions Aligned"
 msgstr ""
 
 msgid "Partition|Controller"
@@ -10024,7 +10421,13 @@ msgstr ""
 msgid "Password fields must match to Validate Database Configuration"
 msgstr ""
 
+msgid "Password or Password+One-Time-Password"
+msgstr ""
+
 msgid "Password/Verify Password do not match"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid ""
@@ -10089,6 +10492,9 @@ msgstr ""
 msgid "Percent Bloat"
 msgstr ""
 
+msgid "Percent Used of Provisioned Size"
+msgstr ""
+
 msgid "Performance Interval"
 msgstr ""
 
@@ -10096,6 +10502,9 @@ msgid "Performance Timeframe"
 msgstr ""
 
 msgid "Period"
+msgstr ""
+
+msgid "Persistent Volume Claim Name"
 msgstr ""
 
 msgid "Picture"
@@ -10137,34 +10546,10 @@ msgstr ""
 msgid "Please select an Instance Type from above"
 msgstr ""
 
-msgid "Pod"
-msgstr ""
-
 msgid "Pods (%s)"
 msgstr ""
 
 msgid "Pods (0)"
-msgstr ""
-
-msgid "Pod|Creation timestamp"
-msgstr ""
-
-msgid "Pod|Dns policy"
-msgstr ""
-
-msgid "Pod|Ems ref"
-msgstr ""
-
-msgid "Pod|Name"
-msgstr ""
-
-msgid "Pod|Namespace"
-msgstr ""
-
-msgid "Pod|Resource version"
-msgstr ""
-
-msgid "Pod|Restart policy"
 msgstr ""
 
 msgid "Policies"
@@ -10215,7 +10600,7 @@ msgstr ""
 msgid "PolicyEvent|Event type"
 msgstr ""
 
-msgid "PolicyEvent|Miq event description"
+msgid "PolicyEvent|Miq event definition description"
 msgstr ""
 
 msgid "PolicyEvent|Miq policy description"
@@ -10237,6 +10622,9 @@ msgid "PolicyEvent|Username"
 msgstr ""
 
 msgid "Port"
+msgstr ""
+
+msgid "Port Configurations"
 msgstr ""
 
 msgid "Power Management"
@@ -10287,7 +10675,19 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
+msgid "Private Keys do not match"
+msgstr ""
+
 msgid "Process ID"
+msgstr ""
+
+msgid "Processor Cores_Per_Socket"
+msgstr ""
+
+msgid "Processor Options"
+msgstr ""
+
+msgid "Processor Sockets"
 msgstr ""
 
 msgid "Processors"
@@ -10305,13 +10705,28 @@ msgstr ""
 msgid "Profile Policies:"
 msgstr ""
 
+msgid "Project/Tenant"
+msgstr ""
+
+msgid "Projects"
+msgstr ""
+
 msgid "Properties"
+msgstr ""
+
+msgid "Property"
 msgstr ""
 
 msgid "Protected"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "Provider"
+msgstr ""
+
+msgid "Provider is not ready to be scaled, another operation is in progress."
 msgstr ""
 
 msgid "Providers"
@@ -10344,7 +10759,10 @@ msgstr ""
 msgid "Provision Order"
 msgstr ""
 
-msgid "Provisioned %s"
+msgid "Provisioned Hosts"
+msgstr ""
+
+msgid "Provisioned Size"
 msgstr ""
 
 msgid "Provisioned VMs"
@@ -10437,10 +10855,10 @@ msgstr ""
 msgid "Queued At"
 msgstr ""
 
-msgid "Quick Start"
+msgid "Quotas"
 msgstr ""
 
-msgid "Quotas"
+msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr ""
 
 msgid "RSA key pair"
@@ -10455,6 +10873,21 @@ msgstr ""
 msgid "RSS Feed no longer exists"
 msgstr ""
 
+msgid "Rados Ceph Monitors"
+msgstr ""
+
+msgid "Rados Image Name"
+msgstr ""
+
+msgid "Rados Keyring"
+msgstr ""
+
+msgid "Rados Pool Name"
+msgstr ""
+
+msgid "Rados User Name"
+msgstr ""
+
 msgid "Range"
 msgstr ""
 
@@ -10465,6 +10898,12 @@ msgid "Rate"
 msgstr ""
 
 msgid "Rate Details"
+msgstr ""
+
+msgid "Rates"
+msgstr ""
+
+msgid "Re-apply the previous change"
 msgstr ""
 
 msgid "Read Only"
@@ -10480,6 +10919,9 @@ msgid "Read Only %{model} \"%{name}\" cannot be edited"
 msgstr ""
 
 msgid "Read only"
+msgstr ""
+
+msgid "Read-Only"
 msgstr ""
 
 msgid "Realm"
@@ -10524,9 +10966,6 @@ msgstr ""
 msgid "Red Hat Updates"
 msgstr ""
 
-msgid "Redo the next change"
-msgstr ""
-
 msgid "Reference VM Profile"
 msgstr ""
 
@@ -10558,6 +10997,9 @@ msgid "Region:"
 msgstr ""
 
 msgid "Register"
+msgstr ""
+
+msgid "Register to"
 msgstr ""
 
 msgid "Registration"
@@ -10621,6 +11063,9 @@ msgid "Relationship|Relationship"
 msgstr ""
 
 msgid "Relationship|Resource type"
+msgstr ""
+
+msgid "Release"
 msgstr ""
 
 msgid "Remote Console plugin is not properly installed."
@@ -10716,6 +11161,12 @@ msgstr ""
 msgid "Replication Worker"
 msgstr ""
 
+msgid "Replicators (%s)"
+msgstr ""
+
+msgid "Replicators (0)"
+msgstr ""
+
 msgid "Report"
 msgstr ""
 
@@ -10786,6 +11237,12 @@ msgid "Repositories"
 msgstr ""
 
 msgid "Repository"
+msgstr ""
+
+msgid "Repository Name(s)"
+msgstr ""
+
+msgid "Repository Name(s):"
 msgstr ""
 
 msgid "Repository|Created on"
@@ -11007,19 +11464,28 @@ msgstr ""
 msgid "Retirement"
 msgstr ""
 
-msgid "Retirement %s removed"
-msgstr ""
-
-msgid "Retirement %{date_text} set to %{rdate}"
-msgstr ""
-
 msgid "Retirement Date"
 msgstr ""
 
 msgid "Retirement Entry Point"
 msgstr ""
 
+msgid "Retirement Entry Point (NameSpace/Class/Instance)"
+msgstr ""
+
 msgid "Retirement Warning"
+msgstr ""
+
+msgid "Retirement date removed"
+msgstr ""
+
+msgid "Retirement date set to %s"
+msgstr ""
+
+msgid "Retirement dates removed"
+msgstr ""
+
+msgid "Retirement dates set to %s"
 msgstr ""
 
 msgid "Right Size Recommendation for %{model} \"%{name}\""
@@ -11085,7 +11551,9 @@ msgstr ""
 msgid "RssFeed|Yml file mtime"
 msgstr ""
 
-msgid "Ruby Script"
+msgid ""
+"Ruby scripts are no longer supported in expressions, please change or remove t"
+"hem."
 msgstr ""
 
 msgid "Run"
@@ -11175,6 +11643,9 @@ msgid "Save this %s search as:"
 msgstr ""
 
 msgid "Save..."
+msgstr ""
+
+msgid "Saved Chargeback Reports"
 msgstr ""
 
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
@@ -11330,7 +11801,7 @@ msgstr ""
 msgid "Search by Name within results"
 msgstr ""
 
-msgid "Second band unit:"
+msgid "Second band unit"
 msgstr ""
 
 msgid "Secondary (Display) Filter"
@@ -11342,7 +11813,13 @@ msgstr ""
 msgid "Secret Access Key"
 msgstr ""
 
+msgid "Secret Access Keys do not match"
+msgstr ""
+
 msgid "Secret Key"
+msgstr ""
+
+msgid "Secret Name"
 msgstr ""
 
 msgid "Security"
@@ -11379,6 +11856,9 @@ msgid "Select Alerts to be Evaluated"
 msgstr ""
 
 msgid "Select Entry Point %s"
+msgstr ""
+
+msgid "Select Host to validate against"
 msgstr ""
 
 msgid "Select Policy Profiles"
@@ -11453,6 +11933,9 @@ msgstr ""
 msgid "Select only one or consecutive %s to move up"
 msgstr ""
 
+msgid "Select to change to another Group"
+msgstr ""
+
 msgid "Selected"
 msgstr ""
 
@@ -11490,6 +11973,9 @@ msgid "Selection"
 msgstr ""
 
 msgid "Selections"
+msgstr ""
+
+msgid "Selector"
 msgstr ""
 
 msgid "Send E-mail"
@@ -11537,12 +12023,10 @@ msgstr ""
 msgid "Server Roles"
 msgstr ""
 
-msgid ""
-"Server information, Username and matching password fields are needed to perfor"
-"m verification of credentials"
+msgid "Server role"
 msgstr ""
 
-msgid "Server role"
+msgid "Server: %s"
 msgstr ""
 
 msgid "ServerRole|Created on"
@@ -11584,7 +12068,7 @@ msgstr ""
 msgid "Service Dialog \"%s\" was successfully created"
 msgstr ""
 
-msgid "Service Dialog Information"
+msgid "Service Dialog Import/Export"
 msgstr ""
 
 msgid "Service Dialog Name"
@@ -11767,9 +12251,6 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-msgid "Settings and Operations"
-msgstr ""
-
 msgid "Shortcuts"
 msgstr ""
 
@@ -11777,6 +12258,9 @@ msgid "Show"
 msgstr ""
 
 msgid "Show %s"
+msgstr ""
+
+msgid "Show %s %s"
 msgstr ""
 
 msgid "Show %s & %s"
@@ -11806,10 +12290,25 @@ msgstr ""
 msgid "Show Capacity & Utilization"
 msgstr ""
 
+msgid "Show Container Groups"
+msgstr ""
+
 msgid "Show Container Nodes"
 msgstr ""
 
+msgid "Show Container Projects"
+msgstr ""
+
+msgid "Show Container Replicators"
+msgstr ""
+
+msgid "Show Container Routes"
+msgstr ""
+
 msgid "Show Container Services"
+msgstr ""
+
+msgid "Show Containers"
 msgstr ""
 
 msgid "Show Costs by"
@@ -11819,6 +12318,12 @@ msgid "Show Event Logs on this VM"
 msgstr ""
 
 msgid "Show Host Events"
+msgstr ""
+
+msgid "Show Image Registries"
+msgstr ""
+
+msgid "Show Images"
 msgstr ""
 
 msgid "Show Input Parameters"
@@ -11837,6 +12342,9 @@ msgid "Show Pods"
 msgstr ""
 
 msgid "Show Refresh Button"
+msgstr ""
+
+msgid "Show Replicators"
 msgstr ""
 
 msgid "Show Resource Pools"
@@ -11932,16 +12440,13 @@ msgstr ""
 msgid "Show all registered %s"
 msgstr ""
 
-msgid "Show all used %s on this %s"
-msgstr ""
-
 msgid "Show at Login"
 msgstr ""
 
 msgid "Show configuration"
 msgstr ""
 
-msgid "Show daily data from:"
+msgid "Show daily data from"
 msgstr ""
 
 msgid "Show disks"
@@ -11953,10 +12458,10 @@ msgstr ""
 msgid "Show event logs on this VM"
 msgstr ""
 
-msgid "Show events from last:"
+msgid "Show events from last"
 msgstr ""
 
-msgid "Show hourly data from:"
+msgid "Show hourly data from"
 msgstr ""
 
 msgid "Show in Console"
@@ -12082,9 +12587,6 @@ msgstr ""
 msgid "Show this Flavor's parent %s"
 msgstr ""
 
-msgid "Show this Pod's parent %s"
-msgstr ""
-
 msgid "Show this Security Group's parent %s"
 msgstr ""
 
@@ -12100,10 +12602,25 @@ msgstr ""
 msgid "Show this Vm's parent %s"
 msgstr ""
 
+msgid "Show this container group's parent %s"
+msgstr ""
+
 msgid "Show this container node's parent %s"
 msgstr ""
 
+msgid "Show this container replicator's parent %s"
+msgstr ""
+
 msgid "Show this container service's parent %s"
+msgstr ""
+
+msgid "Show this images registry %s"
+msgstr ""
+
+msgid "Show this pod's parent %s"
+msgstr ""
+
+msgid "Show topology"
 msgstr ""
 
 msgid "Show tree of all VMs in this Resource Pool"
@@ -12158,6 +12675,9 @@ msgid "Small Trees"
 msgstr ""
 
 msgid "Smart Management"
+msgstr ""
+
+msgid "SmartProxy Affinity"
 msgstr ""
 
 msgid "SmartProxy Server IP"
@@ -12224,6 +12744,9 @@ msgid "Snapshot|Uid ems"
 msgstr ""
 
 msgid "Snapshot|Updated on"
+msgstr ""
+
+msgid "Sockets"
 msgstr ""
 
 msgid ""
@@ -12304,6 +12827,9 @@ msgstr ""
 msgid "State"
 msgstr ""
 
+msgid "State Machine (NS/Cls/Inst)"
+msgstr ""
+
 msgid "Status"
 msgstr ""
 
@@ -12329,6 +12855,9 @@ msgid "Storage Adapters"
 msgstr ""
 
 msgid "Storage Managers"
+msgstr ""
+
+msgid "Storage Medium Type"
 msgstr ""
 
 msgid "Storage Relationships"
@@ -12490,7 +13019,13 @@ msgstr ""
 msgid "Subscribe to this feed"
 msgstr ""
 
+msgid "Substitute: %s"
+msgstr ""
+
 msgid "Substitution:"
+msgstr ""
+
+msgid "Successful"
 msgstr ""
 
 msgid "Successfully deleted %s from the CFME Database"
@@ -12538,6 +13073,9 @@ msgstr ""
 msgid "Synchronous"
 msgstr ""
 
+msgid "Sysprep"
+msgstr ""
+
 msgid "Sysprep \"%s\" upload was successful"
 msgstr ""
 
@@ -12545,6 +13083,9 @@ msgid "System Default"
 msgstr ""
 
 msgid "System service"
+msgstr ""
+
+msgid "System/Process"
 msgstr ""
 
 msgid "System/Process/"
@@ -12631,7 +13172,7 @@ msgstr ""
 msgid "Tag edits were successfully saved"
 msgstr ""
 
-msgid "Tag to Apply:"
+msgid "Tag to Apply"
 msgstr ""
 
 msgid "Tagging"
@@ -12655,10 +13196,13 @@ msgstr ""
 msgid "Target Options/Limits"
 msgstr ""
 
-msgid "Task State:"
+msgid "Target Port"
 msgstr ""
 
-msgid "Task Status:"
+msgid "Task State"
+msgstr ""
+
+msgid "Task Status"
 msgstr ""
 
 msgid "Tasks"
@@ -12685,7 +13229,76 @@ msgstr ""
 msgid "Tenancy"
 msgstr ""
 
+msgid "Tenant"
+msgstr ""
+
+msgid "Tenant ID"
+msgstr ""
+
+msgid "Tenant quota"
+msgstr ""
+
+msgid "TenantQuota|Name"
+msgstr ""
+
+msgid "TenantQuota|Unit"
+msgstr ""
+
+msgid "TenantQuota|Value"
+msgstr ""
+
 msgid "Tenants"
+msgstr ""
+
+msgid "Tenants (%s)"
+msgstr ""
+
+msgid "Tenant|Ancestry"
+msgstr ""
+
+msgid "Tenant|Description"
+msgstr ""
+
+msgid "Tenant|Divisible"
+msgstr ""
+
+msgid "Tenant|Domain"
+msgstr ""
+
+msgid "Tenant|Login logo content type"
+msgstr ""
+
+msgid "Tenant|Login logo file name"
+msgstr ""
+
+msgid "Tenant|Login logo file size"
+msgstr ""
+
+msgid "Tenant|Login logo updated at"
+msgstr ""
+
+msgid "Tenant|Login text"
+msgstr ""
+
+msgid "Tenant|Logo content type"
+msgstr ""
+
+msgid "Tenant|Logo file name"
+msgstr ""
+
+msgid "Tenant|Logo file size"
+msgstr ""
+
+msgid "Tenant|Logo updated at"
+msgstr ""
+
+msgid "Tenant|Name"
+msgstr ""
+
+msgid "Tenant|Subdomain"
+msgstr ""
+
+msgid "Tenant|Use config for attributes"
 msgstr ""
 
 msgid "Test E-mail Address"
@@ -12792,7 +13405,7 @@ msgid ""
 "or edited manually."
 msgstr ""
 
-msgid "Third band unit:"
+msgid "Third band unit"
 msgstr ""
 
 msgid "This Action is not assigned to any Policies."
@@ -12868,6 +13481,9 @@ msgid "Time Profile"
 msgstr ""
 
 msgid "Time Profile Information"
+msgstr ""
+
+msgid "Time Profiles"
 msgstr ""
 
 msgid "Time Zone"
@@ -12962,7 +13578,16 @@ msgstr ""
 msgid "Toggle All/None"
 msgstr ""
 
+msgid "Token"
+msgstr ""
+
 msgid "Top values to show"
+msgstr ""
+
+msgid "Topology"
+msgstr ""
+
+msgid "Total Processors"
 msgstr ""
 
 msgid "Total VMs: 0"
@@ -13028,6 +13653,9 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
+msgid "Type: %s"
+msgstr ""
+
 msgid "UI Worker"
 msgstr ""
 
@@ -13053,16 +13681,22 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
+msgid "Unassigned Profiles Group"
+msgstr ""
+
 msgid "Unassigned:"
 msgstr ""
 
 msgid "Unattended GUI"
 msgstr ""
 
-msgid "Undo the previous change"
+msgid "Undo the last change"
 msgstr ""
 
 msgid "Unexpected error encountered"
+msgstr ""
+
+msgid "Units"
 msgstr ""
 
 msgid "Unknown"
@@ -13078,9 +13712,6 @@ msgid "Update"
 msgstr ""
 
 msgid "Update Password"
-msgstr ""
-
-msgid "Update Repository"
 msgstr ""
 
 msgid "Update Status"
@@ -13140,6 +13771,9 @@ msgstr ""
 msgid "Use Custom Logo Image"
 msgstr ""
 
+msgid "Use HTTP Proxy"
+msgstr ""
+
 msgid "Use the Browse button to locate %s file"
 msgstr ""
 
@@ -13150,6 +13784,9 @@ msgid "Use the Browse button to locate an Import file"
 msgstr ""
 
 msgid "Use the Browse button to locate an Upload file"
+msgstr ""
+
+msgid "Used Size"
 msgstr ""
 
 msgid "Used for SSH connection to all %s in this provider."
@@ -13215,9 +13852,6 @@ msgstr ""
 msgid "User will input the value"
 msgstr ""
 
-msgid "User:"
-msgstr ""
-
 msgid "Username"
 msgstr ""
 
@@ -13231,6 +13865,9 @@ msgid "Users (%s)"
 msgstr ""
 
 msgid "Users (0)"
+msgstr ""
+
+msgid "Users are only allowed to delete their own requests"
 msgstr ""
 
 msgid "Users in this Group"
@@ -13343,6 +13980,9 @@ msgstr ""
 msgid "VM/Instance"
 msgstr ""
 
+msgid "VMDB"
+msgstr ""
+
 msgid "VMM Information"
 msgstr ""
 
@@ -13367,7 +14007,16 @@ msgstr ""
 msgid "VMware Console Support"
 msgstr ""
 
+msgid "VMware MKS Plugin"
+msgstr ""
+
 msgid "VMware MKS Plugin Version"
+msgstr ""
+
+msgid "VMware VMRC Plugin"
+msgstr ""
+
+msgid "VNC"
 msgstr ""
 
 msgid "VNC Console"
@@ -13394,6 +14043,9 @@ msgstr ""
 msgid "Validate the LDAP Settings by binding with the %s"
 msgstr ""
 
+msgid "Validate the credentials"
+msgstr ""
+
 msgid "Validate the credentials by logging into the Server"
 msgstr ""
 
@@ -13416,6 +14068,9 @@ msgid "Value to Set"
 msgstr ""
 
 msgid "Value:"
+msgstr ""
+
+msgid "Values"
 msgstr ""
 
 msgid "Variable Object ID"
@@ -13442,16 +14097,31 @@ msgstr ""
 msgid "Verify %s"
 msgstr ""
 
+msgid "Verify Client Key"
+msgstr ""
+
 msgid "Verify Password"
 msgstr ""
 
 msgid "Verify Peer Certificate"
 msgstr ""
 
+msgid "Verify Private Key"
+msgstr ""
+
+msgid "Verify Secret Access Key"
+msgstr ""
+
 msgid "Version"
 msgstr ""
 
 msgid "Version / Build"
+msgstr ""
+
+msgid "View %s"
+msgstr ""
+
+msgid "View %s %s"
 msgstr ""
 
 msgid "View %s Folder"
@@ -13481,6 +14151,9 @@ msgstr ""
 msgid "View LDAP Regions"
 msgstr ""
 
+msgid "View Parent Tenant"
+msgstr ""
+
 msgid "View Roles"
 msgstr ""
 
@@ -13488,6 +14161,9 @@ msgid "View Schedules"
 msgstr ""
 
 msgid "View Storage Rates"
+msgstr ""
+
+msgid "View Tenants"
 msgstr ""
 
 msgid "View This Alert"
@@ -13617,6 +14293,21 @@ msgid "Virtual Machines"
 msgstr ""
 
 msgid "Visibility"
+msgstr ""
+
+msgid "Visual"
+msgstr ""
+
+msgid "Vm"
+msgstr ""
+
+msgid "Vm Compliance Policies"
+msgstr ""
+
+msgid "Vm Control Policies"
+msgstr ""
+
+msgid "Vm Policies"
 msgstr ""
 
 msgid "Vm or template"
@@ -13931,6 +14622,15 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
+msgid "Volume ID"
+msgstr ""
+
+msgid "Volume Path"
+msgstr ""
+
+msgid "Volumes"
+msgstr ""
+
 msgid "Volume|Created on"
 msgstr ""
 
@@ -14127,6 +14827,9 @@ msgstr ""
 msgid "back"
 msgstr ""
 
+msgid "blank"
+msgstr ""
+
 msgid "bold"
 msgstr ""
 
@@ -14157,6 +14860,12 @@ msgstr ""
 msgid "instances"
 msgstr ""
 
+msgid "ldap"
+msgstr ""
+
+msgid "ldaps"
+msgstr ""
+
 msgid "locale_name"
 msgstr "English"
 
@@ -14166,13 +14875,13 @@ msgstr ""
 msgid "memory_cpu"
 msgstr ""
 
+msgid "no value"
+msgstr ""
+
 msgid "none"
 msgstr ""
 
 msgid "normal"
-msgstr ""
-
-msgid "not specified"
 msgstr ""
 
 msgid "numvcpus"

--- a/config/locales/ja/manageiq.po
+++ b/config/locales/ja/manageiq.po
@@ -8,7 +8,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: manageiq 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-11 22:51+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -34,8 +33,7 @@ msgstr " (次を含む名前 \"%s\")"
 msgid " (current)"
 msgstr " (現在)"
 
-msgid ""
-" * Multiple UI workers can not be configured with session store as memory"
+msgid " * Multiple UI workers can not be configured with session store as memory"
 msgstr " * 複数の UI ワーカーをメモリーとしてセッションストアで設定することはできません"
 
 msgid " Selected Actions:"
@@ -43,6 +41,9 @@ msgstr " 選択したアクション:"
 
 msgid " Selected Alerts:"
 msgstr " 選択したアラート:"
+
+msgid " Valid numeric quota value required "
+msgstr ""
 
 msgid " that match the entered search string"
 msgstr " 入力した検索文字列に一致する"
@@ -74,6 +75,13 @@ msgstr "\"%{name}\": %{rep_count} が使用中のため、削除できません"
 msgid "\"%{record}\": %{task} successfully initiated"
 msgstr "\"%{record}\": %{task} が正常に実行されました"
 
+#, fuzzy
+msgid "\"%{record}\": Analysis successfully initiated"
+msgstr "\"%{record}\": %{task} が正常に実行されました"
+
+msgid "\"Unable to initiate scaling, obtaining of status failed: #{ex}\""
+msgstr ""
+
 msgid "% Savings"
 msgstr "% 節約"
 
@@ -89,10 +97,11 @@ msgstr "%s"
 msgid "%s  Ending with"
 msgstr "%s:  終了"
 
-msgid "%s & %s"
-msgstr "%s & %s"
-
 msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#, fuzzy
+msgid "%s (0)"
 msgstr "%s (%s)"
 
 msgid "%s (All %s)"
@@ -100,6 +109,10 @@ msgstr "%s (すべての %s)"
 
 msgid "%s (All cloud tenants present on this host)"
 msgstr "%s (このホストにあるすべてのクラウドテナント)"
+
+#, fuzzy
+msgid "%s Alert Profiles"
+msgstr "アラートプロファイル"
 
 msgid "%s Being Tagged"
 msgstr "%s のタグ付け"
@@ -115,11 +128,6 @@ msgstr "%s 条件"
 
 msgid "%s Credentials validated successfully"
 msgstr "%s 認証情報が正常に検証されました"
-
-msgid "%s Day"
-msgid_plural "%s Days"
-msgstr[0] "%s 日"
-msgstr[1] "%s 日"
 
 msgid "%s Days Ago"
 msgstr "%s 日前"
@@ -170,9 +178,6 @@ msgstr "%s 設定"
 msgid "%s Summary"
 msgstr "%s 概要"
 
-msgid "%s Tags"
-msgstr "%s タグ"
-
 msgid "%s Utilization"
 msgstr "%s 使用率"
 
@@ -199,7 +204,8 @@ msgstr "選択したサーバー用に %s が開始されました"
 msgid "%s has no network adapters"
 msgstr "%s にはネットワークアダプターがありません"
 
-msgid "%s has no snapshots."
+#, fuzzy
+msgid "%s has no snapshots"
 msgstr "%s にはスナップショットがありません。"
 
 msgid "%s is currently being used in the Display Filter"
@@ -250,6 +256,10 @@ msgstr "%s は存在しません。このアラートは再設定する必要が
 msgid "%s record no longer exists"
 msgstr "%s 記録は存在しません"
 
+#, fuzzy
+msgid "%s requests cannot be deleted"
+msgstr "'%s' は削除できません"
+
 msgid "%s saved"
 msgstr "%s が保存されました"
 
@@ -270,11 +280,6 @@ msgstr "タイムフィールドが最低 1 つ選択されていない場合 %s
 
 msgid "%s tab is not available until at least 1 field has been selected"
 msgstr "フィールドが最低 1 つ選択されていない場合 %s タブは利用できません "
-
-msgid ""
-"%s to validate against, Username and matching password fields are needed to "
-"perform verification of credentials"
-msgstr "検証対象の %s、ユーザー名および一致するパスワードフィールドは、認証情報を確認するために必要です"
 
 msgid "%s was cancelled by the user"
 msgstr "%s がユーザーによりキャンセルされました"
@@ -302,6 +307,10 @@ msgstr "%{field} 値エラー: %{msg}"
 
 msgid "%{field} cannot contain \"%{character}\""
 msgstr "%{field} には \"%{character}\" を含めることができません"
+
+#, fuzzy
+msgid "%{model}"
+msgstr "%{typ} %{model}"
 
 msgid "%{model} \"%{name}\""
 msgstr "%{model} \"%{name}\""
@@ -334,6 +343,10 @@ msgid "%{model} \"%{name}\": Delete successful"
 msgstr "%{model} \"%{name}\": 正常に削除されました"
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
+msgstr "%{model} \"%{name}\": '%{task}' の実行中にエラーが発生しました: "
+
+#, fuzzy
+msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr "%{model} \"%{name}\": '%{task}' の実行中にエラーが発生しました: "
 
 msgid "%{model} for \"%{name}\""
@@ -375,13 +388,25 @@ msgstr "%{task} %{model} \"%{name}\""
 msgid "%{task} does not apply because you selected at least one %{model}"
 msgstr "1 つ以上の %{model} が選択されているので %{task} は適用されません"
 
+msgid "%{task} does not apply because you selected at least one un-reconfigurable VM"
+msgstr ""
+
+#, fuzzy
+msgid "%{task} does not apply to at least one of the selected %{model}"
+msgstr "1 つ以上の %{model} が選択されているので %{task} は適用されません"
+
 msgid "%{task} does not apply to selected %{model}"
 msgstr "選択した %{model} に %{task} は適用されません"
 
-msgid "%{task} initiated for %{count_model} (Foreman) from the CFME Database"
+#, fuzzy
+msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
 msgstr "CFME データベースから %{count_model} (Foreman) の %{task} が実行されました"
 
 msgid "%{task} initiated for %{count_model} from the CFME Database"
+msgstr "CFME データベースから %{count_model} の %{task} が実行されました"
+
+#, fuzzy
+msgid "%{task} initiated for %{model} from the CFME Database"
 msgstr "CFME データベースから %{count_model} の %{task} が実行されました"
 
 msgid "%{typ} %{model}"
@@ -394,21 +419,21 @@ msgid "%{typ} %{model} \"%{name}\" (current)"
 msgstr "%{typ} %{model} \"%{name}\" (current)"
 
 msgid ""
-"%{typ} Request was Submitted, you will be notified when your %{title} are "
-"ready"
+"%{typ} Request was Submitted, you will be notified when your %{title} are read"
+"y"
 msgstr "%{typ} リクエストが送信されました。%{title} の準備ができた時点で通知が送信されます"
 
 msgid ""
-"%{typ} Request was re-submitted, you will be notified when your %{title} are "
-"ready"
+"%{typ} Request was re-submitted, you will be notified when your %{title} are r"
+"eady"
 msgstr "%{typ} リクエストが再送信されました。%{title} の準備ができた時点で通知が送信されます"
 
 msgid "%{typ} in %{model} \"%{name}\""
 msgstr "%{model} \"%{name}\" 内の %{typ} "
 
 msgid ""
-"%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone "
-"\"%{zone}\""
+"%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone"
+"}\""
 msgstr "%{typ} 設定が CFME サーバー \"%{name} [%{server_id}]\" のゾーン \"%{zone}\" に保存されました"
 
 msgid "%{val} missing for %{field}"
@@ -447,9 +472,6 @@ msgstr "(LDAP グループ検索)"
 msgid "(MB) memory"
 msgstr "(MB) メモリー"
 
-msgid "(NS/Cls/Inst)"
-msgstr "(名前空間/クラス/インスタンス)"
-
 msgid "(Row %{start_number} of %{pages})"
 msgstr "(%{start_number} 行/%{pages})"
 
@@ -471,8 +493,7 @@ msgstr "(オプション) 代替サービスのアドレス"
 msgid "(optional) your HTTP proxy information"
 msgstr "(オプション)  HTTP プロキシー情報"
 
-msgid ""
-"* 'Name' and 'Single Value' fields cannot be edited after adding a category."
+msgid "* 'Name' and 'Single Value' fields cannot be edited after adding a category."
 msgstr "* '名前' および '単一値' フィールドは、カテゴリーの追加後に編集することができません。"
 
 msgid "* Base the report on"
@@ -481,29 +502,26 @@ msgstr "* レポートのベース"
 msgid "* Cannot be changed while this Alert belongs to an Alert Profile."
 msgstr "* このアラートがアラートプロファイルに属している間は変更できません。"
 
-msgid ""
-"* Caution: Changing these fields will clear all selected values below them!"
+msgid "* Caution: Changing these fields will clear all selected values below them!"
 msgstr "* 注意: これらのフィールドを変更すると、それらのフィールドの下で選択したすべての値がクリアされます!"
 
-msgid ""
-"* Changing the Time Zone will reset the Starting Date and Time fields below"
+msgid "* Changing the Time Zone will reset the Starting Date and Time fields below"
 msgstr "* タイムゾーンを変更すると、以下の開始日と時間フィールドがリセットされます。"
 
-msgid ""
-"* Changing the Zone will reset all of this Server's priorities to secondary."
+msgid "* Changing the Zone will reset all of this Server's priorities to secondary."
 msgstr "* ゾーンを変更すると、このサーバーの優先順位がすべて「セカンダリー」にリセットされます。"
 
 msgid ""
-"* Checking this box will remove this setting from all other PXE Images on "
-"this PXE Server"
+"* Checking this box will remove this setting from all other PXE Images on this"
+" PXE Server"
 msgstr "* このボックスをチェックすると、この PXE サーバーにある他のすべての PXE イメージからこの設定が削除されます"
 
 msgid "* Click on any MyTag to permanently delete and unassign it."
 msgstr "* MyTag を永久削除し、割り当て解除するには、それをクリックしてください。"
 
 msgid ""
-"* Daily charts only include days for which all 24 hours of data has been "
-"collected."
+"* Daily charts only include days for which all 24 hours of data has been colle"
+"cted."
 msgstr "* 日次チャートには、24 時間分のデータすべてが収集される日のみが含まれます。"
 
 msgid "* Dashboard name cannot be changed"
@@ -528,13 +546,13 @@ msgid "* Fields are read only for default Widgets"
 msgstr "* デフォルトウィジェットの場合、フィールドは読み取り専用になります。"
 
 msgid ""
-"* If all Conditions are removed from a Policy, it will be unconditional and "
-"always evaluate to true."
+"* If all Conditions are removed from a Policy, it will be unconditional and al"
+"ways evaluate to true."
 msgstr "* ポリシーからすべての条件が削除された場合は、無条件となり常に true と評価されます。"
 
 msgid ""
-"* Information shown is based on available trend data from %s to %s in the %s "
-"time zone."
+"* Information shown is based on available trend data from %s to %s in the %s t"
+"ime zone."
 msgstr "* 表示されている情報は %s から %s (タイムゾーン %s) の入手可能なトレンドデータに基づいています。"
 
 msgid "* Information shown is based on available trend data going back %s."
@@ -544,8 +562,8 @@ msgid "* Items in"
 msgstr "* 次の項目"
 
 msgid ""
-"* Items in <font color=\"red\"><i>red italics</i></font> do not change the "
-"outcome of the scope or expression."
+"* Items in <font color=\"red\"><i>red italics</i></font> do not change the outco"
+"me of the scope or expression."
 msgstr "* <font color=\"red\"><i>赤字イタリック</i></font> の項目はスコープまたは数式の結果を変更しません。"
 
 msgid "* No Actions are configured for this Event."
@@ -605,6 +623,9 @@ msgstr "* 指定された NTP 設定はこのゾーンにのみ適用され、�
 msgid "* Style \"If\" conditions are evaluated top to bottom for each column"
 msgstr "* スタイル \"If\" 条件の評価は、1 列ごとに上から下に向かって実行されます。"
 
+msgid "-- OR --"
+msgstr ""
+
 msgid "1 - Select a Reference VM."
 msgstr "1 - 参照 VM を選択してください。"
 
@@ -618,14 +639,15 @@ msgid "10 Minutes"
 msgstr "10 分"
 
 msgid ""
-"2 - Specify the VM Options to define the source of the values used for the "
-"plan calculations."
+"2 - Specify the VM Options to define the source of the values used for the pla"
+"n calculations."
 msgstr "2 - 計画の計算に使用する値のソースを定義するために VM オプションを指定してください。"
 
 msgid "2 Weeks before retirement"
 msgstr "リタイアの 2 週間前"
 
-msgid "24 Hour Time Period:"
+#, fuzzy
+msgid "24 Hour Time Period"
 msgstr "24 時間単位の期間:"
 
 msgid "3 - Specify Target Options to qualify target %s or %s."
@@ -634,12 +656,14 @@ msgstr "3 - ターゲット %s または %s を限定するにはターゲット
 msgid "30 Days before retirement"
 msgstr "リタイアの30日前"
 
-msgid ""
-"4 - Change the Trend Options used to calculate the daily trends, if desired."
+msgid "4 - Change the Trend Options used to calculate the daily trends, if desired."
 msgstr "4 - 毎日のトレンドを計算するためのトレンドオプションを変更することができます。"
 
 msgid "5 - Press the Submit button."
 msgstr "5 - 「送信」ボタンを押してください。"
+
+msgid "<Archived>"
+msgstr ""
 
 msgid "<Choose a Group>"
 msgstr "<グループの選択>"
@@ -667,6 +691,17 @@ msgstr "<新規 LDAP サーバー>"
 
 msgid "<No Depot>"
 msgstr "<デポなし>"
+
+#, fuzzy
+msgid "<No chart>"
+msgstr "<デポなし>"
+
+#, fuzzy
+msgid "<Orphaned>"
+msgstr "単独データ"
+
+msgid "<Unnamed>"
+msgstr ""
 
 msgid "A %s must be chosen to commit this expression element"
 msgstr "この式要素を使用するには %s を選択することが必要です"
@@ -704,14 +739,15 @@ msgstr "AM:"
 msgid "AMQP"
 msgstr "AMQP"
 
-msgid "AMQP Messaging"
-msgstr "AMQP メッセージング"
-
 msgid "AND with a new expression element"
 msgstr "新規の式要素との論理積 (AND)"
 
 msgid "API Port"
 msgstr "API ポート"
+
+#, fuzzy
+msgid "API Version"
+msgstr "CFME バージョン"
 
 msgid "About"
 msgstr "情報"
@@ -722,12 +758,15 @@ msgstr "アクセスキー"
 msgid "Access Key ID"
 msgstr "アクセスキー ID"
 
+msgid "Access Rules for all Virtual Machines"
+msgstr ""
+
 msgid "Access URL"
 msgstr "アクセス URL"
 
 msgid ""
-"Accessing Management Engine from multiple tabs or windows of the same "
-"browser on a single machine."
+"Accessing Management Engine from multiple tabs or windows of the same browser "
+"on a single machine."
 msgstr "単一マシンの同じブラウザーの複数タブまたはウィンドウから管理エンジンにアクセスしています。"
 
 msgid "Account"
@@ -808,6 +847,10 @@ msgstr "ユーザーの追加"
 msgid "Add a new %s Provider"
 msgstr "新規の %s プロバイダーの追加"
 
+#, fuzzy
+msgid "Add of %{model} was cancelled by the user"
+msgstr "%{action} %{model} はユーザーによりキャンセルされました"
+
 msgid "Add of new %s was cancelled by the user"
 msgstr "新規の %s の追加がユーザーによりキャンセルされました"
 
@@ -816,9 +859,6 @@ msgstr "サブフォルダーを選択したフィルターに追加する"
 
 msgid "Add this %s"
 msgstr "この %s を追加"
-
-msgid "Add this Host"
-msgstr "このホストを追加"
 
 msgid "Add this LDAP Server"
 msgstr "この LDAP サーバーを追加"
@@ -943,13 +983,99 @@ msgstr "すべての %{typ} %{model}"
 msgid "All (%s)"
 msgstr "すべて (%s)"
 
+#, fuzzy
+msgid "All Actions"
+msgstr "セクションの適用"
+
+#, fuzzy
+msgid "All Alert Profiles"
+msgstr "アラートプロファイル"
+
+#, fuzzy
+msgid "All Alerts"
+msgstr "すべてのユーザー"
+
+#, fuzzy
+msgid "All Catalog Items"
+msgstr "カタログ項目"
+
+#, fuzzy
+msgid "All Catalogs"
+msgstr "カタログ"
+
+#, fuzzy
+msgid "All Conditions"
+msgstr "%s 条件"
+
+#, fuzzy
+msgid "All Containers"
+msgstr "コンテナー"
+
 msgid ""
-"All Datastore customizations will be lost. Are you sure you want to reset "
-"all classes and instances to default?"
+"All Datastore customizations will be lost. Are you sure you want to reset all "
+"classes and instances to default?"
 msgstr "カスタマイズされたデータストアがすべて削除されます。すべてのクラスとインスタンスをデフォルトにリセットしますか?"
+
+#, fuzzy
+msgid "All Dialogs"
+msgstr "すべてのファイル"
+
+#, fuzzy
+msgid "All Events"
+msgstr "すべてのユーザー"
 
 msgid "All Files"
 msgstr "すべてのファイル"
+
+#, fuzzy
+msgid "All ISO Datastores"
+msgstr "ISO データストア"
+
+#, fuzzy
+msgid "All Images"
+msgstr "ISO イメージ"
+
+msgid "All Images by Provider that I can see"
+msgstr ""
+
+#, fuzzy
+msgid "All Instances"
+msgstr "インスタンスの表示"
+
+msgid "All Instances by Provider that I can see"
+msgstr ""
+
+#, fuzzy
+msgid "All Orchestration Templates"
+msgstr "オーケストレーションテンプレート"
+
+#, fuzzy
+msgid "All PXE Servers"
+msgstr "LDAP サーバー"
+
+#, fuzzy
+msgid "All Policies"
+msgstr "%s ポリシー"
+
+#, fuzzy
+msgid "All Policy Profiles"
+msgstr "ポリシープロファイル"
+
+#, fuzzy
+msgid "All Services"
+msgstr "マイサービス"
+
+#, fuzzy
+msgid "All System Image Types"
+msgstr "%s のすべてのシステムサービス"
+
+#, fuzzy
+msgid "All Templates"
+msgstr "すべてのテンプレート: 0"
+
+#, fuzzy
+msgid "All Templates & Images"
+msgstr "テンプレート & イメージ"
 
 msgid "All Templates: %s"
 msgstr "すべてのテンプレート: %s"
@@ -960,8 +1086,22 @@ msgstr "すべてのテンプレート: 0"
 msgid "All Users"
 msgstr "すべてのユーザー"
 
+msgid "All VM and Instance Conditions"
+msgstr ""
+
 msgid "All VMs"
 msgstr "すべての VM"
+
+#, fuzzy
+msgid "All VMs & Instances"
+msgstr "VM & インスタンス"
+
+#, fuzzy
+msgid "All VMs & Templates"
+msgstr "VM & テンプレートの表示"
+
+msgid "All VMs & Templates that I can see"
+msgstr ""
 
 msgid "All VMs (Tree View): %s"
 msgstr "すべての VM (ツリービュー): %s"
@@ -986,6 +1126,24 @@ msgstr "カスタマイズしたクラスとインスタンスのすべてがデ
 
 msgid "All fields are needed to perform verification of Database Settings"
 msgstr "すべてのフィールドは、データベース設定の検証を実行するために必要です"
+
+msgid "All of the Images that I can see"
+msgstr ""
+
+msgid "All of the Instances that I can see"
+msgstr ""
+
+msgid "All of the Templates & Images that I can see"
+msgstr ""
+
+msgid "All of the Templates that I can see"
+msgstr ""
+
+msgid "All of the VMs & Instances that I can see"
+msgstr ""
+
+msgid "All of the VMs that I can see"
+msgstr ""
 
 msgid "All selected %s are not in the current region"
 msgstr "選択した %s がすべて現在のリージョンに属していません"
@@ -1013,6 +1171,9 @@ msgstr "内部システムエラー。"
 
 msgid "Analysis"
 msgstr "分析"
+
+msgid "Analysis Affinity was saved"
+msgstr ""
 
 msgid "Analysis History (%s)"
 msgstr "分析履歴 (%s)"
@@ -1086,17 +1247,25 @@ msgstr "承認/否認"
 msgid "Approved/Denied on"
 msgstr "承認/否認日"
 
+msgid "Arch"
+msgstr ""
+
 msgid "Architecture"
 msgstr "アーキテクチャー"
+
+#, fuzzy
+msgid "Archived Instances"
+msgstr "インスタンスの表示"
+
+#, fuzzy
+msgid "Archived VMs and Templates"
+msgstr "VM & テンプレートの表示"
 
 msgid "Are you sure you want to Run Database Garbage Collection Now?"
 msgstr "データベースガベージコレクションを実行してもよろしいですか?"
 
 msgid "Are you sure you want to Run a Database Backup Now?"
 msgstr "データベースのバックアップを実行してもよろしいですか?"
-
-msgid "Are you sure you want to delete build %s?"
-msgstr "ビルド %s を削除してもよろしいですか?"
 
 msgid "Are you sure you want to delete category '%s'?"
 msgstr "カテゴリー '%s' を削除してもよろしいですか?"
@@ -1117,8 +1286,8 @@ msgid "Are you sure you want to remove '%s'from the Dashboard?"
 msgstr "'%s' をダッシュボードから削除してもよろしいですか?"
 
 msgid ""
-"Are you sure you want to remove the '%{a_parent}[%{a}]' assignment from all "
-"of the items below?"
+"Are you sure you want to remove the '%{a_parent}[%{a}]' assignment from all of"
+" the items below?"
 msgstr "'%{a_parent}[%{a}]' の割り当てを以下のすべての項目から削除してもよろしいですか?"
 
 msgid "Are you sure you want to remove this Custom Image?"
@@ -1295,6 +1464,19 @@ msgstr "ユーザー ID"
 msgid "Authorization Error"
 msgstr "認証エラー"
 
+msgid "Auto Refresh other fields when modified"
+msgstr ""
+
+msgid "Auto refresh"
+msgstr ""
+
+msgid "Automate"
+msgstr ""
+
+#, fuzzy
+msgid "Automate Workers"
+msgstr "優先順位ワーカー"
+
 msgid "Automate button %s has been cleared"
 msgstr "自動ボタン %s がクリアされました"
 
@@ -1328,8 +1510,9 @@ msgstr "利用可能な %s アラート:"
 msgid "Available %s Conditions:"
 msgstr "利用可能な %s 条件:"
 
-msgid "Available %s:"
-msgstr "利用可能な %s:"
+#, fuzzy
+msgid "Available %{title}:"
+msgstr "利用可能なアクション:"
 
 msgid "Available Actions:"
 msgstr "利用可能なアクション:"
@@ -1451,6 +1634,23 @@ msgstr "バインド DN"
 msgid "Bind Password"
 msgstr "バインドパスワード"
 
+msgid "Blacklisted event"
+msgstr ""
+
+#, fuzzy
+msgid "BlacklistedEvent|Enabled"
+msgstr "有効化"
+
+#, fuzzy
+msgid "BlacklistedEvent|Event name"
+msgstr "イベントタイプ"
+
+msgid "BlacklistedEvent|Provider model"
+msgstr ""
+
+msgid "BlacklistedEvent|System"
+msgstr ""
+
 msgid "Bottleneck Event Details"
 msgstr "ボトルネックイベント詳細"
 
@@ -1568,8 +1768,7 @@ msgstr "CFME データベース設定が正常に検証されました"
 msgid "CFME Log"
 msgstr "CFME ログ"
 
-msgid ""
-"CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
+msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr "CFME サーバー \"%{name}\" をロール \"%{role_description}\" の %{priority} に設定する"
 
 msgid "CFME Version"
@@ -1612,8 +1811,8 @@ msgid "Calculations"
 msgstr "計算"
 
 msgid ""
-"Can not delete folder, one or more reports in the selected folder are not "
-"owned by your group"
+"Can not delete folder, one or more reports in the selected folder are not owne"
+"d by your group"
 msgstr "フォルダーを削除できません。選択したフォルダー中の 1 つ以上のレポートがあなたのグループによって所有されていません"
 
 msgid "Cancel"
@@ -1647,8 +1846,8 @@ msgid "Cannot display binary content"
 msgstr "バイナリーコンテンツを表示できません"
 
 msgid ""
-"Cannot start log collection, a log collection is already in progress within "
-"this scope"
+"Cannot start log collection, a log collection is already in progress within th"
+"is scope"
 msgstr "ログ収集を開始できません。このスコープのログ収集がすでに進行中です"
 
 msgid "Cannot start log collection, requires a started server"
@@ -1708,8 +1907,7 @@ msgstr "カテゴリータグエントリー"
 msgid "Caution:"
 msgstr "注意:"
 
-msgid ""
-"Caution: Changing the Database settings could make the Server unstartable!"
+msgid "Caution: Changing the Database settings could make the Server unstartable!"
 msgstr "注意: データベースの設定を変更すると、サーバーを起動できなくなる可能性があります!"
 
 msgid "Caution: Manual changes to configuration files can disable the Server!"
@@ -1718,14 +1916,25 @@ msgstr "注意: 設定ファイルを手動で変更すると、サーバーが�
 msgid "Change %s value to submit reconfigure request"
 msgstr "%s 値を変更して再設定のリクエストを送信する"
 
-msgid "Change Password / Confirm Password"
-msgstr "パスワードの変更 / パスワードの確認"
+#, fuzzy
+msgid "Change Group:"
+msgstr "<グループの選択>"
+
+#, fuzzy
+msgid "Change Password"
+msgstr "バインドパスワード"
 
 msgid "Changes"
 msgstr "変更"
 
 msgid "Changing the UI Workers Count will immediately restart the webserver"
 msgstr "UI ワーカー数を変更するとウェブサイトが即時リスタートします"
+
+msgid "Channel Name(s)"
+msgstr ""
+
+msgid "Channel Name(s):"
+msgstr ""
 
 msgid "Chargeback"
 msgstr "チャージバック"
@@ -1808,6 +2017,10 @@ msgstr "チャート設定"
 msgid "Chart Theme"
 msgstr "チャートテーマ"
 
+#, fuzzy
+msgid "Chart mode"
+msgstr "チャートテーマ"
+
 msgid "Chart no longer exists"
 msgstr "チャートは存在しません"
 
@@ -1828,6 +2041,10 @@ msgstr "更新をチェック"
 
 msgid "Checked default filters will be visible."
 msgstr "チェックされているデフォルトフィルターは表示されます。"
+
+#, fuzzy
+msgid "Child Tenants"
+msgstr "クラウドテナント:"
 
 msgid "Child VM Selection"
 msgstr "子 VM の選択"
@@ -1940,6 +2157,14 @@ msgstr "ホストをクリックして設定を取得する"
 msgid "Click on this row to create a new entry"
 msgstr "この行をクリックして新しいエントリーを作成する"
 
+#, fuzzy
+msgid "Click to Logout"
+msgstr "(クリックして削除)"
+
+#, fuzzy
+msgid "Click to add a new category"
+msgstr "クリックして新しいエントリーを追加する"
+
 msgid "Click to add a new entry"
 msgstr "クリックして新しいエントリーを追加する"
 
@@ -1961,9 +2186,6 @@ msgstr "クリックしてこのユーザーの単独の記録を削除する"
 msgid "Click to delete this LDAP Server"
 msgstr "クリックしてこの LDAP サーバーを削除する"
 
-msgid "Click to delete this build"
-msgstr "クリックしてこのビルドを削除する"
-
 msgid "Click to delete this category"
 msgstr "クリックしてこのカテゴリーを削除する"
 
@@ -1979,11 +2201,23 @@ msgstr "クリックしてこのフォレストを削除する"
 msgid "Click to delete this input field from method"
 msgstr "クリックしてこの入力フィールドをメソッドから削除する"
 
+#, fuzzy
+msgid "Click to edit this category"
+msgstr "クリックしてこのカテゴリーを削除する"
+
 msgid "Click to edit this forest"
 msgstr "クリックしてこのフォレストを編集する"
 
 msgid "Click to go to this location"
 msgstr "クリックしてこの場所に移動する"
+
+#, fuzzy
+msgid "Click to open"
+msgstr "(クリックして削除)"
+
+#, fuzzy
+msgid "Click to remove message"
+msgstr "クリックしてメッセージを削除する"
 
 msgid "Click to remove messages"
 msgstr "クリックしてメッセージを削除する"
@@ -2024,6 +2258,14 @@ msgstr "クリックしてポリシーを表示する"
 msgid "Click to view Time Profile"
 msgstr "クリックしてタイムプロファイルを表示する"
 
+#, fuzzy
+msgid "Click to view child Tenant"
+msgstr "クリックして保存されたレポートを表示する"
+
+#, fuzzy
+msgid "Click to view child TenantProject"
+msgstr "クリックしてタイムプロファイルを表示する"
+
 msgid "Click to view details"
 msgstr "クリックして詳細を表示する"
 
@@ -2051,8 +2293,22 @@ msgstr "クリックしてタイムプロファイルを表示/編集する"
 msgid "Client Connections"
 msgstr "クライアント接続"
 
+#, fuzzy
+msgid "Client ID"
+msgstr "オブジェクト ID"
+
+#, fuzzy
+msgid "Client Key"
+msgstr "プライベートキー"
+
+msgid "Client Keys do not match"
+msgstr ""
+
 msgid "Close any duplicate browser sessions, then select a menu option above."
 msgstr "重複したブラウザーセッションを閉じてから、上のメニューオプションを選択します。"
+
+msgid "Cloud Intelligence"
+msgstr ""
 
 msgid "Cloud Networks (%s)"
 msgstr "クラウドネットワーク (%s)"
@@ -2087,6 +2343,10 @@ msgstr "クラウドボリューム"
 msgid "Cloud volume snapshot"
 msgstr "クラウドボリュームスナップショット"
 
+#, fuzzy
+msgid "CloudInit"
+msgstr "クラウドサブネット"
+
 msgid "CloudNetwork|Cidr"
 msgstr "CIDR"
 
@@ -2101,6 +2361,10 @@ msgstr "外部接続"
 
 msgid "CloudNetwork|Name"
 msgstr "名前"
+
+#, fuzzy
+msgid "CloudNetwork|Shared"
+msgstr "有効化"
 
 msgid "CloudNetwork|Status"
 msgstr "ステータス"
@@ -2247,17 +2511,21 @@ msgid "Collect for All %s"
 msgstr "すべての %s を収集"
 
 msgid ""
-"Collect for All %s must be checked to be able to collect C & U data from "
-"Cloud Providers such as Red Hat OpenStack or Amazon EC2"
+"Collect for All %s must be checked to be able to collect C & U data from Cloud"
+" Providers such as Red Hat OpenStack or Amazon EC2"
 msgstr ""
-"Red Hat OpenStack または Amazon EC2 などのクラウドプロバイダーから C & U データを収集できるように、すべての %s "
-"の収集をチェックする必要があります。"
+"Red Hat OpenStack または Amazon EC2 などのクラウドプロバイダーから C & U データを収集できるように、すべての %s の収"
+"集をチェックする必要があります。"
 
 msgid "Collect for All Datastores"
 msgstr "すべてのデータストアの収集"
 
 msgid "Collection Options"
 msgstr "収集オプション"
+
+#, fuzzy
+msgid "Column"
+msgstr "列:"
 
 msgid "Column %s"
 msgstr "列 %s"
@@ -2276,9 +2544,6 @@ msgstr "列 4"
 
 msgid "Column Name"
 msgstr "列名"
-
-msgid "Column:"
-msgstr "列:"
 
 msgid "Commit"
 msgstr "コミット"
@@ -2320,6 +2585,10 @@ msgid "Compliance"
 msgstr "コンプライアンス"
 
 msgid "Compliance Check"
+msgstr "コンプライアンスチェック"
+
+#, fuzzy
+msgid "Compliance Policies"
 msgstr "コンプライアンスチェック"
 
 msgid "Compliance detail"
@@ -2464,8 +2733,8 @@ msgid "Configuration (%s)"
 msgstr "設定 (%s)"
 
 msgid ""
-"Configuration File selection can not be changed until changes are saved or "
-"reset."
+"Configuration File selection can not be changed until changes are saved or res"
+"et."
 msgstr "設定ファイルの選択は、変更が保存またはリセットされるまで変更することができません。"
 
 msgid "Configuration File to Edit"
@@ -2475,6 +2744,13 @@ msgid "Configuration Location"
 msgstr "設定場所"
 
 msgid "Configuration Management"
+msgstr "設定管理"
+
+msgid "Configuration Management Configured Systems"
+msgstr ""
+
+#, fuzzy
+msgid "Configuration Management Providers"
 msgstr "設定管理"
 
 msgid "Configuration Organization"
@@ -2555,6 +2831,10 @@ msgstr "タイプ"
 msgid "Configuration|Updated on"
 msgstr "更新日"
 
+#, fuzzy
+msgid "Configure"
+msgstr "再設定"
+
 msgid "Configure Report Columns"
 msgstr "レポート列の設定"
 
@@ -2588,6 +2868,10 @@ msgstr "マネージャー参照"
 msgid "ConfiguredSystem|Puppet status"
 msgstr "Puppet ステータス"
 
+#, fuzzy
+msgid "Confirm Password"
+msgstr "バインドパスワード"
+
 msgid "Connecting (unencrypted) to: %s"
 msgstr "以下に接続中です (暗号化解除): %s"
 
@@ -2612,11 +2896,13 @@ msgstr "記録を統合すると、レポート内に詳細の記録が表示さ
 msgid "Container"
 msgstr "コンテナー"
 
-msgid "Pods (%s)"
-msgstr "ポッド (%s)"
+#, fuzzy
+msgid "Container Images"
+msgstr "イメージ"
 
-msgid "Pods (0)"
-msgstr "ポッド (0)"
+#, fuzzy
+msgid "Container Nodes"
+msgstr "コンテナーノード"
 
 msgid "Container Nodes (%s)"
 msgstr "コンテナーノード (%s)"
@@ -2624,17 +2910,54 @@ msgstr "コンテナーノード (%s)"
 msgid "Container Nodes (0)"
 msgstr "コンテナーノード (0)"
 
+#, fuzzy
+msgid "Container Projects (%s)"
+msgstr "コンテナーノード (%s)"
+
+#, fuzzy
+msgid "Container Projects (0)"
+msgstr "コンテナーノード (0)"
+
+#, fuzzy
+msgid "Container Routes (%s)"
+msgstr "コンテナーノード (%s)"
+
+#, fuzzy
+msgid "Container Routes (0)"
+msgstr "コンテナーノード (0)"
+
+#, fuzzy
+msgid "Container Services"
+msgstr "コンテナーサービス"
+
 msgid "Container Services (%s)"
 msgstr "コンテナーサービス (%s)"
 
 msgid "Container Services (0)"
 msgstr "コンテナーサービス (0)"
 
+#, fuzzy
+msgid "Container condition"
+msgstr "コンテナー定義"
+
 msgid "Container definition"
 msgstr "コンテナー定義"
 
-msgid "Pod"
-msgstr "ポッド"
+#, fuzzy
+msgid "Container env var"
+msgstr "コンテナーノード"
+
+#, fuzzy
+msgid "Container group"
+msgstr "コンテナーノード"
+
+#, fuzzy
+msgid "Container image"
+msgstr "イメージ"
+
+#, fuzzy
+msgid "Container image registry"
+msgstr "コンテナーサービス"
 
 msgid "Container node"
 msgstr "コンテナーノード"
@@ -2642,11 +2965,50 @@ msgstr "コンテナーノード"
 msgid "Container port config"
 msgstr "コンテナーポート設定"
 
-msgid "Container replication controller"
-msgstr "コンテナー複製コントローラー"
+#, fuzzy
+msgid "Container project"
+msgstr "コンテナーノード"
+
+#, fuzzy
+msgid "Container replicator"
+msgstr "コンテナー定義"
+
+#, fuzzy
+msgid "Container route"
+msgstr "コンテナーノード"
 
 msgid "Container service"
 msgstr "コンテナーサービス"
+
+#, fuzzy
+msgid "Container service port config"
+msgstr "コンテナーポート設定"
+
+#, fuzzy
+msgid "ContainerCondition|Container entity type"
+msgstr "コンテナーポート"
+
+msgid "ContainerCondition|Last heartbeat time"
+msgstr ""
+
+msgid "ContainerCondition|Last transition time"
+msgstr ""
+
+#, fuzzy
+msgid "ContainerCondition|Message"
+msgstr "イメージ"
+
+#, fuzzy
+msgid "ContainerCondition|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerCondition|Reason"
+msgstr "メモリー"
+
+#, fuzzy
+msgid "ContainerCondition|Status"
+msgstr "イメージ"
 
 msgid "ContainerDefinition|Cpu cores"
 msgstr "CPU コア"
@@ -2666,26 +3028,84 @@ msgstr "メモリー"
 msgid "ContainerDefinition|Name"
 msgstr "名前"
 
-msgid "Pod|Creation timestamp"
-msgstr "作成タイムスタンプ"
+msgid "ContainerEnvVar|Field path"
+msgstr ""
 
-msgid "Pod|Dns policy"
-msgstr "DNS ポリシー"
-
-msgid "Pod|Ems ref"
-msgstr "EMS 参照"
-
-msgid "Pod|Name"
+#, fuzzy
+msgid "ContainerEnvVar|Name"
 msgstr "名前"
 
-msgid "Pod|Namespace"
-msgstr "名前空間"
+#, fuzzy
+msgid "ContainerEnvVar|Value"
+msgstr "名前"
 
-msgid "Pod|Resource version"
+#, fuzzy
+msgid "ContainerGroup|Creation timestamp"
+msgstr "作成タイムスタンプ"
+
+#, fuzzy
+msgid "ContainerGroup|Dns policy"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerGroup|Ems ref"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerGroup|Ipaddress"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerGroup|Message"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerGroup|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerGroup|Phase"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerGroup|Reason"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerGroup|Resource version"
 msgstr "リソースバージョン"
 
-msgid "Pod|Restart policy"
-msgstr "再起動ポリシー"
+#, fuzzy
+msgid "ContainerGroup|Restart policy"
+msgstr "再起動数"
+
+#, fuzzy
+msgid "ContainerImageRegistry|Host"
+msgstr "ポート"
+
+#, fuzzy
+msgid "ContainerImageRegistry|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerImageRegistry|Port"
+msgstr "ポート"
+
+#, fuzzy
+msgid "ContainerImage|Image ref"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerImage|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerImage|Tag"
+msgstr "イメージ"
+
+#, fuzzy
+msgid "ContainerNode|Container runtime version"
+msgstr "リソースバージョン"
 
 msgid "ContainerNode|Creation timestamp"
 msgstr "作成タイムスタンプ"
@@ -2702,8 +3122,20 @@ msgstr "Identity マシン"
 msgid "ContainerNode|Identity system"
 msgstr "Identity システム"
 
+#, fuzzy
+msgid "ContainerNode|Kubernetes kubelet version"
+msgstr "リソースバージョン"
+
+#, fuzzy
+msgid "ContainerNode|Kubernetes proxy version"
+msgstr "リソースバージョン"
+
 msgid "ContainerNode|Lives on type"
 msgstr "ライブのタイプ"
+
+#, fuzzy
+msgid "ContainerNode|Max container groups"
+msgstr "コンテナーポート"
 
 msgid "ContainerNode|Name"
 msgstr "名前"
@@ -2726,29 +3158,93 @@ msgstr "ポート"
 msgid "ContainerPortConfig|Protocol"
 msgstr "プロトコル"
 
-msgid "ContainerReplicationController|Creation timestamp"
+#, fuzzy
+msgid "ContainerProject|Creation timestamp"
 msgstr "作成タイムスタンプ"
 
-msgid "ContainerReplicationController|Current replicas"
-msgstr "現在のレプリカ"
+#, fuzzy
+msgid "ContainerProject|Display name"
+msgstr "表示名"
 
-msgid "ContainerReplicationController|Ems ref"
+#, fuzzy
+msgid "ContainerProject|Ems ref"
 msgstr "EMS 参照"
 
-msgid "ContainerReplicationController|Name"
+#, fuzzy
+msgid "ContainerProject|Name"
 msgstr "名前"
 
-msgid "ContainerReplicationController|Namespace"
-msgstr "名前空間"
-
-msgid "ContainerReplicationController|Replicas"
-msgstr "レプリカ"
-
-msgid "ContainerReplicationController|Resource version"
+#, fuzzy
+msgid "ContainerProject|Resource version"
 msgstr "リソースバージョン"
 
-msgid "ContainerService|Container port"
-msgstr "コンテナーポート"
+#, fuzzy
+msgid "ContainerReplicator|Creation timestamp"
+msgstr "作成タイムスタンプ"
+
+#, fuzzy
+msgid "ContainerReplicator|Current replicas"
+msgstr "レプリカ"
+
+#, fuzzy
+msgid "ContainerReplicator|Ems ref"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerReplicator|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerReplicator|Replicas"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerReplicator|Resource version"
+msgstr "リソースバージョン"
+
+#, fuzzy
+msgid "ContainerRoute|Creation timestamp"
+msgstr "作成タイムスタンプ"
+
+#, fuzzy
+msgid "ContainerRoute|Ems ref"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerRoute|Host name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerRoute|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerRoute|Path"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerRoute|Resource version"
+msgstr "リソースバージョン"
+
+#, fuzzy
+msgid "ContainerServicePortConfig|Ems ref"
+msgstr "EMS 参照"
+
+#, fuzzy
+msgid "ContainerServicePortConfig|Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "ContainerServicePortConfig|Port"
+msgstr "ポート"
+
+#, fuzzy
+msgid "ContainerServicePortConfig|Protocol"
+msgstr "プロトコル"
+
+#, fuzzy
+msgid "ContainerServicePortConfig|Target port"
+msgstr "ホストポート"
 
 msgid "ContainerService|Creation timestamp"
 msgstr "作成タイムスタンプ"
@@ -2759,17 +3255,8 @@ msgstr "EMS 参照"
 msgid "ContainerService|Name"
 msgstr "名前"
 
-msgid "ContainerService|Namespace"
-msgstr "名前空間"
-
-msgid "ContainerService|Port"
-msgstr "ポート"
-
 msgid "ContainerService|Portal ip"
 msgstr "ポータル IP"
-
-msgid "ContainerService|Protocol"
-msgstr "プロトコル"
 
 msgid "ContainerService|Resource version"
 msgstr "リソースバージョン"
@@ -2780,14 +3267,19 @@ msgstr "セッションアフィニティー"
 msgid "Containers"
 msgstr "コンテナー"
 
+#, fuzzy
+msgid "Containers (%s)"
+msgstr "コンテナーノード (%s)"
+
+#, fuzzy
+msgid "Containers (0)"
+msgstr "コンテナーノード (0)"
+
 msgid "Container|Backing ref"
 msgstr "バッキング参照"
 
 msgid "Container|Ems ref"
 msgstr "EMS 参照"
-
-msgid "Container|Image"
-msgstr "イメージ"
 
 msgid "Container|Name"
 msgstr "名前"
@@ -2813,6 +3305,10 @@ msgstr "続行"
 msgid "Control"
 msgstr "コントロール"
 
+#, fuzzy
+msgid "Control Policies"
+msgstr "ポリシーの選択"
+
 msgid "Copy"
 msgstr "コピー"
 
@@ -2830,6 +3326,10 @@ msgstr "同じパスへコピー"
 
 msgid "Copying %s"
 msgstr "%s のコピー中"
+
+#, fuzzy
+msgid "Cores Per socket"
+msgstr "ソケットあたりのコア"
 
 msgid "Count"
 msgstr "カウント"
@@ -2884,6 +3384,10 @@ msgstr "現在の %{model} \"%{name}\" を削除することができません"
 
 msgid "Current Backlog"
 msgstr "現在のバックログ"
+
+#, fuzzy
+msgid "Current Group"
+msgstr "イベントグループ"
 
 msgid "Current Rates"
 msgstr "現在のレート"
@@ -3131,6 +3635,13 @@ msgstr "データタイプ"
 msgid "Data Type:"
 msgstr "データタイプ:"
 
+msgid "Data column"
+msgstr ""
+
+#, fuzzy
+msgid "Data type: %s"
+msgstr "データタイプ:"
+
 msgid "Data validated successfully"
 msgstr "データが正常に検証されました"
 
@@ -3153,8 +3664,8 @@ msgid "Database backup"
 msgstr "データベースのバックアップ"
 
 msgid ""
-"Database settings successfully saved, they will take effect upon CFME Server "
-"restart"
+"Database settings successfully saved, they will take effect upon CFME Server r"
+"estart"
 msgstr "データベースの設定が正常に保存されました。この設定は CFME サーバーが再起動した時点で有効になります"
 
 msgid "DatabaseBackup|Name"
@@ -3215,6 +3726,10 @@ msgstr "デフォルト %{model} \"%{name}\" は編集することができま�
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr "デフォルト %{model} \"%{name}\" は削除することができません"
 
+#, fuzzy
+msgid "Default Filters"
+msgstr "デフォルト値"
+
 msgid "Default Filters saved successfully"
 msgstr "デフォルトフィルターが正常に保存されました"
 
@@ -3235,6 +3750,17 @@ msgstr "デフォルトのリポジトリー SmartProxy"
 
 msgid "Default Value"
 msgstr "デフォルト値"
+
+#, fuzzy
+msgid "Default Views"
+msgstr "デフォルト値"
+
+#, fuzzy
+msgid "Default dialogs cannot be edited"
+msgstr "グローバルタイムプロファイルは編集できません"
+
+msgid "Default dialogs cannot be removed from the VMDB"
+msgstr ""
 
 msgid "Delay (mins)"
 msgstr "遅延 (分)"
@@ -3263,12 +3789,10 @@ msgstr "%s という名前のフィルターを削除"
 msgid "Deleting the '%s' LDAP Server, are you sure?"
 msgstr "'%s'　LDAP サーバーを削除します。実行してもよろしいですか?"
 
-msgid ""
-"Deleting the '%s' entry will also unassign it from all items, are you sure?"
+msgid "Deleting the '%s' entry will also unassign it from all items, are you sure?"
 msgstr "'%s' エントリーを削除すると、すべての項目から割り当てが解除されます。実行してもよろしいですか?"
 
-msgid ""
-"Deleting the MyTag '%s' will also unassign it from all items, are you sure?"
+msgid "Deleting the MyTag '%s' will also unassign it from all items, are you sure?"
 msgstr "マイタグ '%s' を削除するとすべての項目から割当が解除されます。実行してもよろしいですか? "
 
 msgid "Deployment Roles"
@@ -3298,11 +3822,12 @@ msgstr "詳細"
 msgid "Details Mode"
 msgstr "詳細モード"
 
-msgid "Details View"
-msgstr "詳細表示"
-
 msgid "Determine at Run Time"
 msgstr "実行時に決定"
+
+#, fuzzy
+msgid "Device Type"
+msgstr "デポタイプ"
 
 msgid "Devices"
 msgstr "デバイス"
@@ -3330,6 +3855,10 @@ msgstr "「カタログ中の表示」が選択されている場合にダイア
 
 msgid "Dialog tab"
 msgstr "ダイアログタブ"
+
+#, fuzzy
+msgid "DialogField|Auto refresh"
+msgstr "リフレッシュボタンの表示"
 
 msgid "DialogField|Data type"
 msgstr "データタイプ"
@@ -3390,6 +3919,10 @@ msgstr "必須のメソッドオプション"
 
 msgid "DialogField|Show refresh button"
 msgstr "リフレッシュボタンの表示"
+
+#, fuzzy
+msgid "DialogField|Trigger auto refresh"
+msgstr "デフォルト値"
 
 msgid "DialogField|Validator rule"
 msgstr "検証ルール"
@@ -3631,6 +4164,9 @@ msgstr "タイムスタンプ"
 msgid "Driving Event"
 msgstr "ドライビングイベント"
 
+msgid "Dropdown elements require some entries"
+msgstr ""
+
 msgid "Dynamic"
 msgstr "ダイナミック"
 
@@ -3670,6 +4206,10 @@ msgstr "計算レート割り当てを編集"
 msgid "Edit Log Depot settings was cancelled by the user"
 msgstr "ログデポ設定の編集がユーザーによりキャンセルされました"
 
+#, fuzzy
+msgid "Edit Registration"
+msgstr "登録"
+
 msgid "Edit Sequence of User Groups was cancelled by the user"
 msgstr "ユーザーグループシーケンスの編集がユーザーによりキャンセルされました"
 
@@ -3680,12 +4220,12 @@ msgid "Edit Tags for Configured Systems"
 msgstr "設定済みシステムのタグの編集"
 
 msgid ""
-"Edit aborted!  CFME does not support the browser's back button or access "
-"from multiple tabs or windows of the same browser.  Please close any "
-"duplicate sessions before proceeding."
+"Edit aborted!  CFME does not support the browser's back button or access from "
+"multiple tabs or windows of the same browser.  Please close any duplicate sess"
+"ions before proceeding."
 msgstr ""
-"編集が中止されました!  CFME はブラウザーの「戻る」ボタン、または同一ブラウザーの複数タブ/"
-"ウィンドウからのアクセスをサポートしていません。重複したセッションを終了してから続行してください。"
+"編集が中止されました!  CFME はブラウザーの「戻る」ボタン、または同一ブラウザーの複数タブ/ウィンドウからのアクセスをサポートしていません。重複したセ"
+"ッションを終了してから続行してください。"
 
 msgid "Edit of %s was cancelled by the user"
 msgstr "%s の編集がユーザーによりキャンセルされました"
@@ -3765,9 +4305,6 @@ msgstr "適格な %s "
 msgid "Ems cluster"
 msgstr "EMS クラスター"
 
-msgid "Ems event"
-msgstr "EMS イベント"
-
 msgid "Ems folder"
 msgstr "EMS フォルダー"
 
@@ -3816,60 +4353,6 @@ msgstr "UID EMS"
 msgid "EmsCluster|Updated on"
 msgstr "更新日"
 
-msgid "EmsEvent|Created on"
-msgstr "作成日"
-
-msgid "EmsEvent|Dest ems cluster name"
-msgstr "宛先 EMS クラスター名"
-
-msgid "EmsEvent|Dest ems cluster uid"
-msgstr "宛先 EMS クラスター UID"
-
-msgid "EmsEvent|Dest host name"
-msgstr "宛先ホスト名"
-
-msgid "EmsEvent|Dest vm location"
-msgstr "宛先 VM ロケーション"
-
-msgid "EmsEvent|Dest vm name"
-msgstr "宛先 VM 名"
-
-msgid "EmsEvent|Ems cluster name"
-msgstr "EMS クラスター名"
-
-msgid "EmsEvent|Ems cluster uid"
-msgstr "EMS クラスター UID"
-
-msgid "EmsEvent|Event type"
-msgstr "イベントタイプ"
-
-msgid "EmsEvent|Full data"
-msgstr "フルデータ"
-
-msgid "EmsEvent|Host name"
-msgstr "ホスト名"
-
-msgid "EmsEvent|Is task"
-msgstr "IS タスク"
-
-msgid "EmsEvent|Message"
-msgstr "メッセージ"
-
-msgid "EmsEvent|Source"
-msgstr "ソース"
-
-msgid "EmsEvent|Timestamp"
-msgstr "タイムスタンプ"
-
-msgid "EmsEvent|Username"
-msgstr "ユーザー名"
-
-msgid "EmsEvent|Vm location"
-msgstr "VM ロケーション"
-
-msgid "EmsEvent|Vm name"
-msgstr "VM 名"
-
 msgid "EmsFolder|Created on"
 msgstr "作成日"
 
@@ -3912,11 +4395,18 @@ msgstr "終了日を開始日より前の日付にすることはできません
 msgid "End Port"
 msgstr "終了ポート"
 
+msgid "Enforced"
+msgstr ""
+
 msgid "Enter Automation Simulation options on the left and press Submit."
 msgstr "左側の自動化シミュレーションオプションを入力して「送信」を押してください。"
 
 msgid "Enter URL Manually"
 msgstr "URL の手動入力"
+
+#, fuzzy
+msgid "Enterprise"
+msgstr "エンタープライズ"
 
 msgid "Entity:"
 msgstr "エンティティー:"
@@ -3958,8 +4448,8 @@ msgid "Error during '%s': "
 msgstr "'%s' 時のエラー: "
 
 msgid ""
-"Error during Orchestration Template creation: new template content cannot be "
-"empty"
+"Error during Orchestration Template creation: new template content cannot be e"
+"mpty"
 msgstr "オーケストレーションテンプレートの作成時のエラー: 新しいテンプレートコンテンツを空にすることはできません"
 
 msgid "Error during Orphaned Records delete for user %s: "
@@ -3972,8 +4462,8 @@ msgid "Error during sending test email: "
 msgstr "メール送信テスト時のエラー: "
 
 msgid ""
-"Error during upload: incorrect Dialog format, only service dialogs can be "
-"imported"
+"Error during upload: incorrect Dialog format, only service dialogs can be impo"
+"rted"
 msgstr "アップロード時のエラー: ダイアログ形式が間違っています、サービスダイアログのみがインポート可能です"
 
 msgid "Error during upload: one of the DialogField types is not supported"
@@ -3997,8 +4487,20 @@ msgstr "エラーテキスト:"
 msgid "Error when adding a new schedule: "
 msgstr "新規スケジュール追加時のエラー: "
 
+#, fuzzy
+msgid "Error when adding a new tenant: "
+msgstr "新規スケジュール追加時のエラー: "
+
 msgid "Error when creating a Service Dialog from Orchestration Template: "
 msgstr "オーケストレーションテンプレートからのサービスダイアログの作成時のエラー: "
+
+#, fuzzy
+msgid "Error when saving new server name: "
+msgstr "新規スケジュール追加時のエラー: "
+
+#, fuzzy
+msgid "Error when saving tenant quota: "
+msgstr "新規スケジュール追加時のエラー: "
 
 msgid "Error: Datastore import file upload expired"
 msgstr "エラー: データストアインポートファイルアップロードが期限切れになっています"
@@ -4060,7 +4562,12 @@ msgstr "イベントタイプ"
 msgid "Event log"
 msgstr "イベントログ"
 
-msgid "Event to position at:"
+#, fuzzy
+msgid "Event stream"
+msgstr "イベントグループ"
+
+#, fuzzy
+msgid "Event to position at"
 msgstr "イベントの位置:"
 
 msgid "Event:"
@@ -4090,14 +4597,96 @@ msgstr "ソース"
 msgid "EventLog|Uid"
 msgstr "UID"
 
+msgid "EventStream|Container group name"
+msgstr ""
+
+msgid "EventStream|Container namespace"
+msgstr ""
+
+msgid "EventStream|Container node name"
+msgstr ""
+
+#, fuzzy
+msgid "EventStream|Created on"
+msgstr "作成日"
+
+#, fuzzy
+msgid "EventStream|Dest ems cluster name"
+msgstr "宛先 EMS クラスター名"
+
+#, fuzzy
+msgid "EventStream|Dest ems cluster uid"
+msgstr "宛先 EMS クラスター UID"
+
+#, fuzzy
+msgid "EventStream|Dest host name"
+msgstr "宛先ホスト名"
+
+#, fuzzy
+msgid "EventStream|Dest vm location"
+msgstr "宛先 VM ロケーション"
+
+#, fuzzy
+msgid "EventStream|Dest vm name"
+msgstr "宛先 VM 名"
+
+#, fuzzy
+msgid "EventStream|Ems cluster name"
+msgstr "EMS クラスター名"
+
+#, fuzzy
+msgid "EventStream|Ems cluster uid"
+msgstr "EMS クラスター UID"
+
+#, fuzzy
+msgid "EventStream|Event type"
+msgstr "イベントタイプ"
+
+#, fuzzy
+msgid "EventStream|Full data"
+msgstr "フルデータ"
+
+#, fuzzy
+msgid "EventStream|Host name"
+msgstr "ホスト名"
+
+#, fuzzy
+msgid "EventStream|Is task"
+msgstr "IS タスク"
+
+#, fuzzy
+msgid "EventStream|Message"
+msgstr "メッセージ"
+
+#, fuzzy
+msgid "EventStream|Source"
+msgstr "ソース"
+
+#, fuzzy
+msgid "EventStream|Target type"
+msgstr "セットタイプ"
+
+#, fuzzy
+msgid "EventStream|Timestamp"
+msgstr "タイムスタンプ"
+
+#, fuzzy
+msgid "EventStream|Username"
+msgstr "ユーザー名"
+
+#, fuzzy
+msgid "EventStream|Vm location"
+msgstr "VM ロケーション"
+
+#, fuzzy
+msgid "EventStream|Vm name"
+msgstr "VM 名"
+
 msgid "Events"
 msgstr "イベント"
 
 msgid "Execute Methods"
 msgstr "実行メソッド"
-
-msgid "Exist Mode"
-msgstr "有無確認モード"
 
 msgid "Exists Mode"
 msgstr "有無確認モード"
@@ -4201,6 +4790,10 @@ msgstr "外部認証 (httpd) 設定"
 msgid "External RSS Feed/URL"
 msgstr "外部 RSS フィード/URL"
 
+#, fuzzy
+msgid "FS Type"
+msgstr "タイプ"
+
 msgid "Failed"
 msgstr "失敗"
 
@@ -4226,8 +4819,8 @@ msgid "Fields"
 msgstr "フィールド"
 
 msgid ""
-"Fields not added: Adding the selected %{count} fields will exceed the "
-"maximum of %{max} fields"
+"Fields not added: Adding the selected %{count} fields will exceed the maximum "
+"of %{max} fields"
 msgstr "フィールドが追加されませんでした: 選択した %{count} フィールドの追加は %{max} フィールド最大数を超えます"
 
 msgid "File"
@@ -4404,7 +4997,8 @@ msgstr "最初"
 msgid "First %s"
 msgstr "最初の %s"
 
-msgid "First band unit:"
+#, fuzzy
+msgid "First band unit"
 msgstr "1 番目のバンドユニット"
 
 msgid "Flavor"
@@ -4415,6 +5009,9 @@ msgstr "フレーバー"
 
 msgid "Flavor|Block storage based only"
 msgstr "ブロックストレージベースのみ"
+
+msgid "Flavor|Cloud subnet required"
+msgstr ""
 
 msgid "Flavor|Cpu cores"
 msgstr "CPU コア"
@@ -4506,6 +5103,10 @@ msgstr "フル&#160;スクリーン"
 msgid "GB"
 msgstr "GB"
 
+#, fuzzy
+msgid "GCE PD Resource"
+msgstr "リソースの追加"
+
 msgid "Genealogy"
 msgstr "ツリー表示"
 
@@ -4533,14 +5134,31 @@ msgstr "外部認証 (httpd) からユーザーグループを取得"
 msgid "Get User Groups from LDAP"
 msgstr "LDAP からユーザーグループを取得"
 
+#, fuzzy
+msgid "Git Repository"
+msgstr "リポジトリー"
+
+msgid "Git Revision"
+msgstr ""
+
 msgid "Global Default"
 msgstr "グローバルデフォルト"
+
+#, fuzzy
+msgid "Global Filters"
+msgstr "すべてのファイル"
+
+msgid "Global Shared Filters"
+msgstr ""
 
 msgid "Global Time Profile cannot be edited"
 msgstr "グローバルタイムプロファイルは編集できません"
 
 msgid "Global search:"
 msgstr "グローバル検索:"
+
+msgid "Glusterfs Endpoint Name"
+msgstr ""
 
 msgid "Grid View"
 msgstr "グリッド表示"
@@ -4677,6 +5295,13 @@ msgstr "UID EMS"
 msgid "HKLM"
 msgstr "HKLM"
 
+#, fuzzy
+msgid "HTTP Proxy Address"
+msgstr "VNC プロキシーアドレス"
+
+msgid "HTTP Proxy:"
+msgstr ""
+
 msgid "Hardware"
 msgstr "ハードウェア"
 
@@ -4782,14 +5407,31 @@ msgstr "ヒント: ゲストからカーソルをリリースするには Ctrl-A
 msgid "Host"
 msgstr "ホスト"
 
+msgid "Host Compliance Policies"
+msgstr ""
+
+#, fuzzy
+msgid "Host Conditions"
+msgstr "%s 条件"
+
+#, fuzzy
+msgid "Host Control Policies"
+msgstr "アカウントポリシー"
+
+#, fuzzy
+msgid "Host Default VNC End Port"
+msgstr "ホストのデフォルト VNC ポート範囲"
+
 msgid "Host Default VNC Port Range"
 msgstr "ホストのデフォルト VNC ポート範囲"
 
-msgid "Host Name"
-msgstr "ホスト名"
+#, fuzzy
+msgid "Host Default VNC Start Port"
+msgstr "ホストのデフォルト VNC ポート範囲"
 
-msgid "Host Name (or IPv4 or IPv6 address)"
-msgstr "ホスト名 (または IPv4 ないしは IPv6 アドレス)"
+#, fuzzy
+msgid "Host Policies"
+msgstr "%s ポリシー"
 
 msgid "Host Protocol"
 msgstr "ホストプロトコル"
@@ -4805,6 +5447,18 @@ msgstr "名前"
 
 msgid "Hostname"
 msgstr "ホスト名"
+
+#, fuzzy
+msgid "Hostname (or IPv4 or IPv6 address)"
+msgstr "ホスト名 (または IPv4 ないしは IPv6 アドレス)"
+
+#, fuzzy
+msgid "Hostname or IP address"
+msgstr "IP アドレス"
+
+#, fuzzy
+msgid "Hostname or IPv4/IPv6 address"
+msgstr "ホスト名 (または IPv4 ないしは IPv6 アドレス)"
 
 msgid "Hosts"
 msgstr "ホスト"
@@ -4932,11 +5586,24 @@ msgstr "IPアドレス"
 msgid "IPMI"
 msgstr "IPMI"
 
+#, fuzzy
+msgid "IPMI Credentials"
+msgstr "認証情報"
+
 msgid "IPMI IP Address"
 msgstr "IPMI IP アドレス"
 
 msgid "IPMI Present"
 msgstr "IPMI 有"
+
+msgid "ISCSI Target Lun Number"
+msgstr ""
+
+msgid "ISCSI Target Portal"
+msgstr ""
+
+msgid "ISCSI Target Qualified Name"
+msgstr ""
 
 msgid "ISO"
 msgstr "ISO"
@@ -4951,12 +5618,19 @@ msgid "If"
 msgstr "If"
 
 msgid ""
-"If this widget is new or has just been added to your dashboard, the data is "
-"being generated and should be available soon."
+"If this widget is new or has just been added to your dashboard, the data is be"
+"ing generated and should be available soon."
 msgstr "データ収集中のため、新規ウィジェットまたはダッシュボードに追加されたばかりのウィジェットはしばらくしてから利用可能になります。"
 
 msgid "Image"
 msgstr "イメージ"
+
+#, fuzzy
+msgid "Image Registries (%s)"
+msgstr "イメージ (%s)"
+
+msgid "Image Registries (0)"
+msgstr ""
 
 msgid "Image Type"
 msgstr "イメージタイプ"
@@ -4969,6 +5643,14 @@ msgstr "イメージ"
 
 msgid "Images (%s)"
 msgstr "イメージ (%s)"
+
+#, fuzzy
+msgid "Images (0)"
+msgstr "イメージ (%s)"
+
+#, fuzzy
+msgid "Images by Provider"
+msgstr "新規の %s プロバイダーの追加"
 
 msgid "Import"
 msgstr "インポート"
@@ -5042,11 +5724,12 @@ msgstr "継承タグ設定"
 msgid "Init Processes (%s)"
 msgstr "Init プロセス (%s)"
 
+#, fuzzy
+msgid "Input Name"
+msgstr "デポタイプ名"
+
 msgid "Input Parameters"
 msgstr "入力パラメーター"
-
-msgid "Insight"
-msgstr "インサイト"
 
 msgid "Instance Type:"
 msgstr "インスタンスタイプ:"
@@ -5057,11 +5740,12 @@ msgstr "インスタンス"
 msgid "Instances (%s)"
 msgstr "インスタンス (%s)"
 
+#, fuzzy
+msgid "Instances by Provider"
+msgstr "新規の %s プロバイダーの追加"
+
 msgid "Integer"
 msgstr "整数"
-
-msgid "Integration Services"
-msgstr "統合サービス"
 
 msgid "Internal"
 msgstr "間隔"
@@ -5176,6 +5860,10 @@ msgstr "カーネルドライバー (%s)"
 msgid "Key:"
 msgstr "キー:"
 
+#, fuzzy
+msgid "Kickstart"
+msgstr "クイックスタート"
+
 msgid "LDAP"
 msgstr "LDAP"
 
@@ -5191,16 +5879,18 @@ msgstr "LDAP グループ検索"
 msgid "LDAP Groups for User"
 msgstr "ユーザーの LDAP グループ"
 
-msgid "LDAP Host Name"
-msgstr "LDAP ホスト名"
-
-msgid ""
-"LDAP Host Name and Port fields are needed to perform verification of LDAP "
-"Settings"
-msgstr "LDAP ホスト名とポートフィールドが LDAP 設定の検証の実行に必要です。"
-
 msgid "LDAP Host Names"
 msgstr "LDAP ホスト名"
+
+#, fuzzy
+msgid "LDAP Hostname"
+msgstr "LDAP ホスト名"
+
+#, fuzzy
+msgid ""
+"LDAP Hostname and Port fields are needed to perform verification of LDAP Setti"
+"ngs"
+msgstr "LDAP ホスト名とポートフィールドが LDAP 設定の検証の実行に必要です。"
 
 msgid "LDAP Port"
 msgstr "LDAP ポート"
@@ -5225,6 +5915,10 @@ msgstr "ラベル"
 
 msgid "Label on Summary Row"
 msgstr "概要列のラベル"
+
+#, fuzzy
+msgid "Labels"
+msgstr "ラベル"
 
 msgid "Lan"
 msgstr "Lan"
@@ -5287,6 +5981,10 @@ msgid "Last Message"
 msgstr "最終メッセージ"
 
 msgid "Last Run Time"
+msgstr "最終実行時間"
+
+#, fuzzy
+msgid "Last Transition Time"
 msgstr "最終実行時間"
 
 msgid "Last Update"
@@ -5455,8 +6153,8 @@ msgid "LdapUser|Zip"
 msgstr "ZIP"
 
 msgid ""
-"Leave all options unchecked to show the original column value from the first "
-"record in the group."
+"Leave all options unchecked to show the original column value from the first r"
+"ecord in the group."
 msgstr "グループ内の最初の記録にある元の列値を表示するには、すべてのオプションのチェックを外したままにします。"
 
 msgid "Level"
@@ -5464,9 +6162,6 @@ msgstr "レベル"
 
 msgid "Lifecycle"
 msgstr "ライフサイクル"
-
-msgid "Lifecycle and Automation"
-msgstr "ライフサイクルと自動化"
 
 msgid "Lifecycle event"
 msgstr "ライフサイクルイベント"
@@ -5591,12 +6286,18 @@ msgstr "更新日"
 msgid "Logging"
 msgstr "ログ"
 
+#, fuzzy
+msgid "Logging into"
+msgstr "ログ"
+
 msgid "Login"
 msgstr "ログイン"
 
-msgid ""
-"Login not allowed, User's %s is missing. Please contact the administrator"
+msgid "Login not allowed, User's %s is missing. Please contact the administrator"
 msgstr "ログインが許可されませんでした、ユーザーの %s が見つかりません。管理者にお問い合わせください"
+
+msgid "Logout"
+msgstr ""
 
 msgid "Logs for this CFME Server are not available for viewing"
 msgstr "この CFME サーバーのログは表示できません"
@@ -5631,11 +6332,23 @@ msgstr "アコーディオン & フォルダーの管理"
 msgid "Manage Reports"
 msgstr "レポートの管理"
 
+#, fuzzy
+msgid "Manage quotas for %{model} \"%{name}\""
+msgstr "%{model} のインデックス\"%{name}\""
+
+#, fuzzy
+msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
+msgstr "%{model} \"%{name}\" のスキーマの編集がユーザーによりキャンセルされました"
+
 msgid "Management Event"
 msgstr "管理イベント"
 
 msgid "Manager"
 msgstr "マネジャー"
+
+#, fuzzy
+msgid "Matching password fields are needed to perform verification of credentials"
+msgstr "LDAP ホスト名とポートフィールドが LDAP 設定の検証の実行に必要です。"
 
 msgid "Max"
 msgstr "最大"
@@ -5654,6 +6367,10 @@ msgstr "最大時間"
 
 msgid "Max VMs"
 msgstr "VM 最大数"
+
+#, fuzzy
+msgid "Max active VM Scans"
+msgstr "アクティブな VM スキャンの最大数"
 
 msgid "Medium"
 msgstr "中"
@@ -6108,26 +6825,8 @@ msgstr "MIQ アクション"
 msgid "Miq action set"
 msgstr "MIQ アクションセット"
 
-msgid "Miq ae class"
-msgstr "MIQ ae クラス"
-
 msgid "Miq ae engine/miq ae workspace"
 msgstr "MIQ ae エンジン/MIQ ae ワークスペース"
-
-msgid "Miq ae field"
-msgstr "MIQ ae フィールド"
-
-msgid "Miq ae instance"
-msgstr "MIQ ae インスタンス"
-
-msgid "Miq ae method"
-msgstr "MIQ ae メソッド"
-
-msgid "Miq ae namespace"
-msgstr "MIQ ae 名前空間"
-
-msgid "Miq ae value"
-msgstr "MIQ ae 値"
 
 msgid "Miq alert"
 msgstr "MIQ アラート"
@@ -6159,11 +6858,13 @@ msgstr "MIQ ダイアログ"
 msgid "Miq enterprise"
 msgstr "MIQ エンタープライズ"
 
-msgid "Miq event"
-msgstr "MIQ イベント"
+#, fuzzy
+msgid "Miq event definition"
+msgstr "定義"
 
-msgid "Miq event set"
-msgstr "MIQ イベントセット"
+#, fuzzy
+msgid "Miq event definition set"
+msgstr "定義"
 
 msgid "Miq group"
 msgstr "MIQ グループ"
@@ -6297,33 +6998,6 @@ msgstr "オプション"
 msgid "MiqAction|Updated on"
 msgstr "更新日"
 
-msgid "MiqAeClass|Created on"
-msgstr "作成日"
-
-msgid "MiqAeClass|Description"
-msgstr "説明"
-
-msgid "MiqAeClass|Display name"
-msgstr "表示名"
-
-msgid "MiqAeClass|Inherits"
-msgstr "継承"
-
-msgid "MiqAeClass|Name"
-msgstr "名前"
-
-msgid "MiqAeClass|Owner"
-msgstr "所有者"
-
-msgid "MiqAeClass|Updated by"
-msgstr "更新者"
-
-msgid "MiqAeClass|Updated on"
-msgstr "更新日"
-
-msgid "MiqAeClass|Visibility"
-msgstr "可視性"
-
 msgid "MiqAeEngine::MiqAeWorkspace|Created on"
 msgstr "作成日"
 
@@ -6341,186 +7015,6 @@ msgstr "URI"
 
 msgid "MiqAeEngine::MiqAeWorkspace|Workspace"
 msgstr "ワークスペース"
-
-msgid "MiqAeField|Aetype"
-msgstr "AE タイプ"
-
-msgid "MiqAeField|Collect"
-msgstr "収集"
-
-msgid "MiqAeField|Condition"
-msgstr "条件"
-
-msgid "MiqAeField|Created on"
-msgstr "作成日"
-
-msgid "MiqAeField|Datatype"
-msgstr "データタイプ"
-
-msgid "MiqAeField|Default value"
-msgstr "デフォルト値"
-
-msgid "MiqAeField|Description"
-msgstr "説明"
-
-msgid "MiqAeField|Display name"
-msgstr "表示名"
-
-msgid "MiqAeField|Max retries"
-msgstr "再試行の最大回数"
-
-msgid "MiqAeField|Max time"
-msgstr "最大時間"
-
-msgid "MiqAeField|Message"
-msgstr "メッセージ"
-
-msgid "MiqAeField|Name"
-msgstr "名前"
-
-msgid "MiqAeField|On entry"
-msgstr "入力時"
-
-msgid "MiqAeField|On error"
-msgstr "エラー時"
-
-msgid "MiqAeField|On exit"
-msgstr "終了時"
-
-msgid "MiqAeField|Owner"
-msgstr "所有者"
-
-msgid "MiqAeField|Priority"
-msgstr "優先順位"
-
-msgid "MiqAeField|Scope"
-msgstr "スコープ"
-
-msgid "MiqAeField|Substitute"
-msgstr "置換"
-
-msgid "MiqAeField|Updated by"
-msgstr "更新者"
-
-msgid "MiqAeField|Updated on"
-msgstr "更新日"
-
-msgid "MiqAeField|Visibility"
-msgstr "可視性"
-
-msgid "MiqAeInstance|Created on"
-msgstr "作成日"
-
-msgid "MiqAeInstance|Description"
-msgstr "説明"
-
-msgid "MiqAeInstance|Display name"
-msgstr "表示名"
-
-msgid "MiqAeInstance|Inherits"
-msgstr "継承"
-
-msgid "MiqAeInstance|Name"
-msgstr "名前"
-
-msgid "MiqAeInstance|Updated by"
-msgstr "更新者"
-
-msgid "MiqAeInstance|Updated on"
-msgstr "更新日"
-
-msgid "MiqAeMethod|Created on"
-msgstr "作成日"
-
-msgid "MiqAeMethod|Data"
-msgstr "データ"
-
-msgid "MiqAeMethod|Description"
-msgstr "説明"
-
-msgid "MiqAeMethod|Display name"
-msgstr "表示名"
-
-msgid "MiqAeMethod|Language"
-msgstr "言語"
-
-msgid "MiqAeMethod|Location"
-msgstr "ロケーション"
-
-msgid "MiqAeMethod|Name"
-msgstr "名前"
-
-msgid "MiqAeMethod|Scope"
-msgstr "スコープ"
-
-msgid "MiqAeMethod|Updated by"
-msgstr "更新者"
-
-msgid "MiqAeMethod|Updated on"
-msgstr "更新日"
-
-msgid "MiqAeNamespace|Created on"
-msgstr "作成日"
-
-msgid "MiqAeNamespace|Description"
-msgstr "説明"
-
-msgid "MiqAeNamespace|Display name"
-msgstr "表示名"
-
-msgid "MiqAeNamespace|Enabled"
-msgstr "有効化"
-
-msgid "MiqAeNamespace|Name"
-msgstr "名前"
-
-msgid "MiqAeNamespace|Priority"
-msgstr "優先順位"
-
-msgid "MiqAeNamespace|System"
-msgstr "システム"
-
-msgid "MiqAeNamespace|Updated by"
-msgstr "更新者"
-
-msgid "MiqAeNamespace|Updated on"
-msgstr "更新日"
-
-msgid "MiqAeValue|Collect"
-msgstr "収集"
-
-msgid "MiqAeValue|Condition"
-msgstr "条件"
-
-msgid "MiqAeValue|Created on"
-msgstr "作成日"
-
-msgid "MiqAeValue|Display name"
-msgstr "表示名"
-
-msgid "MiqAeValue|Max retries"
-msgstr "再試行の最大回数"
-
-msgid "MiqAeValue|Max time"
-msgstr "最大時間"
-
-msgid "MiqAeValue|On entry"
-msgstr "入力時"
-
-msgid "MiqAeValue|On error"
-msgstr "エラー時"
-
-msgid "MiqAeValue|On exit"
-msgstr "終了時"
-
-msgid "MiqAeValue|Updated by"
-msgstr "更新者"
-
-msgid "MiqAeValue|Updated on"
-msgstr "更新日"
-
-msgid "MiqAeValue|Value"
-msgstr "値"
 
 msgid "MiqAlertSet|Created on"
 msgstr "作成日"
@@ -6801,64 +7295,84 @@ msgstr "設定"
 msgid "MiqEnterprise|Updated on"
 msgstr "更新日"
 
-msgid "MiqEventSet|Created on"
+#, fuzzy
+msgid "MiqEventDefinitionSet|Created on"
 msgstr "作成日"
 
-msgid "MiqEventSet|Description"
+#, fuzzy
+msgid "MiqEventDefinitionSet|Description"
 msgstr "説明"
 
-msgid "MiqEventSet|Guid"
-msgstr "GUID"
-
-msgid "MiqEventSet|Mode"
-msgstr "モード"
-
-msgid "MiqEventSet|Name"
-msgstr "名前"
-
-msgid "MiqEventSet|Owner type"
-msgstr "所有者タイプ"
-
-msgid "MiqEventSet|Read only"
-msgstr "読み取り専用"
-
-msgid "MiqEventSet|Set data"
-msgstr "セットデータ"
-
-msgid "MiqEventSet|Set type"
-msgstr "セットタイプ"
-
-msgid "MiqEventSet|Updated on"
-msgstr "更新日"
-
-msgid "MiqEventSet|Userid"
-msgstr "ユーザー ID "
-
-msgid "MiqEvent|Created on"
-msgstr "作成日"
-
-msgid "MiqEvent|Default"
-msgstr "デフォルト"
-
-msgid "MiqEvent|Definition"
+#, fuzzy
+msgid "MiqEventDefinitionSet|Guid"
 msgstr "定義"
 
-msgid "MiqEvent|Description"
+#, fuzzy
+msgid "MiqEventDefinitionSet|Mode"
+msgstr "定義"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Name"
+msgstr "定義"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Owner type"
+msgstr "所有者タイプ"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Read only"
+msgstr "読み取り専用"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Set data"
+msgstr "セットデータ"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Set type"
+msgstr "セットタイプ"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Updated on"
+msgstr "更新日"
+
+#, fuzzy
+msgid "MiqEventDefinitionSet|Userid"
+msgstr "ユーザー ID "
+
+#, fuzzy
+msgid "MiqEventDefinition|Created on"
+msgstr "作成日"
+
+#, fuzzy
+msgid "MiqEventDefinition|Default"
+msgstr "定義"
+
+#, fuzzy
+msgid "MiqEventDefinition|Definition"
+msgstr "定義"
+
+#, fuzzy
+msgid "MiqEventDefinition|Description"
 msgstr "説明"
 
-msgid "MiqEvent|Enabled"
-msgstr "有効化"
+#, fuzzy
+msgid "MiqEventDefinition|Enabled"
+msgstr "定義"
 
-msgid "MiqEvent|Event type"
+#, fuzzy
+msgid "MiqEventDefinition|Event type"
 msgstr "イベントタイプ"
 
-msgid "MiqEvent|Guid"
-msgstr "GUID"
+#, fuzzy
+msgid "MiqEventDefinition|Guid"
+msgstr "定義"
 
-msgid "MiqEvent|Name"
-msgstr "名前"
+#, fuzzy
+msgid "MiqEventDefinition|Name"
+msgstr "定義"
 
-msgid "MiqEvent|Updated on"
+#, fuzzy
+msgid "MiqEventDefinition|Updated on"
 msgstr "更新日"
 
 msgid "MiqGroup|Created on"
@@ -7767,14 +8281,26 @@ msgstr "選択したレポートを上に移動する"
 msgid "My Filters"
 msgstr "マイフィルター"
 
+#, fuzzy
+msgid "My Personal Filters"
+msgstr "メッセージフィルター"
+
 msgid "My Services"
 msgstr "マイサービス"
 
 msgid "My Settings"
 msgstr "マイ設定"
 
+#, fuzzy
+msgid "MyTags"
+msgstr "タグ"
+
 msgid "N/A"
 msgstr "N/A"
+
+#, fuzzy
+msgid "NFS Server"
+msgstr "DNS サーバー"
 
 msgid "NONE"
 msgstr "なし"
@@ -7794,10 +8320,12 @@ msgstr "名前 / 説明"
 msgid "Name: %s | %s Type: %s"
 msgstr "%s タイプ: %s"
 
-msgid "Name: %s | Host Name: %s"
+#, fuzzy
+msgid "Name: %s | Hostname: %s"
 msgstr "ホスト名: %s"
 
-msgid "Name: %s | Host Name: %s | Refresh Status: %s"
+#, fuzzy
+msgid "Name: %s | Hostname: %s | Refresh Status: %s"
 msgstr "リフレッシュステータス: %s"
 
 msgid "Name: %s | Path: %s"
@@ -7875,9 +8403,6 @@ msgstr "サブネットマスク"
 msgid "Never"
 msgstr "なし"
 
-msgid "New Catalog Item"
-msgstr "新規カタログ項目"
-
 msgid "New Entry"
 msgstr "新規入力"
 
@@ -7893,8 +8418,14 @@ msgstr "新規オーケストレーションテンプレート情報"
 msgid "New Parameter"
 msgstr "新規パラメーター"
 
-msgid "New setting will affect %s"
-msgstr "新規設定は %s に影響を与えます。"
+#, fuzzy
+msgid "New Password"
+msgstr "バインドパスワード"
+
+msgid "New setting will affect Orchestration Stack"
+msgid_plural "New setting will affect Orchestration Stacks"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "New setting will affect Service"
 msgid_plural "New setting will affect Services"
@@ -7921,10 +8452,12 @@ msgstr "No"
 msgid "No %s %s Policies are defined %s."
 msgstr "%s と定義された %s %s ポリシーはありません。"
 
-msgid "No %s Alert Profiles are defined%s."
+#, fuzzy
+msgid "No %s Alert Profiles are defined %s."
 msgstr "%s と定義された %s アラートプロファイルはありません。"
 
-msgid "No %s Conditions are defined%s."
+#, fuzzy
+msgid "No %s Conditions are defined %s."
 msgstr "%s と定義された %s 条件はありません。"
 
 msgid "No %s Policy Profiles are defined%s."
@@ -8032,19 +8565,19 @@ msgstr "カタログ項目が見つかりませんでした。"
 msgid "No Choices Available"
 msgstr "使用できる選択肢がありません"
 
-msgid "No Class found for explorer tree node type '%s'"
+#, fuzzy
+msgid "No Class found for explorer tree node id '%s'"
 msgstr "エクスプローラーツリーノードタイプ '%s' のクラスが見つかりませんでした"
 
-msgid ""
-"No Dashboards are defined for this group. Default dashboard will be shown."
+msgid "No Dashboards are defined for this group. Default dashboard will be shown."
 msgstr "このグループに定義されたダッシュボードはありません。デフォルトダッシュボードが表示されます。"
 
 msgid "No Datastores found in the current region."
 msgstr "現在のリージョンにデータストアが見つかりません"
 
 msgid ""
-"No Default Repository SmartProxy is configured, contact your CFME "
-"Administrator"
+"No Default Repository SmartProxy is configured, contact your CFME Administrato"
+"r"
 msgstr "デフォルトのリポジトリー SmartProxy が設定されていません。CFME 管理者にお問い合わせください。"
 
 msgid "No Dialog"
@@ -8055,6 +8588,11 @@ msgstr "表示フィルターが定義されていません。"
 
 msgid "No Group"
 msgstr "グループなし"
+
+msgid ""
+"No Hourly or Daily data is available, real time data from the Most Recent Hour"
+" is being displayed"
+msgstr ""
 
 msgid "No Indexes found for this table."
 msgstr "この表のインデックスが見つかりませんでした"
@@ -8077,8 +8615,7 @@ msgstr "ポリシーが定義されていません。"
 msgid "No Policy Profiles available."
 msgstr "利用可能なポリシープロファイルがありません。"
 
-msgid ""
-"No Policy scope defined, the scope of this policy includes all elements."
+msgid "No Policy scope defined, the scope of this policy includes all elements."
 msgstr "ポリシースコープが定義されていません。このポリシーのスコープはすべての要素を含んでいます。"
 
 msgid "No RSS Feed data found"
@@ -8162,13 +8699,12 @@ msgstr "チャートデータが見つかりませんでした"
 msgid "No child VMs to move right, no action taken"
 msgstr "右側に移動する子 VM はありません。アクションは実行されません"
 
-msgid ""
-"No common configuration profiles available for the selected configured %s"
+msgid "No common configuration profiles available for the selected configured %s"
 msgstr "選択された設定済みの %s に利用可能な共通設定プロファイルがありません。"
 
 msgid ""
-"No conditions defined. This policy is unconditional and will ALWAYS return "
-"true."
+"No conditions defined. This policy is unconditional and will ALWAYS return tru"
+"e."
 msgstr "条件が定義されていません。このポリシーは無条件で常に「true」を返します。"
 
 msgid "No custom image has been uploaded"
@@ -8178,8 +8714,8 @@ msgid "No data found."
 msgstr "データが見つかりませんでした。"
 
 msgid ""
-"No drift history found, an Analysis or Virtual Black Box Synchronization for "
-"this VM may need to be run."
+"No drift history found, an Analysis or Virtual Black Box Synchronization for t"
+"his VM may need to be run."
 msgstr "ドリフト履歴が見つかりません。この VM 用に分析または仮想ブラックボックス同期の実行が必要になる可能性があります。"
 
 msgid "No events available for this timeline"
@@ -8187,9 +8723,6 @@ msgstr "このタイムラインには利用可能なイベントがありませ
 
 msgid "No events available for this timeline."
 msgstr "このタイムラインには利用可能なイベントがありません。"
-
-msgid "No explorer tree node type found for '%s'"
-msgstr "'%s' 用のエクスプローラーのツリーノードタイプが見つかりませんでした"
 
 msgid "No expression defined, a condition must contain a valid expression."
 msgstr "式が定義されていません。条件には有効な式が含まれている必要があります。"
@@ -8245,6 +8778,14 @@ msgstr "有効なインポート記録が見つかりませんでした。別の
 msgid "No variables configured."
 msgstr "変数が設定されていません。"
 
+#, fuzzy
+msgid "Node Port"
+msgstr "終了ポート"
+
+#, fuzzy
+msgid "Node Selector"
+msgstr "ポリシー選択"
+
 msgid "Nodes"
 msgstr "ノード"
 
@@ -8252,8 +8793,8 @@ msgid "Non-VM Files"
 msgstr "VM 以外のファイル"
 
 msgid ""
-"Non-admin users can not access the system until at least 1 VM/Instance has "
-"been discovered"
+"Non-admin users can not access the system until at least 1 VM/Instance has bee"
+"n discovered"
 msgstr "管理者以外のユーザーは 1 つ以上の  VM/インスタンスが検出されるまでシステムにアクセスできません"
 
 msgid "None"
@@ -8286,12 +8827,14 @@ msgstr "注:"
 msgid "Note: Fields marked with * are required."
 msgstr "注* 印のついたフィールドは必須です。"
 
-msgid ""
-"Note: Gap Collection is only available for VMware vSphere Infrastructures"
+msgid "Note: Gap Collection is only available for VMware vSphere Infrastructures"
 msgstr "注: ギャップ収集は VMware vSphere インフラストラクチャーの場合のみ有効です。"
 
 msgid "Note: Only Time Profiles with 'Roll Up Performance' set are shown."
 msgstr "注:  'パフォーマンスのロールアップ' が設定されたタイムプロファイルのみが表示されます。"
+
+msgid "Note: Username must be in the format: name@realm"
+msgstr ""
 
 msgid "Notes"
 msgstr "メモ"
@@ -8319,6 +8862,9 @@ msgstr "VMの数"
 
 msgid "OR with a new expression element"
 msgstr "新規の式要素との論理和 (OR)"
+
+msgid "OS"
+msgstr ""
 
 msgid "OS %s"
 msgstr "OS %s"
@@ -8368,9 +8914,7 @@ msgstr "1 回"
 msgid "One or more %{model} must be selected to %{task}"
 msgstr "%{task} には 1 つ以上の %{model} が選択されている必要があります"
 
-msgid ""
-"One or more selected reports are not owned by your group, they cannot be "
-"moved"
+msgid "One or more selected reports are not owned by your group, they cannot be moved"
 msgstr "選択した 1 つ以上のレポートはあなたのグループによって所有されていないため、移動することができません"
 
 msgid "Only 1 Date or Date/Time element can be present in a Dialog"
@@ -9654,6 +10198,10 @@ msgstr "フルレポートを新規ウィンドウで開く"
 msgid "OpenStack Status"
 msgstr "OpenStack ステータス"
 
+#, fuzzy
+msgid "Openstack Infra Provider"
+msgstr "Openstack インフラプロバイダー"
+
 msgid "Openstack Infra provider"
 msgstr "Openstack インフラプロバイダー"
 
@@ -9683,6 +10231,10 @@ msgstr "ビルド番号"
 
 msgid "OperatingSystem|Distribution"
 msgstr "ディストリビューション"
+
+#, fuzzy
+msgid "OperatingSystem|Kernel version"
+msgstr "バージョン"
 
 msgid "OperatingSystem|Lockout duration"
 msgstr "ロックアウト期間"
@@ -9738,6 +10290,10 @@ msgstr "システムタイプ"
 msgid "OperatingSystem|Version"
 msgstr "バージョン"
 
+#, fuzzy
+msgid "Optimize"
+msgstr "最小化"
+
 msgid "Option 1"
 msgstr "オプション 1"
 
@@ -9761,9 +10317,6 @@ msgstr "オーケストレーションテンプレート"
 
 msgid "Orchestration Template \"%s\" was deleted."
 msgstr "オーケストレーションテンプレート \"%s\" が削除されました。"
-
-msgid "Orchestration Template Information"
-msgstr "オーケストレーションテンプレート情報"
 
 msgid "Orchestration Templates"
 msgstr "オーケストレーションテンプレート"
@@ -9870,6 +10423,10 @@ msgstr "再試行日"
 msgid "OrchestrationStack|Status"
 msgstr "ステータス"
 
+#, fuzzy
+msgid "OrchestrationStack|Status reason"
+msgstr "ステータス"
+
 msgid "OrchestrationTemplate|Content"
 msgstr "コンテンツ"
 
@@ -9900,14 +10457,26 @@ msgstr "このサービスのオーダー"
 msgid "Organization"
 msgstr "組織"
 
+#, fuzzy
+msgid "Organization ID"
+msgstr "組織"
+
 msgid "Original Value"
 msgstr "元ファイル"
 
 msgid "Orphaned Data"
 msgstr "単独データ"
 
+#, fuzzy
+msgid "Orphaned Instances"
+msgstr "単独データ"
+
 msgid "Orphaned Records for userid %s were successfully deleted"
 msgstr "ユーザーID %s の単独の記録が正常に削除されました"
+
+#, fuzzy
+msgid "Orphaned VMs and Templates"
+msgstr "VM & テンプレートの表示"
 
 msgid "Os process"
 msgstr "OS プロセス"
@@ -9954,6 +10523,9 @@ msgstr "送信 SMTP メールサーバー"
 msgid "Outputs (%s)"
 msgstr "出力 (%s)"
 
+msgid "Overview"
+msgstr ""
+
 msgid "Overwrite existing reports?"
 msgstr "既存のレポートを上書きしますか?"
 
@@ -9984,6 +10556,10 @@ msgstr "PXE イメージメニュー"
 msgid "PXE Images"
 msgstr "PXE イメージ"
 
+#, fuzzy
+msgid "Packages"
+msgstr "パッケージ (0)"
+
 msgid "Packages (%s)"
 msgstr "パッケージ (%s)"
 
@@ -9998,6 +10574,10 @@ msgstr "パラメーター"
 
 msgid "Parameters (%s)"
 msgstr "パラメーター (%s)"
+
+#, fuzzy
+msgid "Parent"
+msgstr "親 VM"
 
 msgid "Parent %s: %s"
 msgstr "親 %s: %s"
@@ -10027,6 +10607,10 @@ msgid "Partition"
 msgstr "パーティション"
 
 msgid "Partition Table"
+msgstr "パーティションテーブル"
+
+#, fuzzy
+msgid "Partitions Aligned"
 msgstr "パーティションテーブル"
 
 msgid "Partition|Controller"
@@ -10077,12 +10661,18 @@ msgstr "パスワード"
 msgid "Password fields must match to Validate Database Configuration"
 msgstr "データベース設定の検証のためにパスワードフィールドは一致している必要があります"
 
+msgid "Password or Password+One-Time-Password"
+msgstr ""
+
 msgid "Password/Verify Password do not match"
 msgstr "パスワード/検証パスワードが一致しません"
 
+msgid "Passwords do not match"
+msgstr ""
+
 msgid ""
-"Paste is not available, no object information has been copied from the "
-"Simulation screen"
+"Paste is not available, no object information has been copied from the Simulat"
+"ion screen"
 msgstr "貼り付けはできません。シミュレーション画面からコピーされたオブジェクト情報はありません"
 
 msgid "Paste object details for use in a Button."
@@ -10142,6 +10732,9 @@ msgstr "ページ:"
 msgid "Percent Bloat"
 msgstr "肥大化パーセント"
 
+msgid "Percent Used of Provisioned Size"
+msgstr ""
+
 msgid "Performance Interval"
 msgstr "パフォーマンス間隔"
 
@@ -10150,6 +10743,9 @@ msgstr "パフォーマンス時間枠"
 
 msgid "Period"
 msgstr "期間"
+
+msgid "Persistent Volume Claim Name"
+msgstr ""
 
 msgid "Picture"
 msgstr "ピクチャー"
@@ -10189,6 +10785,12 @@ msgstr "左側のノードを選択して編集します。"
 
 msgid "Please select an Instance Type from above"
 msgstr "上記からインスタンスタイプを選択してください"
+
+msgid "Pods (%s)"
+msgstr "ポッド (%s)"
+
+msgid "Pods (0)"
+msgstr "ポッド (0)"
 
 msgid "Policies"
 msgstr "ポリシー"
@@ -10238,8 +10840,9 @@ msgstr "リソースタイプ"
 msgid "PolicyEvent|Event type"
 msgstr "イベントタイプ"
 
-msgid "PolicyEvent|Miq event description"
-msgstr "Miq イベント説明"
+#, fuzzy
+msgid "PolicyEvent|Miq event definition description"
+msgstr "Miq ポリシー説明"
 
 msgid "PolicyEvent|Miq policy description"
 msgstr "Miq ポリシー説明"
@@ -10262,6 +10865,10 @@ msgstr "ユーザー名"
 msgid "Port"
 msgstr "ポート"
 
+#, fuzzy
+msgid "Port Configurations"
+msgstr "設定"
+
 msgid "Power Management"
 msgstr "電源管理"
 
@@ -10283,8 +10890,7 @@ msgstr "インポートするには「コミット」を押してください"
 msgid "Press submit to start the Database Vacuum process"
 msgstr "「送信」を押してデータベースバキュームプロセスを開始します。"
 
-msgid ""
-"Press the Apply button to import the good records into the CFME database"
+msgid "Press the Apply button to import the good records into the CFME database"
 msgstr "適正な記録を CFME データベースにインポートするには「適用」ボタンを押してください "
 
 msgid "Press your browser's Back button or click a tab to continue"
@@ -10311,8 +10917,22 @@ msgstr "優先順位ワーカー"
 msgid "Private Key"
 msgstr "プライベートキー"
 
+msgid "Private Keys do not match"
+msgstr ""
+
 msgid "Process ID"
 msgstr "プロセス ID"
+
+msgid "Processor Cores_Per_Socket"
+msgstr ""
+
+#, fuzzy
+msgid "Processor Options"
+msgstr "プロセッサー"
+
+#, fuzzy
+msgid "Processor Sockets"
+msgstr "プロセッサー"
 
 msgid "Processors"
 msgstr "プロセッサー"
@@ -10329,14 +10949,32 @@ msgstr "プロファイルアラート:"
 msgid "Profile Policies:"
 msgstr "プロファイルポリシー:"
 
+msgid "Project/Tenant"
+msgstr ""
+
+#, fuzzy
+msgid "Projects"
+msgstr "保護"
+
 msgid "Properties"
+msgstr "プロパティー"
+
+#, fuzzy
+msgid "Property"
 msgstr "プロパティー"
 
 msgid "Protected"
 msgstr "保護"
 
+#, fuzzy
+msgid "Protocol"
+msgstr "ホストプロトコル"
+
 msgid "Provider"
 msgstr "プロバイダー"
+
+msgid "Provider is not ready to be scaled, another operation is in progress."
+msgstr ""
 
 msgid "Providers"
 msgstr "プロバイダー"
@@ -10368,7 +11006,12 @@ msgstr "%{model} のプロビジョニング - %{typ} の選択"
 msgid "Provision Order"
 msgstr "プロビジョニング順序"
 
-msgid "Provisioned %s"
+#, fuzzy
+msgid "Provisioned Hosts"
+msgstr "プロビジョニングされた %s"
+
+#, fuzzy
+msgid "Provisioned Size"
 msgstr "プロビジョニングされた %s"
 
 msgid "Provisioned VMs"
@@ -10461,11 +11104,12 @@ msgstr "処理待ち"
 msgid "Queued At"
 msgstr "処理待機時間"
 
-msgid "Quick Start"
-msgstr "クイックスタート"
-
 msgid "Quotas"
 msgstr "クォータ"
+
+#, fuzzy
+msgid "Quotas for %{model} \"%{name}\" were saved"
+msgstr " %{model} \"%{name}\" のスキーマが保存されました"
 
 msgid "RSA key pair"
 msgstr "RSA キーペア"
@@ -10479,6 +11123,24 @@ msgstr "RSS フィードオプション"
 msgid "RSS Feed no longer exists"
 msgstr "RSS フィードオプションは存在しません"
 
+msgid "Rados Ceph Monitors"
+msgstr ""
+
+#, fuzzy
+msgid "Rados Image Name"
+msgstr "名前"
+
+msgid "Rados Keyring"
+msgstr ""
+
+#, fuzzy
+msgid "Rados Pool Name"
+msgstr "名前"
+
+#, fuzzy
+msgid "Rados User Name"
+msgstr "ユーザー名"
+
 msgid "Range"
 msgstr "範囲"
 
@@ -10490,6 +11152,14 @@ msgstr "レート"
 
 msgid "Rate Details"
 msgstr "レート詳細"
+
+#, fuzzy
+msgid "Rates"
+msgstr "レート"
+
+#, fuzzy
+msgid "Re-apply the previous change"
+msgstr "直前の変更を元に戻す"
 
 msgid "Read Only"
 msgstr "読み取り専用"
@@ -10504,6 +11174,10 @@ msgid "Read Only %{model} \"%{name}\" cannot be edited"
 msgstr "読み取り専用 %{model} \"%{name}\" は編集することができません"
 
 msgid "Read only"
+msgstr "読み取り専用"
+
+#, fuzzy
+msgid "Read-Only"
 msgstr "読み取り専用"
 
 msgid "Realm"
@@ -10548,9 +11222,6 @@ msgstr "Red Hat カスタマーポータル"
 msgid "Red Hat Updates"
 msgstr "Red Hat 更新"
 
-msgid "Redo the next change"
-msgstr "次の変更をやり直す"
-
 msgid "Reference VM Profile"
 msgstr "参照 VM プロファイル"
 
@@ -10582,6 +11253,10 @@ msgid "Region:"
 msgstr "リージョン:"
 
 msgid "Register"
+msgstr "登録"
+
+#, fuzzy
+msgid "Register to"
 msgstr "登録"
 
 msgid "Registration"
@@ -10646,6 +11321,10 @@ msgstr "リレーションシップ"
 
 msgid "Relationship|Resource type"
 msgstr "リソースタイプ"
+
+#, fuzzy
+msgid "Release"
+msgstr "削除"
 
 msgid "Remote Console plugin is not properly installed."
 msgstr "リモートコンソールプラグインが正常にインストールされていません。"
@@ -10740,6 +11419,14 @@ msgstr "複製プロセス"
 msgid "Replication Worker"
 msgstr "複製ワーカー"
 
+#, fuzzy
+msgid "Replicators (%s)"
+msgstr "アプリケーション (%s)"
+
+#, fuzzy
+msgid "Replicators (0)"
+msgstr "アプリケーション (%s)"
+
 msgid "Report"
 msgstr "レポート"
 
@@ -10767,8 +11454,7 @@ msgstr "ユーザー別のレポート結果"
 msgid "Report Selection"
 msgstr "レポート選択"
 
-msgid ""
-"Report can not be saved unless sort field has been configured for Charts"
+msgid "Report can not be saved unless sort field has been configured for Charts"
 msgstr "並べ替えフィールドがチャート用に設定されていない限りレポートを保存することはできません"
 
 msgid "Report cannot be deleted if it's being used by one or more Widgets"
@@ -10795,8 +11481,7 @@ msgstr "レポートは存在しません"
 msgid "Report not found."
 msgstr "レポートが見つかりませんでした"
 
-msgid ""
-"Report preview generation returned: Status [%{status}] Message [%{message}]"
+msgid "Report preview generation returned: Status [%{status}] Message [%{message}]"
 msgstr "レポートプレビュー生成が返されました: ステータス [%{status}] メッセージ [%{message}]"
 
 msgid "Reporting Workers"
@@ -10813,6 +11498,14 @@ msgstr "リポジトリー"
 
 msgid "Repository"
 msgstr "リポジトリー"
+
+#, fuzzy
+msgid "Repository Name(s)"
+msgstr "名前"
+
+#, fuzzy
+msgid "Repository Name(s):"
+msgstr "名前"
 
 msgid "Repository|Created on"
 msgstr "作成日"
@@ -10874,8 +11567,7 @@ msgstr "必須"
 msgid "Required if SSH login is disabled for the Default account."
 msgstr "SSH ログインがデフォルトアカウントに対して無効にされている場合に必須です。"
 
-msgid ""
-"Required. Should have privileged access, such as root or administrator."
+msgid "Required. Should have privileged access, such as root or administrator."
 msgstr "必須情報です。root または管理者などの特権アクセスが必要です。"
 
 msgid "Reserve"
@@ -11034,20 +11726,34 @@ msgstr "結果"
 msgid "Retirement"
 msgstr "リタイア"
 
-msgid "Retirement %s removed"
-msgstr "リタイア %sが削除されました"
-
-msgid "Retirement %{date_text} set to %{rdate}"
-msgstr "リタイア %{date_text} が %{rdate}に設定されました"
-
 msgid "Retirement Date"
 msgstr "リタイア日"
 
 msgid "Retirement Entry Point"
 msgstr "リタイアエントリーポイント"
 
+#, fuzzy
+msgid "Retirement Entry Point (NameSpace/Class/Instance)"
+msgstr "エントリーポイント (名前空間/クラス/インスタンス) の再設定"
+
 msgid "Retirement Warning"
 msgstr "リタイア警告"
+
+#, fuzzy
+msgid "Retirement date removed"
+msgstr "リタイア %sが削除されました"
+
+#, fuzzy
+msgid "Retirement date set to %s"
+msgstr "リタイア %sが削除されました"
+
+#, fuzzy
+msgid "Retirement dates removed"
+msgstr "リタイア %sが削除されました"
+
+#, fuzzy
+msgid "Retirement dates set to %s"
+msgstr "リタイア %sが削除されました"
 
 msgid "Right Size Recommendation for %{model} \"%{name}\""
 msgstr "%{model} \"%{name}\" の適切なサイズの推奨"
@@ -11112,8 +11818,10 @@ msgstr "更新日"
 msgid "RssFeed|Yml file mtime"
 msgstr "YMLファイル修正時間"
 
-msgid "Ruby Script"
-msgstr "Ruby スクリプト"
+msgid ""
+"Ruby scripts are no longer supported in expressions, please change or remove t"
+"hem."
+msgstr ""
 
 msgid "Run"
 msgstr "実行"
@@ -11152,8 +11860,8 @@ msgid "Running system services of %s"
 msgstr "%s の実行中のシステムサービス"
 
 msgid ""
-"SMTP E-mail Server settings and Test E-mail Address are needed to send test "
-"email"
+"SMTP E-mail Server settings and Test E-mail Address are needed to send test em"
+"ail"
 msgstr "テストメールを送信するには、SMTP メールサーバー設定およびテストメールアドレスが必要です。"
 
 msgid "SNMP Trap"
@@ -11203,6 +11911,10 @@ msgstr "この %s 検索を保存:"
 
 msgid "Save..."
 msgstr "保存..."
+
+#, fuzzy
+msgid "Saved Chargeback Reports"
+msgstr "チャージバックレポートを生成"
 
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
 msgstr "保存されたレポート \"%s\" が見つかりませんでした。スケジュールが失敗した可能性があります"
@@ -11357,21 +12069,28 @@ msgstr "検索式のプレビュー"
 msgid "Search by Name within results"
 msgstr "結果内の名前で検索"
 
-msgid "Second band unit:"
+#, fuzzy
+msgid "Second band unit"
 msgstr "2 番目のバンドユニット:"
 
 msgid "Secondary (Display) Filter"
 msgstr "セカンダリー (表示) フィルター"
 
-msgid ""
-"Secondary (Display) Filter - Filters the rows based on child table fields"
+msgid "Secondary (Display) Filter - Filters the rows based on child table fields"
 msgstr "セカンダリー (表示) フィルター - 子テーブルフィールドに基づく行のフィルタリング"
 
 msgid "Secret Access Key"
 msgstr "シークレットアクセスキー"
 
+msgid "Secret Access Keys do not match"
+msgstr ""
+
 msgid "Secret Key"
 msgstr "シークレットキー"
+
+#, fuzzy
+msgid "Secret Name"
+msgstr "サーバー名"
 
 msgid "Security"
 msgstr "セキュリティー"
@@ -11408,6 +12127,10 @@ msgstr "評価するアラートを選択"
 
 msgid "Select Entry Point %s"
 msgstr "エントリーポイント %s の選択"
+
+#, fuzzy
+msgid "Select Host to validate against"
+msgstr "検証対象の %s を選択"
 
 msgid "Select Policy Profiles"
 msgstr "ポリシープロファイルの選択"
@@ -11448,8 +12171,7 @@ msgstr "左側のノードを選択して使用量情報を表示します。"
 msgid "Select a node on the left to view Utilization report."
 msgstr "左側のノードを選択して使用量レポートを表示します。"
 
-msgid ""
-"Select a reference VM or Manual Input source to Submit the Planning Options"
+msgid "Select a reference VM or Manual Input source to Submit the Planning Options"
 msgstr "参照 VM または手動入力情報源を選択して計画オプションを送信"
 
 msgid "Select an Owner:"
@@ -11481,6 +12203,9 @@ msgstr "先頭に移動する連続した %s を 1 つだけ選択する "
 
 msgid "Select only one or consecutive %s to move up"
 msgstr "上に移動する連続した %s を 1 つだけ選択する"
+
+msgid "Select to change to another Group"
+msgstr ""
 
 msgid "Selected"
 msgstr "選択"
@@ -11519,6 +12244,10 @@ msgid "Selection"
 msgstr "選択"
 
 msgid "Selections"
+msgstr "選択"
+
+#, fuzzy
+msgid "Selector"
 msgstr "選択"
 
 msgid "Send E-mail"
@@ -11566,13 +12295,12 @@ msgstr "サーバー名"
 msgid "Server Roles"
 msgstr "サーバーロール"
 
-msgid ""
-"Server information, Username and matching password fields are needed to "
-"perform verification of credentials"
-msgstr "サーバー情報、ユーザー名および一致するパスワードフィールドは認証情報の検証を実行する際に必要です。"
-
 msgid "Server role"
 msgstr "サーバーロール"
+
+#, fuzzy
+msgid "Server: %s"
+msgstr "サービス: %s"
 
 msgid "ServerRole|Created on"
 msgstr "作成日"
@@ -11613,7 +12341,8 @@ msgstr "サービスカタログ"
 msgid "Service Dialog \"%s\" was successfully created"
 msgstr "サービスダイアログ \"%s\" が正常に作成されました"
 
-msgid "Service Dialog Information"
+#, fuzzy
+msgid "Service Dialog Import/Export"
 msgstr "サービスダイアログ情報"
 
 msgid "Service Dialog Name"
@@ -11796,9 +12525,6 @@ msgstr "トレースを true に設定すると、過剰なログ行の書き込
 msgid "Settings"
 msgstr "設定"
 
-msgid "Settings and Operations"
-msgstr "設定および操作"
-
 msgid "Shortcuts"
 msgstr "ショートカット"
 
@@ -11807,6 +12533,10 @@ msgstr "表示"
 
 msgid "Show %s"
 msgstr "%s の表示"
+
+#, fuzzy
+msgid "Show %s %s"
+msgstr "%s & %s の表示"
 
 msgid "Show %s & %s"
 msgstr "%s & %s の表示"
@@ -11835,14 +12565,31 @@ msgstr "%s ストレージアダプターの表示"
 msgid "Show Capacity & Utilization"
 msgstr "容量 & 使用率の表示"
 
-msgid "Show Pods"
-msgstr "ポッドの表示"
+#, fuzzy
+msgid "Show Container Groups"
+msgstr "コンテナーノードの表示"
 
 msgid "Show Container Nodes"
 msgstr "コンテナーノードの表示"
 
+#, fuzzy
+msgid "Show Container Projects"
+msgstr "コンテナーノードの表示"
+
+#, fuzzy
+msgid "Show Container Replicators"
+msgstr "コンテナーサービスの表示"
+
+#, fuzzy
+msgid "Show Container Routes"
+msgstr "コンテナーノードの表示"
+
 msgid "Show Container Services"
 msgstr "コンテナーサービスの表示"
+
+#, fuzzy
+msgid "Show Containers"
+msgstr "コンテナーノードの表示"
 
 msgid "Show Costs by"
 msgstr "コストの表示"
@@ -11852,6 +12599,14 @@ msgstr "この VM にイベントログを表示"
 
 msgid "Show Host Events"
 msgstr "ホストイベントの表示"
+
+#, fuzzy
+msgid "Show Image Registries"
+msgstr "すべてのリソースの表示"
+
+#, fuzzy
+msgid "Show Images"
+msgstr "すべてのイメージの表示"
 
 msgid "Show Input Parameters"
 msgstr "入力パラメーターの表示"
@@ -11865,8 +12620,15 @@ msgstr "親 %s の表示"
 msgid "Show Past Dates"
 msgstr "過去の日付を表示"
 
+msgid "Show Pods"
+msgstr "ポッドの表示"
+
 msgid "Show Refresh Button"
 msgstr "リフレッシュボタンを表示"
+
+#, fuzzy
+msgid "Show Replicators"
+msgstr "リソースプールの表示"
 
 msgid "Show Resource Pools"
 msgstr "リソースプールの表示"
@@ -11961,16 +12723,14 @@ msgstr "すべての管理された %s を表示"
 msgid "Show all registered %s"
 msgstr "すべての登録された %s を表示"
 
-msgid "Show all used %s on this %s"
-msgstr "この %s にすべての使用されている %s を表示"
-
 msgid "Show at Login"
 msgstr "ログイン時に表示する画面"
 
 msgid "Show configuration"
 msgstr "設定の表示"
 
-msgid "Show daily data from:"
+#, fuzzy
+msgid "Show daily data from"
 msgstr "日次データの表示元:"
 
 msgid "Show disks"
@@ -11982,10 +12742,12 @@ msgstr "この VM の ESX ログを表示"
 msgid "Show event logs on this VM"
 msgstr "この VM のイベントログを表示"
 
-msgid "Show events from last:"
+#, fuzzy
+msgid "Show events from last"
 msgstr "前回からのイベントを表示:"
 
-msgid "Show hourly data from:"
+#, fuzzy
+msgid "Show hourly data from"
 msgstr "毎時データの表示元:"
 
 msgid "Show in Console"
@@ -12126,14 +12888,31 @@ msgstr "この VM の親サービスを表示"
 msgid "Show this Vm's parent %s"
 msgstr "この VM の親 %s を表示"
 
-msgid "Show this Pod's parent %s"
-msgstr "このポッドの親 %s を表示"
+#, fuzzy
+msgid "Show this container group's parent %s"
+msgstr "このコンテナーノードの親  %s を表示"
 
 msgid "Show this container node's parent %s"
 msgstr "このコンテナーノードの親  %s を表示"
 
+#, fuzzy
+msgid "Show this container replicator's parent %s"
+msgstr "このコンテナーサービスの親  %s を表示"
+
 msgid "Show this container service's parent %s"
 msgstr "このコンテナーサービスの親  %s を表示"
+
+#, fuzzy
+msgid "Show this images registry %s"
+msgstr "この VM の親 %s を表示"
+
+#, fuzzy
+msgid "Show this pod's parent %s"
+msgstr "このポッドの親 %s を表示"
+
+#, fuzzy
+msgid "Show topology"
+msgstr "コストの表示"
 
 msgid "Show tree of all VMs in this Resource Pool"
 msgstr "このリソースプールにあるすべての VM のツリーを表示"
@@ -12188,6 +12967,10 @@ msgstr "コンパクトツリー"
 
 msgid "Smart Management"
 msgstr "スマート管理"
+
+#, fuzzy
+msgid "SmartProxy Affinity"
+msgstr "SmartProxy サーバー IP"
 
 msgid "SmartProxy Server IP"
 msgstr "SmartProxy サーバー IP"
@@ -12255,13 +13038,17 @@ msgstr "UID EMS"
 msgid "Snapshot|Updated on"
 msgstr "更新日"
 
+#, fuzzy
+msgid "Sockets"
+msgstr "ロック"
+
 msgid ""
-"Software updates have not yet been configured. Select Edit Registration to "
-"register appliances in this region with Red Hat to receive software updates "
-"and other benefits."
+"Software updates have not yet been configured. Select Edit Registration to reg"
+"ister appliances in this region with Red Hat to receive software updates and o"
+"ther benefits."
 msgstr ""
-"ソフトウェア更新はまだ設定されていません。このリージョンのアプリケーションを Red Hat "
-"に登録するために「登録の編集」を選択すると、ソフトウエア更新と他の特典を取得できます。"
+"ソフトウェア更新はまだ設定されていません。このリージョンのアプリケーションを Red Hat に登録するために「登録の編集」を選択すると、ソフトウエア更新と"
+"他の特典を取得できます。"
 
 msgid "Sorry, the username or password you entered is incorrect."
 msgstr "入力したユーザー名またはパスワードが間違っています。"
@@ -12335,6 +13122,10 @@ msgstr "開始プロセスの指定が必要です"
 msgid "State"
 msgstr "状態"
 
+#, fuzzy
+msgid "State Machine (NS/Cls/Inst)"
+msgstr "エントリーポイント (名前空間/クラス/インスタンス)"
+
 msgid "Status"
 msgstr "ステータス"
 
@@ -12361,6 +13152,10 @@ msgstr "ストレージアダプター"
 
 msgid "Storage Managers"
 msgstr "ストレージマネジャー"
+
+#, fuzzy
+msgid "Storage Medium Type"
+msgstr "RSC タイプ"
 
 msgid "Storage Relationships"
 msgstr "ストレージのリレーションシップ"
@@ -12521,8 +13316,15 @@ msgstr "サブネット範囲"
 msgid "Subscribe to this feed"
 msgstr "このフィードを購読"
 
+#, fuzzy
+msgid "Substitute: %s"
+msgstr "置換:"
+
 msgid "Substitution:"
 msgstr "置換:"
+
+msgid "Successful"
+msgstr ""
 
 msgid "Successfully deleted %s from the CFME Database"
 msgstr "CFME データベースから %s が正常に削除されました"
@@ -12569,6 +13371,9 @@ msgstr "更新日"
 msgid "Synchronous"
 msgstr "同期"
 
+msgid "Sysprep"
+msgstr ""
+
 msgid "Sysprep \"%s\" upload was successful"
 msgstr "Sysprep \"%s\" が正常にアップロードされました"
 
@@ -12577,6 +13382,10 @@ msgstr "システムデフォルト"
 
 msgid "System service"
 msgstr "システムサービス"
+
+#, fuzzy
+msgid "System/Process"
+msgstr "システム/プロセス/"
 
 msgid "System/Process/"
 msgstr "システム/プロセス/"
@@ -12662,7 +13471,8 @@ msgstr "タグカテゴリー"
 msgid "Tag edits were successfully saved"
 msgstr "タグ編集が正常に保存されました"
 
-msgid "Tag to Apply:"
+#, fuzzy
+msgid "Tag to Apply"
 msgstr "適用するタグ:"
 
 msgid "Tagging"
@@ -12686,10 +13496,15 @@ msgstr "ターゲットオプション / 上限値"
 msgid "Target Options/Limits"
 msgstr "ターゲットオプション/上限値"
 
-msgid "Task State:"
+msgid "Target Port"
+msgstr ""
+
+#, fuzzy
+msgid "Task State"
 msgstr "タスクの状態:"
 
-msgid "Task Status:"
+#, fuzzy
+msgid "Task Status"
 msgstr "タスクのステータス:"
 
 msgid "Tasks"
@@ -12716,8 +13531,87 @@ msgstr "テンプレート (0)"
 msgid "Tenancy"
 msgstr "テナンシー"
 
+#, fuzzy
+msgid "Tenant"
+msgstr "テナント"
+
+#, fuzzy
+msgid "Tenant ID"
+msgstr "テナント"
+
+msgid "Tenant quota"
+msgstr ""
+
+#, fuzzy
+msgid "TenantQuota|Name"
+msgstr "名前"
+
+msgid "TenantQuota|Unit"
+msgstr ""
+
+#, fuzzy
+msgid "TenantQuota|Value"
+msgstr "デフォルト値"
+
 msgid "Tenants"
 msgstr "テナント"
+
+#, fuzzy
+msgid "Tenants (%s)"
+msgstr "テンプレート (%s)"
+
+#, fuzzy
+msgid "Tenant|Ancestry"
+msgstr "系統"
+
+#, fuzzy
+msgid "Tenant|Description"
+msgstr "説明"
+
+msgid "Tenant|Divisible"
+msgstr ""
+
+#, fuzzy
+msgid "Tenant|Domain"
+msgstr "ドメイン"
+
+msgid "Tenant|Login logo content type"
+msgstr ""
+
+msgid "Tenant|Login logo file name"
+msgstr ""
+
+msgid "Tenant|Login logo file size"
+msgstr ""
+
+msgid "Tenant|Login logo updated at"
+msgstr ""
+
+#, fuzzy
+msgid "Tenant|Login text"
+msgstr "カスタムログイン文字列の使用"
+
+msgid "Tenant|Logo content type"
+msgstr ""
+
+msgid "Tenant|Logo file name"
+msgstr ""
+
+msgid "Tenant|Logo file size"
+msgstr ""
+
+msgid "Tenant|Logo updated at"
+msgstr ""
+
+#, fuzzy
+msgid "Tenant|Name"
+msgstr "名前"
+
+msgid "Tenant|Subdomain"
+msgstr ""
+
+msgid "Tenant|Use config for attributes"
+msgstr ""
 
 msgid "Test E-mail Address"
 msgstr "テストメールアドレス"
@@ -12726,48 +13620,50 @@ msgid "Text"
 msgstr "テキスト"
 
 msgid ""
-"The CFME Server is still starting, you have been redirected to the "
-"diagnostics page for problem determination"
+"The CFME Server is still starting, you have been redirected to the diagnostics"
+" page for problem determination"
 msgstr "CFME サーバーが起動中です。問題判別のため診断ページにリダイレクトされました。"
 
 msgid ""
-"The CFME Server is still starting. If this message persists, please contact "
-"your CFME administrator."
+"The CFME Server is still starting. If this message persists, please contact yo"
+"ur CFME administrator."
 msgstr "CFME サーバーがまだ起動中です。このメッセージが消えない場合、CFME 管理者にお問い合わせください。"
 
 msgid ""
-"The Default Repository SmartProxy is not valid, contact your CFME "
-"Administrator"
+"The Default Repository SmartProxy is not valid, contact your CFME Administrato"
+"r"
 msgstr "デフォルトのリポジトリー SmartProxy が無効です。CFME 管理者にお問い合わせください。"
 
 msgid ""
-"The Default Repository SmartProxy no longer exists, contact your CFME "
-"Administrator"
+"The Default Repository SmartProxy no longer exists, contact your CFME Administ"
+"rator"
 msgstr "デフォルトのリポジトリー SmartProxy が存在しません。CFME 管理者にお問い合わせください。"
 
 msgid ""
-"The Default Repository SmartProxy, \"%s\", is not running, contact your CFME "
-"Administrator"
+"The Default Repository SmartProxy, \"%s\", is not running, contact your CFME Adm"
+"inistrator"
 msgstr "デフォルトのリポジトリー SmartProxy \"%s\" が実行されていません。CFME 管理者にお問い合わせください。"
 
 msgid "The Enterprise"
 msgstr "エンタープライズ"
 
 msgid ""
-"The Host Default VNC Port Range ending port must be equal to or higher than "
-"the starting point"
+"The Host Default VNC Port Range ending port must be equal to or higher than th"
+"e starting point"
 msgstr "ホストデフォルト VNC ポート範囲の終了ポートは開始ポイントと等しいかそれより大きい番号である必要があります "
 
 msgid "The Remote Console is connecting"
 msgstr "リモートコンソールに接続しています"
 
 msgid ""
-"The VM has been suspended, powered off or the connection to the server has "
-"been lost. \\nThis console window will now close."
-msgstr "VM は中断したか、電源がオフになったか、またはサーバーとの接続が失われました。\\nこのコンソールウィンドウは閉じられます。"
+"The VM has been suspended, powered off or the connection to the server has bee"
+"n lost. \n"
+"This console window will now close."
+msgstr ""
+"VM は中断したか、電源がオフになったか、またはサーバーとの接続が失われました。\n"
+"このコンソールウィンドウは閉じられます。"
 
-msgid ""
-"The check count value must be an integer to commit this expression element"
+msgid "The check count value must be an integer to commit this expression element"
 msgstr "この式要素をコミットするために、このチェックカウント値は整数でなければなりません"
 
 msgid "The current search details have been reset"
@@ -12791,8 +13687,7 @@ msgstr "選択された %s は有効にされました"
 msgid "The selected %{model} were marked as %{action}"
 msgstr "選択した %{model} は %{action}としてマークが付けられました"
 
-msgid ""
-"The selected Filter can not be set as Default because it requires user input"
+msgid "The selected Filter can not be set as Default because it requires user input"
 msgstr "ユーザー入力が必要であるため、選択したフィルターはデフォルトに設定することができません"
 
 msgid "The selected Filter record was not found"
@@ -12807,27 +13702,25 @@ msgstr "選択したスケジュールが実行のキューに追加されまし
 msgid "The selected Task was cancelled"
 msgstr "選択したタスクがキャンセルされました"
 
-msgid ""
-"The selected job no longer exists, Delete all older Tasks was not completed"
+msgid "The selected job no longer exists, Delete all older Tasks was not completed"
 msgstr "選択したジョブは存在しなくなりました。古いタスクすべての削除は完了していません"
 
-msgid ""
-"The server is initializing; access is being retried every 10 seconds %s"
+msgid "The server is initializing; access is being retried every 10 seconds %s"
 msgstr "サーバーが初期化しています。10 秒ごとにアクセスが再試行されています: %s"
 
-msgid ""
-"The test email is being delivered, check \"%s\" to verify it was successful"
+msgid "The test email is being delivered, check \"%s\" to verify it was successful"
 msgstr "テストメールが送信されています。正常に送信されたかを確認するために \"%s\" をチェックしてください"
 
 msgid "The user is not authorized for this task or item."
 msgstr "ユーザーにはこのタスクまたは項目についての権限がありません。"
 
 msgid ""
-"There is an error in the selected expression element, perhaps it was "
-"imported or edited manually."
+"There is an error in the selected expression element, perhaps it was imported "
+"or edited manually."
 msgstr "選択した式要素にエラーがあります。手動によりインポートまたは編集された可能性があります。"
 
-msgid "Third band unit:"
+#, fuzzy
+msgid "Third band unit"
 msgstr "3 番目のバンドユニット:"
 
 msgid "This Action is not assigned to any Policies."
@@ -12864,12 +13757,11 @@ msgid "This Week (partial)"
 msgstr "今週 (一部)"
 
 msgid ""
-"This element should be removed and recreated or you can report the error to "
-"your CFME administrator."
+"This element should be removed and recreated or you can report the error to yo"
+"ur CFME administrator."
 msgstr "この要素は削除されるか、または再作成される必要があります。または、CFME 管理者にエラーを報告することができます。"
 
-msgid ""
-"This page requires the VMware MKS plugin. Install the plugin and try again."
+msgid "This page requires the VMware MKS plugin. Install the plugin and try again."
 msgstr "このページには VMware MKS プラグインが必要です。プラグインをインストールしてから再試行してください。"
 
 msgid "This policy does not currently respond to any Events."
@@ -12885,13 +13777,13 @@ msgid "This user is limited to the selected items and their children."
 msgstr "このユーザーは選択した項目とその子に制限されます。"
 
 msgid ""
-"This will show the chart and the entire report (all rows) in your browser. "
-"Do you want to proceed?"
+"This will show the chart and the entire report (all rows) in your browser. Do "
+"you want to proceed?"
 msgstr "ブラウザーにチャートとレポート全体 (すべての行) が表示されます。続行しますか?"
 
 msgid ""
-"This will show the entire report (all rows) in your browser. Do you want to "
-"proceed?"
+"This will show the entire report (all rows) in your browser. Do you want to pr"
+"oceed?"
 msgstr "ブラウザーにレポート全体 (すべての行) が表示されます。続行しますか?"
 
 msgid "Thursday"
@@ -12905,6 +13797,10 @@ msgstr "タイムプロファイル"
 
 msgid "Time Profile Information"
 msgstr "タイムプロファイル情報"
+
+#, fuzzy
+msgid "Time Profiles"
+msgstr "タイムプロファイル"
 
 msgid "Time Zone"
 msgstr "タイムゾーン"
@@ -12988,8 +13884,8 @@ msgid "To Generate a Chargeback Report"
 msgstr "チャージバックレポートを生成"
 
 msgid ""
-"To configure the Host Default VNC Port Range, both start and end ports are "
-"required"
+"To configure the Host Default VNC Port Range, both start and end ports are req"
+"uired"
 msgstr "ホストのデフォルト VNC ポート範囲を設定するには、開始ポートと終了ポートの両方が必要です"
 
 msgid "Today (partial)"
@@ -12998,8 +13894,18 @@ msgstr "今日 (一部)"
 msgid "Toggle All/None"
 msgstr "すべて/なしを切り替え"
 
+msgid "Token"
+msgstr ""
+
 msgid "Top values to show"
 msgstr "表示する先頭の値"
+
+msgid "Topology"
+msgstr ""
+
+#, fuzzy
+msgid "Total Processors"
+msgstr "プロセッサー"
 
 msgid "Total VMs: 0"
 msgstr "VM の合計: 0"
@@ -13064,6 +13970,10 @@ msgstr "作成する 1 つ以上のタグを入力してから「入力」を押
 msgid "Type:"
 msgstr "タイプ:"
 
+#, fuzzy
+msgid "Type: %s"
+msgstr "タイプ:"
+
 msgid "UI Worker"
 msgstr "UI ワーカー"
 
@@ -13074,13 +13984,13 @@ msgid "URL (i.e. www.mypage.com)"
 msgstr "URL (例: www.mypage.com)"
 
 msgid ""
-"Unable to create a new template copy \"%s\": new template content cannot be "
-"empty."
+"Unable to create a new template copy \"%s\": new template content cannot be empt"
+"y."
 msgstr "新しいテンプレートコピー \"%s\" を作成することはできません: 新しいテンプレートコンテンツを空にすることはできません。"
 
 msgid ""
-"Unable to create a new template copy \"%s\": old and new template content "
-"have to differ."
+"Unable to create a new template copy \"%s\": old and new template content have t"
+"o differ."
 msgstr "新しいテンプレートコピー \"%s\" を作成することはできません: 新旧のテンプレートコンテンツは異なっている必要があります。"
 
 msgid "Unable to initiate scaling: %s"
@@ -13089,17 +13999,25 @@ msgstr "サイズ調整を初期化できません: %s"
 msgid "Unassigned"
 msgstr "未割り当て"
 
+#, fuzzy
+msgid "Unassigned Profiles Group"
+msgstr "タイムプロファイルが見つかりませんでした"
+
 msgid "Unassigned:"
 msgstr "未割り当て:"
 
 msgid "Unattended GUI"
 msgstr "自動 GUI"
 
-msgid "Undo the previous change"
-msgstr "直前の変更を元に戻す"
+#, fuzzy
+msgid "Undo the last change"
+msgstr "次の変更をやり直す"
 
 msgid "Unexpected error encountered"
 msgstr "予期しないエラーが発生しました"
+
+msgid "Units"
+msgstr ""
 
 msgid "Unknown"
 msgstr "不明"
@@ -13115,9 +14033,6 @@ msgstr "更新"
 
 msgid "Update Password"
 msgstr "パスワードの更新"
-
-msgid "Update Repository"
-msgstr "リポジトリーの更新"
 
 msgid "Update Status"
 msgstr "ステータスの更新"
@@ -13176,6 +14091,9 @@ msgstr "カスタムログイン文字列の使用"
 msgid "Use Custom Logo Image"
 msgstr "カスタムロゴイメージの使用"
 
+msgid "Use HTTP Proxy"
+msgstr ""
+
 msgid "Use the Browse button to locate %s file"
 msgstr "参照ボタンを使って %s ファイルを検索します。"
 
@@ -13188,6 +14106,10 @@ msgstr "参照ボタンを使ってインポートファイルを検索します
 msgid "Use the Browse button to locate an Upload file"
 msgstr "参照ボタンを使ってアップロードファイルを検索します。"
 
+#, fuzzy
+msgid "Used Size"
+msgstr "ページサイズ"
+
 msgid "Used for SSH connection to all %s in this provider."
 msgstr "このプロバイダーのすべての %s への SSH 接続に使用されます。"
 
@@ -13197,8 +14119,7 @@ msgstr "IPMI へのアクセスに使用されます。"
 msgid "Used for access to Web Services."
 msgstr "Web サービスへのアクセスに使用されます。"
 
-msgid ""
-"Used to authenticate with OpenStack AMQP Messaging Bus for event handling."
+msgid "Used to authenticate with OpenStack AMQP Messaging Bus for event handling."
 msgstr "イベント処理のために OpenStack AMQP Messaging Bus による認証に使用されます。"
 
 msgid "Used to gather Capacity & Utilization metrics."
@@ -13252,9 +14173,6 @@ msgstr "検索するユーザー"
 msgid "User will input the value"
 msgstr "ユーザーは値を入力します"
 
-msgid "User:"
-msgstr "ユーザー:"
-
 msgid "Username"
 msgstr "ユーザー名"
 
@@ -13269,6 +14187,9 @@ msgstr "ユーザー (%s)"
 
 msgid "Users (0)"
 msgstr "ユーザー (0)"
+
+msgid "Users are only allowed to delete their own requests"
+msgstr ""
 
 msgid "Users in this Group"
 msgstr "このグループのユーザー"
@@ -13370,17 +14291,20 @@ msgid "VM Snapshot Files"
 msgstr "VM スナップショットファイル"
 
 msgid ""
-"VM data will be collected for VMs under selected %s only. Data is collected "
-"for a %s and all of its %s when at least one %s is selected."
+"VM data will be collected for VMs under selected %s only. Data is collected fo"
+"r a %s and all of its %s when at least one %s is selected."
 msgstr ""
-"選択された %s の下にある VM の VM データのみが収集されます。1 つ以上の %s が選択されると、%s とその %s "
-"のすべてについてデータが収集されます。"
+"選択された %s の下にある VM の VM データのみが収集されます。1 つ以上の %s が選択されると、%s とその %s のすべてについてデータが収集"
+"されます。"
 
 msgid "VM successfully removed from service \"%s\""
 msgstr "VM がサービス \"%s\" から正常に削除されました"
 
 msgid "VM/Instance"
 msgstr "VM/インスタンス"
+
+msgid "VMDB"
+msgstr ""
 
 msgid "VMM Information"
 msgstr "VMM 情報"
@@ -13406,8 +14330,19 @@ msgstr "VMsafe"
 msgid "VMware Console Support"
 msgstr "VMware コンソールサポート"
 
+#, fuzzy
+msgid "VMware MKS Plugin"
+msgstr "VMware MKS プラグインバージョン"
+
 msgid "VMware MKS Plugin Version"
 msgstr "VMware MKS プラグインバージョン"
+
+#, fuzzy
+msgid "VMware VMRC Plugin"
+msgstr "VMware MKS プラグインバージョン"
+
+msgid "VNC"
+msgstr ""
 
 msgid "VNC Console"
 msgstr "VNC コンソール"
@@ -13433,6 +14368,10 @@ msgstr "Amazon 設定の検証"
 msgid "Validate the LDAP Settings by binding with the %s"
 msgstr "%s を使ったバインドにより LDAP 設定を検証"
 
+#, fuzzy
+msgid "Validate the credentials"
+msgstr "Amazon 設定の検証"
+
 msgid "Validate the credentials by logging into the Server"
 msgstr "サーバーにログインして認証情報を検証"
 
@@ -13456,6 +14395,10 @@ msgstr "設定する値"
 
 msgid "Value:"
 msgstr "値:"
+
+#, fuzzy
+msgid "Values"
+msgstr "値"
 
 msgid "Variable Object ID"
 msgstr "変数オブジェクト ID"
@@ -13481,17 +14424,36 @@ msgstr "確認"
 msgid "Verify %s"
 msgstr "%s の確認"
 
+msgid "Verify Client Key"
+msgstr ""
+
 msgid "Verify Password"
 msgstr "パスワードの確認"
 
 msgid "Verify Peer Certificate"
 msgstr "ピア証明書の確認"
 
+#, fuzzy
+msgid "Verify Private Key"
+msgstr "プライベートキー"
+
+#, fuzzy
+msgid "Verify Secret Access Key"
+msgstr "シークレットアクセスキー"
+
 msgid "Version"
 msgstr "バージョン"
 
 msgid "Version / Build"
 msgstr "バージョン / ビルド"
+
+#, fuzzy
+msgid "View %s"
+msgstr "ロールの表示"
+
+#, fuzzy
+msgid "View %s %s"
+msgstr "ユーザーの表示"
 
 msgid "View %s Folder"
 msgstr "%s フォルダーの表示"
@@ -13520,6 +14482,9 @@ msgstr "インスタンスの表示"
 msgid "View LDAP Regions"
 msgstr "LDAP 領域の表示"
 
+msgid "View Parent Tenant"
+msgstr ""
+
 msgid "View Roles"
 msgstr "ロールの表示"
 
@@ -13528,6 +14493,10 @@ msgstr "スケジュールの表示"
 
 msgid "View Storage Rates"
 msgstr "ストレージ速度の表示"
+
+#, fuzzy
+msgid "View Tenants"
+msgstr "テナント"
 
 msgid "View This Alert"
 msgstr "このアラートを表示"
@@ -13657,6 +14626,24 @@ msgstr "仮想マシン"
 
 msgid "Visibility"
 msgstr "可視性"
+
+msgid "Visual"
+msgstr ""
+
+msgid "Vm"
+msgstr ""
+
+#, fuzzy
+msgid "Vm Compliance Policies"
+msgstr "コンプライアンスチェック"
+
+#, fuzzy
+msgid "Vm Control Policies"
+msgstr "アカウントポリシー"
+
+#, fuzzy
+msgid "Vm Policies"
+msgstr "%s ポリシー"
 
 msgid "Vm or template"
 msgstr "VM またはテンプレート"
@@ -13970,6 +14957,18 @@ msgstr "従前の生メトリック"
 msgid "Volume"
 msgstr "ボリューム"
 
+#, fuzzy
+msgid "Volume ID"
+msgstr "ボリューム"
+
+#, fuzzy
+msgid "Volume Path"
+msgstr "名前"
+
+#, fuzzy
+msgid "Volumes"
+msgstr "ボリューム"
+
 msgid "Volume|Created on"
 msgstr "作成日"
 
@@ -14007,8 +15006,8 @@ msgid "Warn"
 msgstr "警告"
 
 msgid ""
-"Warning: This 'Run Once' timer is in the past and will never run as "
-"currently configured"
+"Warning: This 'Run Once' timer is in the past and will never run as currently "
+"configured"
 msgstr "警告：この '一度実行' タイマーは過去の時間に設定されているため、現在の設定では実行されることはありません "
 
 msgid "Wasted"
@@ -14105,8 +15104,8 @@ msgid "Yesterday"
 msgstr "昨日"
 
 msgid ""
-"You are about to enter fullscreen mode. Press Ctl+Alt to return to windowed "
-"mode."
+"You are about to enter fullscreen mode. Press Ctl+Alt to return to windowed mo"
+"de."
 msgstr "フルスクリーンモードに入ります。ウィンドウモードに戻るには Ctl+Alt を押してください。"
 
 msgid "You are not authorized to view %s"
@@ -14166,6 +15165,10 @@ msgstr "利用可能"
 msgid "back"
 msgstr "戻る"
 
+#, fuzzy
+msgid "blank"
+msgstr "ランク"
+
 msgid "bold"
 msgstr "太字"
 
@@ -14196,6 +15199,12 @@ msgstr "h"
 msgid "instances"
 msgstr "インスタンス"
 
+msgid "ldap"
+msgstr ""
+
+msgid "ldaps"
+msgstr ""
+
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -14205,14 +15214,14 @@ msgstr "m"
 msgid "memory_cpu"
 msgstr "memory_cpu"
 
+msgid "no value"
+msgstr ""
+
 msgid "none"
 msgstr "なし"
 
 msgid "normal"
 msgstr "標準"
-
-msgid "not specified"
-msgstr "指定なし"
 
 msgid "numvcpus"
 msgstr "numvcpus"

--- a/config/locales/manageiq.pot
+++ b/config/locales/manageiq.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: manageiq 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-11 22:51+0200\n"
-"PO-Revision-Date: 2015-05-11 22:51+0200\n"
+"POT-Creation-Date: 2015-10-07 18:51+0200\n"
+"PO-Revision-Date: 2015-10-07 18:51+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -42,6 +42,9 @@ msgstr ""
 msgid " Selected Alerts:"
 msgstr ""
 
+msgid " Valid numeric quota value required "
+msgstr ""
+
 msgid " that match the entered search string"
 msgstr ""
 
@@ -72,6 +75,12 @@ msgstr ""
 msgid "\"%{record}\": %{task} successfully initiated"
 msgstr ""
 
+msgid "\"%{record}\": Analysis successfully initiated"
+msgstr ""
+
+msgid "\"Unable to initiate scaling, obtaining of status failed: #{ex}\""
+msgstr ""
+
 msgid "% Savings"
 msgstr ""
 
@@ -87,16 +96,19 @@ msgstr ""
 msgid "%s  Ending with"
 msgstr ""
 
-msgid "%s & %s"
+msgid "%s (%s)"
 msgstr ""
 
-msgid "%s (%s)"
+msgid "%s (0)"
 msgstr ""
 
 msgid "%s (All %s)"
 msgstr ""
 
 msgid "%s (All cloud tenants present on this host)"
+msgstr ""
+
+msgid "%s Alert Profiles"
 msgstr ""
 
 msgid "%s Being Tagged"
@@ -113,11 +125,6 @@ msgstr ""
 
 msgid "%s Credentials validated successfully"
 msgstr ""
-
-msgid "%s Day"
-msgid_plural "%s Days"
-msgstr[0] ""
-msgstr[1] ""
 
 msgid "%s Days Ago"
 msgstr ""
@@ -168,9 +175,6 @@ msgstr ""
 msgid "%s Summary"
 msgstr ""
 
-msgid "%s Tags"
-msgstr ""
-
 msgid "%s Utilization"
 msgstr ""
 
@@ -197,7 +201,7 @@ msgstr ""
 msgid "%s has no network adapters"
 msgstr ""
 
-msgid "%s has no snapshots."
+msgid "%s has no snapshots"
 msgstr ""
 
 msgid "%s is currently being used in the Display Filter"
@@ -248,6 +252,9 @@ msgstr ""
 msgid "%s record no longer exists"
 msgstr ""
 
+msgid "%s requests cannot be deleted"
+msgstr ""
+
 msgid "%s saved"
 msgstr ""
 
@@ -267,9 +274,6 @@ msgid "%s tab is not available unless at least 1 time field has been selected"
 msgstr ""
 
 msgid "%s tab is not available until at least 1 field has been selected"
-msgstr ""
-
-msgid "%s to validate against, Username and matching password fields are needed to perform verification of credentials"
 msgstr ""
 
 msgid "%s was cancelled by the user"
@@ -297,6 +301,9 @@ msgid "%{field} Value Error: %{msg}"
 msgstr ""
 
 msgid "%{field} cannot contain \"%{character}\""
+msgstr ""
+
+msgid "%{model}"
 msgstr ""
 
 msgid "%{model} \"%{name}\""
@@ -330,6 +337,9 @@ msgid "%{model} \"%{name}\": Delete successful"
 msgstr ""
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
+msgstr ""
+
+msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
 msgid "%{model} for \"%{name}\""
@@ -371,13 +381,22 @@ msgstr ""
 msgid "%{task} does not apply because you selected at least one %{model}"
 msgstr ""
 
+msgid "%{task} does not apply because you selected at least one un-reconfigurable VM"
+msgstr ""
+
+msgid "%{task} does not apply to at least one of the selected %{model}"
+msgstr ""
+
 msgid "%{task} does not apply to selected %{model}"
 msgstr ""
 
-msgid "%{task} initiated for %{count_model} (Foreman) from the CFME Database"
+msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
 msgstr ""
 
 msgid "%{task} initiated for %{count_model} from the CFME Database"
+msgstr ""
+
+msgid "%{task} initiated for %{model} from the CFME Database"
 msgstr ""
 
 msgid "%{typ} %{model}"
@@ -435,9 +454,6 @@ msgid "(Look Up LDAP Groups)"
 msgstr ""
 
 msgid "(MB) memory"
-msgstr ""
-
-msgid "(NS/Cls/Inst)"
 msgstr ""
 
 msgid "(Row %{start_number} of %{pages})"
@@ -581,6 +597,9 @@ msgstr ""
 msgid "* Style \"If\" conditions are evaluated top to bottom for each column"
 msgstr ""
 
+msgid "-- OR --"
+msgstr ""
+
 msgid "1 - Select a Reference VM."
 msgstr ""
 
@@ -599,7 +618,7 @@ msgstr ""
 msgid "2 Weeks before retirement"
 msgstr ""
 
-msgid "24 Hour Time Period:"
+msgid "24 Hour Time Period"
 msgstr ""
 
 msgid "3 - Specify Target Options to qualify target %s or %s."
@@ -612,6 +631,9 @@ msgid "4 - Change the Trend Options used to calculate the daily trends, if desir
 msgstr ""
 
 msgid "5 - Press the Submit button."
+msgstr ""
+
+msgid "<Archived>"
 msgstr ""
 
 msgid "<Choose a Group>"
@@ -639,6 +661,15 @@ msgid "<New LDAP Server>"
 msgstr ""
 
 msgid "<No Depot>"
+msgstr ""
+
+msgid "<No chart>"
+msgstr ""
+
+msgid "<Orphaned>"
+msgstr ""
+
+msgid "<Unnamed>"
 msgstr ""
 
 msgid "A %s must be chosen to commit this expression element"
@@ -677,13 +708,13 @@ msgstr ""
 msgid "AMQP"
 msgstr ""
 
-msgid "AMQP Messaging"
-msgstr ""
-
 msgid "AND with a new expression element"
 msgstr ""
 
 msgid "API Port"
+msgstr ""
+
+msgid "API Version"
 msgstr ""
 
 msgid "About"
@@ -693,6 +724,9 @@ msgid "Access Key"
 msgstr ""
 
 msgid "Access Key ID"
+msgstr ""
+
+msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
 msgid "Access URL"
@@ -779,6 +813,9 @@ msgstr ""
 msgid "Add a new %s Provider"
 msgstr ""
 
+msgid "Add of %{model} was cancelled by the user"
+msgstr ""
+
 msgid "Add of new %s was cancelled by the user"
 msgstr ""
 
@@ -786,9 +823,6 @@ msgid "Add subfolder to selected folder"
 msgstr ""
 
 msgid "Add this %s"
-msgstr ""
-
-msgid "Add this Host"
 msgstr ""
 
 msgid "Add this LDAP Server"
@@ -914,10 +948,76 @@ msgstr ""
 msgid "All (%s)"
 msgstr ""
 
+msgid "All Actions"
+msgstr ""
+
+msgid "All Alert Profiles"
+msgstr ""
+
+msgid "All Alerts"
+msgstr ""
+
+msgid "All Catalog Items"
+msgstr ""
+
+msgid "All Catalogs"
+msgstr ""
+
+msgid "All Conditions"
+msgstr ""
+
+msgid "All Containers"
+msgstr ""
+
 msgid "All Datastore customizations will be lost. Are you sure you want to reset all classes and instances to default?"
 msgstr ""
 
+msgid "All Dialogs"
+msgstr ""
+
+msgid "All Events"
+msgstr ""
+
 msgid "All Files"
+msgstr ""
+
+msgid "All ISO Datastores"
+msgstr ""
+
+msgid "All Images"
+msgstr ""
+
+msgid "All Images by Provider that I can see"
+msgstr ""
+
+msgid "All Instances"
+msgstr ""
+
+msgid "All Instances by Provider that I can see"
+msgstr ""
+
+msgid "All Orchestration Templates"
+msgstr ""
+
+msgid "All PXE Servers"
+msgstr ""
+
+msgid "All Policies"
+msgstr ""
+
+msgid "All Policy Profiles"
+msgstr ""
+
+msgid "All Services"
+msgstr ""
+
+msgid "All System Image Types"
+msgstr ""
+
+msgid "All Templates"
+msgstr ""
+
+msgid "All Templates & Images"
 msgstr ""
 
 msgid "All Templates: %s"
@@ -929,7 +1029,19 @@ msgstr ""
 msgid "All Users"
 msgstr ""
 
+msgid "All VM and Instance Conditions"
+msgstr ""
+
 msgid "All VMs"
+msgstr ""
+
+msgid "All VMs & Instances"
+msgstr ""
+
+msgid "All VMs & Templates"
+msgstr ""
+
+msgid "All VMs & Templates that I can see"
 msgstr ""
 
 msgid "All VMs (Tree View): %s"
@@ -954,6 +1066,24 @@ msgid "All custom classes and instances have been reset to default"
 msgstr ""
 
 msgid "All fields are needed to perform verification of Database Settings"
+msgstr ""
+
+msgid "All of the Images that I can see"
+msgstr ""
+
+msgid "All of the Instances that I can see"
+msgstr ""
+
+msgid "All of the Templates & Images that I can see"
+msgstr ""
+
+msgid "All of the Templates that I can see"
+msgstr ""
+
+msgid "All of the VMs & Instances that I can see"
+msgstr ""
+
+msgid "All of the VMs that I can see"
 msgstr ""
 
 msgid "All selected %s are not in the current region"
@@ -981,6 +1111,9 @@ msgid "An internal system error."
 msgstr ""
 
 msgid "Analysis"
+msgstr ""
+
+msgid "Analysis Affinity was saved"
 msgstr ""
 
 msgid "Analysis History (%s)"
@@ -1055,16 +1188,22 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
+msgid "Arch"
+msgstr ""
+
 msgid "Architecture"
+msgstr ""
+
+msgid "Archived Instances"
+msgstr ""
+
+msgid "Archived VMs and Templates"
 msgstr ""
 
 msgid "Are you sure you want to Run Database Garbage Collection Now?"
 msgstr ""
 
 msgid "Are you sure you want to Run a Database Backup Now?"
-msgstr ""
-
-msgid "Are you sure you want to delete build %s?"
 msgstr ""
 
 msgid "Are you sure you want to delete category '%s'?"
@@ -1262,6 +1401,18 @@ msgstr ""
 msgid "Authorization Error"
 msgstr ""
 
+msgid "Auto Refresh other fields when modified"
+msgstr ""
+
+msgid "Auto refresh"
+msgstr ""
+
+msgid "Automate"
+msgstr ""
+
+msgid "Automate Workers"
+msgstr ""
+
 msgid "Automate button %s has been cleared"
 msgstr ""
 
@@ -1295,7 +1446,7 @@ msgstr ""
 msgid "Available %s Conditions:"
 msgstr ""
 
-msgid "Available %s:"
+msgid "Available %{title}:"
 msgstr ""
 
 msgid "Available Actions:"
@@ -1416,6 +1567,21 @@ msgid "Bind DN"
 msgstr ""
 
 msgid "Bind Password"
+msgstr ""
+
+msgid "Blacklisted event"
+msgstr ""
+
+msgid "BlacklistedEvent|Enabled"
+msgstr ""
+
+msgid "BlacklistedEvent|Event name"
+msgstr ""
+
+msgid "BlacklistedEvent|Provider model"
+msgstr ""
+
+msgid "BlacklistedEvent|System"
 msgstr ""
 
 msgid "Bottleneck Event Details"
@@ -1679,13 +1845,22 @@ msgstr ""
 msgid "Change %s value to submit reconfigure request"
 msgstr ""
 
-msgid "Change Password / Confirm Password"
+msgid "Change Group:"
+msgstr ""
+
+msgid "Change Password"
 msgstr ""
 
 msgid "Changes"
 msgstr ""
 
 msgid "Changing the UI Workers Count will immediately restart the webserver"
+msgstr ""
+
+msgid "Channel Name(s)"
+msgstr ""
+
+msgid "Channel Name(s):"
 msgstr ""
 
 msgid "Chargeback"
@@ -1769,6 +1944,9 @@ msgstr ""
 msgid "Chart Theme"
 msgstr ""
 
+msgid "Chart mode"
+msgstr ""
+
 msgid "Chart no longer exists"
 msgstr ""
 
@@ -1788,6 +1966,9 @@ msgid "Check for updates"
 msgstr ""
 
 msgid "Checked default filters will be visible."
+msgstr ""
+
+msgid "Child Tenants"
 msgstr ""
 
 msgid "Child VM Selection"
@@ -1901,6 +2082,12 @@ msgstr ""
 msgid "Click on this row to create a new entry"
 msgstr ""
 
+msgid "Click to Logout"
+msgstr ""
+
+msgid "Click to add a new category"
+msgstr ""
+
 msgid "Click to add a new entry"
 msgstr ""
 
@@ -1922,9 +2109,6 @@ msgstr ""
 msgid "Click to delete this LDAP Server"
 msgstr ""
 
-msgid "Click to delete this build"
-msgstr ""
-
 msgid "Click to delete this category"
 msgstr ""
 
@@ -1940,10 +2124,19 @@ msgstr ""
 msgid "Click to delete this input field from method"
 msgstr ""
 
+msgid "Click to edit this category"
+msgstr ""
+
 msgid "Click to edit this forest"
 msgstr ""
 
 msgid "Click to go to this location"
+msgstr ""
+
+msgid "Click to open"
+msgstr ""
+
+msgid "Click to remove message"
 msgstr ""
 
 msgid "Click to remove messages"
@@ -1985,6 +2178,12 @@ msgstr ""
 msgid "Click to view Time Profile"
 msgstr ""
 
+msgid "Click to view child Tenant"
+msgstr ""
+
+msgid "Click to view child TenantProject"
+msgstr ""
+
 msgid "Click to view details"
 msgstr ""
 
@@ -2012,7 +2211,19 @@ msgstr ""
 msgid "Client Connections"
 msgstr ""
 
+msgid "Client ID"
+msgstr ""
+
+msgid "Client Key"
+msgstr ""
+
+msgid "Client Keys do not match"
+msgstr ""
+
 msgid "Close any duplicate browser sessions, then select a menu option above."
+msgstr ""
+
+msgid "Cloud Intelligence"
 msgstr ""
 
 msgid "Cloud Networks (%s)"
@@ -2048,6 +2259,9 @@ msgstr ""
 msgid "Cloud volume snapshot"
 msgstr ""
 
+msgid "CloudInit"
+msgstr ""
+
 msgid "CloudNetwork|Cidr"
 msgstr ""
 
@@ -2061,6 +2275,9 @@ msgid "CloudNetwork|External facing"
 msgstr ""
 
 msgid "CloudNetwork|Name"
+msgstr ""
+
+msgid "CloudNetwork|Shared"
 msgstr ""
 
 msgid "CloudNetwork|Status"
@@ -2216,6 +2433,9 @@ msgstr ""
 msgid "Collection Options"
 msgstr ""
 
+msgid "Column"
+msgstr ""
+
 msgid "Column %s"
 msgstr ""
 
@@ -2232,9 +2452,6 @@ msgid "Column 4"
 msgstr ""
 
 msgid "Column Name"
-msgstr ""
-
-msgid "Column:"
 msgstr ""
 
 msgid "Commit"
@@ -2277,6 +2494,9 @@ msgid "Compliance"
 msgstr ""
 
 msgid "Compliance Check"
+msgstr ""
+
+msgid "Compliance Policies"
 msgstr ""
 
 msgid "Compliance detail"
@@ -2432,6 +2652,12 @@ msgstr ""
 msgid "Configuration Management"
 msgstr ""
 
+msgid "Configuration Management Configured Systems"
+msgstr ""
+
+msgid "Configuration Management Providers"
+msgstr ""
+
 msgid "Configuration Organization"
 msgstr ""
 
@@ -2510,6 +2736,9 @@ msgstr ""
 msgid "Configuration|Updated on"
 msgstr ""
 
+msgid "Configure"
+msgstr ""
+
 msgid "Configure Report Columns"
 msgstr ""
 
@@ -2543,6 +2772,9 @@ msgstr ""
 msgid "ConfiguredSystem|Puppet status"
 msgstr ""
 
+msgid "Confirm Password"
+msgstr ""
+
 msgid "Connecting (unencrypted) to: %s"
 msgstr ""
 
@@ -2567,10 +2799,10 @@ msgstr ""
 msgid "Container"
 msgstr ""
 
-msgid "Pods (%s)"
+msgid "Container Images"
 msgstr ""
 
-msgid "Pods (0)"
+msgid "Container Nodes"
 msgstr ""
 
 msgid "Container Nodes (%s)"
@@ -2579,16 +2811,43 @@ msgstr ""
 msgid "Container Nodes (0)"
 msgstr ""
 
+msgid "Container Projects (%s)"
+msgstr ""
+
+msgid "Container Projects (0)"
+msgstr ""
+
+msgid "Container Routes (%s)"
+msgstr ""
+
+msgid "Container Routes (0)"
+msgstr ""
+
+msgid "Container Services"
+msgstr ""
+
 msgid "Container Services (%s)"
 msgstr ""
 
 msgid "Container Services (0)"
 msgstr ""
 
+msgid "Container condition"
+msgstr ""
+
 msgid "Container definition"
 msgstr ""
 
-msgid "Pod"
+msgid "Container env var"
+msgstr ""
+
+msgid "Container group"
+msgstr ""
+
+msgid "Container image"
+msgstr ""
+
+msgid "Container image registry"
 msgstr ""
 
 msgid "Container node"
@@ -2597,10 +2856,40 @@ msgstr ""
 msgid "Container port config"
 msgstr ""
 
-msgid "Container replication controller"
+msgid "Container project"
+msgstr ""
+
+msgid "Container replicator"
+msgstr ""
+
+msgid "Container route"
 msgstr ""
 
 msgid "Container service"
+msgstr ""
+
+msgid "Container service port config"
+msgstr ""
+
+msgid "ContainerCondition|Container entity type"
+msgstr ""
+
+msgid "ContainerCondition|Last heartbeat time"
+msgstr ""
+
+msgid "ContainerCondition|Last transition time"
+msgstr ""
+
+msgid "ContainerCondition|Message"
+msgstr ""
+
+msgid "ContainerCondition|Name"
+msgstr ""
+
+msgid "ContainerCondition|Reason"
+msgstr ""
+
+msgid "ContainerCondition|Status"
 msgstr ""
 
 msgid "ContainerDefinition|Cpu cores"
@@ -2621,25 +2910,64 @@ msgstr ""
 msgid "ContainerDefinition|Name"
 msgstr ""
 
-msgid "Pod|Creation timestamp"
+msgid "ContainerEnvVar|Field path"
 msgstr ""
 
-msgid "Pod|Dns policy"
+msgid "ContainerEnvVar|Name"
 msgstr ""
 
-msgid "Pod|Ems ref"
+msgid "ContainerEnvVar|Value"
 msgstr ""
 
-msgid "Pod|Name"
+msgid "ContainerGroup|Creation timestamp"
 msgstr ""
 
-msgid "Pod|Namespace"
+msgid "ContainerGroup|Dns policy"
 msgstr ""
 
-msgid "Pod|Resource version"
+msgid "ContainerGroup|Ems ref"
 msgstr ""
 
-msgid "Pod|Restart policy"
+msgid "ContainerGroup|Ipaddress"
+msgstr ""
+
+msgid "ContainerGroup|Message"
+msgstr ""
+
+msgid "ContainerGroup|Name"
+msgstr ""
+
+msgid "ContainerGroup|Phase"
+msgstr ""
+
+msgid "ContainerGroup|Reason"
+msgstr ""
+
+msgid "ContainerGroup|Resource version"
+msgstr ""
+
+msgid "ContainerGroup|Restart policy"
+msgstr ""
+
+msgid "ContainerImageRegistry|Host"
+msgstr ""
+
+msgid "ContainerImageRegistry|Name"
+msgstr ""
+
+msgid "ContainerImageRegistry|Port"
+msgstr ""
+
+msgid "ContainerImage|Image ref"
+msgstr ""
+
+msgid "ContainerImage|Name"
+msgstr ""
+
+msgid "ContainerImage|Tag"
+msgstr ""
+
+msgid "ContainerNode|Container runtime version"
 msgstr ""
 
 msgid "ContainerNode|Creation timestamp"
@@ -2657,7 +2985,16 @@ msgstr ""
 msgid "ContainerNode|Identity system"
 msgstr ""
 
+msgid "ContainerNode|Kubernetes kubelet version"
+msgstr ""
+
+msgid "ContainerNode|Kubernetes proxy version"
+msgstr ""
+
 msgid "ContainerNode|Lives on type"
+msgstr ""
+
+msgid "ContainerNode|Max container groups"
 msgstr ""
 
 msgid "ContainerNode|Name"
@@ -2681,28 +3018,70 @@ msgstr ""
 msgid "ContainerPortConfig|Protocol"
 msgstr ""
 
-msgid "ContainerReplicationController|Creation timestamp"
+msgid "ContainerProject|Creation timestamp"
 msgstr ""
 
-msgid "ContainerReplicationController|Current replicas"
+msgid "ContainerProject|Display name"
 msgstr ""
 
-msgid "ContainerReplicationController|Ems ref"
+msgid "ContainerProject|Ems ref"
 msgstr ""
 
-msgid "ContainerReplicationController|Name"
+msgid "ContainerProject|Name"
 msgstr ""
 
-msgid "ContainerReplicationController|Namespace"
+msgid "ContainerProject|Resource version"
 msgstr ""
 
-msgid "ContainerReplicationController|Replicas"
+msgid "ContainerReplicator|Creation timestamp"
 msgstr ""
 
-msgid "ContainerReplicationController|Resource version"
+msgid "ContainerReplicator|Current replicas"
 msgstr ""
 
-msgid "ContainerService|Container port"
+msgid "ContainerReplicator|Ems ref"
+msgstr ""
+
+msgid "ContainerReplicator|Name"
+msgstr ""
+
+msgid "ContainerReplicator|Replicas"
+msgstr ""
+
+msgid "ContainerReplicator|Resource version"
+msgstr ""
+
+msgid "ContainerRoute|Creation timestamp"
+msgstr ""
+
+msgid "ContainerRoute|Ems ref"
+msgstr ""
+
+msgid "ContainerRoute|Host name"
+msgstr ""
+
+msgid "ContainerRoute|Name"
+msgstr ""
+
+msgid "ContainerRoute|Path"
+msgstr ""
+
+msgid "ContainerRoute|Resource version"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Ems ref"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Name"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Port"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Protocol"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Target port"
 msgstr ""
 
 msgid "ContainerService|Creation timestamp"
@@ -2714,16 +3093,7 @@ msgstr ""
 msgid "ContainerService|Name"
 msgstr ""
 
-msgid "ContainerService|Namespace"
-msgstr ""
-
-msgid "ContainerService|Port"
-msgstr ""
-
 msgid "ContainerService|Portal ip"
-msgstr ""
-
-msgid "ContainerService|Protocol"
 msgstr ""
 
 msgid "ContainerService|Resource version"
@@ -2735,13 +3105,16 @@ msgstr ""
 msgid "Containers"
 msgstr ""
 
+msgid "Containers (%s)"
+msgstr ""
+
+msgid "Containers (0)"
+msgstr ""
+
 msgid "Container|Backing ref"
 msgstr ""
 
 msgid "Container|Ems ref"
-msgstr ""
-
-msgid "Container|Image"
 msgstr ""
 
 msgid "Container|Name"
@@ -2768,6 +3141,9 @@ msgstr ""
 msgid "Control"
 msgstr ""
 
+msgid "Control Policies"
+msgstr ""
+
 msgid "Copy"
 msgstr ""
 
@@ -2784,6 +3160,9 @@ msgid "Copy to same path"
 msgstr ""
 
 msgid "Copying %s"
+msgstr ""
+
+msgid "Cores Per socket"
 msgstr ""
 
 msgid "Count"
@@ -2838,6 +3217,9 @@ msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
 msgid "Current Backlog"
+msgstr ""
+
+msgid "Current Group"
 msgstr ""
 
 msgid "Current Rates"
@@ -3086,6 +3468,12 @@ msgstr ""
 msgid "Data Type:"
 msgstr ""
 
+msgid "Data column"
+msgstr ""
+
+msgid "Data type: %s"
+msgstr ""
+
 msgid "Data validated successfully"
 msgstr ""
 
@@ -3163,6 +3551,9 @@ msgstr ""
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
+msgid "Default Filters"
+msgstr ""
+
 msgid "Default Filters saved successfully"
 msgstr ""
 
@@ -3182,6 +3573,15 @@ msgid "Default Repository SmartProxy"
 msgstr ""
 
 msgid "Default Value"
+msgstr ""
+
+msgid "Default Views"
+msgstr ""
+
+msgid "Default dialogs cannot be edited"
+msgstr ""
+
+msgid "Default dialogs cannot be removed from the VMDB"
 msgstr ""
 
 msgid "Delay (mins)"
@@ -3244,10 +3644,10 @@ msgstr ""
 msgid "Details Mode"
 msgstr ""
 
-msgid "Details View"
+msgid "Determine at Run Time"
 msgstr ""
 
-msgid "Determine at Run Time"
+msgid "Device Type"
 msgstr ""
 
 msgid "Devices"
@@ -3275,6 +3675,9 @@ msgid "Dialog has to be set if Display in Catalog is chosen"
 msgstr ""
 
 msgid "Dialog tab"
+msgstr ""
+
+msgid "DialogField|Auto refresh"
 msgstr ""
 
 msgid "DialogField|Data type"
@@ -3335,6 +3738,9 @@ msgid "DialogField|Required method options"
 msgstr ""
 
 msgid "DialogField|Show refresh button"
+msgstr ""
+
+msgid "DialogField|Trigger auto refresh"
 msgstr ""
 
 msgid "DialogField|Validator rule"
@@ -3577,6 +3983,9 @@ msgstr ""
 msgid "Driving Event"
 msgstr ""
 
+msgid "Dropdown elements require some entries"
+msgstr ""
+
 msgid "Dynamic"
 msgstr ""
 
@@ -3614,6 +4023,9 @@ msgid "Edit Compute Rate Assignments"
 msgstr ""
 
 msgid "Edit Log Depot settings was cancelled by the user"
+msgstr ""
+
+msgid "Edit Registration"
 msgstr ""
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
@@ -3706,9 +4118,6 @@ msgstr ""
 msgid "Ems cluster"
 msgstr ""
 
-msgid "Ems event"
-msgstr ""
-
 msgid "Ems folder"
 msgstr ""
 
@@ -3757,60 +4166,6 @@ msgstr ""
 msgid "EmsCluster|Updated on"
 msgstr ""
 
-msgid "EmsEvent|Created on"
-msgstr ""
-
-msgid "EmsEvent|Dest ems cluster name"
-msgstr ""
-
-msgid "EmsEvent|Dest ems cluster uid"
-msgstr ""
-
-msgid "EmsEvent|Dest host name"
-msgstr ""
-
-msgid "EmsEvent|Dest vm location"
-msgstr ""
-
-msgid "EmsEvent|Dest vm name"
-msgstr ""
-
-msgid "EmsEvent|Ems cluster name"
-msgstr ""
-
-msgid "EmsEvent|Ems cluster uid"
-msgstr ""
-
-msgid "EmsEvent|Event type"
-msgstr ""
-
-msgid "EmsEvent|Full data"
-msgstr ""
-
-msgid "EmsEvent|Host name"
-msgstr ""
-
-msgid "EmsEvent|Is task"
-msgstr ""
-
-msgid "EmsEvent|Message"
-msgstr ""
-
-msgid "EmsEvent|Source"
-msgstr ""
-
-msgid "EmsEvent|Timestamp"
-msgstr ""
-
-msgid "EmsEvent|Username"
-msgstr ""
-
-msgid "EmsEvent|Vm location"
-msgstr ""
-
-msgid "EmsEvent|Vm name"
-msgstr ""
-
 msgid "EmsFolder|Created on"
 msgstr ""
 
@@ -3853,10 +4208,16 @@ msgstr ""
 msgid "End Port"
 msgstr ""
 
+msgid "Enforced"
+msgstr ""
+
 msgid "Enter Automation Simulation options on the left and press Submit."
 msgstr ""
 
 msgid "Enter URL Manually"
+msgstr ""
+
+msgid "Enterprise"
 msgstr ""
 
 msgid "Entity:"
@@ -3934,7 +4295,16 @@ msgstr ""
 msgid "Error when adding a new schedule: "
 msgstr ""
 
+msgid "Error when adding a new tenant: "
+msgstr ""
+
 msgid "Error when creating a Service Dialog from Orchestration Template: "
+msgstr ""
+
+msgid "Error when saving new server name: "
+msgstr ""
+
+msgid "Error when saving tenant quota: "
 msgstr ""
 
 msgid "Error: Datastore import file upload expired"
@@ -3997,7 +4367,10 @@ msgstr ""
 msgid "Event log"
 msgstr ""
 
-msgid "Event to position at:"
+msgid "Event stream"
+msgstr ""
+
+msgid "Event to position at"
 msgstr ""
 
 msgid "Event:"
@@ -4027,13 +4400,76 @@ msgstr ""
 msgid "EventLog|Uid"
 msgstr ""
 
+msgid "EventStream|Container group name"
+msgstr ""
+
+msgid "EventStream|Container namespace"
+msgstr ""
+
+msgid "EventStream|Container node name"
+msgstr ""
+
+msgid "EventStream|Created on"
+msgstr ""
+
+msgid "EventStream|Dest ems cluster name"
+msgstr ""
+
+msgid "EventStream|Dest ems cluster uid"
+msgstr ""
+
+msgid "EventStream|Dest host name"
+msgstr ""
+
+msgid "EventStream|Dest vm location"
+msgstr ""
+
+msgid "EventStream|Dest vm name"
+msgstr ""
+
+msgid "EventStream|Ems cluster name"
+msgstr ""
+
+msgid "EventStream|Ems cluster uid"
+msgstr ""
+
+msgid "EventStream|Event type"
+msgstr ""
+
+msgid "EventStream|Full data"
+msgstr ""
+
+msgid "EventStream|Host name"
+msgstr ""
+
+msgid "EventStream|Is task"
+msgstr ""
+
+msgid "EventStream|Message"
+msgstr ""
+
+msgid "EventStream|Source"
+msgstr ""
+
+msgid "EventStream|Target type"
+msgstr ""
+
+msgid "EventStream|Timestamp"
+msgstr ""
+
+msgid "EventStream|Username"
+msgstr ""
+
+msgid "EventStream|Vm location"
+msgstr ""
+
+msgid "EventStream|Vm name"
+msgstr ""
+
 msgid "Events"
 msgstr ""
 
 msgid "Execute Methods"
-msgstr ""
-
-msgid "Exist Mode"
 msgstr ""
 
 msgid "Exists Mode"
@@ -4136,6 +4572,9 @@ msgid "External Authentication (httpd) Settings"
 msgstr ""
 
 msgid "External RSS Feed/URL"
+msgstr ""
+
+msgid "FS Type"
 msgstr ""
 
 msgid "Failed"
@@ -4339,7 +4778,7 @@ msgstr ""
 msgid "First %s"
 msgstr ""
 
-msgid "First band unit:"
+msgid "First band unit"
 msgstr ""
 
 msgid "Flavor"
@@ -4349,6 +4788,9 @@ msgid "Flavors"
 msgstr ""
 
 msgid "Flavor|Block storage based only"
+msgstr ""
+
+msgid "Flavor|Cloud subnet required"
 msgstr ""
 
 msgid "Flavor|Cpu cores"
@@ -4441,6 +4883,9 @@ msgstr ""
 msgid "GB"
 msgstr ""
 
+msgid "GCE PD Resource"
+msgstr ""
+
 msgid "Genealogy"
 msgstr ""
 
@@ -4468,13 +4913,28 @@ msgstr ""
 msgid "Get User Groups from LDAP"
 msgstr ""
 
+msgid "Git Repository"
+msgstr ""
+
+msgid "Git Revision"
+msgstr ""
+
 msgid "Global Default"
+msgstr ""
+
+msgid "Global Filters"
+msgstr ""
+
+msgid "Global Shared Filters"
 msgstr ""
 
 msgid "Global Time Profile cannot be edited"
 msgstr ""
 
 msgid "Global search:"
+msgstr ""
+
+msgid "Glusterfs Endpoint Name"
 msgstr ""
 
 msgid "Grid View"
@@ -4612,6 +5072,12 @@ msgstr ""
 msgid "HKLM"
 msgstr ""
 
+msgid "HTTP Proxy Address"
+msgstr ""
+
+msgid "HTTP Proxy:"
+msgstr ""
+
 msgid "Hardware"
 msgstr ""
 
@@ -4717,13 +5183,25 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
+msgid "Host Compliance Policies"
+msgstr ""
+
+msgid "Host Conditions"
+msgstr ""
+
+msgid "Host Control Policies"
+msgstr ""
+
+msgid "Host Default VNC End Port"
+msgstr ""
+
 msgid "Host Default VNC Port Range"
 msgstr ""
 
-msgid "Host Name"
+msgid "Host Default VNC Start Port"
 msgstr ""
 
-msgid "Host Name (or IPv4 or IPv6 address)"
+msgid "Host Policies"
 msgstr ""
 
 msgid "Host Protocol"
@@ -4739,6 +5217,15 @@ msgid "HostServiceGroup|Name"
 msgstr ""
 
 msgid "Hostname"
+msgstr ""
+
+msgid "Hostname (or IPv4 or IPv6 address)"
+msgstr ""
+
+msgid "Hostname or IP address"
+msgstr ""
+
+msgid "Hostname or IPv4/IPv6 address"
 msgstr ""
 
 msgid "Hosts"
@@ -4867,10 +5354,22 @@ msgstr ""
 msgid "IPMI"
 msgstr ""
 
+msgid "IPMI Credentials"
+msgstr ""
+
 msgid "IPMI IP Address"
 msgstr ""
 
 msgid "IPMI Present"
+msgstr ""
+
+msgid "ISCSI Target Lun Number"
+msgstr ""
+
+msgid "ISCSI Target Portal"
+msgstr ""
+
+msgid "ISCSI Target Qualified Name"
 msgstr ""
 
 msgid "ISO"
@@ -4891,6 +5390,12 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
+msgid "Image Registries (%s)"
+msgstr ""
+
+msgid "Image Registries (0)"
+msgstr ""
+
 msgid "Image Type"
 msgstr ""
 
@@ -4901,6 +5406,12 @@ msgid "Images"
 msgstr ""
 
 msgid "Images (%s)"
+msgstr ""
+
+msgid "Images (0)"
+msgstr ""
+
+msgid "Images by Provider"
 msgstr ""
 
 msgid "Import"
@@ -4975,10 +5486,10 @@ msgstr ""
 msgid "Init Processes (%s)"
 msgstr ""
 
-msgid "Input Parameters"
+msgid "Input Name"
 msgstr ""
 
-msgid "Insight"
+msgid "Input Parameters"
 msgstr ""
 
 msgid "Instance Type:"
@@ -4990,10 +5501,10 @@ msgstr ""
 msgid "Instances (%s)"
 msgstr ""
 
-msgid "Integer"
+msgid "Instances by Provider"
 msgstr ""
 
-msgid "Integration Services"
+msgid "Integer"
 msgstr ""
 
 msgid "Internal"
@@ -5109,6 +5620,9 @@ msgstr ""
 msgid "Key:"
 msgstr ""
 
+msgid "Kickstart"
+msgstr ""
+
 msgid "LDAP"
 msgstr ""
 
@@ -5124,13 +5638,13 @@ msgstr ""
 msgid "LDAP Groups for User"
 msgstr ""
 
-msgid "LDAP Host Name"
-msgstr ""
-
-msgid "LDAP Host Name and Port fields are needed to perform verification of LDAP Settings"
-msgstr ""
-
 msgid "LDAP Host Names"
+msgstr ""
+
+msgid "LDAP Hostname"
+msgstr ""
+
+msgid "LDAP Hostname and Port fields are needed to perform verification of LDAP Settings"
 msgstr ""
 
 msgid "LDAP Port"
@@ -5155,6 +5669,9 @@ msgid "Label"
 msgstr ""
 
 msgid "Label on Summary Row"
+msgstr ""
+
+msgid "Labels"
 msgstr ""
 
 msgid "Lan"
@@ -5218,6 +5735,9 @@ msgid "Last Message"
 msgstr ""
 
 msgid "Last Run Time"
+msgstr ""
+
+msgid "Last Transition Time"
 msgstr ""
 
 msgid "Last Update"
@@ -5394,9 +5914,6 @@ msgstr ""
 msgid "Lifecycle"
 msgstr ""
 
-msgid "Lifecycle and Automation"
-msgstr ""
-
 msgid "Lifecycle event"
 msgstr ""
 
@@ -5520,10 +6037,16 @@ msgstr ""
 msgid "Logging"
 msgstr ""
 
+msgid "Logging into"
+msgstr ""
+
 msgid "Login"
 msgstr ""
 
 msgid "Login not allowed, User's %s is missing. Please contact the administrator"
+msgstr ""
+
+msgid "Logout"
 msgstr ""
 
 msgid "Logs for this CFME Server are not available for viewing"
@@ -5559,10 +6082,19 @@ msgstr ""
 msgid "Manage Reports"
 msgstr ""
 
+msgid "Manage quotas for %{model} \"%{name}\""
+msgstr ""
+
+msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
+msgstr ""
+
 msgid "Management Event"
 msgstr ""
 
 msgid "Manager"
+msgstr ""
+
+msgid "Matching password fields are needed to perform verification of credentials"
 msgstr ""
 
 msgid "Max"
@@ -5581,6 +6113,9 @@ msgid "Max Time"
 msgstr ""
 
 msgid "Max VMs"
+msgstr ""
+
+msgid "Max active VM Scans"
 msgstr ""
 
 msgid "Medium"
@@ -6036,25 +6571,7 @@ msgstr ""
 msgid "Miq action set"
 msgstr ""
 
-msgid "Miq ae class"
-msgstr ""
-
 msgid "Miq ae engine/miq ae workspace"
-msgstr ""
-
-msgid "Miq ae field"
-msgstr ""
-
-msgid "Miq ae instance"
-msgstr ""
-
-msgid "Miq ae method"
-msgstr ""
-
-msgid "Miq ae namespace"
-msgstr ""
-
-msgid "Miq ae value"
 msgstr ""
 
 msgid "Miq alert"
@@ -6087,10 +6604,10 @@ msgstr ""
 msgid "Miq enterprise"
 msgstr ""
 
-msgid "Miq event"
+msgid "Miq event definition"
 msgstr ""
 
-msgid "Miq event set"
+msgid "Miq event definition set"
 msgstr ""
 
 msgid "Miq group"
@@ -6225,33 +6742,6 @@ msgstr ""
 msgid "MiqAction|Updated on"
 msgstr ""
 
-msgid "MiqAeClass|Created on"
-msgstr ""
-
-msgid "MiqAeClass|Description"
-msgstr ""
-
-msgid "MiqAeClass|Display name"
-msgstr ""
-
-msgid "MiqAeClass|Inherits"
-msgstr ""
-
-msgid "MiqAeClass|Name"
-msgstr ""
-
-msgid "MiqAeClass|Owner"
-msgstr ""
-
-msgid "MiqAeClass|Updated by"
-msgstr ""
-
-msgid "MiqAeClass|Updated on"
-msgstr ""
-
-msgid "MiqAeClass|Visibility"
-msgstr ""
-
 msgid "MiqAeEngine::MiqAeWorkspace|Created on"
 msgstr ""
 
@@ -6268,186 +6758,6 @@ msgid "MiqAeEngine::MiqAeWorkspace|Uri"
 msgstr ""
 
 msgid "MiqAeEngine::MiqAeWorkspace|Workspace"
-msgstr ""
-
-msgid "MiqAeField|Aetype"
-msgstr ""
-
-msgid "MiqAeField|Collect"
-msgstr ""
-
-msgid "MiqAeField|Condition"
-msgstr ""
-
-msgid "MiqAeField|Created on"
-msgstr ""
-
-msgid "MiqAeField|Datatype"
-msgstr ""
-
-msgid "MiqAeField|Default value"
-msgstr ""
-
-msgid "MiqAeField|Description"
-msgstr ""
-
-msgid "MiqAeField|Display name"
-msgstr ""
-
-msgid "MiqAeField|Max retries"
-msgstr ""
-
-msgid "MiqAeField|Max time"
-msgstr ""
-
-msgid "MiqAeField|Message"
-msgstr ""
-
-msgid "MiqAeField|Name"
-msgstr ""
-
-msgid "MiqAeField|On entry"
-msgstr ""
-
-msgid "MiqAeField|On error"
-msgstr ""
-
-msgid "MiqAeField|On exit"
-msgstr ""
-
-msgid "MiqAeField|Owner"
-msgstr ""
-
-msgid "MiqAeField|Priority"
-msgstr ""
-
-msgid "MiqAeField|Scope"
-msgstr ""
-
-msgid "MiqAeField|Substitute"
-msgstr ""
-
-msgid "MiqAeField|Updated by"
-msgstr ""
-
-msgid "MiqAeField|Updated on"
-msgstr ""
-
-msgid "MiqAeField|Visibility"
-msgstr ""
-
-msgid "MiqAeInstance|Created on"
-msgstr ""
-
-msgid "MiqAeInstance|Description"
-msgstr ""
-
-msgid "MiqAeInstance|Display name"
-msgstr ""
-
-msgid "MiqAeInstance|Inherits"
-msgstr ""
-
-msgid "MiqAeInstance|Name"
-msgstr ""
-
-msgid "MiqAeInstance|Updated by"
-msgstr ""
-
-msgid "MiqAeInstance|Updated on"
-msgstr ""
-
-msgid "MiqAeMethod|Created on"
-msgstr ""
-
-msgid "MiqAeMethod|Data"
-msgstr ""
-
-msgid "MiqAeMethod|Description"
-msgstr ""
-
-msgid "MiqAeMethod|Display name"
-msgstr ""
-
-msgid "MiqAeMethod|Language"
-msgstr ""
-
-msgid "MiqAeMethod|Location"
-msgstr ""
-
-msgid "MiqAeMethod|Name"
-msgstr ""
-
-msgid "MiqAeMethod|Scope"
-msgstr ""
-
-msgid "MiqAeMethod|Updated by"
-msgstr ""
-
-msgid "MiqAeMethod|Updated on"
-msgstr ""
-
-msgid "MiqAeNamespace|Created on"
-msgstr ""
-
-msgid "MiqAeNamespace|Description"
-msgstr ""
-
-msgid "MiqAeNamespace|Display name"
-msgstr ""
-
-msgid "MiqAeNamespace|Enabled"
-msgstr ""
-
-msgid "MiqAeNamespace|Name"
-msgstr ""
-
-msgid "MiqAeNamespace|Priority"
-msgstr ""
-
-msgid "MiqAeNamespace|System"
-msgstr ""
-
-msgid "MiqAeNamespace|Updated by"
-msgstr ""
-
-msgid "MiqAeNamespace|Updated on"
-msgstr ""
-
-msgid "MiqAeValue|Collect"
-msgstr ""
-
-msgid "MiqAeValue|Condition"
-msgstr ""
-
-msgid "MiqAeValue|Created on"
-msgstr ""
-
-msgid "MiqAeValue|Display name"
-msgstr ""
-
-msgid "MiqAeValue|Max retries"
-msgstr ""
-
-msgid "MiqAeValue|Max time"
-msgstr ""
-
-msgid "MiqAeValue|On entry"
-msgstr ""
-
-msgid "MiqAeValue|On error"
-msgstr ""
-
-msgid "MiqAeValue|On exit"
-msgstr ""
-
-msgid "MiqAeValue|Updated by"
-msgstr ""
-
-msgid "MiqAeValue|Updated on"
-msgstr ""
-
-msgid "MiqAeValue|Value"
 msgstr ""
 
 msgid "MiqAlertSet|Created on"
@@ -6729,64 +7039,64 @@ msgstr ""
 msgid "MiqEnterprise|Updated on"
 msgstr ""
 
-msgid "MiqEventSet|Created on"
+msgid "MiqEventDefinitionSet|Created on"
 msgstr ""
 
-msgid "MiqEventSet|Description"
+msgid "MiqEventDefinitionSet|Description"
 msgstr ""
 
-msgid "MiqEventSet|Guid"
+msgid "MiqEventDefinitionSet|Guid"
 msgstr ""
 
-msgid "MiqEventSet|Mode"
+msgid "MiqEventDefinitionSet|Mode"
 msgstr ""
 
-msgid "MiqEventSet|Name"
+msgid "MiqEventDefinitionSet|Name"
 msgstr ""
 
-msgid "MiqEventSet|Owner type"
+msgid "MiqEventDefinitionSet|Owner type"
 msgstr ""
 
-msgid "MiqEventSet|Read only"
+msgid "MiqEventDefinitionSet|Read only"
 msgstr ""
 
-msgid "MiqEventSet|Set data"
+msgid "MiqEventDefinitionSet|Set data"
 msgstr ""
 
-msgid "MiqEventSet|Set type"
+msgid "MiqEventDefinitionSet|Set type"
 msgstr ""
 
-msgid "MiqEventSet|Updated on"
+msgid "MiqEventDefinitionSet|Updated on"
 msgstr ""
 
-msgid "MiqEventSet|Userid"
+msgid "MiqEventDefinitionSet|Userid"
 msgstr ""
 
-msgid "MiqEvent|Created on"
+msgid "MiqEventDefinition|Created on"
 msgstr ""
 
-msgid "MiqEvent|Default"
+msgid "MiqEventDefinition|Default"
 msgstr ""
 
-msgid "MiqEvent|Definition"
+msgid "MiqEventDefinition|Definition"
 msgstr ""
 
-msgid "MiqEvent|Description"
+msgid "MiqEventDefinition|Description"
 msgstr ""
 
-msgid "MiqEvent|Enabled"
+msgid "MiqEventDefinition|Enabled"
 msgstr ""
 
-msgid "MiqEvent|Event type"
+msgid "MiqEventDefinition|Event type"
 msgstr ""
 
-msgid "MiqEvent|Guid"
+msgid "MiqEventDefinition|Guid"
 msgstr ""
 
-msgid "MiqEvent|Name"
+msgid "MiqEventDefinition|Name"
 msgstr ""
 
-msgid "MiqEvent|Updated on"
+msgid "MiqEventDefinition|Updated on"
 msgstr ""
 
 msgid "MiqGroup|Created on"
@@ -7695,13 +8005,22 @@ msgstr ""
 msgid "My Filters"
 msgstr ""
 
+msgid "My Personal Filters"
+msgstr ""
+
 msgid "My Services"
 msgstr ""
 
 msgid "My Settings"
 msgstr ""
 
+msgid "MyTags"
+msgstr ""
+
 msgid "N/A"
+msgstr ""
+
+msgid "NFS Server"
 msgstr ""
 
 msgid "NONE"
@@ -7722,10 +8041,10 @@ msgstr ""
 msgid "Name: %s | %s Type: %s"
 msgstr ""
 
-msgid "Name: %s | Host Name: %s"
+msgid "Name: %s | Hostname: %s"
 msgstr ""
 
-msgid "Name: %s | Host Name: %s | Refresh Status: %s"
+msgid "Name: %s | Hostname: %s | Refresh Status: %s"
 msgstr ""
 
 msgid "Name: %s | Path: %s"
@@ -7803,9 +8122,6 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-msgid "New Catalog Item"
-msgstr ""
-
 msgid "New Entry"
 msgstr ""
 
@@ -7821,8 +8137,13 @@ msgstr ""
 msgid "New Parameter"
 msgstr ""
 
-msgid "New setting will affect %s"
+msgid "New Password"
 msgstr ""
+
+msgid "New setting will affect Orchestration Stack"
+msgid_plural "New setting will affect Orchestration Stacks"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "New setting will affect Service"
 msgid_plural "New setting will affect Services"
@@ -7849,10 +8170,10 @@ msgstr ""
 msgid "No %s %s Policies are defined %s."
 msgstr ""
 
-msgid "No %s Alert Profiles are defined%s."
+msgid "No %s Alert Profiles are defined %s."
 msgstr ""
 
-msgid "No %s Conditions are defined%s."
+msgid "No %s Conditions are defined %s."
 msgstr ""
 
 msgid "No %s Policy Profiles are defined%s."
@@ -7960,7 +8281,7 @@ msgstr ""
 msgid "No Choices Available"
 msgstr ""
 
-msgid "No Class found for explorer tree node type '%s'"
+msgid "No Class found for explorer tree node id '%s'"
 msgstr ""
 
 msgid "No Dashboards are defined for this group. Default dashboard will be shown."
@@ -7979,6 +8300,9 @@ msgid "No Display Filter defined."
 msgstr ""
 
 msgid "No Group"
+msgstr ""
+
+msgid "No Hourly or Daily data is available, real time data from the Most Recent Hour is being displayed"
 msgstr ""
 
 msgid "No Indexes found for this table."
@@ -8107,9 +8431,6 @@ msgstr ""
 msgid "No events available for this timeline."
 msgstr ""
 
-msgid "No explorer tree node type found for '%s'"
-msgstr ""
-
 msgid "No expression defined, a condition must contain a valid expression."
 msgstr ""
 
@@ -8164,6 +8485,12 @@ msgstr ""
 msgid "No variables configured."
 msgstr ""
 
+msgid "Node Port"
+msgstr ""
+
+msgid "Node Selector"
+msgstr ""
+
 msgid "Nodes"
 msgstr ""
 
@@ -8209,6 +8536,9 @@ msgstr ""
 msgid "Note: Only Time Profiles with 'Roll Up Performance' set are shown."
 msgstr ""
 
+msgid "Note: Username must be in the format: name@realm"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -8234,6 +8564,9 @@ msgid "Number of VMs"
 msgstr ""
 
 msgid "OR with a new expression element"
+msgstr ""
+
+msgid "OS"
 msgstr ""
 
 msgid "OS %s"
@@ -9568,6 +9901,9 @@ msgstr ""
 msgid "OpenStack Status"
 msgstr ""
 
+msgid "Openstack Infra Provider"
+msgstr ""
+
 msgid "Openstack Infra provider"
 msgstr ""
 
@@ -9596,6 +9932,9 @@ msgid "OperatingSystem|Build number"
 msgstr ""
 
 msgid "OperatingSystem|Distribution"
+msgstr ""
+
+msgid "OperatingSystem|Kernel version"
 msgstr ""
 
 msgid "OperatingSystem|Lockout duration"
@@ -9652,6 +9991,9 @@ msgstr ""
 msgid "OperatingSystem|Version"
 msgstr ""
 
+msgid "Optimize"
+msgstr ""
+
 msgid "Option 1"
 msgstr ""
 
@@ -9674,9 +10016,6 @@ msgid "Orchestration Template"
 msgstr ""
 
 msgid "Orchestration Template \"%s\" was deleted."
-msgstr ""
-
-msgid "Orchestration Template Information"
 msgstr ""
 
 msgid "Orchestration Templates"
@@ -9784,6 +10123,9 @@ msgstr ""
 msgid "OrchestrationStack|Status"
 msgstr ""
 
+msgid "OrchestrationStack|Status reason"
+msgstr ""
+
 msgid "OrchestrationTemplate|Content"
 msgstr ""
 
@@ -9814,13 +10156,22 @@ msgstr ""
 msgid "Organization"
 msgstr ""
 
+msgid "Organization ID"
+msgstr ""
+
 msgid "Original Value"
 msgstr ""
 
 msgid "Orphaned Data"
 msgstr ""
 
+msgid "Orphaned Instances"
+msgstr ""
+
 msgid "Orphaned Records for userid %s were successfully deleted"
+msgstr ""
+
+msgid "Orphaned VMs and Templates"
 msgstr ""
 
 msgid "Os process"
@@ -9868,6 +10219,9 @@ msgstr ""
 msgid "Outputs (%s)"
 msgstr ""
 
+msgid "Overview"
+msgstr ""
+
 msgid "Overwrite existing reports?"
 msgstr ""
 
@@ -9898,6 +10252,9 @@ msgstr ""
 msgid "PXE Images"
 msgstr ""
 
+msgid "Packages"
+msgstr ""
+
 msgid "Packages (%s)"
 msgstr ""
 
@@ -9911,6 +10268,9 @@ msgid "Parameters"
 msgstr ""
 
 msgid "Parameters (%s)"
+msgstr ""
+
+msgid "Parent"
 msgstr ""
 
 msgid "Parent %s: %s"
@@ -9941,6 +10301,9 @@ msgid "Partition"
 msgstr ""
 
 msgid "Partition Table"
+msgstr ""
+
+msgid "Partitions Aligned"
 msgstr ""
 
 msgid "Partition|Controller"
@@ -9991,7 +10354,13 @@ msgstr ""
 msgid "Password fields must match to Validate Database Configuration"
 msgstr ""
 
+msgid "Password or Password+One-Time-Password"
+msgstr ""
+
 msgid "Password/Verify Password do not match"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid "Paste is not available, no object information has been copied from the Simulation screen"
@@ -10054,6 +10423,9 @@ msgstr ""
 msgid "Percent Bloat"
 msgstr ""
 
+msgid "Percent Used of Provisioned Size"
+msgstr ""
+
 msgid "Performance Interval"
 msgstr ""
 
@@ -10061,6 +10433,9 @@ msgid "Performance Timeframe"
 msgstr ""
 
 msgid "Period"
+msgstr ""
+
+msgid "Persistent Volume Claim Name"
 msgstr ""
 
 msgid "Picture"
@@ -10100,6 +10475,12 @@ msgid "Please select a node at left to edit."
 msgstr ""
 
 msgid "Please select an Instance Type from above"
+msgstr ""
+
+msgid "Pods (%s)"
+msgstr ""
+
+msgid "Pods (0)"
 msgstr ""
 
 msgid "Policies"
@@ -10150,7 +10531,7 @@ msgstr ""
 msgid "PolicyEvent|Event type"
 msgstr ""
 
-msgid "PolicyEvent|Miq event description"
+msgid "PolicyEvent|Miq event definition description"
 msgstr ""
 
 msgid "PolicyEvent|Miq policy description"
@@ -10172,6 +10553,9 @@ msgid "PolicyEvent|Username"
 msgstr ""
 
 msgid "Port"
+msgstr ""
+
+msgid "Port Configurations"
 msgstr ""
 
 msgid "Power Management"
@@ -10222,7 +10606,19 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
+msgid "Private Keys do not match"
+msgstr ""
+
 msgid "Process ID"
+msgstr ""
+
+msgid "Processor Cores_Per_Socket"
+msgstr ""
+
+msgid "Processor Options"
+msgstr ""
+
+msgid "Processor Sockets"
 msgstr ""
 
 msgid "Processors"
@@ -10240,13 +10636,28 @@ msgstr ""
 msgid "Profile Policies:"
 msgstr ""
 
+msgid "Project/Tenant"
+msgstr ""
+
+msgid "Projects"
+msgstr ""
+
 msgid "Properties"
+msgstr ""
+
+msgid "Property"
 msgstr ""
 
 msgid "Protected"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "Provider"
+msgstr ""
+
+msgid "Provider is not ready to be scaled, another operation is in progress."
 msgstr ""
 
 msgid "Providers"
@@ -10279,7 +10690,10 @@ msgstr ""
 msgid "Provision Order"
 msgstr ""
 
-msgid "Provisioned %s"
+msgid "Provisioned Hosts"
+msgstr ""
+
+msgid "Provisioned Size"
 msgstr ""
 
 msgid "Provisioned VMs"
@@ -10372,10 +10786,10 @@ msgstr ""
 msgid "Queued At"
 msgstr ""
 
-msgid "Quick Start"
+msgid "Quotas"
 msgstr ""
 
-msgid "Quotas"
+msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr ""
 
 msgid "RSA key pair"
@@ -10390,6 +10804,21 @@ msgstr ""
 msgid "RSS Feed no longer exists"
 msgstr ""
 
+msgid "Rados Ceph Monitors"
+msgstr ""
+
+msgid "Rados Image Name"
+msgstr ""
+
+msgid "Rados Keyring"
+msgstr ""
+
+msgid "Rados Pool Name"
+msgstr ""
+
+msgid "Rados User Name"
+msgstr ""
+
 msgid "Range"
 msgstr ""
 
@@ -10400,6 +10829,12 @@ msgid "Rate"
 msgstr ""
 
 msgid "Rate Details"
+msgstr ""
+
+msgid "Rates"
+msgstr ""
+
+msgid "Re-apply the previous change"
 msgstr ""
 
 msgid "Read Only"
@@ -10415,6 +10850,9 @@ msgid "Read Only %{model} \"%{name}\" cannot be edited"
 msgstr ""
 
 msgid "Read only"
+msgstr ""
+
+msgid "Read-Only"
 msgstr ""
 
 msgid "Realm"
@@ -10459,9 +10897,6 @@ msgstr ""
 msgid "Red Hat Updates"
 msgstr ""
 
-msgid "Redo the next change"
-msgstr ""
-
 msgid "Reference VM Profile"
 msgstr ""
 
@@ -10493,6 +10928,9 @@ msgid "Region:"
 msgstr ""
 
 msgid "Register"
+msgstr ""
+
+msgid "Register to"
 msgstr ""
 
 msgid "Registration"
@@ -10556,6 +10994,9 @@ msgid "Relationship|Relationship"
 msgstr ""
 
 msgid "Relationship|Resource type"
+msgstr ""
+
+msgid "Release"
 msgstr ""
 
 msgid "Remote Console plugin is not properly installed."
@@ -10651,6 +11092,12 @@ msgstr ""
 msgid "Replication Worker"
 msgstr ""
 
+msgid "Replicators (%s)"
+msgstr ""
+
+msgid "Replicators (0)"
+msgstr ""
+
 msgid "Report"
 msgstr ""
 
@@ -10721,6 +11168,12 @@ msgid "Repositories"
 msgstr ""
 
 msgid "Repository"
+msgstr ""
+
+msgid "Repository Name(s)"
+msgstr ""
+
+msgid "Repository Name(s):"
 msgstr ""
 
 msgid "Repository|Created on"
@@ -10942,19 +11395,28 @@ msgstr ""
 msgid "Retirement"
 msgstr ""
 
-msgid "Retirement %s removed"
-msgstr ""
-
-msgid "Retirement %{date_text} set to %{rdate}"
-msgstr ""
-
 msgid "Retirement Date"
 msgstr ""
 
 msgid "Retirement Entry Point"
 msgstr ""
 
+msgid "Retirement Entry Point (NameSpace/Class/Instance)"
+msgstr ""
+
 msgid "Retirement Warning"
+msgstr ""
+
+msgid "Retirement date removed"
+msgstr ""
+
+msgid "Retirement date set to %s"
+msgstr ""
+
+msgid "Retirement dates removed"
+msgstr ""
+
+msgid "Retirement dates set to %s"
 msgstr ""
 
 msgid "Right Size Recommendation for %{model} \"%{name}\""
@@ -11020,7 +11482,7 @@ msgstr ""
 msgid "RssFeed|Yml file mtime"
 msgstr ""
 
-msgid "Ruby Script"
+msgid "Ruby scripts are no longer supported in expressions, please change or remove them."
 msgstr ""
 
 msgid "Run"
@@ -11108,6 +11570,9 @@ msgid "Save this %s search as:"
 msgstr ""
 
 msgid "Save..."
+msgstr ""
+
+msgid "Saved Chargeback Reports"
 msgstr ""
 
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
@@ -11263,7 +11728,7 @@ msgstr ""
 msgid "Search by Name within results"
 msgstr ""
 
-msgid "Second band unit:"
+msgid "Second band unit"
 msgstr ""
 
 msgid "Secondary (Display) Filter"
@@ -11275,7 +11740,13 @@ msgstr ""
 msgid "Secret Access Key"
 msgstr ""
 
+msgid "Secret Access Keys do not match"
+msgstr ""
+
 msgid "Secret Key"
+msgstr ""
+
+msgid "Secret Name"
 msgstr ""
 
 msgid "Security"
@@ -11312,6 +11783,9 @@ msgid "Select Alerts to be Evaluated"
 msgstr ""
 
 msgid "Select Entry Point %s"
+msgstr ""
+
+msgid "Select Host to validate against"
 msgstr ""
 
 msgid "Select Policy Profiles"
@@ -11386,6 +11860,9 @@ msgstr ""
 msgid "Select only one or consecutive %s to move up"
 msgstr ""
 
+msgid "Select to change to another Group"
+msgstr ""
+
 msgid "Selected"
 msgstr ""
 
@@ -11423,6 +11900,9 @@ msgid "Selection"
 msgstr ""
 
 msgid "Selections"
+msgstr ""
+
+msgid "Selector"
 msgstr ""
 
 msgid "Send E-mail"
@@ -11470,10 +11950,10 @@ msgstr ""
 msgid "Server Roles"
 msgstr ""
 
-msgid "Server information, Username and matching password fields are needed to perform verification of credentials"
+msgid "Server role"
 msgstr ""
 
-msgid "Server role"
+msgid "Server: %s"
 msgstr ""
 
 msgid "ServerRole|Created on"
@@ -11515,7 +11995,7 @@ msgstr ""
 msgid "Service Dialog \"%s\" was successfully created"
 msgstr ""
 
-msgid "Service Dialog Information"
+msgid "Service Dialog Import/Export"
 msgstr ""
 
 msgid "Service Dialog Name"
@@ -11698,9 +12178,6 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-msgid "Settings and Operations"
-msgstr ""
-
 msgid "Shortcuts"
 msgstr ""
 
@@ -11708,6 +12185,9 @@ msgid "Show"
 msgstr ""
 
 msgid "Show %s"
+msgstr ""
+
+msgid "Show %s %s"
 msgstr ""
 
 msgid "Show %s & %s"
@@ -11737,13 +12217,25 @@ msgstr ""
 msgid "Show Capacity & Utilization"
 msgstr ""
 
-msgid "Show Pods"
+msgid "Show Container Groups"
 msgstr ""
 
 msgid "Show Container Nodes"
 msgstr ""
 
+msgid "Show Container Projects"
+msgstr ""
+
+msgid "Show Container Replicators"
+msgstr ""
+
+msgid "Show Container Routes"
+msgstr ""
+
 msgid "Show Container Services"
+msgstr ""
+
+msgid "Show Containers"
 msgstr ""
 
 msgid "Show Costs by"
@@ -11753,6 +12245,12 @@ msgid "Show Event Logs on this VM"
 msgstr ""
 
 msgid "Show Host Events"
+msgstr ""
+
+msgid "Show Image Registries"
+msgstr ""
+
+msgid "Show Images"
 msgstr ""
 
 msgid "Show Input Parameters"
@@ -11767,7 +12265,13 @@ msgstr ""
 msgid "Show Past Dates"
 msgstr ""
 
+msgid "Show Pods"
+msgstr ""
+
 msgid "Show Refresh Button"
+msgstr ""
+
+msgid "Show Replicators"
 msgstr ""
 
 msgid "Show Resource Pools"
@@ -11863,16 +12367,13 @@ msgstr ""
 msgid "Show all registered %s"
 msgstr ""
 
-msgid "Show all used %s on this %s"
-msgstr ""
-
 msgid "Show at Login"
 msgstr ""
 
 msgid "Show configuration"
 msgstr ""
 
-msgid "Show daily data from:"
+msgid "Show daily data from"
 msgstr ""
 
 msgid "Show disks"
@@ -11884,10 +12385,10 @@ msgstr ""
 msgid "Show event logs on this VM"
 msgstr ""
 
-msgid "Show events from last:"
+msgid "Show events from last"
 msgstr ""
 
-msgid "Show hourly data from:"
+msgid "Show hourly data from"
 msgstr ""
 
 msgid "Show in Console"
@@ -12028,13 +12529,25 @@ msgstr ""
 msgid "Show this Vm's parent %s"
 msgstr ""
 
-msgid "Show this Pod's parent %s"
+msgid "Show this container group's parent %s"
 msgstr ""
 
 msgid "Show this container node's parent %s"
 msgstr ""
 
+msgid "Show this container replicator's parent %s"
+msgstr ""
+
 msgid "Show this container service's parent %s"
+msgstr ""
+
+msgid "Show this images registry %s"
+msgstr ""
+
+msgid "Show this pod's parent %s"
+msgstr ""
+
+msgid "Show topology"
 msgstr ""
 
 msgid "Show tree of all VMs in this Resource Pool"
@@ -12089,6 +12602,9 @@ msgid "Small Trees"
 msgstr ""
 
 msgid "Smart Management"
+msgstr ""
+
+msgid "SmartProxy Affinity"
 msgstr ""
 
 msgid "SmartProxy Server IP"
@@ -12155,6 +12671,9 @@ msgid "Snapshot|Uid ems"
 msgstr ""
 
 msgid "Snapshot|Updated on"
+msgstr ""
+
+msgid "Sockets"
 msgstr ""
 
 msgid "Software updates have not yet been configured. Select Edit Registration to register appliances in this region with Red Hat to receive software updates and other benefits."
@@ -12232,6 +12751,9 @@ msgstr ""
 msgid "State"
 msgstr ""
 
+msgid "State Machine (NS/Cls/Inst)"
+msgstr ""
+
 msgid "Status"
 msgstr ""
 
@@ -12257,6 +12779,9 @@ msgid "Storage Adapters"
 msgstr ""
 
 msgid "Storage Managers"
+msgstr ""
+
+msgid "Storage Medium Type"
 msgstr ""
 
 msgid "Storage Relationships"
@@ -12418,7 +12943,13 @@ msgstr ""
 msgid "Subscribe to this feed"
 msgstr ""
 
+msgid "Substitute: %s"
+msgstr ""
+
 msgid "Substitution:"
+msgstr ""
+
+msgid "Successful"
 msgstr ""
 
 msgid "Successfully deleted %s from the CFME Database"
@@ -12466,6 +12997,9 @@ msgstr ""
 msgid "Synchronous"
 msgstr ""
 
+msgid "Sysprep"
+msgstr ""
+
 msgid "Sysprep \"%s\" upload was successful"
 msgstr ""
 
@@ -12473,6 +13007,9 @@ msgid "System Default"
 msgstr ""
 
 msgid "System service"
+msgstr ""
+
+msgid "System/Process"
 msgstr ""
 
 msgid "System/Process/"
@@ -12559,7 +13096,7 @@ msgstr ""
 msgid "Tag edits were successfully saved"
 msgstr ""
 
-msgid "Tag to Apply:"
+msgid "Tag to Apply"
 msgstr ""
 
 msgid "Tagging"
@@ -12583,10 +13120,13 @@ msgstr ""
 msgid "Target Options/Limits"
 msgstr ""
 
-msgid "Task State:"
+msgid "Target Port"
 msgstr ""
 
-msgid "Task Status:"
+msgid "Task State"
+msgstr ""
+
+msgid "Task Status"
 msgstr ""
 
 msgid "Tasks"
@@ -12613,7 +13153,76 @@ msgstr ""
 msgid "Tenancy"
 msgstr ""
 
+msgid "Tenant"
+msgstr ""
+
+msgid "Tenant ID"
+msgstr ""
+
+msgid "Tenant quota"
+msgstr ""
+
+msgid "TenantQuota|Name"
+msgstr ""
+
+msgid "TenantQuota|Unit"
+msgstr ""
+
+msgid "TenantQuota|Value"
+msgstr ""
+
 msgid "Tenants"
+msgstr ""
+
+msgid "Tenants (%s)"
+msgstr ""
+
+msgid "Tenant|Ancestry"
+msgstr ""
+
+msgid "Tenant|Description"
+msgstr ""
+
+msgid "Tenant|Divisible"
+msgstr ""
+
+msgid "Tenant|Domain"
+msgstr ""
+
+msgid "Tenant|Login logo content type"
+msgstr ""
+
+msgid "Tenant|Login logo file name"
+msgstr ""
+
+msgid "Tenant|Login logo file size"
+msgstr ""
+
+msgid "Tenant|Login logo updated at"
+msgstr ""
+
+msgid "Tenant|Login text"
+msgstr ""
+
+msgid "Tenant|Logo content type"
+msgstr ""
+
+msgid "Tenant|Logo file name"
+msgstr ""
+
+msgid "Tenant|Logo file size"
+msgstr ""
+
+msgid "Tenant|Logo updated at"
+msgstr ""
+
+msgid "Tenant|Name"
+msgstr ""
+
+msgid "Tenant|Subdomain"
+msgstr ""
+
+msgid "Tenant|Use config for attributes"
 msgstr ""
 
 msgid "Test E-mail Address"
@@ -12703,7 +13312,7 @@ msgstr ""
 msgid "There is an error in the selected expression element, perhaps it was imported or edited manually."
 msgstr ""
 
-msgid "Third band unit:"
+msgid "Third band unit"
 msgstr ""
 
 msgid "This Action is not assigned to any Policies."
@@ -12773,6 +13382,9 @@ msgid "Time Profile"
 msgstr ""
 
 msgid "Time Profile Information"
+msgstr ""
+
+msgid "Time Profiles"
 msgstr ""
 
 msgid "Time Zone"
@@ -12865,7 +13477,16 @@ msgstr ""
 msgid "Toggle All/None"
 msgstr ""
 
+msgid "Token"
+msgstr ""
+
 msgid "Top values to show"
+msgstr ""
+
+msgid "Topology"
+msgstr ""
+
+msgid "Total Processors"
 msgstr ""
 
 msgid "Total VMs: 0"
@@ -12931,6 +13552,9 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
+msgid "Type: %s"
+msgstr ""
+
 msgid "UI Worker"
 msgstr ""
 
@@ -12952,16 +13576,22 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
+msgid "Unassigned Profiles Group"
+msgstr ""
+
 msgid "Unassigned:"
 msgstr ""
 
 msgid "Unattended GUI"
 msgstr ""
 
-msgid "Undo the previous change"
+msgid "Undo the last change"
 msgstr ""
 
 msgid "Unexpected error encountered"
+msgstr ""
+
+msgid "Units"
 msgstr ""
 
 msgid "Unknown"
@@ -12977,9 +13607,6 @@ msgid "Update"
 msgstr ""
 
 msgid "Update Password"
-msgstr ""
-
-msgid "Update Repository"
 msgstr ""
 
 msgid "Update Status"
@@ -13039,6 +13666,9 @@ msgstr ""
 msgid "Use Custom Logo Image"
 msgstr ""
 
+msgid "Use HTTP Proxy"
+msgstr ""
+
 msgid "Use the Browse button to locate %s file"
 msgstr ""
 
@@ -13049,6 +13679,9 @@ msgid "Use the Browse button to locate an Import file"
 msgstr ""
 
 msgid "Use the Browse button to locate an Upload file"
+msgstr ""
+
+msgid "Used Size"
 msgstr ""
 
 msgid "Used for SSH connection to all %s in this provider."
@@ -13114,9 +13747,6 @@ msgstr ""
 msgid "User will input the value"
 msgstr ""
 
-msgid "User:"
-msgstr ""
-
 msgid "Username"
 msgstr ""
 
@@ -13130,6 +13760,9 @@ msgid "Users (%s)"
 msgstr ""
 
 msgid "Users (0)"
+msgstr ""
+
+msgid "Users are only allowed to delete their own requests"
 msgstr ""
 
 msgid "Users in this Group"
@@ -13240,6 +13873,9 @@ msgstr ""
 msgid "VM/Instance"
 msgstr ""
 
+msgid "VMDB"
+msgstr ""
+
 msgid "VMM Information"
 msgstr ""
 
@@ -13264,7 +13900,16 @@ msgstr ""
 msgid "VMware Console Support"
 msgstr ""
 
+msgid "VMware MKS Plugin"
+msgstr ""
+
 msgid "VMware MKS Plugin Version"
+msgstr ""
+
+msgid "VMware VMRC Plugin"
+msgstr ""
+
+msgid "VNC"
 msgstr ""
 
 msgid "VNC Console"
@@ -13291,6 +13936,9 @@ msgstr ""
 msgid "Validate the LDAP Settings by binding with the %s"
 msgstr ""
 
+msgid "Validate the credentials"
+msgstr ""
+
 msgid "Validate the credentials by logging into the Server"
 msgstr ""
 
@@ -13313,6 +13961,9 @@ msgid "Value to Set"
 msgstr ""
 
 msgid "Value:"
+msgstr ""
+
+msgid "Values"
 msgstr ""
 
 msgid "Variable Object ID"
@@ -13339,16 +13990,31 @@ msgstr ""
 msgid "Verify %s"
 msgstr ""
 
+msgid "Verify Client Key"
+msgstr ""
+
 msgid "Verify Password"
 msgstr ""
 
 msgid "Verify Peer Certificate"
 msgstr ""
 
+msgid "Verify Private Key"
+msgstr ""
+
+msgid "Verify Secret Access Key"
+msgstr ""
+
 msgid "Version"
 msgstr ""
 
 msgid "Version / Build"
+msgstr ""
+
+msgid "View %s"
+msgstr ""
+
+msgid "View %s %s"
 msgstr ""
 
 msgid "View %s Folder"
@@ -13378,6 +14044,9 @@ msgstr ""
 msgid "View LDAP Regions"
 msgstr ""
 
+msgid "View Parent Tenant"
+msgstr ""
+
 msgid "View Roles"
 msgstr ""
 
@@ -13385,6 +14054,9 @@ msgid "View Schedules"
 msgstr ""
 
 msgid "View Storage Rates"
+msgstr ""
+
+msgid "View Tenants"
 msgstr ""
 
 msgid "View This Alert"
@@ -13514,6 +14186,21 @@ msgid "Virtual Machines"
 msgstr ""
 
 msgid "Visibility"
+msgstr ""
+
+msgid "Visual"
+msgstr ""
+
+msgid "Vm"
+msgstr ""
+
+msgid "Vm Compliance Policies"
+msgstr ""
+
+msgid "Vm Control Policies"
+msgstr ""
+
+msgid "Vm Policies"
 msgstr ""
 
 msgid "Vm or template"
@@ -13828,6 +14515,15 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
+msgid "Volume ID"
+msgstr ""
+
+msgid "Volume Path"
+msgstr ""
+
+msgid "Volumes"
+msgstr ""
+
 msgid "Volume|Created on"
 msgstr ""
 
@@ -14020,6 +14716,9 @@ msgstr ""
 msgid "back"
 msgstr ""
 
+msgid "blank"
+msgstr ""
+
 msgid "bold"
 msgstr ""
 
@@ -14050,6 +14749,12 @@ msgstr ""
 msgid "instances"
 msgstr ""
 
+msgid "ldap"
+msgstr ""
+
+msgid "ldaps"
+msgstr ""
+
 msgid "locale_name"
 msgstr ""
 
@@ -14059,13 +14764,13 @@ msgstr ""
 msgid "memory_cpu"
 msgstr ""
 
+msgid "no value"
+msgstr ""
+
 msgid "none"
 msgstr ""
 
 msgid "normal"
-msgstr ""
-
-msgid "not specified"
 msgstr ""
 
 msgid "numvcpus"

--- a/config/locales/nl/manageiq.po
+++ b/config/locales/nl/manageiq.po
@@ -41,6 +41,9 @@ msgstr ""
 msgid " Selected Alerts:"
 msgstr ""
 
+msgid " Valid numeric quota value required "
+msgstr ""
+
 msgid " that match the entered search string"
 msgstr ""
 
@@ -71,6 +74,12 @@ msgstr ""
 msgid "\"%{record}\": %{task} successfully initiated"
 msgstr ""
 
+msgid "\"%{record}\": Analysis successfully initiated"
+msgstr ""
+
+msgid "\"Unable to initiate scaling, obtaining of status failed: #{ex}\""
+msgstr ""
+
 msgid "% Savings"
 msgstr ""
 
@@ -86,16 +95,19 @@ msgstr ""
 msgid "%s  Ending with"
 msgstr ""
 
-msgid "%s & %s"
+msgid "%s (%s)"
 msgstr ""
 
-msgid "%s (%s)"
+msgid "%s (0)"
 msgstr ""
 
 msgid "%s (All %s)"
 msgstr ""
 
 msgid "%s (All cloud tenants present on this host)"
+msgstr ""
+
+msgid "%s Alert Profiles"
 msgstr ""
 
 msgid "%s Being Tagged"
@@ -112,11 +124,6 @@ msgstr ""
 
 msgid "%s Credentials validated successfully"
 msgstr ""
-
-msgid "%s Day"
-msgid_plural "%s Days"
-msgstr[0] ""
-msgstr[1] ""
 
 msgid "%s Days Ago"
 msgstr ""
@@ -167,9 +174,6 @@ msgstr ""
 msgid "%s Summary"
 msgstr ""
 
-msgid "%s Tags"
-msgstr ""
-
 msgid "%s Utilization"
 msgstr ""
 
@@ -196,7 +200,7 @@ msgstr ""
 msgid "%s has no network adapters"
 msgstr ""
 
-msgid "%s has no snapshots."
+msgid "%s has no snapshots"
 msgstr ""
 
 msgid "%s is currently being used in the Display Filter"
@@ -247,6 +251,9 @@ msgstr ""
 msgid "%s record no longer exists"
 msgstr ""
 
+msgid "%s requests cannot be deleted"
+msgstr ""
+
 msgid "%s saved"
 msgstr ""
 
@@ -266,11 +273,6 @@ msgid "%s tab is not available unless at least 1 time field has been selected"
 msgstr ""
 
 msgid "%s tab is not available until at least 1 field has been selected"
-msgstr ""
-
-msgid ""
-"%s to validate against, Username and matching password fields are needed to pe"
-"rform verification of credentials"
 msgstr ""
 
 msgid "%s was cancelled by the user"
@@ -298,6 +300,9 @@ msgid "%{field} Value Error: %{msg}"
 msgstr ""
 
 msgid "%{field} cannot contain \"%{character}\""
+msgstr ""
+
+msgid "%{model}"
 msgstr ""
 
 msgid "%{model} \"%{name}\""
@@ -331,6 +336,9 @@ msgid "%{model} \"%{name}\": Delete successful"
 msgstr ""
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
+msgstr ""
+
+msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
 msgid "%{model} for \"%{name}\""
@@ -372,13 +380,22 @@ msgstr ""
 msgid "%{task} does not apply because you selected at least one %{model}"
 msgstr ""
 
+msgid "%{task} does not apply because you selected at least one un-reconfigurable VM"
+msgstr ""
+
+msgid "%{task} does not apply to at least one of the selected %{model}"
+msgstr ""
+
 msgid "%{task} does not apply to selected %{model}"
 msgstr ""
 
-msgid "%{task} initiated for %{count_model} (Foreman) from the CFME Database"
+msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
 msgstr ""
 
 msgid "%{task} initiated for %{count_model} from the CFME Database"
+msgstr ""
+
+msgid "%{task} initiated for %{model} from the CFME Database"
 msgstr ""
 
 msgid "%{typ} %{model}"
@@ -442,9 +459,6 @@ msgid "(Look Up LDAP Groups)"
 msgstr ""
 
 msgid "(MB) memory"
-msgstr ""
-
-msgid "(NS/Cls/Inst)"
 msgstr ""
 
 msgid "(Row %{start_number} of %{pages})"
@@ -598,6 +612,9 @@ msgstr ""
 msgid "* Style \"If\" conditions are evaluated top to bottom for each column"
 msgstr ""
 
+msgid "-- OR --"
+msgstr ""
+
 msgid "1 - Select a Reference VM."
 msgstr ""
 
@@ -618,7 +635,7 @@ msgstr ""
 msgid "2 Weeks before retirement"
 msgstr ""
 
-msgid "24 Hour Time Period:"
+msgid "24 Hour Time Period"
 msgstr ""
 
 msgid "3 - Specify Target Options to qualify target %s or %s."
@@ -631,6 +648,9 @@ msgid "4 - Change the Trend Options used to calculate the daily trends, if desir
 msgstr ""
 
 msgid "5 - Press the Submit button."
+msgstr ""
+
+msgid "<Archived>"
 msgstr ""
 
 msgid "<Choose a Group>"
@@ -658,6 +678,15 @@ msgid "<New LDAP Server>"
 msgstr ""
 
 msgid "<No Depot>"
+msgstr ""
+
+msgid "<No chart>"
+msgstr ""
+
+msgid "<Orphaned>"
+msgstr ""
+
+msgid "<Unnamed>"
 msgstr ""
 
 msgid "A %s must be chosen to commit this expression element"
@@ -696,13 +725,13 @@ msgstr ""
 msgid "AMQP"
 msgstr ""
 
-msgid "AMQP Messaging"
-msgstr ""
-
 msgid "AND with a new expression element"
 msgstr ""
 
 msgid "API Port"
+msgstr ""
+
+msgid "API Version"
 msgstr ""
 
 msgid "About"
@@ -712,6 +741,9 @@ msgid "Access Key"
 msgstr ""
 
 msgid "Access Key ID"
+msgstr ""
+
+msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
 msgid "Access URL"
@@ -800,6 +832,9 @@ msgstr ""
 msgid "Add a new %s Provider"
 msgstr ""
 
+msgid "Add of %{model} was cancelled by the user"
+msgstr ""
+
 msgid "Add of new %s was cancelled by the user"
 msgstr ""
 
@@ -807,9 +842,6 @@ msgid "Add subfolder to selected folder"
 msgstr ""
 
 msgid "Add this %s"
-msgstr ""
-
-msgid "Add this Host"
 msgstr ""
 
 msgid "Add this LDAP Server"
@@ -935,12 +967,78 @@ msgstr ""
 msgid "All (%s)"
 msgstr ""
 
+msgid "All Actions"
+msgstr ""
+
+msgid "All Alert Profiles"
+msgstr ""
+
+msgid "All Alerts"
+msgstr ""
+
+msgid "All Catalog Items"
+msgstr ""
+
+msgid "All Catalogs"
+msgstr ""
+
+msgid "All Conditions"
+msgstr ""
+
+msgid "All Containers"
+msgstr ""
+
 msgid ""
 "All Datastore customizations will be lost. Are you sure you want to reset all "
 "classes and instances to default?"
 msgstr ""
 
+msgid "All Dialogs"
+msgstr ""
+
+msgid "All Events"
+msgstr ""
+
 msgid "All Files"
+msgstr ""
+
+msgid "All ISO Datastores"
+msgstr ""
+
+msgid "All Images"
+msgstr ""
+
+msgid "All Images by Provider that I can see"
+msgstr ""
+
+msgid "All Instances"
+msgstr ""
+
+msgid "All Instances by Provider that I can see"
+msgstr ""
+
+msgid "All Orchestration Templates"
+msgstr ""
+
+msgid "All PXE Servers"
+msgstr ""
+
+msgid "All Policies"
+msgstr ""
+
+msgid "All Policy Profiles"
+msgstr ""
+
+msgid "All Services"
+msgstr ""
+
+msgid "All System Image Types"
+msgstr ""
+
+msgid "All Templates"
+msgstr ""
+
+msgid "All Templates & Images"
 msgstr ""
 
 msgid "All Templates: %s"
@@ -952,7 +1050,19 @@ msgstr ""
 msgid "All Users"
 msgstr ""
 
+msgid "All VM and Instance Conditions"
+msgstr ""
+
 msgid "All VMs"
+msgstr ""
+
+msgid "All VMs & Instances"
+msgstr ""
+
+msgid "All VMs & Templates"
+msgstr ""
+
+msgid "All VMs & Templates that I can see"
 msgstr ""
 
 msgid "All VMs (Tree View): %s"
@@ -977,6 +1087,24 @@ msgid "All custom classes and instances have been reset to default"
 msgstr ""
 
 msgid "All fields are needed to perform verification of Database Settings"
+msgstr ""
+
+msgid "All of the Images that I can see"
+msgstr ""
+
+msgid "All of the Instances that I can see"
+msgstr ""
+
+msgid "All of the Templates & Images that I can see"
+msgstr ""
+
+msgid "All of the Templates that I can see"
+msgstr ""
+
+msgid "All of the VMs & Instances that I can see"
+msgstr ""
+
+msgid "All of the VMs that I can see"
 msgstr ""
 
 msgid "All selected %s are not in the current region"
@@ -1004,6 +1132,9 @@ msgid "An internal system error."
 msgstr ""
 
 msgid "Analysis"
+msgstr ""
+
+msgid "Analysis Affinity was saved"
 msgstr ""
 
 msgid "Analysis History (%s)"
@@ -1081,16 +1212,22 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
+msgid "Arch"
+msgstr ""
+
 msgid "Architecture"
+msgstr ""
+
+msgid "Archived Instances"
+msgstr ""
+
+msgid "Archived VMs and Templates"
 msgstr ""
 
 msgid "Are you sure you want to Run Database Garbage Collection Now?"
 msgstr ""
 
 msgid "Are you sure you want to Run a Database Backup Now?"
-msgstr ""
-
-msgid "Are you sure you want to delete build %s?"
 msgstr ""
 
 msgid "Are you sure you want to delete category '%s'?"
@@ -1290,6 +1427,18 @@ msgstr ""
 msgid "Authorization Error"
 msgstr ""
 
+msgid "Auto Refresh other fields when modified"
+msgstr ""
+
+msgid "Auto refresh"
+msgstr ""
+
+msgid "Automate"
+msgstr ""
+
+msgid "Automate Workers"
+msgstr ""
+
 msgid "Automate button %s has been cleared"
 msgstr ""
 
@@ -1323,7 +1472,7 @@ msgstr ""
 msgid "Available %s Conditions:"
 msgstr ""
 
-msgid "Available %s:"
+msgid "Available %{title}:"
 msgstr ""
 
 msgid "Available Actions:"
@@ -1446,6 +1595,21 @@ msgstr ""
 #, fuzzy
 msgid "Bind Password"
 msgstr "Nieuw wachtwoord"
+
+msgid "Blacklisted event"
+msgstr ""
+
+msgid "BlacklistedEvent|Enabled"
+msgstr ""
+
+msgid "BlacklistedEvent|Event name"
+msgstr ""
+
+msgid "BlacklistedEvent|Provider model"
+msgstr ""
+
+msgid "BlacklistedEvent|System"
+msgstr ""
 
 msgid "Bottleneck Event Details"
 msgstr ""
@@ -1713,13 +1877,24 @@ msgstr ""
 msgid "Change %s value to submit reconfigure request"
 msgstr ""
 
-msgid "Change Password / Confirm Password"
+msgid "Change Group:"
 msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Change Password"
+msgstr "Nieuw wachtwoord"
 
 msgid "Changes"
 msgstr ""
 
 msgid "Changing the UI Workers Count will immediately restart the webserver"
+msgstr ""
+
+msgid "Channel Name(s)"
+msgstr ""
+
+msgid "Channel Name(s):"
 msgstr ""
 
 msgid "Chargeback"
@@ -1803,6 +1978,9 @@ msgstr ""
 msgid "Chart Theme"
 msgstr ""
 
+msgid "Chart mode"
+msgstr ""
+
 msgid "Chart no longer exists"
 msgstr ""
 
@@ -1822,6 +2000,9 @@ msgid "Check for updates"
 msgstr ""
 
 msgid "Checked default filters will be visible."
+msgstr ""
+
+msgid "Child Tenants"
 msgstr ""
 
 msgid "Child VM Selection"
@@ -1935,6 +2116,12 @@ msgstr ""
 msgid "Click on this row to create a new entry"
 msgstr ""
 
+msgid "Click to Logout"
+msgstr ""
+
+msgid "Click to add a new category"
+msgstr ""
+
 msgid "Click to add a new entry"
 msgstr ""
 
@@ -1956,9 +2143,6 @@ msgstr ""
 msgid "Click to delete this LDAP Server"
 msgstr ""
 
-msgid "Click to delete this build"
-msgstr ""
-
 msgid "Click to delete this category"
 msgstr ""
 
@@ -1974,10 +2158,19 @@ msgstr ""
 msgid "Click to delete this input field from method"
 msgstr ""
 
+msgid "Click to edit this category"
+msgstr ""
+
 msgid "Click to edit this forest"
 msgstr ""
 
 msgid "Click to go to this location"
+msgstr ""
+
+msgid "Click to open"
+msgstr ""
+
+msgid "Click to remove message"
 msgstr ""
 
 msgid "Click to remove messages"
@@ -2019,6 +2212,12 @@ msgstr ""
 msgid "Click to view Time Profile"
 msgstr ""
 
+msgid "Click to view child Tenant"
+msgstr ""
+
+msgid "Click to view child TenantProject"
+msgstr ""
+
 msgid "Click to view details"
 msgstr ""
 
@@ -2046,7 +2245,19 @@ msgstr ""
 msgid "Client Connections"
 msgstr ""
 
+msgid "Client ID"
+msgstr ""
+
+msgid "Client Key"
+msgstr ""
+
+msgid "Client Keys do not match"
+msgstr ""
+
 msgid "Close any duplicate browser sessions, then select a menu option above."
+msgstr ""
+
+msgid "Cloud Intelligence"
 msgstr ""
 
 msgid "Cloud Networks (%s)"
@@ -2082,6 +2293,9 @@ msgstr ""
 msgid "Cloud volume snapshot"
 msgstr ""
 
+msgid "CloudInit"
+msgstr ""
+
 msgid "CloudNetwork|Cidr"
 msgstr ""
 
@@ -2095,6 +2309,9 @@ msgid "CloudNetwork|External facing"
 msgstr ""
 
 msgid "CloudNetwork|Name"
+msgstr ""
+
+msgid "CloudNetwork|Shared"
 msgstr ""
 
 msgid "CloudNetwork|Status"
@@ -2252,6 +2469,9 @@ msgstr ""
 msgid "Collection Options"
 msgstr ""
 
+msgid "Column"
+msgstr ""
+
 msgid "Column %s"
 msgstr ""
 
@@ -2268,9 +2488,6 @@ msgid "Column 4"
 msgstr ""
 
 msgid "Column Name"
-msgstr ""
-
-msgid "Column:"
 msgstr ""
 
 msgid "Commit"
@@ -2315,6 +2532,11 @@ msgstr "Toestel:"
 
 #, fuzzy
 msgid "Compliance Check"
+msgstr "Toestel:"
+
+#, fuzzy
+#, fuzzy
+msgid "Compliance Policies"
 msgstr "Toestel:"
 
 msgid "Compliance detail"
@@ -2472,6 +2694,12 @@ msgstr ""
 msgid "Configuration Management"
 msgstr ""
 
+msgid "Configuration Management Configured Systems"
+msgstr ""
+
+msgid "Configuration Management Providers"
+msgstr ""
+
 msgid "Configuration Organization"
 msgstr ""
 
@@ -2550,6 +2778,9 @@ msgstr ""
 msgid "Configuration|Updated on"
 msgstr ""
 
+msgid "Configure"
+msgstr ""
+
 msgid "Configure Report Columns"
 msgstr ""
 
@@ -2583,6 +2814,11 @@ msgstr ""
 msgid "ConfiguredSystem|Puppet status"
 msgstr ""
 
+#, fuzzy
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Nieuw wachtwoord"
+
 msgid "Connecting (unencrypted) to: %s"
 msgstr ""
 
@@ -2607,10 +2843,31 @@ msgstr ""
 msgid "Container"
 msgstr ""
 
+msgid "Container Images"
+msgstr ""
+
+msgid "Container Nodes"
+msgstr ""
+
 msgid "Container Nodes (%s)"
 msgstr ""
 
 msgid "Container Nodes (0)"
+msgstr ""
+
+msgid "Container Projects (%s)"
+msgstr ""
+
+msgid "Container Projects (0)"
+msgstr ""
+
+msgid "Container Routes (%s)"
+msgstr ""
+
+msgid "Container Routes (0)"
+msgstr ""
+
+msgid "Container Services"
 msgstr ""
 
 msgid "Container Services (%s)"
@@ -2619,7 +2876,22 @@ msgstr ""
 msgid "Container Services (0)"
 msgstr ""
 
+msgid "Container condition"
+msgstr ""
+
 msgid "Container definition"
+msgstr ""
+
+msgid "Container env var"
+msgstr ""
+
+msgid "Container group"
+msgstr ""
+
+msgid "Container image"
+msgstr ""
+
+msgid "Container image registry"
 msgstr ""
 
 msgid "Container node"
@@ -2628,10 +2900,40 @@ msgstr ""
 msgid "Container port config"
 msgstr ""
 
-msgid "Container replication controller"
+msgid "Container project"
+msgstr ""
+
+msgid "Container replicator"
+msgstr ""
+
+msgid "Container route"
 msgstr ""
 
 msgid "Container service"
+msgstr ""
+
+msgid "Container service port config"
+msgstr ""
+
+msgid "ContainerCondition|Container entity type"
+msgstr ""
+
+msgid "ContainerCondition|Last heartbeat time"
+msgstr ""
+
+msgid "ContainerCondition|Last transition time"
+msgstr ""
+
+msgid "ContainerCondition|Message"
+msgstr ""
+
+msgid "ContainerCondition|Name"
+msgstr ""
+
+msgid "ContainerCondition|Reason"
+msgstr ""
+
+msgid "ContainerCondition|Status"
 msgstr ""
 
 msgid "ContainerDefinition|Cpu cores"
@@ -2652,6 +2954,66 @@ msgstr ""
 msgid "ContainerDefinition|Name"
 msgstr ""
 
+msgid "ContainerEnvVar|Field path"
+msgstr ""
+
+msgid "ContainerEnvVar|Name"
+msgstr ""
+
+msgid "ContainerEnvVar|Value"
+msgstr ""
+
+msgid "ContainerGroup|Creation timestamp"
+msgstr ""
+
+msgid "ContainerGroup|Dns policy"
+msgstr ""
+
+msgid "ContainerGroup|Ems ref"
+msgstr ""
+
+msgid "ContainerGroup|Ipaddress"
+msgstr ""
+
+msgid "ContainerGroup|Message"
+msgstr ""
+
+msgid "ContainerGroup|Name"
+msgstr ""
+
+msgid "ContainerGroup|Phase"
+msgstr ""
+
+msgid "ContainerGroup|Reason"
+msgstr ""
+
+msgid "ContainerGroup|Resource version"
+msgstr ""
+
+msgid "ContainerGroup|Restart policy"
+msgstr ""
+
+msgid "ContainerImageRegistry|Host"
+msgstr ""
+
+msgid "ContainerImageRegistry|Name"
+msgstr ""
+
+msgid "ContainerImageRegistry|Port"
+msgstr ""
+
+msgid "ContainerImage|Image ref"
+msgstr ""
+
+msgid "ContainerImage|Name"
+msgstr ""
+
+msgid "ContainerImage|Tag"
+msgstr ""
+
+msgid "ContainerNode|Container runtime version"
+msgstr ""
+
 msgid "ContainerNode|Creation timestamp"
 msgstr ""
 
@@ -2667,7 +3029,16 @@ msgstr ""
 msgid "ContainerNode|Identity system"
 msgstr ""
 
+msgid "ContainerNode|Kubernetes kubelet version"
+msgstr ""
+
+msgid "ContainerNode|Kubernetes proxy version"
+msgstr ""
+
 msgid "ContainerNode|Lives on type"
+msgstr ""
+
+msgid "ContainerNode|Max container groups"
 msgstr ""
 
 msgid "ContainerNode|Name"
@@ -2691,28 +3062,70 @@ msgstr ""
 msgid "ContainerPortConfig|Protocol"
 msgstr ""
 
-msgid "ContainerReplicationController|Creation timestamp"
+msgid "ContainerProject|Creation timestamp"
 msgstr ""
 
-msgid "ContainerReplicationController|Current replicas"
+msgid "ContainerProject|Display name"
 msgstr ""
 
-msgid "ContainerReplicationController|Ems ref"
+msgid "ContainerProject|Ems ref"
 msgstr ""
 
-msgid "ContainerReplicationController|Name"
+msgid "ContainerProject|Name"
 msgstr ""
 
-msgid "ContainerReplicationController|Namespace"
+msgid "ContainerProject|Resource version"
 msgstr ""
 
-msgid "ContainerReplicationController|Replicas"
+msgid "ContainerReplicator|Creation timestamp"
 msgstr ""
 
-msgid "ContainerReplicationController|Resource version"
+msgid "ContainerReplicator|Current replicas"
 msgstr ""
 
-msgid "ContainerService|Container port"
+msgid "ContainerReplicator|Ems ref"
+msgstr ""
+
+msgid "ContainerReplicator|Name"
+msgstr ""
+
+msgid "ContainerReplicator|Replicas"
+msgstr ""
+
+msgid "ContainerReplicator|Resource version"
+msgstr ""
+
+msgid "ContainerRoute|Creation timestamp"
+msgstr ""
+
+msgid "ContainerRoute|Ems ref"
+msgstr ""
+
+msgid "ContainerRoute|Host name"
+msgstr ""
+
+msgid "ContainerRoute|Name"
+msgstr ""
+
+msgid "ContainerRoute|Path"
+msgstr ""
+
+msgid "ContainerRoute|Resource version"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Ems ref"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Name"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Port"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Protocol"
+msgstr ""
+
+msgid "ContainerServicePortConfig|Target port"
 msgstr ""
 
 msgid "ContainerService|Creation timestamp"
@@ -2724,16 +3137,7 @@ msgstr ""
 msgid "ContainerService|Name"
 msgstr ""
 
-msgid "ContainerService|Namespace"
-msgstr ""
-
-msgid "ContainerService|Port"
-msgstr ""
-
 msgid "ContainerService|Portal ip"
-msgstr ""
-
-msgid "ContainerService|Protocol"
 msgstr ""
 
 msgid "ContainerService|Resource version"
@@ -2745,13 +3149,16 @@ msgstr ""
 msgid "Containers"
 msgstr ""
 
+msgid "Containers (%s)"
+msgstr ""
+
+msgid "Containers (0)"
+msgstr ""
+
 msgid "Container|Backing ref"
 msgstr ""
 
 msgid "Container|Ems ref"
-msgstr ""
-
-msgid "Container|Image"
 msgstr ""
 
 msgid "Container|Name"
@@ -2778,6 +3185,9 @@ msgstr ""
 msgid "Control"
 msgstr ""
 
+msgid "Control Policies"
+msgstr ""
+
 msgid "Copy"
 msgstr ""
 
@@ -2794,6 +3204,9 @@ msgid "Copy to same path"
 msgstr ""
 
 msgid "Copying %s"
+msgstr ""
+
+msgid "Cores Per socket"
 msgstr ""
 
 msgid "Count"
@@ -2848,6 +3261,9 @@ msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
 msgid "Current Backlog"
+msgstr ""
+
+msgid "Current Group"
 msgstr ""
 
 msgid "Current Rates"
@@ -3097,6 +3513,12 @@ msgstr ""
 msgid "Data Type:"
 msgstr ""
 
+msgid "Data column"
+msgstr ""
+
+msgid "Data type: %s"
+msgstr ""
+
 msgid "Data validated successfully"
 msgstr ""
 
@@ -3176,6 +3598,9 @@ msgstr ""
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
+msgid "Default Filters"
+msgstr ""
+
 msgid "Default Filters saved successfully"
 msgstr ""
 
@@ -3195,6 +3620,15 @@ msgid "Default Repository SmartProxy"
 msgstr ""
 
 msgid "Default Value"
+msgstr ""
+
+msgid "Default Views"
+msgstr ""
+
+msgid "Default dialogs cannot be edited"
+msgstr ""
+
+msgid "Default dialogs cannot be removed from the VMDB"
 msgstr ""
 
 msgid "Delay (mins)"
@@ -3257,10 +3691,10 @@ msgstr ""
 msgid "Details Mode"
 msgstr ""
 
-msgid "Details View"
+msgid "Determine at Run Time"
 msgstr ""
 
-msgid "Determine at Run Time"
+msgid "Device Type"
 msgstr ""
 
 msgid "Devices"
@@ -3288,6 +3722,9 @@ msgid "Dialog has to be set if Display in Catalog is chosen"
 msgstr ""
 
 msgid "Dialog tab"
+msgstr ""
+
+msgid "DialogField|Auto refresh"
 msgstr ""
 
 msgid "DialogField|Data type"
@@ -3348,6 +3785,9 @@ msgid "DialogField|Required method options"
 msgstr ""
 
 msgid "DialogField|Show refresh button"
+msgstr ""
+
+msgid "DialogField|Trigger auto refresh"
 msgstr ""
 
 msgid "DialogField|Validator rule"
@@ -3590,6 +4030,9 @@ msgstr ""
 msgid "Driving Event"
 msgstr ""
 
+msgid "Dropdown elements require some entries"
+msgstr ""
+
 msgid "Dynamic"
 msgstr ""
 
@@ -3627,6 +4070,9 @@ msgid "Edit Compute Rate Assignments"
 msgstr ""
 
 msgid "Edit Log Depot settings was cancelled by the user"
+msgstr ""
+
+msgid "Edit Registration"
 msgstr ""
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
@@ -3722,9 +4168,6 @@ msgstr ""
 msgid "Ems cluster"
 msgstr ""
 
-msgid "Ems event"
-msgstr ""
-
 msgid "Ems folder"
 msgstr ""
 
@@ -3773,60 +4216,6 @@ msgstr ""
 msgid "EmsCluster|Updated on"
 msgstr ""
 
-msgid "EmsEvent|Created on"
-msgstr ""
-
-msgid "EmsEvent|Dest ems cluster name"
-msgstr ""
-
-msgid "EmsEvent|Dest ems cluster uid"
-msgstr ""
-
-msgid "EmsEvent|Dest host name"
-msgstr ""
-
-msgid "EmsEvent|Dest vm location"
-msgstr ""
-
-msgid "EmsEvent|Dest vm name"
-msgstr ""
-
-msgid "EmsEvent|Ems cluster name"
-msgstr ""
-
-msgid "EmsEvent|Ems cluster uid"
-msgstr ""
-
-msgid "EmsEvent|Event type"
-msgstr ""
-
-msgid "EmsEvent|Full data"
-msgstr ""
-
-msgid "EmsEvent|Host name"
-msgstr ""
-
-msgid "EmsEvent|Is task"
-msgstr ""
-
-msgid "EmsEvent|Message"
-msgstr ""
-
-msgid "EmsEvent|Source"
-msgstr ""
-
-msgid "EmsEvent|Timestamp"
-msgstr ""
-
-msgid "EmsEvent|Username"
-msgstr ""
-
-msgid "EmsEvent|Vm location"
-msgstr ""
-
-msgid "EmsEvent|Vm name"
-msgstr ""
-
 msgid "EmsFolder|Created on"
 msgstr ""
 
@@ -3869,10 +4258,16 @@ msgstr ""
 msgid "End Port"
 msgstr ""
 
+msgid "Enforced"
+msgstr ""
+
 msgid "Enter Automation Simulation options on the left and press Submit."
 msgstr ""
 
 msgid "Enter URL Manually"
+msgstr ""
+
+msgid "Enterprise"
 msgstr ""
 
 msgid "Entity:"
@@ -3954,7 +4349,16 @@ msgstr ""
 msgid "Error when adding a new schedule: "
 msgstr ""
 
+msgid "Error when adding a new tenant: "
+msgstr ""
+
 msgid "Error when creating a Service Dialog from Orchestration Template: "
+msgstr ""
+
+msgid "Error when saving new server name: "
+msgstr ""
+
+msgid "Error when saving tenant quota: "
 msgstr ""
 
 msgid "Error: Datastore import file upload expired"
@@ -4017,7 +4421,10 @@ msgstr ""
 msgid "Event log"
 msgstr ""
 
-msgid "Event to position at:"
+msgid "Event stream"
+msgstr ""
+
+msgid "Event to position at"
 msgstr ""
 
 msgid "Event:"
@@ -4047,13 +4454,76 @@ msgstr ""
 msgid "EventLog|Uid"
 msgstr ""
 
+msgid "EventStream|Container group name"
+msgstr ""
+
+msgid "EventStream|Container namespace"
+msgstr ""
+
+msgid "EventStream|Container node name"
+msgstr ""
+
+msgid "EventStream|Created on"
+msgstr ""
+
+msgid "EventStream|Dest ems cluster name"
+msgstr ""
+
+msgid "EventStream|Dest ems cluster uid"
+msgstr ""
+
+msgid "EventStream|Dest host name"
+msgstr ""
+
+msgid "EventStream|Dest vm location"
+msgstr ""
+
+msgid "EventStream|Dest vm name"
+msgstr ""
+
+msgid "EventStream|Ems cluster name"
+msgstr ""
+
+msgid "EventStream|Ems cluster uid"
+msgstr ""
+
+msgid "EventStream|Event type"
+msgstr ""
+
+msgid "EventStream|Full data"
+msgstr ""
+
+msgid "EventStream|Host name"
+msgstr ""
+
+msgid "EventStream|Is task"
+msgstr ""
+
+msgid "EventStream|Message"
+msgstr ""
+
+msgid "EventStream|Source"
+msgstr ""
+
+msgid "EventStream|Target type"
+msgstr ""
+
+msgid "EventStream|Timestamp"
+msgstr ""
+
+msgid "EventStream|Username"
+msgstr ""
+
+msgid "EventStream|Vm location"
+msgstr ""
+
+msgid "EventStream|Vm name"
+msgstr ""
+
 msgid "Events"
 msgstr ""
 
 msgid "Execute Methods"
-msgstr ""
-
-msgid "Exist Mode"
 msgstr ""
 
 msgid "Exists Mode"
@@ -4157,6 +4627,11 @@ msgstr ""
 
 msgid "External RSS Feed/URL"
 msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "FS Type"
+msgstr "Gebruikersnaam"
 
 msgid "Failed"
 msgstr ""
@@ -4362,7 +4837,7 @@ msgstr ""
 msgid "First %s"
 msgstr ""
 
-msgid "First band unit:"
+msgid "First band unit"
 msgstr ""
 
 msgid "Flavor"
@@ -4372,6 +4847,9 @@ msgid "Flavors"
 msgstr ""
 
 msgid "Flavor|Block storage based only"
+msgstr ""
+
+msgid "Flavor|Cloud subnet required"
 msgstr ""
 
 msgid "Flavor|Cpu cores"
@@ -4465,6 +4943,9 @@ msgstr ""
 msgid "GB"
 msgstr ""
 
+msgid "GCE PD Resource"
+msgstr ""
+
 msgid "Genealogy"
 msgstr ""
 
@@ -4492,13 +4973,30 @@ msgstr ""
 msgid "Get User Groups from LDAP"
 msgstr ""
 
+#, fuzzy
+#, fuzzy
+msgid "Git Repository"
+msgstr "Wachtwoord veranderen"
+
+msgid "Git Revision"
+msgstr ""
+
 msgid "Global Default"
+msgstr ""
+
+msgid "Global Filters"
+msgstr ""
+
+msgid "Global Shared Filters"
 msgstr ""
 
 msgid "Global Time Profile cannot be edited"
 msgstr ""
 
 msgid "Global search:"
+msgstr ""
+
+msgid "Glusterfs Endpoint Name"
 msgstr ""
 
 msgid "Grid View"
@@ -4636,6 +5134,12 @@ msgstr ""
 msgid "HKLM"
 msgstr ""
 
+msgid "HTTP Proxy Address"
+msgstr ""
+
+msgid "HTTP Proxy:"
+msgstr ""
+
 msgid "Hardware"
 msgstr ""
 
@@ -4741,13 +5245,25 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
+msgid "Host Compliance Policies"
+msgstr ""
+
+msgid "Host Conditions"
+msgstr ""
+
+msgid "Host Control Policies"
+msgstr ""
+
+msgid "Host Default VNC End Port"
+msgstr ""
+
 msgid "Host Default VNC Port Range"
 msgstr ""
 
-msgid "Host Name"
+msgid "Host Default VNC Start Port"
 msgstr ""
 
-msgid "Host Name (or IPv4 or IPv6 address)"
+msgid "Host Policies"
 msgstr ""
 
 msgid "Host Protocol"
@@ -4763,6 +5279,15 @@ msgid "HostServiceGroup|Name"
 msgstr ""
 
 msgid "Hostname"
+msgstr ""
+
+msgid "Hostname (or IPv4 or IPv6 address)"
+msgstr ""
+
+msgid "Hostname or IP address"
+msgstr ""
+
+msgid "Hostname or IPv4/IPv6 address"
 msgstr ""
 
 msgid "Hosts"
@@ -4891,10 +5416,22 @@ msgstr ""
 msgid "IPMI"
 msgstr ""
 
+msgid "IPMI Credentials"
+msgstr ""
+
 msgid "IPMI IP Address"
 msgstr ""
 
 msgid "IPMI Present"
+msgstr ""
+
+msgid "ISCSI Target Lun Number"
+msgstr ""
+
+msgid "ISCSI Target Portal"
+msgstr ""
+
+msgid "ISCSI Target Qualified Name"
 msgstr ""
 
 msgid "ISO"
@@ -4917,6 +5454,12 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
+msgid "Image Registries (%s)"
+msgstr ""
+
+msgid "Image Registries (0)"
+msgstr ""
+
 msgid "Image Type"
 msgstr ""
 
@@ -4927,6 +5470,12 @@ msgid "Images"
 msgstr ""
 
 msgid "Images (%s)"
+msgstr ""
+
+msgid "Images (0)"
+msgstr ""
+
+msgid "Images by Provider"
 msgstr ""
 
 msgid "Import"
@@ -5001,10 +5550,12 @@ msgstr ""
 msgid "Init Processes (%s)"
 msgstr ""
 
-msgid "Input Parameters"
-msgstr ""
+#, fuzzy
+#, fuzzy
+msgid "Input Name"
+msgstr "Gebruikersnaam"
 
-msgid "Insight"
+msgid "Input Parameters"
 msgstr ""
 
 msgid "Instance Type:"
@@ -5016,10 +5567,10 @@ msgstr ""
 msgid "Instances (%s)"
 msgstr ""
 
-msgid "Integer"
+msgid "Instances by Provider"
 msgstr ""
 
-msgid "Integration Services"
+msgid "Integer"
 msgstr ""
 
 msgid "Internal"
@@ -5135,6 +5686,9 @@ msgstr ""
 msgid "Key:"
 msgstr ""
 
+msgid "Kickstart"
+msgstr ""
+
 msgid "LDAP"
 msgstr ""
 
@@ -5150,15 +5704,15 @@ msgstr ""
 msgid "LDAP Groups for User"
 msgstr ""
 
-msgid "LDAP Host Name"
+msgid "LDAP Host Names"
+msgstr ""
+
+msgid "LDAP Hostname"
 msgstr ""
 
 msgid ""
-"LDAP Host Name and Port fields are needed to perform verification of LDAP Sett"
-"ings"
-msgstr ""
-
-msgid "LDAP Host Names"
+"LDAP Hostname and Port fields are needed to perform verification of LDAP Setti"
+"ngs"
 msgstr ""
 
 msgid "LDAP Port"
@@ -5183,6 +5737,9 @@ msgid "Label"
 msgstr ""
 
 msgid "Label on Summary Row"
+msgstr ""
+
+msgid "Labels"
 msgstr ""
 
 msgid "Lan"
@@ -5246,6 +5803,9 @@ msgid "Last Message"
 msgstr ""
 
 msgid "Last Run Time"
+msgstr ""
+
+msgid "Last Transition Time"
 msgstr ""
 
 msgid "Last Update"
@@ -5424,9 +5984,6 @@ msgstr ""
 msgid "Lifecycle"
 msgstr ""
 
-msgid "Lifecycle and Automation"
-msgstr ""
-
 msgid "Lifecycle event"
 msgstr ""
 
@@ -5553,10 +6110,18 @@ msgid "Logging"
 msgstr "Aanmelden"
 
 #, fuzzy
+#, fuzzy
+msgid "Logging into"
+msgstr "Aanmelden"
+
+#, fuzzy
 msgid "Login"
 msgstr "Aanmelden"
 
 msgid "Login not allowed, User's %s is missing. Please contact the administrator"
+msgstr ""
+
+msgid "Logout"
 msgstr ""
 
 msgid "Logs for this CFME Server are not available for viewing"
@@ -5592,10 +6157,19 @@ msgstr ""
 msgid "Manage Reports"
 msgstr ""
 
+msgid "Manage quotas for %{model} \"%{name}\""
+msgstr ""
+
+msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
+msgstr ""
+
 msgid "Management Event"
 msgstr ""
 
 msgid "Manager"
+msgstr ""
+
+msgid "Matching password fields are needed to perform verification of credentials"
 msgstr ""
 
 msgid "Max"
@@ -5614,6 +6188,9 @@ msgid "Max Time"
 msgstr ""
 
 msgid "Max VMs"
+msgstr ""
+
+msgid "Max active VM Scans"
 msgstr ""
 
 msgid "Medium"
@@ -6070,25 +6647,7 @@ msgstr ""
 msgid "Miq action set"
 msgstr ""
 
-msgid "Miq ae class"
-msgstr ""
-
 msgid "Miq ae engine/miq ae workspace"
-msgstr ""
-
-msgid "Miq ae field"
-msgstr ""
-
-msgid "Miq ae instance"
-msgstr ""
-
-msgid "Miq ae method"
-msgstr ""
-
-msgid "Miq ae namespace"
-msgstr ""
-
-msgid "Miq ae value"
 msgstr ""
 
 msgid "Miq alert"
@@ -6121,10 +6680,10 @@ msgstr ""
 msgid "Miq enterprise"
 msgstr ""
 
-msgid "Miq event"
+msgid "Miq event definition"
 msgstr ""
 
-msgid "Miq event set"
+msgid "Miq event definition set"
 msgstr ""
 
 msgid "Miq group"
@@ -6259,33 +6818,6 @@ msgstr ""
 msgid "MiqAction|Updated on"
 msgstr ""
 
-msgid "MiqAeClass|Created on"
-msgstr ""
-
-msgid "MiqAeClass|Description"
-msgstr ""
-
-msgid "MiqAeClass|Display name"
-msgstr ""
-
-msgid "MiqAeClass|Inherits"
-msgstr ""
-
-msgid "MiqAeClass|Name"
-msgstr ""
-
-msgid "MiqAeClass|Owner"
-msgstr ""
-
-msgid "MiqAeClass|Updated by"
-msgstr ""
-
-msgid "MiqAeClass|Updated on"
-msgstr ""
-
-msgid "MiqAeClass|Visibility"
-msgstr ""
-
 msgid "MiqAeEngine::MiqAeWorkspace|Created on"
 msgstr ""
 
@@ -6302,186 +6834,6 @@ msgid "MiqAeEngine::MiqAeWorkspace|Uri"
 msgstr ""
 
 msgid "MiqAeEngine::MiqAeWorkspace|Workspace"
-msgstr ""
-
-msgid "MiqAeField|Aetype"
-msgstr ""
-
-msgid "MiqAeField|Collect"
-msgstr ""
-
-msgid "MiqAeField|Condition"
-msgstr ""
-
-msgid "MiqAeField|Created on"
-msgstr ""
-
-msgid "MiqAeField|Datatype"
-msgstr ""
-
-msgid "MiqAeField|Default value"
-msgstr ""
-
-msgid "MiqAeField|Description"
-msgstr ""
-
-msgid "MiqAeField|Display name"
-msgstr ""
-
-msgid "MiqAeField|Max retries"
-msgstr ""
-
-msgid "MiqAeField|Max time"
-msgstr ""
-
-msgid "MiqAeField|Message"
-msgstr ""
-
-msgid "MiqAeField|Name"
-msgstr ""
-
-msgid "MiqAeField|On entry"
-msgstr ""
-
-msgid "MiqAeField|On error"
-msgstr ""
-
-msgid "MiqAeField|On exit"
-msgstr ""
-
-msgid "MiqAeField|Owner"
-msgstr ""
-
-msgid "MiqAeField|Priority"
-msgstr ""
-
-msgid "MiqAeField|Scope"
-msgstr ""
-
-msgid "MiqAeField|Substitute"
-msgstr ""
-
-msgid "MiqAeField|Updated by"
-msgstr ""
-
-msgid "MiqAeField|Updated on"
-msgstr ""
-
-msgid "MiqAeField|Visibility"
-msgstr ""
-
-msgid "MiqAeInstance|Created on"
-msgstr ""
-
-msgid "MiqAeInstance|Description"
-msgstr ""
-
-msgid "MiqAeInstance|Display name"
-msgstr ""
-
-msgid "MiqAeInstance|Inherits"
-msgstr ""
-
-msgid "MiqAeInstance|Name"
-msgstr ""
-
-msgid "MiqAeInstance|Updated by"
-msgstr ""
-
-msgid "MiqAeInstance|Updated on"
-msgstr ""
-
-msgid "MiqAeMethod|Created on"
-msgstr ""
-
-msgid "MiqAeMethod|Data"
-msgstr ""
-
-msgid "MiqAeMethod|Description"
-msgstr ""
-
-msgid "MiqAeMethod|Display name"
-msgstr ""
-
-msgid "MiqAeMethod|Language"
-msgstr ""
-
-msgid "MiqAeMethod|Location"
-msgstr ""
-
-msgid "MiqAeMethod|Name"
-msgstr ""
-
-msgid "MiqAeMethod|Scope"
-msgstr ""
-
-msgid "MiqAeMethod|Updated by"
-msgstr ""
-
-msgid "MiqAeMethod|Updated on"
-msgstr ""
-
-msgid "MiqAeNamespace|Created on"
-msgstr ""
-
-msgid "MiqAeNamespace|Description"
-msgstr ""
-
-msgid "MiqAeNamespace|Display name"
-msgstr ""
-
-msgid "MiqAeNamespace|Enabled"
-msgstr ""
-
-msgid "MiqAeNamespace|Name"
-msgstr ""
-
-msgid "MiqAeNamespace|Priority"
-msgstr ""
-
-msgid "MiqAeNamespace|System"
-msgstr ""
-
-msgid "MiqAeNamespace|Updated by"
-msgstr ""
-
-msgid "MiqAeNamespace|Updated on"
-msgstr ""
-
-msgid "MiqAeValue|Collect"
-msgstr ""
-
-msgid "MiqAeValue|Condition"
-msgstr ""
-
-msgid "MiqAeValue|Created on"
-msgstr ""
-
-msgid "MiqAeValue|Display name"
-msgstr ""
-
-msgid "MiqAeValue|Max retries"
-msgstr ""
-
-msgid "MiqAeValue|Max time"
-msgstr ""
-
-msgid "MiqAeValue|On entry"
-msgstr ""
-
-msgid "MiqAeValue|On error"
-msgstr ""
-
-msgid "MiqAeValue|On exit"
-msgstr ""
-
-msgid "MiqAeValue|Updated by"
-msgstr ""
-
-msgid "MiqAeValue|Updated on"
-msgstr ""
-
-msgid "MiqAeValue|Value"
 msgstr ""
 
 msgid "MiqAlertSet|Created on"
@@ -6763,64 +7115,64 @@ msgstr ""
 msgid "MiqEnterprise|Updated on"
 msgstr ""
 
-msgid "MiqEventSet|Created on"
+msgid "MiqEventDefinitionSet|Created on"
 msgstr ""
 
-msgid "MiqEventSet|Description"
+msgid "MiqEventDefinitionSet|Description"
 msgstr ""
 
-msgid "MiqEventSet|Guid"
+msgid "MiqEventDefinitionSet|Guid"
 msgstr ""
 
-msgid "MiqEventSet|Mode"
+msgid "MiqEventDefinitionSet|Mode"
 msgstr ""
 
-msgid "MiqEventSet|Name"
+msgid "MiqEventDefinitionSet|Name"
 msgstr ""
 
-msgid "MiqEventSet|Owner type"
+msgid "MiqEventDefinitionSet|Owner type"
 msgstr ""
 
-msgid "MiqEventSet|Read only"
+msgid "MiqEventDefinitionSet|Read only"
 msgstr ""
 
-msgid "MiqEventSet|Set data"
+msgid "MiqEventDefinitionSet|Set data"
 msgstr ""
 
-msgid "MiqEventSet|Set type"
+msgid "MiqEventDefinitionSet|Set type"
 msgstr ""
 
-msgid "MiqEventSet|Updated on"
+msgid "MiqEventDefinitionSet|Updated on"
 msgstr ""
 
-msgid "MiqEventSet|Userid"
+msgid "MiqEventDefinitionSet|Userid"
 msgstr ""
 
-msgid "MiqEvent|Created on"
+msgid "MiqEventDefinition|Created on"
 msgstr ""
 
-msgid "MiqEvent|Default"
+msgid "MiqEventDefinition|Default"
 msgstr ""
 
-msgid "MiqEvent|Definition"
+msgid "MiqEventDefinition|Definition"
 msgstr ""
 
-msgid "MiqEvent|Description"
+msgid "MiqEventDefinition|Description"
 msgstr ""
 
-msgid "MiqEvent|Enabled"
+msgid "MiqEventDefinition|Enabled"
 msgstr ""
 
-msgid "MiqEvent|Event type"
+msgid "MiqEventDefinition|Event type"
 msgstr ""
 
-msgid "MiqEvent|Guid"
+msgid "MiqEventDefinition|Guid"
 msgstr ""
 
-msgid "MiqEvent|Name"
+msgid "MiqEventDefinition|Name"
 msgstr ""
 
-msgid "MiqEvent|Updated on"
+msgid "MiqEventDefinition|Updated on"
 msgstr ""
 
 msgid "MiqGroup|Created on"
@@ -7729,13 +8081,22 @@ msgstr ""
 msgid "My Filters"
 msgstr ""
 
+msgid "My Personal Filters"
+msgstr ""
+
 msgid "My Services"
 msgstr ""
 
 msgid "My Settings"
 msgstr ""
 
+msgid "MyTags"
+msgstr ""
+
 msgid "N/A"
+msgstr ""
+
+msgid "NFS Server"
 msgstr ""
 
 msgid "NONE"
@@ -7756,10 +8117,10 @@ msgstr ""
 msgid "Name: %s | %s Type: %s"
 msgstr ""
 
-msgid "Name: %s | Host Name: %s"
+msgid "Name: %s | Hostname: %s"
 msgstr ""
 
-msgid "Name: %s | Host Name: %s | Refresh Status: %s"
+msgid "Name: %s | Hostname: %s | Refresh Status: %s"
 msgstr ""
 
 msgid "Name: %s | Path: %s"
@@ -7837,9 +8198,6 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-msgid "New Catalog Item"
-msgstr ""
-
 msgid "New Entry"
 msgstr ""
 
@@ -7855,8 +8213,15 @@ msgstr ""
 msgid "New Parameter"
 msgstr ""
 
-msgid "New setting will affect %s"
-msgstr ""
+#, fuzzy
+#, fuzzy
+msgid "New Password"
+msgstr "Nieuw wachtwoord"
+
+msgid "New setting will affect Orchestration Stack"
+msgid_plural "New setting will affect Orchestration Stacks"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "New setting will affect Service"
 msgid_plural "New setting will affect Services"
@@ -7883,10 +8248,10 @@ msgstr ""
 msgid "No %s %s Policies are defined %s."
 msgstr ""
 
-msgid "No %s Alert Profiles are defined%s."
+msgid "No %s Alert Profiles are defined %s."
 msgstr ""
 
-msgid "No %s Conditions are defined%s."
+msgid "No %s Conditions are defined %s."
 msgstr ""
 
 msgid "No %s Policy Profiles are defined%s."
@@ -7994,7 +8359,7 @@ msgstr ""
 msgid "No Choices Available"
 msgstr ""
 
-msgid "No Class found for explorer tree node type '%s'"
+msgid "No Class found for explorer tree node id '%s'"
 msgstr ""
 
 msgid "No Dashboards are defined for this group. Default dashboard will be shown."
@@ -8015,6 +8380,11 @@ msgid "No Display Filter defined."
 msgstr ""
 
 msgid "No Group"
+msgstr ""
+
+msgid ""
+"No Hourly or Daily data is available, real time data from the Most Recent Hour"
+" is being displayed"
 msgstr ""
 
 msgid "No Indexes found for this table."
@@ -8147,9 +8517,6 @@ msgstr ""
 msgid "No events available for this timeline."
 msgstr ""
 
-msgid "No explorer tree node type found for '%s'"
-msgstr ""
-
 msgid "No expression defined, a condition must contain a valid expression."
 msgstr ""
 
@@ -8204,6 +8571,12 @@ msgstr ""
 msgid "No variables configured."
 msgstr ""
 
+msgid "Node Port"
+msgstr ""
+
+msgid "Node Selector"
+msgstr ""
+
 msgid "Nodes"
 msgstr ""
 
@@ -8251,6 +8624,9 @@ msgstr ""
 msgid "Note: Only Time Profiles with 'Roll Up Performance' set are shown."
 msgstr ""
 
+msgid "Note: Username must be in the format: name@realm"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -8276,6 +8652,9 @@ msgid "Number of VMs"
 msgstr ""
 
 msgid "OR with a new expression element"
+msgstr ""
+
+msgid "OS"
 msgstr ""
 
 msgid "OS %s"
@@ -9610,6 +9989,9 @@ msgstr ""
 msgid "OpenStack Status"
 msgstr ""
 
+msgid "Openstack Infra Provider"
+msgstr ""
+
 msgid "Openstack Infra provider"
 msgstr ""
 
@@ -9638,6 +10020,9 @@ msgid "OperatingSystem|Build number"
 msgstr ""
 
 msgid "OperatingSystem|Distribution"
+msgstr ""
+
+msgid "OperatingSystem|Kernel version"
 msgstr ""
 
 msgid "OperatingSystem|Lockout duration"
@@ -9694,6 +10079,9 @@ msgstr ""
 msgid "OperatingSystem|Version"
 msgstr ""
 
+msgid "Optimize"
+msgstr ""
+
 msgid "Option 1"
 msgstr ""
 
@@ -9716,9 +10104,6 @@ msgid "Orchestration Template"
 msgstr ""
 
 msgid "Orchestration Template \"%s\" was deleted."
-msgstr ""
-
-msgid "Orchestration Template Information"
 msgstr ""
 
 msgid "Orchestration Templates"
@@ -9826,6 +10211,9 @@ msgstr ""
 msgid "OrchestrationStack|Status"
 msgstr ""
 
+msgid "OrchestrationStack|Status reason"
+msgstr ""
+
 msgid "OrchestrationTemplate|Content"
 msgstr ""
 
@@ -9856,13 +10244,22 @@ msgstr ""
 msgid "Organization"
 msgstr ""
 
+msgid "Organization ID"
+msgstr ""
+
 msgid "Original Value"
 msgstr ""
 
 msgid "Orphaned Data"
 msgstr ""
 
+msgid "Orphaned Instances"
+msgstr ""
+
 msgid "Orphaned Records for userid %s were successfully deleted"
+msgstr ""
+
+msgid "Orphaned VMs and Templates"
 msgstr ""
 
 msgid "Os process"
@@ -9910,6 +10307,9 @@ msgstr ""
 msgid "Outputs (%s)"
 msgstr ""
 
+msgid "Overview"
+msgstr ""
+
 msgid "Overwrite existing reports?"
 msgstr ""
 
@@ -9940,6 +10340,9 @@ msgstr ""
 msgid "PXE Images"
 msgstr ""
 
+msgid "Packages"
+msgstr ""
+
 msgid "Packages (%s)"
 msgstr ""
 
@@ -9953,6 +10356,9 @@ msgid "Parameters"
 msgstr ""
 
 msgid "Parameters (%s)"
+msgstr ""
+
+msgid "Parent"
 msgstr ""
 
 msgid "Parent %s: %s"
@@ -9983,6 +10389,9 @@ msgid "Partition"
 msgstr ""
 
 msgid "Partition Table"
+msgstr ""
+
+msgid "Partitions Aligned"
 msgstr ""
 
 msgid "Partition|Controller"
@@ -10033,7 +10442,13 @@ msgstr "Wachtwoord"
 msgid "Password fields must match to Validate Database Configuration"
 msgstr ""
 
+msgid "Password or Password+One-Time-Password"
+msgstr ""
+
 msgid "Password/Verify Password do not match"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid ""
@@ -10098,6 +10513,9 @@ msgstr ""
 msgid "Percent Bloat"
 msgstr ""
 
+msgid "Percent Used of Provisioned Size"
+msgstr ""
+
 msgid "Performance Interval"
 msgstr ""
 
@@ -10105,6 +10523,9 @@ msgid "Performance Timeframe"
 msgstr ""
 
 msgid "Period"
+msgstr ""
+
+msgid "Persistent Volume Claim Name"
 msgstr ""
 
 msgid "Picture"
@@ -10146,34 +10567,10 @@ msgstr ""
 msgid "Please select an Instance Type from above"
 msgstr ""
 
-msgid "Pod"
-msgstr ""
-
 msgid "Pods (%s)"
 msgstr ""
 
 msgid "Pods (0)"
-msgstr ""
-
-msgid "Pod|Creation timestamp"
-msgstr ""
-
-msgid "Pod|Dns policy"
-msgstr ""
-
-msgid "Pod|Ems ref"
-msgstr ""
-
-msgid "Pod|Name"
-msgstr ""
-
-msgid "Pod|Namespace"
-msgstr ""
-
-msgid "Pod|Resource version"
-msgstr ""
-
-msgid "Pod|Restart policy"
 msgstr ""
 
 msgid "Policies"
@@ -10224,7 +10621,7 @@ msgstr ""
 msgid "PolicyEvent|Event type"
 msgstr ""
 
-msgid "PolicyEvent|Miq event description"
+msgid "PolicyEvent|Miq event definition description"
 msgstr ""
 
 msgid "PolicyEvent|Miq policy description"
@@ -10246,6 +10643,9 @@ msgid "PolicyEvent|Username"
 msgstr ""
 
 msgid "Port"
+msgstr ""
+
+msgid "Port Configurations"
 msgstr ""
 
 msgid "Power Management"
@@ -10296,7 +10696,19 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
+msgid "Private Keys do not match"
+msgstr ""
+
 msgid "Process ID"
+msgstr ""
+
+msgid "Processor Cores_Per_Socket"
+msgstr ""
+
+msgid "Processor Options"
+msgstr ""
+
+msgid "Processor Sockets"
 msgstr ""
 
 msgid "Processors"
@@ -10314,13 +10726,28 @@ msgstr ""
 msgid "Profile Policies:"
 msgstr ""
 
+msgid "Project/Tenant"
+msgstr ""
+
+msgid "Projects"
+msgstr ""
+
 msgid "Properties"
+msgstr ""
+
+msgid "Property"
 msgstr ""
 
 msgid "Protected"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "Provider"
+msgstr ""
+
+msgid "Provider is not ready to be scaled, another operation is in progress."
 msgstr ""
 
 msgid "Providers"
@@ -10353,7 +10780,10 @@ msgstr ""
 msgid "Provision Order"
 msgstr ""
 
-msgid "Provisioned %s"
+msgid "Provisioned Hosts"
+msgstr ""
+
+msgid "Provisioned Size"
 msgstr ""
 
 msgid "Provisioned VMs"
@@ -10446,10 +10876,10 @@ msgstr ""
 msgid "Queued At"
 msgstr ""
 
-msgid "Quick Start"
+msgid "Quotas"
 msgstr ""
 
-msgid "Quotas"
+msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr ""
 
 msgid "RSA key pair"
@@ -10464,6 +10894,23 @@ msgstr ""
 msgid "RSS Feed no longer exists"
 msgstr ""
 
+msgid "Rados Ceph Monitors"
+msgstr ""
+
+msgid "Rados Image Name"
+msgstr ""
+
+msgid "Rados Keyring"
+msgstr ""
+
+msgid "Rados Pool Name"
+msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Rados User Name"
+msgstr "Gebruikersnaam"
+
 msgid "Range"
 msgstr ""
 
@@ -10474,6 +10921,12 @@ msgid "Rate"
 msgstr ""
 
 msgid "Rate Details"
+msgstr ""
+
+msgid "Rates"
+msgstr ""
+
+msgid "Re-apply the previous change"
 msgstr ""
 
 msgid "Read Only"
@@ -10489,6 +10942,9 @@ msgid "Read Only %{model} \"%{name}\" cannot be edited"
 msgstr ""
 
 msgid "Read only"
+msgstr ""
+
+msgid "Read-Only"
 msgstr ""
 
 msgid "Realm"
@@ -10533,9 +10989,6 @@ msgstr ""
 msgid "Red Hat Updates"
 msgstr ""
 
-msgid "Redo the next change"
-msgstr ""
-
 msgid "Reference VM Profile"
 msgstr ""
 
@@ -10567,6 +11020,9 @@ msgid "Region:"
 msgstr "Regio:"
 
 msgid "Register"
+msgstr ""
+
+msgid "Register to"
 msgstr ""
 
 msgid "Registration"
@@ -10630,6 +11086,9 @@ msgid "Relationship|Relationship"
 msgstr ""
 
 msgid "Relationship|Resource type"
+msgstr ""
+
+msgid "Release"
 msgstr ""
 
 msgid "Remote Console plugin is not properly installed."
@@ -10725,6 +11184,12 @@ msgstr ""
 msgid "Replication Worker"
 msgstr ""
 
+msgid "Replicators (%s)"
+msgstr ""
+
+msgid "Replicators (0)"
+msgstr ""
+
 msgid "Report"
 msgstr ""
 
@@ -10795,6 +11260,12 @@ msgid "Repositories"
 msgstr ""
 
 msgid "Repository"
+msgstr ""
+
+msgid "Repository Name(s)"
+msgstr ""
+
+msgid "Repository Name(s):"
 msgstr ""
 
 msgid "Repository|Created on"
@@ -11016,19 +11487,28 @@ msgstr ""
 msgid "Retirement"
 msgstr ""
 
-msgid "Retirement %s removed"
-msgstr ""
-
-msgid "Retirement %{date_text} set to %{rdate}"
-msgstr ""
-
 msgid "Retirement Date"
 msgstr ""
 
 msgid "Retirement Entry Point"
 msgstr ""
 
+msgid "Retirement Entry Point (NameSpace/Class/Instance)"
+msgstr ""
+
 msgid "Retirement Warning"
+msgstr ""
+
+msgid "Retirement date removed"
+msgstr ""
+
+msgid "Retirement date set to %s"
+msgstr ""
+
+msgid "Retirement dates removed"
+msgstr ""
+
+msgid "Retirement dates set to %s"
 msgstr ""
 
 msgid "Right Size Recommendation for %{model} \"%{name}\""
@@ -11094,7 +11574,9 @@ msgstr ""
 msgid "RssFeed|Yml file mtime"
 msgstr ""
 
-msgid "Ruby Script"
+msgid ""
+"Ruby scripts are no longer supported in expressions, please change or remove t"
+"hem."
 msgstr ""
 
 msgid "Run"
@@ -11184,6 +11666,9 @@ msgid "Save this %s search as:"
 msgstr ""
 
 msgid "Save..."
+msgstr ""
+
+msgid "Saved Chargeback Reports"
 msgstr ""
 
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
@@ -11339,7 +11824,7 @@ msgstr ""
 msgid "Search by Name within results"
 msgstr ""
 
-msgid "Second band unit:"
+msgid "Second band unit"
 msgstr ""
 
 msgid "Secondary (Display) Filter"
@@ -11351,8 +11836,16 @@ msgstr ""
 msgid "Secret Access Key"
 msgstr ""
 
+msgid "Secret Access Keys do not match"
+msgstr ""
+
 msgid "Secret Key"
 msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Secret Name"
+msgstr "Gebruikersnaam"
 
 msgid "Security"
 msgstr ""
@@ -11388,6 +11881,9 @@ msgid "Select Alerts to be Evaluated"
 msgstr ""
 
 msgid "Select Entry Point %s"
+msgstr ""
+
+msgid "Select Host to validate against"
 msgstr ""
 
 msgid "Select Policy Profiles"
@@ -11462,6 +11958,9 @@ msgstr ""
 msgid "Select only one or consecutive %s to move up"
 msgstr ""
 
+msgid "Select to change to another Group"
+msgstr ""
+
 msgid "Selected"
 msgstr ""
 
@@ -11499,6 +11998,9 @@ msgid "Selection"
 msgstr ""
 
 msgid "Selections"
+msgstr ""
+
+msgid "Selector"
 msgstr ""
 
 msgid "Send E-mail"
@@ -11547,13 +12049,13 @@ msgstr ""
 msgid "Server Roles"
 msgstr "Gebruikersnaam"
 
-msgid ""
-"Server information, Username and matching password fields are needed to perfor"
-"m verification of credentials"
-msgstr ""
-
 msgid "Server role"
 msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Server: %s"
+msgstr "Gebruikersnaam"
 
 msgid "ServerRole|Created on"
 msgstr ""
@@ -11594,7 +12096,7 @@ msgstr ""
 msgid "Service Dialog \"%s\" was successfully created"
 msgstr ""
 
-msgid "Service Dialog Information"
+msgid "Service Dialog Import/Export"
 msgstr ""
 
 msgid "Service Dialog Name"
@@ -11777,9 +12279,6 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-msgid "Settings and Operations"
-msgstr ""
-
 msgid "Shortcuts"
 msgstr ""
 
@@ -11787,6 +12286,9 @@ msgid "Show"
 msgstr ""
 
 msgid "Show %s"
+msgstr ""
+
+msgid "Show %s %s"
 msgstr ""
 
 msgid "Show %s & %s"
@@ -11816,10 +12318,25 @@ msgstr ""
 msgid "Show Capacity & Utilization"
 msgstr ""
 
+msgid "Show Container Groups"
+msgstr ""
+
 msgid "Show Container Nodes"
 msgstr ""
 
+msgid "Show Container Projects"
+msgstr ""
+
+msgid "Show Container Replicators"
+msgstr ""
+
+msgid "Show Container Routes"
+msgstr ""
+
 msgid "Show Container Services"
+msgstr ""
+
+msgid "Show Containers"
 msgstr ""
 
 msgid "Show Costs by"
@@ -11829,6 +12346,12 @@ msgid "Show Event Logs on this VM"
 msgstr ""
 
 msgid "Show Host Events"
+msgstr ""
+
+msgid "Show Image Registries"
+msgstr ""
+
+msgid "Show Images"
 msgstr ""
 
 msgid "Show Input Parameters"
@@ -11847,6 +12370,9 @@ msgid "Show Pods"
 msgstr ""
 
 msgid "Show Refresh Button"
+msgstr ""
+
+msgid "Show Replicators"
 msgstr ""
 
 msgid "Show Resource Pools"
@@ -11942,16 +12468,13 @@ msgstr ""
 msgid "Show all registered %s"
 msgstr ""
 
-msgid "Show all used %s on this %s"
-msgstr ""
-
 msgid "Show at Login"
 msgstr ""
 
 msgid "Show configuration"
 msgstr ""
 
-msgid "Show daily data from:"
+msgid "Show daily data from"
 msgstr ""
 
 msgid "Show disks"
@@ -11963,10 +12486,10 @@ msgstr ""
 msgid "Show event logs on this VM"
 msgstr ""
 
-msgid "Show events from last:"
+msgid "Show events from last"
 msgstr ""
 
-msgid "Show hourly data from:"
+msgid "Show hourly data from"
 msgstr ""
 
 msgid "Show in Console"
@@ -12092,9 +12615,6 @@ msgstr ""
 msgid "Show this Flavor's parent %s"
 msgstr ""
 
-msgid "Show this Pod's parent %s"
-msgstr ""
-
 msgid "Show this Security Group's parent %s"
 msgstr ""
 
@@ -12110,10 +12630,25 @@ msgstr ""
 msgid "Show this Vm's parent %s"
 msgstr ""
 
+msgid "Show this container group's parent %s"
+msgstr ""
+
 msgid "Show this container node's parent %s"
 msgstr ""
 
+msgid "Show this container replicator's parent %s"
+msgstr ""
+
 msgid "Show this container service's parent %s"
+msgstr ""
+
+msgid "Show this images registry %s"
+msgstr ""
+
+msgid "Show this pod's parent %s"
+msgstr ""
+
+msgid "Show topology"
 msgstr ""
 
 msgid "Show tree of all VMs in this Resource Pool"
@@ -12168,6 +12703,9 @@ msgid "Small Trees"
 msgstr ""
 
 msgid "Smart Management"
+msgstr ""
+
+msgid "SmartProxy Affinity"
 msgstr ""
 
 msgid "SmartProxy Server IP"
@@ -12234,6 +12772,9 @@ msgid "Snapshot|Uid ems"
 msgstr ""
 
 msgid "Snapshot|Updated on"
+msgstr ""
+
+msgid "Sockets"
 msgstr ""
 
 msgid ""
@@ -12315,6 +12856,9 @@ msgstr ""
 msgid "State"
 msgstr ""
 
+msgid "State Machine (NS/Cls/Inst)"
+msgstr ""
+
 msgid "Status"
 msgstr ""
 
@@ -12340,6 +12884,9 @@ msgid "Storage Adapters"
 msgstr ""
 
 msgid "Storage Managers"
+msgstr ""
+
+msgid "Storage Medium Type"
 msgstr ""
 
 msgid "Storage Relationships"
@@ -12501,7 +13048,13 @@ msgstr ""
 msgid "Subscribe to this feed"
 msgstr ""
 
+msgid "Substitute: %s"
+msgstr ""
+
 msgid "Substitution:"
+msgstr ""
+
+msgid "Successful"
 msgstr ""
 
 msgid "Successfully deleted %s from the CFME Database"
@@ -12549,6 +13102,9 @@ msgstr ""
 msgid "Synchronous"
 msgstr ""
 
+msgid "Sysprep"
+msgstr ""
+
 msgid "Sysprep \"%s\" upload was successful"
 msgstr ""
 
@@ -12556,6 +13112,9 @@ msgid "System Default"
 msgstr ""
 
 msgid "System service"
+msgstr ""
+
+msgid "System/Process"
 msgstr ""
 
 msgid "System/Process/"
@@ -12642,7 +13201,7 @@ msgstr ""
 msgid "Tag edits were successfully saved"
 msgstr ""
 
-msgid "Tag to Apply:"
+msgid "Tag to Apply"
 msgstr ""
 
 msgid "Tagging"
@@ -12666,10 +13225,13 @@ msgstr ""
 msgid "Target Options/Limits"
 msgstr ""
 
-msgid "Task State:"
+msgid "Target Port"
 msgstr ""
 
-msgid "Task Status:"
+msgid "Task State"
+msgstr ""
+
+msgid "Task Status"
 msgstr ""
 
 msgid "Tasks"
@@ -12696,7 +13258,78 @@ msgstr ""
 msgid "Tenancy"
 msgstr ""
 
+msgid "Tenant"
+msgstr ""
+
+msgid "Tenant ID"
+msgstr ""
+
+msgid "Tenant quota"
+msgstr ""
+
+msgid "TenantQuota|Name"
+msgstr ""
+
+msgid "TenantQuota|Unit"
+msgstr ""
+
+msgid "TenantQuota|Value"
+msgstr ""
+
 msgid "Tenants"
+msgstr ""
+
+msgid "Tenants (%s)"
+msgstr ""
+
+msgid "Tenant|Ancestry"
+msgstr ""
+
+msgid "Tenant|Description"
+msgstr ""
+
+msgid "Tenant|Divisible"
+msgstr ""
+
+msgid "Tenant|Domain"
+msgstr ""
+
+msgid "Tenant|Login logo content type"
+msgstr ""
+
+msgid "Tenant|Login logo file name"
+msgstr ""
+
+msgid "Tenant|Login logo file size"
+msgstr ""
+
+msgid "Tenant|Login logo updated at"
+msgstr ""
+
+msgid "Tenant|Login text"
+msgstr ""
+
+msgid "Tenant|Logo content type"
+msgstr ""
+
+msgid "Tenant|Logo file name"
+msgstr ""
+
+msgid "Tenant|Logo file size"
+msgstr ""
+
+msgid "Tenant|Logo updated at"
+msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Tenant|Name"
+msgstr "Gebruikersnaam"
+
+msgid "Tenant|Subdomain"
+msgstr ""
+
+msgid "Tenant|Use config for attributes"
 msgstr ""
 
 msgid "Test E-mail Address"
@@ -12803,7 +13436,7 @@ msgid ""
 "or edited manually."
 msgstr ""
 
-msgid "Third band unit:"
+msgid "Third band unit"
 msgstr ""
 
 msgid "This Action is not assigned to any Policies."
@@ -12879,6 +13512,9 @@ msgid "Time Profile"
 msgstr ""
 
 msgid "Time Profile Information"
+msgstr ""
+
+msgid "Time Profiles"
 msgstr ""
 
 msgid "Time Zone"
@@ -12973,7 +13609,16 @@ msgstr ""
 msgid "Toggle All/None"
 msgstr ""
 
+msgid "Token"
+msgstr ""
+
 msgid "Top values to show"
+msgstr ""
+
+msgid "Topology"
+msgstr ""
+
+msgid "Total Processors"
 msgstr ""
 
 msgid "Total VMs: 0"
@@ -13039,6 +13684,9 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
+msgid "Type: %s"
+msgstr ""
+
 msgid "UI Worker"
 msgstr ""
 
@@ -13064,16 +13712,22 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
+msgid "Unassigned Profiles Group"
+msgstr ""
+
 msgid "Unassigned:"
 msgstr ""
 
 msgid "Unattended GUI"
 msgstr ""
 
-msgid "Undo the previous change"
+msgid "Undo the last change"
 msgstr ""
 
 msgid "Unexpected error encountered"
+msgstr ""
+
+msgid "Units"
 msgstr ""
 
 msgid "Unknown"
@@ -13090,10 +13744,6 @@ msgstr ""
 
 #, fuzzy
 msgid "Update Password"
-msgstr "Wachtwoord veranderen"
-
-#, fuzzy
-msgid "Update Repository"
 msgstr "Wachtwoord veranderen"
 
 msgid "Update Status"
@@ -13156,6 +13806,9 @@ msgstr ""
 msgid "Use Custom Logo Image"
 msgstr ""
 
+msgid "Use HTTP Proxy"
+msgstr ""
+
 msgid "Use the Browse button to locate %s file"
 msgstr ""
 
@@ -13167,6 +13820,11 @@ msgstr ""
 
 msgid "Use the Browse button to locate an Upload file"
 msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Used Size"
+msgstr "Gebruikersnaam"
 
 msgid "Used for SSH connection to all %s in this provider."
 msgstr ""
@@ -13236,9 +13894,6 @@ msgstr ""
 msgid "User will input the value"
 msgstr ""
 
-msgid "User:"
-msgstr ""
-
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -13252,6 +13907,9 @@ msgid "Users (%s)"
 msgstr ""
 
 msgid "Users (0)"
+msgstr ""
+
+msgid "Users are only allowed to delete their own requests"
 msgstr ""
 
 msgid "Users in this Group"
@@ -13364,6 +14022,9 @@ msgstr ""
 msgid "VM/Instance"
 msgstr ""
 
+msgid "VMDB"
+msgstr ""
+
 msgid "VMM Information"
 msgstr ""
 
@@ -13388,7 +14049,16 @@ msgstr ""
 msgid "VMware Console Support"
 msgstr ""
 
+msgid "VMware MKS Plugin"
+msgstr ""
+
 msgid "VMware MKS Plugin Version"
+msgstr ""
+
+msgid "VMware VMRC Plugin"
+msgstr ""
+
+msgid "VNC"
 msgstr ""
 
 msgid "VNC Console"
@@ -13415,6 +14085,9 @@ msgstr ""
 msgid "Validate the LDAP Settings by binding with the %s"
 msgstr ""
 
+msgid "Validate the credentials"
+msgstr ""
+
 msgid "Validate the credentials by logging into the Server"
 msgstr ""
 
@@ -13437,6 +14110,9 @@ msgid "Value to Set"
 msgstr ""
 
 msgid "Value:"
+msgstr ""
+
+msgid "Values"
 msgstr ""
 
 msgid "Variable Object ID"
@@ -13464,10 +14140,19 @@ msgstr ""
 msgid "Verify %s"
 msgstr "Wachtwoord bevestigen"
 
+msgid "Verify Client Key"
+msgstr ""
+
 msgid "Verify Password"
 msgstr "Wachtwoord bevestigen"
 
 msgid "Verify Peer Certificate"
+msgstr ""
+
+msgid "Verify Private Key"
+msgstr ""
+
+msgid "Verify Secret Access Key"
 msgstr ""
 
 msgid "Version"
@@ -13475,6 +14160,16 @@ msgstr ""
 
 msgid "Version / Build"
 msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "View %s"
+msgstr "Gebruikersnaam"
+
+#, fuzzy
+#, fuzzy
+msgid "View %s %s"
+msgstr "Gebruikersnaam"
 
 msgid "View %s Folder"
 msgstr ""
@@ -13503,6 +14198,9 @@ msgstr ""
 msgid "View LDAP Regions"
 msgstr ""
 
+msgid "View Parent Tenant"
+msgstr ""
+
 #, fuzzy
 msgid "View Roles"
 msgstr "Gebruikersnaam"
@@ -13511,6 +14209,9 @@ msgid "View Schedules"
 msgstr ""
 
 msgid "View Storage Rates"
+msgstr ""
+
+msgid "View Tenants"
 msgstr ""
 
 msgid "View This Alert"
@@ -13640,6 +14341,23 @@ msgid "Virtual Machines"
 msgstr ""
 
 msgid "Visibility"
+msgstr ""
+
+msgid "Visual"
+msgstr ""
+
+msgid "Vm"
+msgstr ""
+
+#, fuzzy
+#, fuzzy
+msgid "Vm Compliance Policies"
+msgstr "Toestel:"
+
+msgid "Vm Control Policies"
+msgstr ""
+
+msgid "Vm Policies"
 msgstr ""
 
 msgid "Vm or template"
@@ -13954,6 +14672,15 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
+msgid "Volume ID"
+msgstr ""
+
+msgid "Volume Path"
+msgstr ""
+
+msgid "Volumes"
+msgstr ""
+
 msgid "Volume|Created on"
 msgstr ""
 
@@ -14151,6 +14878,11 @@ msgstr ""
 msgid "back"
 msgstr "Terug"
 
+#, fuzzy
+#, fuzzy
+msgid "blank"
+msgstr "Terug"
+
 msgid "bold"
 msgstr ""
 
@@ -14181,6 +14913,12 @@ msgstr ""
 msgid "instances"
 msgstr ""
 
+msgid "ldap"
+msgstr ""
+
+msgid "ldaps"
+msgstr ""
+
 msgid "locale_name"
 msgstr "Nederlands"
 
@@ -14190,13 +14928,13 @@ msgstr ""
 msgid "memory_cpu"
 msgstr ""
 
+msgid "no value"
+msgstr ""
+
 msgid "none"
 msgstr ""
 
 msgid "normal"
-msgstr ""
-
-msgid "not specified"
 msgstr ""
 
 msgid "numvcpus"


### PR DESCRIPTION
Previous version of manageiq.pot missed multiple strings, because `rake gettext:find` wouldn't
find strings in files, which are older (file timestamp) than manageiq.pot itself.