### PR TITLE
Tenant api user

### DIFF
--- a/app/controllers/api_controller/automation_requests.rb
+++ b/app/controllers/api_controller/automation_requests.rb
@@ -10,9 +10,8 @@ class ApiController
       uri_parts   = hash_fetch(data, "uri_parts")
       parameters  = hash_fetch(data, "parameters")
       requester   = hash_fetch(data, "requester")
-      user_name   = requester["user_name"] || @auth_user
 
-      AutomationRequest.create_from_ws(version_str, user_name, uri_parts, parameters, requester)
+      AutomationRequest.create_from_ws(version_str, @auth_user_obj, uri_parts, parameters, requester)
     end
   end
 end

--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -15,9 +15,7 @@ class ApiController
       ems_custom_attrs  = hash_fetch(data, "ems_custom_attributes")
       miq_custom_attrs  = hash_fetch(data, "miq_custom_attributes")
 
-      user_name = requester["user_name"] || @auth_user
-
-      MiqProvisionVirtWorkflow.from_ws(version_str, user_name, template_fields, vm_fields, requester, tags,
+      MiqProvisionVirtWorkflow.from_ws(version_str, @auth_user_obj, template_fields, vm_fields, requester, tags,
                                        additional_values, ems_custom_attrs, miq_custom_attrs)
     end
   end

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1013,18 +1013,14 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     from_ws_ver_1_x(*prov_args)
   end
 
-  def self.from_ws_2(*args)
-    from_ws_ver_1_x(*args)
-  end
-
-  def self.from_ws_ver_1_0(version, userid, src_name, target_name, auto_approve, tags, additional_values)
-    _log.info "Web-service provisioning starting with interface version <#{version}> for user <#{userid}>"
+  def self.from_ws_ver_1_0(version, user, src_name, target_name, auto_approve, tags, additional_values)
+    _log.info "Web-service provisioning starting with interface version <#{version}> for user <#{user.userid}>"
     values = {}
-    p = new(values, userid, :use_pre_dialog => false)
+    p = new(values, user, :use_pre_dialog => false)
     src_name_down = src_name.downcase
     src = p.allowed_templates.detect { |v| v.name.downcase == src_name_down }
     raise "Source template [#{src_name}] was not found" if src.nil?
-    p = class_for_source(src.id).new(values, userid, :use_pre_dialog => false)
+    p = class_for_source(src.id).new(values, user, :use_pre_dialog => false)
 
     # Populate required fields
     p.init_from_dialog(values)
@@ -1032,9 +1028,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     p.refresh_field_values(values)
     values[:vm_name]          = target_name
     values[:placement_auto]   = [true, 1]
-    values[:owner_first_name] = userid
-    values[:owner_email]      = userid
-    values[:owner_last_name]  = userid
+    values[:owner_first_name] = user.userid
+    values[:owner_email]      = user.userid
+    values[:owner_last_name]  = user.userid
 
     # Tags are passed as category|value|cat2|...  Example: cc|001|environment|test
     p.set_ws_tags(values, tags, :parse_ws_string_v1)
@@ -1046,7 +1042,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       raise "Provision failed for the following reasons:\n#{errors.join("\n")}"
     end
 
-    p.create_request(values, userid, auto_approve)
+    p.create_request(values, nil, auto_approve)
   end
 
   def ws_template_fields(values, fields, ws_values)
@@ -1219,24 +1215,23 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     data.keys.each { |k| set_ws_field_value(values, k, data, dialog_name, dlg_fields) if dlg_fields.key?(k) }
   end
 
-  def self.from_ws_ver_1_x(version, userid, template_fields, vm_fields, requester, tags, options)
+  def self.from_ws_ver_1_x(version, user, template_fields, vm_fields, requester, tags, options)
     options = MiqHashStruct.new if options.nil?
-    _log.warn "Web-service provisioning starting with interface version <#{version}> by requester <#{userid}>"
+    _log.warn "Web-service provisioning starting with interface version <#{version}> by requester <#{user.userid}>"
 
     init_options = {:use_pre_dialog => false, :request_type => request_type(parse_ws_string(template_fields)[:request_type])}
     data = parse_ws_string(requester)
     unless data[:user_name].blank?
-      userid = data[:user_name]
-      _log.warn "Web-service requester changed to <#{userid}>"
+      user = User.find_by_userid!(data[:user_name])
+      _log.warn "Web-service requester changed to <#{user.userid}>"
     end
 
-    p = new(values = {}, userid, init_options)
-    userid = p.requester.userid
+    p = new(values = {}, user, init_options)
     src = p.ws_template_fields(values, template_fields, options.values)
     raise "Source template [#{src_name}] was not found" if src.nil?
     # Allow new workflow class to determine dialog name instead of using the stored value from the first call.
     values.delete(:miq_request_dialog_name)
-    p = class_for_source(src.id).new(values, userid, init_options)
+    p = class_for_source(src.id).new(values, user, init_options)
 
     # Populate required fields
     p.init_from_dialog(values)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,10 @@ class User < ActiveRecord::Base
     in_region.find_by(:userid => userid)
   end
 
+  def self.find_by_userid!(userid)
+    in_region.find_by!(:userid => userid)
+  end
+
   def self.find_by_email(email)
     in_region.find_by(:email => email)
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
@@ -130,12 +130,13 @@ module MiqAeMethodService
       # Need to add the username into the array of params
       # TODO: This code should pass a real username, similar to how the web-service
       #      passes the name of the user that logged into the web-service.
-      args.insert(1, "admin") if args.kind_of?(Array)
+      args.insert(1, User.find_by_userid("admin")) if args.kind_of?(Array)
       MiqAeServiceModelBase.wrap_results(MiqProvisionVirtWorkflow.from_ws(*args))
     end
 
-    def self.create_automation_request(options, userid, auto_approve = false)
-      MiqAeServiceModelBase.wrap_results(AutomationRequest.create_request(options, userid, auto_approve))
+    def self.create_automation_request(options, userid = "admin", auto_approve = false)
+      user = User.find_by_userid!(userid)
+      MiqAeServiceModelBase.wrap_results(AutomationRequest.create_request(options, user, auto_approve))
     end
 
     private

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -40,23 +40,13 @@ describe AutomationRequest do
       ar.options[:attrs][:userid].should == admin.userid
     end
 
-    it "with requester string overriding userid who is NOT in the database" do
+    it "doesnt allow overriding userid who is NOT in the database" do
       user_name = 'oleg'
-      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name=#{user_name}")
-      ar.should be_kind_of(AutomationRequest)
 
-      ar.should == AutomationRequest.first
-      ar.request_state.should == "pending"
-      ar.status.should == "Ok"
-      ar.approval_state.should == "pending_approval"
-      ar.userid.should == user_name
-      ar.options[:message].should == @ae_message
-      ar.options[:instance_name].should == @ae_instance
-      ar.options[:user_id].should         be_nil
-      ar.options[:attrs][:var1].should == @ae_var1
-      ar.options[:attrs][:var2].should == @ae_var2
-      ar.options[:attrs][:var3].should == @ae_var3
-      ar.options[:attrs][:userid].should == user_name
+      expect do
+        AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name=#{user_name}")
+      end.to raise_error(ActiveRecord::RecordNotFound)
+
     end
 
     it "with requester string overriding userid who is in the database" do

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -23,7 +23,7 @@ describe AutomationRequest do
 
   context ".create_from_ws" do
     it "with empty requester string" do
-      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "")
+      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should == AutomationRequest.first
@@ -42,7 +42,7 @@ describe AutomationRequest do
 
     it "with requester string overriding userid who is NOT in the database" do
       user_name = 'oleg'
