### PR TITLE
Add missing respond_to_missing? in OpenStackExtract

### DIFF
--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
@@ -97,4 +97,12 @@ class MiqOpenStackImage
     return miq_vm.send(sym) if args.empty?
     miq_vm.send(sym, args)
   end
+
+  def respond_to_missing?(sym, *args)
+    if SUPPORTED_METHODS.include?(sym)
+      true
+    else
+      super
+    end
+  end
 end

--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -186,4 +186,12 @@ class MiqOpenStackInstance
     return miq_vm.send(sym) if args.empty?
     miq_vm.send(sym, args)
   end
+
+  def respond_to_missing?(sym, *args)
+    if SUPPORTED_METHODS.include?(sym)
+      true
+    else
+      super
+    end
+  end
 end


### PR DESCRIPTION
The code in ManageIQ checks for presence of supported methods by using `respond_to?` and the methods are defined in `SUPPORTED_METHODS`. `method_missing` routes it correctly (I assume), but if you ask the object using `respond_to?`, it will tell you that it does not know that method.

Therefore the code that assumes withether it is a VM object or a string gets a false impression of it being a non-VM-object, therefore applying string operation on it.

Change tested on a downstream appliance that showed the error and the error disappeared.

https://bugzilla.redhat.com/show_bug.cgi?id=1264327