### PR TITLE
Fixed to return correct partial name

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -483,7 +483,8 @@ module ApplicationController::MiqRequestMethods
   end
 
   def dialog_partial_for_workflow
-    case (@edit || @options).try(:[], :wf)
+    workflow = @edit.try(:[], :wf) && !@edit[:stamp_typ] ? @edit[:wf] : @options[:wf]
+    case workflow
     when MiqProvisionVirtWorkflow                    then "shared/views/prov_dialog"
     when ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow then "prov_configured_system_foreman_dialog"
     when MiqHostProvisionWorkflow                    then "prov_host_dialog"

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require "support/controller_spec_helper"
+
+describe MiqRequestController do
+  describe "#dialog_partial_for_workflow" do
+    before do
+      @wf = FactoryGirl.create(:miq_provision_virt_workflow)
+    end
+
+    it "calculates partial using wf from @edit hash" do
+      controller.instance_variable_set(:@edit, :wf => @wf)
+      partial = controller.send(:dialog_partial_for_workflow)
+      partial.should eq('shared/views/prov_dialog')
+    end
+
+    it "calculates partial using wf from @options hash" do
+      controller.instance_variable_set(:@options, :wf => @wf)
+      partial = controller.send(:dialog_partial_for_workflow)
+      partial.should eq('shared/views/prov_dialog')
+    end
+
+    it "calculates partial using wf from @options hash when user is on approve/deny form screen" do
+      controller.instance_variable_set(:@edit, :stamp_typ => 'a')
+      controller.instance_variable_set(:@options, :wf => @wf)
+      partial = controller.send(:dialog_partial_for_workflow)
+      partial.should eq('shared/views/prov_dialog')
+    end
+
+    it "calculates partial using wf from @edit hash when both @edit & @options are present" do
+      controller.instance_variable_set(:@edit, :wf => FactoryGirl.create(:miq_provision_configured_system_foreman_workflow))
+      controller.instance_variable_set(:@options, :wf => @wf)
+      partial = controller.send(:dialog_partial_for_workflow)
+      partial.should eq('prov_configured_system_foreman_dialog')
+    end
+  end
+end


### PR DESCRIPTION
Existing code was returning nil as partial name when changing tabs on Provisioning Approve/Deny screens.
Added spec tests to verify the fix

https://bugzilla.redhat.com/show_bug.cgi?id=1269999
Fixes #4631 

@dclarizio please review/test