### PR TITLE
Support Azure orchestration reconfigure

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -10,9 +10,10 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
     raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
   end
 
-  def raw_update_stack(options)
+  def raw_update_stack(template, options)
+    update_options = {:template => template.content}.merge(options.except(:disable_rollback, :timeout))
     ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
-      service.stacks[name].update(options)
+      service.stacks[name].update(update_options)
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status.rb
@@ -14,4 +14,8 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status < ::
   def deleted?
     status.downcase == "delete_complete"
   end
+
+  def updated?
+    status.downcase == "update_complete"
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -12,11 +12,12 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ::Orche
     raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
   end
 
-  def raw_update_stack(options)
+  def raw_update_stack(template, options)
+    update_options = {:template => template.content}.merge(options.except(:disable_rollback, :timeout_mins))
     connection_options = {:service => "Orchestration"}
     connection_options.merge!(:tenant_name => cloud_tenant.name) if cloud_tenant
     ext_management_system.with_provider_connection(connection_options) do |service|
-      service.stacks.get(name, ems_ref).save(options)
+      service.stacks.get(name, ems_ref).save(update_options)
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status.rb
@@ -14,4 +14,8 @@ class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Status <
   def deleted?
     status.downcase == "delete_complete"
   end
+
+  def updated?
+    status.downcase == "update_complete"
+  end
 end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -59,12 +59,12 @@ class OrchestrationStack < ActiveRecord::Base
     raise NotImplementedError, "raw_create_stack must be implemented in a subclass"
   end
 
-  def raw_update_stack(_options = {})
+  def raw_update_stack(_template, _options = {})
     raise NotImplementedError, "raw_update_stack must be implemented in a subclass"
   end
 
-  def update_stack(options = {})
-    raw_update_stack(options)
+  def update_stack(template, options = {})
+    raw_update_stack(template, options)
   end
 
   def raw_delete_stack

--- a/app/models/orchestration_stack/status.rb
+++ b/app/models/orchestration_stack/status.rb
@@ -28,9 +28,13 @@ class OrchestrationStack
       false
     end
 
+    def updated?
+      false
+    end
+
     # in a non-transient state
     def completed?
-      succeeded? || failed? || rolled_back? || deleted? || canceled?
+      succeeded? || failed? || rolled_back? || deleted? || canceled? || updated?
     end
 
     def normalized_status
@@ -44,6 +48,8 @@ class OrchestrationStack
         ['delete_complete', reason || 'Stack was deleted']
       elsif canceled?
         ['create_canceled', reason || 'Stack creation was canceled']
+      elsif updated?
+        ['update_complete', reason || 'OK']
       else
         ['failed', reason || 'Stack creation failed']
       end

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -62,10 +62,7 @@ class ServiceOrchestration < Service
 
   def update_orchestration_stack
     # use orchestration_template from service_template, which may be different from existing orchestration_template
-    orchestration_stack.raw_update_stack(
-      :template   => service_template.orchestration_template.content,
-      :parameters => update_options[:parameters]
-    )
+    orchestration_stack.raw_update_stack(service_template.orchestration_template, update_options)
   end
 
   def orchestration_stack

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured.rb
@@ -21,14 +21,11 @@ def check_updated(service)
   # check whether the stack update has completed
   status, reason = service.orchestration_stack_status
   case status.downcase
-  when 'update_complete'
+  when 'update_complete', 'create_complete'
     $evm.root['ae_result'] = 'ok'
     # update the orchestration_template only upon completion
     service.orchestration_template = service.service_template.orchestration_template
-  when /rollback_complete$/
-    $evm.root['ae_result'] = 'error'
-    $evm.root['ae_reason'] = 'Stack update was rolled back'
-  when /failed$/
+  when 'rollback_complete', 'delete_complete', /failed$/, /canceled$/
     $evm.root['ae_result'] = 'error'
     $evm.root['ae_reason'] = reason
   else

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status_spec.rb
@@ -8,6 +8,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status d
     status.failed?.should      be_false
     status.deleted?.should     be_false
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == ['create_complete', '']
   end
 
@@ -18,6 +19,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status d
     status.failed?.should      be_false
     status.deleted?.should     be_false
     status.rolled_back?.should be_true
+    status.updated?.should     be_false
     status.normalized_status.should == ['rollback_complete', 'Stack was rolled back']
   end
 
@@ -28,6 +30,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status d
     status.failed?.should      be_false
     status.deleted?.should     be_true
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == ['delete_complete', 'Stack was deleted']
   end
 
