### PR TITLE
Apply RBac to cloud provisioning dialogs

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
@@ -1,13 +1,13 @@
 class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::Providers::CloudManager::ProvisionWorkflow
   def allowed_instance_types(_options = {})
     source = load_ar_obj(get_source_vm)
-    ems = source.try(:ext_management_system)
     architecture = source.try(:hardware).try(:bitness)
     virtualization_type = source.try(:hardware).try(:virtualization_type)
     root_device_type = source.try(:hardware).try(:root_device_type)
 
-    return {} if ems.nil?
-    available = ems.flavors
+    available = get_targets_for_ems(source, :cloud_filter, Flavor, 'flavors')
+    return {} if available.empty?
+
     methods = ["supports_#{architecture}_bit?".to_sym, "supports_#{virtualization_type}?".to_sym]
     methods << :supports_instance_store? if root_device_type == 'instance_store'
 
@@ -23,7 +23,11 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
     security_groups = if src[:cloud_network]
                         load_ar_obj(src[:cloud_network]).security_groups
                       else
-                        load_ar_obj(src[:ems]).security_groups.non_cloud_network
+                        source = load_ar_obj(src[:ems])
+
+                        return source.security_groups.non_cloud_network if source.tags.present?
+
+                        get_targets_for_ems(source, :cloud_filter, SecurityGroup, 'security_groups.non_cloud_network')
                       end
 
     security_groups.each_with_object({}) { |sg, hash| hash[sg.id] = display_name_for_name_description(sg) }
@@ -40,7 +44,9 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
   end
 
   def allowed_availability_zones(_options = {})
-    allowed_ci(:availability_zones, [:cloud_network, :cloud_subnet, :security_group])
+    source = load_ar_obj(get_source_vm)
+    targets = get_targets_for_ems(source, :cloud_filter, AvailabilityZone, 'availability_zones.available')
+    allowed_ci(:availability_zones, [:cloud_network, :cloud_subnet, :security_group], targets.map(&:id))
   end
 
   def validate_cloud_subnet(field, values, dlg, fld, value)

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -3,10 +3,8 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
   def allowed_availability_zones(_options = {})
     source = load_ar_obj(get_source_vm)
-    ems = source.try(:ext_management_system)
-
-    return {} if ems.nil?
-    ems.availability_zones.available.each_with_object({}) { |az, h| h[az.id] = az.name }
+    targets = get_targets_for_ems(source, :cloud_filter, AvailabilityZone, 'availability_zones.available')
+    targets.each_with_object({}) { |az, h| h[az.id] = az.name }
   end
 
   def allowed_cloud_networks(_options = {})
@@ -41,9 +39,15 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def allowed_security_groups(_options = {})
-    return {} unless (src_obj = provider_or_tenant_object)
+    return {} unless (src = provider_or_tenant_object)
 
-    src_obj.security_groups.each_with_object({}) do |sg, h|
+    if src.tags.present?
+      src_obj = get_targets_for_ems(src, :cloud_filter, SecurityGroup, 'security_groups')
+    else
+      src_obj = src.security_groups
+    end
+
+    src_obj.each_with_object({}) do |sg, h|
       h[sg.id] = display_name_for_name_description(sg)
     end
   end
@@ -101,6 +105,13 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
     rails_logger('get_source_and_targets', 1)
     @target_resource = result
+  end
+
+  def get_targets_for_ems(src, filter_name, klass, relats)
+    ems = src.try(:ext_management_system)
+
+    return {} if ems.nil?
+    process_filter(filter_name, klass, ems.deep_send(relats))
   end
 
   def dialog_name_from_automate(message, extra_attrs)

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -1,19 +1,14 @@
 class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqProvisionCloudWorkflow
   def allowed_instance_types(_options = {})
     source = load_ar_obj(get_source_vm)
-    ems = source.try(:ext_management_system)
-
-    return {} if ems.nil?
-    ems.flavors.each_with_object({}) { |f, h| h[f.id] = display_name_for_name_description(f) }
+    ems = get_targets_for_ems(source, :cloud_filter, Flavor, 'flavors')
+    ems.each_with_object({}) { |f, h| h[f.id] = display_name_for_name_description(f) }
   end
 
   def allowed_cloud_tenants(_options = {})
     source = load_ar_obj(get_source_vm)
-    if ems = source.try(:ext_management_system)
-      ems.cloud_tenants.each_with_object({}) { |f, h| h[f.id] = f.name }
-    else
-      {}
-    end
+    ems = get_targets_for_ems(source, :cloud_filter, CloudTenant, 'cloud_tenants')
+    ems.each_with_object({}) { |f, h| h[f.id] = f.name }
   end
 
   def validate_cloud_network(field, values, dlg, fld, value)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -4,8 +4,146 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
   include WorkflowSpecHelper
 
   let(:admin)    { FactoryGirl.create(:user_with_group) }
-  let(:provider) { FactoryGirl.create(:ems_openstack) }
+  let(:provider) do
+    allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
+    FactoryGirl.create(:ems_openstack)
+  end
+
   let(:template) { FactoryGirl.create(:template_openstack, :name => "template", :ext_management_system => provider) }
