### PR TITLE
Fixed "VMs" relationship label on host summary screen

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -294,7 +294,14 @@ module HostHelper::TextualSummary
   end
 
   def textual_vms
-    @record.vms
+    label = "VMs"
+    num   = @record.number_of(:vms)
+    h     = {:label => label, :image => "vm", :value => num}
+    if num > 0 && role_allows(:feature => "vm_show_list")
+      h[:title] = "Show all #{label}"
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'vms')
+    end
+    h
   end
 
   def textual_templates


### PR DESCRIPTION
Reverted textual_vms method to build label & links in the same method, as human_attribute_name method on https://github.com/ManageIQ/manageiq/blob/master/app/helpers/textual_summary_helper.rb#L19 was causing incorrect label to be displayed.

https://bugzilla.redhat.com/show_bug.cgi?id=1270400

@matthewd  @dclarizio please review

before:
![before](https://cloud.githubusercontent.com/assets/3450808/10435072/c4ebb308-70eb-11e5-8325-b742e51bb60c.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/10435079/c92782b2-70eb-11e5-9279-d1d6e481b1d9.png)
