### PR TITLE
adds provisioning dialog directive

### DIFF
--- a/spa_ui/self_service/client/app/components/dialog-content/dialog-content.directive.js
+++ b/spa_ui/self_service/client/app/components/dialog-content/dialog-content.directive.js
@@ -1,0 +1,46 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .directive('dialogContent', DialogContentDirective);
+
+  /** @ngInject */
+  function DialogContentDirective() {
+    var directive = {
+      restrict: 'AE',
+      replace: true,
+      scope: {
+        dialog: '=',
+        options: '=?',
+        inputDisabled: '=?'
+      },
+      link: link,
+      templateUrl: 'app/components/dialog-content/dialog-content.html',
+      controller: DialogContentController,
+      controllerAs: 'vm',
+      bindToController: true
+    };
+
+    return directive;
+
+    function link(scope, element, attrs, vm, transclude) {
+      vm.activate();
+    }
+
+    /** @ngInject */
+    function DialogContentController() {
+      var vm = this;
+      vm.parsedOptions = {};
+      vm.activate = activate;
+
+      function activate() {
+        if (vm.options) {
+          angular.forEach(vm.options, parseOptions);
+        }
+        function parseOptions(value, key) {
+          vm.parsedOptions[key.replace('dialog_', '')] = value;
+        }
+      }
+    }
+  }
+})();

--- a/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
+++ b/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
@@ -1,59 +1,59 @@
 <div>
-  <div ng-if="!vm.dialog.label">
+  <div ng-if=" !vm.dialog.label ">
     <h2>No Provisioning Dialog Available.</h2>
   </div>
-  <div ng-if="vm.dialog.label">
+  <div ng-if=" vm.dialog.label ">
     <div>
       <h2 class="text-capitalize no-wrap">{{ ::vm.dialog.label }} </h2>
       <h4>{{ ::vm.dialog.description }}</h4>
     </div>
     <tabset>
-      <tab ng-repeat="dialogTab in vm.dialog.dialog_tabs" heading="{{ dialogTab.label }}">
-        <div ng-repeat="dialogGroup in dialogTab.dialog_groups">
+      <tab ng-repeat="dialogTab in ::vm.dialog.dialog_tabs " heading="{{ ::dialogTab.label }}">
+        <div ng-repeat="dialogGroup in ::dialogTab.dialog_groups ">
           <div class="panel panel-default">
             <div class="panel-heading">
-              <strong>{{ dialogGroup.label }}</strong>
+              <strong>{{ ::dialogGroup.label }}</strong>
             </div>
             <div class="panel-body">
               <div
-                ng-repeat="dialogField in dialogGroup.dialog_fields"
+                ng-repeat="dialogField in ::dialogGroup.dialog_fields "
                 ng-init="inputTitle = dialogField.description"
                 class="form-horizontal">
                 <div class="form-group">
                   <div class="col-sm-3">
-                    {{ dialogField.label }}
+                    {{ ::dialogField.label }}
                   </div>
                   <div ng-switch on="dialogField.type" class="col-sm-9">
                     <input
                       ng-switch-when="DialogFieldTextBox"
-                      ng-disabled="{{ dialogField.read_only || vm.inputDisabled}}"
+                      ng-disabled="{{ ::dialogField.read_only || vm.inputDisabled}}"
                       class="form-control"
                       type="{{ dialogField.options.protected ? 'password' : 'text' }}"
-                      title="{{ inputTitle }}"
+                      title="{{ ::inputTitle }}"
                       value="{{ vm.options? vm.parsedOptions[dialogField.name] : dialogField.default_value }}">
                     </input>
                     <textarea
                       ng-switch-when="DialogFieldTextAreaBox"
-                      ng-disabled="{{ dialogField.read_only  || vm.inputDisabled}}"
+                      ng-disabled="{{ ::dialogField.read_only  || vm.inputDisabled}}"
                       class="form-control"
-                      title="{{ inputTitle }}"
+                      title="{{ ::inputTitle }}"
                       rows="4">{{ vm.options? vm.parsedOptions[dialogField.name] : dialogField.default_value }}</textarea>
                     <input
                       ng-switch-when="DialogFieldCheckBox"
-                      ng-disabled="{{ dialogField.read_only  || vm.inputDisabled}}"
+                      ng-disabled="{{ ::dialogField.read_only  || vm.inputDisabled}}"
                       class="form-control"
                       type="checkbox"
-                      title="{{ inputTitle }}"
+                      title="{{ ::inputTitle }}"
                       checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
                     </input>
                     <select
                       ng-switch-when="DialogFieldDropDownList"
-                      ng-disabled="{{ dialogField.read_only  || vm.inputDisabled}}"
+                      ng-disabled="{{ ::dialogField.read_only  || vm.inputDisabled}}"
                       class="form-control">
                       <option ng-if="vm.options">{{vm.parsedOptions[dialogField.name]}}</option>
