### PR TITLE
Request user objects

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -450,7 +450,7 @@ module ApplicationController::CiProcessing
         return
       end
 
-      if VmReconfigureRequest.make_request(@edit[:req_id], options, session[:userid])
+      if VmReconfigureRequest.make_request(@edit[:req_id], options, current_user)
         flash = _("VM Reconfigure Request was saved")
         if role_allows(:feature => "miq_request_show_list", :any => true)
           render :update do |page|

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -744,7 +744,7 @@ module ApplicationController::MiqRequestMethods
     if @miq_request.workflow_class
       options = {}
       begin
-        options[:wf] = @miq_request.workflow_class.new(@options, session[:userid])                # Create a new provision workflow for this edit session
+        options[:wf] = @miq_request.workflow_class.new(@options, current_user)
       rescue MiqException::MiqVmError => bang
         @no_wf_msg = _("Cannot create Request Info, error: ") << bang.message
       end

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -413,7 +413,12 @@ class MiqRequest < ActiveRecord::Base
   end
 
   def self.create_request(values, requester_id, auto_approve = false, request_type = request_types.first)
-    requester = requester_id.kind_of?(User) ? requester_id : User.find_by_userid(requester_id)
+    if requester_id.kind_of?(User)
+      requester = requester_id
+      requester_id = requester.userid
+    else
+      requester = User.find_by_userid(requester_id)
+    end
     values[:src_ids] = values[:src_ids].to_miq_a unless values[:src_ids].nil?
     request          = create(:options => values, :userid => requester_id, :request_type => request_type)
     request.save!  # Force validation errors to raise now

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -53,7 +53,7 @@ class MiqRequestWorkflow
   def instance_var_init(values, requester, options)
     @values       = values
     @filters      = {}
-    @requester    = User.lookup_by_identity(requester)
+    @requester    = requester.kind_of?(User) ? requester : User.lookup_by_identity(requester)
     @requester.miq_group_description = values[:requester_group]
     @values.merge!(options) unless options.blank?
   end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -34,7 +34,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
     st = service_template
     return {} if st.blank?
     ra = st.resource_actions.find_by_action("Provision")
-    dialog = ResourceActionWorkflow.new(options[:dialog], userid, ra, {}).dialog
+    dialog = ResourceActionWorkflow.new(options[:dialog], get_user, ra, {}).dialog
     DialogSerializer.new.serialize(Array[dialog]).first
   end
 

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -127,7 +127,7 @@
             = button_tag(t, :class => "btn btn-primary btn-disabled")
   %br
   - if @miq_request.workflow_class
-    = render :partial => "prov_wf", :locals => {:wf => @miq_request.workflow_class.new({:src_vm_id => @miq_request.source_id}, session[:userid]), :show => true}
+    = render :partial => "prov_wf", :locals => {:wf => @miq_request.workflow_class.new({:src_vm_id => @miq_request.source_id}, current_user), :show => true}
   - elsif @miq_request.type == 'ServiceTemplateProvisionRequest'
     = render :partial => "st_prov_show"
   - elsif @miq_request.type == 'ServiceReconfigureRequest'

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -126,7 +126,7 @@ describe AutomationRequest do
       expect(AuditEvent).not_to receive(:success)
       values = {}
 
