### PR TITLE
Fix portal IP to be capitalized in UI for container service

### DIFF
--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -63,7 +63,7 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_portal_ip
-    @record.portal_ip
+    {:label => "Portal IP", :value => @record.portal_ip}
   end
 
   def textual_port_config(port_conf)


### PR DESCRIPTION
@miq-bot add_label ui, providers/containers