+
+  context "without applied tags" do
+    let(:workflow) do
+      stub_dialog
+      described_class.any_instance.stub(:update_field_visibility)
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+    context "availability_zones" do
+      it "#get_targets_for_ems" do
+        az = FactoryGirl.create(:availability_zone_amazon)
+        provider.availability_zones << az
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
+                                 'availability_zones.available')
+        filtered.size.should == 1
+        filtered.first.name.should == az.name
+      end
+
+      it "returns an empty array when no targets are found" do
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
+                                 'availability_zones.available')
+        filtered.should == []
+      end
+    end
+
+    context "security_groups" do
+      context "non cloud network" do
+        it "#get_targets_for_ems" do
+          sg = FactoryGirl.create(:security_group_amazon, :name => "sg_1", :ext_management_system => provider)
+          provider.security_groups << sg
+          filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup,
+                                   'security_groups.non_cloud_network')
+          filtered.size.should == 1
+          filtered.first.name.should == sg.name
+        end
+      end
+
+      context "cloud network" do
+        it "#get_targets_for_ems" do
+          cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => provider)
+          sg_cn = FactoryGirl.create(:security_group_amazon, :name => "sg_2", :ext_management_system => provider,
+                                     :cloud_network => cn1)
+          provider.security_groups << sg_cn
+          filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups')
+          filtered.size.should == 1
+          filtered.first.name.should == sg_cn.name
+        end
+      end
+    end
+
+    context "Instance Type (Flavor)" do
+      it "#get_targets_for_ems" do
+        flavor = FactoryGirl.create(:flavor_openstack, :name => "test_flavor_2")
+        provider.flavors << flavor
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors')
+        filtered.size.should == 1
+        filtered.first.name.should == flavor.name
+      end
+    end
+  end
+
+  context "with applied tags" do
+    let(:workflow) do
+      stub_dialog
+      described_class.any_instance.stub(:update_field_visibility)
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+
+    before do
+      FactoryGirl.create(:classification_cost_center_with_tags)
+      admin.current_group.set_managed_filters([['/managed/cc/001']])
+      admin.current_group.set_belongsto_filters([])
+      admin.current_group.save
+
+      2.times { FactoryGirl.create(:availability_zone_amazon, :ems_id => provider.id) }
+      2.times { FactoryGirl.create(:security_group_amazon, :name => "sgb_1", :ext_management_system => provider) }
+      ct1 = FactoryGirl.create(:cloud_tenant, :name => "admin1")
+      ct2 = FactoryGirl.create(:cloud_tenant, :name => "admin2")
+      provider.cloud_tenants << ct1
+      provider.cloud_tenants << ct2
+      provider.flavors << FactoryGirl.create(:flavor_openstack, :name => "test_flavor_3")
+      provider.flavors << FactoryGirl.create(:flavor_openstack, :name => "test_flavor_4")
+
+      tagged_zone = provider.availability_zones.first
+      tagged_sec = provider.security_groups.first
+      tagged_flavor = provider.flavors.first
+      tagged_tenant = provider.cloud_tenants.first
+      Classification.classify(tagged_zone, 'cc', '001')
+      Classification.classify(tagged_sec, 'cc', '001')
+      Classification.classify(tagged_flavor, 'cc', '001')
+      Classification.classify(tagged_tenant, 'cc', '001')
+    end
+
+    context "availability_zones" do
+      it "#get_targets_for_ems" do
+        provider.availability_zones.size.should == 2
+        provider.availability_zones.first.tags.size.should == 1
+        provider.availability_zones.last.tags.size.should == 0
+
+        filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
+                                 'availability_zones.available')
+        filtered.size.should == 1
+      end
+    end
+
+    context "security groups" do
+      it "#get_targets_for_ems" do
+        provider.security_groups.size.should == 2
+        provider.security_groups.first.tags.size.should == 1
+        provider.security_groups.last.tags.size.should == 0
+
+        workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups').size.should == 1
+      end
+    end
+
+    context "instance types (Flavor)" do
+      it "#get_targets_for_ems" do
+        provider.flavors.size.should == 2
+        provider.flavors.first.tags.size.should == 1
+        provider.flavors.last.tags.size.should == 0
+
+        workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors').size.should == 1
+      end
+    end
+
+    context "allowed_tenants" do
+      it "#get_targets_for_ems" do
+        provider.cloud_tenants.size.should == 2
+        provider.cloud_tenants.first.tags.size.should == 1
+        provider.cloud_tenants.last.tags.size.should == 0
+
+        workflow.send(:get_targets_for_ems, provider, :cloud_filter, CloudTenant, 'cloud_tenants').size.should == 1
+      end
+    end
+  end
 
   context "With a user" do
     it "pass platform attributes to automate" do
@@ -76,7 +214,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       end
 
       context "#display_name_for_name_description" do
-        let(:flavor)   { FactoryGirl.create(:flavor_openstack, :name => "test_flavor") }
+        let(:flavor) { FactoryGirl.create(:flavor_openstack, :name => "test_flavor") }
 
         it "with name only" do
           workflow.display_name_for_name_description(flavor).should == "test_flavor"


### PR DESCRIPTION
Extracted behavior for applying Rbac into a new method - get_targets_for_ems
Applied Rbac for shared cloud provisioning dialogs - Availability Zone, Security Group, Instance Type (Flavor)
Applied Rbac for Openstack provisioning dialog - Tenant

https://bugzilla.redhat.com/show_bug.cgi?id=1248181