### PR TITLE
Persist Component Statuses and add them to the UI

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -21,6 +21,20 @@ module EmsContainerHelper::TextualSummary
     %i(refresh_status)
   end
 
+  def textual_group_component_statuses
+    labels = [_("Name"), _("Type"), _("Status"), _("Error")]
+    h = {:labels => labels}
+    h[:values] = @record.container_component_statuses.collect do |cs|
+      [
+        cs.name,
+        cs.condition,
+        cs.status,
+        (cs.error || "")
+      ]
+    end
+    h
+  end
+
   def textual_group_smart_management
     %i(zone tags)
   end

--- a/app/models/container_component_status.rb
+++ b/app/models/container_component_status.rb
@@ -1,0 +1,5 @@
+class ContainerComponentStatus < ActiveRecord::Base
+  include ReportableMixin
+
+  belongs_to :ext_management_system, :foreign_key => "ems_id"
+end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -4,7 +4,7 @@ module EmsRefresh::SaveInventoryContainer
 
     child_keys = [:container_projects, :container_quotas, :container_limits, :container_nodes,
                   :container_image_registries, :container_images, :container_replicators, :container_groups,
-                  :container_services, :container_routes, :persistent_volumes]
+                  :container_services, :container_routes, :persistent_volumes, :container_component_statuses]
 
     # Save and link other subsections
     child_keys.each do |k|
@@ -301,6 +301,20 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(:container_image_registries, ems, hashes, deletes, [:host, :port])
     store_ids_for_new_records(ems.container_image_registries, hashes, [:host, :port])
+  end
+
+  def save_container_component_statuses_inventory(ems, hashes, target = nil)
+    return if hashes.nil?
+
+    ems.container_component_statuses(true)
+    deletes = if target.kind_of?(ExtManagementSystem)
+                ems.container_component_statuses.dup
+              else
+                []
+              end
+
+    save_inventory_multi(:container_component_statuses, ems, hashes, deletes, [:name])
+    store_ids_for_new_records(ems.container_component_statuses, hashes, :name)
   end
 
   def save_container_inventory(container_definition, hash, _target = nil)

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -11,6 +11,7 @@ module ManageIQ::Providers
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_images, :foreign_key => :ems_id, :dependent => :destroy
     has_many :persistent_volumes, :foreign_key => :parent_id, :dependent => :destroy
+    has_many :container_component_statuses, :foreign_key => :ems_id, :dependent => :destroy
 
     # required by aggregate_hardware
     def all_computer_system_ids

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::Kubernetes
 
     def self.entities
       %w(pods services replication_controllers nodes events endpoints namespaces resource_quotas limit_ranges
-         persistent_volumes persistent_volume_claims)
+         persistent_volumes persistent_volume_claims component_statuses)
     end
 
     def parse_inventory(ems, _targets = nil)

--- a/app/views/ems_container/_main.html.haml
+++ b/app/views/ems_container/_main.html.haml
@@ -4,6 +4,8 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"),
                                                                :items => textual_group_properties}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Status"), :items => textual_group_status}
+    = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Component Statuses"),
+                                                               :items => textual_group_component_statuses}
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                                :items => textual_group_relationships}

--- a/db/migrate/20151012072007_create_container_component_statuses.rb
+++ b/db/migrate/20151012072007_create_container_component_statuses.rb
@@ -1,0 +1,16 @@
+class CreateContainerComponentStatuses < ActiveRecord::Migration
+  def up
+    create_table :container_component_statuses do |t|
+      t.belongs_to :ems, :type => :bigint
+      t.string     :name
+      t.string     :condition
+      t.string     :status
+      t.string     :message
+      t.string     :error
+    end
+  end
+
+  def down
+    drop_table :container_component_statuses
+  end
+end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -23,7 +23,7 @@ gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by
 gem "fog",                     "~>2.0.0.pre.0",     :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
-gem "kubeclient",              "=0.5.1",            :require => false
+gem "kubeclient",              "=0.8.0",            :require => false
 gem "linux_admin",             "~>0.11.1",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.11.0",          :require => false
@@ -31,7 +31,7 @@ gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>1.2.0",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
-gem "openshift_client",        "=0.1.0",            :require => false
+gem "openshift_client",        "=0.2.0",            :require => false
 gem "ovirt",                   "~>0.6.0",           :require => false
 gem "parallel",                "~>0.5.21",          :require => false
 gem "pg",                      "~>0.18.2",          :require => false

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -263,6 +263,57 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
     end
   end
 
