### PR TITLE
Create a rake task to compile the sti loader yaml file.

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -41,4 +41,8 @@ namespace :evm do
     Rake::Task["assets:clobber"].invoke
     Rake::Task["assets:precompile"].invoke
   end
+
+  task :compile_sti_loader => :environment do
+    DescendantLoader.instance.class_inheritance_relationships
+  end
 end


### PR DESCRIPTION
`bundle exec rake evm:compile_sti_loader`

Produces: `tmp/cache/sti_loader.yml`

This can be used to compile the sti loader once at build time.

From: https://github.com/ManageIQ/manageiq/pull/4912

[skip ci]