@@ -38,7 +41,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status d
     status.failed?.should      be_true
     status.deleted?.should     be_false
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == ['failed', 'Stack creation failed']
+  end
+
+  it 'parses UPDATE_COMPLETE' do
+    status = described_class.new('UPDATE_COMPLETE', nil)
+    status.completed?.should   be_true
+    status.succeeded?.should   be_false
+    status.failed?.should      be_false
+    status.deleted?.should     be_false
+    status.rolled_back?.should be_false
+    status.updated?.should     be_true
+    status.normalized_status.should == ['update_complete', 'OK']
   end
 
   it 'parses transient status' do
@@ -48,6 +63,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status d
     status.failed?.should      be_false
     status.deleted?.should     be_false
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == %w(transient CREATING)
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
@@ -47,12 +47,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
     context "#update_stack" do
       it 'updates the stack' do
         expect(the_raw_stack).to receive(:update)
-        orchestration_stack.update_stack({})
+        orchestration_stack.update_stack(template, {})
       end
 
       it 'catches errors from provider' do
         expect(the_raw_stack).to receive(:update).and_throw('bad request')
-        expect { orchestration_stack.update_stack }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+        expect { orchestration_stack.update_stack(template, {}) }.to raise_error(MiqException::MiqOrchestrationUpdateError)
       end
     end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -35,12 +35,12 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
     context "#update_stack" do
       it 'updates the stack' do
         expect(orchestration_service).to receive(:create)
-        orchestration_stack.update_stack({})
+        orchestration_stack.update_stack(template, {})
       end
 
       it 'catches errors from provider' do
         expect(orchestration_service).to receive(:create).and_throw('bad request')
-        expect { orchestration_stack.update_stack }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+        expect { orchestration_stack.update_stack(template, {}) }.to raise_error(MiqException::MiqOrchestrationUpdateError)
       end
     end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status_spec.rb
@@ -8,6 +8,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Statu
     status.failed?.should      be_false
     status.deleted?.should     be_false
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == ['create_complete', '']
   end
 
@@ -18,6 +19,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Statu
     status.failed?.should      be_false
     status.deleted?.should     be_false
     status.rolled_back?.should be_true
+    status.updated?.should     be_false
     status.normalized_status.should == ['rollback_complete', 'Stack was rolled back']
   end
 
@@ -28,6 +30,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Statu
     status.failed?.should      be_false
     status.deleted?.should     be_true
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == ['delete_complete', 'Stack was deleted']
   end
 
@@ -38,7 +41,19 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Statu
     status.failed?.should      be_true
     status.deleted?.should     be_false
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == ['failed', 'Stack creation failed']
+  end
+
+  it 'parses UPDATE_COMPLETE' do
+    status = described_class.new('UPDATE_COMPLETE', nil)
+    status.completed?.should   be_true
+    status.succeeded?.should   be_false
+    status.failed?.should      be_false
+    status.deleted?.should     be_false
+    status.rolled_back?.should be_false
+    status.updated?.should     be_true
+    status.normalized_status.should == ['update_complete', 'OK']
   end
 
   it 'parses transient status' do
@@ -48,6 +63,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Statu
     status.failed?.should      be_false
     status.deleted?.should     be_false
     status.rolled_back?.should be_false
+    status.updated?.should     be_false
     status.normalized_status.should == %w(transient CREATING)
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
@@ -54,12 +54,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
     context "#update_stack" do
       it 'updates the stack' do
         expect(the_raw_stack).to receive(:save)
-        orchestration_stack.update_stack({})
+        orchestration_stack.update_stack(template, {})
       end
 
       it 'catches errors from provider' do
         expect(the_raw_stack).to receive(:save).and_throw('bad request')
-        expect { orchestration_stack.update_stack }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+        expect { orchestration_stack.update_stack(template, {}) }.to raise_error(MiqException::MiqOrchestrationUpdateError)
       end
     end
 

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -119,12 +119,12 @@ describe ServiceTemplate do
     end
 
     it 'updates a stack through cloud manager' do
-      OrchestrationStack.any_instance.stub(:raw_update_stack) do |opts|
+      OrchestrationStack.any_instance.stub(:raw_update_stack) do |new_template, opts|
         opts[:parameters].should include(
           'InstanceType'   => 'cg1.4xlarge',
           'DBRootPassword' => 'admin'
         )
-        opts[:template].should == template_by_setter.content
+        new_template.should == template_by_setter
       end
       reconfigurable_service.update_orchestration_stack
     end


### PR DESCRIPTION
1. Refactor `update_stack` method to accept template as an argument
This refactoring is needed because of the difference in each provider's API to update a stack, more specifically Azure requires to pass template as a Hash rather than a long string.

2. Add `update_complete` as a valid status. `check_reconfigured` will depend on `update_complete` for Amazon and OpenStack, and `created_complete` for Azure.