### PR TITLE
Raise an exception if provider is unreachable

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
@@ -25,6 +25,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Runner < ManageIQ
     event_monitor_handle.start
     event_monitor_handle.each_batch do |events|
       _log.debug { "#{log_prefix} Received events #{events.collect(&:message)}" }
+      event_monitor_running
       @queue.enq events
       sleep_poll_normal
     end

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -7,6 +7,9 @@
 # queue to the AWS Config topic.
 #
 class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
+  class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
+  end
+
   #
   # Creates an event monitor
   #
@@ -91,7 +94,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
                       "Cannot collect Amazon events for AWS Access Key ID #{@aws_access_key_id}")
         $aws_log.warn("#{log_header} Contact Amazon to create the AWS Config service and topic for Amazon events.")
         queue = nil
-        # no need to raise an error
+        raise ProviderUnreachable
       end
     end
     queue

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "aws-sdk"
+
+describe ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream do
+  before do
+    @ems = FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :provider_region => "us-west-1")
+
+    @ems_stream = described_class.new(@ems.authentication_userid,
+                                      @ems.authentication_password,
+                                      @ems.provider_region,
+                                      @ems.guid)
+  end
+
+  context "#each_batch" do
+    it "raises ProviderUnreachable on non existing queue" do
+      expect(@ems_stream).to receive(:sqs).and_raise(AWS::SQS::Errors::NonExistentQueue)
+      @ems_stream.stub(:sns => double(:topics => double(:detect => nil)))
+
+      @ems_stream.start
+      expect do
+        @ems_stream.each_batch
+      end.to raise_error(described_class::ProviderUnreachable)
+    end
+  end
+end

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -20,6 +20,13 @@ describe MiqWorker::Runner do
       @worker_base.start
     end
 
+    it "Handles exception TemporaryFailure" do
+      @worker_base.stub(:heartbeat).and_raise(MiqWorker::Runner::TemporaryFailure)
+      @worker_base.should_receive(:recover_from_temporary_failure)
+      @worker_base.stub(:do_gc).and_raise(RuntimeError, "Done")
+      expect { @worker_base.start }.to raise_error(RuntimeError, "Done")
+    end
+
     it "unhandled signal SIGALRM" do
       @worker_base.stub(:run).and_raise(SignalException, "SIGALRM")
       expect { @worker_base.start }.to raise_error(SignalException, "SIGALRM")


### PR DESCRIPTION
When AWS experiences failures MiQ can loop rapidly producing repetitive log
warning. This PR adds the raising of an exception when this condition is detected
allowing the worker to regroup, preventing the aws.log file from being flooded
with Cannot collect Amazon events..." messages.

https://bugzilla.redhat.com/show_bug.cgi?id=1250444