### PR TITLE
Trimmed leading space from the "Assign To" pull down values

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -442,7 +442,7 @@ module UiConstants
 
   # This set of assignments was created for miq_alerts
   ASSIGN_TOS["ExtManagementSystem"] = {
-    "enterprise"                 => " The Enterprise",
+    "enterprise"                 => "The Enterprise",
     "ext_management_system"      => "Selected #{ui_lookup(:tables => "ems_infra")}",
     "ext_management_system-tags" => "Tagged #{ui_lookup(:tables => "ems_infra")}"
   }
@@ -461,7 +461,7 @@ module UiConstants
     "vm-tags"            => "Tagged #{ui_lookup(:tables => "vm")}"
   }.merge(ASSIGN_TOS["Host"])
   ASSIGN_TOS["Storage"] = {
-    "enterprise"   => " The Enterprise",
+    "enterprise"   => "The Enterprise",
     "storage"      => "Selected #{ui_lookup(:tables => "storage")}",
     "storage-tags" => "Tagged #{ui_lookup(:tables => "storage")}"
   }
@@ -472,7 +472,7 @@ module UiConstants
   # This set of assignments was created for chargeback_rates
   ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]
   ASSIGN_TOS[:chargeback_compute] = {
-    "enterprise"            => " The Enterprise",
+    "enterprise"            => "The Enterprise",
     "ext_management_system" => "Selected #{ui_lookup(:tables => "ext_management_systems")}",
     "ems_cluster"           => "Selected #{ui_lookup(:tables => "ems_cluster")}",
     "vm-tags"               => "Tagged #{ui_lookup(:tables => "vm")}"

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -9,7 +9,7 @@
       %label.col-md-2.control-label
         = _('Assign To')
       .col-md-8
-        - options = ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].invert.sort
+        - options = Array(ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].invert)
         = select_tag("cbshow_typ", options_for_select([[nothing, "nil"]] + options, @edit[:new][:cbshow_typ]),
                     "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
       :javascript


### PR DESCRIPTION
With patternfly select conversions, leading space in front of "The Enterprise" was causing automate tests to fail. Leading space was added to this entry back when ruby hashes did not retain the order to keep this entry at the top of the pull down. Removed sort from view so values can be displayed in the order they were added in the initial Hash.

https://bugzilla.redhat.com/show_bug.cgi?id=1273654

@dclarizio please review