### PR TITLE
Add 'waiting' status to colored statuses in container topology

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -68,6 +68,7 @@ angular.module('topologyApp', ['kubernetesUI'])
                 case "Failed":
                     return "#CC0000";
                 case 'Warning':
+                case 'Waiting':
                 case 'Pending':
                     return "#EC7A08";
                 case 'Unknown':


### PR DESCRIPTION
![waitingtopologystatus](https://cloud.githubusercontent.com/assets/6277245/10630540/e06bb0f6-77df-11e5-9cc3-baf3830b136a.png)

@miq-bot add_label ui, enhancement, providers/containers