### PR TITLE
Simplify MiqAeDatastore.upload a bit

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -51,11 +51,9 @@ module MiqAeDatastore
 
   def self.upload(fd, name = nil, domain_name = ALL_DOMAINS)
     name ||= fd.original_filename
-    ext        = File.extname(name)
-    basename   = File.basename(name, ext)
-    name       = "#{basename}.zip"
-    TMP_DIR.mkpath
+    name      = Pathname(name).basename.sub_ext('.zip')
     filename = TMP_DIR.join(name)
+    TMP_DIR.mkpath
 
     _log.info("Uploading Datastore Import to file <#{filename}>")
 

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -54,23 +54,15 @@ module MiqAeDatastore
     ext        = File.extname(name)
     basename   = File.basename(name, ext)
     name       = "#{basename}.zip"
-    block_size = 65_536
     FileUtils.mkdir_p(TMP_DIR) unless File.directory?(TMP_DIR)
     filename = File.join(TMP_DIR, name)
 
     _log.info("Uploading Datastore Import to file <#{filename}>")
 
-    outfd = File.open(filename, "wb")
-    data  = fd.read(block_size)
-    until fd.eof
-      outfd.write(data)
-      data = fd.read(block_size)
-    end
-    outfd.write(data) if data
+    IO.copy_stream(fd, filename)
     fd.close
-    outfd.close
 
-    _log.info("Upload complete (size=#{File.size(filename)})")
+    _log.info("Upload complete (size=#{filename.size})")
 
     begin
       import_yaml_zip(filename, domain_name, User.current_tenant)

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -54,7 +54,7 @@ module MiqAeDatastore
     ext        = File.extname(name)
     basename   = File.basename(name, ext)
     name       = "#{basename}.zip"
-    TMP_DIR.mkpath unless TMP_DIR.directory?
+    TMP_DIR.mkpath
     filename = TMP_DIR.join(name)
 
     _log.info("Uploading Datastore Import to file <#{filename}>")

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -17,7 +17,7 @@ module MiqAeDatastore
     end
   end
 
-  TMP_DIR = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine"))
+  TMP_DIR = Rails.root.join("tmp/miq_automate_engine").expand_path
 
   def self.temp_domain
     "#{TEMP_DOMAIN_PREFIX}-#{MiqUUID.new_guid}"
@@ -41,7 +41,7 @@ module MiqAeDatastore
 
   def self.convert(filename, domain_name = temp_domain, export_options = {})
     if export_options['zip_file'].blank? && export_options['export_dir'].blank? && export_options['yaml_file'].blank?
-      export_options['export_dir'] = TMP_DIR
+      export_options['export_dir'] = TMP_DIR.to_s
     end
 
     File.open(filename, 'r') do |handle|
@@ -54,8 +54,8 @@ module MiqAeDatastore
     ext        = File.extname(name)
     basename   = File.basename(name, ext)
     name       = "#{basename}.zip"
-    FileUtils.mkdir_p(TMP_DIR) unless File.directory?(TMP_DIR)
-    filename = File.join(TMP_DIR, name)
+    TMP_DIR.mkpath unless TMP_DIR.directory?
+    filename = TMP_DIR.join(name)
 
     _log.info("Uploading Datastore Import to file <#{filename}>")
 
@@ -65,9 +65,9 @@ module MiqAeDatastore
     _log.info("Upload complete (size=#{filename.size})")
 
     begin
-      import_yaml_zip(filename, domain_name, User.current_tenant)
+      import_yaml_zip(filename.to_s, domain_name, User.current_tenant)
     ensure
-      File.delete(filename)
+      filename.delete
     end
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -52,20 +52,20 @@ module MiqAeDatastore
   def self.upload(fd, name = nil, domain_name = ALL_DOMAINS)
     name ||= fd.original_filename
     name      = Pathname(name).basename.sub_ext('.zip')
-    filename = TMP_DIR.join(name)
+    upload_to = TMP_DIR.join(name)
     TMP_DIR.mkpath
 
-    _log.info("Uploading Datastore Import to file <#{filename}>")
+    _log.info("Uploading Datastore Import to file <#{upload_to}>")
 
-    IO.copy_stream(fd, filename)
+    IO.copy_stream(fd, upload_to)
     fd.close
 
-    _log.info("Upload complete (size=#{filename.size})")
+    _log.info("Upload complete (size=#{upload_to.size})")
 
     begin
-      import_yaml_zip(filename.to_s, domain_name, User.current_tenant)
+      import_yaml_zip(upload_to.to_s, domain_name, User.current_tenant)
     ensure
-      filename.delete
+      upload_to.delete
     end
   end
 


### PR DESCRIPTION
It might be hard to see what's going by looking at the overall diff; in case of difficulties please take a look at commits one by one or ask me any questions.

A couple of useful links:

* [IO.copy_stream](http://ruby-doc.org/core-2.2.3/IO.html#method-c-copy_stream)
* [Pathname](http://ruby-doc.org/stdlib-2.2.3/libdoc/pathname/rdoc/Pathname.html) ([mkpath](http://ruby-doc.org/stdlib-2.2.3/libdoc/pathname/rdoc/Pathname.html#method-i-mkpath), [sub_ext](http://ruby-doc.org/stdlib-2.2.3/libdoc/pathname/rdoc/Pathname.html#method-i-sub_ext))
