### PR TITLE
Domain Overrides by Priority fixed for Tenants

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -1008,7 +1008,7 @@ module ApplicationController::Buttons
     # Following commented out since all resolutions start at SYSTEM/PROCESS
     #   @resolve[:starting_objects] = MiqAeClass.find_all_by_namespace("SYSTEM").collect{|c| c.fqname}
 
-    matching_instances = MiqAeClass.find_distinct_instances_across_domains(@resolve[:new][:starting_object])
+    matching_instances = MiqAeClass.find_distinct_instances_across_domains(current_user, @resolve[:new][:starting_object])
     if matching_instances.any?
       @resolve[:instance_names] = matching_instances.collect(&:name)
       instance_name = @custom_button && @custom_button.uri_object_name

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -870,7 +870,7 @@ class CatalogController < ApplicationController
     # Check the validity of the entry points
     %w(fqname reconfigure_fqname retire_fqname).each do |fqname|
       if @edit[:new][fqname.to_sym].present? &&
-         MiqAeClass.find_homonymic_instances_across_domains(@edit[:new][fqname.to_sym]).empty?
+         MiqAeClass.find_homonymic_instances_across_domains(current_user, @edit[:new][fqname.to_sym]).empty?
         level = :error
         msg = _('Please correct invalid %s Entry Point prior to saving')
         case fqname

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2557,7 +2557,7 @@ class MiqAeClassController < ApplicationController
   def domain_overrides
     @domain_overrides = {}
     typ, = x_node.split('-')
-    overrides = TreeBuilder.get_model_for_prefix(typ).constantize.get_homonymic_across_domains(User.current_user, @record.fqname)
+    overrides = TreeBuilder.get_model_for_prefix(typ).constantize.get_homonymic_across_domains(current_user, @record.fqname)
     overrides.each do |obj|
       display_name, id = domain_display_name_using_name(obj, @record.domain.name)
       @domain_overrides[display_name] = id

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2557,7 +2557,7 @@ class MiqAeClassController < ApplicationController
   def domain_overrides
     @domain_overrides = {}
     typ, = x_node.split('-')
-    overrides = TreeBuilder.get_model_for_prefix(typ).constantize.get_homonymic_across_domains(@record.fqname)
+    overrides = TreeBuilder.get_model_for_prefix(typ).constantize.get_homonymic_across_domains(User.current_user, @record.fqname)
     overrides.each do |obj|
       display_name, id = domain_display_name_using_name(obj, @record.domain.name)
       @domain_overrides[display_name] = id

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -210,7 +210,7 @@ module MiqAeDatastore
     matches = arclass.where("lower(name) = ?", name.downcase).collect do |obj|
       get_domain_index_object(domains, obj, klass, ns, enabled, options)
     end.compact
-    matches.sort { |a, b| a[:index] <=> b[:index] }.collect { |v| v[:obj] }
+    matches.sort_by { |a| a[:index] }.collect { |v| v[:obj] }
   end
 
   def self.get_domain_index_object(domains, obj, klass, ns, enabled, options)

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -135,8 +135,8 @@ class MiqAeInstance < ActiveRecord::Base
     end
   end
 
-  def self.get_homonymic_across_domains(fqname, enabled = nil)
-    MiqAeDatastore.get_homonymic_across_domains(::MiqAeInstance, fqname, enabled)
+  def self.get_homonymic_across_domains(user, fqname, enabled = nil)
+    MiqAeDatastore.get_homonymic_across_domains(user, ::MiqAeInstance, fqname, enabled)
   end
 
   private

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -114,8 +114,8 @@ class MiqAeMethod < ActiveRecord::Base
     end
   end
 
-  def self.get_homonymic_across_domains(fqname, enabled = nil)
-    MiqAeDatastore.get_homonymic_across_domains(::MiqAeMethod, fqname, enabled)
+  def self.get_homonymic_across_domains(user, fqname, enabled = nil)
+    MiqAeDatastore.get_homonymic_across_domains(user, ::MiqAeMethod, fqname, enabled)
   end
 
   def self.find_by_class_id_and_name(class_id, name)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe CatalogController do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryGirl.create(:user_with_group) }
   before(:each) do
     set_user_privileges user
   end

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -261,7 +261,8 @@ describe MiqAeClassController do
     end
 
     before do
-      login_as FactoryGirl.create(:user_with_group)
+      @user =  FactoryGirl.create(:user_with_group)
+      login_as @user
       MiqAeDomain.stub(:find_by_name).with("another_fqname").and_return(miq_ae_domain)
       MiqAeDomain.stub(:find_by_name).with("another_fqname2").and_return(miq_ae_domain2)
     end
@@ -282,7 +283,7 @@ describe MiqAeClassController do
         before do
           MiqAeInstance.stub(:find_by_id).with(123).and_return(miq_ae_instance)
           miq_ae_instance.stub(:ae_class).and_return(miq_ae_class)
