### PR TITLE
[api] Enhance custom_actions to return additional details about custom buttons

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -39,6 +39,18 @@ class CustomButton < ActiveRecord::Base
     where(:applies_to_class => applies_to_class, :applies_to_id => applies_to_id)
   end
 
+  def expanded_serializable_hash
+    button_hash = serializable_hash
+    if resource_action
+      resource_action_hash = resource_action.serializable_hash
+      if resource_action.dialog
+        resource_action_hash.merge!(:dialog => DialogSerializer.new.serialize([resource_action.dialog]).first)
+      end
+      button_hash.merge!(:resource_action => resource_action_hash)
+    end
+    button_hash
+  end
+
   def applies_to
     klass = applies_to_class.constantize
     applies_to_id.nil? ? klass : klass.find_by_id(applies_to_id)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -35,8 +35,10 @@ class ServiceTemplate < ActiveRecord::Base
 
   def custom_actions
     {
-      :buttons       => custom_buttons,
-      :button_groups => custom_button_sets.collect { |s| s.serializable_hash.merge(:buttons => s.children) }
+      :buttons       => custom_buttons.collect(&:expanded_serializable_hash),
+      :button_groups => custom_button_sets.collect do |button_set|
+        button_set.serializable_hash.merge(:buttons => button_set.children.collect(&:expanded_serializable_hash))
+      end
     }
   end
 

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -256,7 +256,11 @@ module ApiSpecHelper
   end
 
   def expect_result_to_have_keys(keys)
-    fetch_value(keys).each { |key| expect(@result).to have_key(key) }
+    expect_hash_to_have_keys(@result, keys)
+  end
+
+  def expect_hash_to_have_keys(hash, keys)
+    fetch_value(keys).each { |key| expect(hash).to have_key(key) }
   end
 
   def expect_result_to_have_only_keys(keys)


### PR DESCRIPTION

- For the custom_actions virtual attribute we needed to return additional details about the buttons, including any resource_action and related dialog.
- Added specs

https://trello.com/c/Kk6yx4yo