### PR TITLE
Using #client_connections rather than #database_connections for count

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -115,7 +115,7 @@ class EvmDatabaseOps
   def self.database_connections(database = nil, type = :all)
     database ||= MiqDbConfig.current.options[:database]
     conn = ActiveRecord::Base.connection
-    conn.database_connections(database, type) if conn.respond_to?(:database_connections)
+    conn.client_connections.count { |c| c["database"] == database }
   end
 
   def self.stop


### PR DESCRIPTION
Connection object did not respond to #database_connections causing
an error when attempting to set database region.

https://bugzilla.redhat.com/show_bug.cgi?id=1270782