### PR TITLE
adds toasts to service list and service details states

### DIFF
--- a/spa_ui/self_service/client/app/components/edit-service-modal/edit-service-modal-service.factory.js
+++ b/spa_ui/self_service/client/app/components/edit-service-modal/edit-service-modal-service.factory.js
@@ -33,7 +33,7 @@
   }
 
   /** @ngInject */
-  function EditServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi) {
+  function EditServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, Notifications) {
     var vm = this;
 
     vm.service = serviceDetails;
@@ -57,10 +57,12 @@
 
       function saveSuccess() {
         $modalInstance.close();
+        Notifications.success(vm.service.name + ' was edited.');
         $state.go($state.current, {}, {reload: true});
       }
 
       function saveFailure() {
+        Notifications.error('There was an error editing this service.');
       }
     }
   }

--- a/spa_ui/self_service/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/spa_ui/self_service/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -33,7 +33,7 @@
   }
 
   /** @ngInject */
-  function RetireServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi) {
+  function RetireServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, Notifications) {
     var vm = this;
 
     vm.service = serviceDetails;
@@ -64,10 +64,13 @@
 
       function retireSuccess() {
         $modalInstance.close();
+        Notifications.success('Scheduling retirement for' + vm.service.name  + '.');
         $state.go($state.current, {}, {reload: true});
+        $state.go('services.list');
       }
 
       function retireFailure() {
+        Notifications.error('There was an error retiring this service.');
       }
     }
   }

--- a/spa_ui/self_service/client/app/states/services/details/details.html
+++ b/spa_ui/self_service/client/app/states/services/details/details.html
@@ -5,7 +5,9 @@
   <li class="active"> <strong>Service:</strong> {{ ::vm.service.name }}
   </li>
 </ol>
-  
+
+<pf-notification-list></pf-notification-list>
+
 <div class="panel panel-default ss-details-panel">
   <div class="panel-body">
     <section>

--- a/spa_ui/self_service/client/app/states/services/details/details.state.js
+++ b/spa_ui/self_service/client/app/states/services/details/details.state.js
@@ -45,7 +45,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, Notifications) {
     var vm = this;
 
     vm.title = 'Service Details';
@@ -67,10 +67,12 @@
       CollectionsApi.post('services', vm.service.id, {}, removeAction).then(removeSuccess, removeFailure);
 
       function removeSuccess() {
+        Notifications.success(vm.service.name + ' was removed.');
         $state.go('services.list');
       }
 
       function removeFailure(data) {
+        Notifications.error('There was an error removing this service.');
       }
     }
 
@@ -83,10 +85,12 @@
       CollectionsApi.post('services', vm.service.id, {}, data).then(retireSuccess, retireFailure);
 
       function retireSuccess() {
+        Notifications.success(vm.service.name + ' was retired.');
         $state.go('services.list');
       }
 
       function retireFailure() {
+        Notifications.error('There was an error retiring this service.');
       }
     }
 

--- a/spa_ui/self_service/client/app/states/services/list/list.html
+++ b/spa_ui/self_service/client/app/states/services/list/list.html
@@ -4,6 +4,8 @@
   </div>
 </div>
 
+<pf-notification-list></pf-notification-list>
+
 <div class="col-md-12 list-view-container">
   <div pf-data-list id="serviceList" config="vm.listConfig" items="vm.servicesList">
     <div class="row">


### PR DESCRIPTION

<img width="1920" alt="screen shot 2015-10-09 at 2 32 24 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402440/80c3aa50-6e93-11e5-9af3-ea02b1d48802.png">
<img width="1920" alt="screen shot 2015-10-09 at 2 32 25 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402442/80c7408e-6e93-11e5-9b53-3b2dad096149.png">
<img width="1920" alt="screen shot 2015-10-09 at 2 32 04 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402443/80c74a7a-6e93-11e5-84dd-28c153550317.png">
<img width="1920" alt="screen shot 2015-10-09 at 2 32 12 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402445/80c8a118-6e93-11e5-8c38-a6d57e1a1c74.png">
<img width="1920" alt="screen shot 2015-10-09 at 2 32 14 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402441/80c5acec-6e93-11e5-97a4-23b8130fcbf9.png">
<img width="1920" alt="screen shot 2015-10-09 at 2 32 05 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402444/80c846a0-6e93-11e5-98da-509a57b45023.png">
<img width="1920" alt="screen shot 2015-10-09 at 2 32 42 pm" src="https://cloud.githubusercontent.com/assets/6640236/10402446/80cd0172-6e93-11e5-9155-6eafe1f5e0dc.png">

proper functionality contingent on running the latest and greatest patternfly-angular, this commit employs the pfNotification service to add a basic toast (success and error) for all actions that can be performed to a service (retire, remove, edit) 

multiple screenshots attached to illustrate the presence of notifications across state changes (most toasts have a timeout, error toasts require dismissal)