### PR TITLE
Change "Display" label in "MIQ Categories" & "MIQ Tags" screens

### DIFF
--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -53,10 +53,10 @@ module OpsController::Settings::Tags
         add_flash(_("%s is required") % "Name", :error)
       end
       if @edit[:new][:description].blank?
-        add_flash(_("%s is required") % "Display Name", :error)
+        add_flash(_("%s is required") % "Description", :error)
       end
       if @edit[:new][:example_text].blank?
-        add_flash(_("%s is required") % "Description", :error)
+        add_flash(_("%s is required") % "Long Description", :error)
       end
       unless @flash_array.nil?
         render :update do |page|

--- a/app/views/ops/_category_form.html.haml
+++ b/app/views/ops/_category_form.html.haml
@@ -11,12 +11,12 @@
           = @edit[:new][:name]
       .form-group
         %label.col-md-2.control-label
-          _("Display Name")
+          _("Description")
         .col-md-8
           = @edit[:new][:description]
       .form-group
         %label.col-md-2.control-label
-          = _("Description")
+          = _("Long Description")
         .col-md-8
           = @edit[:new][:example_text]
       .form-group
@@ -59,7 +59,7 @@
                                                   :url      => url}.to_json)
       .form-group
         %label.col-md-2.control-label
-          = _("Display Name")
+          = _("Description")
         .col-md-8
           = text_field_tag("description", @edit[:new][:description],
                            :maxlength         => 50,
@@ -72,7 +72,7 @@
         = javascript_tag(javascript_focus('description'))
       .form-group
         %label.col-md-2.control-label
-          = _("Description")
+          = _("Long Description")
         .col-md-8
           = text_field_tag("example_text", @edit[:new][:example_text],
                            :maxlength         => 255,

--- a/app/views/ops/_classification_entries.html.haml
+++ b/app/views/ops/_classification_entries.html.haml
@@ -6,7 +6,7 @@
       %tr
         %th.narrow
         %th= _("Name")
-        %th= _("Display Name")
+        %th= _("Description")
     %tbody
       - if entry != nil && entry == "new"
         = render :partial => "classification_entry", :locals => {:entry => "new", :edit => true}

--- a/app/views/ops/_settings_co_categories_tab.html.haml
+++ b/app/views/ops/_settings_co_categories_tab.html.haml
@@ -5,7 +5,7 @@
       %tr
         %th.narrow
         %th= _("Name")
-        %th= _("Display Name")
+        %th= _("Description")
         %th= _("Show in Console")
         %th= _("Single Value")
         %th= _("Capture C & U Data")

--- a/app/views/ops/_settings_co_tags_tab.html.haml
+++ b/app/views/ops/_settings_co_tags_tab.html.haml
@@ -16,7 +16,7 @@
             miqSelectPickerEvent('classification_name', "#{url}")
       .form-group
         %label.col-md-2.control-label
-          = _("Description")
+          = _("Long Description")
         .col-md-8
           %p.form-control-static
             = h(@cat.example_text)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1265393
Label "Description" changed as well

changed label from "Display Name" to "Description" in header
before
![miq_cat_list_b](https://cloud.githubusercontent.com/assets/14937244/10538578/bd061bea-73f9-11e5-8807-9f9b487fc82b.png)
after
![miq_cat_list](https://cloud.githubusercontent.com/assets/14937244/10538778/35f2098c-73fb-11e5-8da3-85bc68799745.png)

changed label of field from "Display Name" to "Description" and "Description" to "Long Description"
before
![miq_cat_edit_b](https://cloud.githubusercontent.com/assets/14937244/10538580/bd0a03a4-73f9-11e5-8c5c-e4ddc631223f.png)
after
![miq_cat_edit](https://cloud.githubusercontent.com/assets/14937244/10538762/1bb9f37c-73fb-11e5-88ea-e5bed456872c.png)

changed label of field in flash message from "Display Name" to "Description" and "Description" to "Long Description"
before
![miq_cat_add_flash_b](https://cloud.githubusercontent.com/assets/14937244/10538579/bd084190-73f9-11e5-980d-0792979c6ca7.png)
after
![miq_cat_add_flash](https://cloud.githubusercontent.com/assets/14937244/10538771/2a7250b2-73fb-11e5-842b-012f8c9739fd.png)


changed label "Display Name" to "Description"
before
![miq_tag_header_b](https://cloud.githubusercontent.com/assets/14937244/10538577/bd0516f0-73f9-11e5-8196-18c45915290e.png)

after
![miq_tag_header](https://cloud.githubusercontent.com/assets/14937244/10538795/51c2877c-73fb-11e5-8608-268deb7725fb.png)

before
![mic_cat_long_desc](https://cloud.githubusercontent.com/assets/14937244/10573520/3d34eaaa-7650-11e5-903a-700b7d4ab990.png)

change label "Description" to "Long Description" (under Category drop down)
after
![mic_cat_long_desc_after](https://cloud.githubusercontent.com/assets/14937244/10573521/3d3a6002-7650-11e5-8a3a-63ff179501a5.png)
