### PR TITLE
Fix os_type typo in host discovery

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1058,7 +1058,7 @@ class Host < ActiveRecord::Base
         )
 
         find_method        = host.detect_discovered_hypervisor(ost, ost.ipaddr)
-        os_name, _ost_type = host.detect_discovered_os(ost)
+        os_name, os_type = host.detect_discovered_os(ost)
 
         if Host.send(find_method, ost.ipaddr).nil?
           # It may have been added by someone else while we were discovering


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1266467

Code originally had `os_name, ost_type = host.detect_discovered_os(ost)` then later on using `:product_type => os_type` which caused the exception.