### PR TITLE
[api] Provide virtual attribute user for service_requests and services

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,9 +22,11 @@ class Service < ActiveRecord::Base
   virtual_has_one    :custom_actions
   virtual_has_one    :custom_action_buttons
   virtual_has_one    :provision_dialog
+  virtual_has_one    :user
 
   delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
   delegate :provision_dialog, :to => :miq_request, :allow_nil => true
+  delegate :user, :to => :miq_request, :allow_nil => true
 
   include ServiceMixin
   include OwnershipMixin

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -9,9 +9,14 @@ class ServiceTemplateProvisionRequest < MiqRequest
   virtual_has_one :picture
   virtual_has_one :service_template
   virtual_has_one :provision_dialog
+  virtual_has_one :user
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
+
+  def user
+    get_user
+  end
 
   def my_role
     'ems_operations'

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -46,6 +46,12 @@ describe ApiController do
     expect(provision_dialog["label"]).to eq(provision_dialog1.label)
   end
 
+  def expect_result_to_have_user_email(email)
+    expect_request_success
+    expect_result_to_have_keys(%w(id href user))
+    expect(@result["user"]["email"]).to eq(email)
+  end
+
   describe "Service Requests query" do
     before do
       template.resource_actions = [provision_ra, retire_ra]
@@ -56,6 +62,13 @@ describe ApiController do
       run_get service_requests_url(service_request.id), :attributes => "provision_dialog"
 
       expect_result_to_have_provision_dialog
+    end
+
+    it "can return the request's user.email" do
+      @user.update_attributes!(:email => "admin@api.net")
+      run_get service_requests_url(service_request.id), :attributes => "user.email"
+
+      expect_result_to_have_user_email(@user.email)
     end
   end
 
@@ -69,6 +82,13 @@ describe ApiController do
       run_get services_url(service.id), :attributes => "provision_dialog"
 
       expect_result_to_have_provision_dialog
+    end
+
+    it "can return the request's user.email" do
+      @user.update_attributes!(:email => "admin@api.net")
+      run_get services_url(service.id), :attributes => "user.email"
+
+      expect_result_to_have_user_email(@user.email)
     end
   end
 end


### PR DESCRIPTION
- Allows api users to query --attributes=user or any related attribute
like --attributes=user.name,user.email
- Available for both /api/service_requests/:id and /api/services/:id
- Added specs

https://trello.com/c/FC2WKgNJ

[skip ci]