### PR TITLE
[WIP] Fix validation message in spec test - host required

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -162,7 +162,7 @@ describe ExtManagementSystem do
           provider = FactoryGirl.build(t, :hostname => @same_host_name, :zone => @zone)
 
           if provider.hostname_required?
-            expect { provider.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Host Name has already been taken")
+            expect { provider.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Host Name is required")
           else
             expect { provider.save! }.to_not raise_error
           end


### PR DESCRIPTION
 instead of host already exists.

@miq-bot add_label bug, test