-          MiqAeInstance.stub(:get_homonymic_across_domains).with("fqname").and_return([override, override2])
+          MiqAeInstance.stub(:get_homonymic_across_domains).with(@user, "fqname").and_return([override, override2])
         end
 
         it "return instance record and check count of override instances being returned" do
@@ -313,7 +314,7 @@ describe MiqAeClassController do
       context "when the record exists" do
         before do
           MiqAeClass.stub(:find_by_id).with(1).and_return(miq_ae_class)
-          MiqAeClass.stub(:get_homonymic_across_domains).with("cls_fqname").and_return([override, override2])
+          MiqAeClass.stub(:get_homonymic_across_domains).with(@user, "cls_fqname").and_return([override, override2])
         end
 
         it "returns class record and check count of override classes being returned" do
@@ -345,7 +346,7 @@ describe MiqAeClassController do
         before do
           MiqAeMethod.stub(:find_by_id).with(123).and_return(miq_ae_method)
           miq_ae_method.stub(:ae_class).and_return(miq_ae_class)
-          MiqAeMethod.stub(:get_homonymic_across_domains).with("fqname").and_return([override, override2])
+          MiqAeMethod.stub(:get_homonymic_across_domains).with(@user, "fqname").and_return([override, override2])
         end
 
         it "returns method record and check count of override methods being returned" do

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
@@ -53,6 +53,7 @@ describe MiqAeClass do
     end
 
     before(:each) do
+      @user = FactoryGirl.create(:user_with_group, 'name' => 'Fred')
       model_data_dir = File.join(File.dirname(__FILE__), 'miq_ae_classes')
       EvmSpecHelper.import_yaml_model(File.join(model_data_dir, 'domain1'), "DOMAIN1")
       EvmSpecHelper.import_yaml_model(File.join(model_data_dir, 'domain2'), "DOMAIN2")
@@ -68,78 +69,78 @@ describe MiqAeClass do
     end
 
     it 'invalid path should return an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains('UNKNOWN').should be_empty
-      MiqAeClass.find_distinct_instances_across_domains(nil).should be_empty
-      MiqAeClass.find_distinct_instances_across_domains('UNKNOWN/').should be_empty
+      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN').should be_empty
+      MiqAeClass.find_distinct_instances_across_domains(@user, nil).should be_empty
+      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/').should be_empty
     end
 
     it 'if the namespace does not exist we should get an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains('UNKNOWN/PROCESS').should be_empty
+      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/PROCESS').should be_empty
     end
 
     it 'if the namespace exists but the class does not exist we should get an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains('SYSTEM/UNKNOWN').should be_empty
+      MiqAeClass.find_distinct_instances_across_domains(@user, 'SYSTEM/UNKNOWN').should be_empty
     end
 
     it 'if the namespace does not exist and the class does not exist we should get an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains('UNKNOWN/UNKNOWN').should be_empty
+      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/UNKNOWN').should be_empty
     end
 
     it 'get sorted list of instances across domains with partial namespace' do
       non_fq_klass = 'SYSTEM/PROCESS'
-      x = MiqAeClass.find_distinct_instances_across_domains(non_fq_klass).collect(&:fqname)
+      x = MiqAeClass.find_distinct_instances_across_domains(@user, non_fq_klass).collect(&:fqname)
       @sorted_inst_list.should match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of instances across domains with FQ namespace' do
       fq_klass = 'DOMAIN1/SYSTEM/PROCESS'
-      x = MiqAeClass.find_distinct_instances_across_domains(fq_klass).collect(&:fqname)
+      x = MiqAeClass.find_distinct_instances_across_domains(@user, fq_klass).collect(&:fqname)
       @sorted_inst_list.should match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of instances across domains with /FQ namespace' do
       fq_klass = '/DOMAIN1/SYSTEM/PROCESS'
-      x = MiqAeClass.find_distinct_instances_across_domains(fq_klass).collect(&:fqname)
+      x = MiqAeClass.find_distinct_instances_across_domains(@user, fq_klass).collect(&:fqname)
       @sorted_inst_list.should match_string_array_ignorecase(x)
     end
 
     it 'invalid path for similar named instance should return an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains('UNKNOWN').should be_empty
-      MiqAeClass.find_homonymic_instances_across_domains(nil).should be_empty
-      MiqAeClass.find_homonymic_instances_across_domains('UNKNOWN/').should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN').should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, nil).should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/').should be_empty
     end
 
     it 'invalid path no instance specified we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains('UNKNOWN/PROCESS').should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/PROCESS').should be_empty
     end
 
     it 'if the namespace does not exist but class and instance exist we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains('UNKNOWN/PROCESS/FRED').should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/PROCESS/FRED').should be_empty
     end
 
     it 'if the namespace, instance exists but the class does not exist we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains('SYSTEM/UNKNOWN/FRED').should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, 'SYSTEM/UNKNOWN/FRED').should be_empty
     end
 
     it 'if the namespace,class, instance does not exist we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains('UNKOWN/UNKNOWN/UNKNOWN').should be_empty
