### PR TITLE
Use the columnar mime-types database, instead of JSON

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "winrm",                          "=1.1.3",    :require => false, :git => "g
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required
+gem "mime-types",                     "~>2.6.1",   :require => "mime/types/columnar"
 gem "acts_as_list",                   "~>0.1.4"
 gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be required so that it loads before ancestry
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
@@ -51,7 +52,6 @@ gem "azure-armrest",                  "=0.0.3"
 gem "default_value_for",              "~>3.0.1"
 gem "hamlit-rails",                   "~>0.1.0"
 gem "high_voltage",                   "~>2.4.0"
-gem "mime-types"
 gem "novnc-rails",                    "~>0.2"
 gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "puma",                           "~>2.13"


### PR DESCRIPTION
This saves us a bit of memory, by living in [the future](https://github.com/mime-types/ruby-mime-types#columnar-store).