### PR TITLE
[api] Validate generic GETs

### DIFF
--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -5,6 +5,7 @@ class ApiController
     #
 
     def show_generic(type)
+      validate_api_action
       if @req[:subcollection]
         render_collection_type @req[:subcollection].to_sym, @req[:s_id], true
       else

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -178,8 +178,12 @@ class ApiController
     end
 
     #
-    # For Delete, Patch and Put, we need to make sure we're entitled for them.
+    # For Get, Delete, Patch and Put, we need to make sure we're entitled for them.
     #
+    def validate_get_method
+      validate_method_action(:get, "show")
+    end
+
     def validate_patch_method
       validate_method_action(:post, "edit")
     end
@@ -197,6 +201,7 @@ class ApiController
       cspec = collection_config[cname.to_sym]
       target = request_type_target.last
       aspec = cspec["#{target}_actions".to_sym]
+      return unless aspec
       action_hash = fetch_action_hash(aspec, method_name, action_name)
       raise BadRequestError, "Disabled action #{action_name}" if action_hash[:disabled]
       unless api_user_role_allows?(action_hash[:identifier])
@@ -285,7 +290,7 @@ class ApiController
     end
 
     def fetch_action_hash(aspec, method_name, action_name)
-      Array(aspec[method_name]).detect { |h| h[:name] == action_name }
+      Array(aspec[method_name]).detect { |h| h[:name] == action_name } || {}
     end
   end
 end

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -201,7 +201,7 @@ class ApiController
       cspec = collection_config[cname.to_sym]
       target = request_type_target.last
       aspec = cspec["#{target}_actions".to_sym]
-      return unless aspec
+      return if method_name == :get && aspec.nil?
       action_hash = fetch_action_hash(aspec, method_name, action_name)
       raise BadRequestError, "Disabled action #{action_name}" if action_hash[:disabled]
       unless api_user_role_allows?(action_hash[:identifier])


### PR DESCRIPTION
This allows RBAC identifiers to be applied to GET actions. This is
needed for the Tenants API where show/list actions have RBAC identifiers
that need to be honored.

For collections that _don't_ explicitly define a GET action in
`config/api.yml` a work-around has been made to just return `nil` in
validation if it can't find an `aspec` value, and to return an empty
hash if no action hash can be found. An alternative may be to update the
`api.yml` file to explicitly give each collection that allows GETs a
show action (with no identifier) so validation will not break for them.