### PR TITLE
Two migrations for Azure resource groups

### DIFF
--- a/db/migrate/20151019184531_create_resource_groups.rb
+++ b/db/migrate/20151019184531_create_resource_groups.rb
@@ -1,11 +1,11 @@
 class CreateResourceGroups < ActiveRecord::Migration
   def up
     create_table :resource_groups do |t|
-      t.string  :name
-      t.string  :ems_ref
-      t.integer :ems_id
-      t.string  :type
-      t.timestamps null: false
+      t.string :name
+      t.string :ems_ref
+      t.bigint :ems_id
+      t.string :type
+      t.timestamps :null => false
     end
   end
 

--- a/db/migrate/20151019184531_create_resource_groups.rb
+++ b/db/migrate/20151019184531_create_resource_groups.rb
@@ -1,0 +1,15 @@
+class CreateResourceGroups < ActiveRecord::Migration
+  def up
+    create_table :resource_groups do |t|
+      t.string  :name
+      t.string  :ems_ref
+      t.integer :ems_id
+      t.string  :type
+      t.timestamps null: false
+    end
+  end
+
+  def down
+    drop_table :resource_groups
+  end
+end

--- a/db/migrate/20151021151216_add_resource_group_id_to_vms.rb
+++ b/db/migrate/20151021151216_add_resource_group_id_to_vms.rb
@@ -1,0 +1,9 @@
+class AddResourceGroupIdToVms < ActiveRecord::Migration
+  def up
+    add_column :vms, :resource_group_id, :bigint
+  end
+
+  def down
+    remove_column :vms, :resource_group_id
+  end
+end


### PR DESCRIPTION
This PR addresses the DB changes, described below, required for the modeling of Azure ResourceGroups.
1) The creation of a new resource_groups table
2) The addition of the resource_group_id column to the existing vms table. This will support the has_many association between a Resource Group and the VMs in it.

 A separate PR will be made for the model changes. 