### PR TITLE
Add Watermark Reporting backend support

### DIFF
--- a/app/models/ext_management_system_performance.rb
+++ b/app/models/ext_management_system_performance.rb
@@ -1,0 +1,5 @@
+class ExtManagementSystemPerformance < MetricRollup
+  default_scope { where "resource_type = 'ExtManagementSystem' and resource_id IS NOT NULL" }
+
+  belongs_to :ext_management_system, :foreign_key => :resource_id
+end

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -35,8 +35,9 @@ module Metric::Common
 
     attr_accessor :inside_time_profile, :time_profile_adjusted_timestamp
 
-    virtual_column :v_date, :type => :datetime
-    virtual_column :v_time, :type => :datetime
+    virtual_column :v_date,  :type => :datetime
+    virtual_column :v_month, :type => :string
+    virtual_column :v_time,  :type => :datetime
 
     virtual_column :v_derived_vm_count,            :type => :integer
     virtual_column :v_derived_host_count,          :type => :integer
@@ -112,6 +113,10 @@ module Metric::Common
 
   def v_date
     timestamp
+  end
+
+  def v_month
+    timestamp.strftime("%Y/%m")
   end
 
   def v_time

--- a/app/models/metric/processing.rb
+++ b/app/models/metric/processing.rb
@@ -4,12 +4,15 @@ module Metric::Processing
     :derived_cpu_reserved,
     :derived_host_count_off,
     :derived_host_count_on,
+    :derived_host_count_total,
     :derived_memory_available,
     :derived_memory_reserved,
     :derived_memory_used,
+    :derived_host_sockets,
     :derived_vm_allocated_disk_storage,
     :derived_vm_count_off,
     :derived_vm_count_on,
+    :derived_vm_count_total,
     :derived_vm_numvcpus, # This is actually logical cpus, but needs to be renamed.
     # See VimPerformanceState#capture_numvcpus
     :derived_vm_used_disk_storage,
@@ -88,6 +91,8 @@ module Metric::Processing
         # Do not derive "available" values if there haven't been any usage
         # values collected
         result[col] = state.numvcpus if obj.kind_of?(VmOrTemplate) && have_cpu_metrics && state.numvcpus.to_i > 0
+      when "sockets"
+        result[col] = state.host_sockets
       end
     end
 

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -22,6 +22,7 @@ class MiqExpression
     EmsEvent
     ManageIQ::Providers::InfraManager
     ExtManagementSystem
+    ExtManagementSystemPerformance
     Flavor
     Host
     HostPerformance

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -8,6 +8,7 @@ class VimPerformanceState < ActiveRecord::Base
   # Define accessors for state_data information
   [
     :assoc_ids,
+    :host_sockets,
     :parent_host_id,
     :parent_storage_id,
     :parent_ems_id,
@@ -33,8 +34,11 @@ class VimPerformanceState < ActiveRecord::Base
   # => reserve_cpu
   # => vm_count_on      (derive from assoc_ids)
   # => vm_count_off     (derive from assoc_ids)
+  # => vm_count_total   (derive from assoc_ids)
   # => host_count_on    (derive from assoc_ids)
   # => host_count_off   (derive from assoc_ids)
+  # => host_count_total (derive from assoc_ids)
+  # => host_sockets     (derive from assoc_ids)
 
   def self.capture(obj)
     ts = Time.now.utc
@@ -59,6 +63,7 @@ class VimPerformanceState < ActiveRecord::Base
     state.vm_used_disk_storage = capture_vm_disk_storage(obj, :used_disk)
     state.vm_allocated_disk_storage = capture_vm_disk_storage(obj, :allocated_disk)
     state.tag_names = capture_tag_names(obj)
+    state.host_sockets = capture_host_sockets(obj)
     state.save
 
     state
@@ -72,12 +77,20 @@ class VimPerformanceState < ActiveRecord::Base
     get_assoc(:vms, :off).length
   end
 
+  def vm_count_total
+    get_assoc(:vms).length
+  end
+
   def host_count_on
     get_assoc(:hosts, :on).length
   end
 
   def host_count_off
     get_assoc(:hosts, :off).length
+  end
+
+  def host_count_total
+    get_assoc(:hosts).length
   end
 
   def storages
@@ -190,5 +203,15 @@ class VimPerformanceState < ActiveRecord::Base
     # depending on the name :numvcpus
     # A larger patch should be done outside of a z-stream release
     obj.hardware.logical_cpus
+  end
+
+  def self.capture_host_sockets(obj)
+    if obj.kind_of?(Host)
+      obj.hardware.try(:cpu_sockets)
+    else
+      if obj.respond_to?(:hosts)
+        obj.hosts.includes(:hardware).each_with_object([]) { |h, arr| arr << h.hardware.try(:cpu_sockets) }.compact.sum
+      end
+    end
   end
 end

--- a/app/models/vim_performance_trend.rb
+++ b/app/models/vim_performance_trend.rb
@@ -189,6 +189,13 @@ class VimPerformanceTrend < ActsAsArModel
       :net_usage_rate_average    => {},
       :derived_memory_used       => {:limit_cols => ["derived_memory_available", "derived_memory_reserved"]}
     },