+      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKOWN/UNKNOWN/UNKNOWN').should be_empty
     end
 
     it 'get sorted list of same named instances across domains with partial namespace' do
       non_fq_inst = 'SYSTEM/PROCESS/Inst4'
-      x = MiqAeClass.find_homonymic_instances_across_domains(non_fq_inst).collect(&:fqname)
+      x = MiqAeClass.find_homonymic_instances_across_domains(@user, non_fq_inst).collect(&:fqname)
       @inst4_list.should match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of same named instances across domains with FQ namespace' do
       fq_inst = 'DOMAIN1/SYSTEM/PROCESS/Inst4'
-      x = MiqAeClass.find_homonymic_instances_across_domains(fq_inst).collect(&:fqname)
+      x = MiqAeClass.find_homonymic_instances_across_domains(@user, fq_inst).collect(&:fqname)
       @inst4_list.should match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of same named instances across domains with /FQ namespace' do
       fq_inst = '/DOMAIN1/SYSTEM/PROCESS/Inst4'
-      x = MiqAeClass.find_homonymic_instances_across_domains(fq_inst).collect(&:fqname)
+      x = MiqAeClass.find_homonymic_instances_across_domains(@user, fq_inst).collect(&:fqname)
       @inst4_list.should match_string_array_ignorecase(x)
     end
   end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe MiqAeDomain do
   before do
     EvmSpecHelper.local_guid_miq_server_zone
+    @user = FactoryGirl.create(:user_with_group)
   end
 
   it "should use the highest priority when not specified" do
@@ -86,14 +87,14 @@ describe MiqAeDomain do
     end
 
     it "missing class should get empty array" do
-      result = MiqAeClass.get_homonymic_across_domains('DOM1/CLASS1')
+      result = MiqAeClass.get_homonymic_across_domains(@user, 'DOM1/CLASS1')
       result.should be_empty
     end
 
     it "get same named classes" do
       create_multiple_domains
       expected = %w(/DOM2/A/b/C/cLaSS1 /DOM1/A/B/C/CLASS1 /DOM3/a/B/c/CLASs1)
-      result = MiqAeClass.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1', true)
+      result = MiqAeClass.get_homonymic_across_domains(@user, '/DOM1/A/B/C/CLASS1', true)
       expected.should match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
@@ -104,7 +105,7 @@ describe MiqAeDomain do
     end
 
     it "missing instance should get empty array" do
-      result = MiqAeInstance.get_homonymic_across_domains('DOM1/CLASS1/nothing')
+      result = MiqAeInstance.get_homonymic_across_domains(@user, 'DOM1/CLASS1/nothing')
       result.should be_empty
     end
 
@@ -116,7 +117,7 @@ describe MiqAeDomain do
         /DOM1/A/B/C/CLASS1/instance1
         /DOM3/a/B/c/CLASs1/instance1
       )
-      result = MiqAeInstance.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/instance1')
+      result = MiqAeInstance.get_homonymic_across_domains(@user, '/DOM1/A/B/C/CLASS1/instance1')
       expected.should match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
@@ -127,14 +128,14 @@ describe MiqAeDomain do
     end
 
     it "missing method should get empty array" do
-      result = MiqAeMethod.get_homonymic_across_domains('DOM1/CLASS1/nothing')
+      result = MiqAeMethod.get_homonymic_across_domains(@user, 'DOM1/CLASS1/nothing')
       result.should be_empty
     end
 
     it "get same named methods" do
       create_multiple_domains_with_methods
       expected = %w(/DOM2/A/b/C/cLaSS1/method1 /DOM1/A/B/C/CLASS1/method1 /DOM3/a/B/c/CLASs1/method1)
-      result = MiqAeMethod.get_homonymic_across_domains('/DOM1/A/B/C/CLASS1/method1', true)
+      result = MiqAeMethod.get_homonymic_across_domains(@user, '/DOM1/A/B/C/CLASS1/method1', true)
       expected.should match_string_array_ignorecase(result.collect(&:fqname))
     end
   end

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -7,7 +7,7 @@ module ControllerSpecHelper
     end
   end
 
-  def set_user_privileges(user = FactoryGirl.create(:user))
+  def set_user_privileges(user = FactoryGirl.create(:user_with_group))
     allow(User).to receive(:server_timezone).and_return("UTC")
     described_class.any_instance.stub(:set_user_time_zone)
 


### PR DESCRIPTION
Finding the list of similarly named instances, classes, methods wasn't
excluding the domains from different tenants. Modified code to pass
in the user object from the UI so that the visible domains for the
user can be used.