### PR TITLE
adds provision dialog to the service details state

### DIFF
--- a/spa_ui/self_service/client/app/states/services/details/details.html
+++ b/spa_ui/self_service/client/app/states/services/details/details.html
@@ -194,8 +194,7 @@
   <div class="panel panel-default ss-details-panel">
     <div class="panel-body">
       <section class="ss-details-section">
-        <h2>Service Details</h2>
-        <pre>{{ ::vm.service |json }}</pre>
+        <dialog-content dialog="vm.service.provision_dialog" input-disabled="true" options="vm.service.options.dialog"></dialog-content>
       </section>
     </div>
   </div>

--- a/spa_ui/self_service/client/app/states/services/details/details.state.js
+++ b/spa_ui/self_service/client/app/states/services/details/details.state.js
@@ -39,7 +39,8 @@
       'aggregate_all_vm_disk_space_used',
       'aggregate_all_vm_memory_on_disk',
       'actions',
-      'custom_actions'
+      'custom_actions',
+      'provision_dialog'
     ];
     var options = {attributes: requestAttributes};
 


### PR DESCRIPTION
<img width="1920" alt="screen shot 2015-10-18 at 12 08 22 pm" src="https://cloud.githubusercontent.com/assets/6640236/10564865/f2e960da-7590-11e5-9072-28f261357c88.png">
<img width="1920" alt="screen shot 2015-10-18 at 12 08 05 pm" src="https://cloud.githubusercontent.com/assets/6640236/10564864/f2e78c42-7590-11e5-87e6-fcfb32e32aa1.png">

uses the dialog-content directive