-                      <option ng-if="!vm.options" ng-repeat="fieldValue in dialogField.values"
-                              value="{{ fieldValue[0] }}">
-                        {{ fieldValue[1] }}
+                      <option ng-if="!vm.options" ng-repeat="fieldValue in ::dialogField.values"
+                              value="{{ ::fieldValue[0] }}">
+                        {{ ::fieldValue[1] }}
                       </option>
                     </select>
                     <span ng-switch-default ng-hide="true"></span>

--- a/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
+++ b/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
@@ -1,0 +1,69 @@
+<div>
+  <div ng-if="!vm.dialog.label">
+    <h2>No Provisioning Dialog Available.</h2>
+  </div>
+  <div ng-if="vm.dialog.label">
+    <div>
+      <h2 class="text-capitalize no-wrap">{{ ::vm.dialog.label }} </h2>
+      <h4>{{ ::vm.dialog.description }}</h4>
+    </div>
+    <tabset>
+      <tab ng-repeat="dialogTab in vm.dialog.dialog_tabs" heading="{{ dialogTab.label }}">
+        <div ng-repeat="dialogGroup in dialogTab.dialog_groups">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <strong>{{ dialogGroup.label }}</strong>
+            </div>
+            <div class="panel-body">
+              <div
+                ng-repeat="dialogField in dialogGroup.dialog_fields"
+                ng-init="inputTitle = dialogField.description"
+                class="form-horizontal">
+                <div class="form-group">
+                  <div class="col-sm-3">
+                    {{ dialogField.label }}
+                  </div>
+                  <div ng-switch on="dialogField.type" class="col-sm-9">
+                    <input
+                      ng-switch-when="DialogFieldTextBox"
+                      ng-disabled="{{ dialogField.read_only || vm.inputDisabled}}"
+                      class="form-control"
+                      type="{{ dialogField.options.protected ? 'password' : 'text' }}"
+                      title="{{ inputTitle }}"
+                      value="{{ vm.options? vm.parsedOptions[dialogField.name] : dialogField.default_value }}">
+                    </input>
+                    <textarea
+                      ng-switch-when="DialogFieldTextAreaBox"
+                      ng-disabled="{{ dialogField.read_only  || vm.inputDisabled}}"
+                      class="form-control"
+                      title="{{ inputTitle }}"
+                      rows="4">{{ vm.options? vm.parsedOptions[dialogField.name] : dialogField.default_value }}</textarea>
+                    <input
+                      ng-switch-when="DialogFieldCheckBox"
+                      ng-disabled="{{ dialogField.read_only  || vm.inputDisabled}}"
+                      class="form-control"
+                      type="checkbox"
+                      title="{{ inputTitle }}"
+                      checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
+                    </input>
+                    <select
+                      ng-switch-when="DialogFieldDropDownList"
+                      ng-disabled="{{ dialogField.read_only  || vm.inputDisabled}}"
+                      class="form-control">
+                      <option ng-if="vm.options">{{vm.parsedOptions[dialogField.name]}}</option>
+                      <option ng-if="!vm.options" ng-repeat="fieldValue in dialogField.values"
+                              value="{{ fieldValue[0] }}">
+                        {{ fieldValue[1] }}
+                      </option>
+                    </select>
+                    <span ng-switch-default ng-hide="true"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
+++ b/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
@@ -44,7 +44,7 @@
                       class="form-control"
                       type="checkbox"
                       title="{{ ::inputTitle }}"
-                      checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
+                      ng-checked="vm.parsedOptions[dialogField.name] == 't' || dialogField.default_value == 't'">
                     </input>
                     <select
                       ng-switch-when="DialogFieldDropDownList"

--- a/spa_ui/self_service/client/app/states/marketplace/details/details.html
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.html
@@ -41,66 +41,9 @@
         <div class="col-md-12">
           <div class="row">
             <div ng-repeat="dialog in ::vm.dialogs">
