### PR TITLE
Azure orchestration provision

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_dependency 'manageiq/providers/azure/cloud_manager/refresher'
   require_dependency 'manageiq/providers/azure/cloud_manager/vm'
   require_dependency 'manageiq/providers/azure/cloud_manager/orchestration_stack'
+  require_dependency 'manageiq/providers/azure/cloud_manager/orchestration_service_option_converter'
 
   alias_attribute :azure_tenant_id, :uid_ems
 

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_service_option_converter.rb
@@ -1,0 +1,11 @@
+module ManageIQ::Providers
+  class Azure::CloudManager::OrchestrationServiceOptionConverter < ::ServiceOrchestration::OptionConverter
+    def stack_create_options
+      {
+        :parameters     => stack_parameters,
+        :resource_group => @dialog_options['dialog_resource_group'],
+        :mode           => @dialog_options['dialog_deploy_mode']
+      }
+    end
+  end
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -21,7 +21,6 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ::Orchestra
   end
   private_class_method :correct_parameters
 
-
   def raw_update_stack(options)
     resource_group = options[:resource_group]
     create_options = options.except(:resource_group)
@@ -59,5 +58,4 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ::Orchestra
     _log.error "stack=[#{name}], error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
-
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -1,2 +1,63 @@
 class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ::OrchestrationStack
+  require_dependency 'manageiq/providers/azure/cloud_manager/orchestration_stack/status'
+
+  def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
+    resource_group = options[:resource_group]
+    create_options = {:template => JSON.parse(template.content)}
+    create_options.merge!(options).except!(:resource_group)
+
+    correct_parameters(create_options) if create_options[:parameters]
+
+    orchestration_manager.with_provider_connection do |configure|
+      Azure::Armrest::TemplateDeploymentService.new(configure).create(stack_name, create_options, resource_group)['id']
+    end
+  rescue => err
+    _log.error "stack=[#{stack_name}], error: #{err.inspect}"
+    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+  end
+
+  def self.correct_parameters(options)
+    options[:parameters] = options[:parameters].map { |k, v| [k, {'value' => v}] }.to_h
+  end
+  private_class_method :correct_parameters
+
+
+  def raw_update_stack(options)
+    resource_group = options[:resource_group]
+    create_options = options.except(:resource_group)
+
+    correct_parameters(create_options) if create_options[:parameters]
+
+    # use the same API for stack update and creation
+    ext_management_system.with_provider_connection do |configure|
+      Azure::Armrest::TemplateDeploymentService.new(configure).create(name, create_options, resource_group)
+    end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
+  end
+
+  def raw_delete_stack
+    ext_management_system.with_provider_connection do |configure|
+      Azure::Armrest::TemplateDeploymentService.new(configure).delete(name, resource_group)
+    end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+  end
+
+  def raw_status
+    ext_management_system.with_provider_connection do |configure|
+      raw_stack = ::Azure::Armrest::TemplateDeploymentService.new(configure).get(name, resource_group)
+      Status.new(raw_stack.fetch_path('properties', 'provisioningState'), nil)
+    end
+  rescue => err
+    if err.to_s =~ /[D|d]eployment.+ could not be found/
+      raise MiqException::MiqOrchestrationStackNotExistError, "#{name} does not exist on #{ext_management_system.name}"
+    end
+
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+  end
+
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack/status.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack::Status < ::OrchestrationStack::Status
+  def succeeded?
+    status.downcase == "succeeded"
+  end
+
+  def failed?
+    status.downcase == "failed"
+  end
+
+  def canceled?
+    status.downcase == "canceled"
+  end
+
+  def deleted?
+    status.downcase == "deleted"
+  end
+end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -50,6 +50,7 @@ class OrchestrationStack < ActiveRecord::Base
     klass.create(:name                   => stack_name,
                  :ems_ref                => ems_ref,
                  :status                 => 'CREATE_IN_PROGRESS',
+                 :resource_group         => options[:resource_group],
                  :ext_management_system  => orchestration_manager,
                  :orchestration_template => template)
   end

--- a/app/models/orchestration_stack/status.rb
+++ b/app/models/orchestration_stack/status.rb
@@ -24,9 +24,13 @@ class OrchestrationStack
       false
     end
 
+    def canceled?
+      false
+    end
+
     # in a non-transient state
     def completed?
-      succeeded? || failed? || rolled_back? || deleted?
+      succeeded? || failed? || rolled_back? || deleted? || canceled?
     end
 
     def normalized_status
@@ -38,6 +42,8 @@ class OrchestrationStack
         ['rollback_complete', reason || 'Stack was rolled back']
       elsif deleted?
         ['delete_complete', reason || 'Stack was deleted']
+      elsif canceled?
+        ['create_canceled', reason || 'Stack creation was canceled']
       else
         ['failed', reason || 'Stack creation failed']
       end

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -23,7 +23,7 @@ def check_deployed(service)
   case status.downcase
   when 'create_complete'
     $evm.root['ae_result'] = 'ok'
-  when 'rollback_complete', 'delete_complete', /failed$/
+  when 'rollback_complete', 'delete_complete', /failed$/, /canceled$/
     $evm.root['ae_result'] = 'error'
     $evm.root['ae_reason'] = reason
   else

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-orchestration_stack.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Azure_CloudManager_OrchestrationStack < MiqAeServiceOrchestrationStack
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_template_azure.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_template_azure.rb
@@ -1,0 +1,3 @@
+module MiqAeMethodService
+  class MiqAeServiceOrchestrationTemplateAzure < MiqAeServiceOrchestrationTemplate; end
+end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -2,10 +2,13 @@ FactoryGirl.define do
   factory :orchestration_stack do
   end
 