+  describe "parse_component_statuses" do
+    example_component_statuses = [
+      {
+        :component_status => RecursiveOpenStruct.new(
+          :metadata   => {:name => "example-component-status1"},
+          :conditions => [
+            RecursiveOpenStruct.new(
+              :type    => "Healthy",
+              :status  => "True",
+              :message => "{'health': 'true'}"
+            )
+          ]),
+        :name             => "example-component-status1",
+        :condition        => "Healthy",
+        :status           => "True",
+        :message          => "{'health': 'true'}",
+        :error            => nil
+      },
+      {
+        :component_status => RecursiveOpenStruct.new(
+          :metadata   => {:name => "example-component-status2"},
+          :conditions => [
+            RecursiveOpenStruct.new(
+              :type   => "Healthy",
+              :status => "Unknown",
+              :error  => "Get http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"
+            )
+          ]),
+        :name             => "example-component-status2",
+        :condition        => "Healthy",
+        :status           => "Unknown",
+        :message          => nil,
+        :error            => "Get http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"
+      }
+    ]
+
+    example_component_statuses.each do |ex|
+      it "tests '#{ex[:name]}'" do
+        parsed_component_status = parser.send(:parse_component_status, ex[:component_status])
+
+        parsed_component_status.should have_attributes(
+          :name      => ex[:name],
+          :condition => ex[:condition],
+          :status    => ex[:status],
+          :message   => ex[:message],
+          :error     => ex[:error]
+        )
+      end
+    end
+  end
+
   describe "parse_iec_number" do
     it "converts IEC bytes size to integer value" do
       [

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -38,6 +38,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       assert_specific_container_quota
       assert_specific_container_limit
       assert_specific_container_image_and_registry
+      assert_specific_container_component_status
     end
   end
 
@@ -55,6 +56,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     ContainerLimit.count.should == 3
     ContainerImage.count.should == 3
     ContainerImageRegistry.count.should == 1
+    ContainerComponentStatus.count.should == 3
   end
 
   def assert_ems
@@ -326,5 +328,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :port => "1234",
     )
     @image.container_nodes.count.should == 1
+  end
+
+  def assert_specific_container_component_status
+    @component_status = ContainerComponentStatus.find_by_name("etcd-0")
+    @component_status.should have_attributes(
+      :condition => "Healthy",
+      :status    => "True"
+    )
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/refresher.yml
@@ -982,4 +982,37 @@ http_interactions:
       string: '{"kind":"PersistentVolumeClaimList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/persistentvolumeclaims","resourceVersion":"1769278"}}'
     http_version: 
   recorded_at: Mon, 07 Sep 2015 12:04:51 GMT
+- request:
+    method: get
+    uri: https://10.35.0.169:6443/api/v1/componentstatuses
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.1p85
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 13 Oct 2015 13:03:20 GMT
+      Content-Length:
+      - '925'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ComponentStatusList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/componentstatuses"},"items":[{"metadata":{"name":"controller-manager","selfLink":"/api/v1/namespaces/componentstatuses/controller-manager","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"Unknown","error":"Get
+        http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: connection refused"}]},{"metadata":{"name":"scheduler","selfLink":"/api/v1/namespaces/componentstatuses/scheduler","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"Unknown","error":"Get
+        http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/namespaces/componentstatuses/etcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"True","message":{"health":"true"},"error":"nil"}]}]}'
+    http_version:
+  recorded_at: Tue, 13 Oct 2015 13:03:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher.yml
@@ -427,4 +427,37 @@ http_interactions:
       string: '{"kind":"PersistentVolumeClaimList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/persistentvolumeclaims","resourceVersion":"1770475"}}'
     http_version: 
   recorded_at: Mon, 07 Sep 2015 12:20:04 GMT
+- request:
+    method: get
+    uri: https://10.35.0.174:8443/api/v1/componentstatuses
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.1p85
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 13 Oct 2015 13:03:20 GMT
+      Content-Length:
+      - '925'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ComponentStatusList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/componentstatuses"},"items":[{"metadata":{"name":"controller-manager","selfLink":"/api/v1/namespaces/componentstatuses/controller-manager","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"Unknown","error":"Get
+              http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: connection refused"}]},{"metadata":{"name":"scheduler","selfLink":"/api/v1/namespaces/componentstatuses/scheduler","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"Unknown","error":"Get
+              http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/namespaces/componentstatuses/etcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"True","message":{"health":"true"},"error":"nil"}]}]}'
+    http_version:
+  recorded_at: Tue, 13 Oct 2015 13:03:20 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Add statuses for the following Kubernetes components:
* etcd-0
* scheduler
* controller-manager

Add component statuses table to the provider details page.
![componentstatuses](https://cloud.githubusercontent.com/assets/6347577/10515832/f1c76ee8-735d-11e5-8a17-14619dd2a0ce.png)
