### PR TITLE
[WIP] Remove Sat5 update configuration

### DIFF
--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -350,6 +350,6 @@ module OpsController::Settings::RHN
   private
 
   def reset_repo_name_from_default
-    MiqDatabase.registration_default_value_for_update_repo_name(@edit[:new][:register_to])
+    MiqDatabase.registration_default_value_for_update_repo_name
   end
 end

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -40,9 +40,6 @@ module OpsController::Settings::RHN
     helper_method(:rhn_account_info_string)
     hide_action(:rhn_account_info_string)
 
-    helper_method(:rhn_validate_enabled)
-    hide_action(:rhn_validate_enabled)
-
     helper_method(:rhn_default_enabled)
     hide_action(:rhn_default_enabled)
   end
@@ -55,10 +52,6 @@ module OpsController::Settings::RHN
 
   def rhn_account_info_string
     "Enter your Red Hat#{@edit[:new][:register_to] == "sm_hosted" ? "" : " Network Satellite"} account information"
-  end
-
-  def rhn_validate_enabled
-    @edit[:new][:register_to] != 'rhn_satellite'
   end
 
   def rhn_default_enabled

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -11,7 +11,6 @@ module OpsController::Settings::RHN
 
   SUBSCRIPTION_TYPES =
     [['Red Hat Subscription Management', 'sm_hosted'],
-     ['Red Hat Satellite 5',             'rhn_satellite'],
      ['Red Hat Satellite 6',             'rhn_satellite6']]
 
   def rhn_subscription_types

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -14,7 +14,6 @@ class MiqDatabase < ActiveRecord::Base
   encrypt_column  :csrf_secret_token
   encrypt_column  :session_secret_token
 
-  validate :registration_server_url_is_valid
   validates_presence_of :session_secret_token, :csrf_secret_token, :update_repo_name
 
   default_values REGISTRATION_DEFAULT_VALUES
@@ -77,12 +76,5 @@ class MiqDatabase < ActiveRecord::Base
 
   def registration_organization_name
     registration_organization_display_name || registration_organization
-  end
-
-  private
-
-  def registration_server_url_is_valid
-    return if registration_type != "rhn_satellite"  # Only validating Satellite 5 URL
-    errors.add(:registration_server, "expected https://server.example.com/XMLRPC") unless registration_server =~ %r{\Ahttps?://.+/XMLRPC\z}i
   end
 end

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -32,11 +32,8 @@ class MiqDatabase < ActiveRecord::Base
     REGISTRATION_DEFAULT_VALUES
   end
 
-  def self.registration_default_value_for_update_repo_name(type = "sm_hosted")
-    case type
-    when "rhn_satellite" then "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1"
-    else                      "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms"
-    end
+  def self.registration_default_value_for_update_repo_name
+    "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
   end
 
   def update_repo_names

--- a/app/models/miq_server/update_management.rb
+++ b/app/models/miq_server/update_management.rb
@@ -57,7 +57,7 @@ module MiqServer::UpdateManagement
 
   def attempt_registration
     return unless register
-    attach_products unless MiqDatabase.first.registration_type == "rhn_satellite"  # There is no concept of attaching products in Satellite 5
+    attach_products
     # HACK: #enable_repos is not always successful immediately after #attach_products, retry to ensure they are enabled.
     5.times { repos_enabled? ? break : enable_repos }
   end
@@ -71,11 +71,7 @@ module MiqServer::UpdateManagement
       _log.info("Registering appliance...")
       registration_type = MiqDatabase.first.registration_type
 
-      registration_class =
-        case registration_type
-        when "rhn_satellite" then LinuxAdmin::Rhn
-        else                      LinuxAdmin::SubscriptionManager
-        end
+      registration_class = LinuxAdmin::SubscriptionManager
 
       # TODO: Prompt user for environment in UI for Satellite 6 registration, use default environment for now.
       registration_options = assemble_registration_options

--- a/app/views/ops/_settings_rhn_edit_tab.html.haml
+++ b/app/views/ops/_settings_rhn_edit_tab.html.haml
@@ -84,7 +84,7 @@
                           :record_id    => 'new',
                           :change_url   => url,
                           :validate_url => 'rhn_validate',
-                          :validate     => rhn_validate_enabled}
+                          :validate     => true}
 
     - if 'rhn_satellite' == @edit[:new][:register_to]
       .form-group