-  factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack"do
+  factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 
-  factory :orchestration_stack_openstack, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack"do
+  factory :orchestration_stack_azure, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Azure::CloudManager::OrchestrationStack" do
+  end
+
+  factory :orchestration_stack_openstack, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack" do
   end
 
   factory :orchestration_stack_openstack_infra, :class => "ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack" do

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/status_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack::Status do
+  it 'parses Succeeded' do
+    status = described_class.new('Succeeded', '')
+    status.completed?.should   be_true
+    status.succeeded?.should   be_true
+    status.failed?.should      be_false
+    status.deleted?.should     be_false
+    status.rolled_back?.should be_false
+    status.normalized_status.should == ['create_complete', '']
+  end
+
+  it 'parses Failed' do
+    status = described_class.new('Failed', nil)
+    status.completed?.should   be_true
+    status.succeeded?.should   be_false
+    status.failed?.should      be_true
+    status.deleted?.should     be_false
+    status.rolled_back?.should be_false
+    status.normalized_status.should == ['failed', 'Stack creation failed']
+  end
+
+  it 'parses Deleted' do
+    status = described_class.new('Deleted', nil)
+    status.completed?.should   be_true
+    status.succeeded?.should   be_false
+    status.failed?.should      be_false
+    status.deleted?.should     be_true
+    status.rolled_back?.should be_false
+    status.normalized_status.should == ['delete_complete', 'Stack was deleted']
+  end
+
+  it 'parses Canceled' do
+    status = described_class.new('Canceled', nil)
+    status.completed?.should   be_true
+    status.succeeded?.should   be_false
+    status.canceled?.should    be_true
+    status.deleted?.should     be_false
+    status.rolled_back?.should be_false
+    status.normalized_status.should == ['create_canceled', 'Stack creation was canceled']
+  end
+
+  it 'parses transient status' do
+    status = described_class.new('CREATING', nil)
+    status.completed?.should   be_false
+    status.succeeded?.should   be_false
+    status.failed?.should      be_false
+    status.deleted?.should     be_false
+    status.rolled_back?.should be_false
+    status.normalized_status.should == %w(transient CREATING)
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -61,7 +61,7 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
     context '#raw_status and #raw_exists' do
       it 'gets the stack status and reason' do
         allow(orchestration_service).to receive(:get).and_return(the_raw_stack)
-        the_raw_stack['properties'] = { 'provisioningState' => 'Succeeded'}
+        the_raw_stack['properties'] = {'provisioningState' => 'Succeeded'}
 
         rstatus = orchestration_stack.raw_status
         expect(rstatus).to have_attributes(:status => 'Succeeded', :reason => nil)

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
+  let(:ems) { FactoryGirl.create(:ems_azure_with_authentication) }
+  let(:template) { FactoryGirl.create(:orchestration_template_azure_with_content) }
+  let(:orchestration_stack) do
+    FactoryGirl.create(:orchestration_stack_azure, :ext_management_system => ems, :name => 'test')
+  end
+  let(:orchestration_service) { double }
+  let(:the_raw_stack) { {'id' => 'one_id'} }
+
+  before do
+    allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_return(double)
+    allow(Azure::Armrest::TemplateDeploymentService).to receive(:new).and_return(orchestration_service)
+  end
+
+  describe 'stack operations' do
+    context ".create_stack" do
+      it 'creates a stack' do
+        expect(orchestration_service).to receive(:create).and_return(the_raw_stack)
+
+        stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
+        stack.class.should == described_class
+        stack.name.should == 'mystack'
+        stack.ems_ref.should == the_raw_stack['id']
+      end
+
+      it 'catches errors from provider' do
+        expect(orchestration_service).to receive(:create).and_throw('bad request')
+
+        expect { OrchestrationStack.create_stack(ems, 'mystack', template, {}) }.to raise_error(MiqException::MiqOrchestrationProvisionError)
+      end
+    end
+
+    context "#update_stack" do
+      it 'updates the stack' do
+        expect(orchestration_service).to receive(:create)
+        orchestration_stack.update_stack({})
+      end
+
+      it 'catches errors from provider' do
+        expect(orchestration_service).to receive(:create).and_throw('bad request')
+        expect { orchestration_stack.update_stack }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+      end
+    end
+
+    context "#delete_stack" do
+      it 'updates the stack' do
+        expect(orchestration_service).to receive(:delete)
+        orchestration_stack.delete_stack
+      end
+
+      it 'catches errors from provider' do
+        expect(orchestration_service).to receive(:delete).and_throw('bad request')
+        expect { orchestration_stack.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
+      end
+    end
+  end
+
+  describe 'stack status' do
+    context '#raw_status and #raw_exists' do
+      it 'gets the stack status and reason' do
+        allow(orchestration_service).to receive(:get).and_return(the_raw_stack)
+        the_raw_stack['properties'] = { 'provisioningState' => 'Succeeded'}
+
+        rstatus = orchestration_stack.raw_status
+        expect(rstatus).to have_attributes(:status => 'Succeeded', :reason => nil)
+
+        orchestration_stack.raw_exists?.should be_true
+      end
+
+      it 'parses error message to determine stack not exist' do
+        allow(orchestration_service).to receive(:get).and_throw("Deployment xxx could not be found")
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+
+        orchestration_stack.raw_exists?.should be_false
+      end
+
+      it 'catches errors from provider' do
+        allow(orchestration_service).to receive(:get).and_throw("bad request")
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+
+        expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Add create, update, delete, and status query operations to Azure `OrchestrationStack`
2. Necessary changes to make the existing service orchestration to provision Azure stacks.
3. Add spec tests.