### PR TITLE
Use LinuxAdmin::NetworkInterface for network operations

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -49,10 +49,12 @@ module MiqServer::EnvironmentManagement
     def get_network_information
       ipaddr = hostname = mac_address = ''
       begin
-        if MiqEnvironment::Command.is_linux? && File.exist?('/bin/miqnet.sh')
-          ipaddr      = `/bin/miqnet.sh -GET IP`.chomp
+        if MiqEnvironment::Command.is_linux?
+          eth0 = LinuxAdmin::NetworkInterface.new("eth0")
+
+          ipaddr      = eth0.address
           hostname    = LinuxAdmin::Hosts.new.hostname
-          mac_address = `/bin/miqnet.sh -GET MAC`.chomp
+          mac_address = eth0.mac_address
         else
           require 'MiqSockUtil'
           ipaddr      = MiqSockUtil.getIpAddr

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -24,7 +24,7 @@ gem "fog",                     "~>2.0.0.pre.0",     :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "kubeclient",              "=0.8.0",            :require => false
-gem "linux_admin",             "~>0.11.1",          :require => false
+gem "linux_admin",             "~>0.12.1",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.11.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -96,21 +96,6 @@ require 'appliance_console/scap'
 require 'appliance_console/prompts'
 include ApplianceConsole::Prompts
 
-# Updates the ip address associated with a hostname in the /etc/hosts file
-#
-# @param host [String] The hostname to look for
-# @param ip [String] The address to write
-def update_hostname_ip(host, ip)
-  hosts_file = LinuxAdmin::Hosts.new
-  line_num = hosts_file.parsed_file.find_path(host).first
-  if line_num.nil?
-    hosts_file.update_entry(ip, host)
-  else
-    hosts_file.parsed_file[line_num][:address] = ip
-  end
-  hosts_file.save
-end
-
 module ApplianceConsole
   eth0 = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE)
   ip = eth0.address
@@ -182,23 +167,14 @@ To modify the configuration, use a web browser to access the management page.
         say("DHCP Network Configuration\n\n")
         if agree("Apply DHCP network configuration? (Y/N): ")
           say("\nApplying DHCP network configuration...")
-          # Remove search and nameserver lines from resolv.conf
+
           resolv = LinuxAdmin::Dns.new
           resolv.search_order = []
           resolv.nameservers = []
           resolv.save
 
-          # Enable DHCP for the interface
           eth0.enable_dhcp
           eth0.save
-
-          # Restart networking service
-          LinuxAdmin::Service.new("network").restart
-
-          # Get the new address and update /etc/hosts
-          eth0.reload
-          dhcp_ip = eth0.address
-          update_hostname_ip(host, dhcp_ip)
 
           say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
         end
@@ -231,6 +207,11 @@ Static Network Configuration
         if agree("Apply static network configuration? (Y/N)")
           say("\nApplying static network configuration...")
 
+          resolv = LinuxAdmin::Dns.new
+          resolv.search_order = []
+          resolv.nameservers = []
+          resolv.save
+
           begin
             network_configured = eth0.apply_static(new_ip, new_mask, new_gw, [new_dns1, new_dns2], new_search_order)
           rescue ArgumentError => e
@@ -245,8 +226,6 @@ Static Network Configuration
             next
           end
 
-          update_hostname_ip(host, new_ip)
-
           say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
         end
 
@@ -260,8 +239,11 @@ Static Network Configuration
         if new_host != host
           say("Applying new hostname...")
           system_hosts = LinuxAdmin::Hosts.new
+
+          system_hosts.parsed_file.each { |line| line[:hosts].to_a.delete(host) } unless host =~ /^localhost.*/
+
           system_hosts.hostname = new_host
-          system_hosts.update_entry(ip, new_host)
+          system_hosts.update_entry("127.0.0.1", new_host)
           system_hosts.save
           LinuxAdmin::Service.new("network").restart
         end

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -127,7 +127,12 @@ module Vmdb
 
     def self.get_network
       retVal = {}
-      retVal[:hostname] = LinuxAdmin::Hosts.new.hostname
+      eth0 = LinuxAdmin::NetworkInterface.new("eth0")
+      retVal[:hostname]   = LinuxAdmin::Hosts.new.hostname
+      retVal[:macaddress] = eth0.mac_address
+      retVal[:ipaddress]  = eth0.address
+      retVal[:netmask]    = eth0.netmask
+      retVal[:gateway]    = eth0.gateway
 
       miqnet = "/bin/miqnet.sh"
 
@@ -135,10 +140,6 @@ module Vmdb
         # Make a call to the virtual appliance to get the network information
         cmd     = "#{miqnet} -GET"
 
-        retVal[:macaddress]    = `#{cmd} MAC`
-        retVal[:ipaddress]     = `#{cmd} IP`
-        retVal[:netmask]       = `#{cmd} MASK`
-        retVal[:gateway]       = `#{cmd} GW`
         retVal[:primary_dns]   = `#{cmd} DNS1`
         retVal[:secondary_dns] = `#{cmd} DNS2`
       end


### PR DESCRIPTION
Replaces the use of `miqnet.sh` for setting and getting network information.

Requires https://github.com/ManageIQ/linux_admin/pull/132, https://github.com/ManageIQ/manageiq-appliance-build/pull/66, and a new linux admin gem version