### PR TITLE
Add zanata.xml to our project

### DIFF
--- a/config/locales/zanata.xml
+++ b/config/locales/zanata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config/">
+  <url>https://translate.zanata.org/zanata/</url>
+  <project>manageiq</project>
+  <project-version>master</project-version>
+  <project-type>gettext</project-type>
+  <locales>
+    <locale>ja</locale>
+    <locale>nl</locale>
+  </locales>
+  <rules>
+    <rule pattern="*/*.pot">{locale}/{filename}.po</rule>
+  </rules>
+</config>


### PR DESCRIPTION
This is a project configuration file, which is used by zanata-cli
tool to upload / download translations to / from translate.zanata.org