### PR TITLE
[api] expose provision_dialog on services

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -24,6 +24,7 @@ class Service < ActiveRecord::Base
   virtual_has_one    :provision_dialog
 
   delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
+  delegate :provision_dialog, :to => :miq_request, :allow_nil => true
 
   include ServiceMixin
   include OwnershipMixin
@@ -44,10 +45,6 @@ class Service < ActiveRecord::Base
     super
   end
   alias_method :<<, :add_resource
-
-  def provision_dialog
-    miq_request.try(:provision_dialog)
-  end
 
   def parent_service
     service

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,6 +8,9 @@ class Service < ActiveRecord::Base
 
   has_many :dialogs, -> { uniq }, :through => :service_template
 
+  has_one :miq_request_task, :dependent => :nullify, :as => :destination
+  has_one :miq_request, :through => :miq_request_task
+
   virtual_belongs_to :parent_service
   virtual_has_many   :direct_service_children
   virtual_has_many   :all_service_children
@@ -18,6 +21,7 @@ class Service < ActiveRecord::Base
 
   virtual_has_one    :custom_actions
   virtual_has_one    :custom_action_buttons
+  virtual_has_one    :provision_dialog
 
   delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
 
@@ -40,6 +44,10 @@ class Service < ActiveRecord::Base
     super
   end
   alias_method :<<, :add_resource
+
+  def provision_dialog
+    miq_request.try(:provision_dialog)
+  end
 
   def parent_service
     service

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -4,6 +4,9 @@
 # - Query provision_dialog from service_requests
 #     GET /api/service_requests/:id?attributes=provision_dialog
 #
+# - Query provision_dialog from services
+#     GET /api/services/:id?attributes=provision_dialog
+#
 require 'spec_helper'
 
 describe ApiController do
@@ -23,12 +26,24 @@ describe ApiController do
                        :source_type => template.class.name)
   end
 
+  let(:request_task) { FactoryGirl.create(:miq_request_task, :miq_request => service_request) }
+  let(:service) { FactoryGirl.create(:service, :name => "Service", :miq_request_task => request_task) }
+
   before(:each) do
     init_api_spec_env
   end
 
   def app
     Vmdb::Application
+  end
+
+  def expect_result_to_have_provision_dialog
+    expect_result_to_have_keys(%w(id href provision_dialog))
+    provision_dialog = @result["provision_dialog"]
+    provision_dialog.should be_kind_of(Hash)
+    expect(provision_dialog).to have_key("label")
+    expect(provision_dialog).to have_key("dialog_tabs")
+    expect(provision_dialog["label"]).to eq(provision_dialog1.label)
   end
 
   describe "Service Requests query" do
@@ -40,12 +55,20 @@ describe ApiController do
     it "can return the provision_dialog" do
       run_get service_requests_url(service_request.id), :attributes => "provision_dialog"
 
-      expect_result_to_have_keys(%w(id href provision_dialog))
-      provision_dialog = @result["provision_dialog"]
-      provision_dialog.should be_kind_of(Hash)
-      expect(provision_dialog).to have_key("label")
-      expect(provision_dialog).to have_key("dialog_tabs")
-      expect(provision_dialog["label"]).to eq(provision_dialog1.label)
+      expect_result_to_have_provision_dialog
+    end
+  end
+
+  describe "Service query" do
+    before do
+      template.resource_actions = [provision_ra, retire_ra]
+      api_basic_authorize
+    end
+
+    it "can return the provision_dialog" do
+      run_get services_url(service.id), :attributes => "provision_dialog"
+
+      expect_result_to_have_provision_dialog
     end
   end
 end


### PR DESCRIPTION
- Referencing the same provision_dialog virtual attribute from the related service_requests.
- Added specs

https://trello.com/c/srLkm9mY