### PR TITLE
rbac accepts user objects or ids.

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -302,17 +302,17 @@ module Rbac
     columns.join(', ')
   end
 
-  def self.get_user_info(userid, miq_group_id = nil)
-    user                      = User.find_by_userid(userid)
-    miq_group                 = MiqGroup.find_by_id(miq_group_id)
+  def self.get_user_info(user, userid, miq_group, miq_group_id)
+    user      ||= User.find_by_userid(userid) || User.current_user
+    miq_group ||= MiqGroup.find_by_id(miq_group_id)
     if user && miq_group
       user.current_group = miq_group if user.miq_groups.include?(miq_group)
     end
-    tz                        = user.get_timezone if user
+    # for reports, user is currently nil, so use the group filter
     user_filters = user.try(:get_filters) || miq_group.try(:get_filters) || {}
     user_filters["managed"] ||= []
 
-    return user, miq_group, user_filters, tz
+    [user, miq_group, user_filters]
   end
 
   def self.filtered(objects, options = {})
@@ -410,10 +410,12 @@ module Rbac
     include_for_find  = options.delete(:include_for_find)
     search_filter     = options.delete(:filter)
     results_format    = options.delete(:results_format)
-    userid            = options.delete(:userid) || User.current_userid
-    miq_group_id      = options.delete(:miq_group_id)
 
-    user, miq_group, user_filters, tz = get_user_info(userid, miq_group_id)
+    user, miq_group, user_filters = get_user_info(options.delete(:user),
+                                                  options.delete(:userid),
+                                                  options.delete(:miq_group),
+                                                  options.delete(:miq_group_id))
+    tz                     = user.try(:get_timezone)
     attrs                  = {:user_filters => copy_hash(user_filters)}
     klass                  = class_or_name.kind_of?(Class) ? class_or_name : class_or_name.to_s.constantize
     ids_clause             = nil
@@ -431,7 +433,7 @@ module Rbac
       ids_clause = ["#{klass.table_name}.id IN (?)", target_ids] if klass.respond_to?(:table_name)
     end
 
-    user_filters['ids_via_descendants'] = ids_via_descendants(rbac_class(klass), options.delete(:match_via_descendants), :userid => userid, :current_group_id => miq_group_id)
+    user_filters['ids_via_descendants'] = ids_via_descendants(rbac_class(klass), options.delete(:match_via_descendants), :user => user, :miq_group => miq_group)
 
     exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) unless search_filter.nil? || klass.respond_to?(:instances_are_derived?)
     conditions, include_for_find = MiqExpression.merge_where_clauses_and_includes([conditions, sub_filter, where_clause, exp_sql, ids_clause], [include_for_find, exp_includes])

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -23,7 +23,7 @@ describe BlacklistedEvent do
     end
 
     it 'does not re-seed existing event filters' do
-      User.stub(:current_userid).and_return('admin')
+      User.current_user = FactoryGirl.create(:user)
       filter = FactoryGirl.create(:blacklisted_event,
                                   :event_name     => 'AlarmActionTriggeredEvent',
                                   :provider_model => 'ManageIQ::Providers::Vmware::InfraManager'
@@ -36,7 +36,7 @@ describe BlacklistedEvent do
   end
 
   it '#enabled=' do
-    User.stub(:current_userid).and_return('test_user')
+    User.current_user = FactoryGirl.create(:user)
     f = FactoryGirl.create(:blacklisted_event, :event_name => 'event_1')
     expect(f.enabled).to be_true
 


### PR DESCRIPTION
Going through code and transitioning `User.current_userid` to `User.current_user`.

Found a bug related to how we are looking up `miq_group` - it was passing it using `current_group_id` instead of `miq_group_id`. So in some cases, it will not pass the right group for dependent objects. Not sure if this would have effected any customers. Verified with @lfu and @gmcculloug 

In fixing both of those, it turned out to be easier to just allow a rbac search to pass in the user object. So this is an enhancement.

I would like to start passing in user objects instead of looking them up again in a few places in our code. This will ensure that the tenant doesn't change for rest api, automate, and self service.

---

1. rbac was no properly passing `miq_group_id` to `ids_via_descendants`. Since we are defaulting the group, this did not cause a problem, but causes a problem when the user passed in has a different `current_group` than the database.
2. Instead of fetching `User.current_userid` and looking up the user again (with possibly a different `current_group`) it uses `User.current_user`.
3. `Rbac.search` accepts a user and group object instead of looking it up again.
4. Use `User.current_user` over `User.stub` for tests

/cc @gtanzillo @gmcculloug @matthewd please let me know what you think.