+    :ExtManagementSystemPerformance => {
+      :cpu_usagemhz_rate_average => {:limit_cols => %w(derived_cpu_available derived_cpu_reserved)},
+      :cpu_usage_rate_average    => {},
+      :disk_usage_rate_average   => {},
+      :net_usage_rate_average    => {},
+      :derived_memory_used       => {:limit_cols => %w(derived_memory_available derived_memory_reserved)}
+    },
     :StoragePerformance    => {
       :derived_storage_free   => {:limit_cols => ["derived_storage_total"]},
       :v_derived_storage_used => {:limit_cols => ["derived_storage_total"]}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -667,6 +667,7 @@ en:
       v_is_a_template: Is a Template
       v_memory_percent_of_used: VM Memory Files Percent of Used
       v_message: Message
+      v_month: Activity Sample - Month (YYYY/MM)
       v_owning_blue_folder: Parent Folder (VMs & Templates)
       v_owning_blue_folder_path: Parent Folder Path (VMs & Templates)
       v_owning_cluster: Parent Cluster
@@ -851,6 +852,7 @@ en:
       EmsFolder:                Folder
       #EmsInfra:                 Infrastructure Provider
       ExtManagementSystem:      Provider
+      ExtManagementSystemPerformance: Performance - Provider
       FileDepotFtp:             FTP
       FileDepotFtpAnonymous:    Anonymous FTP
       FileDepotNfs:             NFS

--- a/db/migrate/20151020222634_add_watermark_reporting_fields_to_metric_and_metric_rollup.rb
+++ b/db/migrate/20151020222634_add_watermark_reporting_fields_to_metric_and_metric_rollup.rb
@@ -1,0 +1,10 @@
+class AddWatermarkReportingFieldsToMetricAndMetricRollup < ActiveRecord::Migration
+  def change
+    add_column :metrics,        :derived_host_sockets,     :integer
+    add_column :metrics,        :derived_host_count_total, :integer
+    add_column :metrics,        :derived_vm_count_total,   :integer
+    add_column :metric_rollups, :derived_host_sockets,     :integer
+    add_column :metric_rollups, :derived_host_count_total, :integer
+    add_column :metric_rollups, :derived_vm_count_total,   :integer
+  end
+end

--- a/spec/models/metric/common_spec.rb
+++ b/spec/models/metric/common_spec.rb
@@ -9,6 +9,13 @@ describe Metric::Common do
                                 )
   end
 
