### PR TITLE
container nodes view changes

### DIFF
--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -1,14 +1,4 @@
-- if 'container_groups'.eql?(@display) && @showtype != "compare"
+- if %w(container_routes container_services container_replicators container_groups containers).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-- elsif 'container_services'.eql?(@display) && @showtype != "compare"
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-- elsif 'container_replicators'.eql?(@display) && @showtype != "compare"
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-- elsif 'containers'.eql?(@display) && @showtype != "compare"
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-- elsif @showtype == "timeline"
-  = render(:partial => "layouts/tl_show")
-  :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/layouts/listnav/_container_node.html.haml
+++ b/app/views/layouts/listnav/_container_node.html.haml
@@ -26,47 +26,62 @@
       %ul.nav.nav-pills.nav-stacked
 
         - if role_allows(:feature => "ems_container_show") && !@record.ext_management_system.nil?
+          - entity = ui_lookup(:table => "ems_container")
           %li
-            = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.ext_management_system.name}",
+            = link_to("#{entity}: #{@record.ext_management_system.name}",
                 {:controller => "ems_container", :action => 'show', :id => @record.ext_management_system.id.to_s},
-                :title => _("Show this container node's parent %s") % ui_lookup(:table => "ems_container"))
-        - if role_allows(:feature => "container_group_show_list")
-          - num_groups = @record.number_of(:container_groups)
-          - if num_groups == 0
+                :title => _("Show this container node's parent #{entity}"))
+        - if role_allows(:feature => "container_route_show_list")
+          - num_routes = @record.number_of(:container_routes)
+          - if num_routes == 0
             %li.disabled
-              = link_to(_('Pods (0)'), "#")
+              = link_to(_('Container Routes (0)'), "#")
           - else
             %li
-              = link_to(_("Pods (%s)") % num_groups,
-                  {:action  => 'show', :id => @record, :display => 'container_groups'},
-                  :title => _("Show Pods"))
+              = link_to(_("Container Routes (%s)") % num_routes,
+                  {:action  => 'show', :id => @record, :display => 'container_routes'},
+                  :title => _("Show Container Routes"))
         - if role_allows(:feature => "container_service_show_list")
+          - plural = ui_lookup(:tables => "container_service")
           - num_services = @record.number_of(:container_services)
           - if num_services == 0
             %li.disabled
-              = link_to("#{ui_lookup(:tables => "container_service")} (0)", "#")
+              = link_to("#{plural} (0)", "#")
           - else
             %li
-              = link_to("#{ui_lookup(:tables => "container_service")} (#{num_services})",
+              = link_to("#{plural} (#{num_services})",
                   {:action  => 'show', :id => @record, :display => 'container_services'},
-                  :title => _("Show Container Services"))
+                  :title => _("Show #{plural}"))
         - if role_allows(:feature => "container_replicator_show_list")
+          - plural = ui_lookup(:tables => "container_replicator")
           - num_replicators = @record.number_of(:container_replicators)
           - if num_replicators == 0
             %li.disabled
-              = link_to("#{ui_lookup(:tables => "container_replicator")} (0)", "#")
+              = link_to("#{plural} (0)", "#")
           - else
             %li
-              = link_to("#{ui_lookup(:tables => "container_replicator")} (#{num_replicators})",
+              = link_to("#{plural} (#{num_replicators})",
                   {:action  => 'show', :id => @record, :display => 'container_replicators'},
-                  :title => _("Show Container Replicators"))
+                  :title => _("Show #{plural}"))
+        - if role_allows(:feature => "container_group_show_list")
+          - plural = ui_lookup(:tables => "container_group")
+          - num_groups = @record.number_of(:container_groups)
+          - if num_groups == 0
+            %li.disabled
+              = link_to("#{plural} (0)", "#")
+          - else
+            %li
+              = link_to("#{plural} (#{num_groups})",
+                  {:action  => 'show', :id => @record, :display => 'container_groups'},
+                  :title => _("Show #{plural}"))
         - if role_allows(:feature => "containers")
+          - plural = ui_lookup(:tables => "container")
           - num_containers = @record.number_of(:containers)
           - if num_containers == 0
             %li.disabled
-              = link_to("#{ui_lookup(:tables => "container")} (0)", "#")
+              = link_to("#{plural} (0)", "#")
           - else
             %li
-              = link_to("#{ui_lookup(:tables => "container")} (#{num_containers})",
+              = link_to("#{plural} (#{num_containers})",
                   {:action  => 'show', :id => @record, :display => 'containers'},
-                  :title => _("Show Containers"))
+                  :title => _("Show #{plural}"))


### PR DESCRIPTION
- fix routes list
- simplify relationship conditionals
- add routes to navbar 
- reorder entities in navbar
- replace % formatting with #{}
- acquire entity names using ui_lookup

reordered list:
![manageiq nodes](https://cloud.githubusercontent.com/assets/3010449/10635881/973061fa-7804-11e5-8530-81b8d71f0256.png)