-      request = described_class.make_request(nil, values, admin.userid) # TODO: nil
+      request = described_class.make_request(nil, values, admin)
 
       expect(request).to be_valid
       expect(request).to be_a_kind_of(AutomationRequest)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -265,7 +265,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
       stub_dialog(:get_dialogs)
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_created",
@@ -294,7 +294,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
       stub_get_next_vm_name
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_updated",

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -29,7 +29,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
       stub_dialog(:get_pre_dialogs)
       stub_dialog(:get_dialogs)
 
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "configured_system_provision_request_created",
@@ -54,7 +54,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
       expect(request.requester_name).to eq(admin.name)
 
       # updates a request
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "configured_system_provision_request_updated",

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
@@ -26,7 +26,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
       stub_dialog(:get_dialogs)
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_created",
@@ -55,7 +55,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
 
       stub_get_next_vm_name
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_updated",

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -174,7 +174,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       stub_dialog(:get_dialogs)
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_created",
@@ -203,7 +203,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
 
       stub_get_next_vm_name
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_updated",

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -106,7 +106,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
       stub_dialog(:get_dialogs)
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_created",
@@ -135,7 +135,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
 
       stub_get_next_vm_name
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_updated",

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       stub_dialog(:get_dialogs)
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_created",
@@ -66,7 +66,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
 
       stub_get_next_vm_name
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_provision_request_updated",

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -56,7 +56,7 @@ describe MiqHostProvisionWorkflow do
       stub_dialog(:get_dialogs)
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "host_provision_request_created",
@@ -82,7 +82,7 @@ describe MiqHostProvisionWorkflow do
 
       # updates a request
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "host_provision_request_updated",

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -51,7 +51,7 @@ describe MiqProvisionWorkflow do
       context "#show_customize_fields" do
         it "should show PXE fields when customization supported" do
           fields = {'key' => 'value'}
-          wf = MiqProvisionVirtWorkflow.new({}, @admin.userid)
+          wf = MiqProvisionVirtWorkflow.new({}, @admin)
           wf.should_receive(:supports_customization_template?).and_return(true)
           wf.should_receive(:show_customize_fields_pxe).with(fields)
           wf.show_customize_fields(fields, 'linux')

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -127,7 +127,7 @@ describe ServiceTemplateProvisionRequest do
       # the dialogs populate this
       values = {:src_id => service_template.id}
 
-      request = described_class.make_request(nil, values, admin.userid) # TODO: nil
+      request = described_class.make_request(nil, values, admin)
 
       expect(request).to be_valid
       expect(request).to be_a_kind_of(described_class)
@@ -145,7 +145,7 @@ describe ServiceTemplateProvisionRequest do
         :userid       => alt_user.userid,
         :message      => "Service_Template_Provisioning request updated by <#{alt_user.userid}> for ServiceTemplate:#{service_template.id}"
       )
-      described_class.make_request(request, values, alt_user.userid)
+      described_class.make_request(request, values, alt_user)
     end
   end
 end

--- a/spec/models/vm_migrate_workflow_spec.rb
+++ b/spec/models/vm_migrate_workflow_spec.rb
@@ -8,7 +8,7 @@ describe VmMigrateWorkflow do
 
   context "With a Valid Template," do
     context "#allowed_hosts" do
-      let(:workflow) { VmMigrateWorkflow.new({:src_ids => [vm.id]}, admin.userid) }
+      let(:workflow) { VmMigrateWorkflow.new({:src_ids => [vm.id]}, admin) }
 
       context "#allowed_hosts" do
         it "with no hosts" do
@@ -36,7 +36,7 @@ describe VmMigrateWorkflow do
       stub_dialog
 
       # if running_pre_dialog is set, it will run 'continue_request'
-      workflow = described_class.new(values = {:running_pre_dialog => false}, admin.userid)
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_migrate_request_created",
@@ -62,7 +62,7 @@ describe VmMigrateWorkflow do
 
       # updates a request
 
-      workflow = described_class.new(values, alt_user.userid)
+      workflow = described_class.new(values, alt_user)
 
       expect(AuditEvent).to receive(:success).with(
         :event        => "vm_migrate_request_updated",

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -46,7 +46,7 @@ describe VmReconfigureRequest do
       # the dialogs populate this
       values = {:src_ids => [vm_vmware.id]}
 
-      request = described_class.make_request(nil, values, admin.userid) # TODO: nil
+      request = described_class.make_request(nil, values, admin)
 
       expect(request).to                be_valid
       expect(request).to                be_a_kind_of(described_class)
@@ -64,7 +64,7 @@ describe VmReconfigureRequest do
         :userid       => alt_user.userid,
         :message      => "VM Reconfigure request updated by <#{alt_user.userid}> for Vm:#{[vm_vmware.id].inspect}"
       )
-      described_class.make_request(request, values, alt_user.userid)
+      described_class.make_request(request, values, alt_user)
     end
   end
 


### PR DESCRIPTION
Pass users (not userid) to `miq_request` requests.

/cc @gmcculloug split out the user objects