### PR TITLE
Enforce tenant needed for creating MiqAeDomain

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -2,7 +2,7 @@ class MiqAeDomain < MiqAeNamespace
   default_scope { where(:parent_id => nil).where(arel_table[:name].not_eq("$")) }
   validates_inclusion_of :parent_id, :in => [nil], :message => 'should be nil for Domain'
   # TODO: Once all the specs start passing in the tenant object, enforce its presence
-  # validates_presence_of :tenant, :message => "object is needed to own the domain"
+  validates_presence_of :tenant, :message => "object is needed to own the domain"
   after_destroy :squeeze_priorities
   default_value_for :system,  false
   default_value_for :enabled, false

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -31,7 +31,7 @@ describe MiqAeDatastore do
         </MiqAeClass>
       </MiqAeDatastore>
     XML
-
+    Tenant.seed
     @defaults_miq_ae_field = {}
     @defaults_miq_ae_field[:message]    = MiqAeField.default(:message)
     @defaults_miq_ae_field[:substitute] = MiqAeField.default(:substitute).to_s


### PR DESCRIPTION
Uncommented the validation call that checks if the tenant object
is passed in when creating a domain.
The spec was missing a Tenant.seed