### PR TITLE
Fix exception in azure manager that prevented miq to startup

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_nested :Refresher
   require_nested :Vm
   require_nested :OrchestrationStack
-  require_nested :OrchestrationStackOptionConverter
+  require_nested :OrchestrationServiceOptionConverter
 
   alias_attribute :azure_tenant_id, :uid_ems
 


### PR DESCRIPTION
Fixed exception that prevented miq to startup

/home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:457:in `load': No such file to load -- manageiq/providers/azure/cloud_manager/orchestration_stack_option_converter (LoadError)
        from /home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:457:in `block in load_file'
        from /home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:647:in `new_constants_in'
        from /home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:456:in `load_file'
        from /home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:354:in `require_or_load'
        from /home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:317:in `depend_on'
        from /home/abonas/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:233:in `require_dependency'
        from /home/abonas/manageiqfork/manageiq/lib/extensions/require_nested.rb:8:in `require_nested'
        from /home/abonas/manageiqfork/manageiq/app/models/manageiq/providers/azure/cloud_manager.rb:9:in `<class:CloudManager>'
        from /home/abonas/manageiqfork/manageiq/app/models/manageiq/providers/azure/cloud_manager.rb:1:in `<top (required)>'
        f