### PR TITLE
Availability Zone Block Storage Disk Usage a…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1176,6 +1176,11 @@ module ApplicationHelper
     attributes
   end
 
+  def title_for_availability_zones(plural = false)
+    key = "availability_zone"
+    ui_lookup(:availability_zone_types => plural ? key.pluralize : key)
+  end
+
   def title_for_hosts
     title_for_host(true)
   end

--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -11,6 +11,10 @@ module AvailabilityZoneHelper::TextualSummary
     %i(tags)
   end
 
+  def textual_group_availability_zone_totals
+    %i(block_storage_disk_capacity block_storage_disk_usage)
+  end
+
   #
   # Items
   #
@@ -28,5 +32,15 @@ module AvailabilityZoneHelper::TextualSummary
       h[:title] = "Show all #{label}"
     end
     h
+  end
+
+  def textual_block_storage_disk_capacity
+    return nil unless @record.respond_to?(:block_storage_disk_capacity)
+    {:value => number_to_human_size(@record.block_storage_disk_capacity.gigabytes, :precision => 2)}
+  end
+
+  def textual_block_storage_disk_usage
+    return nil unless @record.respond_to?(:block_storage_disk_usage)
+    {:value => number_to_human_size(@record.block_storage_disk_usage.bytes, :precision => 2)}
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/availability_zone.rb
@@ -1,2 +1,15 @@
 class ManageIQ::Providers::Openstack::CloudManager::AvailabilityZone < ::AvailabilityZone
+  # TODO: Currently, all cinder nodes are installed with the default availability zone,
+  # nova. So we just take the aggregate disk capacity in the BlockStorage cluster.
+  # In the future, when multiple Cinder availability zones are supported in the overcloud
+  # deployment, this needs to be changed so that we only sum up the disk capacities for
+  # hosts that has the matching availability_zone configured in /etc/cinder/cinder.conf.
+  def block_storage_disk_capacity
+    cluster = ext_management_system.provider.infra_ems.ems_clusters.find { |c| c.block_storage? == true }
+    cluster.aggregate_disk_capacity
+  end
+
+  def block_storage_disk_usage
+    cloud_volumes.where.not(:status => "error").sum(:size).to_f
+  end
 end

--- a/app/views/availability_zone/_main.html.haml
+++ b/app/views/availability_zone/_main.html.haml
@@ -3,4 +3,5 @@
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
   .col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for %s") % title_for_availability_zones, :items => textual_group_availability_zone_totals}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -787,6 +787,10 @@ en:
       write_hit_ios_per_sec:       Write Hit (IOPS)
       write_ios_per_sec:           Write (IOPS)
 
+    availability_zone_types:
+      availability_zone:     Availability Zone
+      availability_zones:    Availability Zones
+
     compare:
       Host:         Host Properties
       Vm:           VM Properties

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -84,6 +84,8 @@ module Vmdb
         ui_lookup_for_ems_cluster_types(options[:ems_cluster_types])
       elsif options[:ui_title]
         ui_lookup_for_title(options[:ui_title])
+      elsif options[:availability_zone_types]
+        ui_lookup_for_availability_zone_types(options[:availability_zone_types])
       else
         ''
       end
@@ -108,6 +110,10 @@ module Vmdb
 
     def ui_lookup_for_title(text)
       Dictionary.gettext(text, :type => :ui_title, :notfound => :titleize)
+    end
+
+    def ui_lookup_for_availability_zone_types(text)
+      Dictionary.gettext(text, :type => :availability_zone_types, :notfound => :titleize)
     end
 
     # Wrap a report html table body with html table tags and headers for the columns


### PR DESCRIPTION
…nd Capacity

Adds two fields to the availability zone detail page showing
disk usage and capacity for OpenStack clouds.

Note disk usage is calculated by summing up all of the hosts
that are part of the BlockStorage cluster. It does not take
into account the availability zone of each Cinder storage
node. If multiple Cinder availability zones are deployed, the
disk capacity numbers will not be accurate. But at the moment,
RHELOSP deployments only supports a single Cinder availability
zone so this is fine for now.

When multiple Cinder availability zones are supported, the
refresh process will need to database each Cinder node's
availability zone. And the disk capacity calculation will
need to be adjusted to take zones into account.