### PR TITLE
Fixed a typo.

### DIFF
--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -22,7 +22,7 @@ class TreeBuilderReportRoles < TreeBuilder
     if user.super_admin_user?
       roles = MiqGroup.all
     else
-      roles = [MiqGroup.find_by_id(user.miq_group_id)]
+      roles = [MiqGroup.find_by_id(user.miq_group.id)]
     end
     count_only_or_objects(options[:count_only], roles.sort_by { |o| o.name.downcase }, 'name')
   end

--- a/spec/presenters/tree_builder_report_roles_spec.rb
+++ b/spec/presenters/tree_builder_report_roles_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe TreeBuilderReportRoles do
+  context "#x_get_tree_roots" do
+    before do
+      role = MiqUserRole.find_by_name("EvmRole-operator")
+      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Test Group")
+      login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [@group])
+    end
+
+    it "gets roles/group for the specified user" do
+      tree = TreeBuilderReportRoles.new("roles_tree", "roles", {})
+      roles = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      roles.should eq([@group.description])
+    end
+  end
+end


### PR DESCRIPTION
- Fixed a typo in the roles tree building code while trying to access user's group info, changing accordions in Reports explorer was blowing up because due to this typo reports tree builder did not finish building all the trees.
- Added spec test to verify the fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1272616

@dclarizio please review/test