### PR TITLE
Deploy the auto-focus directive to set the display 'on' on the form

### DIFF
--- a/app/assets/javascripts/directives/autofocus.js
+++ b/app/assets/javascripts/directives/autofocus.js
@@ -5,9 +5,16 @@ ManageIQ.angularApplication.directive('autoFocus', ['$timeout', function($timeou
       scope['form_focus_' + ctrl.$name] = elem[0];
 
       scope.$watch(scope['afterGet'], function() {
-        $timeout(function(){
-          angular.element(scope['form_focus_' + ctrl.$name]).focus();
-        }, 0);
+        angular.element('#' + attr.startFormDiv).css('display', 'block');
+      });
+
+      scope.$watch(function() { return elem.is(':visible') }, function() {
+        angular.element(scope['form_focus_' + ctrl.$name]).focus();
+        if (!angular.element(scope['form_focus_' + ctrl.$name]).is(":focus")) {
+          $timeout(function(){
+            angular.element(scope['form_focus_' + ctrl.$name]).focus();
+          }, 1000);
+        };
       });
     }
   }

--- a/app/views/ops/_schedule_form.html.haml
+++ b/app/views/ops/_schedule_form.html.haml
@@ -1,59 +1,62 @@
 - @angularForm = true
 
-%form.form-horizontal#form_div{"name"          => "angularForm",
-                               "ng-controller" => "scheduleFormController",
-                               "ng-show"       => "afterGet"}
-  = render :partial => "layouts/flash_msg"
-  %div
+.form-horizontal{:id => "start_form_div", :style => "display:none"}
+  %form#form_div{"name"          => "angularForm",
+                 "ng-controller" => "scheduleFormController",
+                 "ng-show"       => "afterGet"}
+    = render :partial => "layouts/flash_msg"
     %div
-      .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
-        %label.col-md-2.control-label{"for" => "textInput-markup"}
-          = _("Name")
-        .col-md-8
-          %input.form-control{"type"        => "text",
-                              "id"          => "textInput-markup",
-                              "name"        => "name",
-                              "ng-model"    => "scheduleModel.name",
-                              "maxlength"   => "#{MAX_NAME_LEN}",
-                              "miqrequired" => "",
-                              "checkchange" => ""}
-          %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
-            = _("Required")
-      .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
-        %label.col-md-2.control-label{"for" => "textInput-markup"}
-          = _("Description")
-        .col-md-8
-          %input.form-control{"type"        => "text",
-                              "id"          => "textInput-markup",
-                              "name"        => "description",
-                              "ng-model"    => "scheduleModel.description",
-                              "maxlength"   => "#{MAX_DESC_LEN}",
-                              "miqrequired" => "",
-                              "checkchange" => ""}
-            %span.help-block{"ng-show" => "angularForm.description.$error.miqrequired"}
+      %div
+        .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+          %label.col-md-2.control-label{"for" => "textInput-markup"}
+            = _("Name")
+          .col-md-8
+            %input.form-control{"type"           => "text",
+                                "id"             => "textInput-markup",
+                                "name"           => "name",
+                                "ng-model"       => "scheduleModel.name",
+                                "maxlength"      => "#{MAX_NAME_LEN}",
+                                "miqrequired"    => "",
+                                "checkchange"    => "",
+                                "auto-focus"     => "",
+                                "start-form-div" => "start_form_div"}
+            %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
               = _("Required")
-      .form-group
-        %label.col-md-2.control-label
-          = _("Active")
-        .col-md-10
-          %input#enabled{"type"        => "checkbox",
-                         "name"        => "enabled",
-                         "ng-model"    => "scheduleModel.enabled",
-                         "checkchange" => ""}
-      .form-group
-        %label.col-md-2.control-label
-          = _("Action")
-        .col-md-10
-          = select_tag('action_typ',
-                       options_for_select(@action_type_options_for_select),
-                       "ng-model"                    => "scheduleModel.action_typ",
-                       "ng-change"                   => "actionTypeChanged()",
-                       "checkchange"                 => "",
-                       "selectpicker-for-select-tag" => "")
+        .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
+          %label.col-md-2.control-label{"for" => "textInput-markup"}
+            = _("Description")
+          .col-md-8
+            %input.form-control{"type"        => "text",
+                                "id"          => "textInput-markup",
+                                "name"        => "description",
+                                "ng-model"    => "scheduleModel.description",
+                                "maxlength"   => "#{MAX_DESC_LEN}",
+                                "miqrequired" => "",
+                                "checkchange" => ""}
+              %span.help-block{"ng-show" => "angularForm.description.$error.miqrequired"}
+                = _("Required")
+        .form-group
+          %label.col-md-2.control-label
+            = _("Active")
+          .col-md-10
+            %input#enabled{"type"        => "checkbox",
+                           "name"        => "enabled",
+                           "ng-model"    => "scheduleModel.enabled",
+                           "checkchange" => ""}
+        .form-group
+          %label.col-md-2.control-label
+            = _("Action")
+          .col-md-10
+            = select_tag('action_typ',
+                         options_for_select(@action_type_options_for_select),
+                         "ng-model"                    => "scheduleModel.action_typ",
+                         "ng-change"                   => "actionTypeChanged()",
+                         "checkchange"                 => "",
+                         "selectpicker-for-select-tag" => "")
 
-  = render :partial => "schedule_form_filter"
-  = render :partial => "schedule_form_timer"
-  = render :partial => "layouts/angular/x_edit_buttons_angular"
+    = render :partial => "schedule_form_filter"
+    = render :partial => "schedule_form_timer"
+    = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angularApplication.value('scheduleFormId', '#{@schedule.id || "new"}');


### PR DESCRIPTION
The ```auto-focus``` directive will now be deployed to set the display 'on' on the form once all the json data is fetched. The directive will then set focus on the first field in the form.

This is being done in order to resolve a known problem with angular forms where just before the form loads, for a brief second or so,  the fields are marked red since the form ```json``` data is still being fetched from the server. This issue is quite pronounced on slower machines.