+  describe "#v_month" do
+    it "returns the timestamp in YYYY/MM format" do
+      m = Metric.new(:timestamp => Time.zone.parse("2015-01-01"))
+      expect(m.v_month).to eq("2015/01")
+    end
+  end
+
   context "#apply_time_profile_hourly" do
     it "with all days and hours selected it should return true" do
       profile = FactoryGirl.create(:time_profile,

--- a/spec/models/metric/processing_spec.rb
+++ b/spec/models/metric/processing_spec.rb
@@ -2,6 +2,19 @@ require "spec_helper"
 
 describe Metric::Processing do
   context ".process_derived_columns" do
+    context "on :derived_host_sockets" do
+      let(:hardware) { FactoryGirl.create(:hardware, :cpu_sockets => 2) }
+      let(:host) { FactoryGirl.create(:host, :hardware => hardware) }
+
+      it "adds the derived host sockets" do
+        m = FactoryGirl.create(:metric_rollup_vm_hr, :resource => host)
+
+        derived_columns = described_class.process_derived_columns(host, m.attributes.symbolize_keys)
+
+        expect(derived_columns[:derived_host_sockets]).to eq(2)
+      end
+    end
+
     context "on :derived_vm_numvcpus" do
       let(:vm) do
         FactoryGirl.create(:vm_vmware, :hardware =>

--- a/spec/models/vim_performance_state_spec.rb
+++ b/spec/models/vim_performance_state_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+RSpec.describe VimPerformanceState do
+  describe ".capture_host_sockets" do
+    it "returns the host sockets when given a host" do
+      hardware = FactoryGirl.build(:hardware, :cpu_sockets => 2)
+      host = FactoryGirl.build(:host, :hardware => hardware)
+
+      expect(described_class.capture_host_sockets(host)).to eq(2)
+    end
+
+    it "rolls up the total sockets when given something that has hosts" do
+      hardware_1 = FactoryGirl.build(:hardware, :cpu_sockets => 2)
+      hardware_2 = FactoryGirl.build(:hardware, :cpu_sockets => 4)
+      host_1 = FactoryGirl.build(:host, :hardware => hardware_1)
+      host_2 = FactoryGirl.build(:host, :hardware => hardware_2)
+      cluster = FactoryGirl.create(:ems_cluster, :hosts => [host_1, host_2])
+
+      expect(described_class.capture_host_sockets(cluster)).to eq(6)
+    end
+  end
+
+  describe "#vm_count_total" do
+    it "will return the total vms regardless of mode" do
+      state_data = {:assoc_ids => {:vms => {:on => [1], :off => [2]}}}
+      actual = described_class.new(:state_data => state_data)
+      expect(actual.vm_count_total).to eq(2)
+    end
+  end
+
+  describe "#host_count_total" do
+    it "will return the total hosts regardless of mode" do
+      state_data = {:assoc_ids => {:hosts => {:on => [1], :off => [2]}}}
+      actual = described_class.new(:state_data => state_data)
+      expect(actual.host_count_total).to eq(2)
+    end
+  end
+
+  describe "#host_sockets" do
+    it "returns the host sockets" do
+      state_data = {:host_sockets => 2}
+      actual = described_class.new(:state_data => state_data)
+      expect(actual.host_sockets).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This adds the necessary migrations and changes to collect the data
necessary for watermark reporting. In particular it adds:

* host sockets
* host count total
* vm count total

to metrics and metric rollups.

It also adds a model for reporting on this data and the necessary copy
to integrate it into the UI.

It also adds the ability to group reports by month of performance timestamp.

Some tests were added to the hardware specs, and the existing tests were
moved into a separate context to restrict their common setup only to
those tests.

Resolves https://trello.com/c/Ab3u7ZXR

***

This PR is basically cherry-picking the commits from https://github.com/ManageIQ/manageiq/pull/4776 that were not in upstream master, rebased and squashed (it was easier than trying to rebase that branch). The three separate migrations from that PR were also rolled into one migration for simplicity.

@gtanzillo please review
@miq-bot add-label core, enhancement, reporting