### PR TITLE
[WIP] Send Work to Automate Worker

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -134,6 +134,7 @@ class MiqRequestTask < ActiveRecord::Base
         :method_name => 'deliver',
         :args        => [args],
         :role        => 'automate',
+        :queue_name  => 'automate',
         :zone        => options.fetch(:miq_zone, zone),
         :task_id     => my_task_id,
       )

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -53,9 +53,10 @@ class ResourceAction < ActiveRecord::Base
   def deliver_to_automate_from_dialog(dialog_hash_values, target, user)
     _log.info("Queuing <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
     MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user),
-                              :zone     => target.try(:my_zone),
-                              :priority => MiqQueue::HIGH_PRIORITY,
-                              :task_id  => "#{self.class.name.underscore}_#{id}")
+                              :zone       => target.try(:my_zone),
+                              :priority   => MiqQueue::HIGH_PRIORITY,
+                              :queue_name => 'automate',
+                              :task_id    => "#{self.class.name.underscore}_#{id}")
   end
 
   def deliver_to_automate_from_dialog_field(dialog_hash_values, target, user)

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -43,6 +43,7 @@ class ServiceReconfigureTask < MiqRequestTask
         :method_name => 'deliver',
         :args        => [args],
         :role        => 'automate',
+        :queue_name  => 'automate',
         :zone        => zone,
         :task_id     => "#{self.class.name.underscore}_#{id}"
       )

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -147,6 +147,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
         :method_name => 'deliver',
         :args        => [args],
         :role        => 'automate',
+        :queue_name  => 'automate',
         :zone        => nil,
         :task_id     => "#{self.class.name.underscore}_#{id}"
       )

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -31,6 +31,7 @@ module MiqAeEngine
       :args        => [args],
       :zone        => MiqServer.my_zone,
       :role        => 'automate',
+      :queue_name  => 'automate',
       :msg_timeout => 60.minutes
     }.merge(options)
 

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -23,6 +23,7 @@ describe ResourceAction do
         :method_name => 'deliver',
         :args        => [q_args],
         :role        => 'automate',
+        :queue_name  => 'automate',
         :zone        => zone_name,
         :priority    => MiqQueue::HIGH_PRIORITY,
         :task_id     => "#{ra.class.name.underscore}_#{ra.id}",

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -89,6 +89,7 @@ describe ServiceReconfigureTask do
           :method_name => 'deliver',
           :args        => [automate_args],
           :role        => 'automate',
+          :queue_name  => 'automate',
           :zone        => nil,
           :task_id     => "service_reconfigure_task_#{task.id}")
         task.deliver_to_automate


### PR DESCRIPTION
Any tasks delivered via the Queue would be handled by the Automate
worker. We still have direct calls into Automate from the UI worker
they have not been changed.