### PR TITLE
removes the footer from self-service ui

### DIFF
--- a/spa_ui/self_service/client/app/layouts/application.html
+++ b/spa_ui/self_service/client/app/layouts/application.html
@@ -2,6 +2,5 @@
 <header-nav></header-nav>
 <sidebar-nav></sidebar-nav>
 <main-content></main-content>
-<footer-content></footer-content>
 </div>
 

--- a/spa_ui/self_service/client/app/states/marketplace/list/_list.sass
+++ b/spa_ui/self_service/client/app/states/marketplace/list/_list.sass
@@ -1,7 +1,6 @@
 .ss-card-view
   padding-left: 20px
   padding-top: 20px
-  height: calc(100vh - 185px)
   overflow-y: auto
   overflow-x: hidden
 

--- a/spa_ui/self_service/client/assets/sass/_list-view.sass
+++ b/spa_ui/self_service/client/assets/sass/_list-view.sass
@@ -1,5 +1,4 @@
 .list-view-container
-  height: calc(100vh - 185px)
   overflow-y: auto
   overflow-x: hidden
   background: $app-color-white

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="app" class="layout-pf-alt layout-pf-alt-fixed transitions">
+<html ng-app="app" class="layout-pf-alt layout-pf-alt-fixed layout-pf-alt-fixed-inner-scroll transitions">
 <head lang="en">
   <title ng-bind="title">ManageIQ Self Service</title>
   <meta charset="utf-8"/>

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="app" class="layout-pf-alt layout-pf-alt-fixed layout-pf-alt-fixed-with-footer layout-pf-alt-fixed-inner-scroll transitions">
+<html ng-app="app" class="layout-pf-alt layout-pf-alt-fixed transitions">
 <head lang="en">
   <title ng-bind="title">ManageIQ Self Service</title>
   <meta charset="utf-8"/>


### PR DESCRIPTION

<img width="1920" alt="screen shot 2015-10-16 at 8 23 43 am" src="https://cloud.githubusercontent.com/assets/6640236/10541484/8c8f05a4-73df-11e5-9a10-64ce2ab8f81e.png">
<img width="1920" alt="screen shot 2015-10-16 at 8 23 52 am" src="https://cloud.githubusercontent.com/assets/6640236/10541486/8c960d9a-73df-11e5-97de-b2cad8170368.png">
<img width="1920" alt="screen shot 2015-10-16 at 8 23 48 am" src="https://cloud.githubusercontent.com/assets/6640236/10541485/8c95b520-73df-11e5-943c-79032a470b29.png">


additionally removes the limit on list-view-container heights (that presents the illusion of a footer)