### PR TITLE
No longer warn admins about missing VMs

### DIFF
--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -74,10 +74,7 @@ class UserValidationService
   def validate_user_handle_no_records
     ValidateResult.new(:pass, nil, url_for(
                                      :controller    => "ems_infra",
-                                     :action        => 'show_list',
-                                     :flash_warning => true,
-                                     :flash_msg     => _("Non-admin users can not access the system until at least 1 VM/Instance has been discovered"))
-                      )
+                                     :action        => 'show_list'))
   end
 
   def validate_user_handle_not_ready(db_user)

--- a/config/locales/en/manageiq.po
+++ b/config/locales/en/manageiq.po
@@ -8562,11 +8562,6 @@ msgstr ""
 msgid "Non-VM Files"
 msgstr ""
 
-msgid ""
-"Non-admin users can not access the system until at least 1 VM/Instance has bee"
-"n discovered"
-msgstr ""
-
 msgid "None"
 msgstr ""
 

--- a/config/locales/ja/manageiq.po
+++ b/config/locales/ja/manageiq.po
@@ -8792,11 +8792,6 @@ msgstr "ノード"
 msgid "Non-VM Files"
 msgstr "VM 以外のファイル"
 
-msgid ""
-"Non-admin users can not access the system until at least 1 VM/Instance has bee"
-"n discovered"
-msgstr "管理者以外のユーザーは 1 つ以上の  VM/インスタンスが検出されるまでシステムにアクセスできません"
-
 msgid "None"
 msgstr "なし"
 

--- a/config/locales/manageiq.pot
+++ b/config/locales/manageiq.pot
@@ -11317,10 +11317,6 @@ msgstr ""
 msgid "Non-VM Files"
 msgstr ""
 
-#: ../../app/services/user_validation_service.rb:69
-msgid "Non-admin users can not access the system until at least 1 VM/Instance has been discovered"
-msgstr ""
-
 #: ../../app/views/ops/_rbac_role_details.html.haml:61 ../../app/views/ops/_rbac_role_details.html.haml:64 ../../app/views/miq_request/_prov_vm_grid.html.haml:30 ../../app/views/miq_request/_prov_host_grid.html.haml:32 ../../app/views/miq_request/_prov_vc_grid.html.haml:26 ../../app/views/miq_request/_prov_pxe_img_grid.html.haml:25 ../../app/views/miq_request/_prov_ds_grid.html.haml:28 ../../app/views/miq_request/_prov_field.html.haml:258 ../../app/views/miq_request/_prov_field.html.haml:308 ../../app/views/miq_request/_prov_field.html.haml:431 ../../app/views/miq_request/_prov_field.html.haml:524 ../../app/views/miq_request/_prov_iso_img_grid.html.haml:25 ../../app/views/miq_request/_prov_template_grid.html.haml:25 ../../app/views/miq_request/_prov_windows_image_grid.html.haml:25 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:127 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:161 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:295 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:439 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/layouts/_edit_to_email.html.haml:22 ../../app/views/report/_form_columns_trend.html.haml:42 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_formatting.html.haml:88 ../../app/views/report/_form_sort.html.haml:119 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:6 ../../app/views/shared/views/_retire.html.haml:51 ../../app/views/catalog/_form_resources_info.html.haml:110 ../../app/views/miq_policy/_alert_snmp.html.haml:129 ../../app/views/miq_policy/_action_options.html.haml:475 ../../app/views/miq_policy/_action_options.html.haml:487 ../../app/views/miq_capacity/_utilization_options.html.haml:46
 msgid "None"
 msgstr ""

--- a/config/locales/nl/manageiq.po
+++ b/config/locales/nl/manageiq.po
@@ -8583,11 +8583,6 @@ msgstr ""
 msgid "Non-VM Files"
 msgstr ""
 
-msgid ""
-"Non-admin users can not access the system until at least 1 VM/Instance has bee"
-"n discovered"
-msgstr ""
-
 msgid "None"
 msgstr ""
 

--- a/config/locales/zh_CN/manageiq.po
+++ b/config/locales/zh_CN/manageiq.po
@@ -8526,11 +8526,6 @@ msgstr "节点"
 msgid "Non-VM Files"
 msgstr "非虚拟机文件"
 
-msgid ""
-"Non-admin users can not access the system until at least 1 VM/Instance has "
-"been discovered"
-msgstr "非管理用户不能访问系统，直到发现至少一个虚拟机实例。"
-
 msgid "None"
 msgstr "无"
 


### PR DESCRIPTION
Removes warning to admins that a VM is missing.
This warning is no longer valid.

Fixes #4667 

/cc @abonas @gmcculloug thanks for bringing to my attention