### PR TITLE
Using .remove_connection to remove test connection from the pool

### DIFF
--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -207,7 +207,7 @@ FRIENDLY
       ensure
         # Disconnect and remove this new connection from the connection pool, to completely clear it out
         conn.disconnect! if conn
-        ActiveRecord::Base.connection_handler.connection_pools.delete(ModelWithNoBackingTable.name)
+        ActiveRecord::Base.connection_handler.remove_connection(ModelWithNoBackingTable)
       end
     end
 


### PR DESCRIPTION
This removes a deprecation warning and also corrects the behavior as
the hash returned from .connection_pools has a connection spec as the key
rather than the owner class name, so the previous implementation wasn't
deleting the connection anyway.

https://bugzilla.redhat.com/show_bug.cgi?id=1264312

@kbrock please review