### PR TITLE
Correct option converter class

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_nested :Refresher
   require_nested :Vm
   require_nested :OrchestrationStack
-  require_nested :OrchestrationStackOptionConverter
+  require_nested :OrchestrationServiceOptionConverter
 
   alias_attribute :azure_tenant_id, :uid_ems
 


### PR DESCRIPTION
Correct class is OrchestrationServiceOptionConverter, this typo is
preventing rake evm:start to work.