### PR TITLE
Add check for archived VMs for UI.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -34,6 +34,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   end
 
   def validate_smartstate_analysis
-    validate_supported
+    validate_supported_check("Smartstate Analysis")
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -78,6 +78,6 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   end
 
   def validate_smartstate_analysis
-    validate_supported
+    validate_supported_check("Smartstate Analysis")
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -45,7 +45,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   end
 
   def validate_smartstate_analysis
-    validate_supported
+    validate_supported_check("Smartstate Analysis")
   end
 
   # Show Reconfigure VM task

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -32,7 +32,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   end
 
   def validate_smartstate_analysis
-    validate_supported
+    validate_supported_check("Smartstate Analysis")
   end
 
   #

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1906,4 +1906,15 @@ class VmOrTemplate < ActiveRecord::Base
   def validate_supported
     {:available => true,   :message => nil}
   end
+
+  def validate_supported_check(message_prefix)
+    message = if self.archived?
+                "#{message_prefix} cannot be performed on archived #{self.class.model_suffix} VM."
+              elsif self.orphaned?
+                "#{message_prefix} cannot be performed on orphaned #{self.class.model_suffix} VM."
+              else
+                nil
+              end
+    {:available => true,   :message => message}
+  end
 end


### PR DESCRIPTION
In the validate_smartstate_analysis methods, check for archived and orphaned VMs,
so the UI won't allow scanning of those VMs.

https://bugzilla.redhat.com/show_bug.cgi?id=1271359