-              <h1 class="marketplace-details-title">{{ dialog.label }}</h1>
-              <tabset>
-                <tab ng-repeat="dialogTab in dialog.dialog_tabs" heading="{{ dialogTab.label }}">
-                  <div ng-repeat="dialogGroup in dialogTab.dialog_groups">
-                    <div class="panel panel-default">
-                      <div class="panel-heading">
-                        <strong>{{ dialogGroup.label }}</strong>
-                      </div>
-
-                      <div class="panel-body">
-                        <div
-                          ng-repeat="dialogField in dialogGroup.dialog_fields"
-                          ng-init="inputTitle = dialogField.description"
-                          class="form-horizontal">
-
-                          <div class="form-group">
-                            <div class="col-sm-3">
-                              {{ dialogField.label }}
-                            </div>
-
-                            <div ng-switch on="dialogField.type" class="col-sm-9">
-                              <input
-                                ng-switch-when="DialogFieldTextBox"
-                                ng-disabled="{{ dialogField.read_only }}"
-                                class="form-control"
-                                type="{{ dialogField.options.protected ? 'password' : 'text' }}"
-                                title="{{ inputTitle }}"
-                                value="{{ dialogField.default_value }}">
-                              </input>
-                              <textarea
-                                ng-switch-when="DialogFieldTextAreaBox"
-                                ng-disabled="{{ dialogField.read_only }}"
-                                class="form-control"
-                                title="{{ inputTitle }}"
-                                rows="4">{{ dialogField.default_value }}</textarea>
-                              <input
-                                ng-switch-when="DialogFieldCheckBox"
-                                ng-disabled="{{ dialogField.read_only }}"
-                                class="form-control"
-                                type="checkbox"
-                                title="{{ inputTitle }}"
-                                checked="{{ dialogField.default_value == 't' ? 'checked' : ''}}">
-                              </input>
-                              <select
-                                ng-switch-when="DialogFieldDropDownList"
-                                ng-disabled="{{ dialogField.read_only }}"
-                                class="form-control">
-                                <option ng-repeat="fieldValue in dialogField.values" value="{{ fieldValue[0] }}">
-                                  {{ fieldValue[1] }}
-                                </option>
-                              </select>
-                              <span ng-switch-default style="display: hidden"></span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </tab>
-              </tabset>
+              <div ng-repeat="dialog in ::vm.dialogs">
+                <dialog-content dialog="dialog"></dialog-content>
+              </div>
             </div>
           </div>
         </div>

--- a/spa_ui/self_service/client/app/states/marketplace/details/details.state.js
+++ b/spa_ui/self_service/client/app/states/marketplace/details/details.state.js
@@ -44,7 +44,10 @@
     var vm = this;
 
     vm.title = 'Service Template Details';
-    vm.dialogs = dialogs.resources[0].content;
     vm.serviceTemplate = serviceTemplate;
+
+    if (dialogs.subcount > 0) {
+      vm.dialogs = dialogs.resources[0].content;
+    }
   }
 })();

--- a/spa_ui/self_service/client/app/states/requests/details/details.html
+++ b/spa_ui/self_service/client/app/states/requests/details/details.html
@@ -110,8 +110,7 @@
   <div class="panel panel-default ss-details-panel">
     <div class="panel-body">
       <section class="ss-details-section">
-        <h2>Request Details</h2>
-        <pre>{{ ::vm.request.options |json }}</pre>
+        <dialog-content dialog="vm.request.provision_dialog" input-disabled="true" options="vm.request.options.dialog"></dialog-content>
       </section>
     </div>
   </div>

--- a/spa_ui/self_service/client/app/states/requests/details/details.state.js
+++ b/spa_ui/self_service/client/app/states/requests/details/details.state.js
@@ -26,7 +26,7 @@
 
   /** @ngInject */
   function resolveRequest($stateParams, CollectionsApi) {
-    var options = {attributes: ['picture', 'picture.image_href']};
+    var options = {attributes: ['provision_dialog', 'picture', 'picture.image_href']};
 
     return CollectionsApi.get('service_requests', $stateParams.requestId, options);
   }

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -98,6 +98,7 @@
   <script src="/client/app/blocks/router/router-helper.provider.js"></script>
   <script src="/client/app/components/confirmation/confirmation.directive.js"></script>
   <script src="/client/app/components/custom-button/custom-button.directive.js"></script>
+  <script src="/client/app/components/dialog-content/dialog-content.directive.js"></script>
   <script src="/client/app/components/edit-service-modal/edit-service-modal-service.factory.js"></script>
   <script src="/client/app/components/footer/footer-content.directive.js"></script>
   <script src="/client/app/components/main-content/main-content.directive.js"></script>


### PR DESCRIPTION

<img width="1920" alt="screen shot 2015-10-13 at 5 14 41 pm" src="https://cloud.githubusercontent.com/assets/6640236/10468609/06f8578c-71ce-11e5-9fbd-726af3508b09.png">
<img width="1920" alt="screen shot 2015-10-13 at 5 14 59 pm" src="https://cloud.githubusercontent.com/assets/6640236/10468610/06fb6314-71ce-11e5-902d-5a06639cb54e.png">
<img width="1920" alt="screen shot 2015-10-13 at 5 14 33 pm" src="https://cloud.githubusercontent.com/assets/6640236/10468611/06ff6e28-71ce-11e5-93a6-b5add9f40989.png">


employed by marketplace and request details states this directive can both display and accept input while also displaying already selected values (input disabled)

this directive takes three parameters:
1. dialog (the dialog object)
2. isDisabled (boolean, if the dialog form is to be used for display only) optional
3. options (the options dialog object, if it exists, for indicating already selected values) optional