### PR TITLE
Renamed "paginator" div to "paging_div" to fix paging controls

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -10,7 +10,7 @@ body, html {
   background-image: linear-gradient(to bottom, #FAFAFA 0%, #EDEDED 100%);
 }
 
-#paginator {
+#paging_div {
   width: 100%;
   height: 34px;
   padding-top: 2px;
@@ -54,7 +54,7 @@ body, html {
     height: 100%;
     overflow: auto;
   }
-  #paginator {
+  #paging_div {
     position: absolute;
     bottom: 0;
   }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1870,7 +1870,7 @@ class CatalogController < ApplicationController
     # Decide whether to show paging controls
     if @tagging
       presenter[:set_visible_elements][:toolbar] = false
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
       action_url = x_active_tree == :ot_tree ? "ot_tags_edit" : "st_tags_edit"
       locals = {
         :record_id           => @edit[:object_ids][0],
@@ -1886,7 +1886,7 @@ class CatalogController < ApplicationController
       if ['button_edit', 'group_edit', 'group_reorder', 'at_st_new',
           'st_new', 'st_catalog_new', 'st_catalog_edit'].include?(action)
         presenter[:set_visible_elements][:toolbar] = false
-        presenter[:set_visible_elements][:paginator] = true
+        presenter[:set_visible_elements][:paging_div] = true
         # incase it was hidden for summary screen, and incase there were no records on show_list
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
@@ -1909,7 +1909,7 @@ class CatalogController < ApplicationController
       elsif action == "dialog_provision"
         presenter[:set_visible_elements][:toolbar] = false
         # incase it was hidden for summary screen, and incase there were no records on show_list
-        presenter[:set_visible_elements][:paginator] = true
+        presenter[:set_visible_elements][:paging_div] = true
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
         @record.dialog_fields.each do |field|
@@ -1922,7 +1922,7 @@ class CatalogController < ApplicationController
         presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_dialog_buttons", :locals => {:action_url => "dialog_form_button_pressed", :record_id => @edit[:rec_id]}]
       elsif %w(ot_edit ot_copy ot_add service_dialog_from_ot).include?(action)
         presenter[:set_visible_elements][:toolbar] = false
-        presenter[:set_visible_elements][:paginator] = true
+        presenter[:set_visible_elements][:paging_div] = true
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
         locals = {:record_id  => @edit[:rec_id],
@@ -1939,13 +1939,13 @@ class CatalogController < ApplicationController
         # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record
         presenter[:set_visible_elements][:buttons_on] = false
         presenter[:set_visible_elements][:toolbar] = true
-        presenter[:set_visible_elements][:paginator] = false
+        presenter[:set_visible_elements][:paging_div] = false
       end
     else
       presenter[:set_visible_elements][:form_buttons_div] = true
       presenter[:set_visible_elements][:pc_div_1] = true
       presenter[:set_visible_elements][:toolbar] = true
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     end
 
     # Rebuild the toolbars

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -799,7 +799,7 @@ class ChargebackController < ApplicationController
          (x_active_tree == :cb_assignments_tree && ["Compute", "Storage"].include?(x_node.split('-').last))
         presenter[:set_visible_elements][:toolbar] = false
         # incase it was hidden for summary screen, and incase there were no records on show_list
-        presenter[:set_visible_elements][:paginator] = true
+        presenter[:set_visible_elements][:paging_div] = true
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
         locals = {:record_id => @edit[:rec_id]}
@@ -817,7 +817,7 @@ class ChargebackController < ApplicationController
         # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record
         presenter[:set_visible_elements][:buttons_on] = false
         presenter[:set_visible_elements][:toolbar] = true
-        presenter[:set_visible_elements][:paginator] = false
+        presenter[:set_visible_elements][:paging_div] = false
       end
     else
       presenter[:set_visible_elements][:form_buttons_div] = false
@@ -828,7 +828,7 @@ class ChargebackController < ApplicationController
         presenter[:set_visible_elements][:toolbar] = false
         presenter[:set_visible_elements][:pc_div_1] = false
       end
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     end
 
     if @record && !@in_a_form

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -255,13 +255,13 @@ class ContainerController < ApplicationController
     elsif record_showing
       presenter[:update_partials][:main_div] = r[:partial => "container/container_show", :locals => {:controller => "container"}]
       presenter[:set_visible_elements][:pc_div_1] = false
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     else
       presenter[:update_partials][:main_div] = r[:partial => "layouts/x_gtl"]
       presenter[:update_partials][:paging_div] = r[:partial => "layouts/x_pagingcontrols"]
       presenter[:set_visible_elements][:form_buttons_div] = false
       presenter[:set_visible_elements][:pc_div_1] = true
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     end
 
     presenter[:replace_partials][:adv_searchbox_div] = r[:partial => 'layouts/x_adv_searchbox']

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -344,7 +344,7 @@ class MiqAeClassController < ApplicationController
     if @in_a_form
       action_url =  create_action_url(nodes.first)
       # incase it was hidden for summary screen, and incase there were no records on show_list
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
       presenter[:set_visible_elements][:form_buttons_div] = true
       presenter[:update_partials][:form_buttons_div] = r[
         :partial => "layouts/x_edit_buttons",
@@ -358,7 +358,7 @@ class MiqAeClassController < ApplicationController
       ]
     else
       # incase it was hidden for summary screen, and incase there were no records on show_list
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
       presenter[:set_visible_elements][:form_buttons_div] = false
     end
 

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -338,9 +338,9 @@ class MiqAeCustomizationController < ApplicationController
         presenter[:set_visible_elements][:pc_div_1] = false
         presenter[:set_visible_elements][:form_buttons_div] = true
       end
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     else
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
   end
 
@@ -415,7 +415,7 @@ class MiqAeCustomizationController < ApplicationController
       presenter[:update_partials][:form_buttons_div] = render_proc[:partial => "dialog_sample_buttons"]
       presenter[:set_visible_elements][:pc_div_1]         = false
       presenter[:set_visible_elements][:form_buttons_div] = false
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     end
   end
 

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -719,14 +719,14 @@ class MiqPolicyController < ApplicationController
       }
       presenter[:set_visible_elements][:toolbar] = false
       # If was hidden for summary screen and there were no records on show_list
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
       presenter[:set_visible_elements][:form_buttons_div] = true
       presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_edit_buttons", :locals => locals]
     else
       # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box when trying to change a node on tree after saving a record
       presenter[:set_visible_elements][:button_on] = false
       presenter[:set_visible_elements][:toolbar] = true
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
 
     # Replace the searchbox

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -739,9 +739,9 @@ class OpsController < ApplicationController
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
       end
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     else
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -766,9 +766,9 @@ class ProviderForemanController < ApplicationController
         presenter[:set_visible_elements][:pc_div_1] = false
         presenter[:set_visible_elements][:form_buttons_div] = true
       end
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     else
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
   end
 

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -238,7 +238,7 @@ class PxeController < ApplicationController
       if @in_a_form
         presenter[:set_visible_elements][:toolbar] = false
         # in case it was hidden for summary screen, and incase there were no records on show_list
-        presenter[:set_visible_elements][:paginator] = true
+        presenter[:set_visible_elements][:paging_div] = true
         presenter[:set_visible_elements][:form_buttons_div] = true
 
         action_url, multi_record = case x_active_tree

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -943,12 +943,12 @@ class ReportController < ApplicationController
         presenter[:set_visible_elements][:rpb_div_1]        = true
         presenter[:set_visible_elements][:pc_div_1]         = false
       end
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     else
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
     if @sb[:active_tab] == 'report_info' && x_node.split('-').length == 5 && !@in_a_form
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
     presenter[:set_visible_elements][:toolbar] = !@in_a_form
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -382,7 +382,7 @@ class ServiceController < ApplicationController
       presenter[:set_visible_elements][:form_buttons_div] = true
       presenter[:set_visible_elements][:pc_div_1] = false
       presenter[:set_visible_elements][:toolbar] = false
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
       if action == "dialog_provision"
         presenter[:update_partials][:form_buttons_div] = r[:partial => "layouts/x_dialog_buttons",
                                                            :locals  => {:action_url => action_url,
@@ -405,12 +405,12 @@ class ServiceController < ApplicationController
       # when trying to change a node on tree after saving a record
       presenter[:set_visible_elements][:buttons_on]  = false
       presenter[:set_visible_elements][:toolbar]   = true
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     else
       presenter[:set_visible_elements][:form_buttons_div] = false
       presenter[:set_visible_elements][:pc_div_1]         = true
       presenter[:set_visible_elements][:toolbar]        = true
-      presenter[:set_visible_elements][:paginator]      = true
+      presenter[:set_visible_elements][:paging_div] = true
     end
 
     # Clear the JS gtl_list_grid var if changing to a type other than list

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1613,9 +1613,9 @@ module VmCommon
         presenter[:set_visible_elements][:pc_div_1] = false
         presenter[:set_visible_elements][:form_buttons_div] = true
       end
-      presenter[:set_visible_elements][:paginator] = true
+      presenter[:set_visible_elements][:paging_div] = true
     else
-      presenter[:set_visible_elements][:paginator] = false
+      presenter[:set_visible_elements][:paging_div] = false
     end
 
     presenter[:right_cell_text] = @right_cell_text

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -25,7 +25,7 @@
         .row{:style => "overflow: auto;height: calc(100% - 130px);"}
           .col-md-12
             = yield
-        .row#paginator
+        .row#paging_div
           .col-md-12
             - if saved_report_paging?
               = render(:partial => 'layouts/saved_report_paging_bar', :locals => {:pages => @sb[:pages]})


### PR DESCRIPTION
layouts/explorer view was deleted in commit: 5762898d50f4626e3a5739612d1df70dcfefea20 that used to wrap paging controls in paging_div. When paging buttons are pressed in all explorers replace_right_cell and other methods update partial and reference paging_div which does not exist in the DOM as a result of that all the paging controls are broken in explorers. Renamed "paginator" to "paging_div" to fix all existing update_partial calls, also updated set_visible_elements calls to match the updated div id.

@epwinchell @skateman @dclarizio please review. To recreate go to any explorer and try paging control buttons.