### PR TITLE
Tune the ruby GC for less aggressive memory growth on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ sudo: false
 cache: bundler
 env:
   global:
-  - RUBY_GC_MALLOC_LIMIT=90000000
+  - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
+  - RUBY_GC_HEAP_INIT_SLOTS=600000
+  - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
   matrix:
   - TEST_SUITE=vmdb
   - TEST_SUITE=automation


### PR DESCRIPTION
Based on findings from: https://github.com/ManageIQ/manageiq-appliance/pull/36

The general rationale is to initialize the heap with the minimum number of slots
we'll know we need, 600,000, grow the heap much slower (1.25x vs. 1.8x), and
allow it to grow the heap by at most 300,000 slots (vs. no limit).