### PR TITLE
Pass tenant to automate for eventing.

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -923,13 +923,13 @@ class MiqAction < ActiveRecord::Base
 
     if inputs[:synchronous]
       MiqPolicy.logger.info("MIQ(action_raise_automation_event): Now executing Raise Automation Event, Event: [#{event}]")
-      MiqAeEvent.raise_synthetic_event(event, aevent)
+      MiqAeEvent.raise_synthetic_event(rec, event, aevent)
     else
       MiqPolicy.logger.info("MIQ(action_raise_automation_event): Queuing Raise Automation Event, Event: [#{event}]")
       MiqQueue.put(
         :class_name  => "MiqAeEvent",
         :method_name => "raise_synthetic_event",
-        :args        => [event, aevent],
+        :args        => [rec, event, aevent],
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => rec.my_zone,
         :role        => "automate"

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -519,7 +519,7 @@ class MiqAlert < ActiveRecord::Base
     expression[:options].each { |k, v| aevent[k] = v } if expression[:options]
 
     begin
-      result = MiqAeEvent.eval_alert_expression(aevent)
+      result = MiqAeEvent.eval_alert_expression(target, aevent)
     rescue => err
       _log.error("#{err.message}")
       result = false

--- a/spec/lib/miq_automation_engine/miq_ae_discovery_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_discovery_spec.rb
@@ -4,12 +4,15 @@ module MiqAeDiscoverySpec
   include MiqAeEngine
   describe "MiqAeDiscovery" do
     before(:each) do
-      @vm     = FactoryGirl.create(:vm_vmware)
-      @event  = FactoryGirl.create(:ems_event, :event_type => "CreateVM_Task_Complete",
-                                  :source => "VC", :ems_id => 1, :vm_or_template_id => @vm.id)
-      @domain = "SPEC_DOMAIN"
       # admin user is needed to process Events
       @admin = FactoryGirl.create(:user_with_group, :userid => "admin", :name => "Administrator")
+      @tenant = Tenant.root_tenant
+      @group  = FactoryGirl.create(:miq_group, :tenant => @tenant)
+      @ems    = FactoryGirl.create(:ext_management_system, :tenant => @tenant)
+      @vm     = FactoryGirl.create(:vm_vmware, :miq_group => @group)
+      @event  = FactoryGirl.create(:ems_event, :event_type => "CreateVM_Task_Complete",
+                                  :source => "VC", :ems_id => @ems.id, :vm_or_template_id => @vm.id)
+      @domain = "SPEC_DOMAIN"
       @model_data_dir = File.join(File.dirname(__FILE__), "data")
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "discovery"), @domain)
     end
@@ -24,21 +27,22 @@ module MiqAeDiscoverySpec
       let(:options) { {'test' => true} }
 
       it "check automate parameters" do
-        attrs = {:event_id          => @event.id,
-                 :event_type        => @event.event_type,
-                 "VmOrTemplate::vm" => @vm.id,
-                 :vm_id             => @vm.id}
-
-        identifiers = {:user_id      => @admin.id,
-                       :miq_group_id => @admin.current_group.id,
-                       :tenant_id    => @admin.current_tenant.id}
+        attrs = {:event_id                  => @event.id,
+                 :event_type                => @event.event_type,
+                 "ExtManagementSystem::ems" => @ems.id,
+                 :ems_id                    => @ems.id,
+                 "VmOrTemplate::vm"         => @vm.id,
+                 :vm_id                     => @vm.id,
+        }
 
         args = {:object_type      => "EmsEvent",
                 :object_id        => @event.id,
                 :attrs            => attrs,
                 :instance_name    => "Event",
-                :automate_message => nil,
-                :state            => nil}.merge(identifiers)
+                :user_id          => @admin.id,
+                :miq_group_id     => @group.id,
+                :tenant_id        => @tenant.id,
+                :automate_message => nil}
 
         MiqAeEngine.should_receive(:deliver).with(args).and_return(workspace)
         ws = MiqAeEvent.raise_ems_event(@event)

