### PR TITLE
Fix MiqAction.create_script_actions_from_dir

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1055,17 +1055,17 @@ class MiqAction < ActiveRecord::Base
 
   def self.create_default_actions
     CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/) do |csv_row|
-      action = csv_row.to_hash
-      action['action_type'] = 'default'
+      action_attributes = csv_row.to_hash
+      action_attributes['action_type'] = 'default'
 
-      rec = find_by_name(action['name'])
+      rec = find_by_name(action_attributes['name'])
       if rec.nil?
-        _log.info("Creating [#{action['name']}]")
-        create(action)
+        _log.info("Creating [#{action_attributes['name']}]")
+        create(action_attributes)
       else
-        rec.attributes = action
+        rec.attributes = action_attributes
         if rec.changed? || (rec.options_was != rec.options)
-          _log.info("Updating [#{action['name']}]")
+          _log.info("Updating [#{action_attributes['name']}]")
           rec.save
         end
       end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1058,17 +1058,7 @@ class MiqAction < ActiveRecord::Base
       action_attributes = csv_row.to_hash
       action_attributes['action_type'] = 'default'
 
-      action = find_by_name(action_attributes['name'])
-      if action.nil?
-        _log.info("Creating [#{action_attributes['name']}]")
-        create(action_attributes)
-      else
-        action.attributes = action_attributes
-        if action.changed? || (action.options_was != action.options)
-          _log.info("Updating [#{action_attributes['name']}]")
-          action.save
-        end
-      end
+      create_or_update(action_attributes)
     end
   end
 
@@ -1081,16 +1071,20 @@ class MiqAction < ActiveRecord::Base
         'options'     => {:filename => f}
       }
 
-      action = find_by_name(action_attributes['name'])
-      if action.nil?
-        _log.info("Creating [#{action_attributes['name']}]")
-        create(action_attributes)
-      else
-        action.attributes = action_attributes
-        if action.changed? || action.options_was != action.options
-          _log.info("Updating [#{action_attributes['name']}]")
-          action.save
-        end
+      create_or_update(action_attributes)
+    end
+  end
+
+  def self.create_or_update(action_attributes)
+    action = find_by_name(action_attributes['name'])
+    if action.nil?
+      _log.info("Creating [#{action_attributes['name']}]")
+      create(action_attributes)
+    else
+      action.attributes = action_attributes
+      if action.changed? || action.options_was != action.options
+        _log.info("Updating [#{action_attributes['name']}]")
+        action.save
       end
     end
   end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1074,21 +1074,21 @@ class MiqAction < ActiveRecord::Base
 
   def self.create_script_actions_from_directory
     Dir.glob(SCRIPT_DIR.join("*")).sort.each do |f|
