### PR TITLE
Use native Ruby CSV parser in MiqAction.create_default_actions

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1079,17 +1079,9 @@ class MiqAction < ActiveRecord::Base
     create_script_actions_from_directory
   end
 
-  def self.create_default_actions
-    fname = FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
-    data  = fname.read.split("\n")
-    cols  = data.shift.split(",").map(&:to_sym)
-
-    data.each do |line|
-      next if line.starts_with?('#') # skip commented lines
-
-      arr = line.split(",")
-
-      action = Hash[cols.zip(arr)]
+  def self.create_default_actions(fname = FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv"))
+    CSV.foreach(fname, :headers => true, :skip_lines => /^#/).each do |csv_row|
+      action = csv_row.to_hash.symbolize_keys
       action[:action_type] = 'default'
 
       rec = find_by_name(action[:name])

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1079,7 +1079,7 @@ class MiqAction < ActiveRecord::Base
     create_script_actions_from_directory
   end
 
-  def self.create_default_actions(fname = FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv"))
+  def self.create_default_actions(fname = fixture_path)
     CSV.foreach(fname, :headers => true, :skip_lines => /^#/).each do |csv_row|
       action = csv_row.to_hash
       action['action_type'] = 'default'
@@ -1096,5 +1096,9 @@ class MiqAction < ActiveRecord::Base
         end
       end
     end
+  end
+
+  def self.fixture_path
+    FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end
 end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1081,17 +1081,17 @@ class MiqAction < ActiveRecord::Base
 
   def self.create_default_actions(fname = FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv"))
     CSV.foreach(fname, :headers => true, :skip_lines => /^#/).each do |csv_row|
-      action = csv_row.to_hash.symbolize_keys
-      action[:action_type] = 'default'
+      action = csv_row.to_hash
+      action['action_type'] = 'default'
 
-      rec = find_by_name(action[:name])
+      rec = find_by_name(action['name'])
       if rec.nil?
-        _log.info("Creating [#{action[:name]}]")
+        _log.info("Creating [#{action['name']}]")
         create(action)
       else
         rec.attributes = action
         if rec.changed? || (rec.options_was != rec.options)
-          _log.info("Updating [#{action[:name]}]")
+          _log.info("Updating [#{action['name']}]")
           rec.save
         end
       end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1080,7 +1080,7 @@ class MiqAction < ActiveRecord::Base
   end
 
   def self.create_default_actions
-    CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/).each do |csv_row|
+    CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/) do |csv_row|
       action = csv_row.to_hash
       action['action_type'] = 'default'
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1079,8 +1079,8 @@ class MiqAction < ActiveRecord::Base
     create_script_actions_from_directory
   end
 
-  def self.create_default_actions(fname = fixture_path)
-    CSV.foreach(fname, :headers => true, :skip_lines => /^#/).each do |csv_row|
+  def self.create_default_actions
+    CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/).each do |csv_row|
       action = csv_row.to_hash
       action['action_type'] = 'default'
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -163,7 +163,7 @@ describe MiqAction do
   context '.create_default_actions' do
     context 'seeding default actions from a file with 3 csv rows and some comments' do
       before do
-        csv = write_to_tempfile <<-CSV.strip_heredoc
+        stub_csv <<-CSV.strip_heredoc
           name,description
           audit,Generate Audit Event
           log,Generate log message
@@ -172,7 +172,7 @@ describe MiqAction do
           evm_event,Show EVM Event on Timeline
         CSV
 
-        MiqAction.create_default_actions(csv.path)
+        MiqAction.create_default_actions
       end
 
       it 'should create 3 new actions' do
@@ -185,7 +185,7 @@ describe MiqAction do
 
       context 'when csv was changed and imported again' do
         before do
-          csv = write_to_tempfile <<-CSV.strip_heredoc
+          stub_csv <<-CSV.strip_heredoc
             name,description
             audit,UPD: Audit Event
             # log,Generate log message
@@ -193,7 +193,7 @@ describe MiqAction do
             evm_event,Show EVM Event on Timeline
           CSV
 
-          MiqAction.create_default_actions(csv.path)
+          MiqAction.create_default_actions
         end
 
         it "should not delete the actions that present in the DB but don't present in the file" do
@@ -209,11 +209,13 @@ describe MiqAction do
         end
       end
 
-      def write_to_tempfile(data)
+      def stub_csv(data)
         Tempfile.open(['actions', '.csv']) do |f|
           f.write(data)
           @tempfile = f # keep the reference in order to delete the file later
         end
+
+        expect(MiqAction).to receive(:fixture_path).and_return(@tempfile.path)
       end
 
       after do


### PR DESCRIPTION
See the shiny new `:skip_lines` option [in the documentation](http://ruby-doc.org/stdlib-2.2.2/libdoc/csv/rdoc/CSV.html#method-c-new). It first appeared in Ruby 2.0.0. The code is much shorter and simpler now, we don't need to parse CSV manually.