### PR TITLE
Added "Use Configuration Settings" checkbox to root tenant edit.

### DIFF
--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -4,7 +4,8 @@ ManageIQ.angularApplication.controller('tenantFormController', ['$http', '$scope
       $scope.tenantModel = {
         name: '',
         description: '',
-        divisible: true
+        divisible: true,
+        use_config_for_attributes: false
       };
       $scope.formId = tenantFormId;
       $scope.afterGet = false;
@@ -13,21 +14,24 @@ ManageIQ.angularApplication.controller('tenantFormController', ['$http', '$scope
       ManageIQ.angularApplication.$scope = $scope;
 
       if (tenantFormId == 'new') {
-        $scope.newRecord               = true;
-        $scope.tenantModel.name        = '';
-        $scope.tenantModel.description = '';
-        $scope.tenantModel.default     = false;
-        $scope.tenantModel.divisible   = tenantType;
-        $scope.afterGet                = true;
-        $scope.modelCopy               = angular.copy( $scope.tenantModel );
+        $scope.newRecord                             = true;
+        $scope.tenantModel.name                      = '';
+        $scope.tenantModel.description               = '';
+        $scope.tenantModel.default                   = false;
+        $scope.tenantModel.divisible                 = tenantType;
+        $scope.tenantModel.use_config_for_attributes = false;
+
+        $scope.afterGet  = true;
+        $scope.modelCopy = angular.copy( $scope.tenantModel );
       } else {
         $scope.newRecord = false;
         miqService.sparkleOn();
         $http.get('/ops/tenant_form_fields/' + tenantFormId).success(function(data) {
-          $scope.tenantModel.name        = data.name;
-          $scope.tenantModel.description = data.description;
-          $scope.tenantModel.default     = data.default;
-          $scope.tenantModel.divisible   = data.divisible;
+          $scope.tenantModel.name                      = data.name;
+          $scope.tenantModel.description               = data.description;
+          $scope.tenantModel.default                   = data.default;
+          $scope.tenantModel.divisible                 = data.divisible;
+          $scope.tenantModel.use_config_for_attributes = data.use_config_for_attributes;
 
           $scope.afterGet = true;
           $scope.modelCopy = angular.copy( $scope.tenantModel );

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -153,19 +153,22 @@ module OpsController::OpsRbac
   end
 
   def tenant_form_fields
-    tenant = Tenant.find_by_id(params[:id])
+    tenant      = Tenant.find_by_id(params[:id])
 
     render :json => {
-      :name        => tenant.name,
-      :description => tenant.description,
-      :default     => tenant.default?,
-      :divisible   => tenant.divisible
+      :name                      => tenant.name,
+      :description               => tenant.description,
+      :default                   => tenant.root?,
+      :divisible                 => tenant.divisible,
+      :use_config_for_attributes => tenant.use_config_for_attributes
     }
   end
 
   def tenant_set_record_vars(tenant)
-    tenant.name        = params[:name]
+    # there is no params[:name] when use_config_attributes is checked
+    tenant.name        = params[:name] if params[:name]
     tenant.description = params[:description]
+    tenant.use_config_for_attributes = tenant.root? && (params[:use_config_for_attributes] == "on")
     unless tenant.id # only set for new records
       tenant.parent    = Tenant.find_by_id(from_cid(x_node.split('-').last))
       tenant.divisible = params[:divisible] == "true"

--- a/app/views/ops/_tenant_form.html.haml
+++ b/app/views/ops/_tenant_form.html.haml
@@ -14,6 +14,7 @@
                               "id"          => "textInput-markup",
                               "name"        => "name",
                               "ng-model"    => "tenantModel.name",
+                              "ng-disabled" => "tenantModel.default && tenantModel.use_config_for_attributes",
                               "maxlength"   => "#{MAX_NAME_LEN}",
                               "miqrequired" => "",
                               "checkchange" => ""}
@@ -32,6 +33,14 @@
                               "checkchange" => ""}
             %span.help-block{"ng-show" => "angularForm.description.$error.miqrequired"}
               = _("Required")
+      .form-group{"ng-show" => "tenantModel.default"}
+        %label.col-md-2.control-label
+          = _("Use Configuration Settings")
+        .col-md-10
+          %input#use_config{"type"        => "checkbox",
+                            "name"        => "use_config_for_attributes",
+                            "ng-model"    => "tenantModel.use_config_for_attributes",
+                            "checkchange" => ""}
       %input{"type" => "hidden", "name" => "divisible", "value" => "{{tenantModel.divisible}}"}
   = render :partial => "layouts/angular/x_edit_buttons_angular"
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -125,6 +125,35 @@ describe OpsController do
     end
 
     context "#tenant_set_record_vars" do
+      before do
+        @tenant = Tenant.seed
+        server = EvmSpecHelper.local_miq_server
+        MiqServer.stub(:my_server).and_return(server)
+      end
+
+      it "saves name in record when use_config_attributes is false" do
+        controller.instance_variable_set(:@_params,
+                                         :divisible                 => true,
+                                         :use_config_for_attributes => "on"
+                                        )
+        controller.send(:tenant_set_record_vars, @tenant)
+        stub_server_configuration(:server => { :company => "Settings Company Name"})
+        expect(@tenant.name).to eq "Settings Company Name"
+      end
+
+      it "does not save name in record when use_config_for_attributes is true" do
+        controller.instance_variable_set(:@_params,
+                                         :name      => "Foo_Bar",
+                                         :divisible => true
+                                        )
+        @tenant.update_attributes(:use_config_for_attributes => false)
+        @tenant.reload
+        controller.send(:tenant_set_record_vars, @tenant)
+        @tenant.name.should eq("Foo_Bar")
+      end
+    end
+
+    context "#tenant_set_record_vars" do
       before :each do
         @tenant = FactoryGirl.create(:tenant,
                                      :name        => "Foo",


### PR DESCRIPTION
- Added "Use Configuration Settings" checkbox to root tenant edit screen, when the new checkbox is checked user will not be able to edit name of root tenant record and tenant name will be displayed from config in a disabled textbox. In case "Use Configuration Settings" is unchecked user will be able to change root tenant's name and it will be saved in the tenant record.
- Added controller spec to verify changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1265221

@kbrock @dclarizio please review.

Root Tenant Edit screen with "Use Configuration Settings" checked
![tenant_with_config](https://cloud.githubusercontent.com/assets/3450808/10586555/bc0ae0cc-766a-11e5-805a-b4d47f43bc5c.png)

Root Tenant Edit screen with "Use Configuration Settings" unchecked
![tenant_edit_without_config](https://cloud.githubusercontent.com/assets/3450808/10586564/c29b517e-766a-11e5-8f12-0dbcfd0cd23d.png)

Other tenant add/edit screens, without "Use Configuration Settings" checkbox
![edit_tenant](https://cloud.githubusercontent.com/assets/3450808/10586567/c888b11c-766a-11e5-82b2-7facbd60256b.png)
![add_new_tenant](https://cloud.githubusercontent.com/assets/3450808/10586569/c88f1372-766a-11e5-8524-d395d6024d79.png)
