### PR TITLE
No need to add "/" at the end of url when url ends with "="

### DIFF
--- a/app/assets/javascripts/miq_dhtmlxgrid.js
+++ b/app/assets/javascripts/miq_dhtmlxgrid.js
@@ -26,7 +26,7 @@ function miqRowClick(row_id, cell_idx) {
     if (typeof row_url_ajax != "undefined" && row_url_ajax) {
       miqJqueryRequest(row_url + row_id, {beforeSend: true, complete: true});
     } else {
-      if (!row_url.endsWith("/")) {
+      if (!row_url.endsWith("/") && !row_url.endsWith("=")) {
         row_url = row_url + "/";
       }
       DoNav(row_url + row_id);


### PR DESCRIPTION
We should not add '/' to the end of url when url ends with '='. This was causing a malformed url to Parameter summary screen when viewing list of Parameters under Cloud Stack.
- Malformed URL: http://localhost:3000/orchestration_stack/parameters/10000000000005?show=/10r15
- Correct URL: http://localhost:3000/orchestration_stack/parameters/10000000000005?show=10r15
Issue was introduced in commit: 2e6ce4ccd76a724495dc016613418302afbb430c

https://bugzilla.redhat.com/show_bug.cgi?id=1271514

@tenderlove please review, i think this issue might have been introduced during restful routes PR.