### PR TITLE
dhtmlxgrid - clean up the use in gtl/list; replace the menu_form1 use

### DIFF
--- a/app/assets/javascripts/miq_dhtmlxgrid.js
+++ b/app/assets/javascripts/miq_dhtmlxgrid.js
@@ -184,18 +184,3 @@ function miqOrderService(id) {
   var url = '/' + ManageIQ.controller + '/x_button/' + id + '?pressed=svc_catalog_provision';
   miqJqueryRequest(url, {beforeSend: true, complete: true});
 }
-
-function miqDhtmlxgridSerialize(gridObj) {
-  var dhtmlxgridXml = "<?xml version='1.0'?>";
-  dhtmlxgridXml += "<rows>";
-  rowIds = gridObj.getAllRowIds().split(',');
-  for (i = 0; i < rowIds.length; i++) {
-    dhtmlxgridXml += "<row id=" + "'" + rowIds[i] + "'>";
-    for (j = 0; j < gridObj.getColumnCount(); j++) {
-      dhtmlxgridXml += "<cell>" + gridObj.cells(rowIds[i], j).getValue() + "</cell>";
-    }
-    dhtmlxgridXml += "</row>";
-  }
-  dhtmlxgridXml += "</rows>";
-  return dhtmlxgridXml;
-}

--- a/app/assets/javascripts/miq_dhtmlxgrid.js
+++ b/app/assets/javascripts/miq_dhtmlxgrid.js
@@ -1,23 +1,4 @@
-// ES6 endsWith polyfill
-if (!String.prototype.endsWith) {
-  String.prototype.endsWith = function(searchString, position) {
-      var subjectString = this.toString();
-      if (position === undefined || position > subjectString.length) {
-        position = subjectString.length;
-      }
-      position -= searchString.length;
-      var lastIndex = subjectString.indexOf(searchString, position);
-      return lastIndex !== -1 && lastIndex === position;
-  };
-}
-
 // Functions used by MIQ for the dhtmlxtree control
