### PR TITLE
ES6 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
 gem "rails",                           "~>4.2.5"
 gem "activerecord-session_store",      "~>0.1.2"
+gem "sprockets-es6",                   "~>0.8.2",  :require => "sprockets/es6"
 
 # Local gems
 path "gems/" do

--- a/config/initializers/sprockets-es6.rb
+++ b/config/initializers/sprockets-es6.rb
@@ -1,0 +1,6 @@
+# unfortunately there seems no other way to set the options because .call is called directly from sprockets
+Sprockets::ES6.instance.instance_variable_set(:@options, {:optional => %w(
+ es7.functionBind
+ es7.decorators
+ es7.objectRestSpread
+)})


### PR DESCRIPTION
This adds ES6 support through babel, via sprockets-es6.

The es6 files need to have the `.es6` extension, instead of `.js`.

Only babel5 is supported as of now, but that's not a problem yet .. but enabling the `es7.functionBind`, `es7.decorators` and `es7.objectRestSpread` settings..

Jasmine tests *can* test es6 files, but the tests themselves **must** be `.js` (and use ES5).

Usage:

... this works:

```diff
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -106,3 +106,4 @@
 //= require miq_toolbar
 //= require resizable_sidebar
 //= require xml_display
+//= require test
```

```diff
--- /dev/null
+++ b/app/assets/javascripts/test.es6
@@ -0,0 +1,13 @@
+class Test {
+  constructor(arr) {
+    this.data = arr;
+  }
+
+  foo(fn) {
+    return this.data.map(fn);
+  }
+}
+
+const t = new Test([ 1, 2, 3 ]);
+t.foo(x => console.log(x));
+t.foo(::console.log);
```