### PR TITLE
Checked if metadata is empty before retrieving snapshot info

### DIFF
--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -30,7 +30,7 @@ class MiqOpenStackInstance
   end
 
   def snapshot_metadata
-    @snapshot_metadata ||= instance.metadata.get(:miq_snapshot)
+    @snapshot_metadata ||= instance.metadata.length > 0 && instance.metadata.get(:miq_snapshot)
   end
 
   def snapshot_image_id


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1222642

The FOG exception was raised because Fog::Compute::OpenStack::Metadata was empty. Added a check before to use it to retrieve snapshot information. 