### PR TITLE
[api] Bumping up versioning to v2.1.0

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -3,12 +3,12 @@
   :module: api
   :name: API
   :description: REST API
-  :version: '2.1.0-pre'
+  :version: '2.1.0'
 :version:
   :regex: !ruby/regexp /^v[0-9]+(?>\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?/
   :definitions:
-  - :name: '2.1.0-pre'
-    :ident: 'v2.1.0-pre'
+  - :name: '2.1.0'
+    :ident: 'v2.1.0'
 :method:
   :names:
   - :get


### PR DESCRIPTION
- With this being the last print, removing the -pre(release) from the API versioning.
