### PR TITLE
Tenant miq prov request

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -874,9 +874,8 @@ class MiqAction < ActiveRecord::Base
   def action_custom_automation(action, rec, inputs)
     ae_hash = action.options[:ae_hash] || {}
     automate_attrs = ae_hash.reject { |key, _value| MiqAeEngine::DEFAULT_ATTRIBUTES.include?(key) }
-    automate_attrs[MiqAeEngine.create_automation_attribute_key(inputs[:policy])]    = MiqAeEngine.create_automation_attribute_value(inputs[:policy]) unless inputs[:policy].nil?
-    automate_attrs[MiqAeEngine.create_automation_attribute_key(inputs[:ems_event])] = MiqAeEngine.create_automation_attribute_value(inputs[:ems_event]) unless inputs[:ems_event].nil?
     automate_attrs[:request] = action.options[:ae_request]
+    MiqAeEngine.set_automation_attributes_from_objects([inputs[:policy], inputs[:ems_event]], automate_attrs)
 
     args = {}
     args[:object_type]      = rec.class.base_class.name

--- a/app/models/miq_provision/automate.rb
+++ b/app/models/miq_provision/automate.rb
@@ -9,10 +9,11 @@ module MiqProvision::Automate
         return nil
       end
 
-      attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_domains'}
-      attrs[MiqAeEngine.create_automation_attribute_key(user)] = MiqAeEngine.create_automation_attribute_value(user) unless user.nil?
+      attrs = MiqAeEngine.set_automation_attributes_from_objects(
+        [user], 'request' => 'UI_PROVISION_INFO', 'message' => 'get_domains')
 
       ws = MiqAeEngine.resolve_automation_object("REQUEST", user, attrs)
+
       if ws.root.nil?
         _log.warn "- Automate Failed (workspace empty)"
         return nil
@@ -33,11 +34,7 @@ module MiqProvision::Automate
   end
 
   def get_placement_via_automate
-    attrs = {
-      'request' => 'UI_PROVISION_INFO',
-      'message' => 'get_placement'
-    }
-    attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
+    attrs = automate_attributes('get_placement')
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
 
@@ -49,22 +46,14 @@ module MiqProvision::Automate
   end
 
   def get_most_suitable_availability_zone
-    attrs = {
-      'request' => 'UI_PROVISION_INFO',
-      'message' => 'get_availability_zone'
-    }
-    attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
+    attrs = automate_attributes('get_availability_zone')
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["availability_zone"])
   end
 
   def get_most_suitable_host_and_storage
-    attrs = {
-      'request' => 'UI_PROVISION_INFO',
-      'message' => 'get_host_and_storage'
-    }
-    attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
+    attrs = automate_attributes('get_host_and_storage')
 
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
@@ -74,22 +63,14 @@ module MiqProvision::Automate
   end
 
   def get_most_suitable_cluster
-    attrs = {
-      'request' => 'UI_PROVISION_INFO',
-      'message' => 'get_cluster'
-    }
-    attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
+    attrs = automate_attributes('get_cluster')
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["cluster"])
   end
 
   def get_most_suitable_host
-    attrs = {
-      'request' => 'UI_PROVISION_INFO',
-      'message' => 'get_host'
-    }
-    attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
+    attrs = automate_attributes('get_host')
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)
     reload
     MiqAeMethodService::MiqAeServiceConverter.svc2obj(ws.root["host"])
@@ -128,11 +109,7 @@ module MiqProvision::Automate
 
     _log.info "<< vlan_name=<#{vlan_name}> vlan_id=#{vlan_id} vc_id=<#{vc_id}> user=<#{get_user}>"
 
-    attrs = {
-      'request' => 'UI_PROVISION_INFO',
-      'message' => 'get_networks'
-    }
-    attrs[MiqAeEngine.create_automation_attribute_key(get_user)] = MiqAeEngine.create_automation_attribute_value(get_user) unless get_user.nil?
+    attrs = automate_attributes('get_networks')
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs)
 
     if ws.root.nil?
@@ -206,5 +183,10 @@ module MiqProvision::Automate
     end
 
     true
+  end
+
+  def automate_attributes(message, objects = [get_user])
+    MiqAeEngine.set_automation_attributes_from_objects(
+      objects, 'request' => 'UI_PROVISION_INFO', 'message' => message)
   end
 end

--- a/app/models/miq_provision/automate.rb
+++ b/app/models/miq_provision/automate.rb
@@ -2,7 +2,7 @@ module MiqProvision::Automate
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def get_domain_details(domain, with_password = false, user = nil)
+    def get_domain_details(domain, with_password, user)
       _log.info "<< domain=<#{domain}> with_password=#{with_password} user=<#{user}>"
       if domain.nil?
         _log.error "Domain Not specified"

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -12,8 +12,9 @@ module MiqProvision::Naming
       if NAME_VIA_AUTOMATE == true
         prov_obj.save
         attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'}
-        attrs[MiqAeEngine.create_automation_attribute_key(prov_obj.get_user)] = MiqAeEngine.create_automation_attribute_value(prov_obj.get_user) unless prov_obj.get_user.nil?
+        MiqAeEngine.set_automation_attributes_from_objects([prov_obj.get_user], attrs)
         ws = MiqAeEngine.resolve_automation_object("REQUEST", prov_obj.get_user, attrs, :vmdb_object => prov_obj)
+
         unresolved_vm_name = ws.root("vmname")
         prov_obj.reload
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -265,6 +265,7 @@ module MiqAeEngine
       value = create_automation_attribute_value(object)
       attrs_hash[key] = value
     end
+    attrs_hash
   end
 
   def self.create_automation_object(name, attrs, options = {})

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
@@ -37,7 +37,7 @@ module MiqAeMethodService
     end
 
     def get_domain_details
-      ar_method { MiqProvision.get_domain_details(@object.get_domain) }
+      ar_method { MiqProvision.get_domain_details(@object.get_domain, false, @object.get_user) }
     end
 
     def set_folder(folder_path)

--- a/spec/models/miq_provision/automate_spec.rb
+++ b/spec/models/miq_provision/automate_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe MiqProvision do
+  context "#get_domain_details" do
+    let(:password) { "secret sauce" }
+    let(:domain) { "domain1" }
+    let(:enc_password) { MiqAePassword.encrypt(password) }
+    let(:t1) { u1.current_tenant }
+    let(:u1) { FactoryGirl.create(:user_with_group) }
+    let(:options) { {'domains' => [{:name => domain, :bind_password => enc_password}]} }
+    let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspace", :root => options) }
+    let(:prov) { FactoryGirl.build(:miq_provision, :tenant => t1) }
+
+    def stub_method
+      MiqAeEngine.should_receive(:resolve_automation_object).with do |uri, _, _, _|
+        uri.should eq('REQUEST')
+      end.and_return(workspace)
+    end
+
+    context "with password" do
+      it "class method" do
+        stub_method
+        details = MiqProvision.get_domain_details(domain, true, u1)
+        expect(details[:name]).to eq(domain)
+        expect(MiqAePassword.decrypt(details[:bind_password])).to eq(password)
+      end
+    end
+
+    context "without password" do
+      it "class method" do
+        stub_method
+        details = MiqProvision.get_domain_details(domain, false, u1)
+        expect(details[:name]).to eq(domain)
+        expect(details[:bind_password]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
simplify calling automate from provisioning.

This is part of the process of reducing the surface area of us calling into automate. So when we add tenant and group id into there, we minimize changes.

/cc @mkanoor 