### PR TITLE
Fix "required" condition for passwords in host editor

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -25,12 +25,12 @@
   .tab-content
     = miq_tab_content('default', 'default') do
       .form-group
-        .col-md-12{"ng-if" => "emsCommonModel.emstype == 'ec2'"}
+        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'ec2'"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",
-                                              :ng_reqd_password       => "emsCommonModel.default_userid != ''",
-                                              :ng_reqd_verify         => "emsCommonModel.default_userid != ''",
+                                              :ng_reqd_password       => "#{ng_model}.default_userid != ''",
+                                              :ng_reqd_verify         => "#{ng_model}.default_userid != ''",
                                               :validate_url           => validate_url,
                                               :userid_label           => _("Access Key ID"),
                                               :password_label         => _("Secret Access Key"),
@@ -42,12 +42,12 @@
                                               :prefix                 => "default",
                                               :verify_title_off       => _("Access Key ID and matching Secret Access Key fields are needed to perform verification of credentials"),
                                               :basic_info_needed      => true}
-        .col-md-12{"ng-if" => "emsCommonModel.emstype != 'ec2'"}
+        .col-md-12{"ng-if" => "#{ng_model}" != "emsCommonModel" || "#{ng_model}.emstype != 'ec2'"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show           => true,
                                               :ng_model          => "#{ng_model}",
-                                              :ng_reqd_password  => "emsCommonModel.default_userid != ''",
-                                              :ng_reqd_verify    => "emsCommonModel.default_userid != ''",
+                                              :ng_reqd_password  => "#{ng_model}" == "hostModel" ? false : "#{ng_model}.default_userid != ''",
+                                              :ng_reqd_verify    => "#{ng_model}" == "hostModel" ? false : "#{ng_model}.default_userid != ''",
                                               :validate_url      => validate_url,
                                               :id                => record.id,
                                               :prefix            => "default",

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -243,4 +243,18 @@ describe HostController do
                                                                                    :ipmi    => ipmi_creds)
     end
   end
+
+  context "#render pages" do
+    render_views
+    before do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+    end
+    it "renders a new page with ng-required condition set to false for password" do
+      get :new
+      expect(response.status).to eq(200)
+      expect(response.body).to include("name='default_password' ng-disabled='!showVerify(&#39;default_userid&#39;)' ng-model='hostModel.default_password' ng-required='false'")
+    end
+  end
 end


### PR DESCRIPTION
Since passwords in host editor could be blank, they should not have the angular ```required``` condition set.