### PR TITLE
fixed repository summary screen.

### DIFF
--- a/app/helpers/repository_helper/textual_summary.rb
+++ b/app/helpers/repository_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module RepositoryHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(vms miq_templates)
+    %i(vms templates)
   end
 
   def textual_group_smart_management
@@ -28,7 +28,10 @@ module RepositoryHelper::TextualSummary
     h
   end
 
-  def textual_miq_templates
-    textual_link(@record.miq_templates)
+  def textual_templates
+    textual_link(@record.miq_templates,
+                 :feature => "miq_template_show_list",
+                 :as      => TemplateInfra,
+                 :link    => url_for(:action => 'show', :id => @record, :display => 'miq_templates'))
   end
 end


### PR DESCRIPTION
Fixed error while trying to access repository summary screen, this issue was introduced in Commit SHA: 8451d63774bf834b2e89e4a19c064d063e69ab3e. This also fixes label from 'Miq Templates' to 'Templates'

@matthewd @dclarizio please review, i was getting following error when trying to access Repository summary screen:
[----] I, [2015-10-12T13:16:59.870218 #29632:ac1994]  INFO -- :   Rendered repository/show.html.haml within layouts/application (96.0ms)
[----] F, [2015-10-12T13:16:59.870585 #29632:ac1994] FATAL -- : Error caught: [ArgumentError] :as and :link are both required when linking to an array
/home/hkataria/dev/manageiq/app/helpers/repository_helper/textual_summary.rb:32:in `textual_miq_templates'
/home/hkataria/dev/manageiq/app/views/shared/summary/_textual.html.haml:1:in `_app_views_shared_summary__textual_html_haml___4214724492632021105_144108940'

after:
![screenshot from 2015-10-12 13 47 08](https://cloud.githubusercontent.com/assets/3450808/10434475/c4edac48-70e7-11e5-9c2b-0a363ad4ace4.png)