### PR TITLE
User group description

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,6 +110,7 @@ class User < ActiveRecord::Base
   def miq_group_description=(group_description)
     if group_description
       desired_group = miq_groups.detect { |g| g.description == group_description }
+      desired_group ||= MiqGroup.find_by_description(group_description) if super_admin_user?
       self.current_group = desired_group if desired_group
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -563,6 +563,13 @@ describe User do
       expect(u.current_group).to eq(g2)
       expect(u.miq_group_description).to eq(g2.description)
     end
+
+    it "sets any group to super admin" do
+      a = FactoryGirl.create(:user, :role => "super_administrator")
+      expect(a).to be_super_admin_user
+
+      a.miq_group_description = g2.description
+      expect(a.current_group).to eq(g2)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -543,16 +543,26 @@ describe User do
     it "ignores blank" do
       u.miq_group_description = ""
       expect(u.current_group).to eq(g1)
+      expect(u.miq_group_description).to eq(g1.description)
     end
 
     it "ignores not found" do
       u.miq_group_description = "not_found"
       expect(u.current_group).to eq(g1)
+      expect(u.miq_group_description).to eq(g1.description)
+    end
+
+    it "ignores a group that you do not belong" do
+      u.miq_group_description = FactoryGirl.create(:miq_group).description
+      expect(u.current_group).to eq(g1)
+      expect(u.miq_group_description).to eq(g1.description)
     end
 
     it "sets by description" do
       u.miq_group_description = g2.description
       expect(u.current_group).to eq(g2)
+      expect(u.miq_group_description).to eq(g2.description)
+    end
     end
   end
 


### PR DESCRIPTION
1. Ensure the group_description doesn't change when assigning a bogus group.
2. Allow super admin to assume the identity in any tenant.

/cc @abellotti This nails down the test cases around assigning a bogus group to user
/cc @mkanoor @gmcculloug If we need to pass an admin user with a specific tenant, we can now do that.