### PR TITLE
api/service_template now uses create_request

### DIFF
--- a/app/controllers/api_controller/service_templates.rb
+++ b/app/controllers/api_controller/service_templates.rb
@@ -31,12 +31,7 @@ class ApiController
 
     def service_templates_order_resource(_object, _type, id = nil, data = nil)
       klass = collection_class(:service_templates)
-      st    = klass.find(id)
-
-      requester_id     = @auth_user
-      options          = {}
-      options[:dialog] = {}
-
+      options = {:dialog => {}, :src_id => id}
       unless data.nil?
         data.each do |key, value|
           dkey = "dialog_#{key}"
@@ -44,21 +39,7 @@ class ApiController
         end
       end
 
-      request_type  = st.request_type.to_s
-      request       = st.request_class.create!(:options      => options,
-                                               :userid       => requester_id,
-                                               :request_type => request_type,
-                                               :source_id    => st.id)
-      request.set_description
-      request.create_request
-
-      event_name    = "#{st.name.underscore}_created"
-      event_message = "Request by [#{requester_id}] for #{st.class.name}:#{st.id}"
-      AuditEvent.success(:event  => event_name,   :target_class => klass,
-                         :userid => requester_id, :message      => event_message)
-
-      request.call_automate_event_queue("request_created")
-      request
+      klass.new.request_class.make_request(nil, options, @auth_user_obj)
     end
 
     private

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -413,7 +413,12 @@ class MiqRequest < ActiveRecord::Base
   end
 
   def self.create_request(values, requester_id, auto_approve = false, request_type = request_types.first)
-    requester = requester_id.kind_of?(User) ? requester_id : User.find_by_userid(requester_id)
+    if requester_id.kind_of?(User)
+      requester = requester_id
+      requester_id = requester.userid
+    else
+      requester = User.find_by_userid(requester_id)
+    end
     values[:src_ids] = values[:src_ids].to_miq_a unless values[:src_ids].nil?
     request          = create(:options => values, :userid => requester_id, :request_type => request_type)
     request.save!  # Force validation errors to raise now


### PR DESCRIPTION
reduce duplication between api and Request.create_request

Did borrow one commit from #4824 but should go away in the merge.

/cc @gmcculloug @abellotti 