-      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "user_name=#{user_name}")
+      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name=#{user_name}")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should == AutomationRequest.first
@@ -60,7 +60,7 @@ describe AutomationRequest do
     end
 
     it "with requester string overriding userid who is in the database" do
-      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "user_name=#{@approver.userid}")
+      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name=#{@approver.userid}")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should == AutomationRequest.first
@@ -78,7 +78,7 @@ describe AutomationRequest do
     end
 
     it "with requester string overriding userid AND auto_approval" do
-      ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "user_name=#{@approver.userid}|auto_approve=true")
+      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name=#{@approver.userid}|auto_approve=true")
       ar.should be_kind_of(AutomationRequest)
 
       ar.should == AutomationRequest.first
@@ -99,7 +99,7 @@ describe AutomationRequest do
   context "#approve" do
     context "an unapproved request with a single approver" do
       before(:each) do
-        @ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "")
+        @ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "")
         @reason = "Why Not?"
       end
 
@@ -140,7 +140,7 @@ describe AutomationRequest do
 
   context "#create_request_tasks" do
     before(:each) do
-      @ar = AutomationRequest.create_from_ws(@version, admin.userid, @uri_parts, @parameters, "")
+      @ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "")
       root = {'ae_result' => 'ok'}
       ws = double('ws')
       ws.stub(:root => root)
@@ -164,9 +164,8 @@ describe AutomationRequest do
 
     def deliver(zone_name)
       parameters  = "miq_zone=#{zone_name}|var1=#{@ae_var1}|var2=#{@ae_var2}|var3=#{@ae_var3}"
-      AutomationRequest.create_from_ws(@version, @approver.userid, @uri_parts, parameters,
-                                       "auto_approve=true")
-      MiqQueue.where(:method_name => "create_request_tasks").first.deliver
+      AutomationRequest.create_from_ws(@version, @approver, @uri_parts, parameters, "auto_approve=true")
+      MiqQueue.find_by(:method_name => "create_request_tasks").deliver
     end
 
     def check_zone(zone_name)
@@ -180,9 +179,8 @@ describe AutomationRequest do
     end
 
     it "zone not specified" do
-      AutomationRequest.create_from_ws(@version, @approver.userid, @uri_parts, @parameters,
-                                       "auto_approve=true")
-      MiqQueue.where(:method_name => "create_request_tasks").first.deliver
+      AutomationRequest.create_from_ws(@version, @approver, @uri_parts, @parameters, "auto_approve=true")
+      MiqQueue.find_by(:method_name => "create_request_tasks").deliver
       check_zone("default")
     end
 


### PR DESCRIPTION
pass tenant user from api through web service layer down to create request.

The functionality of changing the requesting user was in both the api and the `from_ws` method - consolidated, although deleting is also an option.

/cc @gmcculloug for review
/cc @abellotti fyi