### PR TITLE
pass user to get tree objects

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -221,7 +221,7 @@ module ApplicationController::Explorer
     # :full_ids               # stack parent id on top of each node id
 
     roots = x_get_tree_objects(options.merge(
-                                 :userid => session[:userid], # Userid for RBAC filtering
+                                 :user   => current_user,     # Userid for RBAC filtering
                                  :parent => nil               # Asking for roots, no parent
     ))
 
@@ -253,7 +253,7 @@ module ApplicationController::Explorer
   def x_get_tree_objects(options)
     # Options used:
     # :parent                 # Parent object for which we need child tree nodes returned
-    # :userid                 # Signed in user's id
+    # :user                   # Signed in user
     # :count_only             # Return only the count if true
     # :type                   # Type of tree, i.e. :handc, :vandt, :filtered, etc
     # :leaf                   # Model name of leaf nodes, i.e. "Vm"


### PR DESCRIPTION
This ensures the proper tenant/group is going across

This is similar to #4925 - that one is low hanging fruit, while this one requires some thought.

This hash is passed into `Rbac.filtered`, but it goes through many layers. It seems that these values are not stored/used anywhere else, but want a second opinion.

If we don't do this, chances are we will derive the correct `user.current_group` (and therefore `tenant`), But I am fixing all of these to avoid unknown edge cases.

/cc @dclarizio please point me to the best person to nail this down