### PR TITLE
Check for all VC SSO ports during discovery

### DIFF
--- a/gems/pending/discovery/modules/VMwareEsxVcProbe.rb
+++ b/gems/pending/discovery/modules/VMwareEsxVcProbe.rb
@@ -9,8 +9,10 @@ class VMwareEsxVcProbe
       7444  # VC >= 5.1
     ], # and
     [
-      139, # VC < 5.1 or
-      2014  # VC >= 5.1
+      139,  # VC < 5.1 or
+      2012, # VC >= 5.1
+      2013,
+      2014
     ]
   ]
 


### PR DESCRIPTION
When performing a port scan of a VC for provider discovery not all
SSO ports were being checked so that depending on configuration
not all VCs were being detected.

https://bugzilla.redhat.com/show_bug.cgi?id=1272224