### PR TITLE
Addressed Brakeman's Remote Code Execution warning in ApplicationController::Performance

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -355,7 +355,7 @@ module ApplicationController::Performance
       controller = new_opts[:model].underscore
       session[(controller + "_tl").to_sym] ||= {}
       session[(controller + "_tl").to_sym].merge!(new_opts)
-      f, l = data_row["resource_type"].constantize.find(data_row["resource_id"]).first_and_last_event
+      f, l = @record.first_and_last_event
       if f.nil?
         msg = "No events available for this #{model == "EmsCluster" ? "Cluster" : model}"
       elsif @record.kind_of?(MiqServer) # For server charts in OPS

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -316,7 +316,7 @@ module ApplicationController::Performance
       new_opts[:tl_show] = "timeline"
       session[(request.parameters["controller"] + "_tl").to_sym] ||= {}
       session[(request.parameters["controller"] + "_tl").to_sym].merge!(new_opts)
-      f, l = @perf_record.first_and_last_event
+      f = @perf_record.first_event
       if f.nil?
         msg = "No events available for this #{new_opts[:model] == "EmsCluster" ? "Cluster" : new_opts[:model]}"
       elsif @record.kind_of?(MiqServer) # For server charts in OPS
@@ -355,7 +355,7 @@ module ApplicationController::Performance
       controller = new_opts[:model].underscore
       session[(controller + "_tl").to_sym] ||= {}
       session[(controller + "_tl").to_sym].merge!(new_opts)
-      f, l = @record.first_and_last_event
+      f = @record.first_event
       if f.nil?
         msg = "No events available for this #{model == "EmsCluster" ? "Cluster" : model}"
       elsif @record.kind_of?(MiqServer) # For server charts in OPS

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,25 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
-      "fingerprint": "58fcf47340099025db0b33d410f05aa6594508dab67fe0ee04c47580e838d24e",
-      "message": "Unsafe reflection method constantize called with parameter value",
-      "file": "app/controllers/application_controller/performance.rb",
-      "line": 359,
-      "link": "http://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "(@sb[:chart_reports][params[:menu_click].split(\"_\").last.split(\"-\").last.to_i] or @sb[:chart_reports]).table.data[(params[:menu_click].split(\"_\").last.split(\"-\")[-2].to_i - 1)][\"resource_type\"].constantize",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ApplicationController::Performance",
-        "method": "perf_menu_click"
-      },
-      "user_input": "(params[:menu_click].split(\"_\").last.split(\"-\")[-2].to_i - 1)",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Request Forgery",
       "warning_code": 86,
       "fingerprint": "0068de871aa26aa4f84eb376161fbaf45c66ea116f510db814a74fc4b997cb28",


### PR DESCRIPTION
Turns out that we already find in SQL and RBAC validate the record we need [a few lines before](https://github.com/ManageIQ/manageiq/blob/master/app/controllers/application_controller/performance.rb#L344)