### PR TITLE
Simpify javascript_for_timer_type helper a little

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -447,25 +447,29 @@ module ApplicationHelper
   def javascript_for_timer_type(timer_type)
     case timer_type
     when "Monthly"
-      [ javascript_hide("weekly_span"),
+      [
+        javascript_hide("weekly_span"),
         javascript_hide("daily_span"),
         javascript_hide("hourly_span"),
         javascript_show("monthly_span")
       ]
     when "Weekly"
-      [ javascript_hide("daily_span"),
+      [
+        javascript_hide("daily_span"),
         javascript_hide("hourly_span"),
         javascript_hide("monthly_span"),
         javascript_show("weekly_span")
       ]
     when "Daily"
-      [ javascript_hide("hourly_span"),
+      [
+        javascript_hide("hourly_span"),
         javascript_hide("monthly_span"),
         javascript_hide("weekly_span"),
         javascript_show("daily_span")
       ]
     when "Hourly"
-      [ javascript_hide("daily_span"),
+      [
+        javascript_hide("daily_span"),
         javascript_hide("monthly_span"),
         javascript_hide("weekly_span"),
         javascript_show("hourly_span")
@@ -473,7 +477,8 @@ module ApplicationHelper
     when nil
       []
     else
-      [ javascript_hide("daily_span"),
+      [
+        javascript_hide("daily_span"),
         javascript_hide("hourly_span"),
         javascript_hide("monthly_span"),
         javascript_hide("weekly_span")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -445,37 +445,40 @@ module ApplicationHelper
 
   ############# Following methods generate JS lines for render page blocks
   def javascript_for_timer_type(timer_type)
-    js_array = []
-    unless timer_type.nil?
-      case timer_type
-      when "Monthly"
-        js_array << javascript_hide("weekly_span")
-        js_array << javascript_hide("daily_span")
-        js_array << javascript_hide("hourly_span")
-        js_array << javascript_show("monthly_span")
-      when "Weekly"
-        js_array << javascript_hide("daily_span")
-        js_array << javascript_hide("hourly_span")
-        js_array << javascript_hide("monthly_span")
-        js_array << javascript_show("weekly_span")
-      when "Daily"
-        js_array << javascript_hide("hourly_span")
-        js_array << javascript_hide("monthly_span")
-        js_array << javascript_hide("weekly_span")
-        js_array << javascript_show("daily_span")
-      when "Hourly"
-        js_array << javascript_hide("daily_span")
-        js_array << javascript_hide("monthly_span")
-        js_array << javascript_hide("weekly_span")
-        js_array << javascript_show("hourly_span")
-      else
-        js_array << javascript_hide("daily_span")
-        js_array << javascript_hide("hourly_span")
-        js_array << javascript_hide("monthly_span")
-        js_array << javascript_hide("weekly_span")
-      end
+    case timer_type
+    when "Monthly"
+      [ javascript_hide("weekly_span"),
+        javascript_hide("daily_span"),
+        javascript_hide("hourly_span"),
+        javascript_show("monthly_span")
+      ]
+    when "Weekly"
+      [ javascript_hide("daily_span"),
+        javascript_hide("hourly_span"),
+        javascript_hide("monthly_span"),
+        javascript_show("weekly_span")
+      ]
+    when "Daily"
+      [ javascript_hide("hourly_span"),
+        javascript_hide("monthly_span"),
+        javascript_hide("weekly_span"),
+        javascript_show("daily_span")
+      ]
+    when "Hourly"
+      [ javascript_hide("daily_span"),
+        javascript_hide("monthly_span"),
+        javascript_hide("weekly_span"),
+        javascript_show("hourly_span")
+      ]
+    when nil
+      []
+    else
+      [ javascript_hide("daily_span"),
+        javascript_hide("hourly_span"),
+        javascript_hide("monthly_span"),
+        javascript_hide("weekly_span")
+      ]
     end
-    js_array
   end
 
   # Show/hide the Save and Reset buttons based on whether changes have been made


### PR DESCRIPTION
The code is more declarative and faster[1] now, and its structure is more flat.

I also considered writing something like this instead:

```diff
   def javascript_for_timer_type(timer_type)
-    case timer_type
-    when "Monthly"
-      [ javascript_hide("weekly_span"),
-        javascript_hide("daily_span"),
-        javascript_hide("hourly_span"),
-        javascript_show("monthly_span")
-      ]
-    when "Weekly"
-      [ javascript_hide("daily_span"),
-        javascript_hide("hourly_span"),
-        javascript_hide("monthly_span"),
-        javascript_show("weekly_span")
-      ]
-    when "Daily"
-      [ javascript_hide("hourly_span"),
-        javascript_hide("monthly_span"),
-        javascript_hide("weekly_span"),
-        javascript_show("daily_span")
-      ]
-    when "Hourly"
-      [ javascript_hide("daily_span"),
-        javascript_hide("monthly_span"),
-        javascript_hide("weekly_span"),
-        javascript_show("hourly_span")
-      ]
-    when nil
-      []
-    else
-      [ javascript_hide("daily_span"),
-        javascript_hide("hourly_span"),
-        javascript_hide("monthly_span"),
-        javascript_hide("weekly_span")
-      ]
+    return [] if timer_type.nil?
+
+    timer_type = timer_type.downcase
+    %w(hourly daily weekly monthly).map do |type|
+      if timer_type == type
+        javascript_show("#{ type }_span")
+      else
+        javascript_hide("#{ type }_span")
+      end
     end
   end
```

but there are 3 aspects that stopped me from doing so.

1. It's arguably harder to see what is going on.
2. It is not fully equivalent change. The order in which js snippets are generated is different from the original version. Most likely it doesn't matter though; even specs don't rely on any particular order.
3. It is probably slower.

If you guys want me to replace the case-when statement with a lop anyway - just let me know, I'll push it.

[1] Bonus point: benchmarks!

```ruby
Benchmark.ips do |x|
  x.report('4x <<') {
    a = []
    a << 1
    a << 2
    a << 3
    a << 4
  }
  x.report('[4x]') {
    a = [
      1,
      2,
      3,
      4
    ]
  }
  x.compare!
end
__END__
Calculating -------------------------------------
               4x <<    12.342k i/100ms
                [4x]    14.852k i/100ms
-------------------------------------------------
               4x <<    987.619k (±23.1%) i/s -      4.073M
                [4x]      1.307M (±18.6%) i/s -      6.238M

Comparison:
                [4x]:  1307017.3 i/s
               4x <<:   987619.5 i/s - 1.32x slower
```
Performance difference doesn't matter in this particular case, but anyway it's kinda interesting to see.