### PR TITLE
Ensure default fields are set when adding a tenant

### DIFF
--- a/db/migrate/20150903162623_assign_tenant.rb
+++ b/db/migrate/20150903162623_assign_tenant.rb
@@ -4,7 +4,12 @@ class AssignTenant < ActiveRecord::Migration
 
     # seed and return the current root_tenant
     def self.root_tenant
-      Tenant.where(:ancestry => nil).first || Tenant.create!(:use_config_for_attributes => true)
+      Tenant.create_with(
+        :name                      => "My Company",
+        :description               => "Tenant for My Company",
+        :divisible                 => true,
+        :use_config_for_attributes => true,
+      ).find_or_create_by(:ancestry => nil)
     end
   end
 
@@ -33,6 +38,9 @@ class AssignTenant < ActiveRecord::Migration
   end
 
   def change
+    Tenant.connection.schema_cache.clear!
+    Tenant.reset_column_information
+
     models = [ExtManagementSystem, MiqAeNamespace, MiqGroup,
               Provider, TenantQuota, Vm]
 

--- a/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
+++ b/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
@@ -4,7 +4,12 @@ class AssignTenantToMiqRequest < ActiveRecord::Migration
 
     # seed and return the current root_tenant
     def self.root_tenant
-      Tenant.where(:ancestry => nil).first || Tenant.create!(:use_config_for_attributes => true)
+      Tenant.create_with(
+        :name                      => "My Company",
+        :description               => "Tenant for My Company",
+        :divisible                 => true,
+        :use_config_for_attributes => true,
+      ).find_or_create_by(:ancestry => nil)
     end
   end
 

--- a/spec/migrations/20150903162623_assign_tenant_spec.rb
+++ b/spec/migrations/20150903162623_assign_tenant_spec.rb
@@ -26,6 +26,7 @@ describe AssignTenant do
 
         expect(tenant_stub.count).to eq(1)
         expect(tenant_stub.first).to be_use_config_for_attributes
+        expect(tenant_stub.first).to be_divisible
       end
 
       it "doesnt creates additional root_tenant" do
@@ -37,6 +38,7 @@ describe AssignTenant do
         expect(tenant_stub.count).to eq(1)
         # make sure tenant was not modified
         expect(tenant_stub.first).not_to be_use_config_for_attributes
+        expect(tenant_stub.first).not_to be_divisible
       end
     end
 

--- a/spec/migrations/20150915001329_assign_tenant_to_miq_request_spec.rb
+++ b/spec/migrations/20150915001329_assign_tenant_to_miq_request_spec.rb
@@ -35,6 +35,7 @@ describe AssignTenantToMiqRequest do
 
         expect(tenant_stub.count).to eq(1)
         expect(tenant_stub.first).to be_use_config_for_attributes
+        expect(tenant_stub.first).to be_divisible
       end
 
       it "doesnt creates additional root_tenant" do
@@ -46,6 +47,7 @@ describe AssignTenantToMiqRequest do
         expect(tenant_stub.count).to eq(1)
         # make sure tenant was not modified
         expect(tenant_stub.first).not_to be_use_config_for_attributes
+        expect(tenant_stub.first).not_to be_divisible
       end
     end
 


### PR DESCRIPTION
This fixes 2 issues around tenancy:

1. The default tenant created does not have the correct values set. (the values in the `default_value_for columns`)
2. When running the migration, the wrong metadata is cached for tenant and it blows up. This clears out the database metadata, so customers can migrate their database without blowing up.

/cc @dclarizio @h-kataria this should resolve the problems with mk's database.
/cc @abellotti FYI you had mentioned this in the past
/cc @carbonin FYI think you saw this in the console too
/cc @gmcculloug 