### PR TITLE
Automate Method Instance Access Checks

### DIFF
--- a/spec/support/miq_ae_engine_monkeypatch.rb
+++ b/spec/support/miq_ae_engine_monkeypatch.rb
@@ -1,7 +1,0 @@
-module MiqAeEngine
-  def self.instantiate(uri, user = nil)
-    Tenant.seed
-    user ||= FactoryGirl.create(:user_with_group)
-    MiqAeWorkspaceRuntime.instantiate(uri, user)
-  end
-end

--- a/spec/support/miq_ae_engine_monkeypatch.rb
+++ b/spec/support/miq_ae_engine_monkeypatch.rb
@@ -1,5 +1,5 @@
 module MiqAeEngine
-  def self.instantiate(uri, user)
+  def self.instantiate(uri, user = nil)
     Tenant.seed
     user ||= FactoryGirl.create(:user_with_group)
     MiqAeWorkspaceRuntime.instantiate(uri, user)

--- a/spec/support/miq_ae_engine_monkeypatch.rb
+++ b/spec/support/miq_ae_engine_monkeypatch.rb
@@ -1,0 +1,7 @@
+module MiqAeEngine
+  def self.instantiate(uri, user)
+    Tenant.seed
+    user ||= FactoryGirl.create(:user_with_group)
+    MiqAeWorkspaceRuntime.instantiate(uri, user)
+  end
+end

--- a/spec/support/miq_automate_helper.rb
+++ b/spec/support/miq_automate_helper.rb
@@ -64,7 +64,8 @@ module MiqAutomateHelper
   end
 
   def self.create_service_model_method(domain, namespace, klass, instance, method)
-    identifiers = {:domain => domain, :namespace => namespace,
+    Tenant.seed
+    identifiers = {:domain => domain, :namespace => namespace, :tenant => Tenant.root_tenant,
                   :class  => klass, :instance => instance, :method => method}
     fields      = [{:name => 'method1', :type => 'method',
                    :priority => 1, :value => method}]

--- a/spec/support/miq_automate_helper.rb
+++ b/spec/support/miq_automate_helper.rb
@@ -1,8 +1,8 @@
 module MiqAutomateHelper
   def self.create_dummy_method(identifiers, field_array)
-    MiqAeDatastore.reset
     @aed = FactoryGirl.create(:miq_ae_domain, :name => identifiers[:domain],
-                              :priority => 10, :enabled => true)
+                              :priority => 10, :enabled => true,
+                              :tenant   => identifiers[:tenant])
     @aen1 = FactoryGirl.create(:miq_ae_namespace, :name      => identifiers[:namespace],
                                                   :parent_id => @aed.id)
     @aec1 = FactoryGirl.create(:miq_ae_class, :name         => identifiers[:class],


### PR DESCRIPTION
Prevent an automate method from accessing instances that belong to other tenants.