### PR TITLE
Expose user, tenant, group to automate method

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -246,11 +246,8 @@ module MiqAeEngine
     end
 
     def user_info_attributes(user)
-      objects_hash = {'user'      => user,
-                      'tenant'    => user.current_tenant,
-                      'miq_group' => user.current_group}
-      objects_hash.each do |k, v|
-        value = MiqAeObject.convert_value_based_on_datatype(v.id, "#{v.class}")
+      {'user' => user, 'tenant' => user.current_tenant, 'miq_group' => user.current_group}.each do |k, v|
+        value = MiqAeObject.convert_value_based_on_datatype(v.id, v.class.name)
         @attributes[k] = value unless value.nil?
       end
     end

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -245,6 +245,16 @@ module MiqAeEngine
       process_filtered_fields(['assertion'], message)
     end
 
+    def set_user_info(user)
+      objects_hash = {'user'      => user,
+                      'tenant'    => user.current_tenant,
+                      'miq_group' => user.current_group }
+      objects_hash.each do |k, v|
+        value = MiqAeObject.convert_value_based_on_datatype(v.id, "#{v.class}")
+        @attributes[k] = value unless value.nil?
+      end
+    end
+
     def process_args_as_attributes(args = {})
       args.keys.each { |k| MiqAeEngine.automation_attribute_is_array?(k) ? process_args_array(args, k) : process_args_attribute(args, k) }
       @attributes.merge!(args)

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -245,10 +245,10 @@ module MiqAeEngine
       process_filtered_fields(['assertion'], message)
     end
 
-    def set_user_info(user)
+    def user_info_attributes(user)
       objects_hash = {'user'      => user,
                       'tenant'    => user.current_tenant,
-                      'miq_group' => user.current_group }
+                      'miq_group' => user.current_group}
       objects_hash.each do |k, v|
         value = MiqAeObject.convert_value_based_on_datatype(v.id, "#{v.class}")
         @attributes[k] = value unless value.nil?

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -139,6 +139,7 @@ module MiqAeEngine
 
           obj.process_assertions(message)
           obj.process_args_as_attributes(args)
+          obj.set_user_info(@ae_user) unless root
         elsif scheme == "miqaews"
           obj = get_obj_from_path(path)
           raise MiqAeException::ObjectNotFound, "Object [#{path}] not found" if obj.nil?

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -139,7 +139,7 @@ module MiqAeEngine
 
           obj.process_assertions(message)
           obj.process_args_as_attributes(args)
-          obj.set_user_info(@ae_user) unless root
+          obj.user_info_attributes(@ae_user) unless root
         elsif scheme == "miqaews"
           obj = get_obj_from_path(path)
           raise MiqAeException::ObjectNotFound, "Object [#{path}] not found" if obj.nil?

--- a/spec/lib/miq_automation_engine/miq_ae_method_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_tenant_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+include AutomationSpecHelper
+
+describe "MiqAeMethodWithTenat" do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:user2) { FactoryGirl.create(:user_with_group) }
+
+  before do
+    method_script = "$evm.root['result'] = {:tenant_id => $evm.root['tenant'].id,
+                                            :user_id   => $evm.root['user'].id,
+                                            :group_id  => $evm.root['miq_group'].id}"
+    create_ae_model_with_method(:method_script => method_script, :ae_class => 'AUTOMATE',
+                                :ae_namespace  => 'EVM', :instance_name => 'test1',
+                                :method_name   => 'test', :name => 'TEST_DOMAIN')
+  end
+
+  def invoke_ae(url, user)
+    MiqAeEngine.instantiate(url, user)
+  end
+
+  def check_ids(result)
+    check_tenant_id(result)
+    check_user_id(result)
+    check_group_id(result)
+  end
+
+  def check_tenant_id(result)
+    expect(result[:tenant_id]).to eql(Tenant.root_tenant.id)
+  end
+
+  def check_user_id(result)
+    expect(result[:user_id]).to eql(user.id)
+  end
+
+  def check_group_id(result)
+    expect(result[:group_id]).to eql(user.current_group.id)
+  end
+
+  context "automate method" do
+    it "ignore user in url" do
+      result = invoke_ae("/EVM/AUTOMATE/test1?User::user=#{user2.id}", user).root['result']
+      check_ids(result)
+    end
+
+    it "use the passed in user object" do
+      result = invoke_ae("/EVM/AUTOMATE/test1", user).root['result']
+      check_ids(result)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_method_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_tenant_spec.rb
@@ -18,33 +18,21 @@ describe "MiqAeMethodWithTenat" do
     MiqAeEngine.instantiate(url, user)
   end
 
-  def check_ids(result)
-    check_tenant_id(result)
-    check_user_id(result)
-    check_group_id(result)
-  end
-
-  def check_tenant_id(result)
-    expect(result[:tenant_id]).to eql(Tenant.root_tenant.id)
-  end
-
-  def check_user_id(result)
-    expect(result[:user_id]).to eql(user.id)
-  end
-
-  def check_group_id(result)
-    expect(result[:group_id]).to eql(user.current_group.id)
-  end
-
   context "automate method" do
     it "ignore user in url" do
       result = invoke_ae("/EVM/AUTOMATE/test1?User::user=#{user2.id}", user).root['result']
-      check_ids(result)
+
+      expect(result[:tenant_id]).to eql(Tenant.root_tenant.id)
+      expect(result[:user_id]).to eql(user.id)
+      expect(result[:group_id]).to eql(user.current_group.id)
     end
 
     it "use the passed in user object" do
       result = invoke_ae("/EVM/AUTOMATE/test1", user).root['result']
-      check_ids(result)
+
+      expect(result[:tenant_id]).to eql(Tenant.root_tenant.id)
+      expect(result[:user_id]).to eql(user.id)
+      expect(result[:group_id]).to eql(user.current_group.id)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_provision_spec.rb
@@ -66,7 +66,6 @@ module MiqAeProvisionSpec
         roots.should_not be_nil
         roots.should be_a_kind_of(Array)
         roots.length.should == 1
-        roots.first.attributes.length.should == 0
       end
 
       it "should instantiate ttl_warnings" do


### PR DESCRIPTION
The current_tenant and current_group from the passed in
user object is exposed to Automate method as attributes of root
object

- $evm.root['user']      => User Object
- $evm.root['tenant']    => Tenant Object
- $evm.root['miq_group'] => Group Object

These objects are ServiceModel wrapped objects and would
only expose the attributes and functions defined in the service model
for these classes