### PR TITLE
Calculate quota usage for a tenant

### DIFF
--- a/app/models/mixins/active_vm_aggregation_mixin.rb
+++ b/app/models/mixins/active_vm_aggregation_mixin.rb
@@ -10,7 +10,7 @@ module ActiveVmAggregationMixin
   end
 
   def active_vms
-    vms.select(&:active?)
+    vms.includes(:ext_management_system => {}, :hardware => :disks).select(&:active?)
   end
 
   def active_vm_aggregation(field_name)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -6,6 +6,7 @@ class Tenant < ActiveRecord::Base
   DEFAULT_URL = nil
 
   include ReportableMixin
+  include ActiveVmAggregationMixin
   acts_as_miq_taggable
 
   default_value_for :name,        "My Company"
@@ -16,6 +17,8 @@ class Tenant < ActiveRecord::Base
   has_many :providers
   has_many :ext_management_systems
   has_many :vm_or_templates
+  has_many :vms
+  has_many :miq_templates
   has_many :service_template_catalogs
   has_many :service_templates
 
@@ -135,6 +138,12 @@ class Tenant < ActiveRecord::Base
     end
 
     get_quotas
+  end
+
+  def used_quotas
+    tenant_quotas.each_with_object({}) do |q, h|
+      h[q.name.to_sym] = q.quota_hash.merge(:value => q.used)
+    end.reverse_merge(TenantQuota.quota_definitions)
   end
 
   # @return [Boolean] Is this a default tenant?

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -46,6 +46,31 @@ class TenantQuota < ActiveRecord::Base
     end
   end
 
+  def used
+    method = "#{name.split("_").first}_used"
+    send(method)
+  end
+
+  def cpu_used
+    tenant.allocated_vcpu
+  end
+
+  def mem_used
+    tenant.allocated_memory
+  end
+
+  def storage_used
+    tenant.allocated_storage
+  end
+
+  def vms_used
+    tenant.active_vms.count
+  end
+
+  def templates_used
+    tenant.miq_templates.count
+  end
+
   # remove all quotas that are not listed in the keys to keep
   # e.g.: tenant.tenant_quotas.destroy_missing_quotas(include_keys)
   # NOTE: these are already local, no need to hit db to find them


### PR DESCRIPTION
Note: This does not include open provision requests.

https://trello.com/c/yjuAmgiK

Tenant#user_quotas will return the amount used of each quota in the same format as get_quotas. Also, it will only return values for the quotas that have been set on the tenant.

Here's a sample:

```
tenant.used_quotas
{
          :cpu_allocated => {
                 :unit => "fixnum",
               :format => "general_number_precision_0",
        :text_modifier => "Count",
          :description => "Allocated Virtual CPUs",
                :value => 1352,
           :warn_value => nil
    },
          :mem_allocated => {
                 :unit => "bytes",
               :format => "gigabytes_human",
        :text_modifier => "GB",
          :description => "Allocated Memory in GB",
                :value => 2694168,
           :warn_value => nil
    },
      :storage_allocated => {
                 :unit => "bytes",
               :format => "gigabytes_human",
        :text_modifier => "GB",
          :description => "Allocated Storage in GB",
                :value => 2270833779712,
           :warn_value => nil
    },
          :vms_allocated => {
                 :unit => "fixnum",
               :format => "general_number_precision_0",
        :text_modifier => "Count",
          :description => "Allocated Number of Virtual Machines",
                :value => 1254,
           :warn_value => nil
    },
    :templates_allocated => {
                 :unit => "fixnum",
               :format => "general_number_precision_0",
        :text_modifier => "Count",
          :description => "Allocated Number of Templates",
                :value => 11,
           :warn_value => nil
    }
}
```