### PR TITLE
Validate button shift

### DIFF
--- a/app/views/layouts/_auth_credentials.html.haml
+++ b/app/views/layouts/_auth_credentials.html.haml
@@ -39,8 +39,7 @@
                          :placeholder       => placeholder_if_present(@edit[:new]["#{pfx}_verify".to_sym]),
                          "data-miq_observe" => url_json)
 .form-group
-  .col-md-9
-  .col-md-2
+  .col-md-10
     = render(:partial => "/layouts/form_buttons_verify",
              :locals  => {:validate_url => validate_url,
                           :valtype      => "#{pfx}",

--- a/app/views/layouts/_form_buttons_verify.html.haml
+++ b/app/views/layouts/_form_buttons_verify.html.haml
@@ -16,7 +16,7 @@
 %div{:id => "#{valtype}_validate_buttons_on", :style => ("display:none" unless @edit[statuskey])}
   - if serialize
     = button_tag(_("Validate"),
-                 :class   => "btn btn-primary",
+                 :class   => "btn btn-primary pull-right",
                  :alt     => verify_title_on,
                  :title   => verify_title_on,
                  :onclick => "miqAjaxButton('#{url_for(:action => validate_url,
@@ -28,7 +28,7 @@
                :button => "validate",
                :type   => valtype,
                :id     => id},
-              :class                 => "btn btn-primary",
+              :class                 => "btn btn-primary pull-right",
               :alt                   => verify_title_on,
               :title                 => verify_title_on,
               :id                    => "val",
@@ -38,5 +38,5 @@
 
 %div{:id => "#{valtype}_validate_buttons_off", :style => ("display:none" if @edit[statuskey])}
   = button_tag(_("Validate"),
-               :class    => "btn btn-primary btn-disabled",
+               :class    => "btn btn-primary btn-disabled pull-right",
                :disabled => true)

--- a/app/views/miq_ae_class/_method_data.html.haml
+++ b/app/views/miq_ae_class/_method_data.html.haml
@@ -15,7 +15,7 @@
   %tr
     %td
       %span#pwd_note{:style => "color: red;"}
-    %td{:align => "right"}
+    %td
       = render(:partial => "/layouts/form_buttons_verify",
         :locals         => {:validate_url => "validate_method_data",
           :valtype                        => "default",

--- a/app/views/ops/_settings_database_tab.html.haml
+++ b/app/views/ops/_settings_database_tab.html.haml
@@ -52,11 +52,10 @@
                                   "data-miq_observe" => {:interval => '.5',
                                   :url      => url}.to_json)
     .form-group
-      .col-md-2
-      .col-md-8{:align => "left"}
+      .col-md-10
         #validate_button_on{:style => "display:#{@edit[:new][:password] == @edit[:new][:verify] ? "display" : "none"};"}
           = button_tag(_("Validate"),
-                      :class   => "btn btn-primary",
+                      :class   => "btn btn-primary pull-right",
                       :alt     => _("Validate Database Configuration"),
                       :title   => _("Validate Database Configuration"),
                       :onclick => "miqAjaxButton('#{url_for(:action => "settings_update",

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -321,7 +321,7 @@
           .form-group
             .col-md-8
               %span#pwd_note{:style => "color:red"}
-            .col-md-10{:align => "right"}
+            .col-md-10
               = render  :partial => "/layouts/form_buttons_verify",
                 :locals => {:validate_url => "validate_replcation_worker", :valtype => "default",
                 :verify_title_off => _("Matching password fields are needed to perform verification of credentials"),

--- a/app/views/pxe/_pxe_form.html.haml
+++ b/app/views/pxe/_pxe_form.html.haml
@@ -27,8 +27,10 @@
         %label.col-md-2.control-label
           = _('URI')
         .col-md-8
-          #{@edit[:new][:uri_prefix]}://
-          = text_field_tag("uri", @edit[:new][:uri], :maxlength => 100,
+          .input-group
+            .input-group-addon
+              #{@edit[:new][:uri_prefix]}://
+            = text_field_tag("uri", @edit[:new][:uri], :maxlength => 100,
                             :class => "form-control",
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       - if @edit[:new][:uri_prefix] != "nfs"


### PR DESCRIPTION
Validate button shift from left to right using bootstrap, to be consistent with other similar partials.
Also contains text field bootstrap conversion.

Commit1:
Before:
![firefox_screenshot_2015-10-14t09-06-38 663z](https://cloud.githubusercontent.com/assets/9535558/10479893/44555d8e-7267-11e5-86fb-85736356495f.png)

After:
![firefox_screenshot_2015-10-14t09-06-16 552z](https://cloud.githubusercontent.com/assets/9535558/10479896/45c88448-7267-11e5-9f3a-7c135c6e59f6.png)

Commit2:
Before:
![firefox_screenshot_2015-10-14t11-28-33 190z](https://cloud.githubusercontent.com/assets/9535558/10482611/a6d62e18-7279-11e5-8cee-e7c99b9052bd.png)

After:
![firefox_screenshot_2015-10-14t11-46-10 549z](https://cloud.githubusercontent.com/assets/9535558/10482638/f349fbf8-7279-11e5-87f2-8ebac8bd011d.png)