-      rec = {
+      action_attributes = {
         'name'        => File.basename(f).tr(".", "_"),
         'description' => "Execute script: #{File.basename(f)}",
         'action_type' => "script",
         'options'     => {:filename => f}
       }
 
-      action = find_by_name(rec['name'])
+      action = find_by_name(action_attributes['name'])
       if action.nil?
-        _log.info("Creating [#{rec['name']}]")
-        action = create(rec)
+        _log.info("Creating [#{action_attributes['name']}]")
+        action = create(action_attributes)
       else
-        action.attributes = rec
+        action.attributes = action_attributes
         if action.changed? || action.options_was != action.options
-          _log.info("Updating [#{rec['name']}]")
+          _log.info("Updating [#{action_attributes['name']}]")
           action.save
         end
       end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1033,28 +1033,6 @@ class MiqAction < ActiveRecord::Base
     return a, status
   end
 
-  def self.create_script_actions_from_directory
-    Dir.glob(SCRIPT_DIR.join("*")).sort.each do |f|
-      rec = {}
-      rec[:name]        = File.basename(f).tr(".", "_")
-      rec[:description] = "Execute script: #{File.basename(f)}"
-      rec[:action_type] = "script"
-      rec[:options]     = {:filename => f}
-
-      action = find_by_name(rec[:name])
-      if action.nil?
-        _log.info("Creating [#{rec[:name]}]")
-        action = create(rec)
-      else
-        action.attributes = rec
-        if action.changed? || action.options_was != action.options
-          _log.info("Updating [#{rec[:name]}]")
-          action.save
-        end
-      end
-    end
-  end
-
   def check_policy_contents_empty_on_destroy
     raise "Action is referenced in at least one policy and connot be deleted" unless miq_policy_contents.empty?
   end
@@ -1089,6 +1067,28 @@ class MiqAction < ActiveRecord::Base
         if rec.changed? || (rec.options_was != rec.options)
           _log.info("Updating [#{action['name']}]")
           rec.save
+        end
+      end
+    end
+  end
+
+  def self.create_script_actions_from_directory
+    Dir.glob(SCRIPT_DIR.join("*")).sort.each do |f|
+      rec = {}
+      rec[:name]        = File.basename(f).tr(".", "_")
+      rec[:description] = "Execute script: #{File.basename(f)}"
+      rec[:action_type] = "script"
+      rec[:options]     = {:filename => f}
+
+      action = find_by_name(rec[:name])
+      if action.nil?
+        _log.info("Creating [#{rec[:name]}]")
+        action = create(rec)
+      else
+        action.attributes = rec
+        if action.changed? || action.options_was != action.options
+          _log.info("Updating [#{rec[:name]}]")
+          action.save
         end
       end
     end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1074,20 +1074,21 @@ class MiqAction < ActiveRecord::Base
 
   def self.create_script_actions_from_directory
     Dir.glob(SCRIPT_DIR.join("*")).sort.each do |f|
-      rec = {}
-      rec[:name]        = File.basename(f).tr(".", "_")
-      rec[:description] = "Execute script: #{File.basename(f)}"
-      rec[:action_type] = "script"
-      rec[:options]     = {:filename => f}
+      rec = {
+        'name'        => File.basename(f).tr(".", "_"),
+        'description' => "Execute script: #{File.basename(f)}",
+        'action_type' => "script",
+        'options'     => {:filename => f}
+      }
 
-      action = find_by_name(rec[:name])
+      action = find_by_name(rec['name'])
       if action.nil?
-        _log.info("Creating [#{rec[:name]}]")
+        _log.info("Creating [#{rec['name']}]")
         action = create(rec)
       else
         action.attributes = rec
         if action.changed? || action.options_was != action.options
-          _log.info("Updating [#{rec[:name]}]")
+          _log.info("Updating [#{rec['name']}]")
           action.save
         end
       end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1084,7 +1084,7 @@ class MiqAction < ActiveRecord::Base
       action = find_by_name(action_attributes['name'])
       if action.nil?
         _log.info("Creating [#{action_attributes['name']}]")
-        action = create(action_attributes)
+        create(action_attributes)
       else
         action.attributes = action_attributes
         if action.changed? || action.options_was != action.options

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1034,7 +1034,7 @@ class MiqAction < ActiveRecord::Base
   end
 
   def self.create_script_actions_from_directory
-    Dir.glob(SCRIPT_DIR + "/*").sort.each do |f|
+    Dir.glob(SCRIPT_DIR.join("*")).sort.each do |f|
       rec = {}
       rec[:name]        = File.basename(f).tr(".", "_")
       rec[:description] = "Execute script: #{File.basename(f)}"

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1074,16 +1074,17 @@ class MiqAction < ActiveRecord::Base
   end
 
   def self.create_or_update(action_attributes)
-    action = find_by_name(action_attributes['name'])
-    if action.nil?
-      _log.info("Creating [#{action_attributes['name']}]")
-      create(action_attributes)
-    else
+    name = action_attributes['name']
+    action = find_by_name(name)
+    if action
       action.attributes = action_attributes
       if action.changed? || action.options_was != action.options
-        _log.info("Updating [#{action_attributes['name']}]")
+        _log.info("Updating [#{name}]")
         action.save
       end
+    else
+      _log.info("Creating [#{name}]")
+      create(action_attributes)
     end
   end
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1064,14 +1064,12 @@ class MiqAction < ActiveRecord::Base
 
   def self.create_script_actions_from_directory
     Dir.glob(SCRIPT_DIR.join("*")).sort.each do |f|
-      action_attributes = {
+      create_or_update(
         'name'        => File.basename(f).tr(".", "_"),
         'description' => "Execute script: #{File.basename(f)}",
         'action_type' => "script",
         'options'     => {:filename => f}
-      }
-
-      create_or_update(action_attributes)
+      )
     end
   end
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1058,15 +1058,15 @@ class MiqAction < ActiveRecord::Base
       action_attributes = csv_row.to_hash
       action_attributes['action_type'] = 'default'
 
-      rec = find_by_name(action_attributes['name'])
-      if rec.nil?
+      action = find_by_name(action_attributes['name'])
+      if action.nil?
         _log.info("Creating [#{action_attributes['name']}]")
         create(action_attributes)
       else
-        rec.attributes = action_attributes
-        if rec.changed? || (rec.options_was != rec.options)
+        action.attributes = action_attributes
+        if action.changed? || (action.options_was != action.options)
           _log.info("Updating [#{action_attributes['name']}]")
-          rec.save
+          action.save
         end
       end
     end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -233,6 +233,73 @@ describe MiqAction do
     end
   end
 
+  context '.create_script_actions_from_directory' do
+    context 'when there are 3 files in the script directory' do
+      before do
+        @script_dir = Dir.mktmpdir
+        stub_const('::MiqAction::SCRIPT_DIR', Pathname(@script_dir))
+        FileUtils.touch %W[
+          #@script_dir/script2.rb
+          #@script_dir/script.1.sh
+          #@script_dir/script3
+        ]
+      end
+
+      after do
+        FileUtils.remove_entry_secure @script_dir
+      end
+
+      context 'seeding script actions from that directory' do
+        before { MiqAction.create_script_actions_from_directory }
+        let(:first_created_action) { MiqAction.order(:id).first! }
+
+        it 'should create 3 new actions' do
+          expect(MiqAction.count).to eq 3
+        end
+
+        it 'should assign script filename as action name' do
+          expect(first_created_action.name).to eq 'script_1_sh'
+        end
+
+        it 'should set action_type to "script"' do
+          expect(MiqAction.distinct.pluck(:action_type)).to eq ['script']
+        end
+
+        it 'should add description' do
+          expect(first_created_action.description).to eq "Execute script: script.1.sh"
+        end
+
+        it 'should put full file path into options hash' do
+          expect(first_created_action.options).to eq(:filename => "#@script_dir/script.1.sh")
+        end
+
+        context 'after one of the scripts is renamed' do
+          before { FileUtils.mv("#@script_dir/script2.rb", "#@script_dir/run.bat") }
+
+          context 'seeding script actions again' do
+            before { MiqAction.create_script_actions_from_directory }
+
+            it 'should not delete the old action' do
+              expect(MiqAction.where(:name => 'script2_rb')).to exist
+            end
+
+            it 'should create a new action' do
+              expect(MiqAction.where(:name => 'run_bat')).to exist
+            end
+          end
+        end
+
+        context 'seeding script actions again' do
+          before { MiqAction.create_script_actions_from_directory }
+
+          it 'should not add any new actions' do
+            expect(MiqAction.count).to eq 3
+          end
+        end
+      end
+    end
+  end
+
   context '#round_to_nearest_4mb' do
     it 'should round numbers to nearest 4 mb' do
       a = MiqAction.new

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -238,11 +238,11 @@ describe MiqAction do
       before do
         @script_dir = Dir.mktmpdir
         stub_const('::MiqAction::SCRIPT_DIR', Pathname(@script_dir))
-        FileUtils.touch %W[
-          #@script_dir/script2.rb
-          #@script_dir/script.1.sh
-          #@script_dir/script3
-        ]
+        FileUtils.touch %W(
+          #{@script_dir}/script2.rb
+          #{@script_dir}/script.1.sh
+          #{@script_dir}/script3
+        )
       end
 
       after do
@@ -270,11 +270,11 @@ describe MiqAction do
         end
 
         it 'should put full file path into options hash' do
-          expect(first_created_action.options).to eq(:filename => "#@script_dir/script.1.sh")
+          expect(first_created_action.options).to eq(:filename => "#{@script_dir}/script.1.sh")
         end
 
         context 'after one of the scripts is renamed' do
-          before { FileUtils.mv("#@script_dir/script2.rb", "#@script_dir/run.bat") }
+          before { FileUtils.mv("#{@script_dir}/script2.rb", "#{@script_dir}/run.bat") }
 
           context 'seeding script actions again' do
             before { MiqAction.create_script_actions_from_directory }


### PR DESCRIPTION
There were 2 bugs:

1. Instead of searching scripts in `SCRIPT_DIR` directory, the method looked into the root dir of the file system (`/`) and treated all files and directories there (e.g. `etc`, `usr`, `var`, etc.) as scripts. I introduced this bug when I was converting `SCRIPT_DIR` from String to Pathname several days ago.

2.  There was a typo in a local variable name. Because of this typo, any time when a script already exists in the database and `create_script_actions_from_dir` tries to reimport it, it would raise a runtime error. This bug exists since the initial commit.

In order to make sure everything works and prevent regressions, I added several tests.

Also, I took it upon myself to refactor things a little. As it turned out, there was a massive piece of duplicate code. I extracted it into a method which I named `create_or_update`. Now `MiqAction` class is several lines shorter (despite the new method), and both `create_script_actions_from_dir` and `create_default_actions` sizes are halved.