### PR TITLE
"To Domain" pull down should be filtered by current tenant

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1761,7 +1761,7 @@ class MiqAeClassController < ApplicationController
       selected_items[record.id] = record.display_name.blank? ? record.name : "#{record.display_name} (#{record.name})"
       @record = record if i == 0
     end
-    MiqAeDomain.all_unlocked.collect { |domain| domains[domain.id] = domain_display_name(domain) }
+    current_tenant.editable_domains.collect { |domain| domains[domain.id] = domain_display_name(domain) }
     initialize_copy_edit_vars(typ, button_pressed, domains, selected_items)
     @sb[:domain_id] = domains.first.first
     @edit[:current] = copy_hash(@edit[:new])

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -456,4 +456,15 @@ describe MiqAeClassController do
       controller.send(:create_method)
     end
   end
+
+  context "#copy_objects_edit_screen" do
+    it "sets only current tenant's domains to be displayed in To Domain pull down" do
+      FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
+      FactoryGirl.create(:miq_ae_domain, :tenant_id => 2)
+      controller.instance_variable_set(:@sb, {})
+      ns = FactoryGirl.create(:miq_ae_namespace)
+      controller.send(:copy_objects_edit_screen, MiqAeNamespace, [ns.id], "miq_ae_namespace_copy")
+      assigns(:edit)[:domains].count.should eq(1)
+    end
+  end
 end


### PR DESCRIPTION
When copying Automate objects, only display Domains under Current Tenant on "To Domain" pull down list.

Fixes #4871 
@mkanoor please review/test.