### PR TITLE
Add mistakenly removed miq-calendar angular directive

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require services/miq_db_backup_service
 //= require directives/scheduler/updateDropdownForFilter
 //= require directives/scheduler/updateDropdownForTimer
+//= require directives/miq_calendar
 //= require directives/autofocus
 //= require directives/miqrequired
 //= require directives/checkchange


### PR DESCRIPTION
This directive is used by retirement editor.

It was mistakenly removed in the following commit:
aad733884cb52d0a2f82d1e08e976b06bea3a158

https://bugzilla.redhat.com/show_bug.cgi?id=1274314