--- a/spec/lib/miq_automation_engine/miq_ae_event_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_event_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+module MiqAeEventSpec
+  describe MiqAeEvent do
+    before do
+      @tenant = FactoryGirl.create(:tenant)
+      @group  = FactoryGirl.create(:miq_group, :tenant => @tenant)
+      # admin user is needed to process Events
+      @admin  = FactoryGirl.create(:user_with_group, :userid => "admin")
+      @user   = FactoryGirl.create(:user_with_group, :userid => "test", :miq_groups => [@group])
+      @ems    = FactoryGirl.create(:ext_management_system, :tenant => @tenant)
+      @vm     = FactoryGirl.create(:vm_vmware, :ext_management_system => @ems, :miq_group => @group)
+    end
+
+    context ".raise_ems_event" do
+      before do
+        @event  = FactoryGirl.create(:ems_event,
+                                     :event_type        => "CreateVM_Task_Complete",
+                                     :source            => "VC",
+                                     :ems_id            => @ems.id,
+                                     :vm_or_template_id => @vm.id
+                                    )
+
+        @args = {:miq_group_id => @group.id, :tenant_id => @tenant.id}
+      end
+
+      it "VM with user owner" do
+        @vm.update_attributes(:evm_owner => @user)
+        @args.merge!(:user_id => @user.id)
+        expect(MiqAeEngine).to receive(:deliver).with(hash_including(@args))
+
+        MiqAeEvent.raise_ems_event(@event)
+      end
+
+      it "VM with group owner" do
+        miq_group = FactoryGirl.create(:miq_group, :tenant => FactoryGirl.create(:tenant))
+        @vm.update_attributes(:miq_group => miq_group)
+        @args.merge!(:user_id => @admin.id, :miq_group_id => miq_group.id, :tenant_id => miq_group.tenant.id)
+        expect(MiqAeEngine).to receive(:deliver).with(hash_including(@args))
+
+        MiqAeEvent.raise_ems_event(@event)
+      end
+    end
+
+    context ".raise_evm_event" do
+      context "VM" do
+        before do
+          @event = "vm_create"
+          @args  = {:miq_group_id => @group.id, :tenant_id => @tenant.id}
+        end
+
+        it "with user owner" do
+          @vm.update_attributes(:evm_owner => @user)
+          @args.merge!(:user_id => @user.id)
+          expect(MiqAeEngine).to receive(:deliver).with(hash_including(@args))
+
+          MiqAeEvent.raise_evm_event(@event, @vm, :vm => @vm)
+        end
+
+        it "with group owner" do
+          miq_group = FactoryGirl.create(:miq_group, :tenant => FactoryGirl.create(:tenant))
+          @vm.update_attributes(:miq_group => miq_group)
+          @args.merge!(:user_id => @admin.id, :miq_group_id => miq_group.id, :tenant_id => miq_group.tenant.id)
+          expect(MiqAeEngine).to receive(:deliver).with(hash_including(@args))
+
+          MiqAeEvent.raise_evm_event(@event, @vm, :vm => @vm)
+        end
+      end
+
+      it "Host" do
+        # Remove this when miq_group is added to ems
+        @ems.stub(:miq_group => @group)
+        host  = FactoryGirl.create(:host, :ext_management_system => @ems)
+        event = "host_provisioned"
+        args  = {:miq_group_id => @group.id, :tenant_id => @group.tenant.id}
+        expect(MiqAeEngine).to receive(:deliver).with(hash_including(args))
+
+        MiqAeEvent.raise_evm_event(event, host, :host => host)
+      end
+
+      it "MiqServer" do
+        miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
+        worker = FactoryGirl.create(:miq_worker, :miq_server_id => miq_server.id)
+        event  = "evm_worker_start"
+        args   = {:user_id      => @admin.id,
+                  :miq_group_id => @admin.current_group.id,
+                  :tenant_id    => @admin.current_group.current_tenant.id
+        }
+        expect(MiqAeEngine).to receive(:deliver).with(hash_including(args))
+
+        MiqAeEvent.raise_evm_event(event, worker.miq_server)
+      end
+    end
+  end
+end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -70,13 +70,13 @@ describe MiqAction do
     end
 
     it "synchronous" do
-      MiqAeEvent.should_receive(:raise_synthetic_event).with(@event.name, @aevent).once
+      MiqAeEvent.should_receive(:raise_synthetic_event).with(@vm, @event.name, @aevent).once
       MiqQueue.should_receive(:put).never
       @action.action_raise_automation_event(@action, @vm, :vm => @vm, :event => @event, :policy => @policy, :synchronous => true)
     end
 
     it "synchronous, not passing vm in inputs hash" do
-      MiqAeEvent.should_receive(:raise_synthetic_event).with(@event.name, @aevent).once
+      MiqAeEvent.should_receive(:raise_synthetic_event).with(@vm, @event.name, @aevent).once
       MiqQueue.should_receive(:put).never
       @action.action_raise_automation_event(@action, @vm, :vm => nil, :event => @event, :policy => @policy, :synchronous => true)
     end
@@ -88,7 +88,7 @@ describe MiqAction do
       q_options = {
         :class_name  => "MiqAeEvent",
         :method_name => "raise_synthetic_event",
-        :args        => [@event.name, @aevent],
+        :args        => [@vm, @event.name, @aevent],
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => vm_zone,
         :role        => "automate"


### PR DESCRIPTION
Automate needs the tenant information to find out the domain for the event handling.