### PR TITLE
Fix pod's dns policy field to be capitalized in UI

### DIFF
--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -99,7 +99,7 @@ module ContainerGroupHelper::TextualSummary
   end
 
   def textual_dns_policy
-    @record.dns_policy
+    {:label => "DNS Policy", :value => @record.dns_policy}
   end
 
   def textual_ip


### PR DESCRIPTION
@miq-bot add_label ui
@miq-bot add_label providers/containers