### PR TITLE
Checked checkboxes have a value of 't' not 'true'

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1253,7 +1253,7 @@ class MiqRequestWorkflow
     set_value = case data_type
                 when :integer then value.to_i_with_method
                 when :float   then value.to_f
-                when :boolean then (value.to_s.downcase == 'true')
+                when :boolean then (value.to_s.downcase == 'true' || value.to_s.downcase == 't')
                 when :time    then Time.parse(value)
                 when :button  then value # Ignore
                 else value # Ignore


### PR DESCRIPTION
Fixes the case where checked checkboxes have their option set as false
since 't' does not equal 'true'.