### PR TITLE
simplify find_descendants

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -337,12 +337,7 @@ module Rbac
   end
 
   def self.find_descendants(descendant_klass, options = {})
-    search_options                  = options.dup
-    search_options[:class]          = descendant_klass
-    search_options[:results_format] = :objects
-
-    results     = search(search_options)
-    descendants = results.first
+    search(options.merge(:class => descendant_klass, :results_format => :objects)).first
   end
 
   def self.ids_via_descendants(klass, descendant_types, options = {})


### PR DESCRIPTION
simplify Rbac `find_descendants` call.

changed it into a single liner. `merge` is basically a `dup`.

/cc @gtanzillo @matthewd 