-
-// Function to pass ajax request to server, to remember tree states
-function miqTreeState(rowId, state) {
-  miqJqueryRequest('/vm/compare_set_state?rowId=' + rowId + '&state=' + state);
-  return true;
-}
 
 // Handle row click (ajax or normal html trans)
 function miqRowClick(row_id, cell_idx) {
@@ -26,32 +7,12 @@ function miqRowClick(row_id, cell_idx) {
     if (typeof row_url_ajax != "undefined" && row_url_ajax) {
       miqJqueryRequest(row_url + row_id, {beforeSend: true, complete: true});
     } else {
-      if (!row_url.endsWith("/") && !row_url.endsWith("=")) {
+      if (! _.endsWith(row_url, "/") && ! _.endsWith(row_url, "=")) {
         row_url = row_url + "/";
       }
       DoNav(row_url + row_id);
     }
   }
-}
-
-// Handle row click - used by AE
-function miqAeRowSelected(row_id, cell_idx) {
-  if (cell_idx) {
-    var selected_id = this.getSelectedRowId();
-    if (selected_id != null) {
-      if (selected_id.split("_")[0] == "Field") {
-        this.clearSelection();
-      } else {
-        miqDynatreeActivateNode('ae_tree', row_id);
-      }
-    }
-  }
-}
-
-// Method to hide flash_msg when folde ris being edited in menu editor
-function miqMenuRowSelected(row_id, cell_idx) {
-  $('#flash_msg_div_menu_list').hide();
-  folder_list_grid.editCell();
 }
 
 // Handle row click
@@ -127,33 +88,19 @@ function miqInitGrid(grid_name) {
   // Build the grid object, then point a local var at it
   var grid = new dhtmlXGridObject(grid_hash.g_id);
   ManageIQ.grids.grids[grid_name].obj = grid;
+
   var options = grid_hash.opts;
+
   // Start with a clear grid
   grid.clearAll(true);
 
   // Set paths and skin
   grid.setImagePath("/images/dhtmlxgrid/");
   grid.imgURL = "/images/dhtmlxgrid/";
-  grid.setSkin(options.skin);
+  grid.setSkin("style3");
 
-  if (options.alt_row) {
-    grid.enableAlterCss("miq_row0", "miq_row1");
-  } else if (options.alt_row_no_hover) {
-    grid.enableAlterCss("miq_row0 no-hover", "miq_row1 no-hover");
-  } else {
-    grid.enableAlterCss("", "");
-  }
-
-  // Set other grid options
-  if (options.row_edit) {
-    grid.setEditable(true);
-  }
-
-  if (options.multi_select) {
-    grid.enableMultiselect(true);
-  } else {
-    grid.enableMultiselect(false);
-  }
+  grid.enableAlterCss("miq_row0", "miq_row1");
+  grid.enableMultiselect(false);
 
   // Load the grid with XML data, if present
   if (grid_hash.xml) {
@@ -168,10 +115,6 @@ function miqInitGrid(grid_name) {
 
   grid.setSizes();
 
-  if (options.no_resize) {
-    grid.enableResizing("false");
-  }
-
   // Turn on the sort indicator if the options were passed
   if (options.sortcol) {
     if (options.sortdir) {
@@ -182,22 +125,8 @@ function miqInitGrid(grid_name) {
     grid.setSortImgState(true, options.sortcol, dir);
   }
 
-  if (!options.no_save_state) {
-    grid.attachEvent("onOpenEnd", miqTreeState);
-  }
-
-  if (options.grid_url) {
-    grid_url = options.grid_url;
-    grid.attachEvent("onCheck", miqOnAECheck);
-    grid.attachEvent("onRowSelect", miqAeRowSelected);
-  } else {
-    grid.attachEvent("onCheck", miqGridOnCheck);
-    grid.attachEvent("onBeforeSorting", miqGridSort);
-  }
-
-  if (options.menu_grid_edit) {
-    grid.attachEvent("onRowDblClicked", miqMenuRowSelected);
-  }
+  grid.attachEvent("onCheck", miqGridOnCheck);
+  grid.attachEvent("onBeforeSorting", miqGridSort);
 
   // checking existence on "_none_" at the end of string
   if (options.row_url && options.row_url.lastIndexOf("_none_") != (options.row_url.length - 6) ) {
@@ -206,28 +135,13 @@ function miqInitGrid(grid_name) {
     grid.attachEvent("onRowSelect", miqRowClick);
   }
 
-  if (options.save_col_widths) {
-    grid.attachEvent("onResize", miqResizeCol); // Method called when resize starts
-    grid.attachEvent("onResizeEnd", miqResizeColEnd); // Medhod called when resize ends
-    ManageIQ.grids.gridColumnWidths = grid.cellWidthPX.join(","); // Save the original column widths
-  }
+  grid.attachEvent("onResize", miqResizeCol); // Method called when resize starts
+  grid.attachEvent("onResizeEnd", miqResizeColEnd); // Medhod called when resize ends
+  ManageIQ.grids.gridColumnWidths = grid.cellWidthPX.join(","); // Save the original column widths
+
   grid.attachEvent("onXLE", function () {
     miqSparkle(false);
   });
-}
-
-// Handle checkbox
-function miqOnAECheck(row_id, cell_idx, state) {
-  var crows = this.getCheckedRows(0);
-  $("#miq_grid_checks").val(crows);
-  $("#miq_grid_checks2").val(crows);
-
-  var count = crows ? crows.split(",").length : 0;
-  if (miqDomElementExists('center_tb')) {
-    miqSetButtons(count, "center_tb");
-  } else {
-    miqSetButtons(count, "center_buttons_div");
-  }
 }
 
 // Handle sort

--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -446,7 +446,8 @@ function miqMenuChangeRow(action, elem) {
       // quick and dirty edit - FIXME use a $modal when converted to angular
       var text = $(elem).text().trim();
       text = prompt("New name?", text);
-      $(elem).text(text);
+      if (text) // ! cancel
+        $(elem).text(text);
       break;
 
     case "up":
@@ -465,9 +466,19 @@ function miqMenuChangeRow(action, elem) {
 
     case "add":
       var count = grid.find('.list-group-item').length;
-      elem = $('<ul>').addClass('list-group');
-      elem.id("folder" + count);
-      elem.append(grid);
+
+      elem = $('<li>').addClass('list-group-item');
+      elem.attr('id', "folder" + count);
+      elem.text("New Folder");
+      elem.on('click', function() {
+        return miqMenuChangeRow('activate', this);
+      });
+      elem.on('dblclick', function() {
+        return miqMenuChangeRow('edit', this);
+      });
+
+      grid.append(elem);
+
       miqMenuChangeRow('activate', elem);
 
       // just shows a flash message

--- a/app/assets/stylesheets/template.css.erb
+++ b/app/assets/stylesheets/template.css.erb
@@ -91,7 +91,7 @@ ul#searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px; bac
 
 /************ Hover Buttons ************/
 .rollover img, input.rollover { display:block;}
-.rollover img:hover, img.rollover:hover, input.rollover:hover { background:#e4e4e4;}
+.rollover img:hover, img.rollover:hover, input.rollover:hover, i.rollover:hover { background:#e4e4e4;}
 .dimmed { background:#f5f5f5; opacity:0.4; filter:alpha(opacity=40);filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);}
 
 img.small, input.small { float: left;margin: 0;padding: 0;width:24px;height:24px;border: 0;}

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -853,7 +853,7 @@ class ReportController < ApplicationController
       end
     elsif nodetype == "menu_default" || nodetype == "menu_reset"
       presenter[:update_partials][:main_div]   = r[:partial => partial]
-      presenter[:replace_partials][:menu_div1] = r[:partial => "menu_form1"]
+      presenter[:replace_partials][:menu_div1] = r[:partial => "menu_form1", :locals => {:folders => @grid_folders}]
       presenter[:set_visible_elements][:menu_div1]  = false
       presenter[:set_visible_elements][:menu_div2]  = false
       presenter[:set_visible_elements][:menu_div3]  = true
@@ -912,7 +912,7 @@ class ReportController < ApplicationController
       @sb[:tree_err] = false
     elsif nodetype == 'menu_discard_folders' || nodetype == 'menu_discard_reports'
       presenter[:replace_partials][:flash_msg_div_menu_list] = r[:partial => 'layouts/flash_msg', :locals => {:div_num => '_menu_list'}]
-      presenter[:replace_partials][:menu_div1]               = r[:partial => 'menu_form1', :locals => {:action_url => 'menu_update'}]
+      presenter[:replace_partials][:menu_div1]               = r[:partial => 'menu_form1', :locals => {:folders => @grid_folders}]
       presenter[:set_visible_elements][:menu_div1]  = false
       presenter[:set_visible_elements][:menu_div2]  = false
       presenter[:set_visible_elements][:menu_div3]  = true

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -829,8 +829,6 @@ class ReportController < ApplicationController
         presenter[:set_visible_elements][:menu_div2]  = false
         presenter[:set_visible_elements][:treeStatus] = true
         presenter[:set_visible_elements][:flash_msg_div_menu_list] = "hide"
-        # js_options[:set_folder_grid_contents] = true #?!?! FIXME: remove
-        presenter[:grid_name] = 'folder_list_grid' #
         presenter[:element_updates][:folder_top]      = {:title => img_title_top}
         presenter[:element_updates][:folder_up]       = {:title => img_title_up}
         presenter[:element_updates][:folder_down]     = {:title => img_title_down}

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -723,8 +723,7 @@ module ReportController::Menus
       end
     end
     @edit[:folders] = @folders.dup
-    @grid_folders = {:folders => menu_folders(@edit[:folders]),
-                     :header  => @selected[1]}
+    @grid_folders = menu_folders(@edit[:folders])
   end
 
   def menu_get_all

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -651,61 +651,48 @@ module ReportController::Menus
   end
 
   # Render the view data to xml for the grid view
-  def menu_to_xml(view, header)
-    xml = MiqXml.createDoc(nil)
-    # Create root element
-    root = xml.add_element("rows")
-    # Added header properties
-    head = root.add_element("head")
-    new_column = head.add_element("column", "width" => "200", "align" => "left", "sort" => "na")
-    new_column.add_attribute("type", 'edtxt')
-    new_column.text = header.gsub(/&/n, '&amp;') unless header.blank?
-    view.each_with_index do |row, _i|
-      if row      # don't add if row came in a nil
-        if @edit[:user_typ]
-          # if user is admin/super admin, no need to add special characters in id
-          new_row = root.add_element("row", "id" => "i_#{row.gsub(/&/n, '&amp;')}")
-          new_row.add_element("cell", "align" => "left").text = row  # Checkbox column unchecked
-        else
-          if @edit[:group_reports].empty?
-            # if group does not own any reports then add special characters in id, they cannot delete any folders.
-            new_row = root.add_element("row", {"id" => "__|i_#{row.gsub(/&/n, '&amp;')}"})
-            new_row.add_element("cell", "align" => "left").text = row  # Checkbox column unchecked
-          else
-            prefix = "|-|"
-            @edit[:group_reports].each do |rep|
-              # need to check if report is not owned by user add special character to the row id so it can be tracked in JS and folder cannnot be deleted in menu editor
-              nodes = rep.split('/')
-              val = session[:node_selected].split('__')[0]
-              if val == "b"
-                # if top node
-                if nodes[0] == row
-                  # if report belongs to group
-                  @row_id = "i_#{row.gsub(/&/n, '&amp;')}"
-                  # break
-                else
-                  # if report is owned by other group
-                  @row_id = "#{prefix}i_#{row.gsub(/&/n, '&amp;')}"
-                end
-              else
-                # if second level folder node
-                if nodes[1] == row
-                  # if report belongs to group
-                  @row_id = "i_#{row.gsub(/&/n, '&amp;')}"
-                  # break
-                else
-                  # if report is owned by other group
-                  @row_id = "#{prefix}i_#{row.gsub(/&/n, '&amp;')}"
-                end
-              end
+  def menu_folders(view, header)
+    view.compact.map do |row|
+      row_id = nil
+
+      if @edit[:user_typ]
+        # if user is admin/super admin, no need to add special characters in id
+        row_id = "i_#{row.gsub(/&/n, '&amp;')}"
+      elsif @edit[:group_reports].empty?
+        # if group does not own any reports then add special characters in id, they cannot delete any folders.
+        row_id = "__|i_#{row.gsub(/&/n, '&amp;')}"
+      else
+        prefix = "|-|"
+        @edit[:group_reports].each do |rep|
+          # need to check if report is not owned by user add special character to the row id so it can be tracked in JS and folder cannnot be deleted in menu editor
+          nodes = rep.split('/')
+          val = session[:node_selected].split('__')[0]
+          if val == "b"
+            # if top node
+            if nodes[0] == row
+              # if report belongs to group
+              row_id = "i_#{row.gsub(/&/n, '&amp;')}"
+            else
+              # if report is owned by other group
+              row_id = "#{prefix}i_#{row.gsub(/&/n, '&amp;')}"
             end
-            new_row = root.add_element("row", "id" => @row_id)
-            new_row.add_element("cell", "align" => "left").text = row  # Checkbox column unchecked
+          else
+            # if second level folder node
+            if nodes[1] == row
+              # if report belongs to group
+              row_id = "i_#{row.gsub(/&/n, '&amp;')}"
+              # break
+            else
+              # if report is owned by other group
+              row_id = "#{prefix}i_#{row.gsub(/&/n, '&amp;')}"
+            end
           end
         end
       end
+
+      {:id   => row_id,
+       :text => row}
     end
-    xml.to_s
   end
 
   def edit_folder
@@ -737,7 +724,7 @@ module ReportController::Menus
       end
     end
     @edit[:folders] = @folders.dup
-    @grid_xml = menu_to_xml(@edit[:folders], @selected[1])
+    @grid_folders = menu_folders(@edit[:folders], @selected[1])
   end
 
   def menu_get_all

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -64,7 +64,9 @@ module ReportController::Menus
 
     if params[:tree]
       @menu_lastaction = "commit"
-      rows = JSON.parse(params[:tree])
+      @sb[:tree_err] = false
+
+      rows = JSON.parse(params[:tree], :symbolize_names => true)
       rows.each do |row|
         if row[:text].nil?
           @sb[:tree_err] = true
@@ -73,7 +75,6 @@ module ReportController::Menus
           @sb[:tree_err] = true
           add_flash(_("%{field} '%{value}' is already in use") % {:field => "Folder name", :value => row[:text]}, :error)
         else
-          @sb[:tree_err] = false
           @edit[:tree_arr].push(row[:text])
           @edit[:tree_hash][row[:id].split('_')[1]] = row[:text]
         end

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -662,6 +662,8 @@ module ReportController::Menus
         row_id = "__|i_#{row.gsub(/&/n, '&amp;')}"
       else
         prefix = "|-|"
+
+        # FIXME: this is jast .last really, on purpose?
         @edit[:group_reports].each do |rep|
           # need to check if report is not owned by user add special character to the row id so it can be tracked in JS and folder cannnot be deleted in menu editor
           nodes = rep.split('/')

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -656,10 +656,10 @@ module ReportController::Menus
 
       if @edit[:user_typ]
         # if user is admin/super admin, no need to add special characters in id
-        row_id = "i_#{row.gsub(/&/n, '&amp;')}"
+        row_id = "i_#{row}"
       elsif @edit[:group_reports].empty?
         # if group does not own any reports then add special characters in id, they cannot delete any folders.
-        row_id = "__|i_#{row.gsub(/&/n, '&amp;')}"
+        row_id = "__|i_#{row}"
       else
         prefix = "|-|"
 
@@ -672,20 +672,20 @@ module ReportController::Menus
             # if top node
             if nodes[0] == row
               # if report belongs to group
-              row_id = "i_#{row.gsub(/&/n, '&amp;')}"
+              row_id = "i_#{row}"
             else
               # if report is owned by other group
-              row_id = "#{prefix}i_#{row.gsub(/&/n, '&amp;')}"
+              row_id = "#{prefix}i_#{row}"
             end
           else
             # if second level folder node
             if nodes[1] == row
               # if report belongs to group
-              row_id = "i_#{row.gsub(/&/n, '&amp;')}"
+              row_id = "i_#{row}"
               # break
             else
               # if report is owned by other group
-              row_id = "#{prefix}i_#{row.gsub(/&/n, '&amp;')}"
+              row_id = "#{prefix}i_#{row}"
             end
           end
         end

--- a/app/views/layouts/_dhtmlxgrid.html.haml
+++ b/app/views/layouts/_dhtmlxgrid.html.haml
@@ -1,18 +1,13 @@
 = render :partial => "layouts/dhtmlx_tags", :locals => {:control => "grid"}
 
 %input{:type  => 'hidden',
-       :name  => "miq_grid_checks#{options[:grid_num]}",
-       :id    => "miq_grid_checks#{options[:grid_num]}",
+       :name  => "miq_grid_checks",
+       :id    => "miq_grid_checks",
        :value => ''}
-
-- if options[:div_in_js]
-  %div{:id    => options[:grid_id],
-       :style => "width:#{options[:div_width]}; height:#{options[:div_height]}; cursor:#{options[:div_cursor]}; overflow:#{options[:div_overflow]}"}
 
 - grid_name = options[:grid_name]
 - grid_id   = options[:grid_id]
 - grid_xml  = options[:grid_xml]
-- options.delete(:grid_xml)
 
 - unless @parent.nil?
   - layout = @layout
@@ -34,11 +29,11 @@
 :javascript
   ManageIQ.grids.grids["#{j grid_name}"] = {
     g_id: "#{j grid_id}",
-    opts: #{raw options.to_json},
+    opts: #{raw js_options.to_json},
     xml:  "#{raw j(grid_xml)}",
     obj:  null
   };
 
-- if request.xml_http_request?
+- if options[:init_grid]
   :javascript
     miqInitGrid("#{j options[:grid_name]}");

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -1,37 +1,30 @@
 -# New code to use DHTMLXGRID below
 - if @grid_xml
   - url = @showlinks == false ? nil : view_to_url(view, @parent)
+  - grid_options = {:grid_id         => "list_grid",
+                    :grid_name       => "gtl_list_grid",
+                    :grid_xml        => @grid_xml,
+                    :action_url      => action_url,
+                    :init_grid       => request.xml_http_request?}
   - if @explorer
     #list_grid{:style => "cursor: hand;"}
     - ajax_url = !(%w(OntapStorageSystem OntapLogicalDisk OntapStorageVolume OntapFileShare SecurityGroup).include?(view.db) || (request.parameters[:controller] == "service" && view.db == "Vm"))
     -# don't need a row url to be AJAX when displaying a list of other CI's inside explorer
     = render(:partial => 'layouts/dhtmlxgrid',
-      :locals         => {:options => {:grid_id => "list_grid",
-        :grid_name                              => "gtl_list_grid",
-        :grid_xml                               => @grid_xml,
-        :row_url                                => url,
-        :row_url_ajax                           => ajax_url,
-        :action_url                             => action_url,
-        :save_col_widths                        => true,
-        :autosize                               => true,
-        :skin                                   => "style3",
-        :sortcol                                => @sortcol ? @sortcol + 2 : nil,
-        :sortdir                                => @sortdir ? @sortdir[0..2] : nil,
-        :alt_row                                => true}})
+      :locals => {:options    => grid_options,
+                  :js_options => {:autosize        => true,
+                                  :sortcol         => @sortcol ? @sortcol + 2 : nil,
+                                  :sortdir         => @sortdir ? @sortdir[0..2] : nil,
+                                  :row_url         => url,
+                                  :row_url_ajax    => ajax_url}})
   - else
     -# substracting leftcol 219 from @winW to calculate width of div
     #list_grid{:style => "width: #{@winW - 219}; height: #{center_div_height}px; cursor: hand; overflow-x: auto; overflow-y: auto;"}
     = render(:partial => 'layouts/dhtmlxgrid',
-      :locals  => {:options => {:grid_id => "list_grid",
-        :grid_name                       => "gtl_list_grid",
-        :grid_xml                        => @grid_xml,
-        :row_url                         => url,
-        :action_url                      => action_url,
-        :save_col_widths                 => true,
-        :skin                            => "style3",
-        :sortcol                         => @sortcol ? @sortcol + 2 : nil,
-        :sortdir                         => @sortdir ? @sortdir[0..2] : nil,
-        :alt_row                         => true}})
+      :locals  => {:options    => grid_options,
+                   :js_options => {:sortcol         => @sortcol ? @sortcol + 2 : nil,
+                                   :sortdir         => @sortdir ? @sortdir[0..2] : nil,
+                                   :row_url         => url}})
 - else
   %table.table.datatable.table-striped.table-bordered.table-hover.table-selectable
     %thead

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -11,25 +11,34 @@
               #folder_grid
                 = params[:grid].to_json
 
-            %td{:width => "20", :valign => "middle"}
-              - t = _("Move selected folder top")
-              = image_tag('/images/toolbars/top.png', :border => "0", :class => "rollover small", :alt => t, :title => t,
-                :onclick => "return miqMenuChangeRow('folder_list_grid', 'top')", :id => 'folder_top')
-              - t = _("Move selected folder up")
-              = image_tag('/images/toolbars/up.png', :border => "0", :class => "rollover small", :alt => t, :title => t,
-                :onclick => "return miqMenuChangeRow('folder_list_grid', 'up')", :id => 'folder_up')
-              - t = _("Move selected folder down")
-              = image_tag('/images/toolbars/down.png', :border => "0", :class => "rollover small", :alt => t, :title => t,
-                :onclick => "return miqMenuChangeRow('folder_list_grid', 'down')", :id => 'folder_down')
-              - t = _("Move selected folder to bottom")
-              = image_tag('/images/toolbars/bottom.png', :border => "0", :class => "rollover small", :alt => t, :title => t,
-                :onclick => "return miqMenuChangeRow('folder_list_grid', 'bottom')", :id => 'folder_bottom')
-              - t = _("Delete selected folder and its contents")
-              = image_tag('/images/toolbars/delete.png', :border => "0", :class => "rollover small", :alt => t, :title => t,
-                :onclick => "return miqMenuChangeRow('folder_list_grid', 'delete')", :id => 'folder_delete')
-              - t = _("Add subfolder to selected folder")
-              = image_tag('/images/toolbars/new.png', :border => "0", :class => "rollover small", :alt => t, :title => t,
-                :onclick => "return miqMenuChangeRow('folder_list_grid', 'add')", :id => 'folder_add')
+            %td{:width => "24", :valign => "middle"}
+              - buttons = [{:label => _("Move selected folder top"),
+                            :icon => 'fa fa-angle-double-up',
+                            :action => 'top',
+                            :id => 'folder_top'},
+                           {:label => _("Move selected folder up"),
+                            :icon => 'fa fa-angle-up',
+                            :action => 'up',
+                            :id => 'folder_up'},
+                           {:label => _("Move selected folder down"),
+                            :icon => 'fa fa-angle-down',
+                            :action => 'down',
+                            :id => 'folder_down'},
+                           {:label => _("Move selected folder to bottom"),
+                            :icon => 'fa fa-angle-double-down',
+                            :action => 'bottom',
+                            :id => 'folder_bottom'},
+                           {:label => _("Delete selected folder and its contents"),
+                            :icon => 'fa fa-times',
+                            :action => 'delete',
+                            :id => 'folder_delete'},
+                           {:label => _("Add subfolder to selected folder"),
+                            :icon => 'fa fa-plus',
+                            :action => 'add',
+                            :id => 'folder_add'}]
+              - buttons.each do |btn|
+                %i{:class => "rollover fa-2x #{h btn[:icon]}",
+                   :onclick => "return miqMenuChangeRow('folder_list_grid', '#{j btn[:action]}')"}
           %tr
             %td{:colspan => "2", :style => "float: right;"}
               - t = _('Commit expression element changes')

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -11,7 +11,9 @@
               #folder_grid
                 %ul.list-group
                   - folders.each do |folder|
-                    %li.list-group-item{:id => folder[:id], :onclick => "return miqMenuChangeRow('activate', this)", :ondblclick => "return miqMenuChangeRow('edit', this)"}
+                    %li.list-group-item{:id         => folder[:id],
+                                        :onclick    => "return miqMenuChangeRow('activate', this)",
+                                        :ondblclick => "return miqMenuChangeRow('edit', this)"}
                       = h folder[:text]
 
             %td{:width => "24", :valign => "middle"}

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -9,11 +9,8 @@
           %tr
             %td{:valign => "top"}
               #folder_grid
-                %h5
-                  = h folders[:header]
-
                 %ul.list-group
-                  - folders[:folders].each do |folder|
+                  - folders.each do |folder|
                     %li.list-group-item{:id => folder[:id], :onclick => "return miqMenuChangeRow('activate', this)", :ondblclick => "return miqMenuChangeRow('edit', this)"}
                       = h folder[:text]
 

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -9,7 +9,7 @@
           %tr
             %td{:valign => "top"}
               #folder_grid
-                = params[:grid].to_json
+                = raw @grid_xml
 
             %td{:width => "24", :valign => "middle"}
               - buttons = [{:label => _("Move selected folder top"),

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -1,6 +1,3 @@
-- unless @grid_xml.blank?
-  :javascript
-    grid_xml = "#{@grid_xml}"
 #menu_div1
   = form_tag(:action => 'menu_update', :id => "report_menu_form1") do
     %fieldset{:style => "width: 320px; height: 450px;"}
@@ -11,17 +8,9 @@
         %table{:class => "form", :cellspacing => "3"}
           %tr
             %td{:valign => "top"}
-              - @grid_xml = params[:grid] if params[:grid]
-              = render(:partial => 'layouts/dhtmlxgrid',
-                :locals         => {:options => {:grid_id => "folder_grid",
-                  :grid_name                              => "folder_list_grid",
-                  :menu_grid_edit                         => true,
-                  :row_edit                               => true,
-                  :autosize                               => true,
-                  :grid_xml                               => @grid_xml,
-                  :no_resize                              => true,
-                  :skin                                   => "menueditor",
-                  :div_in_js                              => true}})
+              #folder_grid
+                = params[:grid].to_json
+
             %td{:width => "20", :valign => "middle"}
               - t = _("Move selected folder top")
               = image_tag('/images/toolbars/top.png', :border => "0", :class => "rollover small", :alt => t, :title => t,

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -9,7 +9,7 @@
           %tr
             %td{:valign => "top"}
               #folder_grid
-                = raw @grid_xml
+                = raw folders.to_json
 
             %td{:width => "24", :valign => "middle"}
               - buttons = [{:label => _("Move selected folder top"),

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -5,11 +5,17 @@
         %span#menu1_legend
           = _('Manage Accordions')
       #folder_lists
-        %table{:class => "form", :cellspacing => "3"}
+        %table{:style => "width: 100%", :cellspacing => "3"}
           %tr
             %td{:valign => "top"}
               #folder_grid
-                = raw folders.to_json
+                %h5
+                  = h folders[:header]
+
+                %ul.list-group
+                  - folders[:folders].each do |folder|
+                    %li.list-group-item{:id => folder[:id], :onclick => "return miqMenuChangeRow('activate', this)", :ondblclick => "return miqMenuChangeRow('edit', this)"}
+                      = h folder[:text]
 
             %td{:width => "24", :valign => "middle"}
               - buttons = [{:label => _("Move selected folder top"),
@@ -38,7 +44,7 @@
                             :id => 'folder_add'}]
               - buttons.each do |btn|
                 %i{:class => "rollover fa-2x #{h btn[:icon]}",
-                   :onclick => "return miqMenuChangeRow('folder_list_grid', '#{j btn[:action]}')"}
+                   :onclick => "return miqMenuChangeRow('#{j btn[:action]}')"}
           %tr
             %td{:colspan => "2", :style => "float: right;"}
               - t = _('Commit expression element changes')
@@ -50,7 +56,7 @@
                 :id                    => "folder_commit",
                 "data-miq_sparkle_on"  => true,
                 "data-miq_sparkle_off" => true,
-                :onclick               => "return miqMenuChangeRow('folder_list_grid', 'serialize', '/report/menu_field_changed/')")
+                :onclick               => "return miqMenuChangeRow('serialize')")
               - t = _('Discard expression element changes')
               = link_to(image_tag('/images/toolbars/discard.png', :id => "folder_discard", :class => "rollover small", :alt => t),
                 {:action => 'discard_changes', :pressed => 'discard_folders', :title => t},

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -30,7 +30,7 @@
                 :tree_state                => true,
                 :multi_lines               => true})
           %td{:valign => "top"}
-            = render :partial => "report/menu_form1", :grid => params[:grid]
+            = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
             = render :partial => "report/menu_form2"
     - elsif @sb[:menu]
       = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}

--- a/spec/controllers/report_controller/menu_spec.rb
+++ b/spec/controllers/report_controller/menu_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+include UiConstants
+
+describe ReportController do
+  context "#edit_folder" do
+    before(:each) do
+      controller.instance_variable_set(:@grid_folders, nil)
+      session[:node_selected] = 'foo__bar'
+      controller.instance_variable_set(:@edit, {:new => [['bar', ['baz', 'quux']],  # match
+                                                         ['foo', ['frob']]],        # no match
+                                                :group_reports => []})
+    end
+
+    it "sets @folders to be of proper length" do
+      controller.send(:edit_folder)
+      expect(controller.instance_variable_get(:@folders).length).to eq(2)
+    end
+
+    it "sets @grid_folders" do
+      expect(controller).to receive(:menu_folders).and_return({})
+      controller.send(:edit_folder)
+      expect(controller.instance_variable_get(:@grid_folders)).to_not be_nil
+    end
+  end
+
+  context "#menu_folders" do
+    it "can handle nil" do
+      controller.instance_variable_set(:@edit, {:user_typ => true})
+      out = controller.send(:menu_folders, [nil, 'foo'])
+
+      expect(out.size).to eq(1)
+      expect(out.first[:text]).to eq('foo')
+    end
+
+    it "prepends i_ to id for admins" do
+      controller.instance_variable_set(:@edit, {:user_typ => true})
+      arr = %w(foo bar)
+      out = controller.send(:menu_folders, arr)
+
+      expect(out).to eq(arr.map do |s|
+        {:id => "i_#{s}", :text => s}
+      end)
+    end
+
+    it "prepends __|i_ when no reports" do
+      controller.instance_variable_set(:@edit, {:group_reports => []})
+      arr = %w(foo bar)
+      out = controller.send(:menu_folders, arr)
+
+      expect(out).to eq(arr.map do |s|
+        {:id => "__|i_#{s}", :text => s}
+      end)
+    end
+
+    it "handles reports for b__" do
+      session[:node_selected] = 'b__*'
+      controller.instance_variable_set(:@edit, {:group_reports => ['A/*']})
+      out = controller.send(:menu_folders, %w(A B))
+
+      expect(out).to eq([{:id => "i_A", :text => "A"},
+                         {:id => "|-|i_B", :text => "B"}])
+    end
+
+    it "handles reports for non-b__" do
+      session[:node_selected] = '*__*'
+      controller.instance_variable_set(:@edit, {:group_reports => ['*/A']})
+      out = controller.send(:menu_folders, %w(A B))
+
+      expect(out).to eq([{:id => "i_A", :text => "A"},
+                         {:id => "|-|i_B", :text => "B"}])
+    end
+
+  end
+end

--- a/spec/views/layouts/dhtmlxgrid.html.haml_spec.rb
+++ b/spec/views/layouts/dhtmlxgrid.html.haml_spec.rb
@@ -4,6 +4,7 @@ describe "layouts/_dhtmlxgrid.html.haml" do
   context "when showtype is 'performance'" do
     it "renders" do
       view.stub(:options).and_return({})
+      view.stub(:js_options).and_return({})
       record = EmsInfra.new(:id => 1)
       assign(:parent, record)
       render


### PR DESCRIPTION
This replaces the 1 non-gtl use of dhtmlxgrid with a simple list-group, replacing XML with JSON.
In *Dashboard / Reports > Edit Report Menus*:

Before:
![4782_pre](https://cloud.githubusercontent.com/assets/289743/10494799/f43b5c90-72a7-11e5-8bac-49bd3be17234.png)

After:
![4782_post](https://cloud.githubusercontent.com/assets/289743/10494802/f6e052fc-72a7-11e5-92e5-60fc3fe54686.png)

Replaced the icons with patterfly, the dhtmlxgrid items with a list-group. The double-click to edit feature now uses `prompt` which might be sub-optimal, I *could* rewrite to angular and use patterfly's `$modal` for that but I figured replacing dhtmlxgrid first has priority...

The communication back-and-forth generated XML on both JS and Ruby side and parsed on ruby side, this was replaced with a simple list of `{id, text}`. (And the ruby function is menu_folders, not menu_to_xml now.)


This also removes an ES6 endsWith shim, since it was only used once and we do have lodash's `_.endsWith`, removes support for no longer used options from `miqInitGrid`, removes a few unused functions from `miq_dhtmlxgrid.js`, replaces `miqDhtmlxgridSerialize` with a simple jQuery map through the list group elements, separates options for `_dhtmlxgrid.html.haml` into `options` and `js_options`, and generally cleans up dhtmlxgrid so it's clearer what to replace..