### PR TITLE
Removed footer

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -15,7 +15,6 @@ body, html {
 @media (max-width: $screen-sm) {
   body {
     padding-top: 40px !important; //Body 'padding-top' is added because navbar-fixed-top class is applied
-    padding-bottom: 30px !important;
   }
   .scrollable-sm {
     height: 100%;
@@ -37,7 +36,6 @@ body, html {
 @media (min-width: $screen-sm) {
   body {
     padding-top: 100px !important; //Body 'padding-top' is added because navbar-fixed-top class is applied
-    padding-bottom: 30px !important;
   }
 
   .login-pf body {

--- a/app/views/layouts/_dhtmlxlayout_explorer.html.haml
+++ b/app/views/layouts/_dhtmlxlayout_explorer.html.haml
@@ -6,7 +6,6 @@
   function miqInitDhtmlxLayout() {
   - if @explorer
     dhxLayoutB = new dhtmlXLayoutObject("right_div", "3E");
-    dhxLayoutB._mBottom = 30;
     dhxLayoutB._minHeight = 20;
     dhxLayoutB.cells("a").setHeight(32);
     dhxLayoutB.cells("c").setHeight(32);

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,9 +1,3 @@
-%nav.navbar.navbar-default.navbar-fixed-bottom
-  .container-fluid
-    %span#tP
-    %script{:type => "text/javascript"}
-      dateTime('#{Time.zone.now.utc_offset}', '#{Time.zone.now.strftime("%Z")}');
-
 = render :partial => "layouts/adv_search"
 :javascript
   $('#exampleModal').on('show.bs.modal', function (event) {

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,11 +11,6 @@
   %div{:class => "collapse navbar-collapse navbar-collapse-1"}
     %ul{:class => "nav navbar-nav navbar-utility"}
       %li{:class => "brand-white-label #{session[:custom_logo] ? "whitelabeled" : ""}"}
-      %li
-        %a{:href => '#'}
-          %span#tP
-          :javascript
-            dateTime('#{Time.zone.now.utc_offset}', '#{Time.zone.now.strftime("%Z")}');
       - Menu::Manager.menu(:top_right) do |menu_section|
         - if menu_section.visible?
           %li.dropdown

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,6 +11,11 @@
   %div{:class => "collapse navbar-collapse navbar-collapse-1"}
     %ul{:class => "nav navbar-nav navbar-utility"}
       %li{:class => "brand-white-label #{session[:custom_logo] ? "whitelabeled" : ""}"}
+      %li
+        %a{:href => '#'}
+          %span#tP
+          :javascript
+            dateTime('#{Time.zone.now.utc_offset}', '#{Time.zone.now.strftime("%Z")}');
       - Menu::Manager.menu(:top_right) do |menu_section|
         - if menu_section.visible?
           %li.dropdown


### PR DESCRIPTION
I moved the clock to the top of the page, so we can remove bottom navbar, that doesn't look very nice, and takes unnecessary space.

This may also help with some issues with accordion sizing.

Screenshot example:
![screencapture-localhost-3000-dashboard-show-1444739172390](https://cloud.githubusercontent.com/assets/1187051/10454684/ccadbcd2-71b6-11e5-8473-cfa9314f5454.png)

