### PR TITLE
Simplify ReportableMixin#get_include_for_find

### DIFF
--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -98,11 +98,7 @@ module ReportableMixin
       if includes.kind_of?(Hash)
         includes.each_with_object({}) do |(k, v), result|
           v[:include] = v["include"] if v["include"]
-          if !v[:include]
-            result[k] = {}
-          else
-            result[k] = get_include_for_find(v[:include])
-          end
+          result[k] = get_include_for_find(v[:include] || {})
         end
       elsif includes.kind_of?(Array)
         includes.each_with_object({}) do |i, result|

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -100,15 +100,15 @@ module ReportableMixin
         includes.each do |k, v|
           v[:include] = v["include"] if v["include"]
           if v.empty? || !v[:include]
-            result.merge!(k => {})
+            result[k] = {}
           else
-            result.merge!(k => get_include_for_find(v[:include]))
+            result[k] = get_include_for_find(v[:include])
           end
         end
         result
       elsif includes.kind_of?(Array)
         result = {}
-        includes.each { |i| result.merge!(i => {}) }
+        includes.each { |i| result[i] = {} }
         result
       else
         includes

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -98,7 +98,7 @@ module ReportableMixin
       if includes.kind_of?(Hash)
         includes.each_with_object({}) do |(k, v), result|
           v[:include] = v["include"] if v["include"]
-          if v.empty? || !v[:include]
+          if !v[:include]
             result[k] = {}
           else
             result[k] = get_include_for_find(v[:include])

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -96,8 +96,7 @@ module ReportableMixin
     def get_include_for_find(report_option)
       includes = report_option
       if includes.kind_of?(Hash)
-        result = {}
-        includes.each do |k, v|
+        includes.each_with_object({}) do |(k, v), result|
           v[:include] = v["include"] if v["include"]
           if v.empty? || !v[:include]
             result[k] = {}
@@ -105,11 +104,10 @@ module ReportableMixin
             result[k] = get_include_for_find(v[:include])
           end
         end
-        result
       elsif includes.kind_of?(Array)
-        result = {}
-        includes.each { |i| result[i] = {} }
-        result
+        includes.each_with_object({}) do |i, result|
+          result[i] = {}
+        end
       else
         includes
       end

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -93,8 +93,7 @@ module ReportableMixin
 
     # private
 
-    def get_include_for_find(report_option)
-      includes = report_option
+    def get_include_for_find(includes)
       if includes.kind_of?(Hash)
         includes.each_with_object({}) do |(k, v), result|
           v[:include] = v["include"] if v["include"]

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -94,12 +94,13 @@ module ReportableMixin
     # private
 
     def get_include_for_find(includes)
-      if includes.kind_of?(Hash)
+      case includes
+      when Hash
         includes.each_with_object({}) do |(k, v), result|
           v[:include] = v["include"] if v["include"]
           result[k] = get_include_for_find(v[:include] || {})
         end
-      elsif includes.kind_of?(Array)
+      when Array
         includes.each_with_object({}) do |i, result|
           result[i] = {}
         end


### PR DESCRIPTION
It might be not easy to see how I came up with the refactoring from the diff; please see the individual commits for the full story.

As of the very first commit, the one which replaces `h.merge!(k => v)` with `h[k] = v`, here is a microbenchmark for those who curious:

```ruby
Benchmark.ips do |x|
  h = {}; x.report('merge!') { h.merge!(a: 1) }
  h = {}; x.report('[]=')    { h[:a] = 1 }
  x.compare!
end
__END__
Comparison:
                 []=:  2575786.1 i/s
              merge!:   469183.2 i/s - 5.49x slower
```