### PR TITLE
actions: fix action variable name typo

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1047,7 +1047,7 @@ class MiqAction < ActiveRecord::Base
         action = create(rec)
       else
         action.attributes = rec
-        if action.changed? || action.options_was != actions.options
+        if action.changed? || action.options_was != action.options
           _log.info("Updating [#{rec[:name]}]")
           action.save
         end


### PR DESCRIPTION
@chessbyte @Fryguy I am puzzled about this one. It seems really old code, you should have hit this already. I haven't spent much time debugging but I couldn't find a valid `actions` (plural) in the past.