### PR TITLE
Namespace export file shouldn't have tenant id

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -9,7 +9,7 @@ class MiqAeDomain < MiqAeNamespace
   before_save :default_priority
   belongs_to :tenant
 
-  EXPORT_EXCLUDE_KEYS = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/] 
+  EXPORT_EXCLUDE_KEYS = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/]
 
   include TenancyMixin
 

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -9,6 +9,8 @@ class MiqAeDomain < MiqAeNamespace
   before_save :default_priority
   belongs_to :tenant
 
+  EXPORT_EXCLUDE_KEYS = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/] 
+
   include TenancyMixin
 
   def self.enabled

--- a/lib/miq_automation_engine/models/miq_ae_yaml_export.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_export.rb
@@ -235,7 +235,7 @@ class MiqAeYamlExport
 
   def domain_object
     raise MiqAeException::DomainNotAccessible, "Domain [#{@domain}] not accessible" unless domain_accessible?
-    MiqAeNamespace.find_by_fqname(@domain).tap do |dom|
+    MiqAeDomain.find_by_fqname(@domain).tap do |dom|
       if dom.nil?
         _log.error("Domain: <#{@domain}> not found.")
         raise MiqAeException::DomainNotFound, "Domain [#{@domain}] not found in MiqAeDatastore"

--- a/lib/miq_automation_engine/models/mixins/miq_ae_yaml_import_export_mixin.rb
+++ b/lib/miq_automation_engine/models/mixins/miq_ae_yaml_import_export_mixin.rb
@@ -12,14 +12,14 @@ module MiqAeYamlImportExportMixin
   ALL_DOMAINS             = '*'
   VERSION                 = 1.0
 
-  EXPORT_EXCLUDE_KEYS     = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/]
+  EXPORT_EXCLUDE_KEYS     = [/^id$/, /_id$/, /^created_on/, /^updated_on/, /^updated_by/, /^reserved$/]
 
   def export_attributes
-    attributes.dup.delete_if { |k, _| EXPORT_EXCLUDE_KEYS.any? { |rexp| k =~ rexp } }
+    attributes.dup.delete_if { |k, _| self.class::EXPORT_EXCLUDE_KEYS.any? { |rexp| k =~ rexp } }
   end
 
   def export_non_blank_attributes
-    attributes.dup.delete_if { |k, v| EXPORT_EXCLUDE_KEYS.any? { |rexp| k =~ rexp || v.blank? } }
+    attributes.dup.delete_if { |k, v| self.class::EXPORT_EXCLUDE_KEYS.any? { |rexp| k =~ rexp || v.blank? } }
   end
 
   def add_domain(domain_yaml, tenant)

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -166,6 +166,14 @@ describe MiqAeDatastore do
       data = YAML.load_file(domain_file)
       expect(data.fetch_path('object', 'attributes', 'tenant_id')).to eq(@tenant.id)
     end
+
+    it "namespace should not contain tenant id" do
+      export_model(@manageiq_domain.name)
+      namespace_file=File.join(@export_dir, @manageiq_domain.name, @aen1.name, '__namespace__.yaml')
+      data = YAML.load_file(namespace_file)
+      hash = data.fetch_path('object', 'attributes')
+      expect(hash.key?('tenant_id')).to be_false
+    end
   end
 
   context "export import roundtrip" do

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -25,7 +25,7 @@ describe MiqAeDatastore do
     end
 
     it "child namespace as domain" do
-      expect { export_model(@aen1.fqname) }.to raise_error(MiqAeException::InvalidDomain)
+      expect { export_model(@aen1.fqname) }.to raise_error(MiqAeException::DomainNotFound)
     end
 
     it "non existing namespace" do
@@ -169,7 +169,7 @@ describe MiqAeDatastore do
 
     it "namespace should not contain tenant id" do
       export_model(@manageiq_domain.name)
-      namespace_file=File.join(@export_dir, @manageiq_domain.name, @aen1.name, '__namespace__.yaml')
+      namespace_file = File.join(@export_dir, @manageiq_domain.name, @aen1.name, '__namespace__.yaml')
       data = YAML.load_file(namespace_file)
       hash = data.fetch_path('object', 'attributes')
       expect(hash.key?('tenant_id')).to be_false


### PR DESCRIPTION
The domain and namespace reside in the same table miq_ae_namespace which has a new column called tenant_id. This column is only relevant for domains but not for namespaces. Modified code so that we don't export the tenant_id for namespace.