### PR TITLE
Delete session[:group]

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -3,11 +3,11 @@ module ApplicationController::CurrentUser
 
   included do
     helper_method :current_user,  :current_userid
-    helper_method :current_group, :current_groupid
+    helper_method :current_group, :current_group_id
     helper_method :admin_user?, :super_admin_user?
     hide_action :clear_current_user, :current_user=
     hide_action :admin_user?, :super_admin_user?
-    hide_action :current_user, :current_userid, :current_groupid
+    hide_action :current_user, :current_userid, :current_group_id
   end
 
   def clear_current_user
@@ -42,7 +42,7 @@ module ApplicationController::CurrentUser
 
   delegate :current_group, :to => :current_user
 
-  def current_groupid
+  def current_group_id
     current_user.current_group.id
   end
 end

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -13,13 +13,11 @@ module ApplicationController::CurrentUser
   def clear_current_user
     User.current_user = nil
     session[:userid]  = nil
-    session[:group]   = nil
   end
 
   def current_user=(db_user)
     User.current_user = db_user
     session[:userid]  = db_user.userid
-    session[:group]   = db_user.current_group.try(:id)
   end
 
   def admin_user?

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -726,9 +726,9 @@ class DashboardController < ApplicationController
     if ws.nil?
       # Create new db if it doesn't exist
       ws = MiqWidgetSet.new(:name        => db.name,
-                            :group_id    => session[:group],
-                            :userid      => session[:userid],
-                            :description => "#{db.name} dashboard for user #{session[:userid]} in group id #{session[:group]}")
+                            :group_id    => current_group_id,
+                            :userid      => current_userid,
+                            :description => "#{db.name} dashboard for user #{current_userid} in group id #{current_group_id}")
       ws.set_data = db.set_data
       ws.set_data[:last_group_db_updated] = db.updated_on
       ws.save!

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -21,7 +21,7 @@ module ReportController::SavedReports
       return
     end
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name => "#{rr.name} - #{format_timezone(rr.created_on, Time.zone, "gt")}", :model => "Saved Report"}
-    if admin_user? || rr.miq_group_id == session[:group]
+    if admin_user? || rr.miq_group_id == current_group_id
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime] = rr.last_run_on
       task = MiqTask.find_by_id(rr.miq_task_id)
@@ -157,7 +157,7 @@ module ReportController::SavedReports
     # Admin users can see all saved reports
     unless admin_user?
       cond[0] << " AND miq_group_id=?"
-      cond.push(session[:group])
+      cond.push(current_group_id)
     end
 
     cond.flatten

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,13 +86,6 @@ module ApplicationHelper
   end
   module_function :role_allows_intern
 
-  # Check group based filtered authorization for a UI task
-  def group_allows(options = {})
-    auth = MiqGroup.allows?(session[:group], :identifier => options[:identifier])
-    $log.debug("Group Authorization #{auth ? "successful" : "failed"} for: userid [#{session[:userid]}], group id [#{session[:group]}], feature identifier [#{options[:identifier]}]")
-    auth
-  end
-
   # NB: This differs from controller_for_model; until they're unified,
   # make sure you have the right one.
   def model_to_controller(record)

--- a/app/presenters/tree_builder_report_reports_class.rb
+++ b/app/presenters/tree_builder_report_reports_class.rb
@@ -20,7 +20,7 @@ class TreeBuilderReportReportsClass < TreeBuilder
     # Admin users can see all saved reports
     unless u.admin_user?
       cond[0] << ' AND miq_group_id=?'
-      cond.push(session[:group])
+      cond.push(u.current_group_id)
     end
 
     cond.flatten

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -80,7 +80,7 @@ describe DashboardController do
       controller.stub(:get_vmdb_config).and_return(:product => {})
       skip_data_checks('some_url')
       validation = controller.send(:validate_user, user)
-      expect(controller.current_groupid).to eq(user.current_group_id)
+      expect(controller.current_group_id).to eq(user.current_group_id)
       expect(validation.flash_msg).to be_nil
       expect(validation.url).to eq('some_url')
     end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1145,14 +1145,7 @@ describe ReportController do
 
   context "#replace_right_cell" do
     before do
-      miq_group = FactoryGirl.create(:miq_group,
-                                     :description   => "EvmGroup-super_administrator",
-                                     :miq_user_role => FactoryGirl.create(:miq_user_role,
-                                                                          :name => 'EvmRole-super_administrator'))
-      controller.instance_variable_set(:@current_user, FactoryGirl.create(:user,
-                                                                          :name       => "foo",
-                                                                          :miq_groups => [miq_group]))
-      session[:group] = miq_group
+      login_as FactoryGirl.create(:user_admin) # not sure why this needs to be an admin...
     end
 
     it "should rebuild trees when last report result is newer than last tree build time" do
@@ -1214,14 +1207,7 @@ describe ReportController do
 
   context "#rebuild_trees" do
     before do
-      miq_group = FactoryGirl.create(:miq_group,
-                                     :description   => "EvmGroup-super_administrator",
-                                     :miq_user_role => FactoryGirl.create(:miq_user_role,
-                                                                          :name => 'EvmRole-super_administrator'))
-      controller.instance_variable_set(:@current_user, FactoryGirl.create(:user,
-                                                                          :name       => "foo",
-                                                                          :miq_groups => [miq_group]))
-      session[:group] = miq_group
+      login_as FactoryGirl.create(:user_admin) # not sure why this needs to be an admin...
     end
 
     it "rebuild trees, latest report result was created after last time tree was built" do

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -6,7 +6,6 @@ module AuthHelper
   def login_as(user)
     User.current_user = user
     session[:userid]  = user.userid
-    session[:group]   = user.current_group.try(:id)
     user
   end
 end


### PR DESCRIPTION
The `current_user` stores the group information.

Use that instead of directly accessing the `session[:group]`.

With this, we no longer need `session[:group]`.

*Bigger picture:*

For tenancy, this will pave the road to using urls, `current_tenant` in the session (not the database) and other identity goals.