### PR TITLE
Update authentication to use longer lived UI token

### DIFF
--- a/spa_ui/self_service/client/app/components/navigation/header-nav.html
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.html
@@ -55,7 +55,7 @@
         </a>
         <ul class="dropdown-menu">
           <li class="action"><a href="#">Preferences</a></li>
-          <li class="action"><a href="#">Logout</a></li>
+          <li class="action"><a ui-sref="logout">Logout</a></li>
         </ul>
       </li>
     </ul>

--- a/spa_ui/self_service/client/app/config/api.config.js
+++ b/spa_ui/self_service/client/app/config/api.config.js
@@ -2,7 +2,7 @@
   'use strict';
 
   angular.module('app.config')
-    .constant('API_BASE', 'http://localhost:3000')
-    .constant('API_LOGIN', 'admin')
-    .constant('API_PASSWORD', 'smartvm');
+    .constant('API_BASE', location.protocol + '//' + location.host)
+    .constant('API_LOGIN', '')
+    .constant('API_PASSWORD', '');
 })();

--- a/spa_ui/self_service/client/app/resources/authentication-api.factory.js
+++ b/spa_ui/self_service/client/app/resources/authentication-api.factory.js
@@ -5,65 +5,30 @@
     .factory('AuthenticationApi', AuthenticationApiFactory);
 
   /** @ngInject */
