### PR TITLE
Sync on lockHash only if we'll log something

### DIFF
--- a/gems/pending/VMwareWebService/MiqVimBroker.rb
+++ b/gems/pending/VMwareWebService/MiqVimBroker.rb
@@ -532,6 +532,8 @@ class MiqVimBroker
       return
     end
 
+    return unless $vim_log.info?
+
     # server
     $vim_log.info "MiqVimBroker status start"
     $vim_log.info "\tMiqVimBroker: Threads = #{Thread.list.length}"


### PR DESCRIPTION
For the default logger level, warn, we'll acquire the lock, hold it,
traverse the in memory cache, never log anything, and finally release
the lock.

Let's only do this when the log level is high enough to print the
status as it will slow other threads by holding the lock.

https://bugzilla.redhat.com/show_bug.cgi?id=1264188