--- a/app/views/ops/_settings_rhn_edit_tab.html.haml
+++ b/app/views/ops/_settings_rhn_edit_tab.html.haml
@@ -38,7 +38,7 @@
                     :onclick => "miqAjaxButton('#{url_for(:action => 'rhn_default_server', :id => 'rhn_edit')}');")
 
     .form-group
-      - label = @edit[:new][:register_to] == "rhn_satellite" ? _("Channel Name(s):") : _("Repository Name(s):")
+      - label = _("Repository Name(s):")
       %label.col-md-2.control-label
         = label
       .col-md-8
@@ -86,15 +86,7 @@
                           :validate_url => 'rhn_validate',
                           :validate     => true}
 
-    - if 'rhn_satellite' == @edit[:new][:register_to]
-      .form-group
-        %label.col-md-2.control-label
-          = _("Organization ID")
-        .col-md-8
-          = text_field_tag('customer_org', @edit[:new][:customer_org], :maxlength => 200,
-                           :class             => "form-control",
-                           'data-miq_observe' => url_int_jsh)
-    - elsif 'rhn_satellite6' == @edit[:new][:register_to] && !@edit[:organizations].blank?
+    - if 'rhn_satellite6' == @edit[:new][:register_to] && !@edit[:organizations].blank?
       .form-group
         %label.col-md-2.control-label
           = _("Organization")

--- a/app/views/ops/rhn/_info_subscribed.html.haml
+++ b/app/views/ops/rhn/_info_subscribed.html.haml
@@ -27,7 +27,7 @@
       %p.form-control-static
         = @customer.company_name
   .form-group
-    - label = @customer.registration_type == "rhn_satellite" ? _("Channel Name(s)") : _("Repository Name(s)")
+    - label = _("Repository Name(s)")
     %label.control-label.col-md-2
       = label
     .col-md-10

--- a/db/migrate/20151015183729_update_miq_database_default_repo_name.rb
+++ b/db/migrate/20151015183729_update_miq_database_default_repo_name.rb
@@ -1,0 +1,36 @@
+class UpdateMiqDatabaseDefaultRepoName < ActiveRecord::Migration
+  class MiqDatabase < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Updating update_repo_name") do
+      return unless (db = MiqDatabase.first)
+
+      new_repos = "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+      old_repos = "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms"
+      db.update_attributes(:update_repo_name => new_repos) if db.update_repo_name == old_repos
+
+      if db.registration_type == "rhn_satellite"
+        db.update_attributes(
+          :registration_type                      => nil,
+          :registration_organization              => nil,
+          :registration_server                    => nil,
+          :registration_http_proxy_server         => nil,
+          :update_repo_name                       => new_repos,
+          :registration_organization_display_name => nil
+        )
+
+        Authentication.where(
+          :resource_type => 'MiqDatabase',
+          :resource_id   => db.id,
+          :authtype      => [:registration_http_proxy, :registration]
+        ).destroy_all
+      end
+    end
+  end
+end