-  function AuthenticationApiFactory($timeout, $http, $base64, API_BASE, Session, moment) {
+  function AuthenticationApiFactory($http, $base64, API_BASE, Session, Notifications) {
     var service = {
-      login: login,
-      logout: logout
+      login: login
     };
-
-    // Hold on to the credentials so that the token can be refreshed
-    var credentials = {
-      login: '',
-      password: ''
-    };
-
-    var refresh = null;
 
     return service;
 
     function login(userLogin, password) {
-      credentials.login = userLogin;
-      credentials.password = password;
-
-      return doLogin();
-    }
-
-    function logout() {
-      return $http
-        .delete('/api/logout')
-        .success(logoutSuccess);
-
-      function logoutSuccess() {
-        if (refresh) {
-          refresh.cancel();
-        }
-        credentials = {
-          login: '',
-          password: ''
-        };
-        Session.destroy();
-      }
-    }
-
-    // Private
-
-    function doLogin() {
-      return $http.get(API_BASE + '/api/auth', {
+      return $http.get(API_BASE + '/api/auth?requester_type=ui', {
         headers: {
-          'Authorization': 'Basic ' + $base64.encode([credentials.login, credentials.password].join(':')),
+          'Authorization': 'Basic ' + $base64.encode([userLogin, password].join(':')),
           'X-Auth-Token': void 0
         }
       }).then(loginSuccess, loginFailure);
 
       function loginSuccess(response) {
         Session.create(response.data);
-        // Hack; Re-authenticate a little before the token expires to keep it fresh
-        refresh = $timeout(doLogin, Session.current.expiresOn.subtract(30, 'seconds').diff(moment()));
       }
 
       function loginFailure(response) {
         Session.destroy();
-        console.log('TODO: Unhandled loginFailure', response.data);
+        Notifications.message('danger', '', 'Incorrect username or password.', false);
+
+        return response;
       }
     }
   }

--- a/spa_ui/self_service/client/app/states/login/login.html
+++ b/spa_ui/self_service/client/app/states/login/login.html
@@ -8,6 +8,7 @@
     </div><!--/.col-*-->
     <div class="col-sm-8 col-md-6 col-lg-5 login">
       <form class="form-horizontal" role="form" ng-submit="vm.onSubmit()">
+        <pf-notification-list></pf-notification-list>
         <div class="form-group">
           <label for="inputUsername" class="col-sm-2 col-md-2 control-label">Username</label>
           <div class="col-sm-10 col-md-10">

--- a/spa_ui/self_service/client/app/states/logout/logout.state.js
+++ b/spa_ui/self_service/client/app/states/logout/logout.state.js
@@ -21,17 +21,16 @@
   }
 
   /** @ngInject */
-  function StateController($state, logger, lodash, AuthenticationApi) {
+  function StateController($state, Session) {
     var vm = this;
 
-    vm.AuthService = AuthenticationApi;
-    vm.title = '';
+    vm.title = 'Logout';
 
-    vm.AuthService.logout().success(lodash.bind(function() {
-      logger.info('You have been logged out.');
-      $state.transitionTo('login');
-    }, vm)).error(lodash.bind(function() {
-      logger.info('An error has occurred at logout.');
-    }, vm));
+    activate();
+
+    function activate() {
+      Session.destroy();
+      $state.go('login');
+    }
   }
 })();

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -26,7 +26,6 @@
   <link rel="stylesheet" href="/bower_components/toastr/toastr.css" />
   <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly.css" />
   <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly-additions.css" />
-  <link rel="stylesheet" href="/bower_components/angular-patternfly/styles/angular-patternfly.css" />
   <!-- endbower -->
   <!-- endbuild -->
 

--- a/spa_ui/self_service/gulp/tasks/optimize.js
+++ b/spa_ui/self_service/gulp/tasks/optimize.js
@@ -6,7 +6,6 @@ var plumber = require('gulp-plumber');
 var csso = require('gulp-csso');
 var ngAnnotate = require('gulp-ng-annotate');
 var uglify = require('gulp-uglify');
-var replace = require('gulp-replace');
 var rev = require('gulp-rev');
 var revReplace = require('gulp-rev-replace');
 var getHeader = require('../utils/getHeader');
@@ -40,7 +39,6 @@ module.exports = function(gulp, options) {
       .pipe(cssFilter.restore())
       // Get the custom javascript
       .pipe(jsAppFilter)
-      .pipe(replace("'" + config.devHost + "'", "location.protocol + '//' + location.host"))
 
       // FIXME Disabling minifiction and injection until the following issue with ng-annotate has been resolved
       // Issue : https://github.com/olov/ng-annotate/issues/168

--- a/spa_ui/self_service/package.json
+++ b/spa_ui/self_service/package.json
@@ -52,7 +52,6 @@
     "gulp-plumber": "^1.0.0",
     "gulp-print": "^1.1.0",
     "gulp-rename": "^1.2.0",
-    "gulp-replace": "^0.5.0",
     "gulp-rev": "^6.0.1",
     "gulp-rev-replace": "^0.4.0",
     "gulp-ruby-sass": "^2.0.3",


### PR DESCRIPTION
Replace short lived token with client-side keep-alive for a longer lived token and server-side keep-alive.

- Users are sent back to the login screen with the message 'Your session has timed out.' when they've been inactive too long
- Added login failure feedback
- Removed dev only API_BASE value. In development the proxy server will correctly proxy all api commands to the server. This removes the need to replace the API address during the build process. No change is needed for any environment.
- Removed the default login values for admin
- Wired up the logout link in the navigation.

### Unresolved Issue
When a session has expired the server will send back a 401 along with the header 'WWW-Authenticate: Basic', this will be intercepted by the browser and a Basic Auth challenge will be displayed. The application is not able to detect this or even have a chance to react.

If the user provides valid credentials, or in the case of Firefox provides nothing at all, and clicks 'OK' or 'Log In' then the browser will store those credentials as Basic Auth credentials and will use them for any future 401s with the 'WWW-Authenticate: Basic' header.

Because it's possible to provide different credentials to the Basic Auth challenge than those used within the application, the user the server sees and attributes to actions may not be the one actually using the application.

With Basic Auth credentials set in Firefox the user will no longer be able to login using the applications login page, in Chrome they can continue to login but the Basic Auth credentials remain in effect. Chrome does clear the credentials the next time a 401 is received, for example if the user types the wrong password during login. Firefox will only clear them if the history is cleared or the browser is closed.

https://bugzilla.redhat.com/show_bug.cgi?id=1270383
https://bugzilla.redhat.com/show_bug.cgi?id=1270384