### PR TITLE
Add translator hints & location comments to gettext catalogs

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -5,6 +5,9 @@ begin
   # trying to debug something other than their parser, we need to
   # temporarily force it off while we load stuff.
   Vmdb::FastGettextHelper.register_locales
+  gettext_options = %w(--sort-by-msgid --location --no-wrap)
+  Rails.application.config.gettext_i18n_rails.msgmerge = gettext_options
+  Rails.application.config.gettext_i18n_rails.xgettext = gettext_options << "--add-comments=TRANSLATORS"
 ensure
   $DEBUG = old_debug
 end

--- a/config/locales/manageiq.pot
+++ b/config/locales/manageiq.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: manageiq 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-07 18:51+0200\n"
-"PO-Revision-Date: 2015-10-07 18:51+0200\n"
+"POT-Creation-Date: 2015-10-15 14:47+0200\n"
+"PO-Revision-Date: 2015-10-15 14:47+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -18,3507 +18,4673 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:21
 msgid " # of Days"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:645 ../../app/controllers/miq_policy_controller.rb:646
 msgid " %s Assignments"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:51
 msgid " %{name} from %{value} to %{parameters} "
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1434 ../../app/controllers/container_controller.rb:192
 msgid " (Names with \"%s\")"
 msgstr ""
 
+#: ../../app/views/ops/_settings_list_tab.html.haml:27
 msgid " (current)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:212
 msgid " * Multiple UI workers can not be configured with session store as memory"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:71
+msgid " Maximize"
+msgstr ""
+
+#: ../../app/presenters/widget_presenter.rb:71
+msgid " Minimize"
+msgstr ""
+
+#: ../../app/views/miq_policy/_event_details.html.haml:97 ../../app/views/miq_policy/_event_details.html.haml:278
 msgid " Selected Actions:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:308
 msgid " Selected Alerts:"
 msgstr ""
 
+#: ../../app/views/ops/_tenant_quota_form.html.haml:70
 msgid " Valid numeric quota value required "
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_list.html.haml:6 ../../app/views/miq_policy/_event_list.html.haml:8 ../../app/views/miq_policy/_policy_list.html.haml:4 ../../app/views/miq_policy/_condition_list.html.haml:8 ../../app/views/miq_policy/_alert_profile_list.html.haml:6
 msgid " that match the entered search string"
 msgstr ""
 
+#: ../../app/models/miq_alert.rb:324 ../../app/models/miq_alert.rb:333
 msgid "\"#{db}Performance.#{c}\""
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1069
 msgid "\"%s\" is not a valid Orchestration Template type"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:305
 msgid "\"%s\" was executed"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:1829
 msgid "\"%s\": cannot be removed, has vms or hosts"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1802
 msgid "\"%{action}\" for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1978
 msgid "\"%{field}\" %{model} cannot be deleted"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:385
 msgid "\"%{name}\": Global %{model} cannot be deleted"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:389
 msgid "\"%{name}\": In use by %{rep_count}, cannot be deleted"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:288 ../../app/controllers/application_controller.rb:1610 ../../app/controllers/miq_task_controller.rb:263 ../../app/controllers/application_controller/ci_processing.rb:1612 ../../app/controllers/application_controller/ci_processing.rb:1744 ../../app/controllers/application_controller/ci_processing.rb:1746
 msgid "\"%{record}\": %{task} successfully initiated"
 msgstr ""
 
+#: ../../app/controllers/mixins/containers_common_mixin.rb:160
 msgid "\"%{record}\": Analysis successfully initiated"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:60
 msgid "\"Unable to initiate scaling, obtaining of status failed: #{ex}\""
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:168 ../../app/views/vm_common/_right_size.html.haml:252 ../../app/views/vm_common/_right_size.html.haml:335
 msgid "% Savings"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:180
 msgid "%d Months Ago"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:178
 msgid "%d Weeks Ago"
 msgstr ""
 
-msgid "%s"
-msgstr ""
-
+#: ../../app/views/report/_form_filter_chargeback.html.haml:169
 msgid "%s  Ending with"
 msgstr ""
 
-msgid "%s (%s)"
-msgstr ""
-
-msgid "%s (0)"
-msgstr ""
-
+#: ../../app/controllers/ems_cluster_controller.rb:253
 msgid "%s (All %s)"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:95
 msgid "%s (All cloud tenants present on this host)"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_alert_profile.rb:32
 msgid "%s Alert Profiles"
 msgstr ""
 
+#: ../../app/views/layouts/_tag_edit_items.html.haml:7
 msgid "%s Being Tagged"
 msgstr ""
 
+#: ../../app/controllers/application_controller/dialog_runner.rb:84
 msgid "%s Button not yet implemented"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:188
 msgid "%s Client Connections"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_folders.html.haml:20
 msgid "%s Conditions"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings.rb:136
 msgid "%s Credentials validated successfully"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:176
 msgid "%s Days Ago"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:834
 msgid "%s Discovery returned: "
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:113
 msgid "%s Entry Point (NameSpace/Class/Instance)"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:447 ../../app/controllers/catalog_controller.rb:1808
 msgid "%s Group Reorder"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:18
 msgid "%s Group Reorder cancelled"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:43
 msgid "%s Group Reorder saved"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:68
 msgid "%s Guide"
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:62
 msgid "%s Hour"
 msgid_plural "%s Hours"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:196
 msgid "%s Month"
 msgid_plural "%s Months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/views/miq_policy/_policy_folders.html.haml:22
 msgid "%s Policies"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1760
 msgid "%s Policy Assignment"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1751 ../../app/controllers/vm_common.rb:1755
 msgid "%s Policy Simulation"
 msgstr ""
 
+#: ../../app/controllers/application_controller/dialog_runner.rb:43
 msgid "%s Request was Submitted"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:194
 msgid "%s Settings"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:178
 msgid "%s Summary"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:184 ../../app/controllers/ops_controller/db.rb:219
 msgid "%s Utilization"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:194
 msgid "%s Week"
 msgid_plural "%s Weeks"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/controllers/application_controller.rb:1636
 msgid "%s are not in the current region and will be skipped"
 msgstr ""
 
+#: ../../app/views/layouts/gtl/_list.html.haml:219
 msgid "%s bytes"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/events.rb:9 ../../app/controllers/miq_policy_controller/alert_profiles.rb:80 ../../app/controllers/miq_policy_controller.rb:28 ../../app/controllers/miq_policy_controller.rb:203
 msgid "%s cancelled by user"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:387
 msgid "%s file saved"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:307
 msgid "%s has been initiated for the selected Servers"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:202
 msgid "%s has no network adapters"
 msgstr ""
 
+#: ../../app/views/vm_common/_snapshots_desc.html.haml:63
 msgid "%s has no snapshots"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:992
 msgid "%s is currently being used in the Display Filter"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:661 ../../app/controllers/ops_controller/diagnostics.rb:678
 msgid "%s is not allowed for the selected item"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:1635
 msgid "%s is not in the current region and will be skipped"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:358 ../../app/controllers/miq_ae_tools_controller.rb:359 ../../app/controllers/chargeback_controller.rb:149 ../../app/controllers/report_controller/widgets.rb:747 ../../app/controllers/report_controller/menus.rb:72 ../../app/controllers/report_controller/reports.rb:249 ../../app/controllers/miq_policy_controller/miq_actions.rb:379 ../../app/controllers/miq_policy_controller/miq_actions.rb:382 ../../app/controllers/miq_policy_controller/miq_actions.rb:385 ../../app/controllers/miq_policy_controller/alerts.rb:535 ../../app/controllers/miq_policy_controller/alerts.rb:538 ../../app/controllers/vm_common.rb:572 ../../app/controllers/miq_ae_class_controller.rb:613 ../../app/controllers/miq_ae_class_controller.rb:674 ../../app/controllers/miq_ae_class_controller.rb:2082 ../../app/controllers/miq_ae_class_controller.rb:2147 ../../app/controllers/storage_manager_controller.rb:83 ../../app/controllers/storage_manager_controller.rb:90 ../../app/controllers/storage_manager_controller.rb:119 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:249 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:663 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:668 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:673 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:678 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:694 ../../app/controllers/service_controller.rb:158 ../../app/controllers/ontap_file_share_controller.rb:117 ../../app/controllers/ontap_file_share_controller.rb:118 ../../app/controllers/catalog_controller.rb:361 ../../app/controllers/catalog_controller.rb:367 ../../app/controllers/catalog_controller.rb:836 ../../app/controllers/catalog_controller.rb:838 ../../app/controllers/ops_controller/settings/rhn.rb:229 ../../app/controllers/ops_controller/settings/tags.rb:53 ../../app/controllers/ops_controller/settings/tags.rb:56 ../../app/controllers/ops_controller/settings/tags.rb:59 ../../app/controllers/ops_controller/settings/ldap.rb:49 ../../app/controllers/ops_controller/settings/ldap.rb:175 ../../app/controllers/ops_controller/settings/ldap.rb:218 ../../app/controllers/ops_controller/settings/zones.rb:19 ../../app/controllers/ops_controller/settings/zones.rb:22 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:578 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:612 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:670 ../../app/controllers/ops_controller/settings.rb:99 ../../app/controllers/ops_controller/settings.rb:157 ../../app/controllers/configuration_controller.rb:495 ../../app/controllers/configuration_controller.rb:553 ../../app/controllers/ontap_storage_system_controller.rb:124 ../../app/controllers/ontap_storage_system_controller.rb:125 ../../app/controllers/ontap_storage_system_controller.rb:126 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:111 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:114 ../../app/controllers/pxe_controller/iso_datastores.rb:49 ../../app/controllers/pxe_controller/pxe_image_types.rb:166 ../../app/controllers/pxe_controller/pxe_servers.rb:298 ../../app/controllers/pxe_controller/pxe_servers.rb:301 ../../app/controllers/pxe_controller/pxe_servers.rb:304 ../../app/controllers/pxe_controller/pxe_servers.rb:308 ../../app/controllers/pxe_controller/pxe_servers.rb:311 ../../app/controllers/pxe_controller/pxe_servers.rb:314 ../../app/controllers/ems_common.rb:272 ../../app/controllers/ems_common.rb:276 ../../app/controllers/ems_common.rb:656 ../../app/controllers/miq_policy_controller.rb:1019 ../../app/controllers/miq_policy_controller.rb:1023 ../../app/controllers/application_controller/ci_processing.rb:801 ../../app/controllers/application_controller/filter.rb:608 ../../app/controllers/application_controller/buttons.rb:335 ../../app/controllers/application_controller/buttons.rb:339 ../../app/controllers/application_controller/buttons.rb:749 ../../app/controllers/application_controller/buttons.rb:754 ../../app/controllers/application_controller/buttons.rb:756 ../../app/controllers/application_controller/buttons.rb:757
 msgid "%s is required"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:686
 msgid "%s must be alphanumeric characters and underscores without spaces"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alerts.rb:544 ../../app/controllers/miq_policy_controller/alerts.rb:549 ../../app/controllers/ontap_storage_system_controller.rb:127 ../../app/controllers/application_controller/ci_processing.rb:414
 msgid "%s must be an integer"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:253
 msgid "%s must be configured"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:508 ../../app/controllers/ops_controller/ops_rbac.rb:512 ../../app/controllers/ops_controller/ops_rbac.rb:515
 msgid "%s must be entered to perform LDAP Group Look Up"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:257 ../../app/controllers/report_controller/reports.rb:354 ../../app/controllers/report_controller/reports.rb:404 ../../app/controllers/ops_controller/settings/common.rb:529 ../../app/controllers/ems_common.rb:669 ../../app/controllers/ems_common.rb:672
 msgid "%s must be numeric"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:357 ../../app/controllers/report_controller/dashboards.rb:349 ../../app/controllers/report_controller/widgets.rb:730 ../../app/controllers/report_controller/widgets.rb:739 ../../app/controllers/report_controller/widgets.rb:743 ../../app/controllers/report_controller/schedules.rb:233 ../../app/controllers/report_controller/reports.rb:269 ../../app/controllers/report_controller/reports.rb:274 ../../app/controllers/report_controller/reports.rb:279 ../../app/controllers/report_controller/reports.rb:283 ../../app/controllers/miq_policy_controller/miq_actions.rb:380 ../../app/controllers/miq_policy_controller/miq_actions.rb:392 ../../app/controllers/miq_policy_controller/miq_actions.rb:395 ../../app/controllers/miq_policy_controller/miq_actions.rb:398 ../../app/controllers/miq_policy_controller/miq_actions.rb:401 ../../app/controllers/miq_policy_controller/miq_actions.rb:414 ../../app/controllers/miq_policy_controller/alerts.rb:532 ../../app/controllers/miq_policy_controller/alert_profiles.rb:85 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:252 ../../app/controllers/catalog_controller.rb:365 ../../app/controllers/ops_controller/settings/schedules.rb:385 ../../app/controllers/ops_controller/settings/schedules.rb:389 ../../app/controllers/application_controller/filter.rb:1524 ../../app/controllers/application_controller/buttons.rb:343 ../../app/controllers/application_controller/buttons.rb:752
 msgid "%s must be selected"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:343
 msgid "%s must be unique for this group"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:690
 msgid "%s must not be 'action' or 'controller'"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:308 ../../app/controllers/repository_controller.rb:335 ../../app/controllers/chargeback_controller.rb:306 ../../app/controllers/report_controller/widgets.rb:100 ../../app/controllers/report_controller/saved_reports.rb:94 ../../app/controllers/report_controller/schedules.rb:83 ../../app/controllers/report_controller/schedules.rb:108 ../../app/controllers/miq_policy_controller/policies.rb:122 ../../app/controllers/miq_policy_controller/miq_actions.rb:74 ../../app/controllers/miq_policy_controller/alerts.rb:54 ../../app/controllers/miq_policy_controller/alert_profiles.rb:110 ../../app/controllers/miq_policy_controller/conditions.rb:125 ../../app/controllers/miq_policy_controller/policy_profiles.rb:77 ../../app/controllers/miq_request_controller.rb:525 ../../app/controllers/storage_manager_controller.rb:425 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:83 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1344 ../../app/controllers/ops_controller/settings/ldap.rb:121 ../../app/controllers/ops_controller/settings/ldap.rb:297 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:412 ../../app/controllers/ops_controller/settings/schedules.rb:186 ../../app/controllers/ops_controller/ops_rbac.rb:268 ../../app/controllers/ops_controller/ops_rbac.rb:299 ../../app/controllers/ops_controller/ops_rbac.rb:340 ../../app/controllers/ops_controller/ops_rbac.rb:363 ../../app/controllers/ops_controller/diagnostics.rb:697 ../../app/controllers/mixins/containers_common_mixin.rb:142 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:224 ../../app/controllers/pxe_controller/iso_datastores.rb:117 ../../app/controllers/pxe_controller/pxe_image_types.rb:110 ../../app/controllers/pxe_controller/pxe_servers.rb:139 ../../app/controllers/ems_common.rb:949 ../../app/controllers/ems_common.rb:978 ../../app/controllers/ems_common.rb:1009 ../../app/controllers/miq_policy_controller.rb:264 ../../app/controllers/application_controller/ci_processing.rb:1161 ../../app/controllers/application_controller/ci_processing.rb:1228 ../../app/controllers/application_controller/ci_processing.rb:1547 ../../app/controllers/application_controller/ci_processing.rb:1693 ../../app/controllers/application_controller/ci_processing.rb:1772 ../../app/controllers/application_controller/ci_processing.rb:1835 ../../app/controllers/application_controller/ci_processing.rb:1860 ../../app/helpers/application_helper.rb:1018
 msgid "%s no longer exists"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:2561
 msgid "%s no longer exists in the database"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:307
 msgid "%s no longer exists, this alert must be reconfigured"
 msgstr ""
 
+#: ../../app/views/layouts/gtl/_list.html.haml:205 ../../app/views/layouts/gtl/_list.html.haml:317
 msgid "%s record no longer exists"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar_builder.rb:1041
 msgid "%s requests cannot be deleted"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:351 ../../app/controllers/vm_common.rb:905
 msgid "%s saved"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:214
 msgid "%s set to default"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings.rb:107
 msgid "%s should be unique"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:255 ../../app/controllers/ops_controller/diagnostics.rb:277 ../../app/controllers/ops_controller/diagnostics.rb:333 ../../app/controllers/ops_controller/diagnostics.rb:408 ../../app/controllers/ops_controller/diagnostics.rb:669 ../../app/controllers/ops_controller/diagnostics.rb:686
 msgid "%s successfully initiated"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:373
 msgid "%s tab is not available unless a sort field has been selected"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:389
 msgid "%s tab is not available unless at least 1 time field has been selected"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:335 ../../app/controllers/report_controller/reports.rb:340 ../../app/controllers/report_controller/reports.rb:359 ../../app/controllers/report_controller/reports.rb:365 ../../app/controllers/report_controller/reports.rb:370 ../../app/controllers/report_controller/reports.rb:378 ../../app/controllers/report_controller/reports.rb:409 ../../app/controllers/report_controller/reports.rb:422
 msgid "%s tab is not available until at least 1 field has been selected"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:560 ../../app/controllers/vm_common.rb:891 ../../app/controllers/ontap_file_share_controller.rb:99 ../../app/controllers/ops_controller/ops_rbac.rb:605 ../../app/controllers/ontap_storage_system_controller.rb:105 ../../app/controllers/application_controller/explorer.rb:204 ../../app/controllers/application_controller/tags.rb:174 ../../app/controllers/application_controller/ci_processing.rb:117 ../../app/controllers/application_controller/ci_processing.rb:750 ../../app/controllers/application_controller/dialog_runner.rb:22
 msgid "%s was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:225
 msgid "%s with %s Tags"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:25
 msgid "%s: None"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1799
 msgid "%{action} \"%{item_name}\" for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:160
 msgid "%{action} %{model} was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:474
 msgid "%{field1} and %{field2} fields can't be blank"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:75 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:464 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:485
 msgid "%{field} '%{value}' is already in use"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:1402 ../../app/controllers/application_controller/filter.rb:1423 ../../app/controllers/application_controller/filter.rb:1451 ../../app/controllers/application_controller/filter.rb:1480 ../../app/controllers/application_controller/filter.rb:1487
 msgid "%{field} Value Error: %{msg}"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:334
 msgid "%{field} cannot contain \"%{character}\""
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:911
 msgid "%{model}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:550 ../../app/controllers/ops_controller.rb:569 ../../app/controllers/ops_controller.rb:583 ../../app/controllers/ops_controller.rb:594 ../../app/controllers/ops_controller.rb:605 ../../app/controllers/ops_controller.rb:651 ../../app/controllers/ops_controller.rb:659 ../../app/controllers/chargeback_controller.rb:463 ../../app/controllers/chargeback_controller.rb:477 ../../app/controllers/chargeback_controller.rb:511 ../../app/controllers/report_controller/dashboards.rb:260 ../../app/controllers/report_controller/saved_reports.rb:23 ../../app/controllers/report_controller/schedules.rb:520 ../../app/controllers/report_controller/reports.rb:32 ../../app/controllers/report_controller/reports.rb:202 ../../app/controllers/miq_policy_controller/events.rb:116 ../../app/controllers/miq_policy_controller/policies.rb:240 ../../app/controllers/miq_policy_controller/miq_actions.rb:422 ../../app/controllers/miq_policy_controller/alerts.rb:589 ../../app/controllers/miq_policy_controller/alert_profiles.rb:342 ../../app/controllers/miq_policy_controller/conditions.rb:241 ../../app/controllers/miq_policy_controller/policy_profiles.rb:151 ../../app/controllers/vm_common.rb:1376 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:123 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:114 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1374 ../../app/controllers/service_controller.rb:280 ../../app/controllers/service_controller.rb:293 ../../app/controllers/container_controller.rb:178 ../../app/controllers/catalog_controller.rb:1601 ../../app/controllers/catalog_controller.rb:1628 ../../app/controllers/catalog_controller.rb:1631 ../../app/controllers/catalog_controller.rb:1679 ../../app/controllers/ops_controller/db.rb:211 ../../app/controllers/ops_controller/db.rb:225 ../../app/controllers/ops_controller/ops_rbac.rb:855 ../../app/controllers/ops_controller/ops_rbac.rb:858 ../../app/controllers/ops_controller/ops_rbac.rb:861 ../../app/controllers/ops_controller/ops_rbac.rb:865 ../../app/controllers/ops_controller/analytics.rb:43 ../../app/controllers/pxe_controller.rb:182 ../../app/controllers/pxe_controller.rb:186 ../../app/controllers/pxe_controller.rb:188 ../../app/controllers/pxe_controller.rb:200 ../../app/controllers/pxe_controller.rb:204 ../../app/controllers/pxe_controller.rb:215 ../../app/controllers/pxe_controller.rb:229 ../../app/controllers/report_controller.rb:475 ../../app/controllers/report_controller.rb:500 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:256 ../../app/controllers/pxe_controller/iso_datastores.rb:315 ../../app/controllers/pxe_controller/iso_datastores.rb:318 ../../app/controllers/pxe_controller/pxe_image_types.rb:222 ../../app/controllers/pxe_controller/pxe_servers.rb:491 ../../app/controllers/pxe_controller/pxe_servers.rb:494 ../../app/controllers/pxe_controller/pxe_servers.rb:497 ../../app/controllers/provider_foreman_controller.rb:516 ../../app/controllers/provider_foreman_controller.rb:546 ../../app/controllers/provider_foreman_controller.rb:563 ../../app/controllers/provider_foreman_controller.rb:905 ../../app/controllers/miq_policy_controller.rb:619 ../../app/controllers/miq_policy_controller.rb:644 ../../app/controllers/miq_policy_controller.rb:667 ../../app/controllers/miq_policy_controller.rb:672 ../../app/controllers/miq_policy_controller.rb:683 ../../app/controllers/miq_policy_controller.rb:694 ../../app/controllers/miq_policy_controller.rb:702 ../../app/controllers/application_controller/buttons.rb:954 ../../app/controllers/application_controller/buttons.rb:996
 msgid "%{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/miq_capacity_controller.rb:411 ../../app/controllers/miq_capacity_controller.rb:651
 msgid "%{model} \"%{name}\" %{typ}"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/policies.rb:98
 msgid "%{model} \"%{name}\" already exists"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:985
 msgid "%{model} \"%{name}\" successfully added to Service \"%{to_name}\""
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:141
 msgid "%{model} \"%{name}\" was %{action}"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:72 ../../app/controllers/chargeback_controller.rb:163 ../../app/controllers/report_controller/reports/editor.rb:62 ../../app/controllers/report_controller/schedules.rb:241 ../../app/controllers/miq_policy_controller/policies.rb:63 ../../app/controllers/miq_policy_controller/policies.rb:109 ../../app/controllers/miq_policy_controller/miq_actions.rb:46 ../../app/controllers/miq_policy_controller/alerts.rb:26 ../../app/controllers/miq_policy_controller/alert_profiles.rb:53 ../../app/controllers/miq_policy_controller/conditions.rb:60 ../../app/controllers/miq_policy_controller/policy_profiles.rb:52 ../../app/controllers/miq_ae_class_controller.rb:700 ../../app/controllers/miq_ae_class_controller.rb:1249 ../../app/controllers/miq_ae_class_controller.rb:1287 ../../app/controllers/miq_ae_class_controller.rb:1316 ../../app/controllers/storage_manager_controller.rb:101 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:279 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:226 ../../app/controllers/catalog_controller.rb:383 ../../app/controllers/catalog_controller.rb:904 ../../app/controllers/ops_controller/settings/tags.rb:83 ../../app/controllers/ops_controller/settings/zones.rb:35 ../../app/controllers/host_controller.rb:271 ../../app/controllers/configuration_controller.rb:522 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:126 ../../app/controllers/pxe_controller/iso_datastores.rb:59 ../../app/controllers/pxe_controller/pxe_image_types.rb:54 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/application_controller/buttons.rb:398 ../../app/controllers/application_controller/buttons.rb:483
 msgid "%{model} \"%{name}\" was added"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:125 ../../app/controllers/chargeback_controller.rb:187 ../../app/controllers/report_controller/dashboards.rb:82 ../../app/controllers/report_controller/widgets.rb:64 ../../app/controllers/report_controller/reports/editor.rb:61 ../../app/controllers/report_controller/schedules.rb:240 ../../app/controllers/report_controller/reports.rb:33 ../../app/controllers/miq_policy_controller/policies.rb:62 ../../app/controllers/miq_policy_controller/miq_actions.rb:45 ../../app/controllers/miq_policy_controller/alerts.rb:25 ../../app/controllers/miq_policy_controller/alert_profiles.rb:52 ../../app/controllers/miq_policy_controller/conditions.rb:59 ../../app/controllers/miq_policy_controller/policy_profiles.rb:51 ../../app/controllers/vm_common.rb:1089 ../../app/controllers/miq_ae_class_controller.rb:649 ../../app/controllers/miq_ae_class_controller.rb:1033 ../../app/controllers/miq_ae_class_controller.rb:1127 ../../app/controllers/miq_ae_class_controller.rb:1180 ../../app/controllers/storage_manager_controller.rb:192 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:281 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:228 ../../app/controllers/service_controller.rb:174 ../../app/controllers/catalog_controller.rb:382 ../../app/controllers/catalog_controller.rb:621 ../../app/controllers/catalog_controller.rb:904 ../../app/controllers/catalog_controller.rb:988 ../../app/controllers/catalog_controller.rb:1043 ../../app/controllers/catalog_controller.rb:1087 ../../app/controllers/ops_controller/settings/tags.rb:104 ../../app/controllers/ops_controller/settings/ldap.rb:62 ../../app/controllers/ops_controller/settings/ldap.rb:192 ../../app/controllers/ops_controller/settings/zones.rb:34 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:269 ../../app/controllers/ops_controller/settings/schedules.rb:75 ../../app/controllers/ops_controller/ops_rbac.rb:126 ../../app/controllers/ops_controller/ops_rbac.rb:705 ../../app/controllers/ops_controller/settings.rb:178 ../../app/controllers/host_controller.rb:362 ../../app/controllers/configuration_controller.rb:583 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:126 ../../app/controllers/pxe_controller/iso_datastores.rb:182 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:204 ../../app/controllers/pxe_controller/pxe_servers.rb:256 ../../app/controllers/ems_common.rb:287 ../../app/controllers/ems_common.rb:393 ../../app/controllers/ems_cloud_controller.rb:53 ../../app/controllers/ems_cloud_controller.rb:105 ../../app/controllers/application_controller/filter.rb:652 ../../app/controllers/application_controller/buttons.rb:364 ../../app/controllers/application_controller/buttons.rb:539
 msgid "%{model} \"%{name}\" was saved"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:699
 msgid "%{model} \"%{name}\" was successfully loaded"
 msgstr ""
 
+#: ../../app/controllers/miq_request_controller.rb:555 ../../app/controllers/storage_manager_controller.rb:482 ../../app/controllers/ontap_file_share_controller.rb:81 ../../app/controllers/ops_controller/diagnostics.rb:724 ../../app/controllers/ontap_storage_system_controller.rb:87 ../../app/controllers/ems_common.rb:926 ../../app/controllers/application_controller/ci_processing.rb:940 ../../app/controllers/application_controller/ci_processing.rb:1522
 msgid "%{model} \"%{name}\": %{task} successfully initiated"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:286 ../../app/controllers/report_controller/reports.rb:103 ../../app/controllers/miq_request_controller.rb:553 ../../app/controllers/storage_manager_controller.rb:477 ../../app/controllers/ops_controller/settings/tags.rb:22 ../../app/controllers/ops_controller/settings/zones.rb:73 ../../app/controllers/ops_controller/diagnostics.rb:722 ../../app/controllers/ems_common.rb:921 ../../app/controllers/miq_task_controller.rb:260 ../../app/controllers/application_controller/ci_processing.rb:938 ../../app/controllers/application_controller/filter.rb:720 ../../app/controllers/application_controller/buttons.rb:176 ../../app/controllers/application_controller/buttons.rb:254
 msgid "%{model} \"%{name}\": Delete successful"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:282 ../../app/controllers/report_controller/reports.rb:97 ../../app/controllers/miq_request_controller.rb:548 ../../app/controllers/storage_manager_controller.rb:469 ../../app/controllers/catalog_controller.rb:672 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:512 ../../app/controllers/ops_controller/diagnostics.rb:717 ../../app/controllers/configuration_controller.rb:574 ../../app/controllers/ems_common.rb:913 ../../app/controllers/miq_task_controller.rb:254 ../../app/controllers/application_controller/ci_processing.rb:933 ../../app/controllers/application_controller/ci_processing.rb:1492 ../../app/controllers/application_controller/ci_processing.rb:1520 ../../app/controllers/application_controller/ci_processing.rb:1610 ../../app/controllers/application_controller/ci_processing.rb:1741 ../../app/controllers/application_controller/filter.rb:708
 msgid "%{model} \"%{name}\": Error during '%{task}': "
 msgstr ""
 
+#: ../../app/controllers/mixins/containers_common_mixin.rb:155
 msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:240
 msgid "%{model} for \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:926
 msgid "%{model} for \"%{record}\""
 msgstr ""
 
+#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:264
 msgid "%{model} for %{group} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:234
 msgid "%{model} for role \"%{role}\" was saved"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:36 ../../app/controllers/miq_policy_controller/policy_profiles.rb:35
 msgid "%{model} must contain at least one %{field}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:368 ../../app/controllers/application_controller/ci_processing.rb:839 ../../app/controllers/application_controller/ci_processing.rb:1494
 msgid "%{model}: %{task} successfully initiated"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:292
 msgid "%{record} - \"%{button_text}\""
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:172
 msgid "%{role} on %{model}: %{name} [%{id}]"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:346 ../../app/controllers/report_controller/reports.rb:396
 msgid "%{tab} tab is not available until %{field} field has been selected"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:350 ../../app/controllers/report_controller/reports.rb:400 ../../app/controllers/report_controller/reports.rb:415
 msgid "%{tab} tab is not available until %{field} has been configured"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1708
 msgid "%{task} %{model}"
 msgstr ""
 
+#: ../../app/controllers/service_controller.rb:196 ../../app/controllers/catalog_controller.rb:575
 msgid "%{task} %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:1028
 msgid "%{task} does not apply because you selected at least one %{model}"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:1033
 msgid "%{task} does not apply because you selected at least one un-reconfigurable VM"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:2611
 msgid "%{task} does not apply to at least one of the selected %{model}"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1592 ../../app/controllers/application_controller/ci_processing.rb:189 ../../app/controllers/application_controller/ci_processing.rb:327 ../../app/controllers/application_controller/ci_processing.rb:1142
 msgid "%{task} does not apply to selected %{model}"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:1254
 msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:269 ../../app/controllers/repository_controller.rb:305 ../../app/controllers/repository_controller.rb:330 ../../app/controllers/repository_controller.rb:340 ../../app/controllers/storage_manager_controller.rb:454 ../../app/controllers/ems_common.rb:890 ../../app/controllers/ems_common.rb:902 ../../app/controllers/ems_common.rb:946 ../../app/controllers/ems_common.rb:973 ../../app/controllers/ems_common.rb:983 ../../app/controllers/ems_common.rb:1004 ../../app/controllers/ems_common.rb:1014 ../../app/controllers/miq_task_controller.rb:167 ../../app/controllers/miq_task_controller.rb:197 ../../app/controllers/miq_task_controller.rb:224 ../../app/controllers/provider_foreman_controller.rb:67 ../../app/controllers/application_controller/ci_processing.rb:1585 ../../app/controllers/application_controller/ci_processing.rb:1729 ../../app/controllers/application_controller/ci_processing.rb:1857
 msgid "%{task} initiated for %{count_model} from the CFME Database"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:1219
 msgid "%{task} initiated for %{model} from the CFME Database"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:302 ../../app/controllers/chargeback_controller.rb:318 ../../app/controllers/chargeback_controller.rb:432 ../../app/controllers/chargeback_controller.rb:443 ../../app/controllers/report_controller/widgets.rb:268 ../../app/controllers/miq_policy_controller/policies.rb:228 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:54 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:121 ../../app/controllers/ops_controller/settings/common.rb:1122 ../../app/controllers/ops_controller/settings/common.rb:1125 ../../app/controllers/ops_controller/settings/common.rb:1128 ../../app/controllers/ops_controller/settings/common.rb:1131 ../../app/controllers/ops_controller/ops_rbac.rb:841 ../../app/controllers/ops_controller/ops_rbac.rb:844 ../../app/controllers/ops_controller/ops_rbac.rb:847 ../../app/controllers/ops_controller/ops_rbac.rb:850 ../../app/controllers/report_controller.rb:507 ../../app/controllers/report_controller.rb:527 ../../app/controllers/miq_policy_controller.rb:632 ../../app/controllers/miq_policy_controller.rb:945
 msgid "%{typ} %{model}"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:437 ../../app/controllers/report_controller/widgets.rb:274 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:71 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:127 ../../app/controllers/ops_controller/settings/common.rb:867 ../../app/controllers/ops_controller/settings/common.rb:871 ../../app/controllers/ops_controller/settings/common.rb:1078 ../../app/controllers/ops_controller/settings/common.rb:1142 ../../app/controllers/ops_controller/settings/common.rb:1148 ../../app/controllers/ops_controller/settings/common.rb:1152 ../../app/controllers/ops_controller/settings/common.rb:1157 ../../app/controllers/ops_controller/settings/common.rb:1165 ../../app/controllers/ops_controller/ops_rbac.rb:868 ../../app/controllers/ops_controller/settings.rb:149 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39 ../../app/controllers/ops_controller/diagnostics.rb:845 ../../app/controllers/ops_controller/diagnostics.rb:868 ../../app/controllers/ops_controller/diagnostics.rb:931
 msgid "%{typ} %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:866 ../../app/controllers/ops_controller/settings/common.rb:870 ../../app/controllers/ops_controller/settings/common.rb:1164 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39 ../../app/controllers/ops_controller/diagnostics.rb:844 ../../app/controllers/ops_controller/diagnostics.rb:930
 msgid "%{typ} %{model} \"%{name}\" (current)"
 msgstr ""
 
+#: ../../app/controllers/application_controller/miq_request_methods.rb:587
 msgid "%{typ} Request was Submitted, you will be notified when your %{title} are ready"
 msgstr ""
 
+#: ../../app/controllers/application_controller/miq_request_methods.rb:587
 msgid "%{typ} Request was re-submitted, you will be notified when your %{title} are ready"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1639 ../../app/controllers/catalog_controller.rb:1644
 msgid "%{typ} in %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:423 ../../app/controllers/ops_controller/settings/common.rb:425 ../../app/controllers/ops_controller/settings/common.rb:478
 msgid "%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\""
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:363 ../../app/controllers/miq_ae_tools_controller.rb:364 ../../app/controllers/miq_policy_controller/miq_actions.rb:388 ../../app/controllers/miq_policy_controller/miq_actions.rb:389 ../../app/controllers/miq_policy_controller.rb:1028 ../../app/controllers/miq_policy_controller.rb:1030 ../../app/controllers/miq_policy_controller.rb:1032 ../../app/controllers/miq_policy_controller.rb:1033 ../../app/controllers/miq_policy_controller.rb:1035 ../../app/controllers/miq_policy_controller.rb:1037 ../../app/controllers/miq_policy_controller.rb:1039
 msgid "%{val} missing for %{field}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:69
 msgid "'%s' Worker restart initiated successfully"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:236
 msgid "'%s' can not be deleted"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:605
 msgid "'%s' can not be edited"
 msgstr ""
 
+#: ../../app/views/vm_common/_snapshots_desc.html.haml:41
 msgid "(%s bytes)"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20 ../../app/views/configuration/_timeprofile_days_hours.html.haml:68
 msgid "(All)"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:147 ../../app/views/layouts/_pagingcontrols.html.haml:25 ../../app/views/vm_common/_vmtree.html.haml:7
 msgid "(Check All)"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_to_email.html.haml:16
 msgid "(Click to remove)"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_email.html.haml:50 ../../app/views/report/_show_schedule.html.haml:51 ../../app/views/miq_policy/_action_options.html.haml:34 ../../app/views/miq_policy/_alert_details.html.haml:295
 msgid "(Default: %s)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:232
 msgid "(Enter the value between 4 - 65636 MB)"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:44
 msgid "(Look Up LDAP Groups)"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:11
 msgid "(MB) memory"
 msgstr ""
 
+#: ../../app/views/layouts/_saved_report_paging_bar.html.haml:86
 msgid "(Row %{start_number} of %{pages})"
 msgstr ""
 
+#: ../../app/views/layouts/_saved_report_paging_bar.html.haml:95
 msgid "(Rows %{start_number}-%{end_number} of %{pages_items})"
 msgstr ""
 
+#: ../../app/views/layouts/_saved_report_paging_bar.html.haml:91
 msgid "(Rows %{start_number}-%{pages_items} of %{pages_items})"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_zones_tab.html.haml:28
 msgid "(current)"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_email.html.haml:39 ../../app/views/miq_policy/_action_options.html.haml:23
 msgid "(leave blank for default)"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:21
 msgid "(optional) the address of an alternate service"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:19
 msgid "(optional) your HTTP proxy information"
 msgstr ""
 
+#: ../../app/views/ops/_category_form.html.haml:211
 msgid "* 'Name' and 'Single Value' fields cannot be edited after adding a category."
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:13
 msgid "* Base the report on"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:84
 msgid "* Cannot be changed while this Alert belongs to an Alert Profile."
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:41
 msgid "* Caution: Changing these fields will clear all selected values below them!"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_timer.html.haml:54 ../../app/views/report/_schedule_form_timer.html.haml:102
 msgid "* Changing the Time Zone will reset the Starting Date and Time fields below"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:191
 msgid "* Changing the Zone will reset all of this Server's priorities to secondary."
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_img_form.html.haml:48
 msgid "* Checking this box will remove this setting from all other PXE Images on this PXE Server"
 msgstr ""
 
-msgid "* Click on any MyTag to permanently delete and unassign it."
-msgstr ""
-
+#: ../../app/views/layouts/_perf_options.html.haml:190
 msgid "* Daily charts only include days for which all 24 hours of data has been collected."
 msgstr ""
 
+#: ../../app/views/report/_db_form.html.haml:74
 msgid "* Dashboard name cannot be changed"
 msgstr ""
 
-msgid "* Dates/Times on this page are based on UTC Time."
-msgstr ""
-
+#: ../../app/views/layouts/_tl_options.html.haml:277
 msgid "* Dates/Times on this page are based on time zone: %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:104
 msgid "* Enter Policy Simulation options on the left and press Submit"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:255
 msgid "* Enter a reason for this approval and press Submit"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:258
 msgid "* Enter a reason for this denial and press Submit"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:347 ../../app/views/report/_widget_form.html.haml:76
 msgid "* Fields are read only for default Widgets"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:221
 msgid "* If all Conditions are removed from a Policy, it will be unconditional and always evaluate to true."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_report.html.haml:69 ../../app/views/miq_capacity/_utilization_details.html.haml:26 ../../app/views/miq_capacity/_utilization_summary.html.haml:59
 msgid "* Information shown is based on available trend data from %s to %s in the %s time zone."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_summary.html.haml:75 ../../app/views/miq_capacity/_planning_report.html.haml:20
 msgid "* Information shown is based on available trend data going back %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:71
 msgid "* Items in"
 msgstr ""
 
+#: ../../app/views/vm_common/_policies.html.haml:36
 msgid "* Items in <font color=\"red\"><i>red italics</i></font> do not change the outcome of the scope or expression."
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:374
 msgid "* No Actions are configured for this Event."
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_list.html.haml:8
 msgid "* No Events are defined%s."
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_field.html.haml:372
 msgid "* Only a single value can be assigned from these Tag Categories"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_performance.html.haml:6
 msgid "* Performance Interval"
 msgstr ""
 
+#: ../../app/views/layouts/_protect.html.haml:15
 msgid "* Policy Profile is only applied to some of the items below."
 msgstr ""
 
+#: ../../app/views/ops/_zone_tree.html.haml:28
 msgid "* Primary Server Roles shown as %{bold} text."
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:405
 msgid "* Recommendations are subject to minimum of CPU: %s and Memory: %s."
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:151
 msgid "* Report is not owned by your group so it cannot be removed"
 msgstr ""
 
-msgid "* Requirements - Type: jpg/png  Size: 100x100"
-msgstr ""
-
+#: ../../app/views/ops/_settings_import_tab.html.haml:55 ../../app/views/ops/_settings_import_tags_tab.html.haml:44
 msgid "* Requirements: CSV formatted file."
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:106
 msgid "* Requirements: File-type - PNG; Dimensions - 1280x1000."
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:36 ../../app/views/catalog/_sandt_tree_show.html.haml:188
 msgid "* Requirements: File-type - PNG; Dimensions - 350x70."
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:69
 msgid "* Saving a blank date will remove all retirement dates"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_fields_seq_form.html.haml:60
 msgid "* Select one or more consecutive fields to move up or down."
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_domains_priority_form.html.haml:50 ../../app/views/report/_db_seq_form.html.haml:65 ../../app/views/shared/buttons/_group_order_form.html.haml:64
 msgid "* Select one or more consecutive groups to move up or down."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:137
 msgid "* Set in Time Profile"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:117
 msgid "* Some charts my not produce desired results with a single sort field"
 msgstr ""
 
+#: ../../app/views/ops/_zone_form.html.haml:117
 msgid "* Specified NTP settings apply to this zone only and are not global."
 msgstr ""
 
+#: ../../app/views/report/_form_styling.html.haml:136
 msgid "* Style \"If\" conditions are evaluated top to bottom for each column"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:73
 msgid "-- OR --"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_instructions.html.haml:12
 msgid "1 - Select a Reference VM."
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:176
 msgid "1 Week Ago"
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:51
 msgid "1 Week before retirement"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:193
 msgid "10 Minutes"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_instructions.html.haml:22
 msgid "2 - Specify the VM Options to define the source of the values used for the plan calculations."
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:51
 msgid "2 Weeks before retirement"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:59
 msgid "24 Hour Time Period"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_instructions.html.haml:32
 msgid "3 - Specify Target Options to qualify target %s or %s."
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:51
 msgid "30 Days before retirement"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_instructions.html.haml:42
 msgid "4 - Change the Trend Options used to calculate the daily trends, if desired."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_instructions.html.haml:52
 msgid "5 - Press the Submit button."
 msgstr ""
 
+#: ../../app/presenters/tree_builder_instances.rb:21 ../../app/presenters/tree_builder_vandt.rb:14
 msgid "<Archived>"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:166
 msgid "<Choose a Group>"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_region_form.html.haml:60 ../../app/views/ops/_diagnostics_database_tab.html.haml:111 ../../app/views/layouts/_adv_search_body.html.haml:55 ../../app/views/layouts/_edit_to_email.html.haml:58
 msgid "<Choose>"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:98
 msgid "<Click on this row to create a new LDAP Server>"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:43
 msgid "<Click on this row to create a new category>"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:34 ../../app/views/ops/_ap_form_nteventlog.html.haml:36 ../../app/views/ops/_ap_form_nteventlog.html.haml:38 ../../app/views/ops/_ap_form_nteventlog.html.haml:40 ../../app/views/ops/_ap_form_registry.html.haml:34 ../../app/views/ops/_ap_form_registry.html.haml:36 ../../app/views/ops/_classification_entry.html.haml:70
 msgid "<Click on this row to create a new entry>"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:41
 msgid "<Click on this row to create a new forest>"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:32 ../../app/views/ops/_ap_form_file.html.haml:33 ../../app/views/ops/_ap_form_file.html.haml:35 ../../app/views/ops/_ap_form_registry.html.haml:32 ../../app/views/ops/_classification_entry.html.haml:67
 msgid "<New Entry>"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:93
 msgid "<New LDAP Server>"
 msgstr ""
 
+#: ../../app/views/ops/_log_collection.html.haml:26 ../../app/views/ops/_diagnostics_database_tab.html.haml:140 ../../app/views/layouts/_edit_log_depot_settings.html.haml:26
 msgid "<No Depot>"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:20
 msgid "<No chart>"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_instances.rb:22 ../../app/presenters/tree_builder_vandt.rb:15
 msgid "<Orphaned>"
 msgstr ""
 
+#: ../../app/helpers/container_service_helper/textual_summary.rb:22 ../../app/helpers/container_service_helper/textual_summary.rb:72
 msgid "<Unnamed>"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:1394 ../../app/controllers/application_controller/filter.rb:1433 ../../app/controllers/application_controller/filter.rb:1435 ../../app/controllers/application_controller/filter.rb:1467 ../../app/controllers/application_controller/filter.rb:1470
 msgid "A %s must be chosen to commit this expression element"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:1447 ../../app/controllers/application_controller/filter.rb:1449
 msgid "A %s must be entered to commit this expression element"
 msgstr ""
 
+#: ../../app/controllers/report_controller/widgets.rb:735
 msgid "A %s must be selected"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:17
 msgid "A Red Hat subscription that covers your product"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:1264
 msgid "A User Group must be assigned a Role"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:968
 msgid "A User must be assigned to a Group"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_details.html.haml:87
 msgid "A condition must contain a valid expression."
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alerts.rb:529 ../../app/controllers/miq_policy_controller/conditions.rb:51
 msgid "A valid expression must be present"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:76
 msgid "A value must be changed or provider will not be scaled."
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_field.html.haml:34 ../../app/views/miq_capacity/_bottlenecks_options.html.haml:20
 msgid "ALL"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:72
 msgid "AM:"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:25 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:21
 msgid "AMQP"
 msgstr ""
 
+#: ../../app/views/layouts/_exp_editor.html.haml:65 ../../app/views/layouts/_exp_editor.html.haml:90
 msgid "AND with a new expression element"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:141 ../../app/views/shared/views/ems_common/_form.html.haml:61
 msgid "API Port"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/_form.html.haml:78
 msgid "API Version"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:150
 msgid "About"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:220
 msgid "Access Key"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:44 ../../app/views/layouts/_multi_auth_credentials.html.haml:66 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:43
 msgid "Access Key ID"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/rbac_tree.rb:31
 msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_form.html.haml:78
 msgid "Access URL"
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:21
 msgid "Accessing Management Engine from multiple tabs or windows of the same browser on a single machine."
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:45 ../model_attributes.rb:2
 msgid "Account"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:44 ../../app/views/vm_common/_config.html.haml:234
 msgid "Account Policies"
 msgstr ""
 
+#: ../model_attributes.rb:3
 msgid "Account|Acctid"
 msgstr ""
 
+#: ../model_attributes.rb:4
 msgid "Account|Accttype"
 msgstr ""
 
+#: ../model_attributes.rb:5
 msgid "Account|Comment"
 msgstr ""
 
+#: ../model_attributes.rb:6
 msgid "Account|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:7
 msgid "Account|Domain"
 msgstr ""
 
+#: ../model_attributes.rb:8
 msgid "Account|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:9
 msgid "Account|Expires"
 msgstr ""
 
+#: ../model_attributes.rb:10
 msgid "Account|Homedir"
 msgstr ""
 
+#: ../model_attributes.rb:11
 msgid "Account|Last logon"
 msgstr ""
 
+#: ../model_attributes.rb:12
 msgid "Account|Local"
 msgstr ""
 
+#: ../model_attributes.rb:13
 msgid "Account|Name"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form.html.haml:82 ../../app/views/ops/_schedule_show.html.haml:29 ../../app/views/shared/buttons/_ab_form.html.haml:26 ../../app/views/catalog/_form_resources_info.html.haml:48 ../../app/views/catalog/_sandt_tree_show.html.haml:231 ../../app/views/catalog/_sandt_tree_show.html.haml:232
 msgid "Action"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:48 ../../app/views/catalog/_sandt_tree_show.html.haml:231
 msgid "Action Order"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:42
 msgid "Action Type"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1126 ../../app/views/miq_policy/_policy_details.html.haml:348
 msgid "Actions"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/events.rb:37
 msgid "Actions for Policy Event \"%s\" were saved"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form.html.haml:66 ../../app/views/ops/_schedule_show.html.haml:19 ../../app/views/ops/_diagnostics_replication_tab.html.haml:39 ../../app/views/report/_widget_show.html.haml:42 ../../app/views/report/_widget_form.html.haml:54 ../../app/views/report/_show_schedule.html.haml:19 ../../app/views/report/_schedule_form.html.haml:51 ../../app/views/report/_report_info.html.haml:134 ../../app/views/miq_policy/_alert_details.html.haml:43 ../../app/views/miq_policy/_policy_details.html.haml:49 ../../app/views/miq_policy/_policy_details.html.haml:66
 msgid "Active"
 msgstr ""
 
+#: ../../app/views/storage_manager/_form.html.haml:221 ../../app/views/layouts/_x_edit_buttons.html.haml:51 ../../app/views/layouts/_x_edit_buttons.html.haml:146 ../../app/views/layouts/_edit_to_email.html.haml:91 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/vm_common/_add_to_service.html.haml:47 ../../app/views/configuration/_timeprofile_form.html.haml:117 ../../app/views/shared/views/ems_common/_form.html.haml:178
 msgid "Add"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_to_email.html.haml:75
 msgid "Add (enter manually)"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:981
 msgid "Add VM \"%s\" to a Service was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/vm_common/_add_to_service.html.haml:47
 msgid "Add VM to the selected Service"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:17
 msgid "Add a Resource"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_to_email.html.haml:49
 msgid "Add a User"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:634 ../../app/controllers/provider_foreman_controller.rb:718
 msgid "Add a new %s Provider"
 msgstr ""
 
+#: ../../app/controllers/ems_cloud_controller.rb:134
 msgid "Add of %{model} was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:63 ../../app/controllers/report_controller/dashboards.rb:62 ../../app/controllers/report_controller/widgets.rb:47 ../../app/controllers/report_controller/reports/editor.rb:33 ../../app/controllers/report_controller/schedules.rb:217 ../../app/controllers/miq_policy_controller/policies.rb:13 ../../app/controllers/miq_policy_controller/miq_actions.rb:13 ../../app/controllers/miq_policy_controller/alerts.rb:11 ../../app/controllers/miq_policy_controller/alert_profiles.rb:11 ../../app/controllers/miq_policy_controller/conditions.rb:13 ../../app/controllers/miq_policy_controller/policy_profiles.rb:10 ../../app/controllers/miq_ae_class_controller.rb:667 ../../app/controllers/miq_ae_class_controller.rb:1232 ../../app/controllers/miq_ae_class_controller.rb:1264 ../../app/controllers/miq_ae_class_controller.rb:1305 ../../app/controllers/storage_manager_controller.rb:79 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:239 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:197 ../../app/controllers/service_controller.rb:150 ../../app/controllers/catalog_controller.rb:89 ../../app/controllers/catalog_controller.rb:352 ../../app/controllers/catalog_controller.rb:604 ../../app/controllers/ops_controller/settings/tags.rb:40 ../../app/controllers/ops_controller/settings/ldap.rb:36 ../../app/controllers/ops_controller/settings/ldap.rb:162 ../../app/controllers/ops_controller/settings/zones.rb:10 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:222 ../../app/controllers/ops_controller/settings/schedules.rb:41 ../../app/controllers/ops_controller/ops_rbac.rb:101 ../../app/controllers/ops_controller/ops_rbac.rb:630 ../../app/controllers/host_controller.rb:261 ../../app/controllers/configuration_controller.rb:488 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:100 ../../app/controllers/pxe_controller/iso_datastores.rb:43 ../../app/controllers/pxe_controller/pxe_image_types.rb:31 ../../app/controllers/pxe_controller/pxe_servers.rb:48 ../../app/controllers/application_controller/buttons.rb:324 ../../app/controllers/application_controller/buttons.rb:445 ../../app/controllers/application_controller/miq_request_methods.rb:66 ../../app/views/shared/views/ems_common/_form.html.haml:185
 msgid "Add of new %s was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:61
 msgid "Add subfolder to selected folder"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/_form.html.haml:177
 msgid "Add this %s"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:7
 msgid "Add this LDAP Server"
 msgstr ""
 
+#: ../../app/views/storage_manager/_form.html.haml:221
 msgid "Add this Storage Manager"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:117
 msgid "Add this Time Profile"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:48 ../../app/views/ops/_ap_form_nteventlog.html.haml:48 ../../app/views/ops/_ldap_forest_entries.html.haml:60 ../../app/views/ops/_ldap_forest_entries.html.haml:60 ../../app/views/ops/_ap_form_file.html.haml:45 ../../app/views/ops/_ap_form_file.html.haml:45 ../../app/views/ops/_ap_form_registry.html.haml:44 ../../app/views/ops/_ap_form_registry.html.haml:44 ../../app/views/ops/_classification_entry.html.haml:7 ../../app/views/ops/_classification_entry.html.haml:7 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:7 ../../app/views/miq_ae_class/_method_form.html.haml:222 ../../app/views/miq_ae_class/_class_fields.html.haml:178
 msgid "Add this entry"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:545 ../../app/controllers/ops_controller.rb:557 ../../app/controllers/ops_controller.rb:565 ../../app/controllers/ops_controller.rb:578 ../../app/controllers/ops_controller.rb:589 ../../app/controllers/ops_controller.rb:600 ../../app/controllers/ops_controller.rb:646 ../../app/controllers/miq_ae_customization_controller.rb:441 ../../app/controllers/miq_ae_customization_controller.rb:445 ../../app/controllers/miq_ae_customization_controller.rb:460 ../../app/controllers/miq_ae_customization_controller.rb:499 ../../app/controllers/vm_common.rb:1780 ../../app/controllers/miq_ae_class_controller.rb:584 ../../app/controllers/miq_ae_class_controller.rb:729 ../../app/controllers/miq_ae_class_controller.rb:764 ../../app/controllers/miq_ae_class_controller.rb:804 ../../app/controllers/miq_ae_class_controller.rb:2455 ../../app/controllers/catalog_controller.rb:272 ../../app/controllers/catalog_controller.rb:1153 ../../app/controllers/catalog_controller.rb:1299 ../../app/controllers/catalog_controller.rb:1349 ../../app/controllers/catalog_controller.rb:1802 ../../app/controllers/catalog_controller.rb:1806 ../../app/controllers/ops_controller/ops_rbac.rb:681 ../../app/controllers/pxe_controller.rb:180 ../../app/controllers/pxe_controller.rb:198 ../../app/controllers/pxe_controller.rb:212 ../../app/controllers/pxe_controller.rb:228 ../../app/controllers/report_controller.rb:750 ../../app/controllers/report_controller.rb:765 ../../app/controllers/report_controller.rb:770 ../../app/controllers/report_controller.rb:779 ../../app/controllers/report_controller.rb:795 ../../app/controllers/miq_policy_controller.rb:616 ../../app/controllers/miq_policy_controller.rb:640 ../../app/controllers/miq_policy_controller.rb:663 ../../app/controllers/miq_policy_controller.rb:676 ../../app/controllers/miq_policy_controller.rb:691 ../../app/controllers/miq_policy_controller.rb:699
 msgid "Adding a new %s"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:761
 msgid "Adding a new Orchestration Template"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:792
 msgid "Adding a new Service Dialog from Orchestration Template \"%s\""
 msgstr ""
 
+#: ../../app/views/alert/_rss_list.html.haml:24
 msgid "Admin Role Filter:"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:41 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:665
 msgid "Advanced"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_searchbox.html.haml:36 ../../app/views/layouts/_adv_search.html.haml:36 ../../app/views/layouts/_x_adv_searchbox.html.haml:52
 msgid "Advanced Search"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:507
 msgid "Advanced Settings (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:412
 msgid "Advanced Settings (0)"
 msgstr ""
 
+#: ../model_attributes.rb:14
 msgid "Advanced setting"
 msgstr ""
 
+#: ../model_attributes.rb:15
 msgid "AdvancedSetting|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:16
 msgid "AdvancedSetting|Default value"
 msgstr ""
 
+#: ../model_attributes.rb:17
 msgid "AdvancedSetting|Description"
 msgstr ""
 
+#: ../model_attributes.rb:18
 msgid "AdvancedSetting|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:19
 msgid "AdvancedSetting|Max"
 msgstr ""
 
+#: ../model_attributes.rb:20
 msgid "AdvancedSetting|Min"
 msgstr ""
 
+#: ../model_attributes.rb:21
 msgid "AdvancedSetting|Name"
 msgstr ""
 
+#: ../model_attributes.rb:22
 msgid "AdvancedSetting|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:23
 msgid "AdvancedSetting|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:24
 msgid "AdvancedSetting|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:25
 msgid "AdvancedSetting|Value"
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:77
 msgid "Affected Items"
 msgstr ""
 
+#: ../../app/views/miq_request/_reconfigure_show.html.haml:79 ../../app/views/vm_common/_reconfigure.html.haml:190
 msgid "Affected VMs"
 msgstr ""
 
+#: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:26
 msgid "Aggregate (free space)"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:92
 msgid "Alert Profile \"%s\" assignments succesfully saved"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1127 ../../app/views/miq_policy/_alert_profile_folders.html.haml:24
 msgid "Alert Profiles"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:64
 msgid "Alert Selection"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1128 ../../app/views/miq_policy/_export.html.haml:98 ../../app/views/miq_policy/_alert_profile_details.html.haml:39
 msgid "Alerts"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:454
 msgid "Alerts to Evaluate"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:24 ../../app/views/miq_request/_prov_options.html.haml:68 ../../app/views/miq_task/_tasks_options.html.haml:133 ../../app/views/layouts/gtl/_list.html.haml:87 ../../app/views/report/_form_sort.html.haml:206 ../../app/views/report/_form_sort.html.haml:218 ../../app/views/report/_export_widgets.html.haml:119 ../../app/views/miq_capacity/_planning_options.html.haml:289
 msgid "All"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:82 ../../app/controllers/chargeback_controller.rb:83 ../../app/controllers/chargeback_controller.rb:84 ../../app/controllers/chargeback_controller.rb:429 ../../app/controllers/chargeback_controller.rb:445 ../../app/controllers/chargeback_controller.rb:456 ../../app/controllers/report_controller/dashboards.rb:217 ../../app/controllers/report_controller/dashboards.rb:237 ../../app/controllers/report_controller/widgets.rb:248 ../../app/controllers/report_controller/widgets.rb:262 ../../app/controllers/report_controller/menus.rb:751 ../../app/controllers/report_controller/saved_reports.rb:127 ../../app/controllers/report_controller/schedules.rb:52 ../../app/controllers/miq_policy_controller/events.rb:108 ../../app/controllers/miq_policy_controller/policies.rb:232 ../../app/controllers/miq_policy_controller/alert_profiles.rb:324 ../../app/controllers/miq_policy_controller/alert_profiles.rb:332 ../../app/controllers/miq_policy_controller/conditions.rb:226 ../../app/controllers/miq_policy_controller/conditions.rb:234 ../../app/controllers/miq_policy_controller/policy_profiles.rb:143 ../../app/controllers/vm_common.rb:1387 ../../app/controllers/vm_common.rb:1403 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:43 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:107 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1365 ../../app/controllers/service_controller.rb:289 ../../app/controllers/container_controller.rb:175 ../../app/controllers/catalog_controller.rb:1618 ../../app/controllers/catalog_controller.rb:1621 ../../app/controllers/ops_controller/db.rb:190 ../../app/controllers/pxe_controller.rb:175 ../../app/controllers/pxe_controller.rb:195 ../../app/controllers/pxe_controller.rb:227 ../../app/controllers/report_controller.rb:225 ../../app/controllers/report_controller.rb:547 ../../app/controllers/pxe_controller/iso_datastores.rb:307 ../../app/controllers/pxe_controller/pxe_image_types.rb:216 ../../app/controllers/pxe_controller/pxe_servers.rb:483 ../../app/controllers/miq_policy_controller.rb:443 ../../app/controllers/miq_policy_controller.rb:611
 msgid "All %s"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:572 ../../app/controllers/provider_foreman_controller.rb:584
 msgid "All %s Configured Systems"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:192
 msgid "All %s Indexes"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:580
 msgid "All %s Providers"
 msgstr ""
 
+#: ../../app/controllers/ems_cluster_controller.rb:267
 msgid "All %s with %s"
 msgstr ""
 
+#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:249
 msgid "All %{model} - %{group}"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:626 ../../app/controllers/miq_policy_controller.rb:629 ../../app/controllers/miq_policy_controller.rb:952 ../../app/controllers/miq_policy_controller.rb:960 ../../app/controllers/miq_policy_controller.rb:967
 msgid "All %{typ} %{model}"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:86 ../../app/helpers/ems_cluster_helper/textual_summary.rb:63
 msgid "All (%s)"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_action.rb:17
 msgid "All Actions"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_alert_profile.rb:22
 msgid "All Alert Profiles"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_alert.rb:17
 msgid "All Alerts"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:90
 msgid "All Catalog Items"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:93
 msgid "All Catalogs"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_condition.rb:18
 msgid "All Conditions"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:54 ../../app/presenters/tree_builder.rb:55
 msgid "All Containers"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:62
+msgid "All Dashboards"
+msgstr ""
+
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:72
 msgid "All Datastore customizations will be lost. Are you sure you want to reset all classes and instances to default?"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:66 ../../app/presenters/tree_builder.rb:74
 msgid "All Dialogs"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_event.rb:17
 msgid "All Events"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:111
 msgid "All Files"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:73
 msgid "All ISO Datastores"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:72
 msgid "All Images"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:69
 msgid "All Images by Provider that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:71
 msgid "All Instances"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:70
 msgid "All Instances by Provider that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:75
 msgid "All Orchestration Templates"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:80
 msgid "All PXE Servers"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:34
 msgid "All Policies"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy_profile.rb:18
 msgid "All Policy Profiles"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:81
+msgid "All Reports"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:91
+msgid "All Saved Reports"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:92
+msgid "All Schedules"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:94 ../../app/presenters/tree_builder.rb:95
 msgid "All Services"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:79
 msgid "All System Image Types"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:98
 msgid "All Templates"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:100
 msgid "All Templates & Images"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_cluster.html.haml:121
 msgid "All Templates: %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_cluster.html.haml:115
 msgid "All Templates: 0"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:44 ../../app/views/configuration/_timeprofile_form.html.haml:45
 msgid "All Users"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_condition.rb:25
 msgid "All VM and Instance Conditions"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:97 ../../app/views/miq_capacity/_planning_options.html.haml:16
 msgid "All VMs"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:99
 msgid "All VMs & Instances"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:96
 msgid "All VMs & Templates"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:96
 msgid "All VMs & Templates that I can see"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:96 ../../app/views/layouts/listnav/_ems_cluster.html.haml:136
 msgid "All VMs (Tree View): %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_cluster.html.haml:130
 msgid "All VMs (Tree View): 0"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:80 ../../app/views/layouts/listnav/_ems_cluster.html.haml:106
 msgid "All VMs: %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:74 ../../app/views/layouts/listnav/_ems_cluster.html.haml:100
 msgid "All VMs: 0"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:102
+msgid "All Widgets"
+msgstr ""
+
+#: ../../app/views/miq_task/_tasks_options.html.haml:22
 msgid "All Zones"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:148 ../../app/controllers/chargeback_controller.rb:261 ../../app/controllers/chargeback_controller.rb:337 ../../app/controllers/report_controller/dashboards.rb:44 ../../app/controllers/report_controller/dashboards.rb:103 ../../app/controllers/report_controller/widgets.rb:84 ../../app/controllers/report_controller/menus.rb:207 ../../app/controllers/report_controller/reports/editor.rb:85 ../../app/controllers/report_controller/schedules.rb:265 ../../app/controllers/miq_policy_controller/events.rb:17 ../../app/controllers/miq_policy_controller/policies.rb:23 ../../app/controllers/miq_policy_controller/miq_actions.rb:23 ../../app/controllers/miq_policy_controller/alerts.rb:43 ../../app/controllers/miq_policy_controller/alert_profiles.rb:22 ../../app/controllers/miq_policy_controller/alert_profiles.rb:100 ../../app/controllers/miq_policy_controller/conditions.rb:24 ../../app/controllers/miq_policy_controller/policy_profiles.rb:21 ../../app/controllers/vm_common.rb:920 ../../app/controllers/vm_common.rb:924 ../../app/controllers/vm_common.rb:1107 ../../app/controllers/miq_ae_class_controller.rb:655 ../../app/controllers/miq_ae_class_controller.rb:1043 ../../app/controllers/miq_ae_class_controller.rb:1091 ../../app/controllers/miq_ae_class_controller.rb:1136 ../../app/controllers/miq_ae_class_controller.rb:1192 ../../app/controllers/miq_ae_class_controller.rb:1528 ../../app/controllers/miq_ae_class_controller.rb:1568 ../../app/controllers/miq_ae_class_controller.rb:1738 ../../app/controllers/storage_manager_controller.rb:210 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:298 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:255 ../../app/controllers/service_controller.rb:183 ../../app/controllers/catalog_controller.rb:100 ../../app/controllers/catalog_controller.rb:407 ../../app/controllers/catalog_controller.rb:643 ../../app/controllers/catalog_controller.rb:1001 ../../app/controllers/ops_controller/settings/tags.rb:122 ../../app/controllers/ops_controller/settings/ldap.rb:90 ../../app/controllers/ops_controller/settings/ldap.rb:251 ../../app/controllers/ops_controller/settings/zones.rb:53 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:338 ../../app/controllers/ops_controller/settings/cap_and_u.rb:44 ../../app/controllers/ops_controller/settings/schedules.rb:108 ../../app/controllers/ops_controller/settings/common.rb:504 ../../app/controllers/ops_controller/ops_rbac.rb:149 ../../app/controllers/ops_controller/ops_rbac.rb:213 ../../app/controllers/ops_controller/ops_rbac.rb:412 ../../app/controllers/ops_controller/ops_rbac.rb:582 ../../app/controllers/ops_controller/ops_rbac.rb:675 ../../app/controllers/ops_controller/settings.rb:186 ../../app/controllers/host_controller.rb:406 ../../app/controllers/configuration_controller.rb:287 ../../app/controllers/configuration_controller.rb:544 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:143 ../../app/controllers/pxe_controller/iso_datastores.rb:77 ../../app/controllers/pxe_controller/iso_datastores.rb:205 ../../app/controllers/pxe_controller/pxe_image_types.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:87 ../../app/controllers/pxe_controller/pxe_servers.rb:227 ../../app/controllers/pxe_controller/pxe_servers.rb:278 ../../app/controllers/ems_common.rb:418 ../../app/controllers/application_controller/explorer.rb:182 ../../app/controllers/application_controller/tags.rb:149 ../../app/controllers/application_controller/ci_processing.rb:171 ../../app/controllers/application_controller/ci_processing.rb:176 ../../app/controllers/application_controller/dialog_runner.rb:73 ../../app/controllers/application_controller/automate.rb:141 ../../app/controllers/application_controller/buttons.rb:50 ../../app/controllers/application_controller/buttons.rb:417 ../../app/controllers/application_controller/buttons.rb:559 ../../app/controllers/application_controller/policy_support.rb:36
 msgid "All changes have been reset"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:231
 msgid "All custom classes and instances have been reset to default"
 msgstr ""
 
+#: ../../app/views/layouts/_form_buttons.html.haml:95
 msgid "All fields are needed to perform verification of Database Settings"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:72
 msgid "All of the Images that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:71
 msgid "All of the Instances that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:100
 msgid "All of the Templates & Images that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:98
 msgid "All of the Templates that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:99
 msgid "All of the VMs & Instances that I can see"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:97
 msgid "All of the VMs that I can see"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:1632
 msgid "All selected %s are not in the current region"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:188
 msgid "All system services of %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:55
 msgid "Amazon"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:212
 msgid "Amazon Primary AWS Account Settings for IAM"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:231
 msgid "Amazon Settings validation was successful"
 msgstr ""
 
+#: ../../app/views/ops/_amazon_verify_button.html.haml:15
 msgid "Amazon access key and secret are needed to validate Amazon Settings"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:246
 msgid "An alert must contain a valid expression."
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:45
 msgid "An internal system error."
 msgstr ""
 
+#: ../../app/views/ops/_schedule_show.html.haml:46
 msgid "Analysis"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:606
 msgid "Analysis Affinity was saved"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:244 ../../app/views/layouts/listnav/_vm_common.html.haml:250
 msgid "Analysis History (%s)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:430
 msgid "Analysis Profile"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:69 ../../app/views/miq_policy/_action_options.html.haml:505 ../../app/views/miq_policy/_action_options.html.haml:514
 msgid "Analysis Profiles"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:333
 msgid "Analytics Report"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_image_type_form.html.haml:39
 msgid "Any"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:88
 msgid "Appliance"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:104
 msgid "Appliance Name"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:151
 msgid "Appliance Time Zone"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:5
 msgid "Appliance Updates"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:169
 msgid "Appliance:"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:3
 msgid "Appliances in this region can be registered with:"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:401 ../../app/views/layouts/listnav/_vm_common.html.haml:407
 msgid "Applications (%s)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:102 ../../app/views/miq_policy/_action_details.html.haml:309
 msgid "Applied Tag"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:125 ../../app/views/miq_request/_prov_options.html.haml:142 ../../app/views/miq_task/_tasks_options.html.haml:148 ../../app/views/miq_task/_tasks_options.html.haml:164 ../../app/views/layouts/_user_input_filter.html.haml:105 ../../app/views/layouts/_x_edit_buttons.html.haml:59 ../../app/views/layouts/_x_edit_buttons.html.haml:150 ../../app/views/layouts/listnav/_compare_sections.html.haml:180 ../../app/views/layouts/_ae_tree_select.html.haml:70 ../../app/views/layouts/_ae_tree_select.html.haml:89 ../../app/views/layouts/_adv_search_footer.html.haml:26 ../../app/views/layouts/_adv_search_footer.html.haml:29
 msgid "Apply"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:62
 msgid "Apply CFME Update"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_compare_sections.html.haml:180 ../../app/views/layouts/listnav/_compare_sections.html.haml:180
 msgid "Apply sections"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:29
 msgid "Apply the current filter"
 msgstr ""
 
+#: ../../app/views/layouts/_user_input_filter.html.haml:110
 msgid "Apply the current filter (Enter)"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:142 ../../app/views/miq_task/_tasks_options.html.haml:164
 msgid "Apply the selected filters"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_show_list.html.haml:26 ../../app/views/layouts/listnav/_show_list.html.haml:48
 msgid "Apply this filter"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:159
 msgid "Approval State"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:42
 msgid "Approval State:"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:173 ../../app/views/miq_request/_request_details.html.haml:58
 msgid "Approved/Denied by"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:186
 msgid "Approved/Denied on"
 msgstr ""
 
+#: ../../app/helpers/container_image_helper/textual_summary.rb:21
 msgid "Arch"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:88 ../../app/helpers/provider_foreman_helper.rb:169
 msgid "Architecture"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_instances.rb:21
 msgid "Archived Instances"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_vandt.rb:14
 msgid "Archived VMs and Templates"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:227
 msgid "Are you sure you want to Run Database Garbage Collection Now?"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:187
 msgid "Are you sure you want to Run a Database Backup Now?"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:74
 msgid "Are you sure you want to delete category '%s'?"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_class_fields.html.haml:108
 msgid "Are you sure you want to delete field from schema?"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:149
 msgid "Are you sure you want to delete forest %s ?"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_form.html.haml:155
 msgid "Are you sure you want to delete input field from method?"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:28
 msgid "Are you sure you want to delete orphaned records for user '%{user}'?"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:57
 msgid "Are you sure you want to remove '%s'from the Dashboard?"
 msgstr ""
 
+#: ../../app/views/layouts/_classify_table.html.haml:38
 msgid "Are you sure you want to remove the '%{a_parent}[%{a}]' assignment from all of the items below?"
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:149
 msgid "Are you sure you want to remove this Custom Image?"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:168
 msgid "Are you sure you want to remove this Provisioning Entry Point?"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:210
 msgid "Are you sure you want to remove this Reconfigure Entry Point?"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:252
 msgid "Are you sure you want to remove this Retirement Entry Point?"
 msgstr ""
 
+#: ../../app/views/layouts/_pagingcontrols.html.haml:51
 msgid "Asc. by:"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:502 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:599 ../../app/views/report/_form_sort.html.haml:56
 msgid "Ascending"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_group_form.html.haml:91
 msgid "Assign Buttons"
 msgstr ""
 
+#: ../../app/views/catalog/_stcat_form.html.haml:65
 msgid "Assign Catalog Items"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:267
 msgid "Assign Filters"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_assignments.html.haml:18 ../../app/views/miq_policy/_alert_profile_assign.html.haml:30
 msgid "Assign To"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:439
 msgid "Assigned Analysis Profile"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:267
 msgid "Assigned Filters (read only)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:174
 msgid "Assigned To"
 msgstr ""
 
+#: ../../app/views/layouts/_classify_table.html.haml:13 ../../app/views/layouts/_tag_edit_assignments.html.haml:18
 msgid "Assigned Value"
 msgstr ""
 
+#: ../model_attributes.rb:26
 msgid "Assigned server role"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:52 ../../app/views/miq_policy/_condition_details.html.haml:123 ../../app/views/miq_policy/_action_details.html.haml:543
 msgid "Assigned to Policies"
 msgstr ""
 
+#: ../model_attributes.rb:27
 msgid "AssignedServerRole|Active"
 msgstr ""
 
+#: ../model_attributes.rb:28
 msgid "AssignedServerRole|Priority"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:45
 msgid "Assigning %{hosts} but only have %{hosts_count} hosts available."
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:51 ../../app/views/miq_policy/_alert_profile_assign.html.haml:8
 msgid "Assignments"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:122 ../../app/controllers/report_controller.rb:289 ../../app/controllers/miq_policy_controller.rb:40 ../../app/controllers/application_controller/ci_processing.rb:205 ../../app/controllers/application_controller/ci_processing.rb:818 ../../app/controllers/application_controller/ci_processing.rb:1446
 msgid "At least %{num} %{model} must be selected for %{action}"
 msgstr ""
 
+#: ../../app/controllers/application_controller/compare.rb:935 ../../app/controllers/application_controller/compare.rb:986
 msgid "At least 2 %{model} must be selected for %{action}"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:297 ../../app/controllers/miq_policy_controller/alerts.rb:557 ../../app/controllers/miq_policy_controller/alerts.rb:561
 msgid "At least one %s must be configured"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:262 ../../app/controllers/miq_request_controller.rb:356 ../../app/controllers/miq_capacity_controller.rb:98 ../../app/controllers/miq_capacity_controller.rb:238 ../../app/controllers/ops_controller/ops_rbac.rb:1251 ../../app/controllers/configuration_controller.rb:498 ../../app/controllers/configuration_controller.rb:501 ../../app/controllers/configuration_controller.rb:556 ../../app/controllers/configuration_controller.rb:559 ../../app/controllers/application_controller/timelines.rb:62 ../../app/controllers/application_controller/timelines.rb:72 ../../app/controllers/application_controller/buttons.rb:758
 msgid "At least one %s must be selected"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:88
 msgid "At least one Selection must be checked"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:238
 msgid "At least one item must be entered to create Analysis Profile"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:401
 msgid "At least one option must be selected to reconfigure"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:41
 msgid "Attached to Policy"
 msgstr ""
 
+#: ../../app/views/report/_schedule_email_options.html.haml:30
 msgid "Attachments"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:68 ../../app/views/miq_policy/_action_details.html.haml:233
 msgid "Attribute Name"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:190 ../../app/views/shared/buttons/_ab_show.html.haml:164 ../../app/views/miq_policy/_action_details.html.haml:160
 msgid "Attribute/Value Pairs"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:175
 msgid "Audit Log"
 msgstr ""
 
+#: ../model_attributes.rb:29
 msgid "Audit event"
 msgstr ""
 
+#: ../model_attributes.rb:30
 msgid "AuditEvent|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:31
 msgid "AuditEvent|Event"
 msgstr ""
 
+#: ../model_attributes.rb:32
 msgid "AuditEvent|Message"
 msgstr ""
 
+#: ../model_attributes.rb:33
 msgid "AuditEvent|Severity"
 msgstr ""
 
+#: ../model_attributes.rb:34
 msgid "AuditEvent|Source"
 msgstr ""
 
+#: ../model_attributes.rb:35
 msgid "AuditEvent|Status"
 msgstr ""
 
+#: ../model_attributes.rb:36
 msgid "AuditEvent|Target class"
 msgstr ""
 
+#: ../model_attributes.rb:37
 msgid "AuditEvent|Userid"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:7 ../../app/views/ops/_settings_server_tab.html.haml:483 ../../app/views/ops/_all_tabs.html.haml:27 ../model_attributes.rb:38
 msgid "Authentication"
 msgstr ""
 
+#: ../../app/views/host/_main.html.haml:31
 msgid "Authentication Status"
 msgstr ""
 
+#: ../model_attributes.rb:39
 msgid "Authentication|Auth key"
 msgstr ""
 
+#: ../model_attributes.rb:40
 msgid "Authentication|Authtype"
 msgstr ""
 
+#: ../model_attributes.rb:41
 msgid "Authentication|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:42
 msgid "Authentication|Credentials changed on"
 msgstr ""
 
+#: ../model_attributes.rb:43
 msgid "Authentication|Fingerprint"
 msgstr ""
 
+#: ../model_attributes.rb:44
 msgid "Authentication|Last invalid on"
 msgstr ""
 
+#: ../model_attributes.rb:45
 msgid "Authentication|Last valid on"
 msgstr ""
 
+#: ../model_attributes.rb:46
 msgid "Authentication|Name"
 msgstr ""
 
+#: ../model_attributes.rb:47
 msgid "Authentication|Password"
 msgstr ""
 
+#: ../model_attributes.rb:48
 msgid "Authentication|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:49
 msgid "Authentication|Status"
 msgstr ""
 
+#: ../model_attributes.rb:50
 msgid "Authentication|Status details"
 msgstr ""
 
+#: ../model_attributes.rb:51
 msgid "Authentication|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:52
 msgid "Authentication|Userid"
 msgstr ""
 
+#: ../../app/views/dashboard/auth_error.html.haml:5
 msgid "Authorization Error"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:184 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:274 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:350 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:418 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:643
 msgid "Auto Refresh other fields when modified"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:168
 msgid "Auto refresh"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:127
 msgid "Automate"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:322
 msgid "Automate Workers"
 msgstr ""
 
+#: ../../app/controllers/application_controller/automate.rb:58
 msgid "Automate button %s has been cleared"
 msgstr ""
 
+#: ../../app/controllers/application_controller/automate.rb:60
 msgid "Automate button %{btn_num} has been set to %{btn_txt}"
 msgstr ""
 
+#: ../../app/controllers/application_controller/automate.rb:21
 msgid "Automation Error: "
 msgstr ""
 
+#: ../../app/controllers/application_controller/automate.rb:6
 msgid "Automation Simulation has been run"
 msgstr ""
 
+#: ../../app/views/miq_request/_ae_prov_show.html.haml:3
 msgid "Automations Tasks"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:27 ../../app/views/configuration/_ui_2.html.haml:128
 msgid "Availability Zones"
 msgstr ""
 
+#: ../model_attributes.rb:53
 msgid "Availability zone"
 msgstr ""
 
+#: ../model_attributes.rb:54
 msgid "AvailabilityZone|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:55
 msgid "AvailabilityZone|Name"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:70
 msgid "Available %s Alerts:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:151
 msgid "Available %s Conditions:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_export.html.haml:113
 msgid "Available %{title}:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:93 ../../app/views/miq_policy/_event_details.html.haml:274
 msgid "Available Actions:"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_performance.html.haml:36
 msgid "Available Active Data"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:304
 msgid "Available Alerts:"
 msgstr ""
 
+#: ../../app/views/report/_export_custom_reports.html.haml:65
 msgid "Available Custom Reports:"
 msgstr ""
 
+#: ../../app/views/report/_column_lists.html.haml:9
 msgid "Available Fields:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:57
 msgid "Available Policies:"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:16
 msgid "Available Product version:"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:26
 msgid "Available Reports:"
 msgstr ""
 
+#: ../../app/views/vm_common/_snapshots_tree.html.haml:5
 msgid "Available Snapshots"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:107
 msgid "Available VMs:"
 msgstr ""
 
+#: ../../app/views/report/_export_widgets.html.haml:70
 msgid "Available Widgets:"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:30
 msgid "Average"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_performance.html.haml:31
 msgid "Averages Based On"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:190 ../../app/views/miq_ae_tools/_import_export.html.haml:161 ../../app/views/vm_common/_right_size.html.haml:412 ../../app/views/dashboard/login.html.haml:92 ../../app/views/dashboard/login.html.haml:92
 msgid "Back"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:54
 msgid "Back (ABCD...)"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:92
 msgid "Backup Schedules"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:339 ../../app/views/ops/_ldap_region_show.html.haml:73 ../../app/views/ops/_ldap_forest_entries.html.haml:21 ../../app/views/ops/_ldap_domain_form.html.haml:146 ../../app/views/ops/_ldap_domain_show.html.haml:193 ../../app/views/_ldap_domain_form.html.haml:146
 msgid "Base DN"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:23
 msgid "Base Timeline on"
 msgstr ""
 
+#: ../../app/views/report/_report_info.html.haml:66 ../../app/views/miq_policy/_alert_profile_assign.html.haml:17 ../../app/views/miq_policy/_alert_details.html.haml:64
 msgid "Based On"
 msgstr ""
 
-msgid "Based On:"
-msgstr ""
-
+#: ../../app/views/ops/_logs_selected.html.haml:8 ../../app/views/ops/_diagnostics_database_tab.html.haml:12 ../../app/views/miq_ae_customization/_dialog_details.html.haml:18 ../../app/views/chargeback/_cb_rate_edit.html.haml:6 ../../app/views/chargeback/_cb_assignments.html.haml:9 ../../app/views/chargeback/_cb_rate_show.html.haml:7 ../../app/views/shared/buttons/_group_form.html.haml:8 ../../app/views/catalog/_form.html.haml:4 ../../app/views/catalog/_sandt_tree_show.html.haml:8 ../../app/views/catalog/_stcat_form.html.haml:11
 msgid "Basic Info"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:5 ../../app/views/ops/_ldap_region_show.html.haml:9 ../../app/views/ops/_ldap_domain_form.html.haml:6 ../../app/views/ops/_ldap_domain_show.html.haml:7 ../../app/views/ops/_settings_server_tab.html.haml:7 ../../app/views/ops/_ldap_region_form.html.haml:10 ../../app/views/ops/_ap_form.html.haml:11 ../../app/views/storage_manager/_form.html.haml:10 ../../app/views/repository/_form.html.haml:7 ../../app/views/miq_ae_customization/_dialog_info.html.haml:6 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:8 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:11 ../../app/views/_ldap_domain_form.html.haml:6 ../../app/views/vm_common/_form.html.haml:9 ../../app/views/vm_common/_config.html.haml:12 ../../app/views/vm_common/_config.html.haml:82 ../../app/views/report/_widget_show.html.haml:4 ../../app/views/report/_widget_form.html.haml:8 ../../app/views/report/_schedule_form.html.haml:8 ../../app/views/report/_db_show.html.haml:5 ../../app/views/report/_db_form.html.haml:9 ../../app/views/shared/views/ems_common/_form.html.haml:9 ../../app/views/shared/buttons/_ab_list.html.haml:137 ../../app/views/shared/buttons/_ab_show.html.haml:6 ../../app/views/catalog/_sandt_tree_show.html.haml:27 ../../app/views/catalog/_sandt_tree_show.html.haml:195 ../../app/views/pxe/_template_details.html.haml:11 ../../app/views/pxe/_pxe_image_type_form.html.haml:8 ../../app/views/pxe/_template_form.html.haml:7 ../../app/views/pxe/_iso_datastore_form.html.haml:8 ../../app/views/pxe/_iso_datastore_details.html.haml:1 ../../app/views/pxe/_pxe_image_type_details.html.haml:10 ../../app/views/pxe/_pxe_img_form.html.haml:8 ../../app/views/pxe/_pxe_server_details.html.haml:11 ../../app/views/pxe/_pxe_server_details.html.haml:152 ../../app/views/pxe/_pxe_server_details.html.haml:165 ../../app/views/pxe/_iso_img_form.html.haml:8 ../../app/views/pxe/_pxe_wimg_form.html.haml:8 ../../app/views/pxe/_pxe_form.html.haml:8 ../../app/views/miq_policy/_event_details.html.haml:7 ../../app/views/miq_policy/_condition_details.html.haml:12 ../../app/views/miq_policy/_profile_details.html.haml:13 ../../app/views/miq_policy/_alert_profile_details.html.haml:15 ../../app/views/miq_policy/_action_details.html.haml:9 ../../app/views/miq_policy/_policy_details.html.haml:15 ../../app/views/miq_policy/_policy_details.html.haml:60 ../../app/views/miq_capacity/_utilization_report.html.haml:10
 msgid "Basic Information"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:206
 msgid "Basic Options"
 msgstr ""
 
+#: ../../app/views/report/_form.html.haml:11
 msgid "Basic Report Info"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:464
 msgid "Belongs to Alert Profiles"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:445
 msgid "Belongs to Profiles"
 msgstr ""
 
+#: ../../app/controllers/miq_capacity_controller.rb:619
 msgid "Best Fit %s"
 msgstr ""
 
+#: ../model_attributes.rb:56
 msgid "Binary blob"
 msgstr ""
 
+#: ../model_attributes.rb:63
 msgid "Binary blob part"
 msgstr ""
 
+#: ../model_attributes.rb:64
 msgid "BinaryBlobPart|Data"
 msgstr ""
 
+#: ../model_attributes.rb:65
 msgid "BinaryBlobPart|Md5"
 msgstr ""
 
+#: ../model_attributes.rb:66
 msgid "BinaryBlobPart|Size"
 msgstr ""
 
+#: ../model_attributes.rb:57
 msgid "BinaryBlob|Data type"
 msgstr ""
 
+#: ../model_attributes.rb:58
 msgid "BinaryBlob|Md5"
 msgstr ""
 
+#: ../model_attributes.rb:59
 msgid "BinaryBlob|Name"
 msgstr ""
 
+#: ../model_attributes.rb:60
 msgid "BinaryBlob|Part size"
 msgstr ""
 
+#: ../model_attributes.rb:61
 msgid "BinaryBlob|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:62
 msgid "BinaryBlob|Size"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:356 ../../app/views/ops/_ldap_forest_entries.html.haml:23 ../../app/views/ops/_ldap_domain_form.html.haml:163 ../../app/views/ops/_ldap_domain_show.html.haml:209 ../../app/views/_ldap_domain_form.html.haml:163
 msgid "Bind DN"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:373 ../../app/views/ops/_ldap_forest_entries.html.haml:25 ../../app/views/ops/_ldap_domain_form.html.haml:180 ../../app/views/ops/_ldap_domain_show.html.haml:225 ../../app/views/_ldap_domain_form.html.haml:180
 msgid "Bind Password"
 msgstr ""
 
+#: ../model_attributes.rb:67
 msgid "Blacklisted event"
 msgstr ""
 
+#: ../model_attributes.rb:68
 msgid "BlacklistedEvent|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:69
 msgid "BlacklistedEvent|Event name"
 msgstr ""
 
+#: ../model_attributes.rb:70
 msgid "BlacklistedEvent|Provider model"
 msgstr ""
 
+#: ../model_attributes.rb:71
 msgid "BlacklistedEvent|System"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_bottlenecks_report.html.haml:13
 msgid "Bottleneck Event Details"
 msgstr ""
 
+#: ../model_attributes.rb:72
 msgid "Bottleneck event"
 msgstr ""
 
+#: ../model_attributes.rb:73
 msgid "BottleneckEvent|Context data"
 msgstr ""
 
+#: ../model_attributes.rb:74
 msgid "BottleneckEvent|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:75
 msgid "BottleneckEvent|Event type"
 msgstr ""
 
+#: ../model_attributes.rb:76
 msgid "BottleneckEvent|Future"
 msgstr ""
 
+#: ../model_attributes.rb:77
 msgid "BottleneckEvent|Message"
 msgstr ""
 
+#: ../model_attributes.rb:78
 msgid "BottleneckEvent|Resource name"
 msgstr ""
 
+#: ../model_attributes.rb:79
 msgid "BottleneckEvent|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:80
 msgid "BottleneckEvent|Severity"
 msgstr ""
 
+#: ../model_attributes.rb:81
 msgid "BottleneckEvent|Timestamp"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:141
 msgid "Bottlenecks"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:4
 msgid "Box Information"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:17
 msgid "Browser"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:17
 msgid "Browser OS"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:17
 msgid "Browser Version"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_group_form.html.haml:50
 msgid "Button Group Hover Text"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_group_form.html.haml:66
 msgid "Button Group Image"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_group_order_form.html.haml:17
 msgid "Button Group Order:"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_group_form.html.haml:17
 msgid "Button Group Text"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:166 ../../app/views/shared/buttons/_ab_show.html.haml:35 ../../app/views/shared/buttons/_ab_form.html.haml:68
 msgid "Button Hover Text"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_form.html.haml:84
 msgid "Button Image"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:146 ../../app/views/shared/buttons/_ab_show.html.haml:15 ../../app/views/shared/buttons/_ab_form.html.haml:35
 msgid "Button Text"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:193 ../../app/controllers/miq_ae_tools_controller.rb:29 ../../app/controllers/vm_common.rb:20 ../../app/controllers/vm_common.rb:965 ../../app/controllers/miq_request_controller.rb:23 ../../app/controllers/storage_manager_controller.rb:23 ../../app/controllers/service_controller.rb:48 ../../app/controllers/orchestration_stack_controller.rb:123 ../../app/controllers/resource_pool_controller.rb:149 ../../app/controllers/cim_instance_controller.rb:83 ../../app/controllers/storage_controller.rb:137 ../../app/controllers/container_controller.rb:41 ../../app/controllers/host_controller.rb:526 ../../app/controllers/configuration_controller.rb:54 ../../app/controllers/availability_zone_controller.rb:102 ../../app/controllers/miq_policy_controller.rb:92 ../../app/controllers/ems_cluster_controller.rb:192 ../../app/controllers/application_controller/explorer.rb:141 ../../app/controllers/application_controller/filter.rb:45 ../../app/controllers/application_controller/policy_support.rb:151 ../../app/helpers/application_helper.rb:647
 msgid "Button not yet implemented"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:50
 msgid "Buttons"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_capacity/_planning_options.html.haml:16 ../../app/views/miq_capacity/_planning_options.html.haml:16
 msgid "By %s"
 msgstr ""
 
+#: ../../app/helpers/report_helper.rb:25
 msgid "By %{typ}: %{values}"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:16
 msgid "By Filter"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:16
 msgid "By Host"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_show.html.haml:201
 msgid "By Role"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:82 ../../app/views/miq_policy/_policy_details.html.haml:97
 msgid "By Username %s %s"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:80
 msgid "C & U Collection"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:65
 msgid "C & U Data Collectors"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:428
 msgid "C & U Data Processors"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:21 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:18
 msgid "C & U Database"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:140
 msgid "C & U Gap Collection"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:33
 msgid "CFME Appliance restart initiated successfully"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:264
 msgid "CFME Database settings validation was successful"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:172
 msgid "CFME Log"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:742 ../../app/controllers/ops_controller/diagnostics.rb:760
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:96
 msgid "CFME Version"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:39 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18
 msgid "CPU"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "CPU Limit"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:128 ../../app/views/ops/_selected_by_roles.html.haml:176 ../../app/views/ops/_server_desc.html.haml:83
 msgid "CPU Percent"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "CPU Reserve"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "CPU Reserve Expand"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "CPU Shares"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "CPU Shares Level"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:140 ../../app/views/miq_capacity/_planning_options.html.haml:308 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:16 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:67
 msgid "CPU Speed"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:115 ../../app/views/ops/_selected_by_roles.html.haml:163 ../../app/views/ops/_server_desc.html.haml:73
 msgid "CPU Time"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:67
 msgid "CPU Usage"
 msgstr ""
 
+#: ../../app/views/report/_schedule_email_options.html.haml:50
 msgid "CSV"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:107 ../../app/views/report/_form_sort.html.haml:246
 msgid "Calculations"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:49
 msgid "Can not delete folder, one or more reports in the selected folder are not owned by your group"
 msgstr ""
 
+#: ../../app/views/storage_manager/_form.html.haml:227 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:70 ../../app/views/ems_cloud/discover.html.haml:23 ../../app/views/ems_cloud/discover.html.haml:23 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:91 ../../app/views/ems_infra/scaling.html.haml:66 ../../app/views/ems_infra/scaling.html.haml:66 ../../app/views/layouts/_discover.html.haml:108 ../../app/views/layouts/_discover.html.haml:108 ../../app/views/layouts/_user_input_filter.html.haml:123 ../../app/views/layouts/_x_edit_buttons.html.haml:135 ../../app/views/layouts/_x_edit_buttons.html.haml:178 ../../app/views/layouts/_x_edit_buttons.html.haml:198 ../../app/views/layouts/_x_edit_buttons.html.haml:216 ../../app/views/layouts/_form_buttons.html.haml:82 ../../app/views/layouts/_form_buttons.html.haml:105 ../../app/views/layouts/_edit_buttons.html.haml:40 ../../app/views/layouts/_edit_buttons.html.haml:40 ../../app/views/layouts/_edit_buttons.html.haml:65 ../../app/views/layouts/_edit_buttons.html.haml:65 ../../app/views/layouts/_ae_tree_select.html.haml:78 ../../app/views/layouts/_ae_tree_select.html.haml:91 ../../app/views/layouts/_adv_search_footer.html.haml:91 ../../app/views/layouts/_adv_search_footer.html.haml:108 ../../app/views/layouts/_edit_form_buttons.html.haml:133 ../../app/views/layouts/_edit_form_buttons.html.haml:142 ../../app/views/layouts/_edit_form_buttons.html.haml:176 ../../app/views/layouts/_edit_form_buttons.html.haml:185 ../../app/views/layouts/_x_dialog_buttons.html.haml:46 ../../app/views/layouts/_x_dialog_buttons.html.haml:71 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:25 ../../app/views/vm_common/_reconfigure.html.haml:174 ../../app/views/vm_common/_snap.html.haml:67 ../../app/views/vm_common/_add_to_service.html.haml:54 ../../app/views/configuration/_timeprofile_form.html.haml:125 ../../app/views/configuration/_timeprofile_form.html.haml:125 ../../app/views/report/_export_widgets.html.haml:143 ../../app/views/ontap_file_share/_create_datastore.html.haml:73 ../../app/views/shared/views/_retire.html.haml:111 ../../app/views/shared/views/ems_common/_form.html.haml:184 ../../app/views/miq_policy/_export.html.haml:33
 msgid "Cancel"
 msgstr ""
 
+#: ../../app/views/layouts/_user_input_filter.html.haml:123
 msgid "Cancel (Esc)"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_form_buttons.html.haml:133 ../../app/views/layouts/_edit_form_buttons.html.haml:142 ../../app/views/vm_common/_reconfigure.html.haml:174 ../../app/views/report/_export_widgets.html.haml:143 ../../app/views/miq_policy/_export.html.haml:33
 msgid "Cancel Changes"
 msgstr ""
 
+#: ../../app/views/miq_policy/_export.html.haml:33
 msgid "Cancel Import"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:24 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:49
 msgid "Cancel Simulation to go back to Button details"
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:57
 msgid "Cancel after"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:91
 msgid "Cancel the load"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:108
 msgid "Cancel the save"
 msgstr ""
 
+#: ../../app/controllers/application_controller/miq_request_methods.rb:749 ../../app/controllers/application_controller/miq_request_methods.rb:936
 msgid "Cannot create Request Info, error: "
 msgstr ""
 
+#: ../../app/views/layouts/_item.html.haml:134
 msgid "Cannot display binary content"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:617
 msgid "Cannot start log collection, a log collection is already in progress within this scope"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:615
 msgid "Cannot start log collection, requires a started server"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vnc.html.haml:39
 msgid "Canvas not supported."
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:121 ../../app/views/layouts/listnav/_host.html.haml:129 ../../app/views/layouts/listnav/_storage.html.haml:21 ../../app/views/layouts/listnav/_storage.html.haml:29 ../../app/views/layouts/listnav/_ems_cluster.html.haml:36 ../../app/views/layouts/listnav/_ems_cluster.html.haml:44 ../../app/views/layouts/listnav/_vm_common.html.haml:105 ../../app/views/layouts/listnav/_vm_common.html.haml:113
 msgid "Capacity & Utilization"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1745
 msgid "Capacity & Utilization data for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/views/ops/_db_summary.html.haml:7 ../../app/views/ontap_logical_disk/_main.html.haml:16
 msgid "Capacity Data"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/cap_and_u.rb:39
 msgid "Capacity and Utilization Collection settings saved"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:20
 msgid "Capture C & U Data"
 msgstr ""
 
+#: ../../app/views/ops/_category_form.html.haml:85 ../../app/views/ops/_category_form.html.haml:198
 msgid "Capture C & U Data by Tag"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:55 ../../app/views/catalog/_sandt_tree_show.html.haml:56
 msgid "Catalog"
 msgstr ""
 
+#: ../../app/views/catalog/_st_form.html.haml:13
 msgid "Catalog Item Type"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:46 ../../app/views/catalog/_stcat_tree_show.html.haml:49
 msgid "Catalog Items"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:18
 msgid "Catalogs"
 msgstr ""
 
+#: ../../app/views/ops/_ap_show.html.haml:67 ../../app/views/ops/_all_tabs.html.haml:85 ../../app/views/miq_policy/_action_options.html.haml:566 ../../app/views/miq_policy/_action_options.html.haml:596 ../../app/views/miq_policy/_action_details.html.haml:505 ../../app/views/miq_policy/_action_details.html.haml:529
 msgid "Categories"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_tags_tab.html.haml:14 ../../app/views/ops/_ap_form.html.haml:80 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:517 ../../app/views/layouts/_classify_table.html.haml:11 ../../app/views/layouts/_tag_edit_assignments.html.haml:13
 msgid "Category"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:60
 msgid "Category '%s' cannot be deleted"
 msgstr ""
 
+#: ../../app/views/ops/_category_form.html.haml:4
 msgid "Category Information"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_set.html.haml:8
 msgid "Category Selection"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_tag_field_values.html.haml:5
 msgid "Category Tag Entries"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:207
 msgid "Caution:"
 msgstr ""
 
+#: ../../app/views/ops/_settings_database_tab.html.haml:16
 msgid "Caution: Changing the Database settings could make the Server unstartable!"
 msgstr ""
 
+#: ../../app/views/ops/_settings_advanced_tab.html.haml:18
 msgid "Caution: Manual changes to configuration files can disable the Server!"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:412 ../../app/controllers/application_controller/ci_processing.rb:419
 msgid "Change %s value to submit reconfigure request"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:29
 msgid "Change Group:"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:77
 msgid "Change Password"
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:8
 msgid "Changes"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:39
 msgid "Changing the UI Workers Count will immediately restart the webserver"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:75
 msgid "Channel Name(s)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:67
 msgid "Channel Name(s):"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:9
 msgid "Chargeback"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:6
 msgid "Chargeback Filters"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:140
 msgid "Chargeback Interval"
 msgstr ""
 
+#: ../model_attributes.rb:82
 msgid "Chargeback rate"
 msgstr ""
 
+#: ../model_attributes.rb:89
 msgid "Chargeback rate detail"
 msgstr ""
 
+#: ../model_attributes.rb:90
 msgid "ChargebackRateDetail|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:91
 msgid "ChargebackRateDetail|Description"
 msgstr ""
 
+#: ../model_attributes.rb:92
 msgid "ChargebackRateDetail|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:93
 msgid "ChargebackRateDetail|Friendly rate"
 msgstr ""
 
+#: ../model_attributes.rb:94
 msgid "ChargebackRateDetail|Group"
 msgstr ""
 
+#: ../model_attributes.rb:95
 msgid "ChargebackRateDetail|Metric"
 msgstr ""
 
+#: ../model_attributes.rb:96
 msgid "ChargebackRateDetail|Per time"
 msgstr ""
 
+#: ../model_attributes.rb:97
 msgid "ChargebackRateDetail|Per unit"
 msgstr ""
 
+#: ../model_attributes.rb:98
 msgid "ChargebackRateDetail|Rate"
 msgstr ""
 
+#: ../model_attributes.rb:99
 msgid "ChargebackRateDetail|Source"
 msgstr ""
 
+#: ../model_attributes.rb:100
 msgid "ChargebackRateDetail|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:83
 msgid "ChargebackRate|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:84
 msgid "ChargebackRate|Default"
 msgstr ""
 
+#: ../model_attributes.rb:85
 msgid "ChargebackRate|Description"
 msgstr ""
 
+#: ../model_attributes.rb:86
 msgid "ChargebackRate|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:87
 msgid "ChargebackRate|Rate type"
 msgstr ""
 
+#: ../model_attributes.rb:88
 msgid "ChargebackRate|Updated on"
 msgstr ""
 
+#: ../../app/views/report/_report_list.html.haml:144 ../../app/views/report/_report_info.html.haml:56
 msgid "Chart"
 msgstr ""
 
+#: ../../app/views/report/_form_preview.html.haml:25
 msgid "Chart Preview (up to 50 rows)"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_chart.html.haml:4
 msgid "Chart Report"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:6
 msgid "Chart Settings"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:139
 msgid "Chart Theme"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:37
 msgid "Chart mode"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:169
 msgid "Chart no longer exists"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:55 ../../app/views/ops/_settings_cu_collection_tab.html.haml:111 ../../app/views/layouts/exp_atom/_edit_find.html.haml:149 ../../app/views/miq_ae_class/_class_instances.html.haml:13 ../../app/views/miq_ae_class/_class_methods.html.haml:13 ../../app/views/miq_ae_class/_ns_list.html.haml:11 ../../app/views/miq_ae_class/_ns_details.html.haml:11
 msgid "Check All"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_find.html.haml:149
 msgid "Check Any"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_find.html.haml:149
 msgid "Check Count"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:40
 msgid "Check for Updates"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:300
 msgid "Check for updates"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_3.html.haml:10
 msgid "Checked default filters will be visible."
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:85
 msgid "Child Tenants"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:97
 msgid "Child VM Selection"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:103
 msgid "Child VMs:"
 msgstr ""
 
+#: ../../app/views/ops/_settings_import_tab.html.haml:21 ../../app/views/storage_manager/_form.html.haml:46 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:30 ../../app/views/host/_form.html.haml:74 ../../app/views/host/_form.html.haml:74 ../../app/views/miq_request/_prov_field.html.haml:189 ../../app/views/miq_request/_prov_field.html.haml:256 ../../app/views/miq_request/_prov_field.html.haml:306 ../../app/views/miq_request/_prov_field.html.haml:429 ../../app/views/miq_request/_prov_field.html.haml:478 ../../app/views/miq_request/_prov_field.html.haml:522 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:56 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:120 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:161 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:74 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:522 ../../app/views/layouts/exp_atom/_edit_field.html.haml:9 ../../app/views/layouts/exp_atom/_edit_field.html.haml:18 ../../app/views/layouts/exp_atom/_edit_field.html.haml:71 ../../app/views/layouts/exp_atom/_edit_find.html.haml:6 ../../app/views/layouts/exp_atom/_edit_find.html.haml:47 ../../app/views/layouts/exp_atom/_editor.html.haml:59 ../../app/views/layouts/exp_atom/_editor.html.haml:68 ../../app/views/layouts/exp_atom/_editor.html.haml:91 ../../app/views/layouts/exp_atom/_edit_count.html.haml:7 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:9 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:18 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:59 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:289 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:289 ../../app/views/vm_common/_reconfigure.html.haml:98 ../../app/views/vm_common/_reconfigure.html.haml:123 ../../app/views/report/_form_columns_trend.html.haml:11 ../../app/views/report/_schedule_form_filter.html.haml:21 ../../app/views/report/_schedule_form_filter.html.haml:41 ../../app/views/report/_schedule_form_filter.html.haml:60 ../../app/views/report/_schedule_form_filter.html.haml:83 ../../app/views/report/_schedule_form_filter.html.haml:102 ../../app/views/report/_schedule_form_filter.html.haml:120 ../../app/views/report/_form_filter_chargeback.html.haml:21 ../../app/views/report/_widget_form_report.html.haml:20 ../../app/views/report/_widget_form_report.html.haml:32 ../../app/views/report/_widget_form_report.html.haml:44 ../../app/views/ontap_file_share/_create_datastore.html.haml:41 ../../app/views/shared/views/ems_common/angular/_form.html.haml:44 ../../app/views/shared/views/ems_common/angular/_form.html.haml:78 ../../app/views/shared/views/ems_common/angular/_form.html.haml:78 ../../app/views/catalog/_form_resources_info.html.haml:25 ../../app/views/catalog/_form_basic_info.html.haml:101 ../../app/views/catalog/_form_basic_info.html.haml:123 ../../app/views/catalog/_st_form.html.haml:18 ../../app/views/pxe/_template_form.html.haml:54 ../../app/views/pxe/_template_form.html.haml:73 ../../app/views/pxe/_iso_datastore_form.html.haml:22 ../../app/views/pxe/_pxe_form.html.haml:39 ../../app/views/miq_policy/_rsop_form.html.haml:21 ../../app/views/miq_policy/_rsop_form.html.haml:32 ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_policy/_rsop_form.html.haml:59 ../../app/views/miq_policy/_rsop_form.html.haml:68 ../../app/views/miq_policy/_rsop_form.html.haml:77 ../../app/views/miq_policy/_rsop_form.html.haml:86 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:15 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:44 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:66 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:88 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:293 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:329 ../../app/views/miq_policy/_action_options.html.haml:196 ../../app/views/miq_policy/_action_options.html.haml:519 ../../app/views/miq_policy/_alert_details.html.haml:139 ../../app/views/miq_policy/_action_details.html.haml:48 ../../app/views/miq_capacity/_planning_options.html.haml:16
 msgid "Choose"
 msgstr ""
 
+#: ../../app/views/layouts/_policy_sim.html.haml:6
 msgid "Choose Policies"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:38 ../../app/views/miq_capacity/_planning_options.html.haml:48 ../../app/views/miq_capacity/_planning_options.html.haml:58
 msgid "Choose a %s"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:340
 msgid "Choose a %s first"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:84
 msgid "Choose a %s report filter"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_tags_tab.html.haml:7 ../../app/views/chargeback/_cb_assignments.html.haml:46 ../../app/views/report/_form_filter_chargeback.html.haml:65
 msgid "Choose a Category"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:68
 msgid "Choose a Filter"
 msgstr ""
 
+#: ../../app/views/report/_export.html.haml:5
+msgid "Choose a Import/Export type from the menus on the left."
+msgstr ""
+
+#: ../../app/views/report/show_saved.html.haml:3 ../../app/views/report/_savedreports_list.html.haml:24
 msgid "Choose a Report from the menus on the left."
 msgstr ""
 
-msgid "Choose a Report to edit from the menus on the left."
-msgstr ""
-
+#: ../../app/views/report/_reports.html.haml:2 ../../app/views/report/_report_list.html.haml:232
 msgid "Choose a Report to view from the menus on the left."
 msgstr ""
 
+#: ../../app/views/report/_role_list.html.haml:87
 msgid "Choose a Role to edit from the left."
 msgstr ""
 
+#: ../../app/views/report/_schedule_list.html.haml:18
 msgid "Choose a Schedule to view from the menus on the left."
 msgstr ""
 
+#: ../../app/views/dashboard/_tl_detail.html.haml:26
 msgid "Choose a Timeline from the menus on the left."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:88
 msgid "Choose a VM"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:87
 msgid "Choose a Value"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:15
 msgid "Choose a chart type"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:49
 msgid "Choose a saved %s filter:"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:77
 msgid "Choose a saved filter or report filter to load"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:43
 msgid "Choose an Owner"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:49 ../../app/controllers/ops_controller/settings/common.rb:1108
 msgid "Choose the type of custom variables to be imported"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:44 ../../app/views/shared/views/ems_common/_form.html.haml:41
 msgid "Choose>"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1512
 msgid "Class Schema Sequence was saved"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_fields_seq_form.html.haml:19
 msgid "Class Schema Sequencing:"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_options.html.haml:41 ../model_attributes.rb:101
 msgid "Classification"
 msgstr ""
 
+#: ../model_attributes.rb:102
 msgid "Classification|Default"
 msgstr ""
 
+#: ../model_attributes.rb:103
 msgid "Classification|Description"
 msgstr ""
 
+#: ../model_attributes.rb:104
 msgid "Classification|Example text"
 msgstr ""
 
+#: ../model_attributes.rb:105
 msgid "Classification|Icon"
 msgstr ""
 
+#: ../model_attributes.rb:106
 msgid "Classification|Perf by tag"
 msgstr ""
 
+#: ../model_attributes.rb:107
 msgid "Classification|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:108
 msgid "Classification|Show"
 msgstr ""
 
+#: ../model_attributes.rb:109
 msgid "Classification|Single value"
 msgstr ""
 
+#: ../model_attributes.rb:110
 msgid "Classification|Syntax"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:161
 msgid "Click on a Host to fetch its settings"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_field_value_entry.html.haml:61
 msgid "Click on this row to create a new entry"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:58
 msgid "Click to Logout"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:28
 msgid "Click to add a new category"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:28 ../../app/views/ops/_ldap_server_entry.html.haml:84 ../../app/views/ops/_ap_form_file.html.haml:23 ../../app/views/ops/_ap_form_registry.html.haml:24 ../../app/views/ops/_classification_entry.html.haml:52 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:48
 msgid "Click to add a new entry"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:32
 msgid "Click to add a new forest"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_form.html.haml:193
 msgid "Click to add a new parameter"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:141 ../../app/views/layouts/exp_atom/_edit_find.html.haml:114 ../../app/views/layouts/exp_atom/_edit_find.html.haml:249
 msgid "Click to change to a relative Date/Time format"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:150 ../../app/views/layouts/exp_atom/_edit_find.html.haml:123 ../../app/views/layouts/exp_atom/_edit_find.html.haml:258
 msgid "Click to change to a specific Date/Time format"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:31
 msgid "Click to delete Orphaned Records for this user"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:113
 msgid "Click to delete this LDAP Server"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:75
 msgid "Click to delete this category"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:166 ../../app/views/ops/_ap_form_file.html.haml:72 ../../app/views/ops/_ap_form_registry.html.haml:114 ../../app/views/ops/_ap_form_registry.html.haml:128 ../../app/views/ops/_classification_entry.html.haml:79 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:86 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:97
 msgid "Click to delete this entry"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_class_fields.html.haml:108
 msgid "Click to delete this field from schema"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:150
 msgid "Click to delete this forest"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_form.html.haml:155 ../../app/views/miq_ae_class/_method_form.html.haml:155
 msgid "Click to delete this input field from method"
 msgstr ""
 
+#: ../../app/views/ops/_settings_co_categories_tab.html.haml:86
 msgid "Click to edit this category"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:161 ../../app/views/ops/_ldap_forest_entries.html.haml:166 ../../app/views/ops/_ldap_forest_entries.html.haml:171 ../../app/views/ops/_ldap_forest_entries.html.haml:176 ../../app/views/ops/_ldap_forest_entries.html.haml:181 ../../app/views/ops/_ldap_forest_entries.html.haml:186
 msgid "Click to edit this forest"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_menu.html.haml:21
 msgid "Click to go to this location"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_utilization.rb:13
 msgid "Click to open"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:28
 msgid "Click to remove message"
 msgstr ""
 
+#: ../../app/views/layouts/_flash_msg.html.haml:14
 msgid "Click to remove messages"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:74 ../../app/views/catalog/_form_resources_info.html.haml:74
 msgid "Click to remove this Resource from the Catalog Item"
 msgstr ""
 
+#: ../../app/views/layouts/_classify_table.html.haml:39 ../../app/views/layouts/_tag_edit_assignments.html.haml:45
 msgid "Click to remove this assignment"
 msgstr ""
 
+#: ../../app/views/layouts/_policy_sim.html.haml:56
 msgid "Click to remove this policy"
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:256 ../../app/views/catalog/_stcat_tree_show.html.haml:57
 msgid "Click to this Catalog Item"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:118
 msgid "Click to update this LDAP Server"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:171 ../../app/views/ops/_ap_form_nteventlog.html.haml:176 ../../app/views/ops/_ap_form_nteventlog.html.haml:181 ../../app/views/ops/_ap_form_nteventlog.html.haml:187 ../../app/views/ops/_ap_form_nteventlog.html.haml:192 ../../app/views/ops/_ap_form_nteventlog.html.haml:197 ../../app/views/ops/_ap_form_file.html.haml:77 ../../app/views/ops/_ap_form_file.html.haml:82 ../../app/views/ops/_ap_form_registry.html.haml:135 ../../app/views/ops/_ap_form_registry.html.haml:140 ../../app/views/ops/_ap_form_registry.html.haml:145 ../../app/views/ops/_classification_entry.html.haml:90 ../../app/views/ops/_classification_entry.html.haml:95 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:103 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:109
 msgid "Click to update this entry"
 msgstr ""
 
+#: ../../app/views/layouts/gtl/_list.html.haml:209
 msgid "Click to view %s"
 msgstr ""
 
+#: ../../app/views/report/_db_list.html.haml:66
 msgid "Click to view %s "
 msgstr ""
 
+#: ../../app/views/report/_db_list.html.haml:111
 msgid "Click to view '%s (%s)'"
 msgstr ""
 
+#: ../../app/views/report/_db_list.html.haml:23
 msgid "Click to view '%s'"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:62 ../../app/views/miq_policy/_condition_details.html.haml:133 ../../app/views/miq_policy/_action_details.html.haml:553
 msgid "Click to view Policy"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_4.html.haml:30
 msgid "Click to view Time Profile"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:99
 msgid "Click to view child Tenant"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:131
 msgid "Click to view child TenantProject"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_region_show.html.haml:83 ../../app/views/miq_request/_request.html.haml:228 ../../app/views/miq_request/_request.html.haml:242 ../../app/views/report/_report_list.html.haml:53 ../../app/views/report/_report_list.html.haml:92 ../../app/views/report/_report_list.html.haml:159 ../../app/views/shared/buttons/_ab_list.html.haml:19 ../../app/views/shared/buttons/_ab_list.html.haml:64 ../../app/views/shared/buttons/_ab_list.html.haml:99 ../../app/views/shared/buttons/_ab_list.html.haml:219
 msgid "Click to view details"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:228
 msgid "Click to view index"
 msgstr ""
 
+#: ../../app/views/chargeback/_reports_list.html.haml:69
 msgid "Click to view saved report"
 msgstr ""
 
+#: ../../app/views/report/_report_info.html.haml:261
 msgid "Click to view selected widget"
 msgstr ""
 
+#: ../../app/views/layouts/gtl/_list.html.haml:217
 msgid "Click to view target %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_domain_overrides.html.haml:13
 msgid "Click to view this %s in the \"%s\" Domain"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:59 ../../app/views/ops/_settings_server_tab.html.haml:65 ../../app/views/layouts/gtl/_list.html.haml:120 ../../app/views/layouts/gtl/_list.html.haml:199
 msgid "Click to view this VM"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_4.html.haml:30
 msgid "Click to view/edit Time Profile"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:295
 msgid "Client Connections"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:273
 msgid "Client ID"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:273
 msgid "Client Key"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:273
 msgid "Client Keys do not match"
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:23 ../../app/views/layouts/_exception_contents.html.haml:37
 msgid "Close any duplicate browser sessions, then select a menu option above."
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:5
 msgid "Cloud Intelligence"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:72 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:78
 msgid "Cloud Networks (%s)"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:18
 msgid "Cloud Quota"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:22
 msgid "Cloud Tenant:"
 msgstr ""
 
+#: ../model_attributes.rb:111
 msgid "Cloud network"
 msgstr ""
 
+#: ../model_attributes.rb:119
 msgid "Cloud object store container"
 msgstr ""
 
+#: ../model_attributes.rb:124
 msgid "Cloud object store object"
 msgstr ""
 
+#: ../model_attributes.rb:131
 msgid "Cloud resource quota"
 msgstr ""
 
+#: ../model_attributes.rb:136
 msgid "Cloud subnet"
 msgstr ""
 
+#: ../model_attributes.rb:144
 msgid "Cloud tenant"
 msgstr ""
 
+#: ../model_attributes.rb:149
 msgid "Cloud volume"
 msgstr ""
 
+#: ../model_attributes.rb:158
 msgid "Cloud volume snapshot"
 msgstr ""
 
+#: ../../app/views/pxe/_template_form.html.haml:73
 msgid "CloudInit"
 msgstr ""
 
+#: ../model_attributes.rb:112
 msgid "CloudNetwork|Cidr"
 msgstr ""
 
+#: ../model_attributes.rb:113
 msgid "CloudNetwork|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:114
 msgid "CloudNetwork|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:115
 msgid "CloudNetwork|External facing"
 msgstr ""
 
+#: ../model_attributes.rb:116
 msgid "CloudNetwork|Name"
 msgstr ""
 
+#: ../model_attributes.rb:117
 msgid "CloudNetwork|Shared"
 msgstr ""
 
+#: ../model_attributes.rb:118
 msgid "CloudNetwork|Status"
 msgstr ""
 
+#: ../model_attributes.rb:120
 msgid "CloudObjectStoreContainer|Bytes"
 msgstr ""
 
+#: ../model_attributes.rb:121
 msgid "CloudObjectStoreContainer|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:122
 msgid "CloudObjectStoreContainer|Key"
 msgstr ""
 
+#: ../model_attributes.rb:123
 msgid "CloudObjectStoreContainer|Object count"
 msgstr ""
 
+#: ../model_attributes.rb:125
 msgid "CloudObjectStoreObject|Content length"
 msgstr ""
 
+#: ../model_attributes.rb:126
 msgid "CloudObjectStoreObject|Content type"
 msgstr ""
 
+#: ../model_attributes.rb:127
 msgid "CloudObjectStoreObject|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:128
 msgid "CloudObjectStoreObject|Etag"
 msgstr ""
 
+#: ../model_attributes.rb:129
 msgid "CloudObjectStoreObject|Key"
 msgstr ""
 
+#: ../model_attributes.rb:130
 msgid "CloudObjectStoreObject|Last modified"
 msgstr ""
 
+#: ../model_attributes.rb:132
 msgid "CloudResourceQuota|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:133
 msgid "CloudResourceQuota|Name"
 msgstr ""
 
+#: ../model_attributes.rb:134
 msgid "CloudResourceQuota|Service name"
 msgstr ""
 
+#: ../model_attributes.rb:135
 msgid "CloudResourceQuota|Value"
 msgstr ""
 
+#: ../model_attributes.rb:137
 msgid "CloudSubnet|Cidr"
 msgstr ""
 
+#: ../model_attributes.rb:138
 msgid "CloudSubnet|Dhcp enabled"
 msgstr ""
 
+#: ../model_attributes.rb:139
 msgid "CloudSubnet|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:140
 msgid "CloudSubnet|Gateway"
 msgstr ""
 
+#: ../model_attributes.rb:141
 msgid "CloudSubnet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:142
 msgid "CloudSubnet|Network protocol"
 msgstr ""
 
+#: ../model_attributes.rb:143
 msgid "CloudSubnet|Status"
 msgstr ""
 
+#: ../model_attributes.rb:145
 msgid "CloudTenant|Description"
 msgstr ""
 
+#: ../model_attributes.rb:146
 msgid "CloudTenant|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:147
 msgid "CloudTenant|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:148
 msgid "CloudTenant|Name"
 msgstr ""
 
+#: ../model_attributes.rb:159
 msgid "CloudVolumeSnapshot|Creation time"
 msgstr ""
 
+#: ../model_attributes.rb:160
 msgid "CloudVolumeSnapshot|Description"
 msgstr ""
 
+#: ../model_attributes.rb:161
 msgid "CloudVolumeSnapshot|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:162
 msgid "CloudVolumeSnapshot|Name"
 msgstr ""
 
+#: ../model_attributes.rb:163
 msgid "CloudVolumeSnapshot|Size"
 msgstr ""
 
+#: ../model_attributes.rb:164
 msgid "CloudVolumeSnapshot|Status"
 msgstr ""
 
+#: ../model_attributes.rb:150
 msgid "CloudVolume|Bootable"
 msgstr ""
 
+#: ../model_attributes.rb:151
 msgid "CloudVolume|Creation time"
 msgstr ""
 
+#: ../model_attributes.rb:152
 msgid "CloudVolume|Description"
 msgstr ""
 
+#: ../model_attributes.rb:153
 msgid "CloudVolume|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:154
 msgid "CloudVolume|Name"
 msgstr ""
 
+#: ../model_attributes.rb:155
 msgid "CloudVolume|Size"
 msgstr ""
 
+#: ../model_attributes.rb:156
 msgid "CloudVolume|Status"
 msgstr ""
 
+#: ../model_attributes.rb:157
 msgid "CloudVolume|Volume type"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:25 ../../app/views/configuration/_ui_2.html.haml:106
 msgid "Clouds"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:38
 msgid "Clusters"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:38
 msgid "Clusters / Deployment Roles"
 msgstr ""
 
+#: ../../app/views/vm_common/_policies.html.haml:15 ../../app/views/shared/views/_compliance_history.html.haml:6
 msgid "Collapse All"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:97 ../../app/views/miq_ae_class/_instance_fields.html.haml:25 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Collect"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_file.html.haml:15
 msgid "Collect Contents?"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:137 ../../app/views/ops/_all_tabs.html.haml:168
 msgid "Collect Logs"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:22
 msgid "Collect for All %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:37
 msgid "Collect for All %s must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:86
 msgid "Collect for All Datastores"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:17
 msgid "Collection Options"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_trend.html.haml:39
 msgid "Column"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:265
 msgid "Column %s"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:15 ../../app/views/report/_widget_columns.html.haml:6
 msgid "Column 1"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:37 ../../app/views/report/_widget_columns.html.haml:28
 msgid "Column 2"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:59 ../../app/views/report/_widget_columns.html.haml:50
 msgid "Column 3"
 msgstr ""
 
+#: ../../app/views/report/_widget_columns.html.haml:72
 msgid "Column 4"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:102 ../../app/views/report/_form_formatting.html.haml:48 ../../app/views/report/_form_styling.html.haml:20 ../../app/views/report/_form_sort.html.haml:236
 msgid "Column Name"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:88 ../../app/views/miq_ae_tools/_import_export.html.haml:158 ../../app/views/report/_export_widgets.html.haml:141 ../../app/views/miq_policy/_export.html.haml:18 ../../app/views/miq_policy/_export.html.haml:24
 msgid "Commit"
 msgstr ""
 
+#: ../../app/views/report/_export_widgets.html.haml:141
 msgid "Commit Changes"
 msgstr ""
 
+#: ../../app/views/miq_policy/_export.html.haml:24
 msgid "Commit Import"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_editor.html.haml:28 ../../app/views/report/_menu_form1.html.haml:71
 msgid "Commit expression element changes"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:128
 msgid "Commit report management changes"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:87
 msgid "Company Name"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:18
 msgid "Compare"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1701
 msgid "Compare %s"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:18
 msgid "Compare Mode"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:157
 msgid "Compare To"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_compare_sections.html.haml:157
 msgid "Comparison Sections"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:140
 msgid "Completed"
 msgstr ""
 
+#: ../../app/views/vm_cloud/_main.html.haml:26 ../../app/views/host/_main.html.haml:17 ../../app/views/vm_common/_main.html.haml:27 ../model_attributes.rb:165
 msgid "Compliance"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_show.html.haml:38
 msgid "Compliance Check"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:43
 msgid "Compliance Policies"
 msgstr ""
 
+#: ../model_attributes.rb:171
 msgid "Compliance detail"
 msgstr ""
 
+#: ../model_attributes.rb:172
 msgid "ComplianceDetail|Condition desc"
 msgstr ""
 
+#: ../model_attributes.rb:173
 msgid "ComplianceDetail|Condition result"
 msgstr ""
 
+#: ../model_attributes.rb:174
 msgid "ComplianceDetail|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:175
 msgid "ComplianceDetail|Miq policy desc"
 msgstr ""
 
+#: ../model_attributes.rb:176
 msgid "ComplianceDetail|Miq policy result"
 msgstr ""
 
+#: ../model_attributes.rb:177
 msgid "ComplianceDetail|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:166
 msgid "Compliance|Compliant"
 msgstr ""
 
+#: ../model_attributes.rb:167
 msgid "Compliance|Event type"
 msgstr ""
 
+#: ../model_attributes.rb:168
 msgid "Compliance|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:169
 msgid "Compliance|Timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:170
 msgid "Compliance|Updated on"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:46 ../../app/helpers/configuration_helper/configuration_view_helper.rb:51
 msgid "Compressed View"
 msgstr ""
 
+#: ../../app/views/chargeback/_assignments_list.html.haml:22
 msgid "Compute"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:84 ../../app/helpers/provider_foreman_helper.rb:165
 msgid "Compute Profile"
 msgstr ""
 
+#: ../model_attributes.rb:178
 msgid "Computer system"
 msgstr ""
 
+#: ../model_attributes.rb:179
 msgid "ComputerSystem|Managed entity type"
 msgstr ""
 
+#: ../model_attributes.rb:180
 msgid "Condition"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/conditions.rb:110
 msgid "Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\""
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:139
 msgid "Condition Selection"
 msgstr ""
 
+#: ../model_attributes.rb:193
 msgid "Condition set"
 msgstr ""
 
+#: ../model_attributes.rb:194
 msgid "ConditionSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:195
 msgid "ConditionSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:196
 msgid "ConditionSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:197
 msgid "ConditionSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:198
 msgid "ConditionSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:199
 msgid "ConditionSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:200
 msgid "ConditionSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:201
 msgid "ConditionSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:202
 msgid "ConditionSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:203
 msgid "ConditionSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:204
 msgid "ConditionSet|Userid"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1125 ../../app/views/container_group/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:17 ../../app/views/miq_policy/_policy_details.html.haml:229
 msgid "Conditions"
 msgstr ""
 
+#: ../model_attributes.rb:181
 msgid "Condition|Applies to exp"
 msgstr ""
 
+#: ../model_attributes.rb:182
 msgid "Condition|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:183
 msgid "Condition|Description"
 msgstr ""
 
+#: ../model_attributes.rb:184
 msgid "Condition|Expression"
 msgstr ""
 
+#: ../model_attributes.rb:185
 msgid "Condition|File mtime"
 msgstr ""
 
+#: ../model_attributes.rb:186
 msgid "Condition|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:187
 msgid "Condition|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:188
 msgid "Condition|Modifier"
 msgstr ""
 
+#: ../model_attributes.rb:189
 msgid "Condition|Name"
 msgstr ""
 
+#: ../model_attributes.rb:190
 msgid "Condition|Notes"
 msgstr ""
 
+#: ../model_attributes.rb:191
 msgid "Condition|Towhat"
 msgstr ""
 
+#: ../model_attributes.rb:192
 msgid "Condition|Updated on"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:149 ../../app/views/resource_pool/_main.html.haml:14 ../../app/views/vm_cloud/_main.html.haml:32 ../../app/views/host/_main.html.haml:21 ../../app/views/ems_cluster/_main.html.haml:19 ../../app/views/layouts/listnav/_host.html.haml:358 ../../app/views/layouts/listnav/_ems_cluster.html.haml:21 ../../app/views/layouts/listnav/_ems_cluster.html.haml:27 ../../app/views/vm_common/_main.html.haml:33 ../model_attributes.rb:205
 msgid "Configuration"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:94
 msgid "Configuration (%s)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_advanced_tab.html.haml:38
 msgid "Configuration File selection can not be changed until changes are saved or reset."
 msgstr ""
 
+#: ../../app/views/ops/_settings_advanced_tab.html.haml:24
 msgid "Configuration File to Edit"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:109 ../../app/helpers/provider_foreman_helper.rb:190
 msgid "Configuration Location"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:53
 msgid "Configuration Management"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:346
 msgid "Configuration Management Configured Systems"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:332
 msgid "Configuration Management Providers"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:115 ../../app/helpers/provider_foreman_helper.rb:196
 msgid "Configuration Organization"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:33
 msgid "Configuration Profile Description"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:150
 msgid "Configuration files of %s"
 msgstr ""
 
+#: ../model_attributes.rb:210
 msgid "Configuration location"
 msgstr ""
 
+#: ../model_attributes.rb:215
 msgid "Configuration organization"
 msgstr ""
 
+#: ../model_attributes.rb:220
 msgid "Configuration profile"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:427 ../../app/controllers/configuration_controller.rb:273
 msgid "Configuration settings saved"
 msgstr ""
 
+#: ../model_attributes.rb:225
 msgid "Configuration tag"
 msgstr ""
 
+#: ../model_attributes.rb:211
 msgid "ConfigurationLocation|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:212
 msgid "ConfigurationLocation|Name"
 msgstr ""
 
+#: ../model_attributes.rb:213
 msgid "ConfigurationLocation|Parent ref"
 msgstr ""
 
+#: ../model_attributes.rb:214
 msgid "ConfigurationLocation|Title"
 msgstr ""
 
+#: ../model_attributes.rb:216
 msgid "ConfigurationOrganization|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:217
 msgid "ConfigurationOrganization|Name"
 msgstr ""
 
+#: ../model_attributes.rb:218
 msgid "ConfigurationOrganization|Parent ref"
 msgstr ""
 
+#: ../model_attributes.rb:219
 msgid "ConfigurationOrganization|Title"
 msgstr ""
 
+#: ../model_attributes.rb:221
 msgid "ConfigurationProfile|Description"
 msgstr ""
 
+#: ../model_attributes.rb:222
 msgid "ConfigurationProfile|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:223
 msgid "ConfigurationProfile|Name"
 msgstr ""
 
+#: ../model_attributes.rb:224
 msgid "ConfigurationProfile|Parent ref"
 msgstr ""
 
+#: ../model_attributes.rb:226
 msgid "ConfigurationTag|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:227
 msgid "ConfigurationTag|Name"
 msgstr ""
 
+#: ../model_attributes.rb:206
 msgid "Configuration|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:207
 msgid "Configuration|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:208
 msgid "Configuration|Typ"
 msgstr ""
 
+#: ../model_attributes.rb:209
 msgid "Configuration|Updated on"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:146
 msgid "Configure"
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:6
 msgid "Configure Report Columns"
 msgstr ""
 
+#: ../../app/views/provider_foreman/_configuration_profile.html.haml:7 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:36
 msgid "Configured Systems"
 msgstr ""
 
+#: ../model_attributes.rb:228
 msgid "Configured system"
 msgstr ""
 
+#: ../model_attributes.rb:229
 msgid "ConfiguredSystem|Build state"
 msgstr ""
 
+#: ../model_attributes.rb:230
 msgid "ConfiguredSystem|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:231
 msgid "ConfiguredSystem|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:232
 msgid "ConfiguredSystem|Ipmi present"
 msgstr ""
 
+#: ../model_attributes.rb:233
 msgid "ConfiguredSystem|Last checkin"
 msgstr ""
 
+#: ../model_attributes.rb:234
 msgid "ConfiguredSystem|Mac address"
 msgstr ""
 
+#: ../model_attributes.rb:235
 msgid "ConfiguredSystem|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:236
 msgid "ConfiguredSystem|Puppet status"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:97
 msgid "Confirm Password"
 msgstr ""
 
+#: ../../app/views/vm_common/console_spice.html.haml:38
 msgid "Connecting (unencrypted) to: %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:147
 msgid "Connection Broker"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:601
 msgid "Connection Broker cache cleared successfully"
 msgstr ""
 
+#: ../../app/views/vm_common/console_mks.html.haml:136
 msgid "Connection failed."
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1260 ../../app/controllers/vm_common.rb:1267 ../../app/controllers/vm_common.rb:1280
 msgid "Console access failed: %s"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:149
 msgid "Console access failed: proxy errror"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:84
 msgid "Consolidating records will not show detail records in the report."
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:43 ../../app/views/layouts/listnav/_vm_common.html.haml:49 ../model_attributes.rb:237
 msgid "Container"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:93
 msgid "Container Images"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:78
 msgid "Container Nodes"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:48
 msgid "Container Nodes (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:42
 msgid "Container Nodes (0)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:114
 msgid "Container Projects (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:108
 msgid "Container Projects (0)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:98 ../../app/views/layouts/listnav/_container_service.html.haml:67 ../../app/views/layouts/listnav/_container_project.html.haml:91
 msgid "Container Routes (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:92 ../../app/views/layouts/listnav/_container_service.html.haml:61 ../../app/views/layouts/listnav/_container_project.html.haml:85
 msgid "Container Routes (0)"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:86
 msgid "Container Services"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:65 ../../app/views/layouts/listnav/_container_project.html.haml:74
 msgid "Container Services (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:59 ../../app/views/layouts/listnav/_container_project.html.haml:68
 msgid "Container Services (0)"
 msgstr ""
 
+#: ../model_attributes.rb:243
 msgid "Container condition"
 msgstr ""
 
+#: ../model_attributes.rb:251
 msgid "Container definition"
 msgstr ""
 
+#: ../model_attributes.rb:258
 msgid "Container env var"
 msgstr ""
 
+#: ../model_attributes.rb:262
 msgid "Container group"
 msgstr ""
 
+#: ../model_attributes.rb:273
 msgid "Container image"
 msgstr ""
 
+#: ../model_attributes.rb:277
 msgid "Container image registry"
 msgstr ""
 
+#: ../model_attributes.rb:281
 msgid "Container node"
 msgstr ""
 
+#: ../model_attributes.rb:294
 msgid "Container port config"
 msgstr ""
 
+#: ../model_attributes.rb:300
 msgid "Container project"
 msgstr ""
 
+#: ../model_attributes.rb:306
 msgid "Container replicator"
 msgstr ""
 
+#: ../model_attributes.rb:313
 msgid "Container route"
 msgstr ""
 
+#: ../model_attributes.rb:320
 msgid "Container service"
 msgstr ""
 
+#: ../model_attributes.rb:327
 msgid "Container service port config"
 msgstr ""
 
+#: ../model_attributes.rb:244
 msgid "ContainerCondition|Container entity type"
 msgstr ""
 
+#: ../model_attributes.rb:245
 msgid "ContainerCondition|Last heartbeat time"
 msgstr ""
 
+#: ../model_attributes.rb:246
 msgid "ContainerCondition|Last transition time"
 msgstr ""
 
+#: ../model_attributes.rb:247
 msgid "ContainerCondition|Message"
 msgstr ""
 
+#: ../model_attributes.rb:248
 msgid "ContainerCondition|Name"
 msgstr ""
 
+#: ../model_attributes.rb:249
 msgid "ContainerCondition|Reason"
 msgstr ""
 
+#: ../model_attributes.rb:250
 msgid "ContainerCondition|Status"
 msgstr ""
 
+#: ../model_attributes.rb:252
 msgid "ContainerDefinition|Cpu cores"
 msgstr ""
 
+#: ../model_attributes.rb:253
 msgid "ContainerDefinition|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:254
 msgid "ContainerDefinition|Image"
 msgstr ""
 
+#: ../model_attributes.rb:255
 msgid "ContainerDefinition|Image pull policy"
 msgstr ""
 
+#: ../model_attributes.rb:256
 msgid "ContainerDefinition|Memory"
 msgstr ""
 
+#: ../model_attributes.rb:257
 msgid "ContainerDefinition|Name"
 msgstr ""
 
+#: ../model_attributes.rb:259
 msgid "ContainerEnvVar|Field path"
 msgstr ""
 
+#: ../model_attributes.rb:260
 msgid "ContainerEnvVar|Name"
 msgstr ""
 
+#: ../model_attributes.rb:261
 msgid "ContainerEnvVar|Value"
 msgstr ""
 
+#: ../model_attributes.rb:263
 msgid "ContainerGroup|Creation timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:264
 msgid "ContainerGroup|Dns policy"
 msgstr ""
 
+#: ../model_attributes.rb:265
 msgid "ContainerGroup|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:266
 msgid "ContainerGroup|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:267
 msgid "ContainerGroup|Message"
 msgstr ""
 
+#: ../model_attributes.rb:268
 msgid "ContainerGroup|Name"
 msgstr ""
 
+#: ../model_attributes.rb:269
 msgid "ContainerGroup|Phase"
 msgstr ""
 
+#: ../model_attributes.rb:270
 msgid "ContainerGroup|Reason"
 msgstr ""
 
+#: ../model_attributes.rb:271
 msgid "ContainerGroup|Resource version"
 msgstr ""
 
+#: ../model_attributes.rb:272
 msgid "ContainerGroup|Restart policy"
 msgstr ""
 
+#: ../model_attributes.rb:278
 msgid "ContainerImageRegistry|Host"
 msgstr ""
 
+#: ../model_attributes.rb:279
 msgid "ContainerImageRegistry|Name"
 msgstr ""
 
+#: ../model_attributes.rb:280
 msgid "ContainerImageRegistry|Port"
 msgstr ""
 
+#: ../model_attributes.rb:274
 msgid "ContainerImage|Image ref"
 msgstr ""
 
+#: ../model_attributes.rb:275
 msgid "ContainerImage|Name"
 msgstr ""
 
+#: ../model_attributes.rb:276
 msgid "ContainerImage|Tag"
 msgstr ""
 
+#: ../model_attributes.rb:282
 msgid "ContainerNode|Container runtime version"
 msgstr ""
 
+#: ../model_attributes.rb:283
 msgid "ContainerNode|Creation timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:284
 msgid "ContainerNode|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:285
 msgid "ContainerNode|Identity infra"
 msgstr ""
 
+#: ../model_attributes.rb:286
 msgid "ContainerNode|Identity machine"
 msgstr ""
 
+#: ../model_attributes.rb:287
 msgid "ContainerNode|Identity system"
 msgstr ""
 
+#: ../model_attributes.rb:288
 msgid "ContainerNode|Kubernetes kubelet version"
 msgstr ""
 
+#: ../model_attributes.rb:289
 msgid "ContainerNode|Kubernetes proxy version"
 msgstr ""
 
+#: ../model_attributes.rb:290
 msgid "ContainerNode|Lives on type"
 msgstr ""
 
+#: ../model_attributes.rb:291
 msgid "ContainerNode|Max container groups"
 msgstr ""
 
+#: ../model_attributes.rb:292
 msgid "ContainerNode|Name"
 msgstr ""
 
+#: ../model_attributes.rb:293
 msgid "ContainerNode|Resource version"
 msgstr ""
 
+#: ../model_attributes.rb:295
 msgid "ContainerPortConfig|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:296
 msgid "ContainerPortConfig|Host port"
 msgstr ""
 
+#: ../model_attributes.rb:297
 msgid "ContainerPortConfig|Name"
 msgstr ""
 
+#: ../model_attributes.rb:298
 msgid "ContainerPortConfig|Port"
 msgstr ""
 
+#: ../model_attributes.rb:299
 msgid "ContainerPortConfig|Protocol"
 msgstr ""
 
+#: ../model_attributes.rb:301
 msgid "ContainerProject|Creation timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:302
 msgid "ContainerProject|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:303
 msgid "ContainerProject|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:304
 msgid "ContainerProject|Name"
 msgstr ""
 
+#: ../model_attributes.rb:305
 msgid "ContainerProject|Resource version"
 msgstr ""
 
+#: ../model_attributes.rb:307
 msgid "ContainerReplicator|Creation timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:308
 msgid "ContainerReplicator|Current replicas"
 msgstr ""
 
+#: ../model_attributes.rb:309
 msgid "ContainerReplicator|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:310
 msgid "ContainerReplicator|Name"
 msgstr ""
 
+#: ../model_attributes.rb:311
 msgid "ContainerReplicator|Replicas"
 msgstr ""
 
+#: ../model_attributes.rb:312
 msgid "ContainerReplicator|Resource version"
 msgstr ""
 
+#: ../model_attributes.rb:314
 msgid "ContainerRoute|Creation timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:315
 msgid "ContainerRoute|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:316
 msgid "ContainerRoute|Host name"
 msgstr ""
 
+#: ../model_attributes.rb:317
 msgid "ContainerRoute|Name"
 msgstr ""
 
+#: ../model_attributes.rb:318
 msgid "ContainerRoute|Path"
 msgstr ""
 
+#: ../model_attributes.rb:319
 msgid "ContainerRoute|Resource version"
 msgstr ""
 
+#: ../model_attributes.rb:328
 msgid "ContainerServicePortConfig|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:329
 msgid "ContainerServicePortConfig|Name"
 msgstr ""
 
+#: ../model_attributes.rb:330
 msgid "ContainerServicePortConfig|Port"
 msgstr ""
 
+#: ../model_attributes.rb:331
 msgid "ContainerServicePortConfig|Protocol"
 msgstr ""
 
+#: ../model_attributes.rb:332
 msgid "ContainerServicePortConfig|Target port"
 msgstr ""
 
+#: ../model_attributes.rb:321
 msgid "ContainerService|Creation timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:322
 msgid "ContainerService|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:323
 msgid "ContainerService|Name"
 msgstr ""
 
+#: ../model_attributes.rb:324
 msgid "ContainerService|Portal ip"
 msgstr ""
 
+#: ../model_attributes.rb:325
 msgid "ContainerService|Resource version"
 msgstr ""
 
+#: ../model_attributes.rb:326
 msgid "ContainerService|Session affinity"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:75 ../../app/views/configuration/_ui_2.html.haml:72
 msgid "Containers"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:66 ../../app/views/layouts/listnav/_ems_container.html.haml:146
 msgid "Containers (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:60 ../../app/views/layouts/listnav/_ems_container.html.haml:140
 msgid "Containers (0)"
 msgstr ""
 
+#: ../model_attributes.rb:238
 msgid "Container|Backing ref"
 msgstr ""
 
+#: ../model_attributes.rb:239
 msgid "Container|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:240
 msgid "Container|Name"
 msgstr ""
 
+#: ../model_attributes.rb:241
 msgid "Container|Restart count"
 msgstr ""
 
+#: ../model_attributes.rb:242
 msgid "Container|State"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:77 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:53 ../../app/views/layouts/listnav/_storage.html.haml:108 ../../app/views/storage/_main.html.haml:19
 msgid "Content"
 msgstr ""
 
+#: ../../app/controllers/report_controller/widgets.rb:129
 msgid "Content generation for this Widget has been initiated"
 msgstr ""
 
+#: ../../app/views/layouts/_item.html.haml:124
 msgid "Contents"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:83 ../../app/views/layouts/_x_edit_buttons.html.haml:156 ../../app/views/layouts/_edit_form_buttons.html.haml:46 ../../app/views/layouts/_edit_form_buttons.html.haml:46 ../../app/views/layouts/_edit_form_buttons.html.haml:76 ../../app/views/layouts/_edit_form_buttons.html.haml:158 ../../app/views/layouts/_x_dialog_buttons.html.haml:32 ../../app/views/layouts/_x_dialog_buttons.html.haml:65
 msgid "Continue"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:118
 msgid "Control"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:44
 msgid "Control Policies"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:97 ../../app/views/layouts/_x_edit_buttons.html.haml:159
 msgid "Copy"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1749
 msgid "Copy %s was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1008
 msgid "Copy of %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1724
 msgid "Copy selected %s was saved"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:78
 msgid "Copy to same path"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:689
 msgid "Copying %s"
 msgstr ""
 
+#: ../../app/views/vm_common/_reconfigure.html.haml:117
 msgid "Cores Per socket"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:20 ../../app/views/ops/_settings_workers_tab.html.haml:22 ../../app/views/ops/_settings_workers_tab.html.haml:74 ../../app/views/ops/_settings_workers_tab.html.haml:187 ../../app/views/ops/_settings_workers_tab.html.haml:229 ../../app/views/ops/_settings_workers_tab.html.haml:280 ../../app/views/ops/_settings_workers_tab.html.haml:331 ../../app/views/ops/_settings_workers_tab.html.haml:386 ../../app/views/ops/_settings_workers_tab.html.haml:437 ../../app/views/ops/_settings_workers_tab.html.haml:516
 msgid "Count"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:43 ../../app/views/report/_form_chart.html.haml:54 ../../app/views/report/_form_sort.html.haml:78
 msgid "Counts"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:90 ../../app/views/vm_common/_snap.html.haml:60
 msgid "Create"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:597
 msgid "Create Snapshot for %{model} \"%{name}\" was started"
 msgstr ""
 
+#: ../../app/views/vm_common/_snap.html.haml:60
 msgid "Create snapshot"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:76
 msgid "Created"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:113 ../../app/views/miq_ae_customization/_dialog_info.html.haml:44 ../../app/views/vm_common/_snapshots_desc.html.haml:50 ../../app/views/miq_ae_class/_method_inputs.html.haml:80 ../../app/views/miq_ae_class/_method_form.html.haml:88 ../../app/views/catalog/_ot_tree_show.html.haml:63
 msgid "Created On"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1059
 msgid "Creation of a new Orchestration Template was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1111
 msgid "Creation of a new Service Dialog was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:176
 msgid "Credential validation returned: %s"
 msgstr ""
 
+#: ../../app/controllers/ems_common.rb:445 ../../app/controllers/ems_cloud_controller.rb:83
 msgid "Credential validation was not successful: %s"
 msgstr ""
 
+#: ../../app/controllers/storage_manager_controller.rb:133 ../../app/controllers/storage_manager_controller.rb:227 ../../app/controllers/ops_controller/settings/rhn.rb:179 ../../app/controllers/ops_controller/settings/ldap.rb:154 ../../app/controllers/host_controller.rb:296 ../../app/controllers/host_controller.rb:433 ../../app/controllers/ems_common.rb:443 ../../app/controllers/provider_foreman_controller.rb:194 ../../app/controllers/ems_cloud_controller.rb:81
 msgid "Credential validation was successful"
 msgstr ""
 
+#: ../../app/views/provider_foreman/_form.html.haml:77 ../../app/views/storage_manager/_form.html.haml:143 ../../app/views/ems_cloud/discover.html.haml:5 ../../app/views/miq_request/_prov_host_dialog.html.haml:78 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:45 ../../app/views/layouts/_container_auth.html.haml:2 ../../app/views/layouts/_multi_auth_credentials.html.haml:3 ../../app/views/shared/views/_prov_dialog.html.haml:365 ../../app/views/shared/views/ems_common/angular/_form.html.haml:270
 msgid "Credentials"
 msgstr ""
 
+#: ../../app/views/ops/_zone_form.html.haml:124
 msgid "Credentials - Windows Domain"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:393
 msgid "Credentials/Settings saved successfully"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:164 ../../app/views/vm_common/_right_size.html.haml:248 ../../app/views/vm_common/_right_size.html.haml:331
 msgid "Current"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:562
 msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_replication_tab.html.haml:48
 msgid "Current Backlog"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:41
 msgid "Current Group"
 msgstr ""
 
+#: ../../app/views/chargeback/_chargeback_rates.html.haml:3
 msgid "Current Rates"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:71
 msgid "Current Status"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:45
 msgid "Current User"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:59
 msgid "Custom Attribute Settings"
 msgstr ""
 
+#: ../../app/views/service/_svcs_show.html.haml:13 ../../app/views/vm_cloud/_main.html.haml:19 ../../app/views/host/_main.html.haml:27 ../../app/views/vm_common/_main.html.haml:20
 msgid "Custom Attributes"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:271 ../../app/views/miq_policy/_action_details.html.haml:110
 msgid "Custom Automation"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:92 ../../app/views/vm_common/_form.html.haml:18
 msgid "Custom Identifier"
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:133
 msgid "Custom Image"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:457
 msgid "Custom Image file \"%s\" successfully uploaded"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:449
 msgid "Custom Image must be a %s file"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:444
 msgid "Custom Image successfully removed"
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:62
 msgid "Custom Login Background Image"
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:135
 msgid "Custom Login Panel Text ("
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:5
 msgid "Custom Logo Image (Shown on top right of all screens)"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:30
 msgid "Custom Logo file \"%s\" uploaded"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:37
 msgid "Custom Logos"
 msgstr ""
 
+#: ../../app/views/report/_export_custom_reports.html.haml:7
 msgid "Custom Reports"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:215 ../../app/views/shared/views/_prov_dialog.html.haml:293 ../../app/views/shared/views/_prov_dialog.html.haml:330
 msgid "Custom Specification"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:659
 msgid "Custom Support URL"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:525
 msgid "Custom Support URL and Description both must be entered."
 msgstr ""
 
+#: ../model_attributes.rb:333
 msgid "Custom attribute"
 msgstr ""
 
+#: ../model_attributes.rb:339
 msgid "Custom button"
 msgstr ""
 
+#: ../model_attributes.rb:351
 msgid "Custom button set"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:32
 msgid "Custom login file \"%s\" uploaded"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:24
 msgid "Custom login image must be a .png file"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:22
 msgid "Custom logo image must be a .png file"
 msgstr ""
 
+#: ../model_attributes.rb:334
 msgid "CustomAttribute|Name"
 msgstr ""
 
+#: ../model_attributes.rb:335
 msgid "CustomAttribute|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:336
 msgid "CustomAttribute|Section"
 msgstr ""
 
+#: ../model_attributes.rb:337
 msgid "CustomAttribute|Source"
 msgstr ""
 
+#: ../model_attributes.rb:338
 msgid "CustomAttribute|Value"
 msgstr ""
 
+#: ../model_attributes.rb:352
 msgid "CustomButtonSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:353
 msgid "CustomButtonSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:354
 msgid "CustomButtonSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:355
 msgid "CustomButtonSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:356
 msgid "CustomButtonSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:357
 msgid "CustomButtonSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:358
 msgid "CustomButtonSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:359
 msgid "CustomButtonSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:360
 msgid "CustomButtonSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:361
 msgid "CustomButtonSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:362
 msgid "CustomButtonSet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:340
 msgid "CustomButton|Applies to class"
 msgstr ""
 
+#: ../model_attributes.rb:341
 msgid "CustomButton|Applies to exp"
 msgstr ""
 
+#: ../model_attributes.rb:342
 msgid "CustomButton|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:343
 msgid "CustomButton|Description"
 msgstr ""
 
+#: ../model_attributes.rb:344
 msgid "CustomButton|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:345
 msgid "CustomButton|Name"
 msgstr ""
 
+#: ../model_attributes.rb:346
 msgid "CustomButton|Options"
 msgstr ""
 
+#: ../model_attributes.rb:347
 msgid "CustomButton|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:348
 msgid "CustomButton|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:349
 msgid "CustomButton|Visibility"
 msgstr ""
 
+#: ../model_attributes.rb:350
 msgid "CustomButton|Wait for complete"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:144
 msgid "Customer Information successfully saved"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:130
 msgid "Customization"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_form.html.haml:123
 msgid "Customization Directory"
 msgstr ""
 
+#: ../model_attributes.rb:363
 msgid "Customization script"
 msgstr ""
 
+#: ../model_attributes.rb:366
 msgid "Customization spec"
 msgstr ""
 
+#: ../model_attributes.rb:372
 msgid "Customization template"
 msgstr ""
 
+#: ../model_attributes.rb:364
 msgid "CustomizationScript|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:365
 msgid "CustomizationScript|Name"
 msgstr ""
 
+#: ../model_attributes.rb:367
 msgid "CustomizationSpec|Description"
 msgstr ""
 
+#: ../model_attributes.rb:368
 msgid "CustomizationSpec|Last update time"
 msgstr ""
 
+#: ../model_attributes.rb:369
 msgid "CustomizationSpec|Name"
 msgstr ""
 
+#: ../model_attributes.rb:370
 msgid "CustomizationSpec|Spec"
 msgstr ""
 
+#: ../model_attributes.rb:371
 msgid "CustomizationSpec|Typ"
 msgstr ""
 
+#: ../model_attributes.rb:373
 msgid "CustomizationTemplate|Description"
 msgstr ""
 
+#: ../model_attributes.rb:374
 msgid "CustomizationTemplate|Name"
 msgstr ""
 
+#: ../model_attributes.rb:375
 msgid "CustomizationTemplate|Script"
 msgstr ""
 
+#: ../model_attributes.rb:376
 msgid "CustomizationTemplate|System"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_host_dialog.html.haml:102 ../../app/views/shared/views/_prov_dialog.html.haml:389
 msgid "Customize Template"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:211
 msgid "DHCP Enabled"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:211
 msgid "DHCP Server"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_host_dialog.html.haml:94 ../../app/views/shared/views/_prov_dialog.html.haml:347 ../../app/views/shared/views/_prov_dialog.html.haml:381
 msgid "DNS"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:211
 msgid "DNS Server"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:51 ../../app/views/report/_schedule_form_timer.html.haml:20 ../../app/views/report/_form_columns_performance.html.haml:12 ../../app/views/report/_form_columns_performance.html.haml:15
 msgid "Daily"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:6
 msgid "Dashboard"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:31
 msgid "Dashboard Sequence was saved"
 msgstr ""
 
+#: ../../app/views/report/_db_seq_form.html.haml:19
 msgid "Dashboards:"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:95 ../../app/views/miq_ae_class/_method_form.html.haml:100
 msgid "Data"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:132 ../../app/views/miq_ae_class/_method_form.html.haml:143 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Data Type"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:124 ../../app/views/miq_ae_class/_class_fields.html.haml:47
 msgid "Data Type:"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:62
 msgid "Data column"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_fields.html.haml:55
 msgid "Data type: %s"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:822
 msgid "Data validated successfully"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_regkey.html.haml:30
 msgid "Data:"
 msgstr ""
 
+#: ../../app/views/ops/_settings_database_tab.html.haml:22 ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_all_tabs.html.haml:34 ../../app/views/ops/_all_tabs.html.haml:236 ../../app/views/ops/_settings_workers_tab.html.haml:567
 msgid "Database"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_show.html.haml:41
 msgid "Database Backup"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:128 ../../app/views/layouts/_edit_log_depot_settings.html.haml:11
 msgid "Database Backup Settings"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:51
 msgid "Database Name"
 msgstr ""
 
+#: ../model_attributes.rb:377
 msgid "Database backup"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:361
 msgid "Database settings successfully saved, they will take effect upon CFME Server restart"
 msgstr ""
 
+#: ../model_attributes.rb:378
 msgid "DatabaseBackup|Name"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:27 ../../app/views/shared/views/_prov_dialog.html.haml:97
 msgid "Datacenter"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:40 ../../app/presenters/tree_builder.rb:41 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:60 ../../app/views/miq_request/_prov_host_dialog.html.haml:69 ../../app/views/shared/views/_prov_dialog.html.haml:140
 msgid "Datastore"
 msgstr ""
 
+#: ../../app/views/vm_common/_main.html.haml:37
 msgid "Datastore Actual Usage Summary"
 msgstr ""
 
+#: ../../app/views/vm_common/_main.html.haml:35
 msgid "Datastore Allocation Summary"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:380 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:94
 msgid "Datastore Space"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:124
 msgid "Datastore import was cancelled or is finished"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:146 ../../app/controllers/miq_ae_tools_controller.rb:191
 msgid ""
 "Datastore import was successful.\n"
 "Namespaces updated/added: %{namespace_stats}\n"
@@ -3527,11295 +4693,15049 @@ msgid ""
 "Methods updated/added: %{method_stats}"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:67 ../../app/views/layouts/_perf_options.html.haml:63 ../../app/views/report/_form_filter_chargeback.html.haml:122
 msgid "Date"
 msgstr ""
 
+#: ../../app/views/miq_request/_request_details.html.haml:71
 msgid "Date Approved/Denied"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:154
 msgid "Day"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:11 ../../app/views/configuration/_ui_4.html.haml:15
 msgid "Days"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:79 ../../app/views/ops/_settings_co_categories_tab.html.haml:22 ../../app/views/miq_request/_prov_options.html.haml:129 ../../app/views/miq_request/_prov_options.html.haml:160 ../../app/views/miq_task/_tasks_options.html.haml:152 ../../app/views/miq_task/_tasks_options.html.haml:182 ../../app/views/layouts/_container_auth.html.haml:14 ../../app/views/layouts/_x_edit_buttons.html.haml:128 ../../app/views/layouts/_x_edit_buttons.html.haml:170 ../../app/views/layouts/listnav/_show_list.html.haml:23 ../../app/views/layouts/_edit_form_buttons.html.haml:104 ../../app/views/layouts/_edit_form_buttons.html.haml:167 ../../app/views/layouts/_multi_auth_credentials.html.haml:16 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:14 ../../app/views/report/_widget_show.html.haml:53 ../../app/views/report/_form_styling.html.haml:68 ../../app/views/report/_form_styling.html.haml:116
 msgid "Default"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:388 ../../app/controllers/ops_controller/ops_rbac.rb:335
 msgid "Default %{model} \"%{name}\" can not be deleted"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:210
 msgid "Default %{model} \"%{name}\" can not be edited"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:69 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:90 ../../app/controllers/ops_controller/ops_rbac.rb:248 ../../app/controllers/ops_controller/ops_rbac.rb:560 ../../app/controllers/configuration_controller.rb:381
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:635
 msgid "Default Filters"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:245 ../../app/controllers/configuration_controller.rb:262
 msgid "Default Filters saved successfully"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:211
 msgid "Default Gateway"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:284
 msgid "Default Group for Users"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:104
 msgid "Default Items Per Page"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:42
+msgid "Default Limit"
+msgstr ""
+
+#: ../../app/views/ops/_settings_server_tab.html.haml:171
 msgid "Default Locale"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:227
 msgid "Default Repository SmartProxy"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:43
+msgid "Default Request"
+msgstr ""
+
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:201 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:434 ../../app/views/miq_ae_class/_method_inputs.html.haml:130 ../../app/views/miq_ae_class/_method_form.html.haml:141 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Default Value"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:634
 msgid "Default Views"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar_builder.rb:93
 msgid "Default dialogs cannot be edited"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar_builder.rb:96
 msgid "Default dialogs cannot be removed from the VMDB"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:48 ../../app/views/catalog/_sandt_tree_show.html.haml:231 ../../app/views/catalog/_sandt_tree_show.html.haml:232
 msgid "Delay (mins)"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:41
 msgid "Delete"
 msgstr ""
 
-msgid "Delete and unassign MyTag '%s'"
-msgstr ""
-
+#: ../../app/views/miq_policy/_action_options.html.haml:191
 msgid "Delete if Older than"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:95
 msgid "Delete if older than"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:57
 msgid "Delete selected folder and its contents"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:41
 msgid "Delete the %{model} filter named %{filter}?"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:41
 msgid "Delete the filter named %s"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:112
 msgid "Deleting the '%s' LDAP Server, are you sure?"
 msgstr ""
 
+#: ../../app/views/ops/_classification_entry.html.haml:78
 msgid "Deleting the '%s' entry will also unassign it from all items, are you sure?"
 msgstr ""
 
-msgid "Deleting the MyTag '%s' will also unassign it from all items, are you sure?"
-msgstr ""
-
+#: ../../app/presenters/menu/default_menu.rb:38
 msgid "Deployment Roles"
 msgstr ""
 
+#: ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:8 ../../app/views/layouts/_edit_log_depot_settings.html.haml:43 ../../app/views/layouts/angular/_edit_log_depot_settings_angular.html.haml:6
 msgid "Depot Name"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_form.html.haml:34
 msgid "Depot Type"
 msgstr ""
 
+#: ../../app/views/layouts/_pagingcontrols.html.haml:54
 msgid "Desc. by:"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:502 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:599 ../../app/views/report/_form_sort.html.haml:56
 msgid "Descending"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:29 ../../app/views/ops/_category_form.html.haml:40 ../../app/views/ops/_category_form.html.haml:150 ../../app/views/ops/_ldap_region_show.html.haml:31 ../../app/views/ops/_ap_show.html.haml:32 ../../app/views/ops/_settings_details_tab.html.haml:19 ../../app/views/ops/_zone_form.html.haml:37 ../../app/views/ops/_rbac_tenant_details.html.haml:30 ../../app/views/ops/_tenant_form.html.haml:41 ../../app/views/ops/_settings_co_tags_tab.html.haml:34 ../../app/views/ops/_schedule_form.html.haml:41 ../../app/views/ops/_settings_server_tab.html.haml:685 ../../app/views/ops/_schedule_show.html.haml:9 ../../app/views/ops/_tenant_quota_form.html.haml:27 ../../app/views/ops/_ldap_region_form.html.haml:38 ../../app/views/ops/_rbac_group_details.html.haml:23 ../../app/views/ops/_ap_form.html.haml:38 ../../app/views/service/_service_form.html.haml:38 ../../app/views/miq_request/_request.html.haml:87 ../../app/views/miq_request/_ae_prov_show.html.haml:16 ../../app/views/miq_ae_customization/_dialog_info.html.haml:28 ../../app/views/miq_ae_customization/_field_values.html.haml:19 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:15 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:36 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:33 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:31 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:32 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:36 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:52 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/chargeback/_cb_rate_edit.html.haml:15 ../../app/views/chargeback/_cb_rate_edit.html.haml:43 ../../app/views/chargeback/_cb_rate_show.html.haml:15 ../../app/views/chargeback/_cb_rate_show.html.haml:40 ../../app/views/alert/_rss_list.html.haml:41 ../../app/views/vm_common/_snap.html.haml:27 ../../app/views/vm_common/_snapshots_desc.html.haml:15 ../../app/views/vm_common/_form.html.haml:36 ../../app/views/vm_common/_config.html.haml:211 ../../app/views/miq_ae_class/_ns_list.html.haml:18 ../../app/views/miq_ae_class/_ns_list.html.haml:110 ../../app/views/miq_ae_class/_instance_form.html.haml:63 ../../app/views/miq_ae_class/_class_form.html.haml:61 ../../app/views/miq_ae_class/_class_props.html.haml:55 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/configuration/_timeprofile_form.html.haml:19 ../../app/views/report/_widget_show.html.haml:29 ../../app/views/report/_db_list.html.haml:57 ../../app/views/report/_db_list.html.haml:102 ../../app/views/report/_widget_form.html.haml:37 ../../app/views/report/_show_schedule.html.haml:9 ../../app/views/report/_schedule_form.html.haml:35 ../../app/views/report/_report_info.html.haml:129 ../../app/views/report/_report_info.html.haml:248 ../../app/views/catalog/_ot_tree_show.html.haml:24 ../../app/views/catalog/_ot_add.html.haml:34 ../../app/views/catalog/_ot_copy.html.haml:42 ../../app/views/catalog/_svccat_tree_show.html.haml:43 ../../app/views/catalog/_sandt_tree_show.html.haml:231 ../../app/views/catalog/_stcat_tree_show.html.haml:27 ../../app/views/catalog/_stcat_form.html.haml:43 ../../app/views/catalog/_ot_edit.html.haml:34 ../../app/views/pxe/_template_form.html.haml:34 ../../app/views/pxe/_pxe_server_details.html.haml:61 ../../app/views/pxe/_pxe_server_details.html.haml:108 ../../app/views/miq_policy/_event_details.html.haml:15 ../../app/views/miq_policy/_event_details.html.haml:219 ../../app/views/miq_policy/_event_details.html.haml:404 ../../app/views/miq_policy/_condition_details.html.haml:20 ../../app/views/miq_policy/_profile_details.html.haml:22 ../../app/views/miq_policy/_alert_profile_details.html.haml:21 ../../app/views/miq_policy/_alert_details.html.haml:23 ../../app/views/miq_policy/_action_details.html.haml:21 ../../app/views/miq_policy/_policy_details.html.haml:24 ../../app/views/miq_policy/_policy_details.html.haml:243 ../../app/views/miq_policy/_policy_details.html.haml:346
 msgid "Description"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:21
+msgid "Desired"
+msgstr ""
+
+#: ../../app/views/layouts/_tl_options.html.haml:190
 msgid "Detail"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:77 ../../app/views/catalog/_form.html.haml:8 ../../app/views/catalog/_sandt_tree_show.html.haml:12 ../../app/views/miq_capacity/_utilization_tabs.html.haml:7
 msgid "Details"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:55 ../../app/helpers/configuration_helper/configuration_view_helper.rb:60
 msgid "Details Mode"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:75
 msgid "Determine at Run Time"
 msgstr ""
 
+#: ../../app/views/vm_common/_disks.html.haml:7
 msgid "Device Type"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:46 ../../app/views/layouts/listnav/_host.html.haml:52 ../../app/views/vm_common/_config.html.haml:113
 msgid "Devices"
 msgstr ""
 
+#: ../../app/views/vm_cloud/_main.html.haml:34 ../../app/views/host/_main.html.haml:23 ../../app/views/layouts/listnav/_vm_common.html.haml:526 ../../app/views/vm_common/_main.html.haml:39
 msgid "Diagnostics"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_edit_tree.html.haml:11 ../../app/views/shared/buttons/_ab_show.html.haml:61 ../../app/views/shared/buttons/_ab_form.html.haml:107 ../../app/views/catalog/_form_basic_info.html.haml:78 ../../app/views/catalog/_sandt_tree_show.html.haml:69 ../model_attributes.rb:379
 msgid "Dialog"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:5
 msgid "Dialog Information"
 msgstr ""
 
+#: ../../app/views/miq_request/_service_reconfigure_show.html.haml:12 ../../app/views/miq_request/_st_prov_show.html.haml:11
 msgid "Dialog Options"
 msgstr ""
 
+#: ../model_attributes.rb:383
 msgid "Dialog field"
 msgstr ""
 
+#: ../model_attributes.rb:411
 msgid "Dialog group"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:2005
 msgid "Dialog has to be set if Display in Catalog is chosen"
 msgstr ""
 
+#: ../model_attributes.rb:418
 msgid "Dialog tab"
 msgstr ""
 
+#: ../model_attributes.rb:384
 msgid "DialogField|Auto refresh"
 msgstr ""
 
+#: ../model_attributes.rb:385
 msgid "DialogField|Data type"
 msgstr ""
 
+#: ../model_attributes.rb:386
 msgid "DialogField|Default value"
 msgstr ""
 
+#: ../model_attributes.rb:387
 msgid "DialogField|Description"
 msgstr ""
 
+#: ../model_attributes.rb:388
 msgid "DialogField|Display"
 msgstr ""
 
+#: ../model_attributes.rb:389
 msgid "DialogField|Display method"
 msgstr ""
 
+#: ../model_attributes.rb:390
 msgid "DialogField|Display method options"
 msgstr ""
 
+#: ../model_attributes.rb:391
 msgid "DialogField|Dynamic"
 msgstr ""
 
+#: ../model_attributes.rb:392
 msgid "DialogField|Label"
 msgstr ""
 
+#: ../model_attributes.rb:393
 msgid "DialogField|Load values on init"
 msgstr ""
 
+#: ../model_attributes.rb:394
 msgid "DialogField|Name"
 msgstr ""
 
+#: ../model_attributes.rb:395
 msgid "DialogField|Notes"
 msgstr ""
 
+#: ../model_attributes.rb:396
 msgid "DialogField|Notes display"
 msgstr ""
 
+#: ../model_attributes.rb:397
 msgid "DialogField|Options"
 msgstr ""
 
+#: ../model_attributes.rb:398
 msgid "DialogField|Position"
 msgstr ""
 
+#: ../model_attributes.rb:399
 msgid "DialogField|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:400
 msgid "DialogField|Reconfigurable"
 msgstr ""
 
+#: ../model_attributes.rb:401
 msgid "DialogField|Required"
 msgstr ""
 
+#: ../model_attributes.rb:402
 msgid "DialogField|Required method"
 msgstr ""
 
+#: ../model_attributes.rb:403
 msgid "DialogField|Required method options"
 msgstr ""
 
+#: ../model_attributes.rb:404
 msgid "DialogField|Show refresh button"
 msgstr ""
 
+#: ../model_attributes.rb:405
 msgid "DialogField|Trigger auto refresh"
 msgstr ""
 
+#: ../model_attributes.rb:406
 msgid "DialogField|Validator rule"
 msgstr ""
 
+#: ../model_attributes.rb:407
 msgid "DialogField|Validator type"
 msgstr ""
 
+#: ../model_attributes.rb:408
 msgid "DialogField|Values"
 msgstr ""
 
+#: ../model_attributes.rb:409
 msgid "DialogField|Values method"
 msgstr ""
 
+#: ../model_attributes.rb:410
 msgid "DialogField|Values method options"
 msgstr ""
 
+#: ../model_attributes.rb:412
 msgid "DialogGroup|Description"
 msgstr ""
 
+#: ../model_attributes.rb:413
 msgid "DialogGroup|Display"
 msgstr ""
 
+#: ../model_attributes.rb:414
 msgid "DialogGroup|Display method"
 msgstr ""
 
+#: ../model_attributes.rb:415
 msgid "DialogGroup|Display method options"
 msgstr ""
 
+#: ../model_attributes.rb:416
 msgid "DialogGroup|Label"
 msgstr ""
 
+#: ../model_attributes.rb:417
 msgid "DialogGroup|Position"
 msgstr ""
 
+#: ../model_attributes.rb:419
 msgid "DialogTab|Description"
 msgstr ""
 
+#: ../model_attributes.rb:420
 msgid "DialogTab|Display"
 msgstr ""
 
+#: ../model_attributes.rb:421
 msgid "DialogTab|Display method"
 msgstr ""
 
+#: ../model_attributes.rb:422
 msgid "DialogTab|Display method options"
 msgstr ""
 
+#: ../model_attributes.rb:423
 msgid "DialogTab|Label"
 msgstr ""
 
+#: ../model_attributes.rb:424
 msgid "DialogTab|Position"
 msgstr ""
 
+#: ../model_attributes.rb:380
 msgid "Dialog|Buttons"
 msgstr ""
 
+#: ../model_attributes.rb:381
 msgid "Dialog|Description"
 msgstr ""
 
+#: ../model_attributes.rb:382
 msgid "Dialog|Label"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:64 ../../app/views/layouts/listnav/_ems_cluster.html.haml:91
 msgid "Direct VMs: %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:58 ../../app/views/layouts/listnav/_ems_cluster.html.haml:85
 msgid "Direct VMs: 0"
 msgstr ""
 
+#: ../../app/views/security_group/_main.html.haml:20
 msgid "Direction"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_editor.html.haml:39 ../../app/views/report/_menu_form1.html.haml:82
 msgid "Discard expression element changes"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:136
 msgid "Discard report management changes"
 msgstr ""
 
+#: ../../app/views/layouts/_discover.html.haml:7
 msgid "Discover"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_repository.html.haml:25 ../../app/views/layouts/listnav/_repository.html.haml:31
 msgid "Discovered VMs (%s)"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../model_attributes.rb:425
 msgid "Disk"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:223 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:43
 msgid "Disk Space"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:498
 msgid "Disks (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:492
 msgid "Disks (0)"
 msgstr ""
 
+#: ../model_attributes.rb:426
 msgid "Disk|Auto detect"
 msgstr ""
 
+#: ../model_attributes.rb:427
 msgid "Disk|Backing type"
 msgstr ""
 
+#: ../model_attributes.rb:428
 msgid "Disk|Controller type"
 msgstr ""
 
+#: ../model_attributes.rb:429
 msgid "Disk|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:430
 msgid "Disk|Device name"
 msgstr ""
 
+#: ../model_attributes.rb:431
 msgid "Disk|Device type"
 msgstr ""
 
+#: ../model_attributes.rb:432
 msgid "Disk|Disk type"
 msgstr ""
 
+#: ../model_attributes.rb:433
 msgid "Disk|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:434
 msgid "Disk|Free space"
 msgstr ""
 
+#: ../model_attributes.rb:435
 msgid "Disk|Location"
 msgstr ""
 
+#: ../model_attributes.rb:436
 msgid "Disk|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:437
 msgid "Disk|Present"
 msgstr ""
 
+#: ../model_attributes.rb:438
 msgid "Disk|Size"
 msgstr ""
 
+#: ../model_attributes.rb:439
 msgid "Disk|Size on disk"
 msgstr ""
 
+#: ../model_attributes.rb:440
 msgid "Disk|Start connected"
 msgstr ""
 
+#: ../model_attributes.rb:441
 msgid "Disk|Updated on"
 msgstr ""
 
+#: ../../app/views/ops/_category_form.html.haml:127 ../../app/views/ops/_classification_entries.html.haml:17 ../../app/views/ops/_settings_co_categories_tab.html.haml:14 ../../app/views/miq_ae_class/_method_inputs.html.haml:48 ../../app/views/miq_ae_class/_instance_form.html.haml:46 ../../app/views/miq_ae_class/_method_form.html.haml:48 ../../app/views/miq_ae_class/_class_form.html.haml:45 ../../app/views/miq_ae_class/_class_props.html.haml:42 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Display Name"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:10 ../../app/views/miq_capacity/_planning_summary.html.haml:7
 msgid "Display Options"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:136
 msgid "Display Settings"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:43 ../../app/views/catalog/_sandt_tree_show.html.haml:47
 msgid "Display in Catalog"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:158 ../../app/views/shared/buttons/_ab_show.html.haml:27 ../../app/views/shared/buttons/_ab_form.html.haml:54 ../../app/views/shared/buttons/_group_form.html.haml:36
 msgid "Display on Button"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_domain_form.html.haml:40 ../../app/views/ops/_ldap_domain_show.html.haml:54 ../../app/views/_ldap_domain_form.html.haml:40
 msgid "Distinguished Name (CN=<user>)"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_domain_form.html.haml:40 ../../app/views/ops/_ldap_domain_show.html.haml:57 ../../app/views/_ldap_domain_form.html.haml:40
 msgid "Distinguished Name (UID=<user>)"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:108 ../../app/views/catalog/_form_resources_info.html.haml:109
 msgid "Do Nothing"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:68 ../../app/views/ops/_settings_server_tab.html.haml:431
 msgid "Domain"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:242
 msgid "Domain Information"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_domain_overrides.html.haml:2
 msgid "Domain Overrides (by priority)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:157
 msgid "Domain Prefix: <domain>\\<user>"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_domains_priority_form.html.haml:17
 msgid "Domains:"
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:23 ../../app/views/shared/views/_ownership.html.haml:52
 msgid "Don't change"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:50
 msgid "Double Click on 'New Folder' to edit"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:124
 msgid "Double click a feature to open/close all children."
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:67 ../../app/views/layouts/_x_edit_buttons.html.haml:206
 msgid "Download Report to YAML"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:82
 msgid "Download the full report (all rows) as a PDF file"
 msgstr ""
 
+#: ../../app/views/catalog/_ot_tree_show.html.haml:37 ../../app/views/catalog/_ot_add.html.haml:77 ../../app/views/catalog/_ot_copy.html.haml:62 ../../app/views/catalog/_ot_edit.html.haml:55
 msgid "Draft"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_menu.html.haml:35
 msgid "Drag this Shortcut to a new location"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_resource.html.haml:5
 msgid "Drag this Tab to a new location"
 msgstr ""
 
+#: ../../app/views/report/_db_widget.html.haml:5
 msgid "Drag/drop Widget \"%s\""
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:18
 msgid "Drift"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:255 ../../app/views/layouts/listnav/_ems_cluster.html.haml:160 ../../app/views/layouts/listnav/_ems_cluster.html.haml:166 ../../app/views/layouts/listnav/_vm_common.html.haml:229 ../../app/views/layouts/listnav/_vm_common.html.haml:235
 msgid "Drift History (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:249
 msgid "Drift History (0)"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:18
 msgid "Drift Mode"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_compare_sections.html.haml:157
 msgid "Drift Sections"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1703
 msgid "Drift for %{model} \"%{name}\""
 msgstr ""
 
+#: ../model_attributes.rb:442
 msgid "Drift state"
 msgstr ""
 
+#: ../model_attributes.rb:443
 msgid "DriftState|Data"
 msgstr ""
 
+#: ../model_attributes.rb:444
 msgid "DriftState|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:445
 msgid "DriftState|Timestamp"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:134 ../../app/views/miq_policy/_alert_details.html.haml:157
 msgid "Driving Event"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:698
 msgid "Dropdown elements require some entries"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:96
 msgid "Dynamic"
 msgstr ""
 
+#: ../../app/views/report/_show_schedule.html.haml:29
 msgid "E-Mail after Running"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_email.html.haml:1
 msgid "E-mail"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:114 ../../app/views/ops/_ldap_domain_form.html.haml:40 ../../app/views/ops/_ldap_domain_show.html.haml:51 ../../app/views/_ldap_domain_form.html.haml:40
 msgid "E-mail Address"
 msgstr ""
 
+#: ../../app/views/report/_schedule_email_options.html.haml:7
 msgid "E-mail Options"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:10 ../../app/views/miq_policy/_action_details.html.haml:187
 msgid "E-mail Settings"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:404 ../../app/controllers/miq_policy_controller/miq_actions.rb:405
 msgid "E-mail address '%s' is not valid"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form.html.haml:68
 msgid "E-mail after Running"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:152 ../../app/views/layouts/listnav/_host.html.haml:158
 msgid "ESX Logs"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:636 ../../app/controllers/provider_foreman_controller.rb:720
 msgid "Edit %s Provider"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1720
 msgid "Edit CFME Server Relationship for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/views/chargeback/_assignments_list.html.haml:9 ../../app/views/chargeback/_assignments_list.html.haml:20 ../../app/views/chargeback/_assignments_list.html.haml:28 ../../app/views/chargeback/_assignments_list.html.haml:33
 msgid "Edit Compute Rate Assignments"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:94
 msgid "Edit Log Depot settings was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:95
 msgid "Edit Registration"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:379
 msgid "Edit Sequence of User Groups was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1776 ../../app/controllers/service_controller.rb:321
 msgid "Edit Tags for %s"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:610
 msgid "Edit Tags for Configured Systems"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:825
 msgid "Edit aborted!  CFME does not support the browser's back button or access from multiple tabs or windows of the same browser.  Please close any duplicate sessions before proceeding."
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:630
 msgid "Edit of %s was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:117 ../../app/controllers/report_controller/dashboards.rb:64 ../../app/controllers/report_controller/widgets.rb:49 ../../app/controllers/report_controller/reports/editor.rb:32 ../../app/controllers/report_controller/schedules.rb:219 ../../app/controllers/miq_policy_controller/policies.rb:11 ../../app/controllers/miq_policy_controller/miq_actions.rb:11 ../../app/controllers/miq_policy_controller/alerts.rb:13 ../../app/controllers/miq_policy_controller/alert_profiles.rb:13 ../../app/controllers/miq_policy_controller/conditions.rb:11 ../../app/controllers/miq_policy_controller/policy_profiles.rb:12 ../../app/controllers/vm_common.rb:1049 ../../app/controllers/vm_common.rb:1053 ../../app/controllers/miq_ae_class_controller.rb:608 ../../app/controllers/miq_ae_class_controller.rb:1015 ../../app/controllers/miq_ae_class_controller.rb:1109 ../../app/controllers/miq_ae_class_controller.rb:1153 ../../app/controllers/storage_manager_controller.rb:180 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:241 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:195 ../../app/controllers/service_controller.rb:148 ../../app/controllers/catalog_controller.rb:87 ../../app/controllers/catalog_controller.rb:350 ../../app/controllers/catalog_controller.rb:602 ../../app/controllers/catalog_controller.rb:960 ../../app/controllers/ops_controller/settings/tags.rb:42 ../../app/controllers/ops_controller/settings/ldap.rb:38 ../../app/controllers/ops_controller/settings/ldap.rb:164 ../../app/controllers/ops_controller/settings/zones.rb:9 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:220 ../../app/controllers/ops_controller/settings/schedules.rb:43 ../../app/controllers/ops_controller/ops_rbac.rb:103 ../../app/controllers/host_controller.rb:349 ../../app/controllers/configuration_controller.rb:535 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:99 ../../app/controllers/pxe_controller/iso_datastores.rb:173 ../../app/controllers/pxe_controller/pxe_image_types.rb:29 ../../app/controllers/pxe_controller/pxe_servers.rb:46 ../../app/controllers/pxe_controller/pxe_servers.rb:195 ../../app/controllers/pxe_controller/pxe_servers.rb:247 ../../app/controllers/ems_common.rb:377 ../../app/controllers/ems_cloud_controller.rb:33 ../../app/controllers/application_controller/buttons.rb:322 ../../app/controllers/application_controller/buttons.rb:443 ../../app/controllers/application_controller/miq_request_methods.rb:178
 msgid "Edit of %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:193
 msgid "Edit of %{model} for role \"%{role}\" was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1493
 msgid "Edit of Class Schema Sequence was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:518
 msgid "Edit of Customer Information was cancelled"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:9
 msgid "Edit of Dashboard Sequence was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1555
 msgid "Edit of Priority Order was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:342
 msgid "Edit of credentials for selected %s was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1059
 msgid "Edit of schema for %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/application_controller/policy_support.rb:33
 msgid "Edit policy assignments was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/report/_form_filter.html.haml:22
 msgid "Edit the Record Filter"
 msgstr ""
 
+#: ../../app/views/report/_form_filter.html.haml:22 ../../app/views/report/_form_filter.html.haml:61 ../../app/views/miq_policy/_form_expression.html.haml:10
 msgid "Edit this Expression"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:49 ../../app/views/ops/_settings_details_tab.html.haml:54
 msgid "Edit this Region"
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_scope.html.haml:12
 msgid "Edit this Scope"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:325
 msgid "Edit this Widget to configure a timer."
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:102
 msgid "Editing"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:683 ../../app/controllers/catalog_controller.rb:1002
 msgid "Editing %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_advanced_tab.html.haml:67
 msgid "Editing %s File"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:549 ../../app/controllers/ops_controller.rb:559 ../../app/controllers/ops_controller.rb:568 ../../app/controllers/ops_controller.rb:582 ../../app/controllers/ops_controller.rb:593 ../../app/controllers/ops_controller.rb:604 ../../app/controllers/ops_controller.rb:650 ../../app/controllers/miq_ae_customization_controller.rb:440 ../../app/controllers/miq_ae_customization_controller.rb:444 ../../app/controllers/miq_ae_customization_controller.rb:461 ../../app/controllers/miq_ae_customization_controller.rb:502 ../../app/controllers/report_controller/menus.rb:760 ../../app/controllers/vm_common.rb:1716 ../../app/controllers/miq_ae_class_controller.rb:585 ../../app/controllers/miq_ae_class_controller.rb:730 ../../app/controllers/miq_ae_class_controller.rb:765 ../../app/controllers/miq_ae_class_controller.rb:805 ../../app/controllers/miq_ae_class_controller.rb:2455 ../../app/controllers/service_controller.rb:317 ../../app/controllers/container_controller.rb:201 ../../app/controllers/catalog_controller.rb:1152 ../../app/controllers/catalog_controller.rb:1301 ../../app/controllers/catalog_controller.rb:1351 ../../app/controllers/catalog_controller.rb:1801 ../../app/controllers/catalog_controller.rb:1805 ../../app/controllers/ops_controller/ops_rbac.rb:679 ../../app/controllers/pxe_controller.rb:214 ../../app/controllers/report_controller.rb:750 ../../app/controllers/report_controller.rb:764 ../../app/controllers/report_controller.rb:770 ../../app/controllers/report_controller.rb:778 ../../app/controllers/report_controller.rb:794 ../../app/controllers/report_controller.rb:923 ../../app/controllers/miq_policy_controller.rb:618 ../../app/controllers/miq_policy_controller.rb:643 ../../app/controllers/miq_policy_controller.rb:666 ../../app/controllers/miq_policy_controller.rb:672 ../../app/controllers/miq_policy_controller.rb:679 ../../app/controllers/miq_policy_controller.rb:693 ../../app/controllers/miq_policy_controller.rb:702
 msgid "Editing %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:584 ../../app/controllers/application_controller/explorer.rb:183
 msgid "Editing %{model} for \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/report_controller.rb:747
 msgid "Editing %{model} sequence for \"%{name}\""
 msgstr ""
 
+#: ../../app/views/ops/_log_collection.html.haml:11 ../../app/views/layouts/_edit_log_depot_settings.html.haml:14
 msgid "Editing Log Depot Settings for %{class}: %{display}"
 msgstr ""
 
-msgid "Editing MyTags"
-msgstr ""
-
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:6
 msgid "Element Information"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_summary.html.haml:39
 msgid "Eligible %s "
 msgstr ""
 
+#: ../model_attributes.rb:446
 msgid "Ems cluster"
 msgstr ""
 
+#: ../model_attributes.rb:462
 msgid "Ems folder"
 msgstr ""
 
+#: ../model_attributes.rb:447
 msgid "EmsCluster|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:448
 msgid "EmsCluster|Drs automation level"
 msgstr ""
 
+#: ../model_attributes.rb:449
 msgid "EmsCluster|Drs enabled"
 msgstr ""
 
+#: ../model_attributes.rb:450
 msgid "EmsCluster|Drs migration threshold"
 msgstr ""
 
+#: ../model_attributes.rb:451
 msgid "EmsCluster|Effective cpu"
 msgstr ""
 
+#: ../model_attributes.rb:452
 msgid "EmsCluster|Effective memory"
 msgstr ""
 
+#: ../model_attributes.rb:453
 msgid "EmsCluster|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:454
 msgid "EmsCluster|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:455
 msgid "EmsCluster|Ha admit control"
 msgstr ""
 
+#: ../model_attributes.rb:456
 msgid "EmsCluster|Ha enabled"
 msgstr ""
 
+#: ../model_attributes.rb:457
 msgid "EmsCluster|Ha max failures"
 msgstr ""
 
+#: ../model_attributes.rb:458
 msgid "EmsCluster|Last perf capture on"
 msgstr ""
 
+#: ../model_attributes.rb:459
 msgid "EmsCluster|Name"
 msgstr ""
 
+#: ../model_attributes.rb:460
 msgid "EmsCluster|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:461
 msgid "EmsCluster|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:463
 msgid "EmsFolder|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:464
 msgid "EmsFolder|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:465
 msgid "EmsFolder|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:466
 msgid "EmsFolder|Is datacenter"
 msgstr ""
 
+#: ../model_attributes.rb:467
 msgid "EmsFolder|Name"
 msgstr ""
 
+#: ../model_attributes.rb:468
 msgid "EmsFolder|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:469
 msgid "EmsFolder|Updated on"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:49
 msgid "Enable Collection by %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:105
 msgid "Enable Collection by Datastore"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:447
 msgid "Enable Single Sign-On"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_ns_list.html.haml:20 ../../app/views/miq_ae_class/_ns_list.html.haml:128 ../../app/views/report/_report_info.html.haml:253
 msgid "Enabled"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:61
 msgid "End Date"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:243
 msgid "End Date cannot be greater than Start Date"
 msgstr ""
 
+#: ../../app/views/security_group/_main.html.haml:20
 msgid "End Port"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/views/ops/_tenant_quota_form.html.haml:22
 msgid "Enforced"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_xml.html.haml:17 ../../app/views/miq_ae_tools/_results_uri.html.haml:53 ../../app/views/miq_ae_tools/_results_tree.html.haml:16
 msgid "Enter Automation Simulation options on the left and press Submit."
 msgstr ""
 
+#: ../../app/views/report/_widget_form_rss.html.haml:64
 msgid "Enter URL Manually"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:44
 msgid "Enterprise"
 msgstr ""
 
+#: ../../app/views/generic_mailer/policy_action_email.text.haml:5 ../../app/views/generic_mailer/policy_action_email.html.haml:25
 msgid "Entity:"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_field_values.html.haml:5
 msgid "Entries"
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:115
 msgid "Entry Point"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:120
 msgid "Entry Point (NS/Cls/Inst)"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:682
 msgid "Entry Point must be given."
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:64 ../../app/views/provider_foreman/_main.html.haml:9 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:9
 msgid "Environment"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:112 ../../app/views/miq_task/_tasks_options.html.haml:112
 msgid "Error"
 msgstr ""
 
+#: ../../app/controllers/miq_capacity_controller.rb:725 ../../app/controllers/dashboard_controller.rb:778 ../../app/controllers/application_controller/timelines.rb:222 ../../app/controllers/application_controller/timelines.rb:477
 msgid "Error building timeline "
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:105
 msgid "Error details: %s"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:1618
 msgid "Error during %s delete from the CFME Database"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:366 ../../app/controllers/ops_controller/settings/common.rb:604
 msgid "Error during %s: "
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:228
 msgid "Error during %{task}: Status [%{status}] Message [%{message}]"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:252 ../../app/controllers/miq_ae_tools_controller.rb:198 ../../app/controllers/chargeback_controller.rb:346 ../../app/controllers/miq_policy_controller/alerts.rb:482 ../../app/controllers/miq_policy_controller/alert_profiles.rb:49 ../../app/controllers/miq_policy_controller/policy_profiles.rb:48 ../../app/controllers/vm_common.rb:594 ../../app/controllers/vm_common.rb:989 ../../app/controllers/vm_common.rb:1002 ../../app/controllers/vm_common.rb:1086 ../../app/controllers/miq_ae_class_controller.rb:635 ../../app/controllers/miq_ae_class_controller.rb:692 ../../app/controllers/miq_ae_class_controller.rb:1026 ../../app/controllers/miq_ae_class_controller.rb:1072 ../../app/controllers/miq_ae_class_controller.rb:1118 ../../app/controllers/miq_ae_class_controller.rb:1168 ../../app/controllers/miq_ae_class_controller.rb:1243 ../../app/controllers/miq_ae_class_controller.rb:1280 ../../app/controllers/miq_ae_class_controller.rb:1718 ../../app/controllers/application_controller.rb:553 ../../app/controllers/storage_manager_controller.rb:448 ../../app/controllers/service_controller.rb:172 ../../app/controllers/catalog_controller.rb:618 ../../app/controllers/catalog_controller.rb:737 ../../app/controllers/catalog_controller.rb:985 ../../app/controllers/catalog_controller.rb:1040 ../../app/controllers/catalog_controller.rb:1084 ../../app/controllers/catalog_controller.rb:1261 ../../app/controllers/ops_controller/settings/tags.rb:76 ../../app/controllers/ops_controller/settings/upload.rb:77 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:262 ../../app/controllers/ops_controller/ops_rbac.rb:535 ../../app/controllers/ops_controller/settings.rb:21 ../../app/controllers/ops_controller/diagnostics.rb:29 ../../app/controllers/ops_controller/diagnostics.rb:65 ../../app/controllers/ops_controller/diagnostics.rb:124 ../../app/controllers/ops_controller/diagnostics.rb:148 ../../app/controllers/ops_controller/diagnostics.rb:252 ../../app/controllers/ops_controller/diagnostics.rb:275 ../../app/controllers/ops_controller/diagnostics.rb:406 ../../app/controllers/ops_controller/diagnostics.rb:597 ../../app/controllers/report_controller.rb:80 ../../app/controllers/configuration_controller.rb:514 ../../app/controllers/miq_policy_controller.rb:63 ../../app/controllers/miq_policy_controller.rb:157 ../../app/controllers/miq_policy_controller.rb:189 ../../app/controllers/application_controller/tags.rb:227 ../../app/controllers/application_controller/ci_processing.rb:1217 ../../app/controllers/application_controller/ci_processing.rb:1252 ../../app/controllers/application_controller/dialog_runner.rb:29 ../../app/controllers/application_controller/automate.rb:55 ../../app/controllers/application_controller/buttons.rb:370 ../../app/controllers/application_controller/buttons.rb:404 ../../app/controllers/application_controller/buttons.rb:507 ../../app/controllers/application_controller/buttons.rb:545
 msgid "Error during '%s': "
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1072
 msgid "Error during Orchestration Template creation: new template content cannot be empty"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:420
 msgid "Error during Orphaned Records delete for user %s: "
 msgstr ""
 
+#: ../../app/controllers/application_controller/sysprep_answer_file.rb:16
 msgid "Error during Sysprep \"%s\" file upload: "
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:249
 msgid "Error during sending test email: "
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:59
 msgid "Error during upload: incorrect Dialog format, only service dialogs can be imported"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:61
 msgid "Error during upload: one of the DialogField types is not supported"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:303
 msgid "Error executing: \"%s\" "
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:309
 msgid "Error occured when queuing action: %s"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:826
 msgid "Error on line %{line_num}: %{err_txt}"
 msgstr ""
 
+#: ../../app/controllers/miq_request_controller.rb:326
 msgid "Error retrieving LDAP info: "
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:60
 msgid "Error text:"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/schedules.rb:69
 msgid "Error when adding a new schedule: "
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:120
 msgid "Error when adding a new tenant: "
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1124
 msgid "Error when creating a Service Dialog from Orchestration Template: "
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:411
 msgid "Error when saving new server name: "
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:194
 msgid "Error when saving tenant quota: "
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:152
 msgid "Error: Datastore import file upload expired"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:77
 msgid "Error: ImportFileUpload expired"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:282 ../../app/controllers/report_controller/schedules.rb:6 ../../app/controllers/vm_common.rb:1184 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:23 ../../app/controllers/mixins/vm_show_mixin.rb:105 ../../app/controllers/provider_foreman_controller.rb:351 ../../app/helpers/application_helper.rb:1019
 msgid "Error: Record no longer exists in the database"
 msgstr ""
 
+#: ../../app/controllers/report_controller.rb:327
 msgid "Error: Widget import file upload expired"
 msgstr ""
 
+#: ../../app/controllers/report_controller.rb:310
 msgid "Error: the file uploaded contains no widgets"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:57 ../../app/controllers/report_controller.rb:308
 msgid "Error: the file uploaded is not of the supported format"
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:12
 msgid "Errors in Management Engine can be caused by:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:30
 msgid "Event Group"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:206 ../../app/views/miq_capacity/_bottlenecks_options.html.haml:15
 msgid "Event Groups"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form.html.haml:76 ../../app/views/ops/_ap_form.html.haml:89
 msgid "Event Log"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:3
 msgid "Event Log Entry"
 msgstr ""
 
+#: ../../app/views/ops/_ap_show.html.haml:132
 msgid "Event Log Items"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:135 ../../app/views/layouts/listnav/_vm_common.html.haml:141
 msgid "Event Logs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:553
 msgid "Event Logs (Available)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:547
 msgid "Event Logs (Not Available)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:116
 msgid "Event Monitor"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_mgmt_event.html.haml:33 ../../app/views/miq_policy/_alert_details.html.haml:445
 msgid "Event Name"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_form.html.haml:15 ../../app/views/miq_policy/_policy_details.html.haml:312
 msgid "Event Selection"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:138
 msgid "Event Type"
 msgstr ""
 
+#: ../model_attributes.rb:470
 msgid "Event log"
 msgstr ""
 
+#: ../model_attributes.rb:479
 msgid "Event stream"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:116
 msgid "Event to position at"
 msgstr ""
 
+#: ../../app/views/generic_mailer/policy_action_email.text.haml:3 ../../app/views/generic_mailer/policy_action_email.html.haml:15 ../../app/views/miq_policy/_rsop_form.html.haml:28
 msgid "Event:"
 msgstr ""
 
+#: ../model_attributes.rb:471
 msgid "EventLog|Category"
 msgstr ""
 
+#: ../model_attributes.rb:472
 msgid "EventLog|Computer name"
 msgstr ""
 
+#: ../model_attributes.rb:473
 msgid "EventLog|Generated"
 msgstr ""
 
+#: ../model_attributes.rb:474
 msgid "EventLog|Level"
 msgstr ""
 
+#: ../model_attributes.rb:475
 msgid "EventLog|Message"
 msgstr ""
 
+#: ../model_attributes.rb:476
 msgid "EventLog|Name"
 msgstr ""
 
+#: ../model_attributes.rb:477
 msgid "EventLog|Source"
 msgstr ""
 
+#: ../model_attributes.rb:478
 msgid "EventLog|Uid"
 msgstr ""
 
+#: ../model_attributes.rb:480
 msgid "EventStream|Container group name"
 msgstr ""
 
+#: ../model_attributes.rb:481
 msgid "EventStream|Container namespace"
 msgstr ""
 
+#: ../model_attributes.rb:482
 msgid "EventStream|Container node name"
 msgstr ""
 
+#: ../model_attributes.rb:483
 msgid "EventStream|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:484
 msgid "EventStream|Dest ems cluster name"
 msgstr ""
 
+#: ../model_attributes.rb:485
 msgid "EventStream|Dest ems cluster uid"
 msgstr ""
 
+#: ../model_attributes.rb:486
 msgid "EventStream|Dest host name"
 msgstr ""
 
+#: ../model_attributes.rb:487
 msgid "EventStream|Dest vm location"
 msgstr ""
 
+#: ../model_attributes.rb:488
 msgid "EventStream|Dest vm name"
 msgstr ""
 
+#: ../model_attributes.rb:489
 msgid "EventStream|Ems cluster name"
 msgstr ""
 
+#: ../model_attributes.rb:490
 msgid "EventStream|Ems cluster uid"
 msgstr ""
 
+#: ../model_attributes.rb:491
 msgid "EventStream|Event type"
 msgstr ""
 
+#: ../model_attributes.rb:492
 msgid "EventStream|Full data"
 msgstr ""
 
+#: ../model_attributes.rb:493
 msgid "EventStream|Host name"
 msgstr ""
 
+#: ../model_attributes.rb:494
 msgid "EventStream|Is task"
 msgstr ""
 
+#: ../model_attributes.rb:495
 msgid "EventStream|Message"
 msgstr ""
 
+#: ../model_attributes.rb:496
 msgid "EventStream|Source"
 msgstr ""
 
+#: ../model_attributes.rb:497
 msgid "EventStream|Target type"
 msgstr ""
 
+#: ../model_attributes.rb:498
 msgid "EventStream|Timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:499
 msgid "EventStream|Username"
 msgstr ""
 
+#: ../model_attributes.rb:500
 msgid "EventStream|Vm location"
 msgstr ""
 
+#: ../model_attributes.rb:501
 msgid "EventStream|Vm name"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1124 ../../app/views/miq_policy/_policy_details.html.haml:332
 msgid "Events"
 msgstr ""
 
+#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:263
+msgid "Examples (read only)"
+msgstr ""
+
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:173
 msgid "Execute Methods"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:56 ../../app/helpers/configuration_helper/configuration_view_helper.rb:61
 msgid "Exists Mode"
 msgstr ""
 
+#: ../../app/views/vm_common/_policies.html.haml:15 ../../app/views/shared/views/_compliance_history.html.haml:6
 msgid "Expand All"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:45 ../../app/helpers/configuration_helper/configuration_view_helper.rb:50
 msgid "Expanded View"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:119 ../../app/presenters/menu/default_menu.rb:128
 msgid "Explorer"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:52 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:60 ../../app/views/layouts/_x_edit_buttons.html.haml:68 ../../app/views/layouts/_x_edit_buttons.html.haml:206 ../../app/views/miq_ae_tools/_import_export.html.haml:56 ../../app/views/report/_export_custom_reports.html.haml:55 ../../app/views/report/_export_widgets.html.haml:61 ../../app/views/miq_policy/_export.html.haml:75 ../../app/views/miq_policy/_export.html.haml:141
 msgid "Export"
 msgstr ""
 
+#: ../../app/views/miq_policy/_export.html.haml:140
 msgid "Export Selected %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:60
 msgid "Export all classes and instances"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:105
 msgid "Export generation returned: Status [%{status}] Message [%{message}]"
 msgstr ""
 
+#: ../../app/views/miq_policy/_export.html.haml:93
 msgid "Export:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_details.html.haml:70 ../../app/views/miq_policy/_alert_details.html.haml:121 ../../app/views/miq_policy/_alert_details.html.haml:228 ../../app/views/miq_policy/_policy_details.html.haml:292
 msgid "Expression"
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_expression.html.haml:3 ../../app/views/miq_policy/_alert_details.html.haml:204
 msgid "Expression (Choose an element of the expression to edit)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:104 ../../app/views/miq_policy/_alert_details.html.haml:107
 msgid "Expression (Custom)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_expression.html.haml:8
 msgid "Expression (Press the \"Edit\" button to edit the expression)"
 msgstr ""
 
+#: ../model_attributes.rb:502
 msgid "Ext management system"
 msgstr ""
 
+#: ../model_attributes.rb:503
 msgid "ExtManagementSystem|Api version"
 msgstr ""
 
+#: ../model_attributes.rb:504
 msgid "ExtManagementSystem|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:505
 msgid "ExtManagementSystem|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:506
 msgid "ExtManagementSystem|Host default vnc port end"
 msgstr ""
 
+#: ../model_attributes.rb:507
 msgid "ExtManagementSystem|Host default vnc port start"
 msgstr ""
 
+#: ../model_attributes.rb:508
 msgid "ExtManagementSystem|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:509
 msgid "ExtManagementSystem|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:510
 msgid "ExtManagementSystem|Last refresh date"
 msgstr ""
 
+#: ../model_attributes.rb:511
 msgid "ExtManagementSystem|Last refresh error"
 msgstr ""
 
+#: ../model_attributes.rb:512
 msgid "ExtManagementSystem|Name"
 msgstr ""
 
+#: ../model_attributes.rb:513
 msgid "ExtManagementSystem|Port"
 msgstr ""
 
+#: ../model_attributes.rb:514
 msgid "ExtManagementSystem|Provider region"
 msgstr ""
 
+#: ../model_attributes.rb:515
 msgid "ExtManagementSystem|Realm"
 msgstr ""
 
+#: ../model_attributes.rb:516
 msgid "ExtManagementSystem|Security protocol"
 msgstr ""
 
+#: ../model_attributes.rb:517
 msgid "ExtManagementSystem|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:518
 msgid "ExtManagementSystem|Updated on"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:173 ../../app/views/report/_widget_form_rss.html.haml:20
 msgid "External"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:55
 msgid "External (httpd)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:438
 msgid "External Authentication (httpd) Settings"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:213 ../../app/views/report/_widget_form_rss.html.haml:59
 msgid "External RSS Feed/URL"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:49
 msgid "FS Type"
 msgstr ""
 
+#: ../../app/views/vm_common/_policy_options.html.haml:54 ../../app/views/miq_policy/_rsop_results.html.haml:57
 msgid "Failed"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:79 ../../app/helpers/ems_cluster_helper/textual_summary.rb:56
 msgid "Failed (%s)"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:185
 msgid "Failed system services of %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:388 ../../app/views/report/_show_schedule.html.haml:35 ../../app/views/catalog/_ot_tree_show.html.haml:42 ../../app/views/catalog/_ot_tree_show.html.haml:55
 msgid "False"
 msgstr ""
 
+#: ../../app/views/alert/_rss_list.html.haml:43
 msgid "Feed URL"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:99
 msgid "Fetch settings from a schedule"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_editor.html.haml:68 ../../app/views/layouts/exp_atom/_editor.html.haml:79
 msgid "Field"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:79 ../../app/views/miq_ae_class/_instance_fields.html.haml:3
 msgid "Fields"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:895
 msgid "Fields not added: Adding the selected %{count} fields will exceed the maximum of %{max} fields"
 msgstr ""
 
+#: ../../app/views/ops/_settings_import_tab.html.haml:38 ../../app/views/ops/_settings_advanced_tab.html.haml:33 ../../app/views/ops/_ap_form.html.haml:73 ../../app/views/ops/_ap_form.html.haml:83
 msgid "File"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_file.html.haml:3
 msgid "File Entry"
 msgstr ""
 
+#: ../../app/views/ops/_ap_show.html.haml:86
 msgid "File Items"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:446 ../../app/views/layouts/listnav/_vm_common.html.haml:452
 msgid "File System Drivers (%s)"
 msgstr ""
 
+#: ../model_attributes.rb:519
 msgid "File depot"
 msgstr ""
 
+#: ../../app/models/miq_bulk_import.rb:7
 msgid "File is empty"
 msgstr ""
 
+#: ../model_attributes.rb:520
 msgid "FileDepot|Name"
 msgstr ""
 
+#: ../model_attributes.rb:521
 msgid "FileDepot|Support case"
 msgstr ""
 
+#: ../model_attributes.rb:522
 msgid "FileDepot|Uri"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:33 ../../app/views/pxe/_pxe_form.html.haml:150
 msgid "Filename"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:145
 msgid "Files"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:402 ../../app/views/layouts/listnav/_vm_common.html.haml:369 ../../app/views/layouts/listnav/_vm_common.html.haml:375 ../../app/views/layouts/listnav/_vm_common.html.haml:386 ../../app/views/layouts/listnav/_vm_common.html.haml:392 ../../app/views/layouts/listnav/_vm_common.html.haml:461 ../../app/views/layouts/listnav/_vm_common.html.haml:467
 msgid "Files (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:396
 msgid "Files (0)"
 msgstr ""
 
+#: ../model_attributes.rb:523
 msgid "Filesystem"
 msgstr ""
 
+#: ../model_attributes.rb:524
 msgid "Filesystem|Atime"
 msgstr ""
 
+#: ../model_attributes.rb:525
 msgid "Filesystem|Base name"
 msgstr ""
 
+#: ../model_attributes.rb:526
 msgid "Filesystem|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:527
 msgid "Filesystem|Ctime"
 msgstr ""
 
+#: ../model_attributes.rb:528
 msgid "Filesystem|File version"
 msgstr ""
 
+#: ../model_attributes.rb:529
 msgid "Filesystem|File version header"
 msgstr ""
 
+#: ../model_attributes.rb:530
 msgid "Filesystem|Group"
 msgstr ""
 
+#: ../model_attributes.rb:531
 msgid "Filesystem|Md5"
 msgstr ""
 
+#: ../model_attributes.rb:532
 msgid "Filesystem|Mtime"
 msgstr ""
 
+#: ../model_attributes.rb:533
 msgid "Filesystem|Name"
 msgstr ""
 
+#: ../model_attributes.rb:534
 msgid "Filesystem|Owner"
 msgstr ""
 
+#: ../model_attributes.rb:535
 msgid "Filesystem|Permissions"
 msgstr ""
 
+#: ../model_attributes.rb:536
 msgid "Filesystem|Product version"
 msgstr ""
 
+#: ../model_attributes.rb:537
 msgid "Filesystem|Product version header"
 msgstr ""
 
+#: ../model_attributes.rb:538
 msgid "Filesystem|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:539
 msgid "Filesystem|Rsc type"
 msgstr ""
 
+#: ../model_attributes.rb:540
 msgid "Filesystem|Size"
 msgstr ""
 
+#: ../model_attributes.rb:541
 msgid "Filesystem|Updated on"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_filter.html.haml:14 ../../app/views/ops/_schedule_show.html.haml:52 ../../app/views/report/_widget_show.html.haml:156 ../../app/views/report/_widget_form_chart.html.haml:15 ../../app/views/report/_schedule_form_filter.html.haml:16 ../../app/views/report/_schedule_form_filter.html.haml:78 ../../app/views/report/_widget_form_report.html.haml:15 ../../app/views/miq_capacity/_planning_options.html.haml:284
 msgid "Filter"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:8 ../../app/views/miq_task/_tasks_options.html.haml:6
 msgid "Filter By"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:15
 msgid "Filter Message"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_show_list.html.haml:11 ../../app/views/configuration/_ui_3.html.haml:8
 msgid "Filters"
 msgstr ""
 
+#: ../../app/controllers/miq_task_controller.rb:139
 msgid "Finished Task cannot be cancelled"
 msgstr ""
 
+#: ../../app/views/security_group/_main.html.haml:20
 msgid "Firewall Rules"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:352
 msgid "Firewall Rules (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:346
 msgid "Firewall Rules (0)"
 msgstr ""
 
+#: ../model_attributes.rb:542
 msgid "Firewall rule"
 msgstr ""
 
+#: ../model_attributes.rb:543
 msgid "FirewallRule|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:544
 msgid "FirewallRule|Direction"
 msgstr ""
 
+#: ../model_attributes.rb:545
 msgid "FirewallRule|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:546
 msgid "FirewallRule|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:547
 msgid "FirewallRule|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:548
 msgid "FirewallRule|End port"
 msgstr ""
 
+#: ../model_attributes.rb:549
 msgid "FirewallRule|Group"
 msgstr ""
 
+#: ../model_attributes.rb:550
 msgid "FirewallRule|Host protocol"
 msgstr ""
 
+#: ../model_attributes.rb:551
 msgid "FirewallRule|Name"
 msgstr ""
 
+#: ../model_attributes.rb:552
 msgid "FirewallRule|Network protocol"
 msgstr ""
 
+#: ../model_attributes.rb:553
 msgid "FirewallRule|Port"
 msgstr ""
 
+#: ../model_attributes.rb:554
 msgid "FirewallRule|Required"
 msgstr ""
 
+#: ../model_attributes.rb:555
 msgid "FirewallRule|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:556
 msgid "FirewallRule|Source ip range"
 msgstr ""
 
+#: ../model_attributes.rb:557
 msgid "FirewallRule|Updated on"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:121
 msgid "First"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:206
 msgid "First %s"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:45
 msgid "First band unit"
 msgstr ""
 
+#: ../model_attributes.rb:558
 msgid "Flavor"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:29 ../../app/views/configuration/_ui_2.html.haml:156
 msgid "Flavors"
 msgstr ""
 
+#: ../model_attributes.rb:559
 msgid "Flavor|Block storage based only"
 msgstr ""
 
+#: ../model_attributes.rb:560
 msgid "Flavor|Cloud subnet required"
 msgstr ""
 
+#: ../model_attributes.rb:561
 msgid "Flavor|Cpu cores"
 msgstr ""
 
+#: ../model_attributes.rb:562
 msgid "Flavor|Cpus"
 msgstr ""
 
+#: ../model_attributes.rb:563
 msgid "Flavor|Description"
 msgstr ""
 
+#: ../model_attributes.rb:564
 msgid "Flavor|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:565
 msgid "Flavor|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:566
 msgid "Flavor|Memory"
 msgstr ""
 
+#: ../model_attributes.rb:567
 msgid "Flavor|Name"
 msgstr ""
 
+#: ../model_attributes.rb:568
 msgid "Flavor|Supports 32 bit"
 msgstr ""
 
+#: ../model_attributes.rb:569
 msgid "Flavor|Supports 64 bit"
 msgstr ""
 
+#: ../model_attributes.rb:570
 msgid "Flavor|Supports hvm"
 msgstr ""
 
+#: ../model_attributes.rb:571
 msgid "Flavor|Supports paravirtual"
 msgstr ""
 
+#: ../model_attributes.rb:572
 msgid "Floating ip"
 msgstr ""
 
+#: ../model_attributes.rb:573
 msgid "FloatingIp|Address"
 msgstr ""
 
+#: ../model_attributes.rb:574
 msgid "FloatingIp|Cloud network only"
 msgstr ""
 
+#: ../model_attributes.rb:575
 msgid "FloatingIp|Ems ref"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:122
 msgid "Folder"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:324 ../../app/views/ops/_ldap_domain_form.html.haml:131 ../../app/views/ops/_ldap_domain_show.html.haml:177 ../../app/views/_ldap_domain_form.html.haml:131
 msgid "Follow Referrals"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:83
 msgid "For questions or problem reporting, go to the"
 msgstr ""
 
+#: ../../app/views/report/_form_formatting.html.haml:58
 msgid "Format"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:114
 msgid "Format on Summary Row"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Friday"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_email.html.haml:35 ../../app/views/miq_policy/_alert_details.html.haml:289
 msgid "From"
 msgstr ""
 
+#: ../../app/views/layouts/_discover.html.haml:57
 msgid "From Address"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:18
 msgid "From Domain"
 msgstr ""
 
+#: ../../app/views/report/_show_schedule.html.haml:44
 msgid "From E-mail"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:539 ../../app/views/miq_policy/_action_options.html.haml:19 ../../app/views/miq_policy/_action_details.html.haml:196
 msgid "From E-mail Address"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:54
 msgid "Front (...1234)"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:21
 msgid "Full Name"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:443
 msgid "Full&#160;Screen"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:243
 msgid "GB"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:34
 msgid "GCE PD Resource"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:219
 msgid "Genealogy"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:15
 msgid "General"
 msgstr ""
 
+#: ../../app/views/report/_form_preview.html.haml:53
 msgid "Generate Report Preview"
 msgstr ""
 
+#: ../../app/views/report/_form_preview.html.haml:62
 msgid "Generate Report preview"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:13
 msgid "Generic Workers"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:309 ../../app/views/ops/_ldap_domain_form.html.haml:116 ../../app/views/ops/_ldap_domain_show.html.haml:161 ../../app/views/_ldap_domain_form.html.haml:116
 msgid "Get Roles from Home Forest"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:412
 msgid "Get User Groups from Amazon"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:474
 msgid "Get User Groups from External Authentication (httpd)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:265 ../../app/views/ops/_ldap_domain_form.html.haml:101 ../../app/views/ops/_ldap_domain_show.html.haml:145 ../../app/views/_ldap_domain_form.html.haml:101
 msgid "Get User Groups from LDAP"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:35
 msgid "Git Repository"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:36
 msgid "Git Revision"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:139
 msgid "Global Default"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_vms_filter.rb:21
 msgid "Global Filters"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_vms_filter.rb:21
 msgid "Global Shared Filters"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:362
 msgid "Global Time Profile cannot be edited"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:147
 msgid "Global search:"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:41
 msgid "Glusterfs Endpoint Name"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:75 ../../app/helpers/configuration_helper/configuration_view_helper.rb:81 ../../app/helpers/configuration_helper/configuration_view_helper.rb:87 ../../app/views/configuration/_ui_1.html.haml:107
 msgid "Grid View"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:17
 msgid "Grid/Tile Icons"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:139 ../../app/views/chargeback/_cb_rate_edit.html.haml:41 ../../app/views/chargeback/_cb_rate_show.html.haml:38
 msgid "Group"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:11
 msgid "Group Information"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:6
 msgid "Group Records by up to 3 Columns"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:98 ../../app/views/report/_form_filter_chargeback.html.haml:117
 msgid "Group by"
 msgstr ""
 
+#: ../../app/views/layouts/_role_visibility.html.haml:71 ../../app/views/layouts/_item.html.haml:94
 msgid "Groups"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:69 ../../app/views/layouts/listnav/_host.html.haml:320 ../../app/views/layouts/listnav/_vm_common.html.haml:306 ../../app/views/layouts/listnav/_vm_common.html.haml:312
 msgid "Groups (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:314
 msgid "Groups (0)"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:81
 msgid "Groups Using this Role"
 msgstr ""
 
+#: ../model_attributes.rb:576
 msgid "Guest application"
 msgstr ""
 
+#: ../model_attributes.rb:591
 msgid "Guest device"
 msgstr ""
 
+#: ../model_attributes.rb:577
 msgid "GuestApplication|Arch"
 msgstr ""
 
+#: ../model_attributes.rb:578
 msgid "GuestApplication|Description"
 msgstr ""
 
+#: ../model_attributes.rb:579
 msgid "GuestApplication|Install time"
 msgstr ""
 
+#: ../model_attributes.rb:580
 msgid "GuestApplication|Language"
 msgstr ""
 
+#: ../model_attributes.rb:581
 msgid "GuestApplication|Name"
 msgstr ""
 
+#: ../model_attributes.rb:582
 msgid "GuestApplication|Package name"
 msgstr ""
 
+#: ../model_attributes.rb:583
 msgid "GuestApplication|Path"
 msgstr ""
 
+#: ../model_attributes.rb:584
 msgid "GuestApplication|Product icon"
 msgstr ""
 
+#: ../model_attributes.rb:585
 msgid "GuestApplication|Product key"
 msgstr ""
 
+#: ../model_attributes.rb:586
 msgid "GuestApplication|Release"
 msgstr ""
 
+#: ../model_attributes.rb:587
 msgid "GuestApplication|Transform"
 msgstr ""
 
+#: ../model_attributes.rb:588
 msgid "GuestApplication|Typename"
 msgstr ""
 
+#: ../model_attributes.rb:589
 msgid "GuestApplication|Vendor"
 msgstr ""
 
+#: ../model_attributes.rb:590
 msgid "GuestApplication|Version"
 msgstr ""
 
+#: ../model_attributes.rb:592
 msgid "GuestDevice|Address"
 msgstr ""
 
+#: ../model_attributes.rb:593
 msgid "GuestDevice|Auto detect"
 msgstr ""
 
+#: ../model_attributes.rb:594
 msgid "GuestDevice|Chap auth enabled"
 msgstr ""
 
+#: ../model_attributes.rb:595
 msgid "GuestDevice|Controller type"
 msgstr ""
 
+#: ../model_attributes.rb:596
 msgid "GuestDevice|Device name"
 msgstr ""
 
+#: ../model_attributes.rb:597
 msgid "GuestDevice|Device type"
 msgstr ""
 
+#: ../model_attributes.rb:598
 msgid "GuestDevice|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:599
 msgid "GuestDevice|Free space"
 msgstr ""
 
+#: ../model_attributes.rb:600
 msgid "GuestDevice|Iscsi alias"
 msgstr ""
 
+#: ../model_attributes.rb:601
 msgid "GuestDevice|Iscsi name"
 msgstr ""
 
+#: ../model_attributes.rb:602
 msgid "GuestDevice|Location"
 msgstr ""
 
+#: ../model_attributes.rb:603
 msgid "GuestDevice|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:604
 msgid "GuestDevice|Model"
 msgstr ""
 
+#: ../model_attributes.rb:605
 msgid "GuestDevice|Present"
 msgstr ""
 
+#: ../model_attributes.rb:606
 msgid "GuestDevice|Size"
 msgstr ""
 
+#: ../model_attributes.rb:607
 msgid "GuestDevice|Size on disk"
 msgstr ""
 
+#: ../model_attributes.rb:608
 msgid "GuestDevice|Start connected"
 msgstr ""
 
+#: ../model_attributes.rb:609
 msgid "GuestDevice|Uid ems"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_registry.html.haml:51 ../../app/views/ops/_ap_form_registry.html.haml:87 ../../app/views/ops/_ap_form_registry.html.haml:137
 msgid "HKLM"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:111
 msgid "HTTP Proxy Address"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:91
 msgid "HTTP Proxy:"
 msgstr ""
 
+#: ../model_attributes.rb:610
 msgid "Hardware"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:248
 msgid "Hardware Attribute"
 msgstr ""
 
+#: ../model_attributes.rb:611
 msgid "Hardware|Annotation"
 msgstr ""
 
+#: ../model_attributes.rb:612
 msgid "Hardware|Bios"
 msgstr ""
 
+#: ../model_attributes.rb:613
 msgid "Hardware|Bios location"
 msgstr ""
 
+#: ../model_attributes.rb:614
 msgid "Hardware|Bitness"
 msgstr ""
 
+#: ../model_attributes.rb:615
 msgid "Hardware|Config version"
 msgstr ""
 
+#: ../model_attributes.rb:616
 msgid "Hardware|Cores per socket"
 msgstr ""
 
+#: ../model_attributes.rb:617
 msgid "Hardware|Cpu speed"
 msgstr ""
 
+#: ../model_attributes.rb:618
 msgid "Hardware|Cpu type"
 msgstr ""
 
+#: ../model_attributes.rb:619
 msgid "Hardware|Cpu usage"
 msgstr ""
 
+#: ../model_attributes.rb:620
 msgid "Hardware|Disk capacity"
 msgstr ""
 
+#: ../model_attributes.rb:621
 msgid "Hardware|Disk free space"
 msgstr ""
 
+#: ../model_attributes.rb:622
 msgid "Hardware|Guest os"
 msgstr ""
 
+#: ../model_attributes.rb:623
 msgid "Hardware|Guest os full name"
 msgstr ""
 
+#: ../model_attributes.rb:624
 msgid "Hardware|Logical cpus"
 msgstr ""
 
+#: ../model_attributes.rb:625
 msgid "Hardware|Manufacturer"
 msgstr ""
 
+#: ../model_attributes.rb:626
 msgid "Hardware|Memory console"
 msgstr ""
 
+#: ../model_attributes.rb:627
 msgid "Hardware|Memory cpu"
 msgstr ""
 
+#: ../model_attributes.rb:628
 msgid "Hardware|Memory usage"
 msgstr ""
 
+#: ../model_attributes.rb:629
 msgid "Hardware|Model"
 msgstr ""
 
+#: ../model_attributes.rb:630
 msgid "Hardware|Number of nics"
 msgstr ""
 
+#: ../model_attributes.rb:631
 msgid "Hardware|Numvcpus"
 msgstr ""
 
+#: ../model_attributes.rb:632
 msgid "Hardware|Root device type"
 msgstr ""
 
+#: ../model_attributes.rb:633
 msgid "Hardware|Size on disk"
 msgstr ""
 
+#: ../model_attributes.rb:634
 msgid "Hardware|Time sync"
 msgstr ""
 
+#: ../model_attributes.rb:635
 msgid "Hardware|Virtual hw version"
 msgstr ""
 
+#: ../model_attributes.rb:636
 msgid "Hardware|Virtualization type"
 msgstr ""
 
+#: ../model_attributes.rb:637
 msgid "Hardware|Vmotion enabled"
 msgstr ""
 
+#: ../../app/views/report/_form_formatting.html.haml:53 ../../app/views/report/_form_sort.html.haml:241
 msgid "Header"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:96
 msgid "Hide Detail Rows"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_form.html.haml:116
 msgid "Hide Input Parameters"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:25
 msgid "High"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:75 ../../app/views/vm_common/console_vmrc.html.haml:100
 msgid "Hint: Press Ctrl-Alt to release the cursor from the guest"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:397 ../../app/views/ops/_settings_workers_tab.html.haml:652 ../../app/views/configuration/_ui_1.html.haml:22 ../model_attributes.rb:638
 msgid "Host"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:17
 msgid "Host Compliance Policies"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_condition.rb:24
 msgid "Host Conditions"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:19
 msgid "Host Control Policies"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:239
 msgid "Host Default VNC End Port"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/_form.html.haml:146
 msgid "Host Default VNC Port Range"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:215
 msgid "Host Default VNC Start Port"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:25
 msgid "Host Policies"
 msgstr ""
 
+#: ../../app/views/security_group/_main.html.haml:20
 msgid "Host Protocol"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:69
 msgid "Host platform"
 msgstr ""
 
+#: ../model_attributes.rb:668
 msgid "Host service group"
 msgstr ""
 
+#: ../model_attributes.rb:669
 msgid "HostServiceGroup|Name"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:13 ../../app/views/ops/_selected_by_servers.html.haml:22 ../../app/views/ops/_server_desc.html.haml:9 ../../app/views/ops/_ldap_domain_show.html.haml:255 ../../app/views/ops/_settings_server_tab.html.haml:16 ../../app/views/ops/_ldap_server_entries.html.haml:18 ../../app/views/ops/_diagnostics_database_tab.html.haml:35 ../../app/views/storage_manager/_form.html.haml:61 ../../app/views/host/_config.html.haml:47
 msgid "Hostname"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:45 ../../app/views/shared/views/ems_common/angular/_form.html.haml:92
 msgid "Hostname (or IPv4 or IPv6 address)"
 msgstr ""
 
+#: ../../app/views/ems_infra/_form_fields.html.haml:6 ../../app/views/ems_container/_form_fields.html.haml:6
 msgid "Hostname or IP address"
 msgstr ""
 
+#: ../../app/views/ems_infra/_form_fields.html.haml:11 ../../app/views/ems_container/_form_fields.html.haml:11
 msgid "Hostname or IPv4/IPv6 address"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:37
 msgid "Hosts"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:37
 msgid "Hosts / Nodes"
 msgstr ""
 
+#: ../../app/controllers/ems_cluster_controller.rb:264
 msgid "Hosts with failed %s"
 msgstr ""
 
+#: ../../app/controllers/ems_cluster_controller.rb:261
 msgid "Hosts with running %s"
 msgstr ""
 
+#: ../model_attributes.rb:639
 msgid "Host|Admin disabled"
 msgstr ""
 
+#: ../model_attributes.rb:640
 msgid "Host|Asset tag"
 msgstr ""
 
+#: ../model_attributes.rb:641
 msgid "Host|Connection state"
 msgstr ""
 
+#: ../model_attributes.rb:642
 msgid "Host|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:643
 msgid "Host|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:644
 msgid "Host|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:645
 msgid "Host|Failover"
 msgstr ""
 
+#: ../model_attributes.rb:646
 msgid "Host|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:647
 msgid "Host|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:648
 msgid "Host|Hyperthreading"
 msgstr ""
 
+#: ../model_attributes.rb:649
 msgid "Host|Hypervisor hostname"
 msgstr ""
 
+#: ../model_attributes.rb:650
 msgid "Host|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:651
 msgid "Host|Ipmi address"
 msgstr ""
 
+#: ../model_attributes.rb:652
 msgid "Host|Last perf capture on"
 msgstr ""
 
+#: ../model_attributes.rb:653
 msgid "Host|Mac address"
 msgstr ""
 
+#: ../model_attributes.rb:654
 msgid "Host|Name"
 msgstr ""
 
+#: ../model_attributes.rb:655
 msgid "Host|Next available vnc port"
 msgstr ""
 
+#: ../model_attributes.rb:656
 msgid "Host|Power state"
 msgstr ""
 
+#: ../model_attributes.rb:657
 msgid "Host|Service tag"
 msgstr ""
 
+#: ../model_attributes.rb:658
 msgid "Host|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:659
 msgid "Host|Smart"
 msgstr ""
 
+#: ../model_attributes.rb:660
 msgid "Host|Ssh permit root login"
 msgstr ""
 
+#: ../model_attributes.rb:661
 msgid "Host|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:662
 msgid "Host|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:663
 msgid "Host|User assigned os"
 msgstr ""
 
+#: ../model_attributes.rb:664
 msgid "Host|Vmm buildnumber"
 msgstr ""
 
+#: ../model_attributes.rb:665
 msgid "Host|Vmm product"
 msgstr ""
 
+#: ../model_attributes.rb:666
 msgid "Host|Vmm vendor"
 msgstr ""
 
+#: ../model_attributes.rb:667
 msgid "Host|Vmm version"
 msgstr ""
 
-msgid "Hour"
-msgstr ""
-
+#: ../../app/views/layouts/_tl_options.html.haml:51 ../../app/views/report/_schedule_form_timer.html.haml:20 ../../app/views/report/_form_columns_performance.html.haml:15
 msgid "Hourly"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:139
 msgid "Hourly Timer"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:58 ../../app/views/configuration/_ui_4.html.haml:15
 msgid "Hours"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:56 ../../app/views/shared/buttons/_ab_list.html.haml:210
 msgid "Hover Text"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:24 ../../app/views/ops/_selected_by_servers.html.haml:35 ../../app/views/ops/_server_desc.html.haml:19 ../../app/views/ops/_settings_server_tab.html.haml:32 ../../app/views/storage_manager/_form.html.haml:78 ../../app/views/host/_config.html.haml:63
 msgid "IP Address"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_host_dialog.html.haml:86 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:53 ../../app/views/shared/views/_prov_dialog.html.haml:339 ../../app/views/shared/views/_prov_dialog.html.haml:373
 msgid "IP Address Information"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:211
 msgid "IPAddress"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:39 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:34
 msgid "IPMI"
 msgstr ""
 
+#: ../../app/views/layouts/_discover.html.haml:44
 msgid "IPMI Credentials"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:110
 msgid "IPMI IP Address"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:20
 msgid "IPMI Present"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:40
 msgid "ISCSI Target Lun Number"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:38
 msgid "ISCSI Target Portal"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:39
 msgid "ISCSI Target Qualified Name"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:60
 msgid "ISO"
 msgstr ""
 
+#: ../../app/views/pxe/_iso_datastore_details.html.haml:17
 msgid "ISO Images"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:233
 msgid "Identification"
 msgstr ""
 
+#: ../../app/views/report/_form_styling.html.haml:30
 msgid "If"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_blank.html.haml:11
 msgid "If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon."
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:179 ../../app/views/shared/buttons/_ab_show.html.haml:48
 msgid "Image"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:162
 msgid "Image Registries (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:156
 msgid "Image Registries (0)"
 msgstr ""
 
+#: ../../app/views/pxe/_template_form.html.haml:49
 msgid "Image Type"
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:74
 msgid "Image shown at 25% of actual size"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:184
 msgid "Images"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:50 ../../app/views/layouts/listnav/_ems_container.html.haml:178 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:63 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:69
 msgid "Images (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:44 ../../app/views/layouts/listnav/_ems_container.html.haml:172
 msgid "Images (0)"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:69
 msgid "Images by Provider"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:7 ../../app/views/ops/_ldap_server_entry.html.haml:44 ../../app/views/ops/_all_tabs.html.haml:96 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:24 ../../app/views/report/_export_custom_reports.html.haml:12 ../../app/views/report/_export_widgets.html.haml:30 ../../app/views/miq_policy/_export.html.haml:9
 msgid "Import"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:121 ../../app/presenters/menu/default_menu.rb:131 ../../app/presenters/tree_builder.rb:68 ../../app/controllers/report_controller.rb:757
 msgid "Import / Export"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:87
 msgid "Import Datastore classes"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:26
 msgid "Import Datastore classes (*.zip)"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:71
 msgid "Import Service Dialogs"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:93
 msgid "Import Tags"
 msgstr ""
 
+#: ../../app/views/report/_export_widgets.html.haml:113
 msgid "Import Widgets"
 msgstr ""
 
+#: ../../app/controllers/report_controller.rb:71
 msgid "Import file cannot be empty"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:54 ../../app/controllers/miq_ae_tools_controller.rb:172 ../../app/controllers/report_controller.rb:305 ../../app/controllers/miq_policy_controller.rb:192
 msgid "Import file was uploaded successfully"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:209
 msgid "Import not available due to conflicts"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:84
 msgid "Import validation complete: %{good_record}, %{bad_record}"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:110
 msgid "In use by %s reports, cannot be disabled"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_replication_tab.html.haml:39
 msgid "Inactive"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_tree_select.html.haml:65
 msgid "Include Domain prefix in the path"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:6 ../../app/views/pxe/_pxe_server_details.html.haml:112
 msgid "Index"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:200 ../../app/views/ops/_all_tabs.html.haml:289
 msgid "Indexes"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:207
 msgid "Indexes for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/views/ops/_ap_show.html.haml:7 ../../app/views/resource_pool/_config.html.haml:9 ../../app/views/miq_ae_class/_ns_list.html.haml:69 ../../app/views/miq_policy/_alert_details.html.haml:13
 msgid "Info"
 msgstr ""
 
+#: ../../app/views/storage/_main.html.haml:9
 msgid "Information for Registered VMs"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:40 ../../app/views/configuration/_ui_2.html.haml:212
 msgid "Infrastructure"
 msgstr ""
 
+#: ../../app/views/ontap_storage_system/_main.html.haml:16 ../../app/views/ontap_logical_disk/_main.html.haml:11 ../../app/views/ontap_storage_volume/_main.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:46 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:58 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:58 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:55 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:66 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:64 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:65 ../../app/views/ontap_file_share/_main.html.haml:16
 msgid "Infrastructure Relationships"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:483
 msgid "Inherit Tags"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:536
 msgid "Inherit Tags Settings"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:354 ../../app/views/layouts/listnav/_vm_common.html.haml:360
 msgid "Init Processes (%s)"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:128
 msgid "Input Name"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:120 ../../app/views/miq_ae_class/_method_form.html.haml:106
 msgid "Input Parameters"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:34
 msgid "Instance Type:"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:31 ../../app/views/miq_ae_class/_class_instances.html.haml:5 ../../app/views/miq_ae_class/_all_tabs.html.haml:8 ../../app/views/miq_ae_class/_all_tabs.html.haml:35 ../../app/views/miq_ae_class/_class_props.html.haml:68 ../../app/views/configuration/_ui_2.html.haml:170
 msgid "Instances"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:19 ../../app/views/layouts/listnav/_flavor.html.haml:34 ../../app/views/layouts/listnav/_flavor.html.haml:40 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:48 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:54 ../../app/views/layouts/listnav/_availability_zone.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:41 ../../app/views/layouts/listnav/_security_group.html.haml:33 ../../app/views/layouts/listnav/_security_group.html.haml:39 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:41 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:47
 msgid "Instances (%s)"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:70
 msgid "Instances by Provider"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:461 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:559
 msgid "Integer"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:173 ../../app/views/report/_widget_form_rss.html.haml:20
 msgid "Internal"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:192 ../../app/views/report/_widget_form_rss.html.haml:37
 msgid "Internal RSS Feed"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:46 ../../app/views/layouts/_perf_options.html.haml:11 ../../app/views/report/_report_info.html.haml:139
 msgid "Interval"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:39
 msgid "Invalid Single Sign-On credentials"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:77
 msgid "Invalid button action."
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_chart.html.haml:33
 msgid "Invalid chart data. Try regenerating the widgets."
 msgstr ""
 
+#: ../../lib/report_formatter/chart_common.rb:565
+msgid "Invalid chart definition"
+msgstr ""
+
+#: ../model_attributes.rb:670
 msgid "Iso datastore"
 msgstr ""
 
+#: ../model_attributes.rb:672
 msgid "Iso image"
 msgstr ""
 
+#: ../model_attributes.rb:671
 msgid "IsoDatastore|Last refresh on"
 msgstr ""
 
+#: ../model_attributes.rb:673
 msgid "IsoImage|Name"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:133
 msgid "Item"
 msgid_plural "Items"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../model_attributes.rb:674
 msgid "Job"
 msgstr ""
 
+#: ../model_attributes.rb:675
 msgid "Job|Agent class"
 msgstr ""
 
+#: ../model_attributes.rb:676
 msgid "Job|Agent message"
 msgstr ""
 
+#: ../model_attributes.rb:677
 msgid "Job|Agent name"
 msgstr ""
 
+#: ../model_attributes.rb:678
 msgid "Job|Agent state"
 msgstr ""
 
+#: ../model_attributes.rb:679
 msgid "Job|Archive"
 msgstr ""
 
+#: ../model_attributes.rb:680
 msgid "Job|Code"
 msgstr ""
 
+#: ../model_attributes.rb:681
 msgid "Job|Context"
 msgstr ""
 
+#: ../model_attributes.rb:682
 msgid "Job|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:683
 msgid "Job|Dispatch status"
 msgstr ""
 
+#: ../model_attributes.rb:684
 msgid "Job|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:685
 msgid "Job|Message"
 msgstr ""
 
+#: ../model_attributes.rb:686
 msgid "Job|Name"
 msgstr ""
 
+#: ../model_attributes.rb:687
 msgid "Job|Options"
 msgstr ""
 
+#: ../model_attributes.rb:688
 msgid "Job|Process"
 msgstr ""
 
+#: ../model_attributes.rb:689
 msgid "Job|Started on"
 msgstr ""
 
+#: ../model_attributes.rb:690
 msgid "Job|State"
 msgstr ""
 
+#: ../model_attributes.rb:691
 msgid "Job|Status"
 msgstr ""
 
+#: ../model_attributes.rb:692
 msgid "Job|Sync key"
 msgstr ""
 
+#: ../model_attributes.rb:693
 msgid "Job|Target class"
 msgstr ""
 
+#: ../model_attributes.rb:694
 msgid "Job|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:695
 msgid "Job|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:696
 msgid "Job|Zone"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:63
 msgid "Kernel"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:431 ../../app/views/layouts/listnav/_vm_common.html.haml:437
 msgid "Kernel Drivers (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_regkey.html.haml:6
 msgid "Key:"
 msgstr ""
 
+#: ../../app/views/pxe/_template_form.html.haml:73
 msgid "Kickstart"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279
 msgid "LDAP"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_region_show.html.haml:58
 msgid "LDAP Domains"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:150
 msgid "LDAP Group Look Up"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:174 ../../app/views/ops/_rbac_group_details.html.haml:174 ../../app/views/ops/_rbac_group_details.html.haml:245 ../../app/views/ops/_rbac_group_details.html.haml:245 ../../app/views/miq_request/_prov_field.html.haml:139
 msgid "LDAP Group Lookup"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_auth_users.html.haml:9
 msgid "LDAP Groups for User"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:80
 msgid "LDAP Host Names"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:15
 msgid "LDAP Hostname"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_verify_button.html.haml:17
 msgid "LDAP Hostname and Port fields are needed to perform verification of LDAP Settings"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:113 ../../app/views/ops/_ldap_forest_entries.html.haml:19
 msgid "LDAP Port"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:109
 msgid "LDAP Regions"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_domain_show.html.haml:242 ../../app/views/ops/_ldap_server_entries.html.haml:8
 msgid "LDAP Servers"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:72 ../../app/views/ops/_ldap_domain_form.html.haml:29 ../../app/views/ops/_ldap_domain_show.html.haml:33 ../../app/views/_ldap_domain_form.html.haml:29
 msgid "LDAP Settings"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:209
 msgid "LDAP Settings validation was successful"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279
 msgid "LDAPS"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_info.html.haml:15 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:14 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:15
 msgid "Label"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:138
 msgid "Label on Summary Row"
 msgstr ""
 
+#: ../../app/views/container_service/_main.html.haml:11 ../../app/views/container_group/_main.html.haml:9 ../../app/views/container_replicator/_main.html.haml:9 ../../app/views/container_node/_main.html.haml:9
 msgid "Labels"
 msgstr ""
 
+#: ../model_attributes.rb:697
 msgid "Lan"
 msgstr ""
 
+#: ../model_attributes.rb:698
 msgid "Lan|Allow promiscuous"
 msgstr ""
 
+#: ../model_attributes.rb:699
 msgid "Lan|Computed allow promiscuous"
 msgstr ""
 
+#: ../model_attributes.rb:700
 msgid "Lan|Computed forged transmits"
 msgstr ""
 
+#: ../model_attributes.rb:701
 msgid "Lan|Computed mac changes"
 msgstr ""
 
+#: ../model_attributes.rb:702
 msgid "Lan|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:703
 msgid "Lan|Forged transmits"
 msgstr ""
 
+#: ../model_attributes.rb:704
 msgid "Lan|Mac changes"
 msgstr ""
 
+#: ../model_attributes.rb:705
 msgid "Lan|Name"
 msgstr ""
 
+#: ../model_attributes.rb:706
 msgid "Lan|Tag"
 msgstr ""
 
+#: ../model_attributes.rb:707
 msgid "Lan|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:708
 msgid "Lan|Updated on"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:65 ../../app/helpers/configuration_helper/configuration_view_helper.rb:70
 msgid "Large Trees"
 msgstr ""
 
+#: ../../app/views/ops/_db_summary.html.haml:14
 msgid "Largest Tables"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:121
 msgid "Last"
 msgstr ""
 
+#: ../../app/views/ops/_log_viewer.html.haml:4
 msgid "Last 1000 lines from server %{name} [%{id}] in zone %{zone}"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/show.html.haml:3 ../../app/views/show.html.haml:7
 msgid "Last 1000 lines from the Automation log"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:94
 msgid "Last Checked for updates"
 msgstr ""
 
+#: ../../app/views/ops/_logs_selected.html.haml:24
 msgid "Last Log Collection"
 msgstr ""
 
+#: ../../app/views/ops/_logs_selected.html.haml:35 ../../app/views/ops/rhn/_server_table.html.haml:100 ../../app/views/miq_request/_request.html.haml:100 ../../app/views/miq_request/_request_details.html.haml:108
 msgid "Last Message"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_show.html.haml:94 ../../app/views/report/_widget_show.html.haml:96 ../../app/views/report/_show_schedule.html.haml:92 ../../app/views/report/_report_info.html.haml:144
 msgid "Last Run Time"
 msgstr ""
 
+#: ../../app/helpers/container_node_helper/textual_summary.rb:17
 msgid "Last Transition Time"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:126 ../../app/views/miq_request/_request_details.html.haml:31
 msgid "Last Update"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:91
 msgid "Last Updated"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:178
 msgid "Last Week"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:479 ../../app/controllers/application_controller/explorer.rb:775
 msgid "Last selected %s no longer exists"
 msgstr ""
 
+#: ../model_attributes.rb:709
 msgid "Ldap domain"
 msgstr ""
 
+#: ../model_attributes.rb:723
 msgid "Ldap group"
 msgstr ""
 
+#: ../model_attributes.rb:729
 msgid "Ldap region"
 msgstr ""
 
+#: ../model_attributes.rb:732
 msgid "Ldap server"
 msgstr ""
 
+#: ../model_attributes.rb:736
 msgid "Ldap user"
 msgstr ""
 
+#: ../model_attributes.rb:710
 msgid "LdapDomain|Base dn"
 msgstr ""
 
+#: ../model_attributes.rb:711
 msgid "LdapDomain|Bind timeout"
 msgstr ""
 
+#: ../model_attributes.rb:712
 msgid "LdapDomain|Follow referrals"
 msgstr ""
 
+#: ../model_attributes.rb:713
 msgid "LdapDomain|Get direct groups"
 msgstr ""
 
+#: ../model_attributes.rb:714
 msgid "LdapDomain|Get roles from home forest"
 msgstr ""
 
+#: ../model_attributes.rb:715
 msgid "LdapDomain|Get user groups"
 msgstr ""
 
+#: ../model_attributes.rb:716
 msgid "LdapDomain|Group membership max depth"
 msgstr ""
 
+#: ../model_attributes.rb:717
 msgid "LdapDomain|Last group sync"
 msgstr ""
 
+#: ../model_attributes.rb:718
 msgid "LdapDomain|Last user sync"
 msgstr ""
 
+#: ../model_attributes.rb:719
 msgid "LdapDomain|Name"
 msgstr ""
 
+#: ../model_attributes.rb:720
 msgid "LdapDomain|Search timeout"
 msgstr ""
 
+#: ../model_attributes.rb:721
 msgid "LdapDomain|User suffix"
 msgstr ""
 
+#: ../model_attributes.rb:722
 msgid "LdapDomain|User type"
 msgstr ""
 
+#: ../model_attributes.rb:724
 msgid "LdapGroup|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:725
 msgid "LdapGroup|Dn"
 msgstr ""
 
+#: ../model_attributes.rb:726
 msgid "LdapGroup|Mail"
 msgstr ""
 
+#: ../model_attributes.rb:727
 msgid "LdapGroup|Whenchanged"
 msgstr ""
 
+#: ../model_attributes.rb:728
 msgid "LdapGroup|Whencreated"
 msgstr ""
 
+#: ../model_attributes.rb:730
 msgid "LdapRegion|Description"
 msgstr ""
 
+#: ../model_attributes.rb:731
 msgid "LdapRegion|Name"
 msgstr ""
 
+#: ../model_attributes.rb:733
 msgid "LdapServer|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:734
 msgid "LdapServer|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:735
 msgid "LdapServer|Port"
 msgstr ""
 
+#: ../model_attributes.rb:737
 msgid "LdapUser|Address"
 msgstr ""
 
+#: ../model_attributes.rb:738
 msgid "LdapUser|City"
 msgstr ""
 
+#: ../model_attributes.rb:739
 msgid "LdapUser|Company"
 msgstr ""
 
+#: ../model_attributes.rb:740
 msgid "LdapUser|Country"
 msgstr ""
 
+#: ../model_attributes.rb:741
 msgid "LdapUser|Department"
 msgstr ""
 
+#: ../model_attributes.rb:742
 msgid "LdapUser|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:743
 msgid "LdapUser|Dn"
 msgstr ""
 
+#: ../model_attributes.rb:744
 msgid "LdapUser|Fax"
 msgstr ""
 
+#: ../model_attributes.rb:745
 msgid "LdapUser|First name"
 msgstr ""
 
+#: ../model_attributes.rb:746
 msgid "LdapUser|Last name"
 msgstr ""
 
+#: ../model_attributes.rb:747
 msgid "LdapUser|Mail"
 msgstr ""
 
+#: ../model_attributes.rb:748
 msgid "LdapUser|Office"
 msgstr ""
 
+#: ../model_attributes.rb:749
 msgid "LdapUser|Phone"
 msgstr ""
 
+#: ../model_attributes.rb:750
 msgid "LdapUser|Phone home"
 msgstr ""
 
+#: ../model_attributes.rb:751
 msgid "LdapUser|Phone mobile"
 msgstr ""
 
+#: ../model_attributes.rb:752
 msgid "LdapUser|Sam account name"
 msgstr ""
 
+#: ../model_attributes.rb:753
 msgid "LdapUser|Sid"
 msgstr ""
 
+#: ../model_attributes.rb:754
 msgid "LdapUser|State"
 msgstr ""
 
+#: ../model_attributes.rb:755
 msgid "LdapUser|Title"
 msgstr ""
 
+#: ../model_attributes.rb:756
 msgid "LdapUser|Upn"
 msgstr ""
 
+#: ../model_attributes.rb:757
 msgid "LdapUser|Whenchanged"
 msgstr ""
 
+#: ../model_attributes.rb:758
 msgid "LdapUser|Whencreated"
 msgstr ""
 
+#: ../model_attributes.rb:759
 msgid "LdapUser|Zip"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:152
 msgid "Leave all options unchecked to show the original column value from the first record in the group."
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:17 ../../app/views/layouts/_tl_options.html.haml:185
 msgid "Level"
 msgstr ""
 
+#: ../../app/views/service/_svcs_show.html.haml:9 ../../app/views/vm_cloud/_main.html.haml:9 ../../app/views/vm_common/_main.html.haml:9
 msgid "Lifecycle"
 msgstr ""
 
+#: ../model_attributes.rb:760
 msgid "Lifecycle event"
 msgstr ""
 
+#: ../model_attributes.rb:761
 msgid "LifecycleEvent|Created by"
 msgstr ""
 
+#: ../model_attributes.rb:762
 msgid "LifecycleEvent|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:763
 msgid "LifecycleEvent|Event"
 msgstr ""
 
+#: ../model_attributes.rb:764
 msgid "LifecycleEvent|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:765
 msgid "LifecycleEvent|Location"
 msgstr ""
 
+#: ../model_attributes.rb:766
 msgid "LifecycleEvent|Message"
 msgstr ""
 
+#: ../model_attributes.rb:767
 msgid "LifecycleEvent|Status"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:416
 msgid "Lifespan"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_summary.html.haml:11
 msgid "Limit Chart to"
 msgstr ""
 
+#: ../../app/views/container_project/_main.html.haml:12
+msgid "Limit Ranges"
+msgstr ""
+
+#: ../../app/helpers/container_project_helper/textual_summary.rb:43
+msgid "Limit Request Ratio"
+msgstr ""
+
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:77 ../../app/helpers/configuration_helper/configuration_view_helper.rb:83 ../../app/helpers/configuration_helper/configuration_view_helper.rb:89 ../../app/views/configuration/_ui_1.html.haml:107
 msgid "List View"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:77 ../../app/views/layouts/_adv_search_footer.html.haml:83 ../../app/views/report/_form_preview.html.haml:63
 msgid "Load"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:152
 msgid "Load Values on Init"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:16
 msgid "Load a filter"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:83
 msgid "Load the filter shown above"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:9 ../../app/views/layouts/_adv_search_footer.html.haml:16
 msgid "Load..."
 msgstr ""
 
+#: ../../app/views/vm_common/console_vnc.html.haml:31
 msgid "Loading ..."
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:139
 msgid "Locale"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:47 ../../app/controllers/ops_controller/settings/common.rb:1100
 msgid "Locate and upload a file to start the import process"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:64 ../../app/views/miq_ae_class/_method_form.html.haml:65
 msgid "Location"
 msgstr ""
 
+#: ../../app/views/report/_db_show.html.haml:46 ../../app/views/report/_db_form.html.haml:58
 msgid "Locked"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:122 ../../app/presenters/menu/default_menu.rb:132 ../../app/views/ops/_all_tabs.html.haml:180
 msgid "Log"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:130
 msgid "Log Depot Settings were saved"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:150
 msgid "Log Depot Settings were validated"
 msgstr ""
 
+#: ../../app/views/ops/_logs_selected.html.haml:14
 msgid "Log Depot URI"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:639
 msgid "Log Level"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:622
 msgid "Log collection error returned: "
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:624
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr ""
 
+#: ../model_attributes.rb:768
 msgid "Log file"
 msgstr ""
 
+#: ../model_attributes.rb:769
 msgid "LogFile|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:770
 msgid "LogFile|Description"
 msgstr ""
 
+#: ../model_attributes.rb:771
 msgid "LogFile|Historical"
 msgstr ""
 
+#: ../model_attributes.rb:772
 msgid "LogFile|Local file"
 msgstr ""
 
+#: ../model_attributes.rb:773
 msgid "LogFile|Log uri"
 msgstr ""
 
+#: ../model_attributes.rb:774
 msgid "LogFile|Logging ended on"
 msgstr ""
 
+#: ../model_attributes.rb:775
 msgid "LogFile|Logging started on"
 msgstr ""
 
+#: ../model_attributes.rb:776
 msgid "LogFile|Name"
 msgstr ""
 
+#: ../model_attributes.rb:777
 msgid "LogFile|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:778
 msgid "LogFile|State"
 msgstr ""
 
+#: ../model_attributes.rb:779
 msgid "LogFile|Updated on"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:630
 msgid "Logging"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:68
 msgid "Logging into"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:112
 msgid "Login"
 msgstr ""
 
+#: ../../app/services/user_validation_service.rb:42
 msgid "Login not allowed, User's %s is missing. Please contact the administrator"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:60
 msgid "Logout"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:38 ../../app/controllers/miq_ae_tools_controller.rb:50 ../../app/controllers/ops_controller/diagnostics.rb:192 ../../app/controllers/ops_controller/diagnostics.rb:203 ../../app/controllers/ops_controller/diagnostics.rb:214 ../../app/controllers/ops_controller/diagnostics.rb:874 ../../app/controllers/ops_controller/diagnostics.rb:880 ../../app/controllers/ops_controller/diagnostics.rb:886 ../../app/controllers/miq_policy_controller.rb:325 ../../app/controllers/miq_policy_controller.rb:340
 msgid "Logs for this CFME Server are not available for viewing"
 msgstr ""
 
+#: ../../app/views/catalog/_form_details_info.html.haml:4 ../../app/views/catalog/_svccat_tree_show.html.haml:59 ../../app/views/catalog/_sandt_tree_show.html.haml:204
 msgid "Long Description"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_field.html.haml:139
 msgid "Lookup"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:128
 msgid "MAC Address"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:214
 msgid "MB"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:160
 msgid "MHz"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:28
 msgid "Mac address"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:7 ../../app/views/miq_ae_class/_instance_form.html.haml:5 ../../app/views/miq_ae_class/_method_form.html.haml:6
 msgid "Main Info"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:14
 msgid "Manage Accordions"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:105
 msgid "Manage Accordions & Folders"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:8
 msgid "Manage Reports"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:658
 msgid "Manage quotas for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:180
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_mgmt_event.html.haml:5
 msgid "Management Event"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:19 ../../app/views/miq_request/_prov_host_dialog.html.haml:18 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:18 ../../app/views/shared/views/_prov_dialog.html.haml:19
 msgid "Manager"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:674
 msgid "Matching password fields are needed to perform verification of credentials"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/vm_common/_right_size.html.haml:20
 msgid "Max"
 msgstr ""
 
+#: ../../app/views/ops/_zone_form.html.haml:194
 msgid "Max Active VM Scans"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:209 ../../app/views/ops/_selected_by_roles.html.haml:28
 msgid "Max Concurrent"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_fields.html.haml:27 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Max Retries"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_fields.html.haml:29 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Max Time"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_summary.html.haml:51
 msgid "Max VMs"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:78
 msgid "Max active VM Scans"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:96 ../../app/helpers/provider_foreman_helper.rb:177
 msgid "Medium"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_service.html.haml:24 ../../app/views/layouts/listnav/_service.html.haml:30
 msgid "Member VMs (%s)"
 msgstr ""
 
+#: ../../app/views/miq_request/_reconfigure_show.html.haml:17 ../../app/views/vm_common/_reconfigure.html.haml:14 ../../app/views/vm_common/_right_size.html.haml:95 ../../app/views/vm_common/_right_size.html.haml:208 ../../app/views/vm_common/_right_size.html.haml:292 ../../app/views/vm_common/_right_size.html.haml:375 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18
 msgid "Memory"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "Memory Limit"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "Memory Reserve"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "Memory Reserve Expand"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "Memory Shares"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:240
 msgid "Memory Shares Level"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:102 ../../app/views/ops/_selected_by_roles.html.haml:150 ../../app/views/ops/_server_desc.html.haml:63 ../../app/views/miq_policy/_action_options.html.haml:221 ../../app/views/miq_policy/_action_details.html.haml:294 ../../app/views/miq_capacity/_planning_options.html.haml:194 ../../app/views/miq_capacity/_planning_options.html.haml:356 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:34 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:85
 msgid "Memory Size"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:89 ../../app/views/ops/_selected_by_roles.html.haml:137 ../../app/views/ops/_server_desc.html.haml:53 ../../app/views/vm_common/_right_size.html.haml:123
 msgid "Memory Usage"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:42 ../../app/views/ops/_settings_workers_tab.html.haml:94 ../../app/views/ops/_settings_workers_tab.html.haml:125 ../../app/views/ops/_settings_workers_tab.html.haml:156 ../../app/views/ops/_settings_workers_tab.html.haml:249 ../../app/views/ops/_settings_workers_tab.html.haml:300 ../../app/views/ops/_settings_workers_tab.html.haml:351 ../../app/views/ops/_settings_workers_tab.html.haml:406 ../../app/views/ops/_settings_workers_tab.html.haml:457 ../../app/views/ops/_settings_workers_tab.html.haml:488 ../../app/views/ops/_settings_workers_tab.html.haml:536
 msgid "Memory threshold"
 msgstr ""
 
+#: ../../app/views/report/_form.html.haml:18
 msgid "Menu Name"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_menu.html.haml:4
 msgid "Menu Shortcuts"
 msgstr ""
 
+#: ../../app/views/miq_request/_ae_prov_show.html.haml:20 ../../app/views/layouts/_ae_resolve_options.html.haml:42 ../../app/views/miq_ae_class/_instance_fields.html.haml:31 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94 ../../app/views/report/_widget_show.html.haml:106 ../../app/views/shared/buttons/_ab_show.html.haml:98
 msgid "Message"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:220
 msgid "Message Filter"
 msgstr ""
 
+#: ../../app/views/ops/_settings_import_tab.html.haml:3 ../../app/views/ops/_settings_import_tags_tab.html.haml:6
 msgid "Messages"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_all_tabs.html.haml:44
 msgid "Method Inputs"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_class_methods.html.haml:5 ../../app/views/miq_ae_class/_all_tabs.html.haml:11
 msgid "Methods"
 msgstr ""
 
+#: ../model_attributes.rb:780
 msgid "Metric"
 msgstr ""
 
+#: ../model_attributes.rb:844
 msgid "Metric rollup"
 msgstr ""
 
+#: ../model_attributes.rb:845
 msgid "MetricRollup|Assoc ids"
 msgstr ""
 
+#: ../model_attributes.rb:846
 msgid "MetricRollup|Capture interval"
 msgstr ""
 
+#: ../model_attributes.rb:847
 msgid "MetricRollup|Capture interval name"
 msgstr ""
 
+#: ../model_attributes.rb:848
 msgid "MetricRollup|Cpu ready delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:849
 msgid "MetricRollup|Cpu system delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:850
 msgid "MetricRollup|Cpu usage rate average"
 msgstr ""
 
+#: ../model_attributes.rb:851
 msgid "MetricRollup|Cpu usagemhz rate average"
 msgstr ""
 
+#: ../model_attributes.rb:852
 msgid "MetricRollup|Cpu used delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:853
 msgid "MetricRollup|Cpu wait delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:854
 msgid "MetricRollup|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:855
 msgid "MetricRollup|Derived cpu available"
 msgstr ""
 
+#: ../model_attributes.rb:856
 msgid "MetricRollup|Derived cpu reserved"
 msgstr ""
 
+#: ../model_attributes.rb:857
 msgid "MetricRollup|Derived host count off"
 msgstr ""
 
+#: ../model_attributes.rb:858
 msgid "MetricRollup|Derived host count on"
 msgstr ""
 
+#: ../model_attributes.rb:859
 msgid "MetricRollup|Derived memory available"
 msgstr ""
 
+#: ../model_attributes.rb:860
 msgid "MetricRollup|Derived memory reserved"
 msgstr ""
 
+#: ../model_attributes.rb:861
 msgid "MetricRollup|Derived memory used"
 msgstr ""
 
+#: ../model_attributes.rb:862
 msgid "MetricRollup|Derived storage disk managed"
 msgstr ""
 
+#: ../model_attributes.rb:863
 msgid "MetricRollup|Derived storage disk registered"
 msgstr ""
 
+#: ../model_attributes.rb:864
 msgid "MetricRollup|Derived storage disk unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:865
 msgid "MetricRollup|Derived storage disk unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:866
 msgid "MetricRollup|Derived storage free"
 msgstr ""
 
+#: ../model_attributes.rb:867
 msgid "MetricRollup|Derived storage mem managed"
 msgstr ""
 
+#: ../model_attributes.rb:868
 msgid "MetricRollup|Derived storage mem registered"
 msgstr ""
 
+#: ../model_attributes.rb:869
 msgid "MetricRollup|Derived storage mem unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:870
 msgid "MetricRollup|Derived storage mem unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:871
 msgid "MetricRollup|Derived storage snapshot managed"
 msgstr ""
 
+#: ../model_attributes.rb:872
 msgid "MetricRollup|Derived storage snapshot registered"
 msgstr ""
 
+#: ../model_attributes.rb:873
 msgid "MetricRollup|Derived storage snapshot unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:874
 msgid "MetricRollup|Derived storage snapshot unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:875
 msgid "MetricRollup|Derived storage total"
 msgstr ""
 
+#: ../model_attributes.rb:876
 msgid "MetricRollup|Derived storage used managed"
 msgstr ""
 
+#: ../model_attributes.rb:877
 msgid "MetricRollup|Derived storage used registered"
 msgstr ""
 
+#: ../model_attributes.rb:878
 msgid "MetricRollup|Derived storage used unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:879
 msgid "MetricRollup|Derived storage used unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:880
 msgid "MetricRollup|Derived storage vm count managed"
 msgstr ""
 
+#: ../model_attributes.rb:881
 msgid "MetricRollup|Derived storage vm count registered"
 msgstr ""
 
+#: ../model_attributes.rb:882
 msgid "MetricRollup|Derived storage vm count unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:883
 msgid "MetricRollup|Derived storage vm count unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:884
 msgid "MetricRollup|Derived vm allocated disk storage"
 msgstr ""
 
+#: ../model_attributes.rb:885
 msgid "MetricRollup|Derived vm count off"
 msgstr ""
 
+#: ../model_attributes.rb:886
 msgid "MetricRollup|Derived vm count on"
 msgstr ""
 
+#: ../model_attributes.rb:887
 msgid "MetricRollup|Derived vm numvcpus"
 msgstr ""
 
+#: ../model_attributes.rb:888
 msgid "MetricRollup|Derived vm used disk storage"
 msgstr ""
 
+#: ../model_attributes.rb:889
 msgid "MetricRollup|Disk devicelatency absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:890
 msgid "MetricRollup|Disk kernellatency absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:891
 msgid "MetricRollup|Disk queuelatency absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:892
 msgid "MetricRollup|Disk usage rate average"
 msgstr ""
 
+#: ../model_attributes.rb:893
 msgid "MetricRollup|Intervals in rollup"
 msgstr ""
 
+#: ../model_attributes.rb:894
 msgid "MetricRollup|Mem swapin absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:895
 msgid "MetricRollup|Mem swapout absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:896
 msgid "MetricRollup|Mem swapped absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:897
 msgid "MetricRollup|Mem swaptarget absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:898
 msgid "MetricRollup|Mem usage absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:899
 msgid "MetricRollup|Mem vmmemctl absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:900
 msgid "MetricRollup|Mem vmmemctltarget absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:901
 msgid "MetricRollup|Min max"
 msgstr ""
 
+#: ../model_attributes.rb:902
 msgid "MetricRollup|Net usage rate average"
 msgstr ""
 
+#: ../model_attributes.rb:903
 msgid "MetricRollup|Resource name"
 msgstr ""
 
+#: ../model_attributes.rb:904
 msgid "MetricRollup|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:905
 msgid "MetricRollup|Sys uptime absolute latest"
 msgstr ""
 
+#: ../model_attributes.rb:906
 msgid "MetricRollup|Tag names"
 msgstr ""
 
+#: ../model_attributes.rb:907
 msgid "MetricRollup|Timestamp"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:34
 msgid "Metrics"
 msgstr ""
 
+#: ../model_attributes.rb:781
 msgid "Metric|Assoc ids"
 msgstr ""
 
+#: ../model_attributes.rb:782
 msgid "Metric|Capture interval"
 msgstr ""
 
+#: ../model_attributes.rb:783
 msgid "Metric|Capture interval name"
 msgstr ""
 
+#: ../model_attributes.rb:784
 msgid "Metric|Cpu ready delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:785
 msgid "Metric|Cpu system delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:786
 msgid "Metric|Cpu usage rate average"
 msgstr ""
 
+#: ../model_attributes.rb:787
 msgid "Metric|Cpu usagemhz rate average"
 msgstr ""
 
+#: ../model_attributes.rb:788
 msgid "Metric|Cpu used delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:789
 msgid "Metric|Cpu wait delta summation"
 msgstr ""
 
+#: ../model_attributes.rb:790
 msgid "Metric|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:791
 msgid "Metric|Derived cpu available"
 msgstr ""
 
+#: ../model_attributes.rb:792
 msgid "Metric|Derived cpu reserved"
 msgstr ""
 
+#: ../model_attributes.rb:793
 msgid "Metric|Derived host count off"
 msgstr ""
 
+#: ../model_attributes.rb:794
 msgid "Metric|Derived host count on"
 msgstr ""
 
+#: ../model_attributes.rb:795
 msgid "Metric|Derived memory available"
 msgstr ""
 
+#: ../model_attributes.rb:796
 msgid "Metric|Derived memory reserved"
 msgstr ""
 
+#: ../model_attributes.rb:797
 msgid "Metric|Derived memory used"
 msgstr ""
 
+#: ../model_attributes.rb:798
 msgid "Metric|Derived storage disk managed"
 msgstr ""
 
+#: ../model_attributes.rb:799
 msgid "Metric|Derived storage disk registered"
 msgstr ""
 
+#: ../model_attributes.rb:800
 msgid "Metric|Derived storage disk unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:801
 msgid "Metric|Derived storage disk unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:802
 msgid "Metric|Derived storage free"
 msgstr ""
 
+#: ../model_attributes.rb:803
 msgid "Metric|Derived storage mem managed"
 msgstr ""
 
+#: ../model_attributes.rb:804
 msgid "Metric|Derived storage mem registered"
 msgstr ""
 
+#: ../model_attributes.rb:805
 msgid "Metric|Derived storage mem unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:806
 msgid "Metric|Derived storage mem unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:807
 msgid "Metric|Derived storage snapshot managed"
 msgstr ""
 
+#: ../model_attributes.rb:808
 msgid "Metric|Derived storage snapshot registered"
 msgstr ""
 
+#: ../model_attributes.rb:809
 msgid "Metric|Derived storage snapshot unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:810
 msgid "Metric|Derived storage snapshot unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:811
 msgid "Metric|Derived storage total"
 msgstr ""
 
+#: ../model_attributes.rb:812
 msgid "Metric|Derived storage used managed"
 msgstr ""
 
+#: ../model_attributes.rb:813
 msgid "Metric|Derived storage used registered"
 msgstr ""
 
+#: ../model_attributes.rb:814
 msgid "Metric|Derived storage used unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:815
 msgid "Metric|Derived storage used unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:816
 msgid "Metric|Derived storage vm count managed"
 msgstr ""
 
+#: ../model_attributes.rb:817
 msgid "Metric|Derived storage vm count registered"
 msgstr ""
 
+#: ../model_attributes.rb:818
 msgid "Metric|Derived storage vm count unmanaged"
 msgstr ""
 
+#: ../model_attributes.rb:819
 msgid "Metric|Derived storage vm count unregistered"
 msgstr ""
 
+#: ../model_attributes.rb:820
 msgid "Metric|Derived vm allocated disk storage"
 msgstr ""
 
+#: ../model_attributes.rb:821
 msgid "Metric|Derived vm count off"
 msgstr ""
 
+#: ../model_attributes.rb:822
 msgid "Metric|Derived vm count on"
 msgstr ""
 
+#: ../model_attributes.rb:823
 msgid "Metric|Derived vm numvcpus"
 msgstr ""
 
+#: ../model_attributes.rb:824
 msgid "Metric|Derived vm used disk storage"
 msgstr ""
 
+#: ../model_attributes.rb:825
 msgid "Metric|Disk devicelatency absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:826
 msgid "Metric|Disk kernellatency absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:827
 msgid "Metric|Disk queuelatency absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:828
 msgid "Metric|Disk usage rate average"
 msgstr ""
 
+#: ../model_attributes.rb:829
 msgid "Metric|Intervals in rollup"
 msgstr ""
 
+#: ../model_attributes.rb:830
 msgid "Metric|Mem swapin absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:831
 msgid "Metric|Mem swapout absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:832
 msgid "Metric|Mem swapped absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:833
 msgid "Metric|Mem swaptarget absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:834
 msgid "Metric|Mem usage absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:835
 msgid "Metric|Mem vmmemctl absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:836
 msgid "Metric|Mem vmmemctltarget absolute average"
 msgstr ""
 
+#: ../model_attributes.rb:837
 msgid "Metric|Min max"
 msgstr ""
 
+#: ../model_attributes.rb:838
 msgid "Metric|Net usage rate average"
 msgstr ""
 
+#: ../model_attributes.rb:839
 msgid "Metric|Resource name"
 msgstr ""
 
+#: ../model_attributes.rb:840
 msgid "Metric|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:841
 msgid "Metric|Sys uptime absolute latest"
 msgstr ""
 
+#: ../model_attributes.rb:842
 msgid "Metric|Tag names"
 msgstr ""
 
+#: ../model_attributes.rb:843
 msgid "Metric|Timestamp"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:54
 msgid "Middle (AB...34)"
 msgstr ""
 
-msgid "Minimize"
+#: ../../app/helpers/container_project_helper/textual_summary.rb:42
+msgid "Min"
 msgstr ""
 
+#: ../model_attributes.rb:908
 msgid "Miq action"
 msgstr ""
 
+#: ../model_attributes.rb:916
 msgid "Miq action set"
 msgstr ""
 
+#: ../model_attributes.rb:928
 msgid "Miq ae engine/miq ae workspace"
 msgstr ""
 
+#: ../model_attributes.rb:935
 msgid "Miq alert"
 msgstr ""
 
+#: ../model_attributes.rb:945
 msgid "Miq alert set"
 msgstr ""
 
+#: ../model_attributes.rb:957
 msgid "Miq alert status"
 msgstr ""
 
+#: ../model_attributes.rb:961
 msgid "Miq approval"
 msgstr ""
 
+#: ../model_attributes.rb:971
 msgid "Miq cim association"
 msgstr ""
 
+#: ../model_attributes.rb:979
 msgid "Miq cim derived metric"
 msgstr ""
 
+#: ../model_attributes.rb:1000
 msgid "Miq cim instance"
 msgstr ""
 
+#: ../model_attributes.rb:1012
 msgid "Miq database"
 msgstr ""
 
+#: ../model_attributes.rb:1024
 msgid "Miq dialog"
 msgstr ""
 
+#: ../model_attributes.rb:1032
 msgid "Miq enterprise"
 msgstr ""
 
+#: ../model_attributes.rb:1038
 msgid "Miq event definition"
 msgstr ""
 
+#: ../model_attributes.rb:1048
 msgid "Miq event definition set"
 msgstr ""
 
+#: ../model_attributes.rb:1060
 msgid "Miq group"
 msgstr ""
 
+#: ../model_attributes.rb:1070
 msgid "Miq policy"
 msgstr ""
 
+#: ../model_attributes.rb:1083
 msgid "Miq policy content"
 msgstr ""
 
+#: ../model_attributes.rb:1091
 msgid "Miq policy set"
 msgstr ""
 
+#: ../model_attributes.rb:1103
 msgid "Miq product feature"
 msgstr ""
 
+#: ../model_attributes.rb:1110
 msgid "Miq queue"
 msgstr ""
 
+#: ../model_attributes.rb:1130
 msgid "Miq region"
 msgstr ""
 
+#: ../model_attributes.rb:1134
 msgid "Miq report"
 msgstr ""
 
+#: ../model_attributes.rb:1167
 msgid "Miq report result"
 msgstr ""
 
+#: ../model_attributes.rb:1178
 msgid "Miq report result detail"
 msgstr ""
 
+#: ../model_attributes.rb:1181
 msgid "Miq request"
 msgstr ""
 
+#: ../model_attributes.rb:1196
 msgid "Miq request task"
 msgstr ""
 
+#: ../model_attributes.rb:1210
 msgid "Miq schedule"
 msgstr ""
 
+#: ../model_attributes.rb:1223
 msgid "Miq scsi lun"
 msgstr ""
 
+#: ../model_attributes.rb:1233
 msgid "Miq scsi target"
 msgstr ""
 
+#: ../model_attributes.rb:1239
 msgid "Miq search"
 msgstr ""
 
+#: ../model_attributes.rb:1247
 msgid "Miq server"
 msgstr ""
 
+#: ../model_attributes.rb:1280
 msgid "Miq shortcut"
 msgstr ""
 
+#: ../model_attributes.rb:1287
 msgid "Miq storage metric"
 msgstr ""
 
+#: ../model_attributes.rb:1289
 msgid "Miq task"
 msgstr ""
 
+#: ../model_attributes.rb:1301
 msgid "Miq user role"
 msgstr ""
 
+#: ../model_attributes.rb:1305
 msgid "Miq widget"
 msgstr ""
 
+#: ../model_attributes.rb:1316
 msgid "Miq widget content"
 msgstr ""
 
+#: ../model_attributes.rb:1319
 msgid "Miq widget set"
 msgstr ""
 
+#: ../model_attributes.rb:1331
 msgid "Miq widget shortcut"
 msgstr ""
 
+#: ../model_attributes.rb:1334
 msgid "Miq worker"
 msgstr ""
 
+#: ../model_attributes.rb:917
 msgid "MiqActionSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:918
 msgid "MiqActionSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:919
 msgid "MiqActionSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:920
 msgid "MiqActionSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:921
 msgid "MiqActionSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:922
 msgid "MiqActionSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:923
 msgid "MiqActionSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:924
 msgid "MiqActionSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:925
 msgid "MiqActionSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:926
 msgid "MiqActionSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:927
 msgid "MiqActionSet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:909
 msgid "MiqAction|Action type"
 msgstr ""
 
+#: ../model_attributes.rb:910
 msgid "MiqAction|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:911
 msgid "MiqAction|Description"
 msgstr ""
 
+#: ../model_attributes.rb:912
 msgid "MiqAction|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:913
 msgid "MiqAction|Name"
 msgstr ""
 
+#: ../model_attributes.rb:914
 msgid "MiqAction|Options"
 msgstr ""
 
+#: ../model_attributes.rb:915
 msgid "MiqAction|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:929
 msgid "MiqAeEngine::MiqAeWorkspace|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:930
 msgid "MiqAeEngine::MiqAeWorkspace|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:931
 msgid "MiqAeEngine::MiqAeWorkspace|Setters"
 msgstr ""
 
+#: ../model_attributes.rb:932
 msgid "MiqAeEngine::MiqAeWorkspace|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:933
 msgid "MiqAeEngine::MiqAeWorkspace|Uri"
 msgstr ""
 
+#: ../model_attributes.rb:934
 msgid "MiqAeEngine::MiqAeWorkspace|Workspace"
 msgstr ""
 
+#: ../model_attributes.rb:946
 msgid "MiqAlertSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:947
 msgid "MiqAlertSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:948
 msgid "MiqAlertSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:949
 msgid "MiqAlertSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:950
 msgid "MiqAlertSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:951
 msgid "MiqAlertSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:952
 msgid "MiqAlertSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:953
 msgid "MiqAlertSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:954
 msgid "MiqAlertSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:955
 msgid "MiqAlertSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:956
 msgid "MiqAlertSet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:958
 msgid "MiqAlertStatus|Evaluated on"
 msgstr ""
 
+#: ../model_attributes.rb:959
 msgid "MiqAlertStatus|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:960
 msgid "MiqAlertStatus|Result"
 msgstr ""
 
+#: ../model_attributes.rb:936
 msgid "MiqAlert|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:937
 msgid "MiqAlert|Db"
 msgstr ""
 
+#: ../model_attributes.rb:938
 msgid "MiqAlert|Description"
 msgstr ""
 
+#: ../model_attributes.rb:939
 msgid "MiqAlert|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:940
 msgid "MiqAlert|Expression"
 msgstr ""
 
+#: ../model_attributes.rb:941
 msgid "MiqAlert|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:942
 msgid "MiqAlert|Options"
 msgstr ""
 
+#: ../model_attributes.rb:943
 msgid "MiqAlert|Responds to events"
 msgstr ""
 
+#: ../model_attributes.rb:944
 msgid "MiqAlert|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:962
 msgid "MiqApproval|Approver name"
 msgstr ""
 
+#: ../model_attributes.rb:963
 msgid "MiqApproval|Approver type"
 msgstr ""
 
+#: ../model_attributes.rb:964
 msgid "MiqApproval|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:965
 msgid "MiqApproval|Description"
 msgstr ""
 
+#: ../model_attributes.rb:966
 msgid "MiqApproval|Reason"
 msgstr ""
 
+#: ../model_attributes.rb:967
 msgid "MiqApproval|Stamped on"
 msgstr ""
 
+#: ../model_attributes.rb:968
 msgid "MiqApproval|Stamper name"
 msgstr ""
 
+#: ../model_attributes.rb:969
 msgid "MiqApproval|State"
 msgstr ""
 
+#: ../model_attributes.rb:970
 msgid "MiqApproval|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:972
 msgid "MiqCimAssociation|Assoc class"
 msgstr ""
 
+#: ../model_attributes.rb:973
 msgid "MiqCimAssociation|Obj name"
 msgstr ""
 
+#: ../model_attributes.rb:974
 msgid "MiqCimAssociation|Result class"
 msgstr ""
 
+#: ../model_attributes.rb:975
 msgid "MiqCimAssociation|Result obj name"
 msgstr ""
 
+#: ../model_attributes.rb:976
 msgid "MiqCimAssociation|Result role"
 msgstr ""
 
+#: ../model_attributes.rb:977
 msgid "MiqCimAssociation|Role"
 msgstr ""
 
+#: ../model_attributes.rb:978
 msgid "MiqCimAssociation|Status"
 msgstr ""
 
+#: ../model_attributes.rb:980
 msgid "MiqCimDerivedMetric|Avg read size"
 msgstr ""
 
+#: ../model_attributes.rb:981
 msgid "MiqCimDerivedMetric|Avg write size"
 msgstr ""
 
+#: ../model_attributes.rb:982
 msgid "MiqCimDerivedMetric|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:983
 msgid "MiqCimDerivedMetric|K bytes read per sec"
 msgstr ""
 
+#: ../model_attributes.rb:984
 msgid "MiqCimDerivedMetric|K bytes transferred per sec"
 msgstr ""
 
+#: ../model_attributes.rb:985
 msgid "MiqCimDerivedMetric|K bytes written per sec"
 msgstr ""
 
+#: ../model_attributes.rb:986
 msgid "MiqCimDerivedMetric|Pct hit"
 msgstr ""
 
+#: ../model_attributes.rb:987
 msgid "MiqCimDerivedMetric|Pct read"
 msgstr ""
 
+#: ../model_attributes.rb:988
 msgid "MiqCimDerivedMetric|Pct write"
 msgstr ""
 
+#: ../model_attributes.rb:989
 msgid "MiqCimDerivedMetric|Queue depth"
 msgstr ""
 
+#: ../model_attributes.rb:990
 msgid "MiqCimDerivedMetric|Read hit ios per sec"
 msgstr ""
 
+#: ../model_attributes.rb:991
 msgid "MiqCimDerivedMetric|Read ios per sec"
 msgstr ""
 
+#: ../model_attributes.rb:992
 msgid "MiqCimDerivedMetric|Response time sec"
 msgstr ""
 
+#: ../model_attributes.rb:993
 msgid "MiqCimDerivedMetric|Service time sec"
 msgstr ""
 
+#: ../model_attributes.rb:994
 msgid "MiqCimDerivedMetric|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:995
 msgid "MiqCimDerivedMetric|Total ios per sec"
 msgstr ""
 
+#: ../model_attributes.rb:996
 msgid "MiqCimDerivedMetric|Utilization"
 msgstr ""
 
+#: ../model_attributes.rb:997
 msgid "MiqCimDerivedMetric|Wait time sec"
 msgstr ""
 
+#: ../model_attributes.rb:998
 msgid "MiqCimDerivedMetric|Write hit ios per sec"
 msgstr ""
 
+#: ../model_attributes.rb:999
 msgid "MiqCimDerivedMetric|Write ios per sec"
 msgstr ""
 
+#: ../model_attributes.rb:1001
 msgid "MiqCimInstance|Class hier"
 msgstr ""
 
+#: ../model_attributes.rb:1002
 msgid "MiqCimInstance|Class name"
 msgstr ""
 
+#: ../model_attributes.rb:1003
 msgid "MiqCimInstance|Is top managed element"
 msgstr ""
 
+#: ../model_attributes.rb:1004
 msgid "MiqCimInstance|Last update status"
 msgstr ""
 
+#: ../model_attributes.rb:1005
 msgid "MiqCimInstance|Namespace"
 msgstr ""
 
+#: ../model_attributes.rb:1006
 msgid "MiqCimInstance|Obj"
 msgstr ""
 
+#: ../model_attributes.rb:1007
 msgid "MiqCimInstance|Obj name"
 msgstr ""
 
+#: ../model_attributes.rb:1008
 msgid "MiqCimInstance|Obj name str"
 msgstr ""
 
+#: ../model_attributes.rb:1009
 msgid "MiqCimInstance|Source"
 msgstr ""
 
+#: ../model_attributes.rb:1010
 msgid "MiqCimInstance|Type spec obj"
 msgstr ""
 
+#: ../model_attributes.rb:1011
 msgid "MiqCimInstance|Vmdb obj type"
 msgstr ""
 
+#: ../model_attributes.rb:1013
 msgid "MiqDatabase|Cfme version available"
 msgstr ""
 
+#: ../model_attributes.rb:1014
 msgid "MiqDatabase|Csrf secret token"
 msgstr ""
 
+#: ../model_attributes.rb:1015
 msgid "MiqDatabase|Last replication count"
 msgstr ""
 
+#: ../model_attributes.rb:1016
 msgid "MiqDatabase|Postgres update available"
 msgstr ""
 
+#: ../model_attributes.rb:1017
 msgid "MiqDatabase|Registration http proxy server"
 msgstr ""
 
+#: ../model_attributes.rb:1018
 msgid "MiqDatabase|Registration organization"
 msgstr ""
 
+#: ../model_attributes.rb:1019
 msgid "MiqDatabase|Registration organization display name"
 msgstr ""
 
+#: ../model_attributes.rb:1020
 msgid "MiqDatabase|Registration server"
 msgstr ""
 
+#: ../model_attributes.rb:1021
 msgid "MiqDatabase|Registration type"
 msgstr ""
 
+#: ../model_attributes.rb:1022
 msgid "MiqDatabase|Session secret token"
 msgstr ""
 
+#: ../model_attributes.rb:1023
 msgid "MiqDatabase|Update repo name"
 msgstr ""
 
+#: ../model_attributes.rb:1025
 msgid "MiqDialog|Content"
 msgstr ""
 
+#: ../model_attributes.rb:1026
 msgid "MiqDialog|Default"
 msgstr ""
 
+#: ../model_attributes.rb:1027
 msgid "MiqDialog|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1028
 msgid "MiqDialog|Dialog type"
 msgstr ""
 
+#: ../model_attributes.rb:1029
 msgid "MiqDialog|File mtime"
 msgstr ""
 
+#: ../model_attributes.rb:1030
 msgid "MiqDialog|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:1031
 msgid "MiqDialog|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1033
 msgid "MiqEnterprise|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1034
 msgid "MiqEnterprise|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1035
 msgid "MiqEnterprise|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1036
 msgid "MiqEnterprise|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:1037
 msgid "MiqEnterprise|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1049
 msgid "MiqEventDefinitionSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1050
 msgid "MiqEventDefinitionSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1051
 msgid "MiqEventDefinitionSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1052
 msgid "MiqEventDefinitionSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:1053
 msgid "MiqEventDefinitionSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1054
 msgid "MiqEventDefinitionSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:1055
 msgid "MiqEventDefinitionSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:1056
 msgid "MiqEventDefinitionSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:1057
 msgid "MiqEventDefinitionSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:1058
 msgid "MiqEventDefinitionSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1059
 msgid "MiqEventDefinitionSet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1039
 msgid "MiqEventDefinition|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1040
 msgid "MiqEventDefinition|Default"
 msgstr ""
 
+#: ../model_attributes.rb:1041
 msgid "MiqEventDefinition|Definition"
 msgstr ""
 
+#: ../model_attributes.rb:1042
 msgid "MiqEventDefinition|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1043
 msgid "MiqEventDefinition|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:1044
 msgid "MiqEventDefinition|Event type"
 msgstr ""
 
+#: ../model_attributes.rb:1045
 msgid "MiqEventDefinition|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1046
 msgid "MiqEventDefinition|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1047
 msgid "MiqEventDefinition|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1061
 msgid "MiqGroup|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1062
 msgid "MiqGroup|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1063
 msgid "MiqGroup|Filters"
 msgstr ""
 
+#: ../model_attributes.rb:1064
 msgid "MiqGroup|Group type"
 msgstr ""
 
+#: ../model_attributes.rb:1065
 msgid "MiqGroup|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1066
 msgid "MiqGroup|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:1067
 msgid "MiqGroup|Sequence"
 msgstr ""
 
+#: ../model_attributes.rb:1068
 msgid "MiqGroup|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:1069
 msgid "MiqGroup|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1084
 msgid "MiqPolicyContent|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1085
 msgid "MiqPolicyContent|Failure sequence"
 msgstr ""
 
+#: ../model_attributes.rb:1086
 msgid "MiqPolicyContent|Failure synchronous"
 msgstr ""
 
+#: ../model_attributes.rb:1087
 msgid "MiqPolicyContent|Qualifier"
 msgstr ""
 
+#: ../model_attributes.rb:1088
 msgid "MiqPolicyContent|Success sequence"
 msgstr ""
 
+#: ../model_attributes.rb:1089
 msgid "MiqPolicyContent|Success synchronous"
 msgstr ""
 
+#: ../model_attributes.rb:1090
 msgid "MiqPolicyContent|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1092
 msgid "MiqPolicySet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1093
 msgid "MiqPolicySet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1094
 msgid "MiqPolicySet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1095
 msgid "MiqPolicySet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:1096
 msgid "MiqPolicySet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1097
 msgid "MiqPolicySet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:1098
 msgid "MiqPolicySet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:1099
 msgid "MiqPolicySet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:1100
 msgid "MiqPolicySet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:1101
 msgid "MiqPolicySet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1102
 msgid "MiqPolicySet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1071
 msgid "MiqPolicy|Active"
 msgstr ""
 
+#: ../model_attributes.rb:1072
 msgid "MiqPolicy|Created by"
 msgstr ""
 
+#: ../model_attributes.rb:1073
 msgid "MiqPolicy|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1074
 msgid "MiqPolicy|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1075
 msgid "MiqPolicy|Expression"
 msgstr ""
 
+#: ../model_attributes.rb:1076
 msgid "MiqPolicy|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1077
 msgid "MiqPolicy|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:1078
 msgid "MiqPolicy|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1079
 msgid "MiqPolicy|Notes"
 msgstr ""
 
+#: ../model_attributes.rb:1080
 msgid "MiqPolicy|Towhat"
 msgstr ""
 
+#: ../model_attributes.rb:1081
 msgid "MiqPolicy|Updated by"
 msgstr ""
 
+#: ../model_attributes.rb:1082
 msgid "MiqPolicy|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1104
 msgid "MiqProductFeature|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1105
 msgid "MiqProductFeature|Feature type"
 msgstr ""
 
+#: ../model_attributes.rb:1106
 msgid "MiqProductFeature|Hidden"
 msgstr ""
 
+#: ../model_attributes.rb:1107
 msgid "MiqProductFeature|Identifier"
 msgstr ""
 
+#: ../model_attributes.rb:1108
 msgid "MiqProductFeature|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1109
 msgid "MiqProductFeature|Protected"
 msgstr ""
 
+#: ../model_attributes.rb:1111
 msgid "MiqQueue|Args"
 msgstr ""
 
+#: ../model_attributes.rb:1112
 msgid "MiqQueue|Class name"
 msgstr ""
 
+#: ../model_attributes.rb:1113
 msgid "MiqQueue|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1114
 msgid "MiqQueue|Deliver on"
 msgstr ""
 
+#: ../model_attributes.rb:1115
 msgid "MiqQueue|Expires on"
 msgstr ""
 
+#: ../model_attributes.rb:1116
 msgid "MiqQueue|For user"
 msgstr ""
 
+#: ../model_attributes.rb:1117
 msgid "MiqQueue|Handler type"
 msgstr ""
 
+#: ../model_attributes.rb:1118
 msgid "MiqQueue|Lock version"
 msgstr ""
 
+#: ../model_attributes.rb:1119
 msgid "MiqQueue|Method name"
 msgstr ""
 
+#: ../model_attributes.rb:1120
 msgid "MiqQueue|Miq callback"
 msgstr ""
 
+#: ../model_attributes.rb:1121
 msgid "MiqQueue|Msg data"
 msgstr ""
 
+#: ../model_attributes.rb:1122
 msgid "MiqQueue|Msg timeout"
 msgstr ""
 
+#: ../model_attributes.rb:1123
 msgid "MiqQueue|Priority"
 msgstr ""
 
+#: ../model_attributes.rb:1124
 msgid "MiqQueue|Queue name"
 msgstr ""
 
+#: ../model_attributes.rb:1125
 msgid "MiqQueue|Role"
 msgstr ""
 
+#: ../model_attributes.rb:1126
 msgid "MiqQueue|Server guid"
 msgstr ""
 
+#: ../model_attributes.rb:1127
 msgid "MiqQueue|State"
 msgstr ""
 
+#: ../model_attributes.rb:1128
 msgid "MiqQueue|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1129
 msgid "MiqQueue|Zone"
 msgstr ""
 
+#: ../model_attributes.rb:1131
 msgid "MiqRegion|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1132
 msgid "MiqRegion|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1133
 msgid "MiqRegion|Region"
 msgstr ""
 
+#: ../model_attributes.rb:1179
 msgid "MiqReportResultDetail|Data"
 msgstr ""
 
+#: ../model_attributes.rb:1180
 msgid "MiqReportResultDetail|Data type"
 msgstr ""
 
+#: ../model_attributes.rb:1168
 msgid "MiqReportResult|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1169
 msgid "MiqReportResult|Db"
 msgstr ""
 
+#: ../model_attributes.rb:1170
 msgid "MiqReportResult|Last accessed on"
 msgstr ""
 
+#: ../model_attributes.rb:1171
 msgid "MiqReportResult|Last run on"
 msgstr ""
 
+#: ../model_attributes.rb:1172
 msgid "MiqReportResult|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1173
 msgid "MiqReportResult|Report"
 msgstr ""
 
+#: ../model_attributes.rb:1174
 msgid "MiqReportResult|Report rows per detail row"
 msgstr ""
 
+#: ../model_attributes.rb:1175
 msgid "MiqReportResult|Report source"
 msgstr ""
 
+#: ../model_attributes.rb:1176
 msgid "MiqReportResult|Scheduled on"
 msgstr ""
 
+#: ../model_attributes.rb:1177
 msgid "MiqReportResult|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1135
 msgid "MiqReport|Categories"
 msgstr ""
 
+#: ../model_attributes.rb:1136
 msgid "MiqReport|Col formats"
 msgstr ""
 
+#: ../model_attributes.rb:1137
 msgid "MiqReport|Col options"
 msgstr ""
 
+#: ../model_attributes.rb:1138
 msgid "MiqReport|Col order"
 msgstr ""
 
+#: ../model_attributes.rb:1139
 msgid "MiqReport|Cols"
 msgstr ""
 
+#: ../model_attributes.rb:1140
 msgid "MiqReport|Conditions"
 msgstr ""
 
+#: ../model_attributes.rb:1141
 msgid "MiqReport|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1142
 msgid "MiqReport|Db"
 msgstr ""
 
+#: ../model_attributes.rb:1143
 msgid "MiqReport|Db options"
 msgstr ""
 
+#: ../model_attributes.rb:1144
 msgid "MiqReport|Dims"
 msgstr ""
 
+#: ../model_attributes.rb:1145
 msgid "MiqReport|Display filter"
 msgstr ""
 
+#: ../model_attributes.rb:1146
 msgid "MiqReport|File mtime"
 msgstr ""
 
+#: ../model_attributes.rb:1147
 msgid "MiqReport|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:1148
 msgid "MiqReport|Generate cols"
 msgstr ""
 
+#: ../model_attributes.rb:1149
 msgid "MiqReport|Generate rows"
 msgstr ""
 
+#: ../model_attributes.rb:1150
 msgid "MiqReport|Graph"
 msgstr ""
 
+#: ../model_attributes.rb:1151
 msgid "MiqReport|Group"
 msgstr ""
 
+#: ../model_attributes.rb:1152
 msgid "MiqReport|Headers"
 msgstr ""
 
+#: ../model_attributes.rb:1153
 msgid "MiqReport|Include"
 msgstr ""
 
+#: ../model_attributes.rb:1154
 msgid "MiqReport|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1155
 msgid "MiqReport|Order"
 msgstr ""
 
+#: ../model_attributes.rb:1156
 msgid "MiqReport|Priority"
 msgstr ""
 
+#: ../model_attributes.rb:1157
 msgid "MiqReport|Rpt group"
 msgstr ""
 
+#: ../model_attributes.rb:1158
 msgid "MiqReport|Rpt options"
 msgstr ""
 
+#: ../model_attributes.rb:1159
 msgid "MiqReport|Rpt type"
 msgstr ""
 
+#: ../model_attributes.rb:1160
 msgid "MiqReport|Sortby"
 msgstr ""
 
+#: ../model_attributes.rb:1161
 msgid "MiqReport|Template type"
 msgstr ""
 
+#: ../model_attributes.rb:1162
 msgid "MiqReport|Timeline"
 msgstr ""
 
+#: ../model_attributes.rb:1163
 msgid "MiqReport|Title"
 msgstr ""
 
+#: ../model_attributes.rb:1164
 msgid "MiqReport|Tz"
 msgstr ""
 
+#: ../model_attributes.rb:1165
 msgid "MiqReport|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1166
 msgid "MiqReport|Where clause"
 msgstr ""
 
+#: ../model_attributes.rb:1197
 msgid "MiqRequestTask|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1198
 msgid "MiqRequestTask|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1199
 msgid "MiqRequestTask|Destination type"
 msgstr ""
 
+#: ../model_attributes.rb:1200
 msgid "MiqRequestTask|Message"
 msgstr ""
 
+#: ../model_attributes.rb:1201
 msgid "MiqRequestTask|Options"
 msgstr ""
 
+#: ../model_attributes.rb:1202
 msgid "MiqRequestTask|Phase"
 msgstr ""
 
+#: ../model_attributes.rb:1203
 msgid "MiqRequestTask|Phase context"
 msgstr ""
 
+#: ../model_attributes.rb:1204
 msgid "MiqRequestTask|Request type"
 msgstr ""
 
+#: ../model_attributes.rb:1205
 msgid "MiqRequestTask|Source type"
 msgstr ""
 
+#: ../model_attributes.rb:1206
 msgid "MiqRequestTask|State"
 msgstr ""
 
+#: ../model_attributes.rb:1207
 msgid "MiqRequestTask|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1208
 msgid "MiqRequestTask|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1209
 msgid "MiqRequestTask|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1182
 msgid "MiqRequest|Approval state"
 msgstr ""
 
+#: ../model_attributes.rb:1183
 msgid "MiqRequest|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1184
 msgid "MiqRequest|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1185
 msgid "MiqRequest|Destination type"
 msgstr ""
 
+#: ../model_attributes.rb:1186
 msgid "MiqRequest|Fulfilled on"
 msgstr ""
 
+#: ../model_attributes.rb:1187
 msgid "MiqRequest|Message"
 msgstr ""
 
+#: ../model_attributes.rb:1188
 msgid "MiqRequest|Options"
 msgstr ""
 
+#: ../model_attributes.rb:1189
 msgid "MiqRequest|Request state"
 msgstr ""
 
+#: ../model_attributes.rb:1190
 msgid "MiqRequest|Request type"
 msgstr ""
 
+#: ../model_attributes.rb:1191
 msgid "MiqRequest|Requester name"
 msgstr ""
 
+#: ../model_attributes.rb:1192
 msgid "MiqRequest|Source type"
 msgstr ""
 
+#: ../model_attributes.rb:1193
 msgid "MiqRequest|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1194
 msgid "MiqRequest|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1195
 msgid "MiqRequest|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1211
 msgid "MiqSchedule|Adhoc"
 msgstr ""
 
+#: ../model_attributes.rb:1212
 msgid "MiqSchedule|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1213
 msgid "MiqSchedule|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1214
 msgid "MiqSchedule|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:1215
 msgid "MiqSchedule|Filter"
 msgstr ""
 
+#: ../model_attributes.rb:1216
 msgid "MiqSchedule|Last run on"
 msgstr ""
 
+#: ../model_attributes.rb:1217
 msgid "MiqSchedule|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1218
 msgid "MiqSchedule|Prod default"
 msgstr ""
 
+#: ../model_attributes.rb:1219
 msgid "MiqSchedule|Run at"
 msgstr ""
 
+#: ../model_attributes.rb:1220
 msgid "MiqSchedule|Sched action"
 msgstr ""
 
+#: ../model_attributes.rb:1221
 msgid "MiqSchedule|Towhat"
 msgstr ""
 
+#: ../model_attributes.rb:1222
 msgid "MiqSchedule|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1224
 msgid "MiqScsiLun|Block"
 msgstr ""
 
+#: ../model_attributes.rb:1225
 msgid "MiqScsiLun|Block size"
 msgstr ""
 
+#: ../model_attributes.rb:1226
 msgid "MiqScsiLun|Canonical name"
 msgstr ""
 
+#: ../model_attributes.rb:1227
 msgid "MiqScsiLun|Capacity"
 msgstr ""
 
+#: ../model_attributes.rb:1228
 msgid "MiqScsiLun|Device name"
 msgstr ""
 
+#: ../model_attributes.rb:1229
 msgid "MiqScsiLun|Device type"
 msgstr ""
 
+#: ../model_attributes.rb:1230
 msgid "MiqScsiLun|Lun"
 msgstr ""
 
+#: ../model_attributes.rb:1231
 msgid "MiqScsiLun|Lun type"
 msgstr ""
 
+#: ../model_attributes.rb:1232
 msgid "MiqScsiLun|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:1234
 msgid "MiqScsiTarget|Address"
 msgstr ""
 
+#: ../model_attributes.rb:1235
 msgid "MiqScsiTarget|Iscsi alias"
 msgstr ""
 
+#: ../model_attributes.rb:1236
 msgid "MiqScsiTarget|Iscsi name"
 msgstr ""
 
+#: ../model_attributes.rb:1237
 msgid "MiqScsiTarget|Target"
 msgstr ""
 
+#: ../model_attributes.rb:1238
 msgid "MiqScsiTarget|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:1240
 msgid "MiqSearch|Db"
 msgstr ""
 
+#: ../model_attributes.rb:1241
 msgid "MiqSearch|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1242
 msgid "MiqSearch|Filter"
 msgstr ""
 
+#: ../model_attributes.rb:1243
 msgid "MiqSearch|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1244
 msgid "MiqSearch|Options"
 msgstr ""
 
+#: ../model_attributes.rb:1245
 msgid "MiqSearch|Search key"
 msgstr ""
 
+#: ../model_attributes.rb:1246
 msgid "MiqSearch|Search type"
 msgstr ""
 
+#: ../model_attributes.rb:1248
 msgid "MiqServer|Build"
 msgstr ""
 
+#: ../model_attributes.rb:1249
 msgid "MiqServer|Capabilities"
 msgstr ""
 
+#: ../model_attributes.rb:1250
 msgid "MiqServer|Cpu time"
 msgstr ""
 
+#: ../model_attributes.rb:1251
 msgid "MiqServer|Drb uri"
 msgstr ""
 
+#: ../model_attributes.rb:1252
 msgid "MiqServer|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1253
 msgid "MiqServer|Has active userinterface"
 msgstr ""
 
+#: ../model_attributes.rb:1254
 msgid "MiqServer|Has active webservices"
 msgstr ""
 
+#: ../model_attributes.rb:1255
 msgid "MiqServer|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:1256
 msgid "MiqServer|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:1257
 msgid "MiqServer|Is master"
 msgstr ""
 
+#: ../model_attributes.rb:1258
 msgid "MiqServer|Last heartbeat"
 msgstr ""
 
+#: ../model_attributes.rb:1259
 msgid "MiqServer|Last update check"
 msgstr ""
 
+#: ../model_attributes.rb:1260
 msgid "MiqServer|Logo"
 msgstr ""
 
+#: ../model_attributes.rb:1261
 msgid "MiqServer|Mac address"
 msgstr ""
 
+#: ../model_attributes.rb:1262
 msgid "MiqServer|Memory size"
 msgstr ""
 
+#: ../model_attributes.rb:1263
 msgid "MiqServer|Memory usage"
 msgstr ""
 
+#: ../model_attributes.rb:1264
 msgid "MiqServer|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1265
 msgid "MiqServer|Os priority"
 msgstr ""
 
+#: ../model_attributes.rb:1266
 msgid "MiqServer|Percent cpu"
 msgstr ""
 
+#: ../model_attributes.rb:1267
 msgid "MiqServer|Percent memory"
 msgstr ""
 
+#: ../model_attributes.rb:1268
 msgid "MiqServer|Pid"
 msgstr ""
 
+#: ../model_attributes.rb:1269
 msgid "MiqServer|Rh registered"
 msgstr ""
 
+#: ../model_attributes.rb:1270
 msgid "MiqServer|Rh subscribed"
 msgstr ""
 
+#: ../model_attributes.rb:1271
 msgid "MiqServer|Rhn mirror"
 msgstr ""
 
+#: ../model_attributes.rb:1272
 msgid "MiqServer|Sql spid"
 msgstr ""
 
+#: ../model_attributes.rb:1273
 msgid "MiqServer|Started on"
 msgstr ""
 
+#: ../model_attributes.rb:1274
 msgid "MiqServer|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1275
 msgid "MiqServer|Stopped on"
 msgstr ""
 
+#: ../model_attributes.rb:1276
 msgid "MiqServer|Updates available"
 msgstr ""
 
+#: ../model_attributes.rb:1277
 msgid "MiqServer|Upgrade message"
 msgstr ""
 
+#: ../model_attributes.rb:1278
 msgid "MiqServer|Upgrade status"
 msgstr ""
 
+#: ../model_attributes.rb:1279
 msgid "MiqServer|Version"
 msgstr ""
 
+#: ../model_attributes.rb:1281
 msgid "MiqShortcut|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1282
 msgid "MiqShortcut|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1283
 msgid "MiqShortcut|Rbac feature name"
 msgstr ""
 
+#: ../model_attributes.rb:1284
 msgid "MiqShortcut|Sequence"
 msgstr ""
 
+#: ../model_attributes.rb:1285
 msgid "MiqShortcut|Startup"
 msgstr ""
 
+#: ../model_attributes.rb:1286
 msgid "MiqShortcut|Url"
 msgstr ""
 
+#: ../model_attributes.rb:1288
 msgid "MiqStorageMetric|Metric obj"
 msgstr ""
 
+#: ../model_attributes.rb:1290
 msgid "MiqTask|Context data"
 msgstr ""
 
+#: ../model_attributes.rb:1291
 msgid "MiqTask|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1292
 msgid "MiqTask|Identifier"
 msgstr ""
 
+#: ../model_attributes.rb:1293
 msgid "MiqTask|Message"
 msgstr ""
 
+#: ../model_attributes.rb:1294
 msgid "MiqTask|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1295
 msgid "MiqTask|Pct complete"
 msgstr ""
 
+#: ../model_attributes.rb:1296
 msgid "MiqTask|Results"
 msgstr ""
 
+#: ../model_attributes.rb:1297
 msgid "MiqTask|State"
 msgstr ""
 
+#: ../model_attributes.rb:1298
 msgid "MiqTask|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1299
 msgid "MiqTask|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1300
 msgid "MiqTask|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1302
 msgid "MiqUserRole|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1303
 msgid "MiqUserRole|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:1304
 msgid "MiqUserRole|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:1317
 msgid "MiqWidgetContent|Contents"
 msgstr ""
 
+#: ../model_attributes.rb:1318
 msgid "MiqWidgetContent|Timezone"
 msgstr ""
 
+#: ../model_attributes.rb:1320
 msgid "MiqWidgetSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1321
 msgid "MiqWidgetSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1322
 msgid "MiqWidgetSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1323
 msgid "MiqWidgetSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:1324
 msgid "MiqWidgetSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1325
 msgid "MiqWidgetSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:1326
 msgid "MiqWidgetSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:1327
 msgid "MiqWidgetSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:1328
 msgid "MiqWidgetSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:1329
 msgid "MiqWidgetSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1330
 msgid "MiqWidgetSet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1332
 msgid "MiqWidgetShortcut|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1333
 msgid "MiqWidgetShortcut|Sequence"
 msgstr ""
 
+#: ../model_attributes.rb:1306
 msgid "MiqWidget|Content type"
 msgstr ""
 
+#: ../model_attributes.rb:1307
 msgid "MiqWidget|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1308
 msgid "MiqWidget|Enabled"
 msgstr ""
 
+#: ../model_attributes.rb:1309
 msgid "MiqWidget|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1310
 msgid "MiqWidget|Last generated content on"
 msgstr ""
 
+#: ../model_attributes.rb:1311
 msgid "MiqWidget|Options"
 msgstr ""
 
+#: ../model_attributes.rb:1312
 msgid "MiqWidget|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:1313
 msgid "MiqWidget|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:1314
 msgid "MiqWidget|Title"
 msgstr ""
 
+#: ../model_attributes.rb:1315
 msgid "MiqWidget|Visibility"
 msgstr ""
 
+#: ../model_attributes.rb:1335
 msgid "MiqWorker|Command line"
 msgstr ""
 
+#: ../model_attributes.rb:1336
 msgid "MiqWorker|Cpu time"
 msgstr ""
 
+#: ../model_attributes.rb:1337
 msgid "MiqWorker|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1338
 msgid "MiqWorker|Last heartbeat"
 msgstr ""
 
+#: ../model_attributes.rb:1339
 msgid "MiqWorker|Memory size"
 msgstr ""
 
+#: ../model_attributes.rb:1340
 msgid "MiqWorker|Memory usage"
 msgstr ""
 
+#: ../model_attributes.rb:1341
 msgid "MiqWorker|Os priority"
 msgstr ""
 
+#: ../model_attributes.rb:1342
 msgid "MiqWorker|Percent cpu"
 msgstr ""
 
+#: ../model_attributes.rb:1343
 msgid "MiqWorker|Percent memory"
 msgstr ""
 
+#: ../model_attributes.rb:1344
 msgid "MiqWorker|Pid"
 msgstr ""
 
+#: ../model_attributes.rb:1345
 msgid "MiqWorker|Queue name"
 msgstr ""
 
+#: ../model_attributes.rb:1346
 msgid "MiqWorker|Sql spid"
 msgstr ""
 
+#: ../model_attributes.rb:1347
 msgid "MiqWorker|Started on"
 msgstr ""
 
+#: ../model_attributes.rb:1348
 msgid "MiqWorker|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1349
 msgid "MiqWorker|Stopped on"
 msgstr ""
 
+#: ../model_attributes.rb:1350
 msgid "MiqWorker|Uri"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:50 ../../app/views/ops/_ldap_forest_entries.html.haml:17 ../../app/views/ops/_ldap_domain_show.html.haml:257 ../../app/views/ops/_settings_server_tab.html.haml:591 ../../app/views/ops/_ldap_server_entries.html.haml:20 ../../app/views/vm_common/_disks.html.haml:11
 msgid "Mode"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Monday"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:154
 msgid "Month"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form_timer.html.haml:20
 msgid "Monthly"
 msgstr ""
 
+#: ../../app/views/catalog/_column_lists.html.haml:48
 msgid "Move Selected buttons left"
 msgstr ""
 
+#: ../../app/views/catalog/_column_lists.html.haml:33
 msgid "Move Selected buttons right"
 msgstr ""
 
+#: ../../app/views/catalog/_column_lists.html.haml:48
 msgid "Move Selected fields left"
 msgstr ""
 
+#: ../../app/views/catalog/_column_lists.html.haml:33
 msgid "Move Selected fields right"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:141
 msgid "Move all VMs to right"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:170
 msgid "Move selected Action down"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:161
 msgid "Move selected Action up"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:119
 msgid "Move selected Actions into this Event"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:329
 msgid "Move selected Alerts into this Action"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:93
 msgid "Move selected Alerts into this Profile"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:177
 msgid "Move selected Conditions into this Policy"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:83
 msgid "Move selected Policies into this Profile"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:154
 msgid "Move selected VMs to left"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:128
 msgid "Move selected VMs to right"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_field_value_entry.html.haml:82
 msgid "Move selected field down"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_field_value_entry.html.haml:74
 msgid "Move selected field up"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_seq_form.html.haml:56 ../../app/views/ops/_ldap_seq_form.html.haml:56 ../../app/views/miq_ae_class/_fields_seq_form.html.haml:46 ../../app/views/miq_ae_class/_domains_priority_form.html.haml:40 ../../app/views/report/_column_lists.html.haml:35 ../../app/views/report/_column_lists.html.haml:95 ../../app/views/report/_db_seq_form.html.haml:54 ../../app/views/shared/buttons/_column_lists.html.haml:95 ../../app/views/shared/buttons/_group_order_form.html.haml:53
 msgid "Move selected fields down"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_column_lists.html.haml:49
 msgid "Move selected fields left"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_column_lists.html.haml:37
 msgid "Move selected fields right"
 msgstr ""
 
+#: ../../app/views/report/_column_lists.html.haml:103 ../../app/views/shared/buttons/_column_lists.html.haml:107
 msgid "Move selected fields to bottom"
 msgstr ""
 
+#: ../../app/views/report/_column_lists.html.haml:79 ../../app/views/shared/buttons/_column_lists.html.haml:72
 msgid "Move selected fields to top"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_seq_form.html.haml:46 ../../app/views/ops/_ldap_seq_form.html.haml:46 ../../app/views/miq_ae_class/_fields_seq_form.html.haml:35 ../../app/views/miq_ae_class/_domains_priority_form.html.haml:33 ../../app/views/report/_column_lists.html.haml:43 ../../app/views/report/_column_lists.html.haml:87 ../../app/views/report/_db_seq_form.html.haml:43 ../../app/views/shared/buttons/_column_lists.html.haml:84 ../../app/views/shared/buttons/_group_order_form.html.haml:41
 msgid "Move selected fields up"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:49
 msgid "Move selected folder down"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:53
 msgid "Move selected folder to bottom"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:41
 msgid "Move selected folder top"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:45
 msgid "Move selected folder up"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:93
 msgid "Move selected reports down"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:49
 msgid "Move selected reports left"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:60
 msgid "Move selected reports right"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:104
 msgid "Move selected reports to bottom"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:71
 msgid "Move selected reports to top"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:82
 msgid "Move selected reports up"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_vms_filter.rb:22 ../../app/views/layouts/listnav/_show_list.html.haml:37
 msgid "My Filters"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_vms_filter.rb:22
 msgid "My Personal Filters"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:17 ../../app/views/configuration/_ui_2.html.haml:46
 msgid "My Services"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:147
 msgid "My Settings"
 msgstr ""
 
-msgid "MyTags"
-msgstr ""
-
+#: ../../app/views/miq_policy/_policy_details.html.haml:82 ../../app/views/miq_policy/_policy_details.html.haml:97
 msgid "N/A"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:37
 msgid "NFS Server"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:211 ../../app/views/layouts/_tl_options.html.haml:231 ../../app/views/layouts/_tl_options.html.haml:252
 msgid "NONE"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_editor.html.haml:54
 msgid "NOT"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:61 ../../app/views/ops/_zone_form.html.haml:78 ../../app/views/ops/_settings_server_tab.html.haml:340
 msgid "NTP Servers"
 msgstr ""
 
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18 ../../app/helpers/container_image_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/helpers/container_group_helper/textual_summary.rb:16 ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/ops/_db_info.html.haml:15 ../../app/views/ops/_db_info.html.haml:118 ../../app/views/ops/_db_info.html.haml:213 ../../app/views/ops/_ap_form_nteventlog.html.haml:13 ../../app/views/ops/_settings_evm_servers_tab.html.haml:13 ../../app/views/ops/_category_form.html.haml:109 ../../app/views/ops/_ldap_region_show.html.haml:18 ../../app/views/ops/_ldap_region_show.html.haml:71 ../../app/views/ops/_ap_show.html.haml:16 ../../app/views/ops/_ap_show.html.haml:94 ../../app/views/ops/_zone_form.html.haml:16 ../../app/views/ops/_rbac_tenant_details.html.haml:17 ../../app/views/ops/_rbac_tenant_details.html.haml:93 ../../app/views/ops/_rbac_tenant_details.html.haml:125 ../../app/views/ops/_tenant_form.html.haml:17 ../../app/views/ops/_ap_form_file.html.haml:13 ../../app/views/ops/_ldap_domain_form.html.haml:12 ../../app/views/ops/_classification_entries.html.haml:15 ../../app/views/ops/_schedule_form.html.haml:17 ../../app/views/ops/_ldap_domain_show.html.haml:16 ../../app/views/ops/_ldap_region_form.html.haml:19 ../../app/views/ops/_rbac_role_details.html.haml:25 ../../app/views/ops/_ap_form.html.haml:18 ../../app/views/ops/_settings_co_categories_tab.html.haml:12 ../../app/views/provider_foreman/_form.html.haml:13 ../../app/views/service/_service_form.html.haml:17 ../../app/views/storage_manager/_form.html.haml:19 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:12 ../../app/views/repository/_form.html.haml:16 ../../app/views/host/_form.html.haml:21 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:17 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:20 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:35 ../../app/views/_ldap_domain_form.html.haml:12 ../../app/views/chargeback/_cb_assignments.html.haml:72 ../../app/views/chargeback/_reports_list.html.haml:58 ../../app/views/vm_common/_snap.html.haml:14 ../../app/views/miq_ae_class/_method_inputs.html.haml:32 ../../app/views/miq_ae_class/_ns_list.html.haml:16 ../../app/views/miq_ae_class/_ns_list.html.haml:91 ../../app/views/miq_ae_class/_instance_form.html.haml:27 ../../app/views/miq_ae_class/_instance_form.html.haml:87 ../../app/views/miq_ae_class/_instance_fields.html.haml:15 ../../app/views/miq_ae_class/_method_form.html.haml:31 ../../app/views/miq_ae_class/_method_form.html.haml:139 ../../app/views/miq_ae_class/_class_form.html.haml:27 ../../app/views/miq_ae_class/_class_props.html.haml:29 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94 ../../app/views/configuration/_timeprofile_form.html.haml:160 ../../app/views/report/_schedule_form.html.haml:17 ../../app/views/report/_report_list.html.haml:49 ../../app/views/report/_report_list.html.haml:88 ../../app/views/report/_report_list.html.haml:124 ../../app/views/report/_db_show.html.haml:14 ../../app/views/report/_db_form.html.haml:20 ../../app/views/report/_report_info.html.haml:124 ../../app/views/ontap_file_share/_create_datastore.html.haml:18 ../../app/views/shared/views/ems_common/angular/_form.html.haml:13 ../../app/views/shared/views/ems_common/_form.html.haml:18 ../../app/views/catalog/_form_resources_info.html.haml:48 ../../app/views/catalog/_ot_tree_show.html.haml:11 ../../app/views/catalog/_ot_add.html.haml:14 ../../app/views/catalog/_ot_copy.html.haml:22 ../../app/views/catalog/_svccat_tree_show.html.haml:27 ../../app/views/catalog/_sandt_tree_show.html.haml:231 ../../app/views/catalog/_stcat_tree_show.html.haml:11 ../../app/views/catalog/_stcat_form.html.haml:20 ../../app/views/catalog/_ot_edit.html.haml:14 ../../app/views/pxe/_pxe_image_type_form.html.haml:17 ../../app/views/pxe/_template_form.html.haml:15 ../../app/views/pxe/_iso_datastore_details.html.haml:25 ../../app/views/pxe/_pxe_server_details.html.haml:59 ../../app/views/pxe/_pxe_server_details.html.haml:106 ../../app/views/pxe/_pxe_form.html.haml:17 ../../app/views/miq_policy/_action_details.html.haml:76 ../../app/views/miq_capacity/_planning_summary.html.haml:49
 msgid "Name"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:15 ../../app/views/catalog/_sandt_tree_show.html.haml:36
 msgid "Name / Description"
 msgstr ""
 
+#: ../../app/views/layouts/quadicon/_storage.html.haml:61 ../../app/views/layouts/quadicon/_storage.html.haml:67
 msgid "Name: %s | %s Type: %s"
 msgstr ""
 
+#: ../../app/views/layouts/quadicon/_host.html.haml:76 ../../app/views/layouts/quadicon/_host.html.haml:85 ../../app/views/layouts/quadicon/_host.html.haml:94
 msgid "Name: %s | Hostname: %s"
 msgstr ""
 
+#: ../../app/views/layouts/quadicon/_ext_management_system.html.haml:78
 msgid "Name: %s | Hostname: %s | Refresh Status: %s"
 msgstr ""
 
+#: ../../app/views/layouts/quadicon/_repository.html.haml:28 ../../app/views/layouts/quadicon/_repository.html.haml:34
 msgid "Name: %s | Path: %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:114
 msgid "Namespace"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_all_tabs.html.haml:64
 msgid "Namespace Details"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_all_tabs.html.haml:78
 msgid "Namespaces"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:78 ../../app/views/shared/views/_prov_dialog.html.haml:284
 msgid "Naming"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:61 ../../app/views/layouts/listnav/_host.html.haml:67 ../model_attributes.rb:1351
 msgid "Network"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:196
 msgid "Network Adapter Information"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:189
 msgid "Network Adapters"
 msgstr ""
 
+#: ../../app/views/security_group/_main.html.haml:20
 msgid "Network Protocol"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:138
 msgid "Network Type"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:72
 msgid "Networks"
 msgstr ""
 
+#: ../model_attributes.rb:1352
 msgid "Network|Default gateway"
 msgstr ""
 
+#: ../model_attributes.rb:1353
 msgid "Network|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1354
 msgid "Network|Dhcp enabled"
 msgstr ""
 
+#: ../model_attributes.rb:1355
 msgid "Network|Dhcp server"
 msgstr ""
 
+#: ../model_attributes.rb:1356
 msgid "Network|Dns server"
 msgstr ""
 
+#: ../model_attributes.rb:1357
 msgid "Network|Domain"
 msgstr ""
 
+#: ../model_attributes.rb:1358
 msgid "Network|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1359
 msgid "Network|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:1360
 msgid "Network|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:1361
 msgid "Network|Ipv6address"
 msgstr ""
 
+#: ../model_attributes.rb:1362
 msgid "Network|Lease expires"
 msgstr ""
 
+#: ../model_attributes.rb:1363
 msgid "Network|Lease obtained"
 msgstr ""
 
+#: ../model_attributes.rb:1364
 msgid "Network|Subnet mask"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_footer.html.haml:13
 msgid "Never"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_field_value_entry.html.haml:58
 msgid "New Entry"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_class_fields.html.haml:164
 msgid "New Field"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:62
 msgid "New Name"
 msgstr ""
 
+#: ../../app/views/catalog/_ot_copy.html.haml:8
 msgid "New Orchestration Template Information"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_form.html.haml:203
 msgid "New Parameter"
 msgstr ""
 
+#: ../../app/views/dashboard/_login_more.html.haml:8
 msgid "New Password"
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:80
 msgid "New setting will affect Orchestration Stack"
 msgid_plural "New setting will affect Orchestration Stacks"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/views/shared/views/_retire.html.haml:77
 msgid "New setting will affect Service"
 msgid_plural "New setting will affect Services"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/views/shared/views/_retire.html.haml:84
 msgid "New setting will affect VM"
 msgid_plural "New setting will affect VMs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/controllers/catalog_controller.rb:972
 msgid "New template content cannot be empty"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_footer.html.haml:17
 msgid "Next"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_show.html.haml:108 ../../app/views/report/_widget_show.html.haml:305 ../../app/views/report/_show_schedule.html.haml:106 ../../app/views/report/_report_info.html.haml:149
 msgid "Next Run Time"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:78 ../../app/views/report/_report_list.html.haml:180 ../../app/views/miq_policy/_alert_details.html.haml:55 ../../app/views/miq_policy/_policy_details.html.haml:70
 msgid "No"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_list.html.haml:5
 msgid "No %s %s Policies are defined %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_list.html.haml:7
 msgid "No %s Alert Profiles are defined %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_list.html.haml:9
 msgid "No %s Conditions are defined %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_list.html.haml:7
 msgid "No %s Policy Profiles are defined%s."
 msgstr ""
 
+#: ../../app/views/layouts/_classify_table.html.haml:24 ../../app/views/layouts/_tag_edit_assignments.html.haml:31
 msgid "No %s Tags are assigned"
 msgstr ""
 
+#: ../../app/views/layouts/_classify_table.html.haml:27 ../../app/views/layouts/_tag_edit_assignments.html.haml:34
 msgid "No %s Tags are common to all of the items below"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tag_box.html.haml:19
 msgid "No %s Tags have been assigned"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:287
 msgid "No %s found"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:44
 msgid "No %s found in the current region."
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_resources.html.haml:24
 msgid "No %s found."
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:898
 msgid "No %s selected to set to Asynchronous"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:881
 msgid "No %s selected to set to Synchronous"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:925
 msgid "No %s were moved up"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:294 ../../app/controllers/configuration_controller.rb:375 ../../app/controllers/ems_common.rb:943
 msgid "No %s were selected for deletion"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:140 ../../app/controllers/ops_controller/settings/schedules.rb:204
 msgid "No %s were selected to be disabled"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:137 ../../app/controllers/ops_controller/settings/schedules.rb:202
 msgid "No %s were selected to be enabled"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:727
 msgid "No %s were selected to move bottom"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:464 ../../app/controllers/report_controller/menus.rb:505 ../../app/controllers/report_controller/menus.rb:549 ../../app/controllers/report_controller/reports/editor.rb:893 ../../app/controllers/report_controller/reports/editor.rb:1022 ../../app/controllers/miq_ae_class_controller.rb:2359 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:649 ../../app/controllers/ops_controller/ops_rbac.rb:460 ../../app/controllers/application_controller/buttons.rb:1057
 msgid "No %s were selected to move down"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:440 ../../app/controllers/miq_policy_controller/miq_actions.rb:189 ../../app/controllers/miq_policy_controller/miq_actions.rb:209 ../../app/controllers/vm_common.rb:1829 ../../app/controllers/application_controller.rb:592 ../../app/controllers/miq_policy_controller.rb:796 ../../app/controllers/miq_policy_controller.rb:834
 msgid "No %s were selected to move left"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:455 ../../app/controllers/miq_policy_controller/miq_actions.rb:199 ../../app/controllers/vm_common.rb:1817 ../../app/controllers/application_controller.rb:593 ../../app/controllers/miq_policy_controller.rb:817
 msgid "No %s were selected to move right"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:1068
 msgid "No %s were selected to move to the bottom"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:1046
 msgid "No %s were selected to move to the top"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:706
 msgid "No %s were selected to move top"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:440 ../../app/controllers/report_controller/menus.rb:484 ../../app/controllers/report_controller/menus.rb:528 ../../app/controllers/report_controller/reports/editor.rb:923 ../../app/controllers/report_controller/reports/editor.rb:1000 ../../app/controllers/miq_ae_class_controller.rb:2340 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:640 ../../app/controllers/ops_controller/ops_rbac.rb:438 ../../app/controllers/application_controller/buttons.rb:1036
 msgid "No %s were selected to move up"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:302 ../../app/controllers/repository_controller.rb:327 ../../app/controllers/miq_request_controller.rb:519 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:62 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1336 ../../app/controllers/service_controller.rb:260 ../../app/controllers/catalog_controller.rb:335 ../../app/controllers/catalog_controller.rb:1188 ../../app/controllers/ops_controller/settings/ldap.rb:113 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:381 ../../app/controllers/ops_controller/settings/schedules.rb:175 ../../app/controllers/mixins/containers_common_mixin.rb:129 ../../app/controllers/ems_common.rb:970 ../../app/controllers/ems_common.rb:1001 ../../app/controllers/miq_task_controller.rb:128 ../../app/controllers/miq_task_controller.rb:153 ../../app/controllers/miq_task_controller.rb:183 ../../app/controllers/provider_foreman_controller.rb:53 ../../app/controllers/application_controller/ci_processing.rb:1148 ../../app/controllers/application_controller/ci_processing.rb:1236 ../../app/controllers/application_controller/ci_processing.rb:1535 ../../app/controllers/application_controller/ci_processing.rb:1681 ../../app/controllers/application_controller/ci_processing.rb:1760 ../../app/controllers/application_controller/ci_processing.rb:1821 ../../app/controllers/application_controller/ci_processing.rb:1854
 msgid "No %{model} were selected for %{task}"
 msgstr ""
 
+#: ../../app/controllers/storage_manager_controller.rb:413 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:214 ../../app/controllers/pxe_controller/iso_datastores.rb:107 ../../app/controllers/pxe_controller/pxe_image_types.rb:100 ../../app/controllers/pxe_controller/pxe_servers.rb:129
 msgid "No %{model} were selected to %{button}"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:2489
 msgid "No %{model} were selected to be marked as %{action}"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_list.html.haml:4
 msgid "No Actions are defined %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_list.html.haml:4
 msgid "No Alerts are defined %s."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:42
 msgid "No Alerts are defined."
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:458
 msgid "No Alerts have been selected."
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:181
 msgid "No Attribute/Value Pairs found"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_show.html.haml:168
 msgid "No Attribute/Value Pairs found."
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:107
 msgid "No Backup Schedules are defined"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:192
 msgid "No Buttons found."
 msgstr ""
 
+#: ../../app/views/layouts/_perf_charts.html.haml:27 ../../app/views/layouts/_perf_charts.html.haml:97 ../../app/views/layouts/_perf_charts.html.haml:125 ../../app/views/layouts/_perf_charts.html.haml:162
 msgid "No Capacity & Utilization data available."
 msgstr ""
 
+#: ../../app/views/catalog/_stcat_tree_show.html.haml:38
 msgid "No Catalog Items found."
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_field.html.haml:184 ../../app/views/miq_request/_prov_field.html.haml:250 ../../app/views/miq_request/_prov_field.html.haml:300 ../../app/views/miq_request/_prov_field.html.haml:423 ../../app/views/miq_request/_prov_field.html.haml:473 ../../app/views/miq_request/_prov_field.html.haml:516
 msgid "No Choices Available"
 msgstr ""
 
+#: ../../app/controllers/application_controller/explorer.rb:768
 msgid "No Class found for explorer tree node id '%s'"
 msgstr ""
 
+#: ../../app/views/report/_db_list.html.haml:89
 msgid "No Dashboards are defined for this group. Default dashboard will be shown."
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:100
 msgid "No Datastores found in the current region."
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:242
 msgid "No Default Repository SmartProxy is configured, contact your CFME Administrator"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:86
 msgid "No Dialog"
 msgstr ""
 
+#: ../../app/views/report/_form_filter.html.haml:71
 msgid "No Display Filter defined."
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:52 ../../app/views/shared/views/_ownership.html.haml:54
 msgid "No Group"
 msgstr ""
 
+#: ../../app/controllers/application_controller/performance.rb:48
 msgid "No Hourly or Daily data is available, real time data from the Most Recent Hour is being displayed"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:204
 msgid "No Indexes found for this table."
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_list.html.haml:32
 msgid "No Items found."
 msgstr ""
 
-msgid "No MyTags have been created"
-msgstr ""
-
+#: ../../app/controllers/catalog_controller.rb:593
 msgid "No Ordering Dialog is available"
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:23 ../../app/views/shared/views/_ownership.html.haml:25
 msgid "No Owner"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:134
 msgid "No Policies are defined."
 msgstr ""
 
+#: ../../app/views/layouts/_protect.html.haml:8
 msgid "No Policy Profiles available."
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:130
 msgid "No Policy scope defined, the scope of this policy includes all elements."
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_rss.html.haml:7
 msgid "No RSS Feed data found"
 msgstr ""
 
+#: ../../app/views/alert/_rss_list.html.haml:12
 msgid "No RSS Feeds Found"
 msgstr ""
 
+#: ../../app/views/report/_form_filter.html.haml:32
 msgid "No Record Filter defined."
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:7 ../../app/views/ops/_ldap_region_show.html.haml:62 ../../app/views/ops/_ldap_domain_show.html.haml:246 ../../app/views/ops/_analytics_details_tab.html.haml:14 ../../app/views/miq_request/_ae_prov_show.html.haml:7 ../../app/views/layouts/_gtl.html.haml:29 ../../app/views/layouts/_drift.html.haml:6 ../../app/views/layouts/_compare.html.haml:4 ../../app/views/layouts/_x_gtl.html.haml:23 ../../app/views/configuration/_ui_4.html.haml:8
 msgid "No Records Found."
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:100
 msgid "No Report Schedules were selected to be Run now"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_report.html.haml:10
 msgid "No Report data found"
 msgstr ""
 
+#: ../../app/views/chargeback/_reports_list.html.haml:15 ../../app/views/chargeback/_reports_list.html.haml:45 ../../app/views/chargeback/_reports_list.html.haml:99 ../../app/views/report/_report_list.html.haml:32 ../../app/views/report/_savedreports_list.html.haml:11
 msgid "No Reports available."
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:224
 msgid "No Resources found."
 msgstr ""
 
+#: ../../app/views/report/_report_saved_reports.html.haml:6 ../../app/views/report/_role_list.html.haml:61
 msgid "No Saved Reports available."
 msgstr ""
 
+#: ../../app/views/report/_schedule_list.html.haml:12
 msgid "No Schedules available."
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:292
 msgid "No Server was selected"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:166
 msgid "No Servers Found."
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_roles_servers_tab.html.haml:19 ../../app/views/ops/_diagnostics_servers_roles_tab.html.haml:19
 msgid "No Servers found."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:121
 msgid "No Time Profile Selected"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:136 ../../app/views/report/_form_filter_performance.html.haml:58 ../../app/views/miq_capacity/_utilization_options.html.haml:73 ../../app/views/miq_capacity/_planning_options.html.haml:441
 msgid "No Time Profiles found"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_bottlenecks_tl_detail.html.haml:21
 msgid "No Timeline data available."
 msgstr ""
 
+#: ../../app/controllers/application_controller/performance.rb:195
 msgid "No Utilization data available"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_utilization_tab.html.haml:11
 msgid "No Utilization data available for this Server's Virtual Machine."
 msgstr ""
 
+#: ../../app/controllers/miq_capacity_controller.rb:110
 msgid "No Utilization data available to generate planning results"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:85
 msgid "No VMs found"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/rsop.rb:28
 msgid "No VMs match the selection criteria"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_report.html.haml:56
 msgid "No Widget compatible Reports found"
 msgstr ""
 
+#: ../../app/views/report/_widget_list.html.haml:4 ../../app/views/report/_widget_list.html.haml:11
 msgid "No Widgets available."
 msgstr ""
 
+#: ../../app/views/ops/_settings_list_tab.html.haml:6 ../../app/views/ops/_diagnostics_zones_tab.html.haml:6
 msgid "No Zones found."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:326
 msgid "No alarms found for the selected %s"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_chart.html.haml:13
 msgid "No chart data found"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1841
 msgid "No child VMs to move right, no action taken"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:96
 msgid "No common configuration profiles available for the selected configured %s"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:232
 msgid "No conditions defined. This policy is unconditional and will ALWAYS return true."
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:164
 msgid "No custom image has been uploaded"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_blank.html.haml:9
 msgid "No data found."
 msgstr ""
 
+#: ../../app/views/layouts/_drift_history.html.haml:13
 msgid "No drift history found, an Analysis or Virtual Black Box Synchronization for this VM may need to be run."
 msgstr ""
 
+#: ../../app/controllers/application_controller/timelines.rb:107
 msgid "No events available for this timeline"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_bottlenecks_tl_detail.html.haml:17
 msgid "No events available for this timeline."
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_expression.html.haml:20
 msgid "No expression defined, a condition must contain a valid expression."
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_show_list.html.haml:4
 msgid "No filters defined."
 msgstr ""
 
+#: ../../app/controllers/application_controller/compare.rb:941 ../../app/controllers/application_controller/compare.rb:990
 msgid "No more than %{max} %{model} can be selected for %{action}"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_details.html.haml:115 ../../app/views/miq_policy/_profile_details.html.haml:189 ../../app/views/miq_policy/_alert_profile_details.html.haml:165 ../../app/views/miq_policy/_policy_details.html.haml:436
 msgid "No notes have been entered."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_report.html.haml:29 ../../app/views/miq_capacity/_utilization_details.html.haml:18 ../../app/views/miq_capacity/_utilization_summary.html.haml:53
 msgid "No performance data is available for the selected item."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_summary.html.haml:34
 msgid "No planning data is available for the selected item."
 msgstr ""
 
+#: ../../app/views/layouts/_policy_sim.html.haml:45
 msgid "No policies have been chosen yet"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:418 ../../app/controllers/report_controller/saved_reports.rb:75 ../../app/controllers/application_controller.rb:802 ../../app/helpers/application_helper/toolbar_builder.rb:87 ../../app/helpers/application_helper/toolbar_builder.rb:172
 msgid "No records found for this report"
 msgstr ""
 
+#: ../../app/controllers/miq_capacity_controller.rb:736 ../../app/controllers/dashboard_controller.rb:784 ../../app/controllers/application_controller/timelines.rb:225 ../../app/controllers/application_controller/timelines.rb:481
 msgid "No records found for this timeline"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:9
 msgid "No saved filters or report filters are available to load"
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_scope.html.haml:22 ../../app/views/miq_policy/_condition_details.html.haml:62
 msgid "No scope defined, the scope of this condition includes all elements."
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_menu.html.haml:26
 msgid "No shortcuts are authorized for this user, contact your Administrator"
 msgstr ""
 
+#: ../../app/views/layouts/gtl/_list.html.haml:212
 msgid "No task target captured"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:323
 msgid "No timer is attached to this Widget, its contents will not be updated."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:29
 msgid "No type set"
 msgstr ""
 
-msgid "No usage data found for specified options"
-msgstr ""
-
+#: ../../app/controllers/ops_controller/settings/upload.rb:86
 msgid "No valid import records were found, please upload another file"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:387
 msgid "No variables configured."
 msgstr ""
 
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18
 msgid "Node Port"
 msgstr ""
 
+#: ../../app/views/container_group/_main.html.haml:12
 msgid "Node Selector"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:37
 msgid "Nodes"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:151
 msgid "Non-VM Files"
 msgstr ""
 
+#: ../../app/services/user_validation_service.rb:69
 msgid "Non-admin users can not access the system until at least 1 VM/Instance has been discovered"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:61 ../../app/views/ops/_rbac_role_details.html.haml:64 ../../app/views/miq_request/_prov_vm_grid.html.haml:30 ../../app/views/miq_request/_prov_host_grid.html.haml:32 ../../app/views/miq_request/_prov_vc_grid.html.haml:26 ../../app/views/miq_request/_prov_pxe_img_grid.html.haml:25 ../../app/views/miq_request/_prov_ds_grid.html.haml:28 ../../app/views/miq_request/_prov_field.html.haml:258 ../../app/views/miq_request/_prov_field.html.haml:308 ../../app/views/miq_request/_prov_field.html.haml:431 ../../app/views/miq_request/_prov_field.html.haml:524 ../../app/views/miq_request/_prov_iso_img_grid.html.haml:25 ../../app/views/miq_request/_prov_template_grid.html.haml:25 ../../app/views/miq_request/_prov_windows_image_grid.html.haml:25 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:127 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:161 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:295 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:439 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/layouts/_edit_to_email.html.haml:22 ../../app/views/report/_form_columns_trend.html.haml:42 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_formatting.html.haml:88 ../../app/views/report/_form_sort.html.haml:119 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:6 ../../app/views/shared/views/_retire.html.haml:51 ../../app/views/catalog/_form_resources_info.html.haml:110 ../../app/views/miq_policy/_alert_snmp.html.haml:129 ../../app/views/miq_policy/_action_options.html.haml:475 ../../app/views/miq_policy/_action_options.html.haml:487 ../../app/views/miq_capacity/_utilization_options.html.haml:46
 msgid "None"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:233 ../../app/views/miq_request/_prov_options.html.haml:34
 msgid "None Available"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_to_email.html.haml:55
 msgid "None Available or All Selected"
 msgstr ""
 
+#: ../../app/views/report/_form_styling.html.haml:56
 msgid "Normal"
 msgstr ""
 
+#: ../../app/views/vm_common/_main.html.haml:18
 msgid "Normal Operating Ranges (over 30 days)"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:8
 msgid "Normal Operating Ranges (up to 30 days' data)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:75 ../../app/views/resource_pool/_config.html.haml:18 ../../app/views/ems_cluster/_config.html.haml:8 ../../app/views/layouts/_item.html.haml:137 ../../app/views/vm_common/_right_size.html.haml:1 ../../app/views/vm_common/_config.html.haml:55
 msgid "Not Available"
 msgstr ""
 
+#: ../../app/views/vm_common/_evm_relationship.html.haml:22
 msgid "Not a Server"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:81 ../../app/views/report/_form_consolidate.html.haml:149
 msgid "Note:"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_edit.html.haml:12 ../../app/views/catalog/_form_request_info.html.haml:15
 msgid "Note: Fields marked with * are required."
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:75
 msgid "Note: Gap Collection is only available for VMware vSphere Infrastructures"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_performance.html.haml:77
 msgid "Note: Only Time Profiles with 'Roll Up Performance' set are shown."
 msgstr ""
 
+#: ../../app/views/layouts/_auth_credentials.html.haml:27
 msgid "Note: Username must be in the format: name@realm"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_details.html.haml:95 ../../app/views/miq_policy/_condition_details.html.haml:112 ../../app/views/miq_policy/_profile_details.html.haml:167 ../../app/views/miq_policy/_profile_details.html.haml:186 ../../app/views/miq_policy/_alert_profile_details.html.haml:137 ../../app/views/miq_policy/_alert_profile_details.html.haml:161 ../../app/views/miq_policy/_policy_details.html.haml:414 ../../app/views/miq_policy/_policy_details.html.haml:433
 msgid "Notes"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_assignments.html.haml:1 ../../app/views/miq_policy/_alert_profile_assign.html.haml:35 ../../app/views/miq_policy/_alert_profile_details.html.haml:236
 msgid "Nothing"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:171
 msgid "Notification Frequency"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:249 ../../app/views/miq_policy/_action_details.html.haml:270
 msgid "Number of CPU's"
 msgstr ""
 
+#: ../../app/views/ems_infra/scaling.html.haml:27
 msgid "Number of Hosts"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:69
 msgid "Number of Instances"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:200
 msgid "Number of Rows to Show"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:69
 msgid "Number of VMs"
 msgstr ""
 
+#: ../../app/views/layouts/_exp_editor.html.haml:65 ../../app/views/layouts/_exp_editor.html.haml:90
 msgid "OR with a new expression element"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:173
 msgid "OS"
 msgstr ""
 
+#: ../../app/views/report/sample_chart.html.haml:93 ../../app/views/report/sample_chart.html.haml:147
 msgid "OS %s"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:92 ../../app/views/layouts/listnav/_host.html.haml:91 ../../app/views/layouts/listnav/_host.html.haml:97
 msgid "OS Information"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_tabs.html.haml:10
 msgid "Object"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:83 ../../app/views/layouts/_ae_resolve_options.html.haml:107 ../../app/views/shared/buttons/_ab_show.html.haml:126
 msgid "Object Attribute"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_uri.html.haml:30
 msgid "Object Attribute Name"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_uri.html.haml:43
 msgid "Object Attribute Type"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:12 ../../app/views/shared/buttons/_ab_show.html.haml:76 ../../app/views/miq_policy/_action_details.html.haml:123
 msgid "Object Details"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:443 ../../app/views/miq_policy/_action_details.html.haml:396
 msgid "Object ID"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_uri.html.haml:7
 msgid "Object Info"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:39 ../../app/views/shared/buttons/_ab_list.html.haml:11
 msgid "Object Types"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:21
+msgid "Observed"
+msgstr ""
+
+#: ../../app/views/miq_task/_tasks_options.html.haml:104 ../../app/views/miq_task/_tasks_options.html.haml:104
 msgid "Ok"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:91 ../../app/views/miq_ae_class/_instance_fields.html.haml:19 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "On Entry"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:95 ../../app/views/miq_ae_class/_instance_fields.html.haml:23 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "On Error"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:93 ../../app/views/miq_ae_class/_instance_fields.html.haml:21 ../../app/views/miq_ae_class/_class_fields.html.haml:16 ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "On Exit"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form_timer.html.haml:20
 msgid "Once"
 msgstr ""
 
+#: ../../app/controllers/application_controller/tags.rb:122 ../../app/controllers/application_controller/ci_processing.rb:34 ../../app/controllers/application_controller/ci_processing.rb:321 ../../app/controllers/application_controller/ci_processing.rb:1023 ../../app/controllers/application_controller/policy_support.rb:170
 msgid "One or more %{model} must be selected to %{task}"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:467
 msgid "One or more selected reports are not owned by your group, they cannot be moved"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:88
 msgid "Only 1 Date or Date/Time element can be present in a Dialog"
 msgstr ""
 
+#: ../model_attributes.rb:1365
 msgid "Ontap aggregate derived metric"
 msgstr ""
 
+#: ../model_attributes.rb:1376
 msgid "Ontap aggregate metrics rollup"
 msgstr ""
 
+#: ../model_attributes.rb:1402
 msgid "Ontap disk derived metric"
 msgstr ""
 
+#: ../model_attributes.rb:1433
 msgid "Ontap disk metrics rollup"
 msgstr ""
 
+#: ../model_attributes.rb:1519
 msgid "Ontap lun derived metric"
 msgstr ""
 
+#: ../model_attributes.rb:1531
 msgid "Ontap lun metrics rollup"
 msgstr ""
 
+#: ../model_attributes.rb:1560
 msgid "Ontap system derived metric"
 msgstr ""
 
+#: ../model_attributes.rb:1582
 msgid "Ontap system metrics rollup"
 msgstr ""
 
+#: ../model_attributes.rb:1641
 msgid "Ontap volume derived metric"
 msgstr ""
 
+#: ../model_attributes.rb:1680
 msgid "Ontap volume metrics rollup"
 msgstr ""
 
+#: ../model_attributes.rb:1366
 msgid "OntapAggregateDerivedMetric|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1367
 msgid "OntapAggregateDerivedMetric|Cp read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1368
 msgid "OntapAggregateDerivedMetric|Cp reads"
 msgstr ""
 
+#: ../model_attributes.rb:1369
 msgid "OntapAggregateDerivedMetric|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1370
 msgid "OntapAggregateDerivedMetric|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1371
 msgid "OntapAggregateDerivedMetric|Total transfers"
 msgstr ""
 
+#: ../model_attributes.rb:1372
 msgid "OntapAggregateDerivedMetric|User read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1373
 msgid "OntapAggregateDerivedMetric|User reads"
 msgstr ""
 
+#: ../model_attributes.rb:1374
 msgid "OntapAggregateDerivedMetric|User write blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1375
 msgid "OntapAggregateDerivedMetric|User writes"
 msgstr ""
 
+#: ../model_attributes.rb:1377
 msgid "OntapAggregateMetricsRollup|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1378
 msgid "OntapAggregateMetricsRollup|Cp read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1379
 msgid "OntapAggregateMetricsRollup|Cp read blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1380
 msgid "OntapAggregateMetricsRollup|Cp read blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1381
 msgid "OntapAggregateMetricsRollup|Cp reads"
 msgstr ""
 
+#: ../model_attributes.rb:1382
 msgid "OntapAggregateMetricsRollup|Cp reads max"
 msgstr ""
 
+#: ../model_attributes.rb:1383
 msgid "OntapAggregateMetricsRollup|Cp reads min"
 msgstr ""
 
+#: ../model_attributes.rb:1384
 msgid "OntapAggregateMetricsRollup|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1385
 msgid "OntapAggregateMetricsRollup|Rollup type"
 msgstr ""
 
+#: ../model_attributes.rb:1386
 msgid "OntapAggregateMetricsRollup|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1387
 msgid "OntapAggregateMetricsRollup|Total transfers"
 msgstr ""
 
+#: ../model_attributes.rb:1388
 msgid "OntapAggregateMetricsRollup|Total transfers max"
 msgstr ""
 
+#: ../model_attributes.rb:1389
 msgid "OntapAggregateMetricsRollup|Total transfers min"
 msgstr ""
 
+#: ../model_attributes.rb:1390
 msgid "OntapAggregateMetricsRollup|User read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1391
 msgid "OntapAggregateMetricsRollup|User read blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1392
 msgid "OntapAggregateMetricsRollup|User read blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1393
 msgid "OntapAggregateMetricsRollup|User reads"
 msgstr ""
 
+#: ../model_attributes.rb:1394
 msgid "OntapAggregateMetricsRollup|User reads max"
 msgstr ""
 
+#: ../model_attributes.rb:1395
 msgid "OntapAggregateMetricsRollup|User reads min"
 msgstr ""
 
+#: ../model_attributes.rb:1396
 msgid "OntapAggregateMetricsRollup|User write blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1397
 msgid "OntapAggregateMetricsRollup|User write blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1398
 msgid "OntapAggregateMetricsRollup|User write blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1399
 msgid "OntapAggregateMetricsRollup|User writes"
 msgstr ""
 
+#: ../model_attributes.rb:1400
 msgid "OntapAggregateMetricsRollup|User writes max"
 msgstr ""
 
+#: ../model_attributes.rb:1401
 msgid "OntapAggregateMetricsRollup|User writes min"
 msgstr ""
 
+#: ../model_attributes.rb:1403
 msgid "OntapDiskDerivedMetric|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1404
 msgid "OntapDiskDerivedMetric|Cp read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1405
 msgid "OntapDiskDerivedMetric|Cp read chain"
 msgstr ""
 
+#: ../model_attributes.rb:1406
 msgid "OntapDiskDerivedMetric|Cp read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1407
 msgid "OntapDiskDerivedMetric|Cp reads"
 msgstr ""
 
+#: ../model_attributes.rb:1408
 msgid "OntapDiskDerivedMetric|Disk busy"
 msgstr ""
 
+#: ../model_attributes.rb:1409
 msgid "OntapDiskDerivedMetric|Guarenteed read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1410
 msgid "OntapDiskDerivedMetric|Guarenteed read chain"
 msgstr ""
 
+#: ../model_attributes.rb:1411
 msgid "OntapDiskDerivedMetric|Guarenteed read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1412
 msgid "OntapDiskDerivedMetric|Guarenteed reads"
 msgstr ""
 
+#: ../model_attributes.rb:1413
 msgid "OntapDiskDerivedMetric|Guarenteed write blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1414
 msgid "OntapDiskDerivedMetric|Guarenteed write chain"
 msgstr ""
 
+#: ../model_attributes.rb:1415
 msgid "OntapDiskDerivedMetric|Guarenteed write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1416
 msgid "OntapDiskDerivedMetric|Guarenteed writes"
 msgstr ""
 
+#: ../model_attributes.rb:1417
 msgid "OntapDiskDerivedMetric|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1418
 msgid "OntapDiskDerivedMetric|Io pending"
 msgstr ""
 
+#: ../model_attributes.rb:1419
 msgid "OntapDiskDerivedMetric|Io queued"
 msgstr ""
 
+#: ../model_attributes.rb:1420
 msgid "OntapDiskDerivedMetric|Skip blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1421
 msgid "OntapDiskDerivedMetric|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1422
 msgid "OntapDiskDerivedMetric|Total transfers"
 msgstr ""
 
+#: ../model_attributes.rb:1423
 msgid "OntapDiskDerivedMetric|User read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1424
 msgid "OntapDiskDerivedMetric|User read chain"
 msgstr ""
 
+#: ../model_attributes.rb:1425
 msgid "OntapDiskDerivedMetric|User read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1426
 msgid "OntapDiskDerivedMetric|User reads"
 msgstr ""
 
+#: ../model_attributes.rb:1427
 msgid "OntapDiskDerivedMetric|User skip write ios"
 msgstr ""
 
+#: ../model_attributes.rb:1428
 msgid "OntapDiskDerivedMetric|User write blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1429
 msgid "OntapDiskDerivedMetric|User write chain"
 msgstr ""
 
+#: ../model_attributes.rb:1430
 msgid "OntapDiskDerivedMetric|User write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1431
 msgid "OntapDiskDerivedMetric|User writes"
 msgstr ""
 
+#: ../model_attributes.rb:1432
 msgid "OntapDiskDerivedMetric|User writes in skip mask"
 msgstr ""
 
+#: ../model_attributes.rb:1434
 msgid "OntapDiskMetricsRollup|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1435
 msgid "OntapDiskMetricsRollup|Cp read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1436
 msgid "OntapDiskMetricsRollup|Cp read blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1437
 msgid "OntapDiskMetricsRollup|Cp read blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1438
 msgid "OntapDiskMetricsRollup|Cp read chain"
 msgstr ""
 
+#: ../model_attributes.rb:1439
 msgid "OntapDiskMetricsRollup|Cp read chain max"
 msgstr ""
 
+#: ../model_attributes.rb:1440
 msgid "OntapDiskMetricsRollup|Cp read chain min"
 msgstr ""
 
+#: ../model_attributes.rb:1441
 msgid "OntapDiskMetricsRollup|Cp read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1442
 msgid "OntapDiskMetricsRollup|Cp read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1443
 msgid "OntapDiskMetricsRollup|Cp read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1444
 msgid "OntapDiskMetricsRollup|Cp reads"
 msgstr ""
 
+#: ../model_attributes.rb:1445
 msgid "OntapDiskMetricsRollup|Cp reads max"
 msgstr ""
 
+#: ../model_attributes.rb:1446
 msgid "OntapDiskMetricsRollup|Cp reads min"
 msgstr ""
 
+#: ../model_attributes.rb:1447
 msgid "OntapDiskMetricsRollup|Disk busy"
 msgstr ""
 
+#: ../model_attributes.rb:1448
 msgid "OntapDiskMetricsRollup|Disk busy max"
 msgstr ""
 
+#: ../model_attributes.rb:1449
 msgid "OntapDiskMetricsRollup|Disk busy min"
 msgstr ""
 
+#: ../model_attributes.rb:1450
 msgid "OntapDiskMetricsRollup|Guarenteed read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1451
 msgid "OntapDiskMetricsRollup|Guarenteed read blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1452
 msgid "OntapDiskMetricsRollup|Guarenteed read blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1453
 msgid "OntapDiskMetricsRollup|Guarenteed read chain"
 msgstr ""
 
+#: ../model_attributes.rb:1454
 msgid "OntapDiskMetricsRollup|Guarenteed read chain max"
 msgstr ""
 
+#: ../model_attributes.rb:1455
 msgid "OntapDiskMetricsRollup|Guarenteed read chain min"
 msgstr ""
 
+#: ../model_attributes.rb:1456
 msgid "OntapDiskMetricsRollup|Guarenteed read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1457
 msgid "OntapDiskMetricsRollup|Guarenteed read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1458
 msgid "OntapDiskMetricsRollup|Guarenteed read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1459
 msgid "OntapDiskMetricsRollup|Guarenteed reads"
 msgstr ""
 
+#: ../model_attributes.rb:1460
 msgid "OntapDiskMetricsRollup|Guarenteed reads max"
 msgstr ""
 
+#: ../model_attributes.rb:1461
 msgid "OntapDiskMetricsRollup|Guarenteed reads min"
 msgstr ""
 
+#: ../model_attributes.rb:1462
 msgid "OntapDiskMetricsRollup|Guarenteed write blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1463
 msgid "OntapDiskMetricsRollup|Guarenteed write blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1464
 msgid "OntapDiskMetricsRollup|Guarenteed write blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1465
 msgid "OntapDiskMetricsRollup|Guarenteed write chain"
 msgstr ""
 
+#: ../model_attributes.rb:1466
 msgid "OntapDiskMetricsRollup|Guarenteed write chain max"
 msgstr ""
 
+#: ../model_attributes.rb:1467
 msgid "OntapDiskMetricsRollup|Guarenteed write chain min"
 msgstr ""
 
+#: ../model_attributes.rb:1468
 msgid "OntapDiskMetricsRollup|Guarenteed write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1469
 msgid "OntapDiskMetricsRollup|Guarenteed write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1470
 msgid "OntapDiskMetricsRollup|Guarenteed write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1471
 msgid "OntapDiskMetricsRollup|Guarenteed writes"
 msgstr ""
 
+#: ../model_attributes.rb:1472
 msgid "OntapDiskMetricsRollup|Guarenteed writes max"
 msgstr ""
 
+#: ../model_attributes.rb:1473
 msgid "OntapDiskMetricsRollup|Guarenteed writes min"
 msgstr ""
 
+#: ../model_attributes.rb:1474
 msgid "OntapDiskMetricsRollup|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1475
 msgid "OntapDiskMetricsRollup|Io pending"
 msgstr ""
 
+#: ../model_attributes.rb:1476
 msgid "OntapDiskMetricsRollup|Io pending max"
 msgstr ""
 
+#: ../model_attributes.rb:1477
 msgid "OntapDiskMetricsRollup|Io pending min"
 msgstr ""
 
+#: ../model_attributes.rb:1478
 msgid "OntapDiskMetricsRollup|Io queued"
 msgstr ""
 
+#: ../model_attributes.rb:1479
 msgid "OntapDiskMetricsRollup|Io queued max"
 msgstr ""
 
+#: ../model_attributes.rb:1480
 msgid "OntapDiskMetricsRollup|Io queued min"
 msgstr ""
 
+#: ../model_attributes.rb:1481
 msgid "OntapDiskMetricsRollup|Rollup type"
 msgstr ""
 
+#: ../model_attributes.rb:1482
 msgid "OntapDiskMetricsRollup|Skip blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1483
 msgid "OntapDiskMetricsRollup|Skip blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1484
 msgid "OntapDiskMetricsRollup|Skip blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1485
 msgid "OntapDiskMetricsRollup|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1486
 msgid "OntapDiskMetricsRollup|Total transfers"
 msgstr ""
 
+#: ../model_attributes.rb:1487
 msgid "OntapDiskMetricsRollup|Total transfers max"
 msgstr ""
 
+#: ../model_attributes.rb:1488
 msgid "OntapDiskMetricsRollup|Total transfers min"
 msgstr ""
 
+#: ../model_attributes.rb:1489
 msgid "OntapDiskMetricsRollup|User read blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1490
 msgid "OntapDiskMetricsRollup|User read blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1491
 msgid "OntapDiskMetricsRollup|User read blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1492
 msgid "OntapDiskMetricsRollup|User read chain"
 msgstr ""
 
+#: ../model_attributes.rb:1493
 msgid "OntapDiskMetricsRollup|User read chain max"
 msgstr ""
 
+#: ../model_attributes.rb:1494
 msgid "OntapDiskMetricsRollup|User read chain min"
 msgstr ""
 
+#: ../model_attributes.rb:1495
 msgid "OntapDiskMetricsRollup|User read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1496
 msgid "OntapDiskMetricsRollup|User read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1497
 msgid "OntapDiskMetricsRollup|User read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1498
 msgid "OntapDiskMetricsRollup|User reads"
 msgstr ""
 
+#: ../model_attributes.rb:1499
 msgid "OntapDiskMetricsRollup|User reads max"
 msgstr ""
 
+#: ../model_attributes.rb:1500
 msgid "OntapDiskMetricsRollup|User reads min"
 msgstr ""
 
+#: ../model_attributes.rb:1501
 msgid "OntapDiskMetricsRollup|User skip write ios"
 msgstr ""
 
+#: ../model_attributes.rb:1502
 msgid "OntapDiskMetricsRollup|User skip write ios max"
 msgstr ""
 
+#: ../model_attributes.rb:1503
 msgid "OntapDiskMetricsRollup|User skip write ios min"
 msgstr ""
 
+#: ../model_attributes.rb:1504
 msgid "OntapDiskMetricsRollup|User write blocks"
 msgstr ""
 
+#: ../model_attributes.rb:1505
 msgid "OntapDiskMetricsRollup|User write blocks max"
 msgstr ""
 
+#: ../model_attributes.rb:1506
 msgid "OntapDiskMetricsRollup|User write blocks min"
 msgstr ""
 
+#: ../model_attributes.rb:1507
 msgid "OntapDiskMetricsRollup|User write chain"
 msgstr ""
 
+#: ../model_attributes.rb:1508
 msgid "OntapDiskMetricsRollup|User write chain max"
 msgstr ""
 
+#: ../model_attributes.rb:1509
 msgid "OntapDiskMetricsRollup|User write chain min"
 msgstr ""
 
+#: ../model_attributes.rb:1510
 msgid "OntapDiskMetricsRollup|User write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1511
 msgid "OntapDiskMetricsRollup|User write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1512
 msgid "OntapDiskMetricsRollup|User write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1513
 msgid "OntapDiskMetricsRollup|User writes"
 msgstr ""
 
+#: ../model_attributes.rb:1514
 msgid "OntapDiskMetricsRollup|User writes in skip mask"
 msgstr ""
 
+#: ../model_attributes.rb:1515
 msgid "OntapDiskMetricsRollup|User writes in skip mask max"
 msgstr ""
 
+#: ../model_attributes.rb:1516
 msgid "OntapDiskMetricsRollup|User writes in skip mask min"
 msgstr ""
 
+#: ../model_attributes.rb:1517
 msgid "OntapDiskMetricsRollup|User writes max"
 msgstr ""
 
+#: ../model_attributes.rb:1518
 msgid "OntapDiskMetricsRollup|User writes min"
 msgstr ""
 
+#: ../model_attributes.rb:1520
 msgid "OntapLunDerivedMetric|Avg latency"
 msgstr ""
 
+#: ../model_attributes.rb:1521
 msgid "OntapLunDerivedMetric|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1522
 msgid "OntapLunDerivedMetric|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1523
 msgid "OntapLunDerivedMetric|Other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1524
 msgid "OntapLunDerivedMetric|Queue full"
 msgstr ""
 
+#: ../model_attributes.rb:1525
 msgid "OntapLunDerivedMetric|Read data"
 msgstr ""
 
+#: ../model_attributes.rb:1526
 msgid "OntapLunDerivedMetric|Read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1527
 msgid "OntapLunDerivedMetric|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1528
 msgid "OntapLunDerivedMetric|Total ops"
 msgstr ""
 
+#: ../model_attributes.rb:1529
 msgid "OntapLunDerivedMetric|Write data"
 msgstr ""
 
+#: ../model_attributes.rb:1530
 msgid "OntapLunDerivedMetric|Write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1532
 msgid "OntapLunMetricsRollup|Avg latency"
 msgstr ""
 
+#: ../model_attributes.rb:1533
 msgid "OntapLunMetricsRollup|Avg latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1534
 msgid "OntapLunMetricsRollup|Avg latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1535
 msgid "OntapLunMetricsRollup|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1536
 msgid "OntapLunMetricsRollup|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1537
 msgid "OntapLunMetricsRollup|Other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1538
 msgid "OntapLunMetricsRollup|Other ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1539
 msgid "OntapLunMetricsRollup|Other ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1540
 msgid "OntapLunMetricsRollup|Queue full"
 msgstr ""
 
+#: ../model_attributes.rb:1541
 msgid "OntapLunMetricsRollup|Queue full max"
 msgstr ""
 
+#: ../model_attributes.rb:1542
 msgid "OntapLunMetricsRollup|Queue full min"
 msgstr ""
 
+#: ../model_attributes.rb:1543
 msgid "OntapLunMetricsRollup|Read data"
 msgstr ""
 
+#: ../model_attributes.rb:1544
 msgid "OntapLunMetricsRollup|Read data max"
 msgstr ""
 
+#: ../model_attributes.rb:1545
 msgid "OntapLunMetricsRollup|Read data min"
 msgstr ""
 
+#: ../model_attributes.rb:1546
 msgid "OntapLunMetricsRollup|Read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1547
 msgid "OntapLunMetricsRollup|Read ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1548
 msgid "OntapLunMetricsRollup|Read ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1549
 msgid "OntapLunMetricsRollup|Rollup type"
 msgstr ""
 
+#: ../model_attributes.rb:1550
 msgid "OntapLunMetricsRollup|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1551
 msgid "OntapLunMetricsRollup|Total ops"
 msgstr ""
 
+#: ../model_attributes.rb:1552
 msgid "OntapLunMetricsRollup|Total ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1553
 msgid "OntapLunMetricsRollup|Total ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1554
 msgid "OntapLunMetricsRollup|Write data"
 msgstr ""
 
+#: ../model_attributes.rb:1555
 msgid "OntapLunMetricsRollup|Write data max"
 msgstr ""
 
+#: ../model_attributes.rb:1556
 msgid "OntapLunMetricsRollup|Write data min"
 msgstr ""
 
+#: ../model_attributes.rb:1557
 msgid "OntapLunMetricsRollup|Write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1558
 msgid "OntapLunMetricsRollup|Write ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1559
 msgid "OntapLunMetricsRollup|Write ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1561
 msgid "OntapSystemDerivedMetric|Avg processor busy"
 msgstr ""
 
+#: ../model_attributes.rb:1562
 msgid "OntapSystemDerivedMetric|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1563
 msgid "OntapSystemDerivedMetric|Cifs ops"
 msgstr ""
 
+#: ../model_attributes.rb:1564
 msgid "OntapSystemDerivedMetric|Cpu busy"
 msgstr ""
 
+#: ../model_attributes.rb:1565
 msgid "OntapSystemDerivedMetric|Disk data read"
 msgstr ""
 
+#: ../model_attributes.rb:1566
 msgid "OntapSystemDerivedMetric|Disk data written"
 msgstr ""
 
+#: ../model_attributes.rb:1567
 msgid "OntapSystemDerivedMetric|Fcp ops"
 msgstr ""
 
+#: ../model_attributes.rb:1568
 msgid "OntapSystemDerivedMetric|Http ops"
 msgstr ""
 
+#: ../model_attributes.rb:1569
 msgid "OntapSystemDerivedMetric|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1570
 msgid "OntapSystemDerivedMetric|Iscsi ops"
 msgstr ""
 
+#: ../model_attributes.rb:1571
 msgid "OntapSystemDerivedMetric|Net data recv"
 msgstr ""
 
+#: ../model_attributes.rb:1572
 msgid "OntapSystemDerivedMetric|Net data sent"
 msgstr ""
 
+#: ../model_attributes.rb:1573
 msgid "OntapSystemDerivedMetric|Nfs ops"
 msgstr ""
 
+#: ../model_attributes.rb:1574
 msgid "OntapSystemDerivedMetric|Read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1575
 msgid "OntapSystemDerivedMetric|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1576
 msgid "OntapSystemDerivedMetric|Sys avg latency"
 msgstr ""
 
+#: ../model_attributes.rb:1577
 msgid "OntapSystemDerivedMetric|Sys read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1578
 msgid "OntapSystemDerivedMetric|Sys write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1579
 msgid "OntapSystemDerivedMetric|Total ops"
 msgstr ""
 
+#: ../model_attributes.rb:1580
 msgid "OntapSystemDerivedMetric|Total processor busy"
 msgstr ""
 
+#: ../model_attributes.rb:1581
 msgid "OntapSystemDerivedMetric|Write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1583
 msgid "OntapSystemMetricsRollup|Avg processor busy"
 msgstr ""
 
+#: ../model_attributes.rb:1584
 msgid "OntapSystemMetricsRollup|Avg processor busy max"
 msgstr ""
 
+#: ../model_attributes.rb:1585
 msgid "OntapSystemMetricsRollup|Avg processor busy min"
 msgstr ""
 
+#: ../model_attributes.rb:1586
 msgid "OntapSystemMetricsRollup|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1587
 msgid "OntapSystemMetricsRollup|Cifs ops"
 msgstr ""
 
+#: ../model_attributes.rb:1588
 msgid "OntapSystemMetricsRollup|Cifs ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1589
 msgid "OntapSystemMetricsRollup|Cifs ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1590
 msgid "OntapSystemMetricsRollup|Cpu busy"
 msgstr ""
 
+#: ../model_attributes.rb:1591
 msgid "OntapSystemMetricsRollup|Cpu busy max"
 msgstr ""
 
+#: ../model_attributes.rb:1592
 msgid "OntapSystemMetricsRollup|Cpu busy min"
 msgstr ""
 
+#: ../model_attributes.rb:1593
 msgid "OntapSystemMetricsRollup|Disk data read"
 msgstr ""
 
+#: ../model_attributes.rb:1594
 msgid "OntapSystemMetricsRollup|Disk data read max"
 msgstr ""
 
+#: ../model_attributes.rb:1595
 msgid "OntapSystemMetricsRollup|Disk data read min"
 msgstr ""
 
+#: ../model_attributes.rb:1596
 msgid "OntapSystemMetricsRollup|Disk data written"
 msgstr ""
 
+#: ../model_attributes.rb:1597
 msgid "OntapSystemMetricsRollup|Disk data written max"
 msgstr ""
 
+#: ../model_attributes.rb:1598
 msgid "OntapSystemMetricsRollup|Disk data written min"
 msgstr ""
 
+#: ../model_attributes.rb:1599
 msgid "OntapSystemMetricsRollup|Fcp ops"
 msgstr ""
 
+#: ../model_attributes.rb:1600
 msgid "OntapSystemMetricsRollup|Fcp ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1601
 msgid "OntapSystemMetricsRollup|Fcp ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1602
 msgid "OntapSystemMetricsRollup|Http ops"
 msgstr ""
 
+#: ../model_attributes.rb:1603
 msgid "OntapSystemMetricsRollup|Http ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1604
 msgid "OntapSystemMetricsRollup|Http ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1605
 msgid "OntapSystemMetricsRollup|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1606
 msgid "OntapSystemMetricsRollup|Iscsi ops"
 msgstr ""
 
+#: ../model_attributes.rb:1607
 msgid "OntapSystemMetricsRollup|Iscsi ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1608
 msgid "OntapSystemMetricsRollup|Iscsi ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1609
 msgid "OntapSystemMetricsRollup|Net data recv"
 msgstr ""
 
+#: ../model_attributes.rb:1610
 msgid "OntapSystemMetricsRollup|Net data recv max"
 msgstr ""
 
+#: ../model_attributes.rb:1611
 msgid "OntapSystemMetricsRollup|Net data recv min"
 msgstr ""
 
+#: ../model_attributes.rb:1612
 msgid "OntapSystemMetricsRollup|Net data sent"
 msgstr ""
 
+#: ../model_attributes.rb:1613
 msgid "OntapSystemMetricsRollup|Net data sent max"
 msgstr ""
 
+#: ../model_attributes.rb:1614
 msgid "OntapSystemMetricsRollup|Net data sent min"
 msgstr ""
 
+#: ../model_attributes.rb:1615
 msgid "OntapSystemMetricsRollup|Nfs ops"
 msgstr ""
 
+#: ../model_attributes.rb:1616
 msgid "OntapSystemMetricsRollup|Nfs ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1617
 msgid "OntapSystemMetricsRollup|Nfs ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1618
 msgid "OntapSystemMetricsRollup|Read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1619
 msgid "OntapSystemMetricsRollup|Read ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1620
 msgid "OntapSystemMetricsRollup|Read ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1621
 msgid "OntapSystemMetricsRollup|Rollup type"
 msgstr ""
 
+#: ../model_attributes.rb:1622
 msgid "OntapSystemMetricsRollup|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1623
 msgid "OntapSystemMetricsRollup|Sys avg latency"
 msgstr ""
 
+#: ../model_attributes.rb:1624
 msgid "OntapSystemMetricsRollup|Sys avg latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1625
 msgid "OntapSystemMetricsRollup|Sys avg latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1626
 msgid "OntapSystemMetricsRollup|Sys read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1627
 msgid "OntapSystemMetricsRollup|Sys read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1628
 msgid "OntapSystemMetricsRollup|Sys read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1629
 msgid "OntapSystemMetricsRollup|Sys write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1630
 msgid "OntapSystemMetricsRollup|Sys write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1631
 msgid "OntapSystemMetricsRollup|Sys write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1632
 msgid "OntapSystemMetricsRollup|Total ops"
 msgstr ""
 
+#: ../model_attributes.rb:1633
 msgid "OntapSystemMetricsRollup|Total ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1634
 msgid "OntapSystemMetricsRollup|Total ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1635
 msgid "OntapSystemMetricsRollup|Total processor busy"
 msgstr ""
 
+#: ../model_attributes.rb:1636
 msgid "OntapSystemMetricsRollup|Total processor busy max"
 msgstr ""
 
+#: ../model_attributes.rb:1637
 msgid "OntapSystemMetricsRollup|Total processor busy min"
 msgstr ""
 
+#: ../model_attributes.rb:1638
 msgid "OntapSystemMetricsRollup|Write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1639
 msgid "OntapSystemMetricsRollup|Write ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1640
 msgid "OntapSystemMetricsRollup|Write ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1642
 msgid "OntapVolumeDerivedMetric|Avg latency"
 msgstr ""
 
+#: ../model_attributes.rb:1643
 msgid "OntapVolumeDerivedMetric|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1644
 msgid "OntapVolumeDerivedMetric|Cifs other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1645
 msgid "OntapVolumeDerivedMetric|Cifs other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1646
 msgid "OntapVolumeDerivedMetric|Cifs read data"
 msgstr ""
 
+#: ../model_attributes.rb:1647
 msgid "OntapVolumeDerivedMetric|Cifs read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1648
 msgid "OntapVolumeDerivedMetric|Cifs read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1649
 msgid "OntapVolumeDerivedMetric|Cifs write data"
 msgstr ""
 
+#: ../model_attributes.rb:1650
 msgid "OntapVolumeDerivedMetric|Cifs write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1651
 msgid "OntapVolumeDerivedMetric|Cifs write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1652
 msgid "OntapVolumeDerivedMetric|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1653
 msgid "OntapVolumeDerivedMetric|Nfs other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1654
 msgid "OntapVolumeDerivedMetric|Nfs other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1655
 msgid "OntapVolumeDerivedMetric|Nfs read data"
 msgstr ""
 
+#: ../model_attributes.rb:1656
 msgid "OntapVolumeDerivedMetric|Nfs read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1657
 msgid "OntapVolumeDerivedMetric|Nfs read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1658
 msgid "OntapVolumeDerivedMetric|Nfs write data"
 msgstr ""
 
+#: ../model_attributes.rb:1659
 msgid "OntapVolumeDerivedMetric|Nfs write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1660
 msgid "OntapVolumeDerivedMetric|Nfs write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1661
 msgid "OntapVolumeDerivedMetric|Other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1662
 msgid "OntapVolumeDerivedMetric|Other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1663
 msgid "OntapVolumeDerivedMetric|Queue depth"
 msgstr ""
 
+#: ../model_attributes.rb:1664
 msgid "OntapVolumeDerivedMetric|Read data"
 msgstr ""
 
+#: ../model_attributes.rb:1665
 msgid "OntapVolumeDerivedMetric|Read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1666
 msgid "OntapVolumeDerivedMetric|Read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1667
 msgid "OntapVolumeDerivedMetric|San other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1668
 msgid "OntapVolumeDerivedMetric|San other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1669
 msgid "OntapVolumeDerivedMetric|San read data"
 msgstr ""
 
+#: ../model_attributes.rb:1670
 msgid "OntapVolumeDerivedMetric|San read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1671
 msgid "OntapVolumeDerivedMetric|San read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1672
 msgid "OntapVolumeDerivedMetric|San write data"
 msgstr ""
 
+#: ../model_attributes.rb:1673
 msgid "OntapVolumeDerivedMetric|San write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1674
 msgid "OntapVolumeDerivedMetric|San write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1675
 msgid "OntapVolumeDerivedMetric|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1676
 msgid "OntapVolumeDerivedMetric|Total ops"
 msgstr ""
 
+#: ../model_attributes.rb:1677
 msgid "OntapVolumeDerivedMetric|Write data"
 msgstr ""
 
+#: ../model_attributes.rb:1678
 msgid "OntapVolumeDerivedMetric|Write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1679
 msgid "OntapVolumeDerivedMetric|Write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1681
 msgid "OntapVolumeMetricsRollup|Avg latency"
 msgstr ""
 
+#: ../model_attributes.rb:1682
 msgid "OntapVolumeMetricsRollup|Avg latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1683
 msgid "OntapVolumeMetricsRollup|Avg latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1684
 msgid "OntapVolumeMetricsRollup|Base counters"
 msgstr ""
 
+#: ../model_attributes.rb:1685
 msgid "OntapVolumeMetricsRollup|Cifs other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1686
 msgid "OntapVolumeMetricsRollup|Cifs other latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1687
 msgid "OntapVolumeMetricsRollup|Cifs other latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1688
 msgid "OntapVolumeMetricsRollup|Cifs other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1689
 msgid "OntapVolumeMetricsRollup|Cifs other ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1690
 msgid "OntapVolumeMetricsRollup|Cifs other ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1691
 msgid "OntapVolumeMetricsRollup|Cifs read data"
 msgstr ""
 
+#: ../model_attributes.rb:1692
 msgid "OntapVolumeMetricsRollup|Cifs read data max"
 msgstr ""
 
+#: ../model_attributes.rb:1693
 msgid "OntapVolumeMetricsRollup|Cifs read data min"
 msgstr ""
 
+#: ../model_attributes.rb:1694
 msgid "OntapVolumeMetricsRollup|Cifs read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1695
 msgid "OntapVolumeMetricsRollup|Cifs read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1696
 msgid "OntapVolumeMetricsRollup|Cifs read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1697
 msgid "OntapVolumeMetricsRollup|Cifs read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1698
 msgid "OntapVolumeMetricsRollup|Cifs read ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1699
 msgid "OntapVolumeMetricsRollup|Cifs read ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1700
 msgid "OntapVolumeMetricsRollup|Cifs write data"
 msgstr ""
 
+#: ../model_attributes.rb:1701
 msgid "OntapVolumeMetricsRollup|Cifs write data max"
 msgstr ""
 
+#: ../model_attributes.rb:1702
 msgid "OntapVolumeMetricsRollup|Cifs write data min"
 msgstr ""
 
+#: ../model_attributes.rb:1703
 msgid "OntapVolumeMetricsRollup|Cifs write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1704
 msgid "OntapVolumeMetricsRollup|Cifs write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1705
 msgid "OntapVolumeMetricsRollup|Cifs write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1706
 msgid "OntapVolumeMetricsRollup|Cifs write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1707
 msgid "OntapVolumeMetricsRollup|Cifs write ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1708
 msgid "OntapVolumeMetricsRollup|Cifs write ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1709
 msgid "OntapVolumeMetricsRollup|Interval"
 msgstr ""
 
+#: ../model_attributes.rb:1710
 msgid "OntapVolumeMetricsRollup|Nfs other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1711
 msgid "OntapVolumeMetricsRollup|Nfs other latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1712
 msgid "OntapVolumeMetricsRollup|Nfs other latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1713
 msgid "OntapVolumeMetricsRollup|Nfs other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1714
 msgid "OntapVolumeMetricsRollup|Nfs other ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1715
 msgid "OntapVolumeMetricsRollup|Nfs other ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1716
 msgid "OntapVolumeMetricsRollup|Nfs read data"
 msgstr ""
 
+#: ../model_attributes.rb:1717
 msgid "OntapVolumeMetricsRollup|Nfs read data max"
 msgstr ""
 
+#: ../model_attributes.rb:1718
 msgid "OntapVolumeMetricsRollup|Nfs read data min"
 msgstr ""
 
+#: ../model_attributes.rb:1719
 msgid "OntapVolumeMetricsRollup|Nfs read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1720
 msgid "OntapVolumeMetricsRollup|Nfs read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1721
 msgid "OntapVolumeMetricsRollup|Nfs read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1722
 msgid "OntapVolumeMetricsRollup|Nfs read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1723
 msgid "OntapVolumeMetricsRollup|Nfs read ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1724
 msgid "OntapVolumeMetricsRollup|Nfs read ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1725
 msgid "OntapVolumeMetricsRollup|Nfs write data"
 msgstr ""
 
+#: ../model_attributes.rb:1726
 msgid "OntapVolumeMetricsRollup|Nfs write data max"
 msgstr ""
 
+#: ../model_attributes.rb:1727
 msgid "OntapVolumeMetricsRollup|Nfs write data min"
 msgstr ""
 
+#: ../model_attributes.rb:1728
 msgid "OntapVolumeMetricsRollup|Nfs write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1729
 msgid "OntapVolumeMetricsRollup|Nfs write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1730
 msgid "OntapVolumeMetricsRollup|Nfs write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1731
 msgid "OntapVolumeMetricsRollup|Nfs write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1732
 msgid "OntapVolumeMetricsRollup|Nfs write ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1733
 msgid "OntapVolumeMetricsRollup|Nfs write ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1734
 msgid "OntapVolumeMetricsRollup|Other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1735
 msgid "OntapVolumeMetricsRollup|Other latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1736
 msgid "OntapVolumeMetricsRollup|Other latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1737
 msgid "OntapVolumeMetricsRollup|Other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1738
 msgid "OntapVolumeMetricsRollup|Other ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1739
 msgid "OntapVolumeMetricsRollup|Other ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1740
 msgid "OntapVolumeMetricsRollup|Read data"
 msgstr ""
 
+#: ../model_attributes.rb:1741
 msgid "OntapVolumeMetricsRollup|Read data max"
 msgstr ""
 
+#: ../model_attributes.rb:1742
 msgid "OntapVolumeMetricsRollup|Read data min"
 msgstr ""
 
+#: ../model_attributes.rb:1743
 msgid "OntapVolumeMetricsRollup|Read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1744
 msgid "OntapVolumeMetricsRollup|Read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1745
 msgid "OntapVolumeMetricsRollup|Read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1746
 msgid "OntapVolumeMetricsRollup|Read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1747
 msgid "OntapVolumeMetricsRollup|Read ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1748
 msgid "OntapVolumeMetricsRollup|Read ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1749
 msgid "OntapVolumeMetricsRollup|Rollup type"
 msgstr ""
 
+#: ../model_attributes.rb:1750
 msgid "OntapVolumeMetricsRollup|San other latency"
 msgstr ""
 
+#: ../model_attributes.rb:1751
 msgid "OntapVolumeMetricsRollup|San other latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1752
 msgid "OntapVolumeMetricsRollup|San other latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1753
 msgid "OntapVolumeMetricsRollup|San other ops"
 msgstr ""
 
+#: ../model_attributes.rb:1754
 msgid "OntapVolumeMetricsRollup|San other ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1755
 msgid "OntapVolumeMetricsRollup|San other ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1756
 msgid "OntapVolumeMetricsRollup|San read data"
 msgstr ""
 
+#: ../model_attributes.rb:1757
 msgid "OntapVolumeMetricsRollup|San read data max"
 msgstr ""
 
+#: ../model_attributes.rb:1758
 msgid "OntapVolumeMetricsRollup|San read data min"
 msgstr ""
 
+#: ../model_attributes.rb:1759
 msgid "OntapVolumeMetricsRollup|San read latency"
 msgstr ""
 
+#: ../model_attributes.rb:1760
 msgid "OntapVolumeMetricsRollup|San read latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1761
 msgid "OntapVolumeMetricsRollup|San read latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1762
 msgid "OntapVolumeMetricsRollup|San read ops"
 msgstr ""
 
+#: ../model_attributes.rb:1763
 msgid "OntapVolumeMetricsRollup|San read ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1764
 msgid "OntapVolumeMetricsRollup|San read ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1765
 msgid "OntapVolumeMetricsRollup|San write data"
 msgstr ""
 
+#: ../model_attributes.rb:1766
 msgid "OntapVolumeMetricsRollup|San write data max"
 msgstr ""
 
+#: ../model_attributes.rb:1767
 msgid "OntapVolumeMetricsRollup|San write data min"
 msgstr ""
 
+#: ../model_attributes.rb:1768
 msgid "OntapVolumeMetricsRollup|San write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1769
 msgid "OntapVolumeMetricsRollup|San write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1770
 msgid "OntapVolumeMetricsRollup|San write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1771
 msgid "OntapVolumeMetricsRollup|San write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1772
 msgid "OntapVolumeMetricsRollup|San write ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1773
 msgid "OntapVolumeMetricsRollup|San write ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1774
 msgid "OntapVolumeMetricsRollup|Statistic time"
 msgstr ""
 
+#: ../model_attributes.rb:1775
 msgid "OntapVolumeMetricsRollup|Total ops"
 msgstr ""
 
+#: ../model_attributes.rb:1776
 msgid "OntapVolumeMetricsRollup|Total ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1777
 msgid "OntapVolumeMetricsRollup|Total ops min"
 msgstr ""
 
+#: ../model_attributes.rb:1778
 msgid "OntapVolumeMetricsRollup|Write data"
 msgstr ""
 
+#: ../model_attributes.rb:1779
 msgid "OntapVolumeMetricsRollup|Write data max"
 msgstr ""
 
+#: ../model_attributes.rb:1780
 msgid "OntapVolumeMetricsRollup|Write data min"
 msgstr ""
 
+#: ../model_attributes.rb:1781
 msgid "OntapVolumeMetricsRollup|Write latency"
 msgstr ""
 
+#: ../model_attributes.rb:1782
 msgid "OntapVolumeMetricsRollup|Write latency max"
 msgstr ""
 
+#: ../model_attributes.rb:1783
 msgid "OntapVolumeMetricsRollup|Write latency min"
 msgstr ""
 
+#: ../model_attributes.rb:1784
 msgid "OntapVolumeMetricsRollup|Write ops"
 msgstr ""
 
+#: ../model_attributes.rb:1785
 msgid "OntapVolumeMetricsRollup|Write ops max"
 msgstr ""
 
+#: ../model_attributes.rb:1786
 msgid "OntapVolumeMetricsRollup|Write ops min"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_folders.html.haml:13 ../../app/views/miq_policy/_alert_profile_folders.html.haml:10
 msgid "Open Folder"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:31
 msgid "Open the chart and full report in a new window"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:41
 msgid "Open the full report in a new window"
 msgstr ""
 
+#: ../../app/views/host/_main.html.haml:33 ../../app/views/ems_cluster/_main.html.haml:23
 msgid "OpenStack Status"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:166
 msgid "Openstack Infra Provider"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/_form.html.haml:99
 msgid "Openstack Infra provider"
 msgstr ""
 
+#: ../../app/views/provider_foreman/_main.html.haml:11 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:11 ../../app/views/layouts/listnav/_vm_common.html.haml:58
 msgid "Operating System"
 msgstr ""
 
+#: ../model_attributes.rb:1787
 msgid "Operating system"
 msgstr ""
 
+#: ../model_attributes.rb:1810
 msgid "Operating system flavor"
 msgstr ""
 
+#: ../model_attributes.rb:1811
 msgid "OperatingSystemFlavor|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1812
 msgid "OperatingSystemFlavor|Manager ref"
 msgstr ""
 
+#: ../model_attributes.rb:1813
 msgid "OperatingSystemFlavor|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1788
 msgid "OperatingSystem|Bitness"
 msgstr ""
 
+#: ../model_attributes.rb:1789
 msgid "OperatingSystem|Build number"
 msgstr ""
 
+#: ../model_attributes.rb:1790
 msgid "OperatingSystem|Distribution"
 msgstr ""
 
+#: ../model_attributes.rb:1791
 msgid "OperatingSystem|Kernel version"
 msgstr ""
 
+#: ../model_attributes.rb:1792
 msgid "OperatingSystem|Lockout duration"
 msgstr ""
 
+#: ../model_attributes.rb:1793
 msgid "OperatingSystem|Lockout threshold"
 msgstr ""
 
+#: ../model_attributes.rb:1794
 msgid "OperatingSystem|Max pw age"
 msgstr ""
 
+#: ../model_attributes.rb:1795
 msgid "OperatingSystem|Min pw age"
 msgstr ""
 
+#: ../model_attributes.rb:1796
 msgid "OperatingSystem|Min pw len"
 msgstr ""
 
+#: ../model_attributes.rb:1797
 msgid "OperatingSystem|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1798
 msgid "OperatingSystem|Product key"
 msgstr ""
 
+#: ../model_attributes.rb:1799
 msgid "OperatingSystem|Product name"
 msgstr ""
 
+#: ../model_attributes.rb:1800
 msgid "OperatingSystem|Product type"
 msgstr ""
 
+#: ../model_attributes.rb:1801
 msgid "OperatingSystem|Productid"
 msgstr ""
 
+#: ../model_attributes.rb:1802
 msgid "OperatingSystem|Pw complex"
 msgstr ""
 
+#: ../model_attributes.rb:1803
 msgid "OperatingSystem|Pw encrypt"
 msgstr ""
 
+#: ../model_attributes.rb:1804
 msgid "OperatingSystem|Pw hist"
 msgstr ""
 
+#: ../model_attributes.rb:1805
 msgid "OperatingSystem|Reset lockout counter"
 msgstr ""
 
+#: ../model_attributes.rb:1806
 msgid "OperatingSystem|Service pack"
 msgstr ""
 
+#: ../model_attributes.rb:1807
 msgid "OperatingSystem|System root"
 msgstr ""
 
+#: ../model_attributes.rb:1808
 msgid "OperatingSystem|System type"
 msgstr ""
 
+#: ../model_attributes.rb:1809
 msgid "OperatingSystem|Version"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:138
 msgid "Optimize"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_sample.html.haml:94
 msgid "Option 1"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_sample.html.haml:94
 msgid "Option 2"
 msgstr ""
 
+#: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:6 ../../app/views/miq_request/_reconfigure_show.html.haml:7 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:110 ../../app/views/layouts/_tl_options.html.haml:9 ../../app/views/vm_common/_reconfigure.html.haml:6 ../../app/views/vm_common/_policy_options.html.haml:7 ../../app/views/ontap_file_share/_create_datastore.html.haml:9 ../../app/views/miq_capacity/_utilization_options.html.haml:7 ../../app/views/miq_capacity/_bottlenecks_options.html.haml:6
 msgid "Options"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:5
 msgid "Options %s"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:6
 msgid "Options %s: %s"
 msgstr ""
 
+#: ../../app/views/ems_infra/scaling.html.haml:14
 msgid "Orchestration Stack"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:106 ../../app/views/catalog/_sandt_tree_show.html.haml:83
 msgid "Orchestration Template"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:739
 msgid "Orchestration Template \"%s\" was deleted."
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:46
 msgid "Orchestration Templates"
 msgstr ""
 
+#: ../model_attributes.rb:1814
 msgid "Orchestration stack"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:32
 msgid "Orchestration stack could not be found."
 msgstr ""
 
+#: ../model_attributes.rb:1827
 msgid "Orchestration stack output"
 msgstr ""
 
+#: ../model_attributes.rb:1832
 msgid "Orchestration stack parameter"
 msgstr ""
 
+#: ../model_attributes.rb:1836
 msgid "Orchestration stack resource"
 msgstr ""
 
+#: ../model_attributes.rb:1846
 msgid "Orchestration template"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:732
 msgid "Orchestration template \"%s\" is read-only and cannot be deleted."
 msgstr ""
 
+#: ../model_attributes.rb:1828
 msgid "OrchestrationStackOutput|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1829
 msgid "OrchestrationStackOutput|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:1830
 msgid "OrchestrationStackOutput|Key"
 msgstr ""
 
+#: ../model_attributes.rb:1831
 msgid "OrchestrationStackOutput|Value"
 msgstr ""
 
+#: ../model_attributes.rb:1833
 msgid "OrchestrationStackParameter|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:1834
 msgid "OrchestrationStackParameter|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1835
 msgid "OrchestrationStackParameter|Value"
 msgstr ""
 
+#: ../model_attributes.rb:1837
 msgid "OrchestrationStackResource|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1838
 msgid "OrchestrationStackResource|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:1839
 msgid "OrchestrationStackResource|Last updated"
 msgstr ""
 
+#: ../model_attributes.rb:1840
 msgid "OrchestrationStackResource|Logical resource"
 msgstr ""
 
+#: ../model_attributes.rb:1841
 msgid "OrchestrationStackResource|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1842
 msgid "OrchestrationStackResource|Physical resource"
 msgstr ""
 
+#: ../model_attributes.rb:1843
 msgid "OrchestrationStackResource|Resource category"
 msgstr ""
 
+#: ../model_attributes.rb:1844
 msgid "OrchestrationStackResource|Resource status"
 msgstr ""
 
+#: ../model_attributes.rb:1845
 msgid "OrchestrationStackResource|Resource status reason"
 msgstr ""
 
+#: ../model_attributes.rb:1815
 msgid "OrchestrationStack|Ancestry"
 msgstr ""
 
+#: ../model_attributes.rb:1816
 msgid "OrchestrationStack|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1817
 msgid "OrchestrationStack|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:1818
 msgid "OrchestrationStack|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1819
 msgid "OrchestrationStack|Retired"
 msgstr ""
 
+#: ../model_attributes.rb:1820
 msgid "OrchestrationStack|Retirement last warn"
 msgstr ""
 
+#: ../model_attributes.rb:1821
 msgid "OrchestrationStack|Retirement requester"
 msgstr ""
 
+#: ../model_attributes.rb:1822
 msgid "OrchestrationStack|Retirement state"
 msgstr ""
 
+#: ../model_attributes.rb:1823
 msgid "OrchestrationStack|Retirement warn"
 msgstr ""
 
+#: ../model_attributes.rb:1824
 msgid "OrchestrationStack|Retires on"
 msgstr ""
 
+#: ../model_attributes.rb:1825
 msgid "OrchestrationStack|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1826
 msgid "OrchestrationStack|Status reason"
 msgstr ""
 
+#: ../model_attributes.rb:1847
 msgid "OrchestrationTemplate|Content"
 msgstr ""
 
+#: ../model_attributes.rb:1848
 msgid "OrchestrationTemplate|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1849
 msgid "OrchestrationTemplate|Draft"
 msgstr ""
 
+#: ../model_attributes.rb:1850
 msgid "OrchestrationTemplate|Md5"
 msgstr ""
 
+#: ../model_attributes.rb:1851
 msgid "OrchestrationTemplate|Name"
 msgstr ""
 
+#: ../../app/views/catalog/_svccat_tree_show.html.haml:79
 msgid "Order"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:78
 msgid "Order of Actions if ALL Conditions are True"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:259
 msgid "Order of Actions if ANY Conditions are False"
 msgstr ""
 
+#: ../../app/views/catalog/_svccat_tree_show.html.haml:79
 msgid "Order this Service"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:169 ../../app/views/ops/rhn/_info_subscribed.html.haml:61
 msgid "Organization"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:153
 msgid "Organization ID"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:35 ../../app/views/report/_form_sort.html.haml:183
 msgid "Original Value"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:239
 msgid "Orphaned Data"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_instances.rb:22
 msgid "Orphaned Instances"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:428
 msgid "Orphaned Records for userid %s were successfully deleted"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_vandt.rb:15
 msgid "Orphaned VMs and Templates"
 msgstr ""
 
+#: ../model_attributes.rb:1852
 msgid "Os process"
 msgstr ""
 
+#: ../model_attributes.rb:1853
 msgid "OsProcess|Cpu time"
 msgstr ""
 
+#: ../model_attributes.rb:1854
 msgid "OsProcess|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1855
 msgid "OsProcess|Memory size"
 msgstr ""
 
+#: ../model_attributes.rb:1856
 msgid "OsProcess|Memory usage"
 msgstr ""
 
+#: ../model_attributes.rb:1857
 msgid "OsProcess|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1858
 msgid "OsProcess|Percent cpu"
 msgstr ""
 
+#: ../model_attributes.rb:1859
 msgid "OsProcess|Percent memory"
 msgstr ""
 
+#: ../model_attributes.rb:1860
 msgid "OsProcess|Pid"
 msgstr ""
 
+#: ../model_attributes.rb:1861
 msgid "OsProcess|Priority"
 msgstr ""
 
+#: ../model_attributes.rb:1862
 msgid "OsProcess|Updated on"
 msgstr ""
 
+#: ../../app/views/report/sample_chart.html.haml:99 ../../app/views/report/sample_chart.html.haml:176 ../../lib/report_formatter/chart_common.rb:344 ../../lib/report_formatter/chart_common.rb:400 ../../lib/report_formatter/chart_common.rb:401 ../../lib/report_formatter/chart_common.rb:433 ../../lib/report_formatter/chart_common.rb:434 ../../lib/report_formatter/chart_common.rb:474
 msgid "Other"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:143
 msgid "Other VM Files"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:388
 msgid "Outgoing SMTP E-mail Server"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:102 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:108
 msgid "Outputs (%s)"
 msgstr ""
 
+#: ../../app/views/ems_container/_main.html.haml:18
 msgid "Overview"
 msgstr ""
 
+#: ../../app/views/report/_export_custom_reports.html.haml:25
 msgid "Overwrite existing reports?"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:21 ../../app/views/report/_form_filter_chargeback.html.haml:38 ../../app/views/report/_form_filter_chargeback.html.haml:104
 msgid "Owner"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:155
 msgid "Ownership saved for selected %s"
 msgstr ""
 
+#: ../../app/views/report/_schedule_email_options.html.haml:60
 msgid "PDF"
 msgstr ""
 
+#: ../../app/views/report/_form_formatting.html.haml:6
 msgid "PDF Output"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:111
 msgid "PM:"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:51 ../../app/views/miq_request/_prov_host_dialog.html.haml:44 ../../app/views/shared/views/_prov_dialog.html.haml:50
 msgid "PXE"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_form.html.haml:93
 msgid "PXE Directory"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:17 ../../app/views/pxe/_pxe_server_details.html.haml:25 ../../app/views/pxe/_pxe_form.html.haml:140
 msgid "PXE Image Menus"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:51
 msgid "PXE Images"
 msgstr ""
 
+#: ../../app/views/container_image/_main.html.haml:10
 msgid "Packages"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:370 ../../app/views/layouts/listnav/_vm_common.html.haml:340 ../../app/views/layouts/listnav/_vm_common.html.haml:345
 msgid "Packages (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:364
 msgid "Packages (0)"
 msgstr ""
 
+#: ../../app/views/report/_form_formatting.html.haml:15
 msgid "Page Size"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:215 ../../app/views/miq_policy/_alert_details.html.haml:255
 msgid "Parameters"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:87 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:93
 msgid "Parameters (%s)"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:45
 msgid "Parent"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:32 ../../app/views/layouts/listnav/_resource_pool.html.haml:48
 msgid "Parent %s: %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:26 ../../app/views/layouts/listnav/_resource_pool.html.haml:42 ../../app/views/layouts/listnav/_vm_common.html.haml:170
 msgid "Parent %s: None"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:545 ../../app/views/miq_policy/_action_details.html.haml:492
 msgid "Parent Type"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:73
 msgid "Parent VM"
 msgstr ""
 
+#: ../../app/views/vm_common/_form.html.haml:64
 msgid "Parent VM Selection"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1061
 msgid "Parent VM can not be one of the child VMs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:205
 msgid "Parent VM: %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:213
 msgid "Parent VM: None"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:52 ../model_attributes.rb:1863
 msgid "Partition"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:100 ../../app/helpers/provider_foreman_helper.rb:181
 msgid "Partition Table"
 msgstr ""
 
+#: ../../app/views/vm_common/_disks.html.haml:13
 msgid "Partitions Aligned"
 msgstr ""
 
+#: ../model_attributes.rb:1864
 msgid "Partition|Controller"
 msgstr ""
 
+#: ../model_attributes.rb:1865
 msgid "Partition|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1866
 msgid "Partition|Free space"
 msgstr ""
 
+#: ../model_attributes.rb:1867
 msgid "Partition|Location"
 msgstr ""
 
+#: ../model_attributes.rb:1868
 msgid "Partition|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1869
 msgid "Partition|Partition type"
 msgstr ""
 
+#: ../model_attributes.rb:1870
 msgid "Partition|Size"
 msgstr ""
 
+#: ../model_attributes.rb:1871
 msgid "Partition|Start address"
 msgstr ""
 
+#: ../model_attributes.rb:1872
 msgid "Partition|Uid"
 msgstr ""
 
+#: ../model_attributes.rb:1873
 msgid "Partition|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1874
 msgid "Partition|Used space"
 msgstr ""
 
+#: ../model_attributes.rb:1875
 msgid "Partition|Virtual disk file"
 msgstr ""
 
+#: ../model_attributes.rb:1876
 msgid "Partition|Volume group"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:46
 msgid "Passed"
 msgstr ""
 
+#: ../../app/views/ops/_zone_form.html.haml:150 ../../app/views/ops/_settings_server_tab.html.haml:521 ../../app/views/ops/_settings_workers_tab.html.haml:618 ../../app/views/ops/_rbac_group_details.html.haml:230 ../../app/views/storage_manager/_form.html.haml:169 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:5 ../../app/views/layouts/_auth_credentials.html.haml:10 ../../app/views/layouts/_discover_credentials.html.haml:29 ../../app/views/dashboard/login.html.haml:63 ../../app/views/dashboard/login.html.haml:67
 msgid "Password"
 msgstr ""
 
+#: ../../app/views/ops/_settings_database_tab.html.haml:112 ../../app/views/ops/_settings_database_tab.html.haml:112
 msgid "Password fields must match to Validate Database Configuration"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:67
 msgid "Password or Password+One-Time-Password"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:461 ../../app/controllers/ops_controller/ops_rbac.rb:964 ../../app/controllers/pxe_controller/pxe_servers.rb:316 ../../app/controllers/ems_common.rb:662 ../../app/controllers/application_controller/ci_processing.rb:811
 msgid "Password/Verify Password do not match"
 msgstr ""
 
+#: ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:10
 msgid "Passwords do not match"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_form.html.haml:17
 msgid "Paste is not available, no object information has been copied from the Simulation screen"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_form.html.haml:7
 msgid "Paste object details for use in a Button."
 msgstr ""
 
+#: ../model_attributes.rb:1877
 msgid "Patch"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:336 ../../app/views/layouts/listnav/_vm_common.html.haml:322 ../../app/views/layouts/listnav/_vm_common.html.haml:328
 msgid "Patches (%s)"
 msgstr ""
 
+#: ../model_attributes.rb:1878
 msgid "Patch|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1879
 msgid "Patch|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1880
 msgid "Patch|Installed"
 msgstr ""
 
+#: ../model_attributes.rb:1881
 msgid "Patch|Installed on"
 msgstr ""
 
+#: ../model_attributes.rb:1882
 msgid "Patch|Is valid"
 msgstr ""
 
+#: ../model_attributes.rb:1883
 msgid "Patch|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1884
 msgid "Patch|Service pack"
 msgstr ""
 
+#: ../model_attributes.rb:1885
 msgid "Patch|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1886
 msgid "Patch|Vendor"
 msgstr ""
 
+#: ../../app/views/repository/_form.html.haml:34 ../../app/views/pxe/_pxe_server_details.html.haml:110
 msgid "Path"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:81 ../../app/controllers/repository_controller.rb:140
 msgid "Path must be a valid reference to a UNC location"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:173 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:183
 msgid "Per Minute"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_rate_edit.html.haml:47 ../../app/views/chargeback/_cb_rate_show.html.haml:44
 msgid "Per Time"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_rate_edit.html.haml:49 ../../app/views/chargeback/_cb_rate_show.html.haml:46
 msgid "Per Unit"
 msgstr ""
 
+#: ../../app/views/layouts/_saved_report_paging_bar.html.haml:25 ../../app/views/layouts/_pagingcontrols.html.haml:65
 msgid "Per page:"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:91 ../../app/views/ops/_db_info.html.haml:184 ../../app/views/ops/_db_info.html.haml:221
 msgid "Percent Bloat"
 msgstr ""
 
+#: ../../app/views/vm_common/_disks.html.haml:19
 msgid "Percent Used of Provisioned Size"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_performance.html.haml:36
 msgid "Performance Interval"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_performance.html.haml:6
 msgid "Performance Timeframe"
 msgstr ""
 
-msgid "Period"
-msgstr ""
-
+#: ../../app/helpers/container_group_helper/textual_summary.rb:42
 msgid "Persistent Volume Claim Name"
 msgstr ""
 
+#: ../model_attributes.rb:1887
 msgid "Picture"
 msgstr ""
 
+#: ../model_attributes.rb:1888
 msgid "Picture|Resource type"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:87
 msgid "Placement"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:150
 msgid "Placement - Options"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_instructions.html.haml:3
 msgid "Plan for VM placement on %s or %s"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:140
 msgid "Planning"
 msgstr ""
 
+#: ../../app/controllers/miq_capacity_controller.rb:563
 msgid "Planning options have been reset by the user"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:98
 msgid "Platform Updates Available"
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:51
 msgid "Please contact your administrator for assistance."
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:849
 msgid "Please correct invalid %s Entry Point prior to saving"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:30
 msgid "Please select a Cloud Tenant from the Environment Tab"
 msgstr ""
 
+#: ../../app/views/report/_menu_form1.html.haml:116
 msgid "Please select a node at left to edit."
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:50
 msgid "Please select an Instance Type from above"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:82 ../../app/views/layouts/listnav/_container_node.html.haml:58 ../../app/views/layouts/listnav/_container_service.html.haml:43 ../../app/views/layouts/listnav/_container_project.html.haml:57
 msgid "Pods (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:76 ../../app/views/layouts/listnav/_container_node.html.haml:52 ../../app/views/layouts/listnav/_container_service.html.haml:37 ../../app/views/layouts/listnav/_container_project.html.haml:51
 msgid "Pods (0)"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1123 ../../app/views/miq_policy/_profile_details.html.haml:131 ../../app/views/miq_policy/_export.html.haml:98
 msgid "Policies"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:155
 msgid "Policy Conditions:"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1122 ../../app/views/miq_policy/_export.html.haml:98
 msgid "Policy Profiles"
 msgstr ""
 
+#: ../../app/views/layouts/_policy_sim.html.haml:32
 msgid "Policy Profiles in Effect"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:45
 msgid "Policy Selection"
 msgstr ""
 
+#: ../../app/views/vm_common/_policies.html.haml:11
 msgid "Policy Simulation Details"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:65
 msgid "Policy Simulation Results"
 msgstr ""
 
+#: ../../app/views/layouts/_policy_sim.html.haml:72
 msgid "Policy Simulation for %s"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/rsop.rb:33
 msgid "Policy Simulation generation returned: "
 msgstr ""
 
+#: ../../app/controllers/application_controller/policy_support.rb:61
 msgid "Policy assignments successfully changed"
 msgstr ""
 
+#: ../../app/views/layouts/_protect.html.haml:23
 msgid "Policy changes will affect %s"
 msgstr ""
 
+#: ../model_attributes.rb:1889
 msgid "Policy event"
 msgstr ""
 
+#: ../model_attributes.rb:1898
 msgid "Policy event content"
 msgstr ""
 
+#: ../model_attributes.rb:1899
 msgid "PolicyEventContent|Resource description"
 msgstr ""
 
+#: ../model_attributes.rb:1900
 msgid "PolicyEventContent|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:1890
 msgid "PolicyEvent|Event type"
 msgstr ""
 
+#: ../model_attributes.rb:1891
 msgid "PolicyEvent|Miq event definition description"
 msgstr ""
 
+#: ../model_attributes.rb:1892
 msgid "PolicyEvent|Miq policy description"
 msgstr ""
 
+#: ../model_attributes.rb:1893
 msgid "PolicyEvent|Result"
 msgstr ""
 
+#: ../model_attributes.rb:1894
 msgid "PolicyEvent|Target class"
 msgstr ""
 
+#: ../model_attributes.rb:1895
 msgid "PolicyEvent|Target name"
 msgstr ""
 
+#: ../model_attributes.rb:1896
 msgid "PolicyEvent|Timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:1897
 msgid "PolicyEvent|Username"
 msgstr ""
 
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18 ../../app/views/ops/_ldap_domain_show.html.haml:259 ../../app/views/ops/_settings_server_tab.html.haml:414 ../../app/views/ops/_settings_workers_tab.html.haml:584 ../../app/views/ops/_ldap_server_entries.html.haml:22 ../../app/views/storage_manager/_form.html.haml:95 ../../app/views/security_group/_main.html.haml:20 ../../app/views/ems_container/_form_fields.html.haml:24
 msgid "Port"
 msgstr ""
 
+#: ../../app/views/container_service/_main.html.haml:9
 msgid "Port Configurations"
 msgstr ""
 
+#: ../../app/views/vm_cloud/_main.html.haml:28 ../../app/views/vm_common/_main.html.haml:29
 msgid "Power Management"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:109
 msgid "Power Off"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:108
 msgid "Power On"
 msgstr ""
 
+#: ../../app/views/vm_common/console_mks.html.haml:41
 msgid "Press Ctl+Alt to release cursor."
 msgstr ""
 
+#: ../../app/views/vm_common/console_mks.html.haml:145
 msgid "Press Ctrl+Alt to release cursor."
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:211
 msgid "Press commit to Import"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:212
 msgid "Press submit to start the Database Vacuum process"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:89
 msgid "Press the Apply button to import the good records into the CFME database"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:125
 msgid "Press your browser's Back button or click a tab to continue"
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:31
 msgid "Pressing the back button during a session."
 msgstr ""
 
+#: ../../app/views/report/_report_list.html.haml:129 ../../app/views/report/_report_info.html.haml:20
 msgid "Primary (Record) Filter"
 msgstr ""
 
+#: ../../app/views/report/_form_filter.html.haml:14
 msgid "Primary (Record) Filter - Filters the %s table records"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:194 ../../app/views/ops/_selected_by_roles.html.haml:78
 msgid "Priority"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1563
 msgid "Priority Order was saved"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:377
 msgid "Priority Workers"
 msgstr ""
 
+#: ../../app/views/layouts/_auth_credentials_keypair.html.haml:8 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:138
 msgid "Private Key"
 msgstr ""
 
+#: ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:138
 msgid "Private Keys do not match"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_roles.html.haml:96
 msgid "Process ID"
 msgstr ""
 
+#: ../../app/views/miq_request/_reconfigure_show.html.haml:49
 msgid "Processor Cores_Per_Socket"
 msgstr ""
 
+#: ../../app/views/vm_common/_reconfigure.html.haml:85
 msgid "Processor Options"
 msgstr ""
 
+#: ../../app/views/miq_request/_reconfigure_show.html.haml:35
 msgid "Processor Sockets"
 msgstr ""
 
+#: ../../app/views/vm_common/_reconfigure.html.haml:64 ../../app/views/vm_common/_right_size.html.haml:180 ../../app/views/vm_common/_right_size.html.haml:264 ../../app/views/vm_common/_right_size.html.haml:347
 msgid "Processors"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:49
 msgid "Product Assistance"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:105
 msgid "Product Features (%s)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:74
 msgid "Profile Alerts:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:61
 msgid "Profile Policies:"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:88
 msgid "Project/Tenant"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:117
 msgid "Projects"
 msgstr ""
 
+#: ../../app/views/ops/_db_summary.html.haml:5 ../../app/views/provider_foreman/_main.html.haml:7 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:7 ../../app/views/service/_svcs_show.html.haml:7 ../../app/views/container_service/_main.html.haml:7 ../../app/views/resource_pool/_main.html.haml:7 ../../app/views/vm_cloud/_main.html.haml:7 ../../app/views/flavor/_main.html.haml:7 ../../app/views/storage_manager/_main.html.haml:7 ../../app/views/ontap_storage_system/_main.html.haml:7 ../../app/views/orchestration_stack/_main.html.haml:7 ../../app/views/repository/_main.html.haml:7 ../../app/views/host/_main.html.haml:7 ../../app/views/ontap_logical_disk/_main.html.haml:7 ../../app/views/container_group/_main.html.haml:7 ../../app/views/container/_container_show.html.haml:7 ../../app/views/security_group/_main.html.haml:7 ../../app/views/ontap_storage_volume/_main.html.haml:7 ../../app/views/container_replicator/_main.html.haml:7 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:7 ../../app/views/layouts/listnav/_resource_pool.html.haml:8 ../../app/views/layouts/listnav/_host.html.haml:33 ../../app/views/layouts/listnav/_container_group.html.haml:11 ../../app/views/layouts/listnav/_repository.html.haml:7 ../../app/views/layouts/listnav/_storage.html.haml:8 ../../app/views/layouts/listnav/_flavor.html.haml:7 ../../app/views/layouts/listnav/_container_image_registry.html.haml:11 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:7 ../../app/views/layouts/listnav/_service.html.haml:7 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:7 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:7 ../../app/views/layouts/listnav/_ems_container.html.haml:11 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:7 ../../app/views/layouts/listnav/_container_image.html.haml:11 ../../app/views/layouts/listnav/_ems_cluster.html.haml:8 ../../app/views/layouts/listnav/_vm_common.html.haml:29 ../../app/views/layouts/listnav/_storage_manager.html.haml:7 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:7 ../../app/views/layouts/listnav/_ems_infra.html.haml:9 ../../app/views/layouts/listnav/_container_replicator.html.haml:11 ../../app/views/layouts/listnav/_container_node.html.haml:11 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:7 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:7 ../../app/views/layouts/listnav/_ems_cloud.html.haml:11 ../../app/views/layouts/listnav/_availability_zone.html.haml:11 ../../app/views/layouts/listnav/_security_group.html.haml:7 ../../app/views/layouts/listnav/_container_route.html.haml:11 ../../app/views/layouts/listnav/_container_service.html.haml:11 ../../app/views/layouts/listnav/_container_project.html.haml:11 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:7 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:7 ../../app/views/layouts/listnav/_pxe_server.html.haml:7 ../../app/views/container_image_registry/_main.html.haml:7 ../../app/views/container_route/_main.html.haml:7 ../../app/views/vm_common/_main.html.haml:7 ../../app/views/storage/_main.html.haml:7 ../../app/views/miq_ae_class/_all_tabs.html.haml:14 ../../app/views/miq_ae_class/_all_tabs.html.haml:55 ../../app/views/miq_ae_class/_class_form.html.haml:5 ../../app/views/miq_ae_class/_class_props.html.haml:6 ../../app/views/ems_container/_main.html.haml:7 ../../app/views/container_node/_main.html.haml:7 ../../app/views/ontap_file_share/_main.html.haml:7 ../../app/views/shared/views/ems_common/_main.html.haml:7 ../../app/views/container_project/_main.html.haml:7 ../../app/views/container_image/_main.html.haml:7
 msgid "Properties"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:57
 msgid "Property"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:236
 msgid "Protected"
 msgstr ""
 
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18
 msgid "Protocol"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:42 ../../app/views/catalog/_form_basic_info.html.haml:128 ../../app/views/catalog/_sandt_tree_show.html.haml:97 ../model_attributes.rb:1901
 msgid "Provider"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:65
 msgid "Provider is not ready to be scaled, another operation is in progress."
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:26 ../../app/presenters/menu/default_menu.rb:41 ../../app/presenters/menu/default_menu.rb:76
 msgid "Providers"
 msgstr ""
 
+#: ../model_attributes.rb:1902
 msgid "Provider|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1903
 msgid "Provider|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1904
 msgid "Provider|Url"
 msgstr ""
 
+#: ../model_attributes.rb:1905
 msgid "Provider|Verify ssl"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1733 ../../app/controllers/vm_common.rb:1737
 msgid "Provision %s"
 msgstr ""
 
+#: ../../app/views/miq_request/_pre_prov.html.haml:8
 msgid "Provision %s based on the selected %s"
 msgstr ""
 
+#: ../../app/controllers/application_controller/miq_request_methods.rb:178
 msgid "Provision %s was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1729
 msgid "Provision %{model} - Select %{typ}"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:48 ../../app/views/catalog/_sandt_tree_show.html.haml:231
 msgid "Provision Order"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:239
 msgid "Provisioned Hosts"
 msgstr ""
 
+#: ../../app/views/vm_common/_disks.html.haml:15
 msgid "Provisioned Size"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:224
 msgid "Provisioned VMs"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:852 ../../app/views/catalog/_sandt_tree_show.html.haml:106
 msgid "Provisioning"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:148
 msgid "Provisioning Entry Point"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:146
 msgid "Provisioning Entry Point (NameSpace/Class/Instance)"
 msgstr ""
 
+#: ../model_attributes.rb:1906
 msgid "Pxe image"
 msgstr ""
 
+#: ../model_attributes.rb:1914
 msgid "Pxe image type"
 msgstr ""
 
+#: ../model_attributes.rb:1917
 msgid "Pxe menu"
 msgstr ""
 
+#: ../model_attributes.rb:1920
 msgid "Pxe server"
 msgstr ""
 
+#: ../model_attributes.rb:1915
 msgid "PxeImageType|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1916
 msgid "PxeImageType|Provision type"
 msgstr ""
 
+#: ../model_attributes.rb:1907
 msgid "PxeImage|Default for windows"
 msgstr ""
 
+#: ../model_attributes.rb:1908
 msgid "PxeImage|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1909
 msgid "PxeImage|Initrd"
 msgstr ""
 
+#: ../model_attributes.rb:1910
 msgid "PxeImage|Kernel"
 msgstr ""
 
+#: ../model_attributes.rb:1911
 msgid "PxeImage|Kernel options"
 msgstr ""
 
+#: ../model_attributes.rb:1912
 msgid "PxeImage|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1913
 msgid "PxeImage|Path"
 msgstr ""
 
+#: ../model_attributes.rb:1918
 msgid "PxeMenu|Contents"
 msgstr ""
 
+#: ../model_attributes.rb:1919
 msgid "PxeMenu|File name"
 msgstr ""
 
+#: ../model_attributes.rb:1921
 msgid "PxeServer|Access url"
 msgstr ""
 
+#: ../model_attributes.rb:1922
 msgid "PxeServer|Customization directory"
 msgstr ""
 
+#: ../model_attributes.rb:1923
 msgid "PxeServer|Last refresh on"
 msgstr ""
 
+#: ../model_attributes.rb:1924
 msgid "PxeServer|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1925
 msgid "PxeServer|Pxe directory"
 msgstr ""
 
+#: ../model_attributes.rb:1926
 msgid "PxeServer|Uri"
 msgstr ""
 
+#: ../model_attributes.rb:1927
 msgid "PxeServer|Uri prefix"
 msgstr ""
 
+#: ../model_attributes.rb:1928
 msgid "PxeServer|Visibility"
 msgstr ""
 
+#: ../model_attributes.rb:1929
 msgid "PxeServer|Windows images directory"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:88 ../../app/views/miq_task/_tasks_options.html.haml:88
 msgid "Queued"
 msgstr ""
 
-msgid "Queued At"
-msgstr ""
-
+#: ../../app/views/cloud_tenant/_main.html.haml:9
 msgid "Quotas"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:199
 msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:29 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:24
 msgid "RSA key pair"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:11
 msgid "RSS"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_rss.html.haml:4
 msgid "RSS Feed Options"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:205
 msgid "RSS Feed no longer exists"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:43
 msgid "Rados Ceph Monitors"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:44
 msgid "Rados Image Name"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:47
 msgid "Rados Keyring"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:45
 msgid "Rados Pool Name"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:46
 msgid "Rados User Name"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:54
 msgid "Range"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_summary.html.haml:47
 msgid "Rank"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_rate_edit.html.haml:45 ../../app/views/chargeback/_cb_assignments.html.haml:74 ../../app/views/chargeback/_cb_rate_show.html.haml:42
 msgid "Rate"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_rate_edit.html.haml:33 ../../app/views/chargeback/_cb_rate_show.html.haml:30
 msgid "Rate Details"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:52
 msgid "Rates"
 msgstr ""
 
+#: ../../app/views/layouts/_exp_editor.html.haml:39
 msgid "Re-apply the previous change"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:102 ../../app/views/catalog/_ot_tree_show.html.haml:50
 msgid "Read Only"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:644
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1931
 msgid "Read Only %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:2404
 msgid "Read Only %{model} \"%{name}\" cannot be edited"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:261 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:335 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:403 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:628
 msgid "Read only"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:50
 msgid "Read-Only"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:72 ../../app/views/ems_infra/_form_fields.html.haml:47
 msgid "Realm"
 msgstr ""
 
+#: ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/miq_request/_request.html.haml:199 ../../app/views/miq_request/_request_details.html.haml:84
 msgid "Reason"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:106
 msgid "Reason:"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:166 ../../app/views/vm_common/_right_size.html.haml:250 ../../app/views/vm_common/_right_size.html.haml:333
 msgid "Recommended"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:674
 msgid "Reconfigurable"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:854 ../../app/views/catalog/_sandt_tree_show.html.haml:108
 msgid "Reconfigure"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1764
 msgid "Reconfigure %s"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:240 ../../app/views/miq_policy/_action_details.html.haml:261
 msgid "Reconfigure CPU"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:189
 msgid "Reconfigure Entry Point"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:187
 msgid "Reconfigure Entry Point (NameSpace/Class/Instance)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:212 ../../app/views/miq_policy/_action_details.html.haml:285
 msgid "Reconfigure Memory"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings.rb:24
 msgid "Records were successfully imported"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:80
 msgid "Red Hat Customer Portal"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:99
 msgid "Red Hat Updates"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:3
 msgid "Reference VM Profile"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:9
 msgid "Reference VM Selection"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:495
 msgid "Referenced by Actions"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:479 ../../app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml:26 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:41
 msgid "Refresh"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:31
 msgid "Refresh List"
 msgstr ""
 
+#: ../../app/controllers/application_controller/performance.rb:184
 msgid "Refresh of recent C&U data has been initiated"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:73
 msgid "Region"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:10
 msgid "Region Information"
 msgstr ""
 
+#: ../../app/views/ops/_zone_tree.html.haml:31
 msgid "Region based nodes shown as %{dimmed} text."
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:149
 msgid "Region:"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:51
 msgid "Register"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:26
 msgid "Register to"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:297
 msgid "Registration"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form.html.haml:86
 msgid "Registry"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:476 ../../app/views/layouts/listnav/_vm_common.html.haml:482
 msgid "Registry Entries (%s)"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_registry.html.haml:3
 msgid "Registry Entry"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_registry.html.haml:13
 msgid "Registry Hive"
 msgstr ""
 
+#: ../../app/views/ops/_ap_show.html.haml:113
 msgid "Registry Items"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_registry.html.haml:15
 msgid "Registry Key"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_registry.html.haml:17
 msgid "Registry Value"
 msgstr ""
 
+#: ../model_attributes.rb:1930
 msgid "Registry item"
 msgstr ""
 
+#: ../model_attributes.rb:1931
 msgid "RegistryItem|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1932
 msgid "RegistryItem|Data"
 msgstr ""
 
+#: ../model_attributes.rb:1933
 msgid "RegistryItem|Format"
 msgstr ""
 
+#: ../model_attributes.rb:1934
 msgid "RegistryItem|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1935
 msgid "RegistryItem|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1936
 msgid "RegistryItem|Value name"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:295
 msgid "Regular Expression"
 msgstr ""
 
+#: ../model_attributes.rb:1937
 msgid "Relationship"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:92 ../../app/views/service/_svcs_show.html.haml:11 ../../app/views/container_service/_main.html.haml:18 ../../app/views/resource_pool/_main.html.haml:9 ../../app/views/vm_cloud/_main.html.haml:12 ../../app/views/vm_cloud/_main.html.haml:15 ../../app/views/flavor/_main.html.haml:9 ../../app/views/ontap_storage_system/_main.html.haml:14 ../../app/views/orchestration_stack/_main.html.haml:9 ../../app/views/host/_main.html.haml:9 ../../app/views/ontap_logical_disk/_main.html.haml:9 ../../app/views/availability_zone/_main.html.haml:7 ../../app/views/ems_cluster/_main.html.haml:7 ../../app/views/container_group/_main.html.haml:21 ../../app/views/container/_container_show.html.haml:12 ../../app/views/security_group/_main.html.haml:12 ../../app/views/ontap_storage_volume/_main.html.haml:14 ../../app/views/container_replicator/_main.html.haml:16 ../../app/views/layouts/listnav/_resource_pool.html.haml:20 ../../app/views/layouts/listnav/_host.html.haml:164 ../../app/views/layouts/listnav/_container_group.html.haml:36 ../../app/views/layouts/listnav/_repository.html.haml:19 ../../app/views/layouts/listnav/_storage.html.haml:33 ../../app/views/layouts/listnav/_storage.html.haml:68 ../../app/views/layouts/listnav/_flavor.html.haml:19 ../../app/views/layouts/listnav/_container_image_registry.html.haml:21 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:19 ../../app/views/layouts/listnav/_service.html.haml:19 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:20 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:20 ../../app/views/layouts/listnav/_ems_container.html.haml:34 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:17 ../../app/views/layouts/listnav/_container_image.html.haml:21 ../../app/views/layouts/listnav/_ems_cluster.html.haml:62 ../../app/views/layouts/listnav/_vm_common.html.haml:147 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:19 ../../app/views/layouts/listnav/_ems_infra.html.haml:34 ../../app/views/layouts/listnav/_container_replicator.html.haml:21 ../../app/views/layouts/listnav/_container_node.html.haml:36 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:19 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:17 ../../app/views/layouts/listnav/_ems_cloud.html.haml:31 ../../app/views/layouts/listnav/_availability_zone.html.haml:21 ../../app/views/layouts/listnav/_security_group.html.haml:19 ../../app/views/layouts/listnav/_container_route.html.haml:21 ../../app/views/layouts/listnav/_container_service.html.haml:21 ../../app/views/layouts/listnav/_container_project.html.haml:35 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:19 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:19 ../../app/views/container_image_registry/_main.html.haml:13 ../../app/views/container_route/_main.html.haml:14 ../../app/views/vm_common/_main.html.haml:11 ../../app/views/storage/_main.html.haml:11 ../../app/views/ems_container/_main.html.haml:15 ../../app/views/container_node/_main.html.haml:15 ../../app/views/ontap_file_share/_main.html.haml:14 ../../app/views/shared/views/ems_common/_main.html.haml:14 ../../app/views/container_project/_main.html.haml:18 ../../app/views/container_image/_main.html.haml:16 ../../app/views/cloud_tenant/_main.html.haml:7
 msgid "Relationships"
 msgstr ""
 
+#: ../model_attributes.rb:1938
 msgid "Relationship|Ancestry"
 msgstr ""
 
+#: ../model_attributes.rb:1939
 msgid "Relationship|Relationship"
 msgstr ""
 
+#: ../model_attributes.rb:1940
 msgid "Relationship|Resource type"
 msgstr ""
 
+#: ../../app/helpers/container_image_helper/textual_summary.rb:21
 msgid "Release"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:415
 msgid "Remote Console plugin is not properly installed."
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:33 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:28
 msgid "Remote Login"
 msgstr ""
 
+#: ../../app/views/report/_form_styling.html.haml:56
 msgid "Remove"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_to_email.html.haml:34
 msgid "Remove %s"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:520
 msgid "Remove Tags"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:587
 msgid "Remove Tags Settings"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:128
 msgid "Remove all Actions from this Event"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:100
 msgid "Remove all Alerts from this Profile"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:186
 msgid "Remove all Conditions from this Policy"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:92
 msgid "Remove all Policies from this Profile"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:55
 msgid "Remove from Dashboard"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:136
 msgid "Remove selected Actions from this Event"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:337
 msgid "Remove selected Alerts from this Action"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:107
 msgid "Remove selected Alerts from this Profile"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:194
 msgid "Remove selected Conditions from this Policy"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:100
 msgid "Remove selected Policies from this Profile"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_searchbox.html.haml:47
 msgid "Remove the current filter"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_res_remove.html.haml:4
 msgid "Remove this %s"
 msgstr ""
 
+#: ../../app/views/catalog/_sandt_tree_show.html.haml:149
 msgid "Remove this Custom Image"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:168
 msgid "Remove this Provisioning Entry Point"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:210
 msgid "Remove this Reconfigure Entry Point"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:252
 msgid "Remove this Retirement Entry Point"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_menu.html.haml:45
 msgid "Remove this Shortcut"
 msgstr ""
 
+#: ../../app/views/layouts/_exp_editor.html.haml:65 ../../app/views/layouts/_exp_editor.html.haml:90
 msgid "Remove this expression element"
 msgstr ""
 
+#: ../../app/views/report/_db_widget_remove.html.haml:4
 msgid "Remove this widget"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:96
 msgid "Replace items if they already exist?"
 msgstr ""
 
+#: ../../app/views/layouts/_lightbox_panel.html.haml:5
 msgid "Replace me."
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_replication_tab.html.haml:16
 msgid "Replicate to Host"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:232
 msgid "Replication"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_replication_tab.html.haml:7
 msgid "Replication Process"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:558
 msgid "Replication Worker"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:130 ../../app/views/layouts/listnav/_container_project.html.haml:108
 msgid "Replicators (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:124 ../../app/views/layouts/listnav/_container_project.html.haml:102
 msgid "Replicators (0)"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_tabs.html.haml:7 ../../app/views/miq_capacity/_bottlenecks_tabs.html.haml:17 ../../app/views/miq_capacity/_utilization_tabs.html.haml:10
 msgid "Report"
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:48
 msgid "Report Creation Timeout"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:135 ../../app/views/report/_show_schedule.html.haml:72
 msgid "Report Filter"
 msgstr ""
 
+#: ../../app/views/report/_report_list.html.haml:216
 msgid "Report Info"
 msgstr ""
 
+#: ../../app/views/report/_role_list.html.haml:93
 msgid "Report Menus for"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_report.html.haml:4
 msgid "Report Options"
 msgstr ""
 
+#: ../../app/views/report/_form_preview.html.haml:42
 msgid "Report Preview (up to 50 rows)"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:3
 msgid "Report Results by User"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form_filter.html.haml:6
 msgid "Report Selection"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:50
 msgid "Report can not be saved unless sort field has been configured for Charts"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:86
 msgid "Report cannot be deleted if it's being used by one or more Widgets"
 msgstr ""
 
+#: ../../app/views/report/_report_info.html.haml:232
 msgid "Report doesn't belong to Widgets."
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:268
 msgid "Report generation returned: Status [%{status}] Message [%{message}]"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:20
 msgid "Report has been successfully queued to run"
 msgstr ""
 
+#: ../../app/views/report/_report_info.html.haml:113
 msgid "Report is not Scheduled."
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:379 ../../app/controllers/report_controller/saved_reports.rb:82
 msgid "Report is not authorized for the logged in user"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:148
 msgid "Report no longer exists"
 msgstr ""
 
+#: ../../app/views/layouts/_show_report.html.haml:2
 msgid "Report not found."
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:50
 msgid "Report preview generation returned: Status [%{status}] Message [%{message}]"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:220
 msgid "Reporting Workers"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:7 ../../app/views/configuration/_ui_1.html.haml:107 ../../app/views/report/_role_list.html.haml:16
 msgid "Reports"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:144
 msgid "Reports Currently Using This Time Profile"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:50 ../../app/views/configuration/_ui_2.html.haml:318
 msgid "Repositories"
 msgstr ""
 
+#: ../model_attributes.rb:1941
 msgid "Repository"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:75
 msgid "Repository Name(s)"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:67
 msgid "Repository Name(s):"
 msgstr ""
 
+#: ../model_attributes.rb:1942
 msgid "Repository|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1943
 msgid "Repository|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1944
 msgid "Repository|Relative path"
 msgstr ""
 
+#: ../model_attributes.rb:1945
 msgid "Repository|Updated on"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:63 ../../app/views/shared/buttons/_ab_show.html.haml:111 ../../app/views/miq_policy/_action_details.html.haml:145
 msgid "Request"
 msgstr ""
 
+#: ../../app/controllers/miq_request_controller.rb:203
 msgid "Request \"%{name}\" was %{task}"
 msgstr ""
 
+#: ../../app/controllers/miq_request_controller.rb:188
 msgid "Request %s was cancelled by the user"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:86
 msgid "Request Date:"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:7 ../../app/views/miq_request/_request_details.html.haml:8
 msgid "Request Details"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:18
 msgid "Request ID"
 msgstr ""
 
+#: ../../app/views/catalog/_form_request_info.html.haml:9 ../../app/views/catalog/_form.html.haml:17 ../../app/views/catalog/_sandt_tree_show.html.haml:21 ../../app/views/catalog/_sandt_tree_show.html.haml:281
 msgid "Request Info"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:11 ../../app/views/miq_request/_prov_host_dialog.html.haml:11 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:11 ../../app/views/shared/views/_prov_dialog.html.haml:10
 msgid "Request Information"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:44
 msgid "Request State"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:71
 msgid "Request Type"
 msgstr ""
 
+#: ../../app/views/miq_request/_request_details.html.haml:18
 msgid "Requested by"
 msgstr ""
 
+#: ../../app/views/miq_request/_request.html.haml:58
 msgid "Requester"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:18
 msgid "Requester:"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:20 ../../app/presenters/menu/default_menu.rb:52 ../../app/presenters/menu/default_menu.rb:133
 msgid "Requests"
 msgstr ""
 
+#: ../../app/views/ops/_tenant_form.html.haml:32 ../../app/views/ops/_tenant_form.html.haml:56 ../../app/views/ops/_schedule_form.html.haml:32 ../../app/views/ops/_schedule_form.html.haml:56 ../../app/views/provider_foreman/_form.html.haml:27 ../../app/views/provider_foreman/_form.html.haml:50 ../../app/views/host/_form.html.haml:36 ../../app/views/host/_form.html.haml:60 ../../app/views/host/_form.html.haml:83 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:249 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:383 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:613 ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:24 ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:57 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:33 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:63 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:93 ../../app/views/shared/views/ems_common/angular/_form.html.haml:29 ../../app/views/shared/views/ems_common/angular/_form.html.haml:107 ../../app/views/shared/views/ems_common/angular/_form.html.haml:131 ../../app/views/shared/views/ems_common/angular/_form.html.haml:156 ../../app/views/shared/views/ems_common/angular/_form.html.haml:229 ../../app/views/shared/views/ems_common/angular/_form.html.haml:253
 msgid "Required"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:138 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:185
 msgid "Required if SSH login is disabled for the Default account."
 msgstr ""
 
+#: ../../app/views/provider_foreman/_form.html.haml:94 ../../app/views/layouts/_multi_auth_credentials.html.haml:59 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:74
 msgid "Required. Should have privileged access, such as root or administrator."
 msgstr ""
 
+#: ../model_attributes.rb:1946
 msgid "Reserve"
 msgstr ""
 
+#: ../model_attributes.rb:1947
 msgid "Reserve|Reserved"
 msgstr ""
 
+#: ../model_attributes.rb:1948
 msgid "Reserve|Resource type"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:127 ../../app/views/miq_request/_prov_options.html.haml:151 ../../app/views/miq_task/_tasks_options.html.haml:150 ../../app/views/miq_task/_tasks_options.html.haml:173 ../../app/views/layouts/_x_edit_buttons.html.haml:166 ../../app/views/layouts/_form_buttons.html.haml:66 ../../app/views/layouts/_form_buttons.html.haml:73 ../../app/views/layouts/_form_buttons.html.haml:101 ../../app/views/layouts/_edit_buttons.html.haml:32 ../../app/views/layouts/_adv_search_footer.html.haml:67 ../../app/views/layouts/_edit_form_buttons.html.haml:97 ../../app/views/layouts/_edit_form_buttons.html.haml:113 ../../app/views/layouts/_edit_form_buttons.html.haml:122 ../../app/views/layouts/_edit_form_buttons.html.haml:164 ../../app/views/layouts/_x_dialog_buttons.html.haml:39 ../../app/views/layouts/_x_dialog_buttons.html.haml:68 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:14 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:39 ../../app/views/miq_capacity/planning.html.haml:18 ../../app/views/miq_capacity/planning.html.haml:34
 msgid "Reset"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:128 ../../app/views/layouts/_x_edit_buttons.html.haml:170
 msgid "Reset All menus to CFME defaults"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_form_buttons.html.haml:104 ../../app/views/layouts/_edit_form_buttons.html.haml:167
 msgid "Reset All menus to defaults"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:121 ../../app/views/layouts/_form_buttons.html.haml:66 ../../app/views/layouts/_form_buttons.html.haml:73 ../../app/views/layouts/_edit_buttons.html.haml:32 ../../app/views/layouts/_edit_form_buttons.html.haml:97 ../../app/views/layouts/_edit_form_buttons.html.haml:113 ../../app/views/layouts/_edit_form_buttons.html.haml:122 ../../app/views/layouts/_x_dialog_buttons.html.haml:39
 msgid "Reset Changes"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:69
 msgid "Reset all Datastore custom classes and instances to default"
 msgstr ""
 
+#: ../../app/views/miq_capacity/planning.html.haml:18 ../../app/views/miq_capacity/planning.html.haml:34
 msgid "Reset all Planning options"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:14 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:39
 msgid "Reset all options"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:151 ../../app/views/miq_task/_tasks_options.html.haml:173
 msgid "Reset filter changes"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:67
 msgid "Reset the filter"
 msgstr ""
 
+#: ../../app/views/report/_widget_form_menu.html.haml:53
 msgid "Reset this Shortcut's text"
 msgstr ""
 
+#: ../../app/views/report/_form_formatting.html.haml:88 ../../app/views/report/_form_sort.html.haml:119
 msgid "Reset to Default"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:48
 msgid "Resides on VM"
 msgstr ""
 
+#: ../../app/views/miq_policy/_export.html.haml:18
 msgid "Resolve conflicts to import the file"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:42
+msgid "Resource"
+msgstr ""
+
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:43 ../../app/views/shared/views/_prov_dialog.html.haml:114
 msgid "Resource Pool"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:47 ../../app/views/configuration/_ui_2.html.haml:290
 msgid "Resource Pools"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:204 ../../app/views/layouts/listnav/_ems_cluster.html.haml:145 ../../app/views/layouts/listnav/_ems_cluster.html.haml:151
 msgid "Resource Pools (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:198
 msgid "Resource Pools (0)"
 msgstr ""
 
+#: ../../app/views/container_project/_main.html.haml:9
+msgid "Resource Quota"
+msgstr ""
+
+#: ../model_attributes.rb:1949
 msgid "Resource action"
 msgstr ""
 
+#: ../model_attributes.rb:1957
 msgid "Resource pool"
 msgstr ""
 
+#: ../model_attributes.rb:1950
 msgid "ResourceAction|Action"
 msgstr ""
 
+#: ../model_attributes.rb:1951
 msgid "ResourceAction|Ae attributes"
 msgstr ""
 
+#: ../model_attributes.rb:1952
 msgid "ResourceAction|Ae class"
 msgstr ""
 
+#: ../model_attributes.rb:1953
 msgid "ResourceAction|Ae instance"
 msgstr ""
 
+#: ../model_attributes.rb:1954
 msgid "ResourceAction|Ae message"
 msgstr ""
 
+#: ../model_attributes.rb:1955
 msgid "ResourceAction|Ae namespace"
 msgstr ""
 
+#: ../model_attributes.rb:1956
 msgid "ResourceAction|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:1958
 msgid "ResourcePool|Cpu limit"
 msgstr ""
 
+#: ../model_attributes.rb:1959
 msgid "ResourcePool|Cpu reserve"
 msgstr ""
 
+#: ../model_attributes.rb:1960
 msgid "ResourcePool|Cpu reserve expand"
 msgstr ""
 
+#: ../model_attributes.rb:1961
 msgid "ResourcePool|Cpu shares"
 msgstr ""
 
+#: ../model_attributes.rb:1962
 msgid "ResourcePool|Cpu shares level"
 msgstr ""
 
+#: ../model_attributes.rb:1963
 msgid "ResourcePool|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1964
 msgid "ResourcePool|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:1965
 msgid "ResourcePool|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:1966
 msgid "ResourcePool|Is default"
 msgstr ""
 
+#: ../model_attributes.rb:1967
 msgid "ResourcePool|Memory limit"
 msgstr ""
 
+#: ../model_attributes.rb:1968
 msgid "ResourcePool|Memory reserve"
 msgstr ""
 
+#: ../model_attributes.rb:1969
 msgid "ResourcePool|Memory reserve expand"
 msgstr ""
 
+#: ../model_attributes.rb:1970
 msgid "ResourcePool|Memory shares"
 msgstr ""
 
+#: ../model_attributes.rb:1971
 msgid "ResourcePool|Memory shares level"
 msgstr ""
 
+#: ../model_attributes.rb:1972
 msgid "ResourcePool|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1973
 msgid "ResourcePool|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:1974
 msgid "ResourcePool|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1975
 msgid "ResourcePool|Vapp"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:520 ../../app/views/catalog/_form_resources_info.html.haml:8 ../../app/views/catalog/_form.html.haml:12 ../../app/views/catalog/_sandt_tree_show.html.haml:219
 msgid "Resources"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:117 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:123
 msgid "Resources (%s)"
 msgstr ""
 
-msgid "Restore"
-msgstr ""
-
+#: ../../app/views/layouts/_tl_options.html.haml:117
 msgid "Result"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:856 ../../app/views/catalog/_sandt_tree_show.html.haml:108
 msgid "Retirement"
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:20
 msgid "Retirement Date"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:232
 msgid "Retirement Entry Point"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:230
 msgid "Retirement Entry Point (NameSpace/Class/Instance)"
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:46
 msgid "Retirement Warning"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:269
 msgid "Retirement date removed"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:277
 msgid "Retirement date set to %s"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:271
 msgid "Retirement dates removed"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:279
 msgid "Retirement dates set to %s"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1772
 msgid "Right Size Recommendation for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:321
 msgid "Right-Sizing (Aggressive - derived from Average NORM)"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:154
 msgid "Right-Sizing (Conservative - derived from Absolute Maximum)"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:238
 msgid "Right-Sizing (Moderate - derived from High NORM)"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:168 ../../app/views/ops/_selected_by_roles.html.haml:7 ../../app/views/ops/_rbac_user_details.html.haml:181 ../../app/views/ops/_rbac_group_details.html.haml:54
 msgid "Role"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:16
 msgid "Role Information"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:256 ../../app/views/ops/_settings_authentication_tab.html.haml:403 ../../app/views/ops/_settings_authentication_tab.html.haml:465 ../../app/views/ops/_ldap_domain_form.html.haml:95 ../../app/views/ops/_ldap_domain_show.html.haml:136 ../../app/views/_ldap_domain_form.html.haml:95
 msgid "Role Settings"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:89
 msgid "Roles (%s)"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:128 ../../app/views/ops/_all_tabs.html.haml:222
 msgid "Roles by Servers"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:97
 msgid "Roll Up Daily Performance"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_4.html.haml:15
 msgid "Roll Up Performance"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:277 ../../app/views/report/_widget_form_rss.html.haml:86 ../../app/views/report/_widget_form_report.html.haml:66
 msgid "Row Count"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:43 ../../app/views/ops/_db_info.html.haml:136 ../../app/views/ops/_db_info.html.haml:215
 msgid "Rows"
 msgstr ""
 
+#: ../model_attributes.rb:1976
 msgid "Rss feed"
 msgstr ""
 
+#: ../model_attributes.rb:1977
 msgid "RssFeed|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1978
 msgid "RssFeed|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1979
 msgid "RssFeed|Link"
 msgstr ""
 
+#: ../model_attributes.rb:1980
 msgid "RssFeed|Name"
 msgstr ""
 
+#: ../model_attributes.rb:1981
 msgid "RssFeed|Title"
 msgstr ""
 
+#: ../model_attributes.rb:1982
 msgid "RssFeed|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:1983
 msgid "RssFeed|Yml file mtime"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/conditions.rb:22 ../../app/controllers/miq_policy_controller/conditions.rb:250
 msgid "Ruby scripts are no longer supported in expressions, please change or remove them."
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_timer.html.haml:11 ../../app/views/report/_schedule_form_timer.html.haml:15
 msgid "Run"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_show.html.haml:84 ../../app/views/report/_widget_show.html.haml:295 ../../app/views/report/_show_schedule.html.haml:82
 msgid "Run At"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:205 ../../app/views/ops/_diagnostics_database_tab.html.haml:224
 msgid "Run Database Garbage Collection Now"
 msgstr ""
 
+#: ../../app/views/chargeback/_reports_list.html.haml:56
 msgid "Run On"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:85 ../../app/views/ops/_diagnostics_database_tab.html.haml:186
 msgid "Run a Database Backup Now"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:96
 msgid "Running"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:72 ../../app/helpers/ems_cluster_helper/textual_summary.rb:49
 msgid "Running (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:532
 msgid "Running Processes (%s Ago)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:87
 msgid "Running Processes (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:81
 msgid "Running Processes (0)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:540
 msgid "Running Processes (Not Available)"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:182
 msgid "Running system services of %s"
 msgstr ""
 
+#: ../../app/views/ops/_email_verify_button.html.haml:17
 msgid "SMTP E-mail Server settings and Test E-mail Address are needed to send test email"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_snmp.html.haml:9 ../../app/views/miq_policy/_action_details.html.haml:333
 msgid "SNMP Trap"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:367
 msgid "SNMP Trap Settings"
 msgstr ""
 
+#: ../../app/views/vm_common/console_spice.html.haml:10
 msgid "SPICE Console"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:464
 msgid "SSL Verify Mode"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:125
 msgid "SSO Login"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_details.html.haml:15 ../../app/views/report/_form_styling.html.haml:125
 msgid "Sample"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:297
 msgid "Sample %{model} \"%{name}\" can not be edited"
 msgstr ""
 
+#: ../../app/views/report/_db_widgets.html.haml:5
 msgid "Sample Dashboard"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_sample.html.haml:7
 msgid "Sample Timeline"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Saturday"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_sample.html.haml:155 ../../app/views/layouts/_x_edit_buttons.html.haml:106 ../../app/views/layouts/_x_edit_buttons.html.haml:113 ../../app/views/layouts/_x_edit_buttons.html.haml:162 ../../app/views/layouts/_form_buttons.html.haml:15 ../../app/views/layouts/_form_buttons.html.haml:29 ../../app/views/layouts/_form_buttons.html.haml:46 ../../app/views/layouts/_form_buttons.html.haml:56 ../../app/views/layouts/_form_buttons.html.haml:99 ../../app/views/layouts/_edit_buttons.html.haml:23 ../../app/views/layouts/_edit_buttons.html.haml:60 ../../app/views/layouts/_adv_search_footer.html.haml:100 ../../app/views/layouts/_edit_form_buttons.html.haml:26 ../../app/views/layouts/_edit_form_buttons.html.haml:57 ../../app/views/layouts/_edit_form_buttons.html.haml:66 ../../app/views/layouts/_edit_form_buttons.html.haml:86 ../../app/views/layouts/_edit_form_buttons.html.haml:161 ../../app/views/layouts/_x_dialog_buttons.html.haml:18 ../../app/views/layouts/_x_dialog_buttons.html.haml:59 ../../app/views/shared/dialogs/_dialog_field.html.haml:48 ../../app/views/shared/views/_retire.html.haml:105
 msgid "Save"
 msgstr ""
 
+#: ../../app/views/layouts/_x_edit_buttons.html.haml:113 ../../app/views/layouts/_form_buttons.html.haml:1 ../../app/views/layouts/_edit_buttons.html.haml:23 ../../app/views/layouts/_edit_form_buttons.html.haml:1 ../../app/views/layouts/_x_dialog_buttons.html.haml:18
 msgid "Save Changes"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:55
 msgid "Save the current filter"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:100
 msgid "Save the current search"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:125
 msgid "Save this %s search as:"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_footer.html.haml:52 ../../app/views/layouts/_adv_search_footer.html.haml:55
 msgid "Save..."
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:53
 msgid "Saved Chargeback Reports"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:388 ../../app/controllers/report_controller/saved_reports.rb:32
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
 msgstr ""
 
+#: ../../app/views/report/_report_list.html.haml:220
 msgid "Saved Reports"
 msgstr ""
 
+#: ../../app/views/vm_common/_right_size.html.haml:170 ../../app/views/vm_common/_right_size.html.haml:254 ../../app/views/vm_common/_right_size.html.haml:337
 msgid "Savings"
 msgstr ""
 
+#: ../../app/views/ems_infra/scaling.html.haml:59
 msgid "Scale"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:26 ../../app/views/ems_infra/scaling.html.haml:59
 msgid "Scale Infrastructure Provider"
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:48
 msgid "Scaling"
 msgstr ""
 
+#: ../model_attributes.rb:1984
 msgid "Scan history"
 msgstr ""
 
+#: ../model_attributes.rb:1992
 msgid "Scan item"
 msgstr ""
 
+#: ../model_attributes.rb:2004
 msgid "Scan item set"
 msgstr ""
 
+#: ../model_attributes.rb:1985
 msgid "ScanHistory|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1986
 msgid "ScanHistory|Finished on"
 msgstr ""
 
+#: ../model_attributes.rb:1987
 msgid "ScanHistory|Message"
 msgstr ""
 
+#: ../model_attributes.rb:1988
 msgid "ScanHistory|Started on"
 msgstr ""
 
+#: ../model_attributes.rb:1989
 msgid "ScanHistory|Status"
 msgstr ""
 
+#: ../model_attributes.rb:1990
 msgid "ScanHistory|Status code"
 msgstr ""
 
+#: ../model_attributes.rb:1991
 msgid "ScanHistory|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:2005
 msgid "ScanItemSet|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2006
 msgid "ScanItemSet|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2007
 msgid "ScanItemSet|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:2008
 msgid "ScanItemSet|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:2009
 msgid "ScanItemSet|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2010
 msgid "ScanItemSet|Owner type"
 msgstr ""
 
+#: ../model_attributes.rb:2011
 msgid "ScanItemSet|Read only"
 msgstr ""
 
+#: ../model_attributes.rb:2012
 msgid "ScanItemSet|Set data"
 msgstr ""
 
+#: ../model_attributes.rb:2013
 msgid "ScanItemSet|Set type"
 msgstr ""
 
+#: ../model_attributes.rb:2014
 msgid "ScanItemSet|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:2015
 msgid "ScanItemSet|Userid"
 msgstr ""
 
+#: ../model_attributes.rb:1993
 msgid "ScanItem|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:1994
 msgid "ScanItem|Definition"
 msgstr ""
 
+#: ../model_attributes.rb:1995
 msgid "ScanItem|Description"
 msgstr ""
 
+#: ../model_attributes.rb:1996
 msgid "ScanItem|File mtime"
 msgstr ""
 
+#: ../model_attributes.rb:1997
 msgid "ScanItem|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:1998
 msgid "ScanItem|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:1999
 msgid "ScanItem|Item type"
 msgstr ""
 
+#: ../model_attributes.rb:2000
 msgid "ScanItem|Mode"
 msgstr ""
 
+#: ../model_attributes.rb:2001
 msgid "ScanItem|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2002
 msgid "ScanItem|Prod default"
 msgstr ""
 
+#: ../model_attributes.rb:2003
 msgid "ScanItem|Updated on"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:78 ../../app/views/miq_request/_prov_host_dialog.html.haml:121 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:63 ../../app/views/report/_show_schedule.html.haml:3 ../../app/views/shared/views/_prov_dialog.html.haml:408
 msgid "Schedule Info"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:148 ../../app/views/ops/_settings_details_tab.html.haml:95 ../../app/views/report/_report_info.html.haml:109
 msgid "Schedules"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_all_tabs.html.haml:17 ../../app/views/miq_ae_class/_class_fields.html.haml:8 ../../app/views/miq_ae_class/_class_fields.html.haml:84
 msgid "Schema"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:1081
 msgid "Schema for %{model} \"%{name}\" was saved"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:40 ../../app/views/miq_policy/_condition_details.html.haml:45 ../../app/views/miq_policy/_policy_details.html.haml:113 ../../app/views/miq_policy/_policy_details.html.haml:280
 msgid "Scope"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:107
 msgid "Scope (Choose an element of the Policy scope to edit)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_scope.html.haml:3
 msgid "Scope (Choose an element of the scope to edit)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_form_scope.html.haml:10
 msgid "Scope (Press the \"Edit\" button to edit the scope)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:245
 msgid "Scopes / Expressions"
 msgstr ""
 
+#: ../../app/views/pxe/_template_details.html.haml:16 ../../app/views/pxe/_template_form.html.haml:91
 msgid "Script"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:101
 msgid "Search Expression"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_search_body.html.haml:27
 msgid "Search Expression Preview"
 msgstr ""
 
+#: ../../app/views/layouts/_adv_searchbox.html.haml:13 ../../app/views/layouts/_adv_searchbox.html.haml:21 ../../app/views/layouts/_x_adv_searchbox.html.haml:27 ../../app/views/miq_policy/_searchbar.html.haml:7 ../../app/views/miq_policy/_searchbar.html.haml:16
 msgid "Search by Name within results"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:67
 msgid "Second band unit"
 msgstr ""
 
+#: ../../app/views/report/_report_list.html.haml:134 ../../app/views/report/_report_info.html.haml:31
 msgid "Secondary (Display) Filter"
 msgstr ""
 
+#: ../../app/views/report/_form_filter.html.haml:54
 msgid "Secondary (Display) Filter - Filters the rows based on child table fields"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:44 ../../app/views/layouts/_multi_auth_credentials.html.haml:66 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:43
 msgid "Secret Access Key"
 msgstr ""
 
+#: ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:43
 msgid "Secret Access Keys do not match"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:237
 msgid "Secret Key"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:53
 msgid "Secret Name"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:610 ../../app/views/vm_cloud/_main.html.haml:30 ../../app/views/host/_main.html.haml:19 ../../app/views/layouts/listnav/_host.html.haml:293 ../../app/views/layouts/listnav/_vm_common.html.haml:287 ../../app/views/layouts/listnav/_vm_common.html.haml:334 ../../app/views/vm_common/_main.html.haml:31
 msgid "Security"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:30
 msgid "Security Groups"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:37 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:57 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:63
 msgid "Security Groups (%s)"
 msgstr ""
 
+#: ../../app/views/ems_infra/_form_fields.html.haml:25
 msgid "Security Protocol"
 msgstr ""
 
+#: ../model_attributes.rb:2016
 msgid "Security group"
 msgstr ""
 
+#: ../model_attributes.rb:2017
 msgid "SecurityGroup|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2018
 msgid "SecurityGroup|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:2019
 msgid "SecurityGroup|Name"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:39
 msgid "Select"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:189
 msgid "Select %s to validate against"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:291
 msgid "Select Alerts to be Evaluated"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_tree_select.html.haml:34
 msgid "Select Entry Point %s"
 msgstr ""
 
+#: ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:284
 msgid "Select Host to validate against"
 msgstr ""
 
+#: ../../app/views/layouts/_protect.html.haml:5
 msgid "Select Policy Profiles"
 msgstr ""
 
+#: ../../app/views/vm_common/_evm_relationship.html.haml:17
 msgid "Select Server:"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_host_dialog.html.haml:26 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:26 ../../app/views/shared/views/_prov_dialog.html.haml:28
 msgid "Select Tags to apply"
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:46
 msgid "Select a Group:"
 msgstr ""
 
+#: ../../app/views/layouts/_policy_sim.html.haml:18
 msgid "Select a Policy Profile to add:"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:128
 msgid "Select a Tag to Apply"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_options.html.haml:32
 msgid "Select a VM to Submit the Simulation Options"
 msgstr ""
 
+#: ../../app/views/layouts/_tag_edit.html.haml:17
 msgid "Select a customer tag to assign:"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_show_list.html.haml:69
 msgid "Select a filter to set it as my default"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_bottlenecks_report.html.haml:3
 msgid "Select a node on the left to view Bottlenecks report."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_bottlenecks_summary.html.haml:3
 msgid "Select a node on the left to view Bottlenecks timeline."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_details.html.haml:16 ../../app/views/miq_capacity/_utilization_summary.html.haml:51
 msgid "Select a node on the left to view Utilization information."
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_report.html.haml:27
 msgid "Select a node on the left to view Utilization report."
 msgstr ""
 
+#: ../../app/views/miq_capacity/planning.html.haml:30
 msgid "Select a reference VM or Manual Input source to Submit the Planning Options"
 msgstr ""
 
+#: ../../app/views/shared/views/_ownership.html.haml:17
 msgid "Select an Owner:"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:1523
 msgid "Select an expression element type"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:117
 msgid "Select domain you wish to import from:"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:96
 msgid "Select existing domain to import into:"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:135
 msgid "Select namespaces you wish to import:"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_seq_form.html.haml:73
 msgid "Select one or more consecutive groups to move up or down."
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:471 ../../app/controllers/report_controller/menus.rb:510 ../../app/controllers/report_controller/menus.rb:554 ../../app/controllers/report_controller/reports/editor.rb:1027 ../../app/controllers/miq_ae_class_controller.rb:2373 ../../app/controllers/ops_controller/ops_rbac.rb:465 ../../app/controllers/miq_policy_controller.rb:865 ../../app/controllers/application_controller/buttons.rb:1062
 msgid "Select only one or consecutive %s to move down"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:1073 ../../app/controllers/application_controller/buttons.rb:732
 msgid "Select only one or consecutive %s to move to the bottom"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:1051 ../../app/controllers/application_controller/buttons.rb:711
 msgid "Select only one or consecutive %s to move to the top"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:447 ../../app/controllers/report_controller/menus.rb:489 ../../app/controllers/report_controller/menus.rb:533 ../../app/controllers/report_controller/reports/editor.rb:1005 ../../app/controllers/miq_ae_class_controller.rb:2352 ../../app/controllers/ops_controller/ops_rbac.rb:443 ../../app/controllers/miq_policy_controller.rb:849 ../../app/controllers/application_controller/buttons.rb:1041
 msgid "Select only one or consecutive %s to move up"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:36
 msgid "Select to change to another Group"
 msgstr ""
 
+#: ../../app/views/host/_form.html.haml:158
 msgid "Selected"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:465 ../../app/controllers/chargeback_controller.rb:480
 msgid "Selected %s Report no longer exists"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:2487
 msgid "Selected %s no longer exists"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_options.html.haml:97
 msgid "Selected Day"
 msgstr ""
 
+#: ../../app/views/report/_column_lists.html.haml:59
 msgid "Selected Fields:"
 msgstr ""
 
+#: ../../app/views/ops/_selected.html.haml:6
 msgid "Selected Item"
 msgstr ""
 
+#: ../../app/views/report/_menu_form2.html.haml:19
 msgid "Selected Reports:"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:37 ../../app/views/catalog/_sandt_tree_show.html.haml:16
 msgid "Selected Resources"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_host_dialog.html.haml:111 ../../app/views/shared/views/_prov_dialog.html.haml:398
 msgid "Selected Template Contents"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:39
 msgid "Selected VM"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_column_lists.html.haml:14 ../../app/views/catalog/_column_lists.html.haml:11
 msgid "Selected:"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:140 ../../app/views/shared/buttons/_ab_show.html.haml:149
 msgid "Selection"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_assignments.html.haml:63 ../../app/views/miq_policy/_alert_profile_assign.html.haml:72
 msgid "Selections"
 msgstr ""
 
+#: ../../app/views/container_service/_main.html.haml:13 ../../app/views/container_replicator/_main.html.haml:11
 msgid "Selector"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:280
 msgid "Send E-mail"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:436
 msgid "Send Management Event"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:318
 msgid "Send SNMP Trap"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_mgmt_event.html.haml:16
 msgid "Send a Management Event"
 msgstr ""
 
+#: ../../app/views/layouts/_edit_email.html.haml:18
 msgid "Send an E-mail"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_snmp.html.haml:19
 msgid "Send an SNMP Trap"
 msgstr ""
 
+#: ../../app/views/report/_schedule_email_options.html.haml:16
 msgid "Send if Report is Empty"
 msgstr ""
 
+#: ../../app/views/ops/_email_verify_button.html.haml:3 ../../app/views/ops/_email_verify_button.html.haml:3
 msgid "Send test email"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:452
 msgid "Send&#160;Ctrl-Alt-Delete"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:24
 msgid "Server"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:29
 msgid "Server Address"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:198
 msgid "Server Control"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:275
 msgid "Server License"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:17
 msgid "Server Name"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:207
 msgid "Server Roles"
 msgstr ""
 
+#: ../model_attributes.rb:2020
 msgid "Server role"
 msgstr ""
 
+#: ../../app/views/layouts/_user_options.html.haml:19
 msgid "Server: %s"
 msgstr ""
 
+#: ../model_attributes.rb:2021
 msgid "ServerRole|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2022
 msgid "ServerRole|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2023
 msgid "ServerRole|External failover"
 msgstr ""
 
+#: ../model_attributes.rb:2024
 msgid "ServerRole|License required"
 msgstr ""
 
+#: ../model_attributes.rb:2025
 msgid "ServerRole|Max concurrent"
 msgstr ""
 
+#: ../model_attributes.rb:2026
 msgid "ServerRole|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2027
 msgid "ServerRole|Role scope"
 msgstr ""
 
+#: ../model_attributes.rb:2028
 msgid "ServerRole|Updated on"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:100 ../../app/views/ops/_settings_evm_servers_tab.html.haml:163 ../../app/views/ops/_zone_form.html.haml:87 ../../app/views/ops/_settings_server_tab.html.haml:349 ../../app/views/ops/_all_tabs.html.haml:134 ../../app/views/ops/_all_tabs.html.haml:228 ../../app/views/vm_common/_evm_relationship.html.haml:8
 msgid "Servers"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:131 ../../app/views/ops/_all_tabs.html.haml:225
 msgid "Servers by Roles"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:13 ../../app/views/vm_common/_add_to_service.html.haml:27 ../model_attributes.rb:2029
 msgid "Service"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:46
 msgid "Service Catalogs"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1129
 msgid "Service Dialog \"%s\" was successfully created"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:67
 msgid "Service Dialog Import/Export"
 msgstr ""
 
+#: ../../app/views/catalog/_service_dialog_from_ot.html.haml:14
 msgid "Service Dialog Name"
 msgstr ""
 
+#: ../../app/views/vm_common/_add_to_service.html.haml:20
 msgid "Service Selection"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:100
 msgid "Service dialog import cancelled"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_customization_controller.rb:75
 msgid "Service dialogs imported successfully"
 msgstr ""
 
+#: ../model_attributes.rb:2041
 msgid "Service resource"
 msgstr ""
 
+#: ../model_attributes.rb:2053
 msgid "Service template"
 msgstr ""
 
+#: ../model_attributes.rb:2063
 msgid "Service template catalog"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:190
 msgid "Service: %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:198
 msgid "Service: None"
 msgstr ""
 
+#: ../model_attributes.rb:2042
 msgid "ServiceResource|Group idx"
 msgstr ""
 
+#: ../model_attributes.rb:2043
 msgid "ServiceResource|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2044
 msgid "ServiceResource|Provision index"
 msgstr ""
 
+#: ../model_attributes.rb:2045
 msgid "ServiceResource|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:2046
 msgid "ServiceResource|Scaling max"
 msgstr ""
 
+#: ../model_attributes.rb:2047
 msgid "ServiceResource|Scaling min"
 msgstr ""
 
+#: ../model_attributes.rb:2048
 msgid "ServiceResource|Source type"
 msgstr ""
 
+#: ../model_attributes.rb:2049
 msgid "ServiceResource|Start action"
 msgstr ""
 
+#: ../model_attributes.rb:2050
 msgid "ServiceResource|Start delay"
 msgstr ""
 
+#: ../model_attributes.rb:2051
 msgid "ServiceResource|Stop action"
 msgstr ""
 
+#: ../model_attributes.rb:2052
 msgid "ServiceResource|Stop delay"
 msgstr ""
 
+#: ../model_attributes.rb:2064
 msgid "ServiceTemplateCatalog|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2065
 msgid "ServiceTemplateCatalog|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2054
 msgid "ServiceTemplate|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2055
 msgid "ServiceTemplate|Display"
 msgstr ""
 
+#: ../model_attributes.rb:2056
 msgid "ServiceTemplate|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:2057
 msgid "ServiceTemplate|Long description"
 msgstr ""
 
+#: ../model_attributes.rb:2058
 msgid "ServiceTemplate|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2059
 msgid "ServiceTemplate|Options"
 msgstr ""
 
+#: ../model_attributes.rb:2060
 msgid "ServiceTemplate|Prov type"
 msgstr ""
 
+#: ../model_attributes.rb:2061
 msgid "ServiceTemplate|Provision cost"
 msgstr ""
 
+#: ../model_attributes.rb:2062
 msgid "ServiceTemplate|Service type"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:16 ../../app/controllers/host_controller.rb:175 ../../app/views/configuration/_ui_2.html.haml:43
 msgid "Services"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:386
 msgid "Services (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:380
 msgid "Services (0)"
 msgstr ""
 
+#: ../model_attributes.rb:2030
 msgid "Service|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2031
 msgid "Service|Display"
 msgstr ""
 
+#: ../model_attributes.rb:2032
 msgid "Service|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:2033
 msgid "Service|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2034
 msgid "Service|Options"
 msgstr ""
 
+#: ../model_attributes.rb:2035
 msgid "Service|Retired"
 msgstr ""
 
+#: ../model_attributes.rb:2036
 msgid "Service|Retirement last warn"
 msgstr ""
 
+#: ../model_attributes.rb:2037
 msgid "Service|Retirement requester"
 msgstr ""
 
+#: ../model_attributes.rb:2038
 msgid "Service|Retirement state"
 msgstr ""
 
+#: ../model_attributes.rb:2039
 msgid "Service|Retirement warn"
 msgstr ""
 
+#: ../model_attributes.rb:2040
 msgid "Service|Retires on"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:13
 msgid "Session Information"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:16
 msgid "Session Timeout"
 msgstr ""
 
+#: ../../app/controllers/dashboard_controller.rb:437
 msgid "Session was timed out due to inactivity. Please log in again."
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:224
 msgid "Set Custom Attribute Settings"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1741 ../../app/controllers/service_controller.rb:309
 msgid "Set Ownership for %s"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_options.html.haml:129 ../../app/views/miq_request/_prov_options.html.haml:160 ../../app/views/miq_task/_tasks_options.html.haml:152 ../../app/views/miq_task/_tasks_options.html.haml:182
 msgid "Set filters to default"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:188
 msgid "Set selected Actions to Asynchronous"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:179
 msgid "Set selected Actions to Synchronous"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_show_list.html.haml:58
 msgid "Set the current filter as my default"
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:37
 msgid "Set to blank"
 msgstr ""
 
+#: ../../app/views/shared/views/_retire.html.haml:11
 msgid "Set/Remove Retirement Date"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1768 ../../app/controllers/service_controller.rb:313
 msgid "Set/Remove retirement date for %s"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:733 ../../app/controllers/ops_controller/diagnostics.rb:751
 msgid "Setting priority is not allowed for the selected item"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:210
 msgid "Setting tracing to true may cause excessive log lines to be written"
 msgstr ""
 
+#: ../../app/views/ops/_zone_form.html.haml:185 ../../app/views/ops/_all_tabs.html.haml:292
 msgid "Settings"
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:227
 msgid "Shortcuts"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:18 ../../app/views/layouts/_tl_options.html.haml:89 ../../app/views/layouts/_perf_options.html.haml:38 ../../app/views/layouts/_perf_options.html.haml:79 ../../app/views/layouts/_role_visibility.html.haml:17 ../../app/views/report/_widget_show.html.haml:337 ../../app/views/shared/buttons/_ab_show.html.haml:206 ../../app/views/miq_capacity/_planning_options.html.haml:261 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:58
 msgid "Show"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:84 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:31 ../../app/views/layouts/listnav/_ems_cluster.html.haml:75
 msgid "Show %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_group.html.haml:98
 msgid "Show %s %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_infra.html.haml:45
 msgid "Show %s & %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:97
 msgid "Show %s OS information"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:33
 msgid "Show %s Quadrants"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:52
 msgid "Show %s devices"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:255
 msgid "Show %s drift history"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:67
 msgid "Show %s network"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:179
 msgid "Show %s parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:82
 msgid "Show %s storage adapters"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:121 ../../app/views/layouts/listnav/_storage.html.haml:21 ../../app/views/layouts/listnav/_ems_cluster.html.haml:36 ../../app/views/layouts/listnav/_vm_common.html.haml:105
 msgid "Show Capacity & Utilization"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_replicator.html.haml:52
 msgid "Show Container Groups"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:48 ../../app/views/layouts/listnav/_container_replicator.html.haml:68 ../../app/views/layouts/listnav/_container_service.html.haml:83
 msgid "Show Container Nodes"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:114
 msgid "Show Container Projects"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_node.html.haml:90
 msgid "Show Container Replicators"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:98 ../../app/views/layouts/listnav/_container_service.html.haml:67 ../../app/views/layouts/listnav/_container_project.html.haml:91
 msgid "Show Container Routes"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_group.html.haml:82 ../../app/views/layouts/listnav/_ems_container.html.haml:65 ../../app/views/layouts/listnav/_container_node.html.haml:74 ../../app/views/layouts/listnav/_container_project.html.haml:74
 msgid "Show Container Services"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:66 ../../app/views/layouts/listnav/_ems_container.html.haml:146 ../../app/views/layouts/listnav/_container_node.html.haml:106
 msgid "Show Containers"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:16 ../../app/views/report/_form_filter_chargeback.html.haml:149
 msgid "Show Costs by"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:553
 msgid "Show Event Logs on this VM"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_bottlenecks_options.html.haml:38
 msgid "Show Host Events"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:162
 msgid "Show Image Registries"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:50 ../../app/views/layouts/listnav/_ems_container.html.haml:178
 msgid "Show Images"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_method_form.html.haml:116
 msgid "Show Input Parameters"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:143
 msgid "Show Other VM files on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:48
 msgid "Show Parent %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:366
 msgid "Show Past Dates"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:82 ../../app/views/layouts/listnav/_container_node.html.haml:58 ../../app/views/layouts/listnav/_container_service.html.haml:43 ../../app/views/layouts/listnav/_container_project.html.haml:57
 msgid "Show Pods"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:136
 msgid "Show Refresh Button"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_container.html.haml:130 ../../app/views/layouts/listnav/_container_project.html.haml:108
 msgid "Show Replicators"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:204 ../../app/views/layouts/listnav/_ems_cluster.html.haml:151
 msgid "Show Resource Pools"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:520
 msgid "Show Resources of this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:532
 msgid "Show Running Processes on this VM"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:73
 msgid "Show Sort Breaks"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:12 ../../app/views/layouts/listnav/_resource_pool.html.haml:13 ../../app/views/layouts/listnav/_host.html.haml:38 ../../app/views/layouts/listnav/_container_group.html.haml:16 ../../app/views/layouts/listnav/_repository.html.haml:12 ../../app/views/layouts/listnav/_storage.html.haml:13 ../../app/views/layouts/listnav/_flavor.html.haml:12 ../../app/views/layouts/listnav/_container_image_registry.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:12 ../../app/views/layouts/listnav/_service.html.haml:12 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:13 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:13 ../../app/views/layouts/listnav/_ems_container.html.haml:16 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:12 ../../app/views/layouts/listnav/_container_image.html.haml:16 ../../app/views/layouts/listnav/_ems_cluster.html.haml:13 ../../app/views/layouts/listnav/_storage_manager.html.haml:12 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:12 ../../app/views/layouts/listnav/_ems_infra.html.haml:14 ../../app/views/layouts/listnav/_container_replicator.html.haml:16 ../../app/views/layouts/listnav/_container_node.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:12 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:12 ../../app/views/layouts/listnav/_ems_cloud.html.haml:16 ../../app/views/layouts/listnav/_availability_zone.html.haml:16 ../../app/views/layouts/listnav/_container_route.html.haml:16 ../../app/views/layouts/listnav/_container_service.html.haml:16 ../../app/views/layouts/listnav/_container_project.html.haml:16 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:12 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:12 ../../app/views/layouts/listnav/_pxe_server.html.haml:12
 msgid "Show Summary"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:136 ../../app/views/layouts/listnav/_container_group.html.haml:23 ../../app/views/layouts/listnav/_ems_container.html.haml:22 ../../app/views/layouts/listnav/_ems_cluster.html.haml:50 ../../app/views/layouts/listnav/_vm_common.html.haml:120 ../../app/views/layouts/listnav/_ems_infra.html.haml:22 ../../app/views/layouts/listnav/_container_node.html.haml:23 ../../app/views/layouts/listnav/_ems_cloud.html.haml:21 ../../app/views/layouts/listnav/_container_project.html.haml:23
 msgid "Show Timelines"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:175
 msgid "Show VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:119
 msgid "Show VM Provisioned Disk Files on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:114
 msgid "Show VM Types"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:135
 msgid "Show VM memory files on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:127
 msgid "Show VM snapshot files on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:112
 msgid "Show VMM information"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:32
 msgid "Show VMs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_infra.html.haml:60
 msgid "Show VMs & Templates"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:64
 msgid "Show VMs in this Resource Pool, but not in Resource Pools below"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:71 ../../app/views/layouts/listnav/_storage.html.haml:91 ../../app/views/layouts/listnav/_storage.html.haml:100 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:38 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:49 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:58 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:67 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:32 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:50 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:61 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:70 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:79 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:32 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:50 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:61 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:70 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:79 ../../app/views/layouts/listnav/_ems_cluster.html.haml:176 ../../app/views/layouts/listnav/_ems_cluster.html.haml:192 ../../app/views/layouts/listnav/_ems_cluster.html.haml:200 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:22 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:31 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:40 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:49 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:58 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:69 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:78 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:87 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:29 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:38 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:47 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:56 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:67 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:76 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:85 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:30 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:39 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:48 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:57 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:68 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:77 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:86
 msgid "Show all %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:78
 msgid "Show all Cloud Networks"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:69
 msgid "Show all Images"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_flavor.html.haml:40 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:54 ../../app/views/layouts/listnav/_availability_zone.html.haml:41 ../../app/views/layouts/listnav/_security_group.html.haml:39 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:47
 msgid "Show all Instances"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:108
 msgid "Show all Outputs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:93
 msgid "Show all Parameters"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:123
 msgid "Show all Resources"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:63
 msgid "Show all Security Groups"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:238 ../../app/views/layouts/listnav/_ems_infra.html.haml:133
 msgid "Show all Templates"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:221 ../../app/views/layouts/listnav/_ems_infra.html.haml:117
 msgid "Show all VMs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:80
 msgid "Show all VMs in this Resource Pool"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_repository.html.haml:46
 msgid "Show all discovered Templates"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_repository.html.haml:31
 msgid "Show all discovered VMs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:111
 msgid "Show all files on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_infra.html.haml:76 ../../app/views/layouts/listnav/_ems_infra.html.haml:92 ../../app/views/layouts/listnav/_ems_infra.html.haml:99
 msgid "Show all managed %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:45
 msgid "Show all registered %s"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:80
 msgid "Show at Login"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_ems_cluster.html.haml:27
 msgid "Show configuration"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_performance.html.haml:19
 msgid "Show daily data from"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:498
 msgid "Show disks"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:158
 msgid "Show esx logs on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:141
 msgid "Show event logs on this VM"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:137
 msgid "Show events from last"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_performance.html.haml:16
 msgid "Show hourly data from"
 msgstr ""
 
+#: ../../app/views/ops/_category_form.html.haml:53 ../../app/views/ops/_category_form.html.haml:167 ../../app/views/ops/_settings_co_tags_tab.html.haml:50 ../../app/views/ops/_settings_co_categories_tab.html.haml:16
 msgid "Show in Console"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:86
 msgid "Show list of all %s"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:92
 msgid "Show list of configuration files of %s"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:79
 msgid "Show list of failed %s"
 msgstr ""
 
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:63
 msgid "Show list of hosts with %s"
 msgstr ""
 
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:56
 msgid "Show list of hosts with failed %s"
 msgstr ""
 
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:49
 msgid "Show list of hosts with running %s"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:72
 msgid "Show list of running %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_service.html.haml:30
 msgid "Show member VMs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:151
 msgid "Show non-VM files on this %s"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_evm_event.html.haml:16 ../../app/views/miq_policy/_alert_details.html.haml:421
 msgid "Show on Timeline"
 msgstr ""
 
+#: ../../app/views/vm_common/_policy_options.html.haml:16 ../../app/views/miq_policy/_rsop_results.html.haml:18
 msgid "Show out of scope items:"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_security_group.html.haml:47 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:24
 msgid "Show parent %s for this %s"
 msgstr ""
 
+#: ../../app/views/vm_common/_policy_options.html.haml:32 ../../app/views/miq_policy/_rsop_results.html.haml:34
 msgid "Show policies:"
 msgstr ""
 
+#: ../../app/views/layouts/quadicon/_quadicon_text.html.haml:44 ../../app/views/layouts/quadicon/_vm_or_template.html.haml:145
 msgid "Show policy details for %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:61
 msgid "Show registered VMs"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:87
 msgid "Show running process on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:96
 msgid "Show snapshot info"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:422
 msgid "Show the Win32 services installed on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:418
 msgid "Show the advanced settings on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:513
 msgid "Show the advanced settings on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:407
 msgid "Show the applications installed on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:452
 msgid "Show the file system drivers installed on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:402
 msgid "Show the files on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:392 ../../app/views/layouts/listnav/_vm_common.html.haml:467
 msgid "Show the files on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:352
 msgid "Show the firewall rules on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:320
 msgid "Show the groups defined on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:312
 msgid "Show the groups defined on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:437
 msgid "Show the kernel drivers installed on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:370
 msgid "Show the packages installed on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:336
 msgid "Show the patches installed on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:328
 msgid "Show the patches installed on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:482
 msgid "Show the registry items on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:386
 msgid "Show the services installed on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:305
 msgid "Show the users defined on this %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:297
 msgid "Show the users defined on this VM"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:169
 msgid "Show this %s parent %s"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:283
 msgid "Show this %s's %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_availability_zone.html.haml:26
 msgid "Show this Availability Zone's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:22
 msgid "Show this Cloud Tenant's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_flavor.html.haml:24
 msgid "Show this Flavor's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_security_group.html.haml:24
 msgid "Show this Security Group's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:205
 msgid "Show this VM's parent"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:162
 msgid "Show this VM's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:190
 msgid "Show this VM's parent Service"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:152 ../../app/views/layouts/listnav/_vm_common.html.haml:175
 msgid "Show this Vm's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image_registry.html.haml:74 ../../app/views/layouts/listnav/_container_image.html.haml:52
 msgid "Show this container group's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_node.html.haml:42
 msgid "Show this container node's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_replicator.html.haml:27
 msgid "Show this container replicator's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_replicator.html.haml:36 ../../app/views/layouts/listnav/_container_route.html.haml:27 ../../app/views/layouts/listnav/_container_route.html.haml:36 ../../app/views/layouts/listnav/_container_route.html.haml:45 ../../app/views/layouts/listnav/_container_service.html.haml:27 ../../app/views/layouts/listnav/_container_service.html.haml:51 ../../app/views/layouts/listnav/_container_project.html.haml:41
 msgid "Show this container service's parent %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_image.html.haml:42
 msgid "Show this images registry %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_group.html.haml:42 ../../app/views/layouts/listnav/_container_group.html.haml:90
 msgid "Show this pod's parent %s"
 msgstr ""
 
+#: ../../app/helpers/ems_container_helper/textual_summary.rb:85
 msgid "Show topology"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:96
 msgid "Show tree of all VMs in this Resource Pool"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:250
 msgid "Show virtual machine Analysis History"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:64
 msgid "Show virtual machine OS information"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:49
 msgid "Show virtual machine container information"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:235
 msgid "Show virtual machine drift history"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:219
 msgid "Show virtual machine genealogy"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:72
 msgid "Show virtual machine networks"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:109
 msgid "Shutdown"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:120 ../../app/presenters/menu/default_menu.rb:129
 msgid "Simulation"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:164
 msgid "Simulation Parameters"
 msgstr ""
 
+#: ../../app/controllers/application_controller/buttons.rb:1030
 msgid "Simulation unavailable: Required Class \"System/Process\" is missing"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:538
 msgid "Single Select"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_form.html.haml:47
 msgid "Single VM"
 msgstr ""
 
+#: ../../app/views/ops/_category_form.html.haml:68 ../../app/views/ops/_category_form.html.haml:182 ../../app/views/ops/_settings_co_categories_tab.html.haml:18
 msgid "Single Value"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:59 ../../app/views/ops/_db_info.html.haml:152 ../../app/views/ops/_db_info.html.haml:217 ../../app/views/vm_common/_snapshots_desc.html.haml:31
 msgid "Size"
 msgstr ""
 
+#: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:41
 msgid "Size (GB)"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:66 ../../app/helpers/configuration_helper/configuration_view_helper.rb:71
 msgid "Small Trees"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tag_box.html.haml:1 ../../app/views/provider_foreman/_main.html.haml:18 ../../app/views/service/_svcs_show.html.haml:20 ../../app/views/container_service/_main.html.haml:20 ../../app/views/resource_pool/_main.html.haml:16 ../../app/views/vm_cloud/_main.html.haml:36 ../../app/views/flavor/_main.html.haml:14 ../../app/views/ontap_storage_system/_main.html.haml:9 ../../app/views/orchestration_stack/_main.html.haml:14 ../../app/views/repository/_main.html.haml:9 ../../app/views/host/_main.html.haml:25 ../../app/views/ontap_logical_disk/_main.html.haml:18 ../../app/views/availability_zone/_main.html.haml:12 ../../app/views/ems_cluster/_main.html.haml:21 ../../app/views/container_group/_main.html.haml:27 ../../app/views/container/_container_show.html.haml:15 ../../app/views/security_group/_main.html.haml:22 ../../app/views/ontap_storage_volume/_main.html.haml:9 ../../app/views/container_replicator/_main.html.haml:18 ../../app/views/container_image_registry/_main.html.haml:16 ../../app/views/container_route/_main.html.haml:18 ../../app/views/vm_common/_main.html.haml:41 ../../app/views/storage/_main.html.haml:21 ../../app/views/ems_container/_main.html.haml:21 ../../app/views/container_node/_main.html.haml:19 ../../app/views/ontap_file_share/_main.html.haml:9 ../../app/views/shared/views/ems_common/_main.html.haml:16 ../../app/views/container_project/_main.html.haml:20 ../../app/views/container_image/_main.html.haml:19 ../../app/views/cloud_tenant/_main.html.haml:14
 msgid "Smart Management"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:11
 msgid "SmartProxy Affinity"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:45 ../../app/views/ops/_zone_form.html.haml:57
 msgid "SmartProxy Server IP"
 msgstr ""
 
+#: ../model_attributes.rb:2066
 msgid "Snapshot"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:182 ../../app/views/miq_policy/_action_details.html.haml:89
 msgid "Snapshot Age Settings"
 msgstr ""
 
+#: ../../app/views/vm_common/_snap.html.haml:6
 msgid "Snapshot Information"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:165
 msgid "Snapshot Name"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:156 ../../app/views/miq_policy/_action_details.html.haml:69
 msgid "Snapshot Settings"
 msgstr ""
 
+#: ../../app/views/vm_common/_snap.html.haml:40
 msgid "Snapshot VM memory"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:96
 msgid "Snapshots"
 msgstr ""
 
+#: ../model_attributes.rb:2067
 msgid "Snapshot|Create time"
 msgstr ""
 
+#: ../model_attributes.rb:2068
 msgid "Snapshot|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2069
 msgid "Snapshot|Current"
 msgstr ""
 
+#: ../model_attributes.rb:2070
 msgid "Snapshot|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2071
 msgid "Snapshot|Disks"
 msgstr ""
 
+#: ../model_attributes.rb:2072
 msgid "Snapshot|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:2073
 msgid "Snapshot|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:2074
 msgid "Snapshot|Filename"
 msgstr ""
 
+#: ../model_attributes.rb:2075
 msgid "Snapshot|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2076
 msgid "Snapshot|Parent uid"
 msgstr ""
 
+#: ../model_attributes.rb:2077
 msgid "Snapshot|Total size"
 msgstr ""
 
+#: ../model_attributes.rb:2078
 msgid "Snapshot|Uid"
 msgstr ""
 
+#: ../model_attributes.rb:2079
 msgid "Snapshot|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:2080
 msgid "Snapshot|Updated on"
 msgstr ""
 
+#: ../../app/views/vm_common/_reconfigure.html.haml:92
 msgid "Sockets"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:5
 msgid "Software updates have not yet been configured. Select Edit Registration to register appliances in this region with Red Hat to receive software updates and other benefits."
 msgstr ""
 
+#: ../../app/services/user_validation_service.rb:106
 msgid "Sorry, the username or password you entered is incorrect."
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:477 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:575 ../../app/views/report/_report_list.html.haml:139 ../../app/views/report/_report_info.html.haml:45
 msgid "Sort By"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:6
 msgid "Sort Criteria"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:497 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:594 ../../app/views/report/_form_sort.html.haml:51
 msgid "Sort Order"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:15
 msgid "Sort the Report By"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:19 ../../app/views/security_group/_main.html.haml:20 ../../app/views/chargeback/_reports_list.html.haml:60 ../../app/views/miq_capacity/_planning_options.html.haml:116 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:7
 msgid "Source"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:381
 msgid "Specified NTP settings applied here will override Zone NTP settings."
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:225
 msgid "Specify Calculations for Summary Rows"
 msgstr ""
 
+#: ../../app/views/report/_form_consolidate.html.haml:91
 msgid "Specify Calculations of Numeric Values for Grouped Records"
 msgstr ""
 
+#: ../../app/views/report/_form_formatting.html.haml:37
 msgid "Specify Column Headers and Formats"
 msgstr ""
 
+#: ../../app/views/report/_form_styling.html.haml:9
 msgid "Specify Column Styles"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:32 ../../app/views/configuration/_ui_2.html.haml:198
 msgid "Stacks"
 msgstr ""
 
+#: ../../app/views/ems_cloud/discover.html.haml:16 ../../app/views/layouts/_discover.html.haml:101 ../../app/views/catalog/_form_resources_info.html.haml:56 ../../app/views/catalog/_form_resources_info.html.haml:56 ../../app/views/catalog/_sandt_tree_show.html.haml:236 ../../app/views/catalog/_sandt_tree_show.html.haml:236
 msgid "Start"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:45
 msgid "Start Date"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:73
 msgid "Start Page"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:448
 msgid "Start TLS Automatically"
 msgstr ""
 
+#: ../../app/views/ems_cloud/discover.html.haml:16 ../../app/views/layouts/_discover.html.haml:101
 msgid "Start the %s Discovery"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:61 ../../app/views/ops/_selected_by_roles.html.haml:109 ../../app/views/ops/_server_desc.html.haml:39
 msgid "Started On"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_timer.html.haml:63 ../../app/views/report/_schedule_form_timer.html.haml:110
 msgid "Starting Date"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:132
 msgid "Starting Message"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_timer.html.haml:92 ../../app/views/report/_schedule_form_timer.html.haml:125
 msgid "Starting Time"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_field.html.haml:606
 msgid "Starting Time (%s)"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:35
 msgid "Starting process must be specified"
 msgstr ""
 
+#: ../../app/views/miq_request/_ae_prov_show.html.haml:18
 msgid "State"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:152 ../../app/views/catalog/_form_basic_info.html.haml:193 ../../app/views/catalog/_form_basic_info.html.haml:236 ../../app/views/catalog/_sandt_tree_show.html.haml:119
 msgid "State Machine (NS/Cls/Inst)"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:16 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/ops/_selected_by_servers.html.haml:48 ../../app/views/ops/_selected_by_servers.html.haml:181 ../../app/views/ops/_selected_by_roles.html.haml:17 ../../app/views/ops/_selected_by_roles.html.haml:64 ../../app/views/ops/_server_desc.html.haml:29 ../../app/views/ops/_diagnostics_replication_tab.html.haml:32 ../../app/views/miq_request/_request.html.haml:31 ../../app/views/miq_request/_request_details.html.haml:44 ../../app/views/miq_request/_ae_prov_show.html.haml:22 ../../app/views/ems_container/_main.html.haml:10 ../../app/views/report/_widget_show.html.haml:65 ../../app/views/shared/views/ems_common/_main.html.haml:9
 msgid "Status"
 msgstr ""
 
+#: ../../app/helpers/application_helper.rb:1287
 msgid "Status = %s"
 msgstr ""
 
+#: ../../app/views/ops/_zone_tree.html.haml:6
 msgid "Status of Regional Roles for Servers in %{kind} %{description}"
 msgstr ""
 
+#: ../../app/views/ops/_zone_tree.html.haml:9
 msgid "Status of Roles for Servers in %{kind} %{description}"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:56 ../../app/views/catalog/_form_resources_info.html.haml:56 ../../app/views/catalog/_sandt_tree_show.html.haml:236 ../../app/views/catalog/_sandt_tree_show.html.haml:236
 msgid "Stop"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:75 ../../app/views/ops/_selected_by_roles.html.haml:123
 msgid "Stopped On"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:108 ../../app/views/chargeback/_assignments_list.html.haml:35 ../../app/views/configuration/_ui_2.html.haml:361 ../model_attributes.rb:2081
 msgid "Storage"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:76 ../../app/views/layouts/listnav/_host.html.haml:82
 msgid "Storage Adapters"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:113 ../../app/views/ops/_settings_evm_servers_tab.html.haml:132 ../../app/views/configuration/_ui_2.html.haml:388
 msgid "Storage Managers"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:33
 msgid "Storage Medium Type"
 msgstr ""
 
+#: ../../app/views/host/_main.html.haml:15 ../../app/views/ems_cluster/_main.html.haml:10 ../../app/views/layouts/listnav/_host.html.haml:262 ../../app/views/layouts/listnav/_ems_cluster.html.haml:173 ../../app/views/layouts/listnav/_vm_common.html.haml:257 ../../app/views/vm_common/_main.html.haml:14 ../../app/views/storage/_main.html.haml:17
 msgid "Storage Relationships"
 msgstr ""
 
+#: ../model_attributes.rb:2100
 msgid "Storage file"
 msgstr ""
 
+#: ../model_attributes.rb:2107
 msgid "Storage manager"
 msgstr ""
 
+#: ../model_attributes.rb:2117
 msgid "Storage metrics metadata"
 msgstr ""
 
+#: ../model_attributes.rb:2101
 msgid "StorageFile|Base name"
 msgstr ""
 
+#: ../model_attributes.rb:2102
 msgid "StorageFile|Ext name"
 msgstr ""
 
+#: ../model_attributes.rb:2103
 msgid "StorageFile|Mtime"
 msgstr ""
 
+#: ../model_attributes.rb:2104
 msgid "StorageFile|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2105
 msgid "StorageFile|Rsc type"
 msgstr ""
 
+#: ../model_attributes.rb:2106
 msgid "StorageFile|Size"
 msgstr ""
 
+#: ../model_attributes.rb:2108
 msgid "StorageManager|Agent type"
 msgstr ""
 
+#: ../model_attributes.rb:2109
 msgid "StorageManager|Hostname"
 msgstr ""
 
+#: ../model_attributes.rb:2110
 msgid "StorageManager|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:2111
 msgid "StorageManager|Last update status"
 msgstr ""
 
+#: ../model_attributes.rb:2112
 msgid "StorageManager|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2113
 msgid "StorageManager|Port"
 msgstr ""
 
+#: ../model_attributes.rb:2114
 msgid "StorageManager|Type spec data"
 msgstr ""
 
+#: ../model_attributes.rb:2115
 msgid "StorageManager|Vendor"
 msgstr ""
 
+#: ../model_attributes.rb:2116
 msgid "StorageManager|Version"
 msgstr ""
 
+#: ../model_attributes.rb:2118
 msgid "StorageMetricsMetadata|Counter info"
 msgstr ""
 
+#: ../model_attributes.rb:2082
 msgid "Storage|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2083
 msgid "Storage|Directory hierarchy supported"
 msgstr ""
 
+#: ../model_attributes.rb:2084
 msgid "Storage|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:2085
 msgid "Storage|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:2086
 msgid "Storage|Free space"
 msgstr ""
 
+#: ../model_attributes.rb:2087
 msgid "Storage|Last perf capture on"
 msgstr ""
 
+#: ../model_attributes.rb:2088
 msgid "Storage|Last scan on"
 msgstr ""
 
+#: ../model_attributes.rb:2089
 msgid "Storage|Location"
 msgstr ""
 
+#: ../model_attributes.rb:2090
 msgid "Storage|Master"
 msgstr ""
 
+#: ../model_attributes.rb:2091
 msgid "Storage|Multiplehostaccess"
 msgstr ""
 
+#: ../model_attributes.rb:2092
 msgid "Storage|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2093
 msgid "Storage|Raw disk mappings supported"
 msgstr ""
 
+#: ../model_attributes.rb:2094
 msgid "Storage|Storage domain type"
 msgstr ""
 
+#: ../model_attributes.rb:2095
 msgid "Storage|Store type"
 msgstr ""
 
+#: ../model_attributes.rb:2096
 msgid "Storage|Thin provisioning supported"
 msgstr ""
 
+#: ../model_attributes.rb:2097
 msgid "Storage|Total space"
 msgstr ""
 
+#: ../model_attributes.rb:2098
 msgid "Storage|Uncommitted"
 msgstr ""
 
+#: ../model_attributes.rb:2099
 msgid "Storage|Updated on"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:461 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:559
 msgid "String"
 msgstr ""
 
+#: ../../app/views/report/_form_styling.html.haml:25
 msgid "Style"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:304
 msgid "Styling for '%s', first value is in error: "
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:306
 msgid "Styling for '%s', second value is in error: "
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:308
 msgid "Styling for '%s', third value is in error: "
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_class_fields.html.haml:94
 msgid "Sub"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_database_tab.html.haml:188 ../../app/views/ops/_diagnostics_database_tab.html.haml:225 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:64 ../../app/views/miq_request/_request.html.haml:266 ../../app/views/layouts/_x_edit_buttons.html.haml:76 ../../app/views/layouts/_x_edit_buttons.html.haml:153 ../../app/views/layouts/_x_dialog_buttons.html.haml:25 ../../app/views/layouts/_x_dialog_buttons.html.haml:62 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:6 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:35 ../../app/views/vm_common/_reconfigure.html.haml:165 ../../app/views/ontap_file_share/_create_datastore.html.haml:67 ../../app/views/miq_policy/_rsop_options.html.haml:32 ../../app/views/miq_capacity/planning.html.haml:9 ../../app/views/miq_capacity/planning.html.haml:30
 msgid "Submit"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:5
 msgid "Submit Automation Simulation with the specified options"
 msgstr ""
 
+#: ../../app/views/miq_capacity/planning.html.haml:9
 msgid "Submit Planning options"
 msgstr ""
 
+#: ../../app/views/ontap_file_share/_create_datastore.html.haml:67
 msgid "Submit this Create Datastore request"
 msgstr ""
 
+#: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:64
 msgid "Submit this Create Logical Disk request"
 msgstr ""
 
+#: ../../app/views/vm_common/_reconfigure.html.haml:165
 msgid "Submit this reconfigure request"
 msgstr ""
 
+#: ../../app/views/vm_common/_config.html.haml:211
 msgid "Subnet Mask"
 msgstr ""
 
+#: ../../app/views/layouts/_discover.html.haml:50
 msgid "Subnet Range"
 msgstr ""
 
+#: ../../app/views/alert/_rss_list.html.haml:50
 msgid "Subscribe to this feed"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_fields.html.haml:63
 msgid "Substitute: %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_form.html.haml:135 ../../app/views/miq_ae_class/_class_fields.html.haml:57
 msgid "Substitution:"
 msgstr ""
 
+#: ../../app/views/vm_common/_policy_options.html.haml:44
 msgid "Successful"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:1615
 msgid "Successfully deleted %s from the CFME Database"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:104
 msgid "Sum 'Other' values"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:162 ../../app/views/ops/_all_tabs.html.haml:281 ../../app/views/provider_foreman/_configuration_profile.html.haml:4 ../../app/views/layouts/_tl_options.html.haml:190 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:12 ../../app/views/layouts/listnav/_resource_pool.html.haml:13 ../../app/views/layouts/listnav/_host.html.haml:38 ../../app/views/layouts/listnav/_container_group.html.haml:16 ../../app/views/layouts/listnav/_repository.html.haml:12 ../../app/views/layouts/listnav/_storage.html.haml:13 ../../app/views/layouts/listnav/_flavor.html.haml:12 ../../app/views/layouts/listnav/_container_image_registry.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:12 ../../app/views/layouts/listnav/_service.html.haml:12 ../../app/views/layouts/listnav/_snia_local_file_system.html.haml:13 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:13 ../../app/views/layouts/listnav/_ems_container.html.haml:16 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:12 ../../app/views/layouts/listnav/_container_image.html.haml:16 ../../app/views/layouts/listnav/_ems_cluster.html.haml:13 ../../app/views/layouts/listnav/_vm_common.html.haml:34 ../../app/views/layouts/listnav/_storage_manager.html.haml:12 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:12 ../../app/views/layouts/listnav/_ems_infra.html.haml:14 ../../app/views/layouts/listnav/_container_replicator.html.haml:16 ../../app/views/layouts/listnav/_container_node.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:12 ../../app/views/layouts/listnav/_cim_storage_extent.html.haml:12 ../../app/views/layouts/listnav/_ems_cloud.html.haml:16 ../../app/views/layouts/listnav/_availability_zone.html.haml:16 ../../app/views/layouts/listnav/_security_group.html.haml:12 ../../app/views/layouts/listnav/_container_route.html.haml:16 ../../app/views/layouts/listnav/_container_service.html.haml:16 ../../app/views/layouts/listnav/_container_project.html.haml:16 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:12 ../../app/views/layouts/listnav/_cim_base_storage_extent.html.haml:12 ../../app/views/layouts/listnav/_pxe_server.html.haml:12 ../../app/views/miq_capacity/_planning_tabs.html.haml:4 ../../app/views/miq_capacity/_bottlenecks_tabs.html.haml:14 ../../app/views/miq_capacity/_utilization_tabs.html.haml:4
 msgid "Summary"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Sunday"
 msgstr ""
 
+#: ../../app/views/catalog/_form_resources_info.html.haml:109
 msgid "Suspend"
 msgstr ""
 
+#: ../model_attributes.rb:2119
 msgid "Switch"
 msgstr ""
 
+#: ../model_attributes.rb:2120
 msgid "Switch|Allow promiscuous"
 msgstr ""
 
+#: ../model_attributes.rb:2121
 msgid "Switch|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2122
 msgid "Switch|Forged transmits"
 msgstr ""
 
+#: ../model_attributes.rb:2123
 msgid "Switch|Mac changes"
 msgstr ""
 
+#: ../model_attributes.rb:2124
 msgid "Switch|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2125
 msgid "Switch|Ports"
 msgstr ""
 
+#: ../model_attributes.rb:2126
 msgid "Switch|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:2127
 msgid "Switch|Updated on"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:221 ../../app/views/miq_policy/_event_details.html.haml:406
 msgid "Synchronous"
 msgstr ""
 
+#: ../../app/views/pxe/_template_form.html.haml:73
 msgid "Sysprep"
 msgstr ""
 
+#: ../../app/controllers/application_controller/sysprep_answer_file.rb:12
 msgid "Sysprep \"%s\" upload was successful"
 msgstr ""
 
+#: ../../app/views/report/_form_columns.html.haml:62
 msgid "System Default"
 msgstr ""
 
+#: ../model_attributes.rb:2128
 msgid "System service"
 msgstr ""
 
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:19
 msgid "System/Process"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_show.html.haml:85
 msgid "System/Process/"
 msgstr ""
 
+#: ../model_attributes.rb:2129
 msgid "SystemService|Depend on group"
 msgstr ""
 
+#: ../model_attributes.rb:2130
 msgid "SystemService|Depend on service"
 msgstr ""
 
+#: ../model_attributes.rb:2131
 msgid "SystemService|Dependencies"
 msgstr ""
 
+#: ../model_attributes.rb:2132
 msgid "SystemService|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2133
 msgid "SystemService|Disable run levels"
 msgstr ""
 
+#: ../model_attributes.rb:2134
 msgid "SystemService|Display name"
 msgstr ""
 
+#: ../model_attributes.rb:2135
 msgid "SystemService|Enable run levels"
 msgstr ""
 
+#: ../model_attributes.rb:2136
 msgid "SystemService|Image path"
 msgstr ""
 
+#: ../model_attributes.rb:2137
 msgid "SystemService|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2138
 msgid "SystemService|Object name"
 msgstr ""
 
+#: ../model_attributes.rb:2139
 msgid "SystemService|Running"
 msgstr ""
 
+#: ../model_attributes.rb:2140
 msgid "SystemService|Start"
 msgstr ""
 
+#: ../model_attributes.rb:2141
 msgid "SystemService|Svc type"
 msgstr ""
 
+#: ../model_attributes.rb:2142
 msgid "SystemService|Systemd active"
 msgstr ""
 
+#: ../model_attributes.rb:2143
 msgid "SystemService|Systemd load"
 msgstr ""
 
+#: ../model_attributes.rb:2144
 msgid "SystemService|Systemd sub"
 msgstr ""
 
+#: ../model_attributes.rb:2145
 msgid "SystemService|Typename"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:110 ../../app/views/layouts/exp_atom/_edit_find.html.haml:218
 msgid "THROUGH"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:4
 msgid "Tab Information"
 msgstr ""
 
+#: ../../app/views/report/_db_show.html.haml:30 ../../app/views/report/_db_form.html.haml:41
 msgid "Tab Title"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:109
 msgid "Table"
 msgstr ""
 
+#: ../../app/views/ops/_db_summary.html.haml:12
 msgid "Tables with Most Rows"
 msgstr ""
 
+#: ../../app/views/ops/_db_summary.html.haml:16
 msgid "Tables with Most Wasted Space"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_editor.html.haml:81 ../../app/views/report/_form_filter_chargeback.html.haml:82 ../../app/views/miq_policy/_action_details.html.haml:318 ../model_attributes.rb:2146
 msgid "Tag"
 msgstr ""
 
+#: ../../app/views/layouts/_tag_edit.html.haml:6
 msgid "Tag Assignment%s"
 msgstr ""
 
+#: ../../app/views/chargeback/_cb_assignments.html.haml:40 ../../app/views/report/_form_filter_chargeback.html.haml:60 ../../app/views/miq_policy/_alert_profile_assign.html.haml:51
 msgid "Tag Category"
 msgstr ""
 
+#: ../../app/controllers/application_controller/tags.rb:229
 msgid "Tag edits were successfully saved"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:111
 msgid "Tag to Apply"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:18 ../model_attributes.rb:2148
 msgid "Tagging"
 msgstr ""
 
+#: ../model_attributes.rb:2149
 msgid "Tagging|Taggable type"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tag_box.html.haml:11 ../../app/views/ops/_all_tabs.html.haml:90 ../../app/views/ops/_rbac_group_details.html.haml:277
 msgid "Tags"
 msgstr ""
 
+#: ../../app/views/layouts/_tag_edit.html.haml:6
 msgid "Tags common to all selected items"
 msgstr ""
 
+#: ../model_attributes.rb:2147
 msgid "Tag|Name"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:252
 msgid "Target Options / Limits"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:54
 msgid "Target Options/Limits"
 msgstr ""
 
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18
 msgid "Target Port"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:128
 msgid "Task State"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:79
 msgid "Task Status"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:148
 msgid "Tasks"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:22
 msgid "Template"
 msgstr ""
 
+#: ../../app/views/catalog/_ot_add.html.haml:54
 msgid "Template Type"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:276
 msgid "Templates"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:46
 msgid "Templates & Images"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:238 ../../app/views/layouts/listnav/_repository.html.haml:40 ../../app/views/layouts/listnav/_repository.html.haml:46 ../../app/views/layouts/listnav/_ems_infra.html.haml:127
 msgid "Templates (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:232
 msgid "Templates (0)"
 msgstr ""
 
+#: ../../app/views/provider_foreman/_main.html.haml:16 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:16
 msgid "Tenancy"
 msgstr ""
 
+#: ../model_attributes.rb:2150
 msgid "Tenant"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:117
 msgid "Tenant ID"
 msgstr ""
 
+#: ../model_attributes.rb:2167
 msgid "Tenant quota"
 msgstr ""
 
+#: ../model_attributes.rb:2168
 msgid "TenantQuota|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2169
 msgid "TenantQuota|Unit"
 msgstr ""
 
+#: ../model_attributes.rb:2170
 msgid "TenantQuota|Value"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:28 ../../app/views/configuration/_ui_2.html.haml:142
 msgid "Tenants"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:109
 msgid "Tenants (%s)"
 msgstr ""
 
+#: ../model_attributes.rb:2151
 msgid "Tenant|Ancestry"
 msgstr ""
 
+#: ../model_attributes.rb:2152
 msgid "Tenant|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2153
 msgid "Tenant|Divisible"
 msgstr ""
 
+#: ../model_attributes.rb:2154
 msgid "Tenant|Domain"
 msgstr ""
 
+#: ../model_attributes.rb:2155
 msgid "Tenant|Login logo content type"
 msgstr ""
 
+#: ../model_attributes.rb:2156
 msgid "Tenant|Login logo file name"
 msgstr ""
 
+#: ../model_attributes.rb:2157
 msgid "Tenant|Login logo file size"
 msgstr ""
 
+#: ../model_attributes.rb:2158
 msgid "Tenant|Login logo updated at"
 msgstr ""
 
+#: ../model_attributes.rb:2159
 msgid "Tenant|Login text"
 msgstr ""
 
+#: ../model_attributes.rb:2160
 msgid "Tenant|Logo content type"
 msgstr ""
 
+#: ../model_attributes.rb:2161
 msgid "Tenant|Logo file name"
 msgstr ""
 
+#: ../model_attributes.rb:2162
 msgid "Tenant|Logo file size"
 msgstr ""
 
+#: ../model_attributes.rb:2163
 msgid "Tenant|Logo updated at"
 msgstr ""
 
+#: ../model_attributes.rb:2164
 msgid "Tenant|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2165
 msgid "Tenant|Subdomain"
 msgstr ""
 
+#: ../model_attributes.rb:2166
 msgid "Tenant|Use config for attributes"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:556
 msgid "Test E-mail Address"
 msgstr ""
 
+#: ../../app/views/report/_schedule_email_options.html.haml:41 ../../app/views/shared/buttons/_ab_list.html.haml:45 ../../app/views/shared/buttons/_ab_list.html.haml:205
 msgid "Text"
 msgstr ""
 
+#: ../../app/services/user_validation_service.rb:90
 msgid "The CFME Server is still starting, you have been redirected to the diagnostics page for problem determination"
 msgstr ""
 
+#: ../../app/services/user_validation_service.rb:94
 msgid "The CFME Server is still starting. If this message persists, please contact your CFME administrator."
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:251
 msgid "The Default Repository SmartProxy is not valid, contact your CFME Administrator"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:245
 msgid "The Default Repository SmartProxy no longer exists, contact your CFME Administrator"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:256
 msgid "The Default Repository SmartProxy, \"%s\", is not running, contact your CFME Administrator"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:181
 msgid "The Enterprise"
 msgstr ""
 
+#: ../../app/controllers/ems_common.rb:683
 msgid "The Host Default VNC Port Range ending port must be equal to or higher than the starting point"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:482
 msgid "The Remote Console is connecting"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:84
 msgid "The VM has been suspended, powered off or the connection to the server has been lost. \\nThis console window will now close."
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:1473
 msgid "The check count value must be an integer to commit this expression element"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:743
 msgid "The current search details have been reset"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:1630
 msgid "The selected %s is not in the current region"
 msgstr ""
 
+#: ../../app/controllers/repository_controller.rb:314 ../../app/controllers/chargeback_controller.rb:315 ../../app/controllers/report_controller/dashboards.rb:119 ../../app/controllers/report_controller/widgets.rb:112 ../../app/controllers/report_controller/saved_reports.rb:101 ../../app/controllers/report_controller/schedules.rb:88 ../../app/controllers/miq_policy_controller/policies.rb:129 ../../app/controllers/miq_policy_controller/miq_actions.rb:80 ../../app/controllers/miq_policy_controller/alerts.rb:60 ../../app/controllers/miq_policy_controller/alert_profiles.rb:116 ../../app/controllers/miq_policy_controller/conditions.rb:132 ../../app/controllers/miq_policy_controller/policy_profiles.rb:83 ../../app/controllers/miq_request_controller.rb:531 ../../app/controllers/catalog_controller.rb:330 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:418 ../../app/controllers/ops_controller/diagnostics.rb:702 ../../app/controllers/ems_common.rb:955 ../../app/controllers/application_controller/ci_processing.rb:1841 ../../app/controllers/application_controller/ci_processing.rb:1866
 msgid "The selected %s was deleted"
 msgstr ""
 
+#: ../../app/controllers/chargeback_controller.rb:300 ../../app/controllers/report_controller/widgets.rb:109 ../../app/controllers/report_controller/schedules.rb:88 ../../app/controllers/miq_ae_class_controller.rb:1880 ../../app/controllers/miq_ae_class_controller.rb:1907 ../../app/controllers/miq_request_controller.rb:522 ../../app/controllers/catalog_controller.rb:338
 msgid "The selected %s were deleted"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:141
 msgid "The selected %s were disabled"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:138
 msgid "The selected %s were enabled"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_class_controller.rb:2496
 msgid "The selected %{model} were marked as %{action}"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:915
 msgid "The selected Filter can not be set as Default because it requires user input"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:913
 msgid "The selected Filter record was not found"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:124
 msgid "The selected Schedule has been queued to run"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:126
 msgid "The selected Schedules have been queued to run"
 msgstr ""
 
+#: ../../app/controllers/miq_task_controller.rb:142
 msgid "The selected Task was cancelled"
 msgstr ""
 
+#: ../../app/controllers/miq_task_controller.rb:228
 msgid "The selected job no longer exists, Delete all older Tasks was not completed"
 msgstr ""
 
+#: ../../app/views/layouts/_spinner.html.haml:10
 msgid "The server is initializing; access is being retried every 10 seconds %s"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:251
 msgid "The test email is being delivered, check \"%s\" to verify it was successful"
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:124 ../../app/controllers/application_controller.rb:1321 ../../app/controllers/application_controller.rb:2585 ../../app/controllers/ontap_file_share_controller.rb:57 ../../app/controllers/ontap_storage_system_controller.rb:62
 msgid "The user is not authorized for this task or item."
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:103
 msgid "There is an error in the selected expression element, perhaps it was imported or edited manually."
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:89
 msgid "Third band unit"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:546
 msgid "This Action is not assigned to any Policies."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:467
 msgid "This Alert is not assigned to any Alert Profiles."
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:498
 msgid "This Alert is not referenced by any Actions."
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_details.html.haml:126
 msgid "This Condition is not assigned to any Policies."
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:393
 msgid "This Event has no false Actions."
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:208
 msgid "This Event has no true Actions."
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:55
 msgid "This Event is not assigned to any Policies."
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:180
 msgid "This Month (partial)"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:448
 msgid "This Policy is not assigned to any Profiles."
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_timelines_tab.html.haml:16 ../../app/views/ops/_diagnostics_utilization_tab.html.haml:13
 msgid "This Server's Virtual Machine has not been identified."
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:178
 msgid "This Week (partial)"
 msgstr ""
 
+#: ../../app/controllers/application_controller/filter.rb:104
 msgid "This element should be removed and recreated or you can report the error to your CFME administrator."
 msgstr ""
 
+#: ../../app/views/vm_common/console_mks.html.haml:200
 msgid "This page requires the VMware MKS plugin. Install the plugin and try again."
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:335
 msgid "This policy does not currently respond to any Events."
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:289
 msgid "This user is limited to items with the selected tags."
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:333
 msgid "This user is limited to the selected folders and their children."
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:311
 msgid "This user is limited to the selected items and their children."
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:32
 msgid "This will show the chart and the entire report (all rows) in your browser. Do you want to proceed?"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:42
 msgid "This will show the entire report (all rows) in your browser. Do you want to proceed?"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Thursday"
 msgstr ""
 
+#: ../../app/helpers/configuration_helper/configuration_view_helper.rb:76 ../../app/helpers/configuration_helper/configuration_view_helper.rb:82 ../../app/helpers/configuration_helper/configuration_view_helper.rb:88 ../../app/views/configuration/_ui_1.html.haml:107
 msgid "Tile View"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:130 ../../app/views/report/_form_filter_performance.html.haml:52 ../../app/views/miq_capacity/_utilization_options.html.haml:67 ../../app/views/miq_capacity/_planning_options.html.haml:435 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:116
 msgid "Time Profile"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_form.html.haml:10
 msgid "Time Profile Information"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:636
 msgid "Time Profiles"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_timer.html.haml:41 ../../app/views/configuration/_ui_1.html.haml:139 ../../app/views/report/_schedule_form_timer.html.haml:86 ../../app/views/report/_form_filter_chargeback.html.haml:212 ../../app/views/miq_capacity/_bottlenecks_options.html.haml:54 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:128
 msgid "Time Zone"
 msgstr ""
 
+#: ../model_attributes.rb:2171
 msgid "Time profile"
 msgstr ""
 
+#: ../model_attributes.rb:2172
 msgid "TimeProfile|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2173
 msgid "TimeProfile|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2174
 msgid "TimeProfile|Profile"
 msgstr ""
 
+#: ../model_attributes.rb:2175
 msgid "TimeProfile|Profile key"
 msgstr ""
 
+#: ../model_attributes.rb:2176
 msgid "TimeProfile|Profile type"
 msgstr ""
 
+#: ../model_attributes.rb:2177
 msgid "TimeProfile|Rollup daily metrics"
 msgstr ""
 
+#: ../model_attributes.rb:2178
 msgid "TimeProfile|Updated on"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_evm_event.html.haml:5 ../../app/views/miq_policy/_alert_details.html.haml:412
 msgid "Timeline Event"
 msgstr ""
 
+#: ../../app/views/report/_form_preview.html.haml:8
 msgid "Timeline Preview (up to 50 rows)"
 msgstr ""
 
+#: ../../app/views/report/_form_tl_settings.html.haml:8
 msgid "Timeline Settings"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:10 ../../app/views/ops/_all_tabs.html.haml:186 ../../app/views/layouts/listnav/_host.html.haml:144 ../../app/views/layouts/listnav/_container_group.html.haml:31 ../../app/views/layouts/listnav/_ems_container.html.haml:22 ../../app/views/layouts/listnav/_ems_container.html.haml:30 ../../app/views/layouts/listnav/_ems_cluster.html.haml:50 ../../app/views/layouts/listnav/_ems_cluster.html.haml:58 ../../app/views/layouts/listnav/_vm_common.html.haml:120 ../../app/views/layouts/listnav/_vm_common.html.haml:128 ../../app/views/layouts/listnav/_ems_infra.html.haml:22 ../../app/views/layouts/listnav/_ems_infra.html.haml:30 ../../app/views/layouts/listnav/_container_node.html.haml:31 ../../app/views/layouts/listnav/_ems_cloud.html.haml:21 ../../app/views/layouts/listnav/_ems_cloud.html.haml:27 ../../app/views/layouts/listnav/_container_project.html.haml:31
 msgid "Timelines"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1784
 msgid "Timelines for %{model} \"%{name}\""
 msgstr ""
 
+#: ../../app/views/report/_widget_show.html.haml:288 ../../app/views/report/_schedule_form_timer.html.haml:6
 msgid "Timer"
 msgstr ""
 
+#: ../../app/views/layouts/_drift_history.html.haml:30
 msgid "Timestamp"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:25 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/configuration/_timeprofile_form.html.haml:70
 msgid "Timezone"
 msgstr ""
 
+#: ../../app/views/alert/_rss_list.html.haml:39 ../../app/views/configuration/_timeprofile_form.html.haml:162 ../../app/views/report/_widget_show.html.haml:14 ../../app/views/report/_widget_form.html.haml:19 ../../app/views/report/_form.html.haml:39 ../../app/views/report/_report_info.html.haml:9 ../../app/views/report/_report_info.html.haml:243
 msgid "Title"
 msgstr ""
 
-msgid "Title:"
-msgstr ""
-
+#: ../../app/views/layouts/_edit_to_email.html.haml:12 ../../app/views/miq_policy/_alert_details.html.haml:306
 msgid "To"
 msgstr ""
 
+#: ../../app/views/layouts/_discover.html.haml:77
 msgid "To Address"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_ab_show.html.haml:201
 msgid "To All"
 msgstr ""
 
+#: ../../app/helpers/report_helper.rb:23
 msgid "To All Users"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:34
 msgid "To Domain"
 msgstr ""
 
+#: ../../app/views/report/_show_schedule.html.haml:58
 msgid "To E-mail"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:42 ../../app/views/miq_policy/_action_details.html.haml:209
 msgid "To E-mail Address"
 msgstr ""
 
+#: ../../app/views/chargeback/_chargeback_instructions.html.haml:3
 msgid "To Generate a Chargeback Report"
 msgstr ""
 
+#: ../../app/controllers/ems_common.rb:678
 msgid "To configure the Host Default VNC Port Range, both start and end ports are required"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:176
 msgid "Today (partial)"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_import_export.html.haml:142
 msgid "Toggle All/None"
 msgstr ""
 
+#: ../../app/views/layouts/_auth_bearer_token.html.haml:8
 msgid "Token"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:83
 msgid "Top values to show"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:102 ../../app/helpers/ems_container_helper/textual_summary.rb:82
 msgid "Topology"
 msgstr ""
 
+#: ../../app/views/miq_request/_reconfigure_show.html.haml:63 ../../app/views/vm_common/_reconfigure.html.haml:141
 msgid "Total Processors"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:90
 msgid "Total VMs: 0"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_report.html.haml:14
 msgid "Total number of VMs that can fit on all of the above %s: %s"
 msgstr ""
 
+#: ../../app/views/ems_cluster/_main.html.haml:15
 msgid "Totals for %s"
 msgstr ""
 
+#: ../../app/views/service/_svcs_show.html.haml:18
 msgid "Totals for Service VMs"
 msgstr ""
 
+#: ../../app/views/ems_cluster/_main.html.haml:17
 msgid "Totals for VMs"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_snmp.html.haml:80 ../../app/views/miq_policy/_action_options.html.haml:411 ../../app/views/miq_policy/_alert_details.html.haml:352 ../../app/views/miq_policy/_action_details.html.haml:364
 msgid "Trap Number"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_snmp.html.haml:80 ../../app/views/miq_policy/_action_options.html.haml:411 ../../app/views/miq_policy/_alert_details.html.haml:352 ../../app/views/miq_policy/_action_details.html.haml:364
 msgid "Trap Object ID"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_tabs.html.haml:4
 msgid "Tree View"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:404 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:105
 msgid "Trend Options"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_trend.html.haml:29
 msgid "Trend Target Limit"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_trend.html.haml:80
 msgid "Trend Target Percents"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:109
 msgid "Trend for Past"
 msgstr ""
 
+#: ../../app/views/report/_form_columns_trend.html.haml:6
 msgid "Trending for"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_utilization_options.html.haml:16 ../../app/views/miq_capacity/_planning_options.html.haml:413
 msgid "Trends for past"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:388 ../../app/views/report/_show_schedule.html.haml:35 ../../app/views/catalog/_ot_tree_show.html.haml:42 ../../app/views/catalog/_ot_tree_show.html.haml:55 ../../app/views/miq_policy/_alert_details.html.haml:426
 msgid "True"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:49
 msgid "Truncate Long Text"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:4
 msgid "Trusted Forest Settings"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Tuesday"
 msgstr ""
 
+#: ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/ops/_settings_database_tab.html.haml:31 ../../app/views/ops/_schedule_form_filter.html.haml:19 ../../app/views/ops/_ap_show.html.haml:48 ../../app/views/ops/_log_collection.html.haml:21 ../../app/views/ops/_settings_import_tab.html.haml:16 ../../app/views/ops/_diagnostics_database_tab.html.haml:19 ../../app/views/ops/_diagnostics_database_tab.html.haml:135 ../../app/views/ops/_ap_form.html.haml:55 ../../app/views/storage_manager/_form.html.haml:37 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:53 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:69 ../../app/views/layouts/_ae_resolve_options.html.haml:92 ../../app/views/layouts/_ae_resolve_options.html.haml:116 ../../app/views/layouts/_edit_log_depot_settings.html.haml:21 ../../app/views/vm_common/_disks.html.haml:9 ../../app/views/miq_ae_class/_class_fields.html.haml:94 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_widget_show.html.haml:178 ../../app/views/report/_db_list.html.haml:15 ../../app/views/report/_widget_form_rss.html.haml:15 ../../app/views/shared/views/ems_common/angular/_form.html.haml:39 ../../app/views/shared/views/ems_common/_form.html.haml:35 ../../app/views/shared/buttons/_ab_list.html.haml:51 ../../app/views/shared/buttons/_ab_show.html.haml:135 ../../app/views/pxe/_pxe_image_type_form.html.haml:34 ../../app/views/pxe/_template_form.html.haml:70 ../../app/views/pxe/_pxe_img_form.html.haml:17 ../../app/views/pxe/_iso_img_form.html.haml:17 ../../app/views/pxe/_pxe_wimg_form.html.haml:17 ../../app/views/miq_policy/_event_details.html.haml:223 ../../app/views/miq_policy/_event_details.html.haml:408 ../../app/views/miq_policy/_alert_snmp.html.haml:108 ../../app/views/miq_policy/_action_options.html.haml:448 ../../app/views/miq_policy/_alert_details.html.haml:380 ../../app/views/miq_policy/_action_details.html.haml:398
 msgid "Type"
 msgstr ""
 
-msgid "Type one or more tags to create and press \"Enter\":"
-msgstr ""
-
+#: ../../app/views/miq_request/_prov_options.html.haml:62 ../../app/views/miq_ae_class/_instance_form.html.haml:113 ../../app/views/miq_ae_class/_class_fields.html.haml:36 ../../app/views/miq_policy/_rsop_form.html.haml:17
 msgid "Type:"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_instance_fields.html.haml:46
 msgid "Type: %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:178
 msgid "UI Worker"
 msgstr ""
 
+#: ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:36 ../../app/views/layouts/_edit_log_depot_settings.html.haml:60 ../../app/views/miq_ae_tools/_results_uri.html.haml:16 ../../app/views/pxe/_pxe_form.html.haml:55
 msgid "URI"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:668
 msgid "URL (i.e. www.mypage.com)"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1027
 msgid "Unable to create a new template copy \"%s\": new template content cannot be empty."
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1022
 msgid "Unable to create a new template copy \"%s\": old and new template content have to differ."
 msgstr ""
 
+#: ../../app/controllers/ems_infra_controller.rb:72
 msgid "Unable to initiate scaling: %s"
 msgstr ""
 
+#: ../../app/views/catalog/_form_basic_info.html.haml:62 ../../app/views/catalog/_sandt_tree_show.html.haml:61
 msgid "Unassigned"
 msgstr ""
 
+#: ../../app/presenters/tree_node_builder.rb:222 ../../app/controllers/provider_foreman_controller.rb:885 ../../app/controllers/provider_foreman_controller.rb:893 ../../app/controllers/provider_foreman_controller.rb:909 ../../app/controllers/provider_foreman_controller.rb:922
 msgid "Unassigned Profiles Group"
 msgstr ""
 
+#: ../../app/views/shared/buttons/_column_lists.html.haml:7 ../../app/views/catalog/_column_lists.html.haml:7
 msgid "Unassigned:"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:225
 msgid "Unattended GUI"
 msgstr ""
 
+#: ../../app/views/layouts/_exp_editor.html.haml:19
 msgid "Undo the last change"
 msgstr ""
 
+#: ../../app/views/layouts/_exception_contents.html.haml:5
 msgid "Unexpected error encountered"
 msgstr ""
 
+#: ../../app/views/ops/_tenant_quota_form.html.haml:37
 msgid "Units"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_footer.html.haml:24 ../../app/views/pxe/_pxe_img_form.html.haml:22 ../../app/views/pxe/_iso_img_form.html.haml:22 ../../app/views/pxe/_pxe_wimg_form.html.haml:22
 msgid "Unknown"
 msgstr ""
 
+#: ../../app/controllers/application_controller/performance.rb:548
 msgid "Unknown error has occurred"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:85 ../../app/views/ops/_zone_form.html.haml:199
 msgid "Unlimited"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:303
 msgid "Update"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:101
 msgid "Update Password"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_server_table.html.haml:92
 msgid "Update Status"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:101
 msgid "Update password"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:44
 msgid "Update this LDAP Server"
 msgstr ""
 
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:108 ../../app/views/ops/_ap_form_nteventlog.html.haml:108 ../../app/views/ops/_ldap_forest_entries.html.haml:105 ../../app/views/ops/_ldap_forest_entries.html.haml:105 ../../app/views/ops/_ap_form_file.html.haml:94 ../../app/views/ops/_ap_form_registry.html.haml:80 ../../app/views/ops/_ap_form_registry.html.haml:80 ../../app/views/ops/_classification_entry.html.haml:28 ../../app/views/ops/_classification_entry.html.haml:28 ../../app/views/miq_ae_customization/_field_value_entry.html.haml:28
 msgid "Update this entry"
 msgstr ""
 
+#: ../../app/views/dashboard/_widget_footer.html.haml:6
 msgid "Updated"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_info.html.haml:60 ../../app/views/report/_report_info.html.haml:96 ../../app/views/catalog/_ot_tree_show.html.haml:76
 msgid "Updated On"
 msgstr ""
 
-msgid "Updated On:"
-msgstr ""
-
+#: ../../app/views/ops/_settings_import_tab.html.haml:53 ../../app/views/ops/_settings_import_tags_tab.html.haml:42 ../../app/views/miq_request/_prov_field.html.haml:657 ../../app/views/miq_request/_prov_field.html.haml:677 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:44 ../../app/views/miq_ae_tools/_import_export.html.haml:46 ../../app/views/report/_export_custom_reports.html.haml:45 ../../app/views/report/_export_widgets.html.haml:50 ../../app/views/catalog/_sandt_tree_show.html.haml:186 ../../app/views/miq_policy/_export.html.haml:65
 msgid "Upload"
 msgstr ""
 
+#: ../../app/views/ops/_settings_import_tab.html.haml:9
 msgid "Upload Custom Variable Values"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:310
 msgid "Upload File"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:319
 msgid "Uploaded File '%s'"
 msgstr ""
 
+#: ../../app/views/provider_foreman/_form.html.haml:36
 msgid "Url"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:261
 msgid "Use"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:36 ../../app/views/layouts/exp_atom/_edit_find.html.haml:24 ../../app/views/layouts/exp_atom/_edit_count.html.haml:25 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:36
 msgid "Use Alias"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:477
 msgid "Use CTRL-ALT-Enter to toggle full screen"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vmrc.html.haml:473
 msgid "Use CTRL-ALT-INS for CTRL-ALT-DEL"
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:120
 msgid "Use Custom Login Background Image"
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:159
 msgid "Use Custom Login Text"
 msgstr ""
 
+#: ../../app/views/ops/_settings_custom_logos_tab.html.haml:49
 msgid "Use Custom Logo Image"
 msgstr ""
 
+#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:101
 msgid "Use HTTP Proxy"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/upload.rb:37 ../../app/controllers/ops_controller/settings/upload.rb:96 ../../app/controllers/ops_controller/settings.rb:29
 msgid "Use the Browse button to locate %s file"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:460
 msgid "Use the Browse button to locate a %s image file"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:203 ../../app/controllers/report_controller.rb:91 ../../app/controllers/miq_policy_controller.rb:162
 msgid "Use the Browse button to locate an Import file"
 msgstr ""
 
+#: ../../app/controllers/application_controller/sysprep_answer_file.rb:22
 msgid "Use the Browse button to locate an Upload file"
 msgstr ""
 
+#: ../../app/views/vm_common/_disks.html.haml:17
 msgid "Used Size"
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:118 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:158
 msgid "Used for SSH connection to all %s in this provider."
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:176 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:237
 msgid "Used for access to IPMI."
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:157 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:211
 msgid "Used for access to Web Services."
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:100 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:128
 msgid "Used to authenticate with OpenStack AMQP Messaging Bus for event handling."
 msgstr ""
 
+#: ../../app/views/layouts/_multi_auth_credentials.html.haml:81 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:102
 msgid "Used to gather Capacity & Utilization metrics."
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:39 ../../app/views/report/_report_list.html.haml:149 ../../app/views/report/_report_info.html.haml:76 ../model_attributes.rb:2179
 msgid "User"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:259
 msgid "User Data"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:398
 msgid "User Group Sequence was saved"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_seq_form.html.haml:17
 msgid "User Group Sequencing for LDAP Look Up:"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:12
 msgid "User Information"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:212 ../../app/controllers/configuration_controller.rb:225
 msgid "User Interface settings saved for User %s"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:214 ../../app/controllers/configuration_controller.rb:227
 msgid "User Interface settings saved for this session"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:503 ../../app/views/support/show.html.haml:17
 msgid "User Name"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_domain_form.html.haml:40 ../../app/views/ops/_ldap_domain_show.html.haml:61 ../../app/views/_ldap_domain_form.html.haml:40
 msgid "User Principal Name"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:17
 msgid "User Role"
 msgstr ""
 
+#: ../../app/views/layouts/_role_visibility.html.haml:38 ../../app/views/shared/buttons/_ab_show.html.haml:220
 msgid "User Roles"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_region_show.html.haml:77
 msgid "User Suffix"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:174 ../../app/views/ops/_ldap_domain_form.html.haml:59 ../../app/views/ops/_ldap_domain_show.html.haml:70 ../../app/views/_ldap_domain_form.html.haml:59
 msgid "User Suffix:"
 msgstr ""
 
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:130 ../../app/views/ops/_ldap_region_show.html.haml:75 ../../app/views/ops/_ldap_domain_form.html.haml:35 ../../app/views/ops/_ldap_domain_show.html.haml:42 ../../app/views/_ldap_domain_form.html.haml:35
 msgid "User Type"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:159 ../../app/views/ops/_rbac_group_details.html.haml:192
 msgid "User to Look Up"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_editor.html.haml:110
 msgid "User will input the value"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:18 ../../app/views/ops/_zone_form.html.haml:133 ../../app/views/ops/_rbac_user_details.html.haml:50 ../../app/views/ops/_settings_workers_tab.html.haml:601 ../../app/views/ops/_rbac_group_details.html.haml:211 ../../app/views/ops/_diagnostics_database_tab.html.haml:67 ../../app/views/storage_manager/_form.html.haml:152 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:4 ../../app/views/layouts/_auth_credentials_keypair.html.haml:7 ../../app/views/layouts/_auth_credentials.html.haml:9 ../../app/views/layouts/_discover_credentials.html.haml:12 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:138 ../../app/views/dashboard/login.html.haml:48 ../../app/views/dashboard/login.html.haml:52 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_report_info.html.haml:155
 msgid "Username"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/ldap.rb:179 ../../app/controllers/ems_common.rb:659 ../../app/controllers/application_controller/ci_processing.rb:806
 msgid "Username must be entered if Password is entered"
 msgstr ""
 
+#: ../../app/views/layouts/_item.html.haml:109
 msgid "Users"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:49 ../../app/views/layouts/listnav/_host.html.haml:305 ../../app/views/layouts/listnav/_vm_common.html.haml:291 ../../app/views/layouts/listnav/_vm_common.html.haml:297
 msgid "Users (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:299
 msgid "Users (0)"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar_builder.rb:1040
 msgid "Users are only allowed to delete their own requests"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:121
 msgid "Users in this Group"
 msgstr ""
 
+#: ../model_attributes.rb:2180
 msgid "User|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2181
 msgid "User|Email"
 msgstr ""
 
+#: ../model_attributes.rb:2182
 msgid "User|Filters"
 msgstr ""
 
+#: ../model_attributes.rb:2183
 msgid "User|First name"
 msgstr ""
 
+#: ../model_attributes.rb:2184
 msgid "User|Icon"
 msgstr ""
 
+#: ../model_attributes.rb:2185
 msgid "User|Last name"
 msgstr ""
 
+#: ../model_attributes.rb:2186
 msgid "User|Lastlogoff"
 msgstr ""
 
+#: ../model_attributes.rb:2187
 msgid "User|Lastlogon"
 msgstr ""
 
+#: ../model_attributes.rb:2188
 msgid "User|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2189
 msgid "User|Password digest"
 msgstr ""
 
+#: ../model_attributes.rb:2190
 msgid "User|Region"
 msgstr ""
 
+#: ../model_attributes.rb:2191
 msgid "User|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:2192
 msgid "User|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:2193
 msgid "User|Userid"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:139 ../../app/views/ops/_all_tabs.html.haml:183 ../../app/views/ops/_all_tabs.html.haml:299
 msgid "Utilization"
 msgstr ""
 
+#: ../../app/views/vm_cloud/_main.html.haml:21 ../../app/views/host/_main.html.haml:29 ../../app/views/vm_common/_main.html.haml:22
 msgid "VC Custom Attributes"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_1.html.haml:22
 msgid "VM"
 msgstr ""
 
+#: ../../app/views/vm_common/console_mks.html.haml:8 ../../app/views/vm_common/console_mks.html.haml:93
 msgid "VM %s Remote Console"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:51
 msgid "VM & Template Access Restriction"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:508
 msgid "VM Analysis Collectors"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_report.html.haml:8
 msgid "VM Counts per %s"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:69
 msgid "VM Hardware"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:172
 msgid "VM Limits"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:135
 msgid "VM Memory Files"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_field.html.haml:157 ../../app/views/miq_request/_prov_field.html.haml:166
 msgid "VM Number"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:107
 msgid "VM Options"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:119
 msgid "VM Provisioned Disk Files"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:389
 msgid "VM Reconfigure Request was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/application_controller/ci_processing.rb:454
 msgid "VM Reconfigure Request was saved"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:180
 msgid "VM Reservations"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_form.html.haml:45
 msgid "VM Selection"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_storage.html.haml:127
 msgid "VM Snapshot Files"
 msgstr ""
 
+#: ../../app/views/ops/_settings_cu_collection_tab.html.haml:71
 msgid "VM data will be collected for VMs under selected %s only. Data is collected for a %s and all of its %s when at least one %s is selected."
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1004
 msgid "VM successfully removed from service \"%s\""
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:122
 msgid "VM/Instance"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:101
 msgid "VMDB"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:106 ../../app/views/layouts/listnav/_host.html.haml:112
 msgid "VMM Information"
 msgstr ""
 
+#: ../../app/views/service/_svcs_show.html.haml:30 ../../app/views/configuration/_ui_2.html.haml:262 ../../app/views/miq_capacity/_planning_summary.html.haml:20
 msgid "VMs"
 msgstr ""
 
+#: ../../app/views/configuration/_ui_2.html.haml:46
 msgid "VMs & Instances"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:283 ../../app/views/layouts/listnav/_ems_infra.html.haml:54 ../../app/views/layouts/listnav/_ems_infra.html.haml:60
 msgid "VMs & Templates"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:221 ../../app/views/layouts/listnav/_storage.html.haml:55 ../../app/views/layouts/listnav/_storage.html.haml:61 ../../app/views/layouts/listnav/_ems_infra.html.haml:111 ../../app/views/layouts/listnav/_ems_infra.html.haml:117
 msgid "VMs (%s)"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_host.html.haml:215
 msgid "VMs (0)"
 msgstr ""
 
+#: ../../app/views/vm_cloud/_main.html.haml:17 ../../app/views/vm_common/_main.html.haml:16
 msgid "VMsafe"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:252
 msgid "VMware Console Support"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:266
 msgid "VMware MKS Plugin"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:283
 msgid "VMware MKS Plugin Version"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:266
 msgid "VMware VMRC Plugin"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:266
 msgid "VNC"
 msgstr ""
 
+#: ../../app/views/vm_common/console_vnc.html.haml:9
 msgid "VNC Console"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:305
 msgid "VNC Proxy Address"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:322
 msgid "VNC Proxy Port"
 msgstr ""
 
+#: ../../app/views/ops/_settings_database_tab.html.haml:101 ../../app/views/ops/_settings_database_tab.html.haml:112 ../../app/views/ops/_ldap_server_entry.html.haml:135 ../../app/views/ops/_amazon_verify_button.html.haml:2 ../../app/views/ops/_amazon_verify_button.html.haml:15 ../../app/views/ops/_ldap_verify_button.html.haml:4 ../../app/views/ops/_ldap_verify_button.html.haml:17 ../../app/views/layouts/_form_buttons.html.haml:23 ../../app/views/layouts/_form_buttons.html.haml:37 ../../app/views/layouts/_edit_form_buttons.html.haml:36 ../../app/views/layouts/_edit_form_buttons.html.haml:36 ../../app/views/layouts/_edit_form_buttons.html.haml:155 ../../app/views/layouts/_form_buttons_verify.html.haml:19 ../../app/views/layouts/_form_buttons_verify.html.haml:28 ../../app/views/layouts/_form_buttons_verify.html.haml:45
 msgid "Validate"
 msgstr ""
 
+#: ../../app/views/ops/_settings_database_tab.html.haml:101 ../../app/views/ops/_settings_database_tab.html.haml:101
 msgid "Validate Database Configuration"
 msgstr ""
 
+#: ../../app/views/layouts/_form_buttons.html.haml:37
 msgid "Validate Database Settings for the Server"
 msgstr ""
 
+#: ../../app/views/ops/_amazon_verify_button.html.haml:2 ../../app/views/ops/_amazon_verify_button.html.haml:2
 msgid "Validate the Amazon Settings"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_server_entry.html.haml:135 ../../app/views/ops/_ldap_verify_button.html.haml:4 ../../app/views/ops/_ldap_verify_button.html.haml:4
 msgid "Validate the LDAP Settings by binding with the %s"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:674
 msgid "Validate the credentials"
 msgstr ""
 
+#: ../../app/views/layouts/_form_buttons_verify.html.haml:14
 msgid "Validate the credentials by logging into the Server"
 msgstr ""
 
+#: ../../app/views/layouts/_form_buttons_verify.html.haml:12
 msgid "Validate the credentials by logging into the selected %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:311
 msgid "Validator Rule"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:290
 msgid "Validator Type"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/views/ops/_tenant_quota_form.html.haml:32 ../../app/views/miq_ae_customization/_field_values.html.haml:17 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:13 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/miq_ae_class/_instance_form.html.haml:89 ../../app/views/miq_ae_class/_instance_fields.html.haml:17 ../../app/views/report/_form_columns_trend.html.haml:61 ../../app/views/miq_policy/_alert_snmp.html.haml:110 ../../app/views/miq_policy/_action_options.html.haml:453 ../../app/views/miq_policy/_alert_details.html.haml:382 ../../app/views/miq_policy/_action_details.html.haml:400
 msgid "Value"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:456 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:554
 msgid "Value Type"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:85 ../../app/views/miq_policy/_action_details.html.haml:246
 msgid "Value to Set"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_regkey.html.haml:14
 msgid "Value:"
 msgstr ""
 
+#: ../../app/views/report/_form_chart.html.haml:43
 msgid "Values"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_snmp.html.haml:106 ../../app/views/miq_policy/_alert_details.html.haml:378
 msgid "Variable Object ID"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_options.html.haml:432 ../../app/views/miq_policy/_action_details.html.haml:383
 msgid "Variables"
 msgstr ""
 
+#: ../../app/views/report/sample_chart.html.haml:123
 msgid "Vendor A"
 msgstr ""
 
+#: ../../app/views/report/sample_chart.html.haml:128
 msgid "Vendor B"
 msgstr ""
 
+#: ../../app/views/report/sample_chart.html.haml:133
 msgid "Vendor C"
 msgstr ""
 
+#: ../../app/views/report/sample_chart.html.haml:138
 msgid "Vendor D"
 msgstr ""
 
+#: ../../app/views/ops/_email_verify_button.html.haml:3 ../../app/views/ops/_email_verify_button.html.haml:17 ../../app/views/layouts/_form_buttons.html.haml:37 ../../app/views/layouts/_form_buttons.html.haml:95 ../../app/views/layouts/_edit_buttons.html.haml:63
 msgid "Verify"
 msgstr ""
 
+#: ../../app/views/layouts/_auth_credentials.html.haml:49
 msgid "Verify %s"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:273
 msgid "Verify Client Key"
 msgstr ""
 
+#: ../../app/views/ops/_settings_database_tab.html.haml:79 ../../app/views/ops/_zone_form.html.haml:167 ../../app/views/ops/_settings_workers_tab.html.haml:635 ../../app/views/storage_manager/_form.html.haml:186 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:6 ../../app/views/layouts/_discover_credentials.html.haml:46 ../../app/views/dashboard/_login_more.html.haml:24
 msgid "Verify Password"
 msgstr ""
 
+#: ../../app/views/provider_foreman/_form.html.haml:59
 msgid "Verify Peer Certificate"
 msgstr ""
 
+#: ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:138
 msgid "Verify Private Key"
 msgstr ""
 
+#: ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:43
 msgid "Verify Secret Access Key"
 msgstr ""
 
+#: ../../app/helpers/container_image_helper/textual_summary.rb:21 ../../app/views/support/show.html.haml:17 ../../app/views/miq_policy/_alert_snmp.html.haml:64 ../../app/views/miq_policy/_action_options.html.haml:393 ../../app/views/miq_policy/_alert_details.html.haml:343 ../../app/views/miq_policy/_action_details.html.haml:355
 msgid "Version"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:141 ../../app/views/ops/_selected_by_roles.html.haml:189 ../../app/views/ops/_server_desc.html.haml:93
 msgid "Version / Build"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_group.html.haml:58 ../../app/views/layouts/listnav/_container_image_registry.html.haml:34 ../../app/views/layouts/listnav/_container_image.html.haml:34
 msgid "View %s"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_container_group.html.haml:66
 msgid "View %s %s"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_old_dialogs_folders.html.haml:9
 msgid "View %s Folder"
 msgstr ""
 
+#: ../../app/views/pxe/_template_folders.html.haml:21
 msgid "View '%s' Folder"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:64 ../../app/views/ops/_settings_details_tab.html.haml:67
 msgid "View Analysis Profiles"
 msgstr ""
 
+#: ../../app/views/chargeback/_rates_list.html.haml:9 ../../app/views/chargeback/_rates_list.html.haml:20
 msgid "View Compute Rates"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_folders.html.haml:10
 msgid "View Condition"
 msgstr ""
 
+#: ../../app/views/pxe/_template_folders.html.haml:9
 msgid "View Examples (read only)' Folder"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:56 ../../app/views/ops/_rbac_details_tab.html.haml:67
 msgid "View Groups"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:19
 msgid "View Instances"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:104 ../../app/views/ops/_settings_details_tab.html.haml:107
 msgid "View LDAP Regions"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:49
 msgid "View Parent Tenant"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:76 ../../app/views/ops/_rbac_details_tab.html.haml:87
 msgid "View Roles"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:90 ../../app/views/ops/_settings_details_tab.html.haml:93
 msgid "View Schedules"
 msgstr ""
 
+#: ../../app/views/chargeback/_rates_list.html.haml:28 ../../app/views/chargeback/_rates_list.html.haml:33
 msgid "View Storage Rates"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:96 ../../app/views/ops/_rbac_details_tab.html.haml:107
 msgid "View Tenants"
 msgstr ""
 
+#: ../../app/views/miq_policy/_action_details.html.haml:465
 msgid "View This Alert"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_details_tab.html.haml:36 ../../app/views/ops/_rbac_details_tab.html.haml:47
 msgid "View Users"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:77 ../../app/views/ops/_settings_details_tab.html.haml:80
 msgid "View Zones"
 msgstr ""
 
+#: ../../app/views/support/show.html.haml:56
 msgid "View the %s Guide"
 msgstr ""
 
+#: ../../app/views/miq_policy/_profile_details.html.haml:140
 msgid "View this %s Policy"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:505
 msgid "View this Action"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_profile_details.html.haml:48
 msgid "View this Alert"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:474 ../../app/views/miq_policy/_alert_profile_list.html.haml:14
 msgid "View this Alert Profile"
 msgstr ""
 
+#: ../../app/views/miq_policy/_condition_list.html.haml:16 ../../app/views/miq_policy/_policy_details.html.haml:252
 msgid "View this Condition"
 msgstr ""
 
+#: ../../app/views/miq_policy/_event_details.html.haml:233 ../../app/views/miq_policy/_event_details.html.haml:418 ../../app/views/miq_policy/_policy_details.html.haml:381 ../../app/views/miq_policy/_policy_details.html.haml:396
 msgid "View this Event Action"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:68 ../../app/views/ops/_rbac_user_details.html.haml:147 ../../app/views/ops/_rbac_role_details.html.haml:88
 msgid "View this Group"
 msgstr ""
 
+#: ../../app/views/pxe/_iso_datastore_details.html.haml:32
 msgid "View this ISO Image"
 msgstr ""
 
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:172
 msgid "View this MiqServer"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:72
 msgid "View this PXE Image"
 msgstr ""
 
+#: ../../app/views/miq_policy/_policy_details.html.haml:357 ../../app/views/miq_policy/_policy_details.html.haml:363
 msgid "View this Policy Event"
 msgstr ""
 
+#: ../../app/views/report/_role_list.html.haml:67 ../../app/views/miq_policy/_profile_list.html.haml:14 ../../app/views/miq_policy/_policy_details.html.haml:455
 msgid "View this Profile"
 msgstr ""
 
+#: ../../app/views/chargeback/_reports_list.html.haml:21
 msgid "View this Report"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_user_details.html.haml:188 ../../app/views/ops/_rbac_group_details.html.haml:62
 msgid "View this Role"
 msgstr ""
 
+#: ../../app/views/report/_report_info.html.haml:169
 msgid "View this Schedule"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_group_details.html.haml:128
 msgid "View this User"
 msgstr ""
 
+#: ../../app/views/report/_db_widget.html.haml:8
 msgid "View this Widget"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:119
 msgid "View this Windows Image"
 msgstr ""
 
+#: ../../app/views/ops/_diagnostics_zones_tab.html.haml:12
 msgid "View this Zone"
 msgstr ""
 
+#: ../../app/views/ops/_settings_list_tab.html.haml:13
 msgid "View this Zone's settings"
 msgstr ""
 
+#: ../model_attributes.rb:2194
 msgid "Vim performance operating range"
 msgstr ""
 
+#: ../model_attributes.rb:2198
 msgid "Vim performance state"
 msgstr ""
 
+#: ../model_attributes.rb:2203
 msgid "Vim performance tag value"
 msgstr ""
 
+#: ../model_attributes.rb:2195
 msgid "VimPerformanceOperatingRange|Days"
 msgstr ""
 
+#: ../model_attributes.rb:2196
 msgid "VimPerformanceOperatingRange|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:2197
 msgid "VimPerformanceOperatingRange|Values"
 msgstr ""
 
+#: ../model_attributes.rb:2199
 msgid "VimPerformanceState|Capture interval"
 msgstr ""
 
+#: ../model_attributes.rb:2200
 msgid "VimPerformanceState|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:2201
 msgid "VimPerformanceState|State data"
 msgstr ""
 
+#: ../model_attributes.rb:2202
 msgid "VimPerformanceState|Timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:2204
 msgid "VimPerformanceTagValue|Assoc ids"
 msgstr ""
 
+#: ../model_attributes.rb:2205
 msgid "VimPerformanceTagValue|Association type"
 msgstr ""
 
+#: ../model_attributes.rb:2206
 msgid "VimPerformanceTagValue|Category"
 msgstr ""
 
+#: ../model_attributes.rb:2207
 msgid "VimPerformanceTagValue|Column name"
 msgstr ""
 
+#: ../model_attributes.rb:2208
 msgid "VimPerformanceTagValue|Metric type"
 msgstr ""
 
+#: ../model_attributes.rb:2209
 msgid "VimPerformanceTagValue|Tag name"
 msgstr ""
 
+#: ../model_attributes.rb:2210
 msgid "VimPerformanceTagValue|Value"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:44
 msgid "Virtual Machines"
 msgstr ""
 
+#: ../../app/views/layouts/_role_visibility.html.haml:8 ../../app/views/report/_widget_show.html.haml:331 ../../app/views/shared/buttons/_ab_show.html.haml:196
 msgid "Visibility"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:633
 msgid "Visual"
 msgstr ""
 
+#: ../../app/views/ops/_settings_import_tab.html.haml:21
 msgid "Vm"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:18
 msgid "Vm Compliance Policies"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:20
 msgid "Vm Control Policies"
 msgstr ""
 
+#: ../../app/presenters/tree_builder_policy.rb:29
 msgid "Vm Policies"
 msgstr ""
 
+#: ../model_attributes.rb:2211
 msgid "Vm or template"
 msgstr ""
 
+#: ../model_attributes.rb:2212
 msgid "VmOrTemplate|Autostart"
 msgstr ""
 
+#: ../model_attributes.rb:2213
 msgid "VmOrTemplate|Boot time"
 msgstr ""
 
+#: ../model_attributes.rb:2214
 msgid "VmOrTemplate|Busy"
 msgstr ""
 
+#: ../model_attributes.rb:2215
 msgid "VmOrTemplate|Cloud"
 msgstr ""
 
+#: ../model_attributes.rb:2216
 msgid "VmOrTemplate|Config xml"
 msgstr ""
 
+#: ../model_attributes.rb:2217
 msgid "VmOrTemplate|Connection state"
 msgstr ""
 
+#: ../model_attributes.rb:2218
 msgid "VmOrTemplate|Cpu affinity"
 msgstr ""
 
+#: ../model_attributes.rb:2219
 msgid "VmOrTemplate|Cpu limit"
 msgstr ""
 
+#: ../model_attributes.rb:2220
 msgid "VmOrTemplate|Cpu reserve"
 msgstr ""
 
+#: ../model_attributes.rb:2221
 msgid "VmOrTemplate|Cpu reserve expand"
 msgstr ""
 
+#: ../model_attributes.rb:2222
 msgid "VmOrTemplate|Cpu shares"
 msgstr ""
 
+#: ../model_attributes.rb:2223
 msgid "VmOrTemplate|Cpu shares level"
 msgstr ""
 
+#: ../model_attributes.rb:2224
 msgid "VmOrTemplate|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2225
 msgid "VmOrTemplate|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2226
 msgid "VmOrTemplate|Ems created on"
 msgstr ""
 
+#: ../model_attributes.rb:2227
 msgid "VmOrTemplate|Ems ref"
 msgstr ""
 
+#: ../model_attributes.rb:2228
 msgid "VmOrTemplate|Ems ref obj"
 msgstr ""
 
+#: ../model_attributes.rb:2229
 msgid "VmOrTemplate|Fault tolerance"
 msgstr ""
 
+#: ../model_attributes.rb:2230
 msgid "VmOrTemplate|Format"
 msgstr ""
 
+#: ../model_attributes.rb:2231
 msgid "VmOrTemplate|Guid"
 msgstr ""
 
+#: ../model_attributes.rb:2232
 msgid "VmOrTemplate|Last perf capture on"
 msgstr ""
 
+#: ../model_attributes.rb:2233
 msgid "VmOrTemplate|Last scan attempt on"
 msgstr ""
 
+#: ../model_attributes.rb:2234
 msgid "VmOrTemplate|Last scan on"
 msgstr ""
 
+#: ../model_attributes.rb:2235
 msgid "VmOrTemplate|Last sync on"
 msgstr ""
 
+#: ../model_attributes.rb:2236
 msgid "VmOrTemplate|Linked clone"
 msgstr ""
 
+#: ../model_attributes.rb:2237
 msgid "VmOrTemplate|Location"
 msgstr ""
 
+#: ../model_attributes.rb:2238
 msgid "VmOrTemplate|Memory limit"
 msgstr ""
 
+#: ../model_attributes.rb:2239
 msgid "VmOrTemplate|Memory reserve"
 msgstr ""
 
+#: ../model_attributes.rb:2240
 msgid "VmOrTemplate|Memory reserve expand"
 msgstr ""
 
+#: ../model_attributes.rb:2241
 msgid "VmOrTemplate|Memory shares"
 msgstr ""
 
+#: ../model_attributes.rb:2242
 msgid "VmOrTemplate|Memory shares level"
 msgstr ""
 
+#: ../model_attributes.rb:2243
 msgid "VmOrTemplate|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2244
 msgid "VmOrTemplate|Power state"
 msgstr ""
 
+#: ../model_attributes.rb:2245
 msgid "VmOrTemplate|Previous state"
 msgstr ""
 
+#: ../model_attributes.rb:2246
 msgid "VmOrTemplate|Publicly available"
 msgstr ""
 
+#: ../model_attributes.rb:2247
 msgid "VmOrTemplate|Raw power state"
 msgstr ""
 
+#: ../model_attributes.rb:2248
 msgid "VmOrTemplate|Registered"
 msgstr ""
 
+#: ../model_attributes.rb:2249
 msgid "VmOrTemplate|Retired"
 msgstr ""
 
+#: ../model_attributes.rb:2250
 msgid "VmOrTemplate|Retirement last warn"
 msgstr ""
 
+#: ../model_attributes.rb:2251
 msgid "VmOrTemplate|Retirement requester"
 msgstr ""
 
+#: ../model_attributes.rb:2252
 msgid "VmOrTemplate|Retirement state"
 msgstr ""
 
+#: ../model_attributes.rb:2253
 msgid "VmOrTemplate|Retirement warn"
 msgstr ""
 
+#: ../model_attributes.rb:2254
 msgid "VmOrTemplate|Retires on"
 msgstr ""
 
+#: ../model_attributes.rb:2255
 msgid "VmOrTemplate|Smart"
 msgstr ""
 
+#: ../model_attributes.rb:2256
 msgid "VmOrTemplate|Standby action"
 msgstr ""
 
+#: ../model_attributes.rb:2257
 msgid "VmOrTemplate|State changed on"
 msgstr ""
 
+#: ../model_attributes.rb:2258
 msgid "VmOrTemplate|Template"
 msgstr ""
 
+#: ../model_attributes.rb:2259
 msgid "VmOrTemplate|Tools status"
 msgstr ""
 
+#: ../model_attributes.rb:2260
 msgid "VmOrTemplate|Uid ems"
 msgstr ""
 
+#: ../model_attributes.rb:2261
 msgid "VmOrTemplate|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:2262
 msgid "VmOrTemplate|Vendor"
 msgstr ""
 
+#: ../model_attributes.rb:2263
 msgid "VmOrTemplate|Version"
 msgstr ""
 
+#: ../model_attributes.rb:2264
 msgid "VmOrTemplate|Vnc port"
 msgstr ""
 
+#: ../model_attributes.rb:2265
 msgid "Vmdb database"
 msgstr ""
 
+#: ../model_attributes.rb:2273
 msgid "Vmdb database metric"
 msgstr ""
 
+#: ../model_attributes.rb:2284
 msgid "Vmdb index"
 msgstr ""
 
+#: ../model_attributes.rb:2287
 msgid "Vmdb metric"
 msgstr ""
 
+#: ../model_attributes.rb:2311
 msgid "Vmdb table"
 msgstr ""
 
+#: ../model_attributes.rb:2274
 msgid "VmdbDatabaseMetric|Active connections"
 msgstr ""
 
+#: ../model_attributes.rb:2275
 msgid "VmdbDatabaseMetric|Capture interval name"
 msgstr ""
 
+#: ../model_attributes.rb:2276
 msgid "VmdbDatabaseMetric|Disk free bytes"
 msgstr ""
 
+#: ../model_attributes.rb:2277
 msgid "VmdbDatabaseMetric|Disk free inodes"
 msgstr ""
 
+#: ../model_attributes.rb:2278
 msgid "VmdbDatabaseMetric|Disk total bytes"
 msgstr ""
 
+#: ../model_attributes.rb:2279
 msgid "VmdbDatabaseMetric|Disk total inodes"
 msgstr ""
 
+#: ../model_attributes.rb:2280
 msgid "VmdbDatabaseMetric|Disk used bytes"
 msgstr ""
 
+#: ../model_attributes.rb:2281
 msgid "VmdbDatabaseMetric|Disk used inodes"
 msgstr ""
 
+#: ../model_attributes.rb:2282
 msgid "VmdbDatabaseMetric|Running processes"
 msgstr ""
 
+#: ../model_attributes.rb:2283
 msgid "VmdbDatabaseMetric|Timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:2266
 msgid "VmdbDatabase|Data directory"
 msgstr ""
 
+#: ../model_attributes.rb:2267
 msgid "VmdbDatabase|Data disk"
 msgstr ""
 
+#: ../model_attributes.rb:2268
 msgid "VmdbDatabase|Ipaddress"
 msgstr ""
 
+#: ../model_attributes.rb:2269
 msgid "VmdbDatabase|Last start time"
 msgstr ""
 
+#: ../model_attributes.rb:2270
 msgid "VmdbDatabase|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2271
 msgid "VmdbDatabase|Vendor"
 msgstr ""
 
+#: ../model_attributes.rb:2272
 msgid "VmdbDatabase|Version"
 msgstr ""
 
+#: ../model_attributes.rb:2285
 msgid "VmdbIndex|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2286
 msgid "VmdbIndex|Prior raw metrics"
 msgstr ""
 
+#: ../model_attributes.rb:2288
 msgid "VmdbMetric|Capture interval name"
 msgstr ""
 
+#: ../model_attributes.rb:2289
 msgid "VmdbMetric|Index rows fetched"
 msgstr ""
 
+#: ../model_attributes.rb:2290
 msgid "VmdbMetric|Index scans"
 msgstr ""
 
+#: ../model_attributes.rb:2291
 msgid "VmdbMetric|Last analyze date"
 msgstr ""
 
+#: ../model_attributes.rb:2292
 msgid "VmdbMetric|Last autoanalyze date"
 msgstr ""
 
+#: ../model_attributes.rb:2293
 msgid "VmdbMetric|Last autovacuum date"
 msgstr ""
 
+#: ../model_attributes.rb:2294
 msgid "VmdbMetric|Last vacuum date"
 msgstr ""
 
+#: ../model_attributes.rb:2295
 msgid "VmdbMetric|Otta"
 msgstr ""
 
+#: ../model_attributes.rb:2296
 msgid "VmdbMetric|Pages"
 msgstr ""
 
+#: ../model_attributes.rb:2297
 msgid "VmdbMetric|Percent bloat"
 msgstr ""
 
+#: ../model_attributes.rb:2298
 msgid "VmdbMetric|Resource type"
 msgstr ""
 
+#: ../model_attributes.rb:2299
 msgid "VmdbMetric|Rows"
 msgstr ""
 
+#: ../model_attributes.rb:2300
 msgid "VmdbMetric|Rows dead"
 msgstr ""
 
+#: ../model_attributes.rb:2301
 msgid "VmdbMetric|Rows deleted"
 msgstr ""
 
+#: ../model_attributes.rb:2302
 msgid "VmdbMetric|Rows hot updated"
 msgstr ""
 
+#: ../model_attributes.rb:2303
 msgid "VmdbMetric|Rows inserted"
 msgstr ""
 
+#: ../model_attributes.rb:2304
 msgid "VmdbMetric|Rows live"
 msgstr ""
 
+#: ../model_attributes.rb:2305
 msgid "VmdbMetric|Rows updated"
 msgstr ""
 
+#: ../model_attributes.rb:2306
 msgid "VmdbMetric|Sequential rows read"
 msgstr ""
 
+#: ../model_attributes.rb:2307
 msgid "VmdbMetric|Size"
 msgstr ""
 
+#: ../model_attributes.rb:2308
 msgid "VmdbMetric|Table scans"
 msgstr ""
 
+#: ../model_attributes.rb:2309
 msgid "VmdbMetric|Timestamp"
 msgstr ""
 
+#: ../model_attributes.rb:2310
 msgid "VmdbMetric|Wasted bytes"
 msgstr ""
 
+#: ../model_attributes.rb:2312
 msgid "VmdbTable|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2313
 msgid "VmdbTable|Prior raw metrics"
 msgstr ""
 
+#: ../model_attributes.rb:2314
 msgid "Volume"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:51
 msgid "Volume ID"
 msgstr ""
 
+#: ../../app/helpers/container_group_helper/textual_summary.rb:48
 msgid "Volume Path"
 msgstr ""
 
+#: ../../app/views/container_group/_main.html.haml:15
 msgid "Volumes"
 msgstr ""
 
+#: ../model_attributes.rb:2315
 msgid "Volume|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2316
 msgid "Volume|Filesystem"
 msgstr ""
 
+#: ../model_attributes.rb:2317
 msgid "Volume|Free space"
 msgstr ""
 
+#: ../model_attributes.rb:2318
 msgid "Volume|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2319
 msgid "Volume|Size"
 msgstr ""
 
+#: ../model_attributes.rb:2320
 msgid "Volume|Typ"
 msgstr ""
 
+#: ../model_attributes.rb:2321
 msgid "Volume|Uid"
 msgstr ""
 
+#: ../model_attributes.rb:2322
 msgid "Volume|Updated on"
 msgstr ""
 
+#: ../model_attributes.rb:2323
 msgid "Volume|Used space"
 msgstr ""
 
+#: ../model_attributes.rb:2324
 msgid "Volume|Volume group"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:356
 msgid "WINS Server"
 msgstr ""
 
+#: ../../app/views/miq_task/_tasks_options.html.haml:96 ../../app/views/miq_task/_tasks_options.html.haml:120 ../../app/views/miq_task/_tasks_options.html.haml:120
 msgid "Warn"
 msgstr ""
 
+#: ../../app/controllers/report_controller/schedules.rb:304 ../../app/controllers/ops_controller/settings/schedules.rb:397
 msgid "Warning: This 'Run Once' timer is in the past and will never run as currently configured"
 msgstr ""
 
+#: ../../app/views/ops/_db_info.html.haml:75 ../../app/views/ops/_db_info.html.haml:168 ../../app/views/ops/_db_info.html.haml:219
 msgid "Wasted"
 msgstr ""
 
+#: ../../app/views/ops/_settings_workers_tab.html.haml:271
 msgid "Web Service Workers"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:582 ../../app/views/layouts/_multi_auth_credentials.html.haml:36 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:31
 msgid "Web Services"
 msgstr ""
 
+#: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Wednesday"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:154
 msgid "Week"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form_timer.html.haml:20
 msgid "Weekly"
 msgstr ""
 
+#: ../../app/views/miq_policy/_alert_details.html.haml:98
 msgid "What to Evaluate"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:535
 msgid "When configuring a VNC Proxy, both Address and Port are required"
 msgstr ""
 
+#: ../../app/controllers/report_controller/widgets.rb:127
 msgid "Widget content generation error: "
 msgstr ""
 
+#: ../../app/controllers/report_controller.rb:350
 msgid "Widget import cancelled"
 msgstr ""
 
+#: ../../app/views/report/_export_widgets.html.haml:24 ../../app/views/report/_report_info.html.haml:228
 msgid "Widgets"
 msgstr ""
 
+#: ../../app/controllers/report_controller.rb:325
 msgid "Widgets imported successfully"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_vm_common.html.haml:416 ../../app/views/layouts/listnav/_vm_common.html.haml:422
 msgid "Win32 Services (%s)"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:65
 msgid "Windows Boot Env"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_img_form.html.haml:37
 msgid "Windows Boot Environment"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_server_details.html.haml:98
 msgid "Windows Images"
 msgstr ""
 
+#: ../../app/views/pxe/_pxe_form.html.haml:108
 msgid "Windows Images Directory"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:267 ../../app/views/shared/views/_prov_dialog.html.haml:301
 msgid "Windows Options"
 msgstr ""
 
+#: ../model_attributes.rb:2325
 msgid "Windows image"
 msgstr ""
 
+#: ../model_attributes.rb:2326
 msgid "WindowsImage|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2327
 msgid "WindowsImage|Index"
 msgstr ""
 
+#: ../model_attributes.rb:2328
 msgid "WindowsImage|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2329
 msgid "WindowsImage|Path"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:163
 msgid "Within Above Field, Sort By"
 msgstr ""
 
+#: ../../app/views/ops/_all_tabs.html.haml:30 ../../app/views/ops/_all_tabs.html.haml:165
 msgid "Workers"
 msgstr ""
 
+#: ../../app/views/shared/views/_prov_dialog.html.haml:251
 msgid "Workgroup Information"
 msgstr ""
 
+#: ../../app/presenters/menu/default_menu.rb:19
 msgid "Workloads"
 msgstr ""
 
+#: ../../app/views/layouts/_exp_editor.html.haml:90
 msgid "Wrap this expression element with a NOT"
 msgstr ""
 
+#: ../../app/views/miq_ae_tools/_results_tabs.html.haml:7
 msgid "XML View"
 msgstr ""
 
+#: ../../app/views/report/_form_sort.html.haml:78 ../../app/views/report/_report_list.html.haml:179 ../../app/views/miq_policy/_alert_details.html.haml:55 ../../app/views/miq_policy/_policy_details.html.haml:70
 msgid "Yes"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:176
 msgid "Yesterday"
 msgstr ""
 
+#: ../../app/views/vm_common/console_mks.html.haml:30
 msgid "You are about to enter fullscreen mode. Press Ctl+Alt to return to windowed mode."
 msgstr ""
 
+#: ../../app/controllers/application_controller.rb:2564
 msgid "You are not authorized to view %s"
 msgstr ""
 
+#: ../../app/controllers/miq_ae_tools_controller.rb:155
 msgid "You must select at least one namespace to import"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:9
 msgid "You will need the following to register:"
 msgstr ""
 
+#: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:15
 msgid "Your Red Hat Account login or Red Hat Network Satellite login"
 msgstr ""
 
+#: ../../app/helpers/provider_foreman_helper.rb:50 ../../app/views/ops/_ldap_region_show.html.haml:44 ../../app/views/ops/rhn/_server_table.html.haml:90 ../../app/views/ops/_schedule_show.html.haml:122 ../../app/views/ops/_all_tabs.html.haml:8 ../../app/views/ops/_ldap_region_form.html.haml:55 ../../app/views/storage_manager/_form.html.haml:112 ../../app/views/miq_task/_tasks_options.html.haml:16 ../../app/views/report/_show_schedule.html.haml:120 ../../app/views/report/_report_info.html.haml:160 ../../app/views/shared/views/ems_common/angular/_form.html.haml:184 ../../app/views/shared/views/ems_common/_form.html.haml:119 ../model_attributes.rb:2330
 msgid "Zone"
 msgstr ""
 
+#: ../../app/views/ops/_zone_form.html.haml:7
 msgid "Zone Information"
 msgstr ""
 
+#: ../../app/views/ops/_settings_server_tab.html.haml:121
 msgid "Zone*"
 msgstr ""
 
+#: ../../app/views/dashboard/login.html.haml:159
 msgid "Zone:"
 msgstr ""
 
+#: ../../app/views/ops/_settings_details_tab.html.haml:82
 msgid "Zones"
 msgstr ""
 
+#: ../model_attributes.rb:2331
 msgid "Zone|Created on"
 msgstr ""
 
+#: ../model_attributes.rb:2332
 msgid "Zone|Description"
 msgstr ""
 
+#: ../model_attributes.rb:2333
 msgid "Zone|Name"
 msgstr ""
 
+#: ../model_attributes.rb:2334
 msgid "Zone|Settings"
 msgstr ""
 
+#: ../model_attributes.rb:2335
 msgid "Zone|Updated on"
 msgstr ""
 
+#: ../../app/presenters/widget_presenter.rb:92
 msgid "Zoom in on this chart"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:186
 msgid "active"
 msgstr ""
 
+#: ../../app/views/miq_ae_customization/_dialog_sample.html.haml:71
 msgid "at"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:186 ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:45
 msgid "available"
 msgstr ""
 
+#: ../../app/views/layouts/_perf_options.html.haml:49 ../../app/views/layouts/_perf_options.html.haml:90
 msgid "back"
 msgstr ""
 
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:171
 msgid "blank"
 msgstr ""
 
+#: ../../app/views/ops/_zone_tree.html.haml:28
 msgid "bold"
 msgstr ""
 
+#: ../../app/models/miq_alert.rb:421
 msgid "cpu_affinity"
 msgstr ""
 
+#: ../../app/views/layouts/_tl_options.html.haml:104
 msgid "days back"
 msgstr ""
 
+#: ../../app/views/ops/_zone_tree.html.haml:31
 msgid "dimmed"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:81
 msgid "do not change the outcome of the scope or expression"
 msgstr ""
 
+#: ../../app/views/ops/_schedule_form_timer.html.haml:24 ../../app/views/report/_schedule_form_timer.html.haml:32 ../../app/views/report/_schedule_form_timer.html.haml:44 ../../app/views/report/_schedule_form_timer.html.haml:56 ../../app/views/report/_schedule_form_timer.html.haml:68
 msgid "every"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:69 ../../app/views/layouts/exp_atom/_edit_find.html.haml:46 ../../app/views/layouts/exp_atom/_edit_find.html.haml:179 ../../app/views/report/_form_styling.html.haml:78
 msgid "false"
 msgstr ""
 
+#: ../../app/views/report/_form_filter_chargeback.html.haml:190 ../../app/views/report/_form_filter_performance.html.haml:34
 msgid "going back"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form_timer.html.haml:150
 msgid "h"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:11
 msgid "instances"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:73 ../../app/views/ops/_ldap_forest_entries.html.haml:118
 msgid "ldap"
 msgstr ""
 
+#: ../../app/views/ops/_ldap_forest_entries.html.haml:73 ../../app/views/ops/_ldap_forest_entries.html.haml:118
 msgid "ldaps"
 msgstr ""
 
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
+#: ../../lib/vmdb/fast_gettext_helper.rb:5
 msgid "locale_name"
 msgstr ""
 
+#: ../../app/views/report/_schedule_form_timer.html.haml:163
 msgid "m"
 msgstr ""
 
+#: ../../app/models/miq_alert.rb:415
 msgid "memory_cpu"
 msgstr ""
 
+#: ../../lib/report_formatter/chart_common.rb:391 ../../lib/report_formatter/chart_common.rb:423 ../../lib/report_formatter/chart_common.rb:471 ../../lib/report_formatter/chart_common.rb:501 ../../lib/report_formatter/chart_common.rb:504
 msgid "no value"
 msgstr ""
 
+#: ../../app/views/ops/_rbac_role_details.html.haml:64
 msgid "none"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:205 ../../app/views/ops/_selected_by_roles.html.haml:90
 msgid "normal"
 msgstr ""
 
+#: ../../app/models/miq_alert.rb:415
 msgid "numvcpus"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:199 ../../app/views/ops/_selected_by_roles.html.haml:84
 msgid "primary"
 msgstr ""
 
+#: ../../app/views/miq_policy/_rsop_results.html.haml:77
 msgid "red italics"
 msgstr ""
 
+#: ../../app/presenters/tree_builder.rb:68
+msgid "report"
+msgstr ""
+
+#: ../../app/views/ops/_selected_by_servers.html.haml:202 ../../app/views/ops/_selected_by_roles.html.haml:87
 msgid "secondary"
 msgstr ""
 
+#: ../../app/views/miq_ae_class/_copy_objects_form.html.haml:133
 msgid "selected to copy"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:96
 msgid "system"
 msgid_plural "systems"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/views/miq_policy/_alert_list.html.haml:4 ../../app/views/miq_policy/_action_list.html.haml:4
 msgid "that match the entered search string"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:69 ../../app/views/layouts/exp_atom/_edit_find.html.haml:46 ../../app/views/layouts/exp_atom/_edit_find.html.haml:179 ../../app/views/report/_form_styling.html.haml:78
 msgid "true"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:189
 msgid "unavailable"
 msgstr ""
 
+#: ../../app/views/ops/_selected_by_servers.html.haml:213 ../../app/views/ops/_selected_by_roles.html.haml:32
 msgid "unlimited"
 msgstr ""
 
+#: ../../app/views/layouts/exp_atom/_edit_field.html.haml:162 ../../app/views/layouts/exp_atom/_edit_count.html.haml:47 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:56
 msgid "user input"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:169 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:25
 msgid "vCPU Count"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:76
 msgid "vCPU per Core"
 msgstr ""
 
+#: ../../app/views/miq_capacity/_planning_options.html.haml:332
 msgid "vCPUs per Core"
 msgstr ""
 
+#: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:11
 msgid "vcpus"
 msgstr ""


### PR DESCRIPTION
These new settings allow for adding string locations and custom comments into
translation catalogs, as hints for translators.

Resolves #1249