--- a/spec/migrations/20151015183729_update_miq_database_default_repo_name_spec.rb
+++ b/spec/migrations/20151015183729_update_miq_database_default_repo_name_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+require_migration
+
+describe UpdateMiqDatabaseDefaultRepoName do
+  let(:db_stub) { migration_stub(:MiqDatabase) }
+
+  migration_context :up do
+    it "migrates the 5.4 repos to 5.5 repos for Sat6 and hosted" do
+      old_repos = "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms"
+      new_repos = "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+      db = db_stub.create!(:update_repo_name => old_repos)
+
+      migrate
+
+      expect(db.reload.update_repo_name).to eq(new_repos)
+    end
+
+    it "removes Sat5 registration info" do
+      db = db_stub.create!(
+        :registration_type                      => "rhn_satellite",
+        :registration_organization              => "org",
+        :registration_server                    => "serv",
+        :registration_http_proxy_server         => "a.proxy",
+        :update_repo_name                       => "repo",
+        :registration_organization_display_name => "name"
+      )
+      Authentication.create!(
+        :resource_type => 'MiqDatabase',
+        :resource_id   => db.id,
+        :authtype      => :registration_http_proxy,
+        :name          => "auth"
+      )
+      Authentication.create!(
+        :resource_type => 'MiqDatabase',
+        :resource_id   => db.id,
+        :authtype      => :registration,
+        :name          => "auth2"
+      )
+      default_auth = Authentication.create!(
+        :resource_type => 'MiqDatabase',
+        :resource_id   => db.id,
+        :authtype      => :default,
+        :name          => "auth3"
+      )
+
+      migrate
+      db.reload
+
+      expect(db).to have_attributes(
+        :registration_type                      => nil,
+        :registration_organization              => nil,
+        :registration_server                    => nil,
+        :registration_http_proxy_server         => nil,
+        :update_repo_name                       => "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms",
+        :registration_organization_display_name => nil
+      )
+
+      auths = Authentication.where(:resource_type => 'MiqDatabase', :resource_id => db.id)
+      expect(auths).to match_array([default_auth])
+    end
+  end
+end

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -20,7 +20,7 @@ describe MiqDatabase do
         db = MiqDatabase.first
         expect(db.csrf_secret_token_encrypted).to be_encrypted
         expect(db.session_secret_token_encrypted).to be_encrypted
-        expect(db.update_repo_name).to eq("cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms")
+        expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         expect(db.registration_type).to eq("sm_hosted")
         expect(db.registration_server).to eq("subscription.rhn.redhat.com")
       end
@@ -38,7 +38,7 @@ describe MiqDatabase do
           db = MiqDatabase.first
           expect(db.csrf_secret_token_encrypted).to be_encrypted
           expect(db.session_secret_token_encrypted).to be_encrypted
-          expect(db.update_repo_name).to eq("cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms")
+          expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         end
 
         it "will not change existing values" do

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -94,16 +94,6 @@ describe MiqServer do
 
       @server.attempt_registration
     end
-
-    it "rhn should not call #attach_products" do
-      database.update_attributes!(:registration_type => "rhn_satellite", :registration_server => "https://server.example.com/XMLRPC")
-
-      @server.should_receive(:register).and_return(true)
-      @server.should_not_receive(:attach_products)
-      @server.should_receive(:repos_enabled?).and_return(true)
-
-      @server.attempt_registration
-    end
   end
 
   context "#register" do
@@ -143,20 +133,6 @@ describe MiqServer do
       @server.register
 
       expect(@server.reload).to be_rh_registered
-      expect(@server.upgrade_message).to eq("registration successful")
-    end
-
-    it "unregistered should use rhn" do
-      database.update_attribute(:registration_type, "rhn_satellite")
-
-      reg_system.stub(:registered?).once.and_return(false, true)
-      LinuxAdmin::Rhn.should_receive(:register).once.with(default_params).and_return(true)
-      File.should_receive(:exist?).twice.and_return(false, true)
-      reg_system.should_receive(:registration_type).once
-
-      @server.register
-
-      expect(@server.reload.rh_registered).to be_true
       expect(@server.upgrade_message).to eq("registration successful")
     end
   end

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -189,7 +189,7 @@ describe MiqServer do
     reg_system.should_receive(:enable_repo).twice
 
     @server.enable_repos
-    expect(@server.upgrade_message).to eq("enabling rhel-server-rhscl-6-rpms")
+    expect(@server.upgrade_message).to eq("enabling rhel-server-rhscl-7-rpms")
   end
 
   it "#check_updates" do


### PR DESCRIPTION
Updating default repo strings and removing support for choosing Sat5 as an update source.
@bdunne 
@Fryguy please review
@h-kataria can you please review the UI changes?

https://bugzilla.redhat.com/show_bug.cgi?id=1266951