### PR TITLE
always set a vm's owner

### DIFF
--- a/app/models/miq_provision/ownership.rb
+++ b/app/models/miq_provision/ownership.rb
@@ -1,11 +1,7 @@
 module MiqProvision::Ownership
   def set_ownership(vm, user)
-    return if user.nil?
-
     _log.info "Setting Owning User to Name=#{user.name}, ID=#{user.id}"
     vm.evm_owner = user
-
-    return if user.current_group.nil?
 
     _log.info "Setting Owning Group to Name=#{user.current_group.name}, ID=#{user.current_group.id}"
     vm.miq_group = user.current_group

--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -61,7 +61,7 @@ module MiqProvision::StateMachine
     _log.info "Destination #{destination.class.base_model.name} ID=#{destination.id}, Name=#{destination.name}"
 
     set_description(destination, get_option(:vm_description))
-    set_ownership(destination, get_owner)
+    set_ownership(destination, get_owner || get_user)
     set_retirement(destination)
     set_genealogy(destination, source)
     set_miq_custom_attributes(destination, get_option(:ws_miq_custom_attributes))

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -61,7 +61,7 @@ module MiqProvisionMixin
     @owner ||= begin
       email = get_option(:owner_email).try(:downcase)
       return if email.blank?
-      User.find_by_lower_email(email, miq_request.requester).tap do |owner|
+      User.find_by_lower_email(email, get_user).tap do |owner|
         owner.miq_group_description = get_option(:owner_group) if owner
       end
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -24,6 +24,10 @@ FactoryGirl.define do
     sequence(:email) { |s| "user#{s}@example.com" }
   end
 
+  factory :user_with_email_and_group, :parent => :user_with_group do
+    sequence(:email) { |s| "user#{s}@example.com" }
+  end
+
   factory :user_with_group, :parent => :user do
     transient do
       tenant { Tenant.seed }

--- a/spec/models/mixins/miq_provision_mixin_spec.rb
+++ b/spec/models/mixins/miq_provision_mixin_spec.rb
@@ -2,24 +2,27 @@ require "spec_helper"
 
 describe MiqProvisionMixin do
   describe "#get_owner" do
-    let(:miq_request) { double("MiqRequest", :requester => requester) }
     let(:owner) { FactoryGirl.create(:user_with_email) }
     let(:options) { {:owner_email => owner.email} }
     let(:requester) { FactoryGirl.create(:user_with_email) }
     subject do
       Class.new do
         include MiqProvisionMixin
-        attr_accessor :options, :miq_request
+        attr_accessor :options
 
-        def initialize(miq_request, options)
-          @miq_request = miq_request
+        def initialize(user, options)
           @options     = options
+          @requester   = user
+        end
+
+        def get_user
+          @requester
         end
 
         def get_option(name)
           options[name]
         end
-      end.new(miq_request, options)
+      end.new(requester, options)
     end
 
     context "with no owner_email" do


### PR DESCRIPTION
Always set the vm's owner.

If there is no "owner" value, or if it is invalid, then set to the requester.

/cc @gmcculloug 