### PR TITLE
Modify maximum allowed tag length to 50 characters

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -17,7 +17,7 @@ class Classification < ActiveRecord::Base
       c.class.in_my_region.exists?(cond)
     }
   validates_presence_of :name, :description
-  validates_length_of :name, :maximum => 30, :message => "must not exceed 30 characters"
+  validates_length_of :name, :maximum => 50, :message => "must not exceed 50 characters"
   validates_length_of :description, :maximum => 255, :message => "must not exceed 255 characters"
   validates_inclusion_of :syntax,
     :in => %w{ string integer boolean },

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -151,7 +151,7 @@ describe Classification do
       ['<My_Name>',
        'My Name',
        'My_Name_is...',
-       '123456789_123456789_123456789_1'
+       '123456789_123456789_123456789_123456789_123456789_1'
       ].each do |name|
         cat = Classification.new(:name => name, :parent_id => 0)
 


### PR DESCRIPTION
Sometimes it becomes necessary to have tags with larger names for proper identification of objects.
Example, A tag that contains names of the Openstack Provider and OpenStack Tenant . Currently
the maximum allowed character length for tag is 30, This commit changes it to 50 characters.

Reference : http://talk.manageiq.org/t/cant-create-a-tag-with-more-than-30-characters/963

Signed-off-by: Prasad Mukhedkar <eprasad96@gmail.com>