### PR TITLE
set current user for api requests

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -30,6 +30,7 @@ class ApiController
           @auth_user     = @api_token_mgr.token_get_info(@module, @auth_token, :userid)
           @auth_user_obj = userid_to_userobj(@auth_user)
           @api_token_mgr.reset_token(@module, @auth_token)
+          User.current_user = @auth_user_obj
         end
       else
         authenticate_options = {
@@ -40,6 +41,7 @@ class ApiController
         if (user = authenticate_with_http_basic { |u, p| User.authenticate(u, p, request, authenticate_options) })
           @auth_user     = user.userid
           @auth_user_obj = userid_to_userobj(@auth_user)
+          User.current_user = @auth_user_obj
         else
           request_http_basic_authentication
         end


### PR DESCRIPTION
We are starting to rely more and more on `User.current_user` (and `User.current_tenant` - Set this for api.

/cc @abellotti this may be in the wrong place, let me know. Also, would like to set the correct `@auth_user_obj.current_group` for the user before this call. So `User.current_user` will have the correct user, group, and tenant.

/cc @gtanzillo fyi