### PR TITLE
Remove an extension which adds `none` to AR

### DIFF
--- a/lib/extensions/ar_none.rb
+++ b/lib/extensions/ar_none.rb
@@ -1,8 +1,0 @@
-module ActiveRecord
-  class Base
-    # TODO: Remove in Rails 4 as it is natively implemented
-    def self.none
-      where("1 = 0")
-    end
-  end
-end


### PR DESCRIPTION
The app uses Rails 4.2.3 currently, and `none` has been built in to Rails [since 4.0.2](http://apidock.com/rails/v4.0.2/ActiveRecord/QueryMethods/none).

Rails' built in implementation is better than the existing one because Rails do not query the database.