### PR TITLE
Allow for automate state machine restarts

### DIFF
--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -35,6 +35,26 @@ describe "MiqAeStateMachineRetry" do
     RUBY
   end
 
+  def perpetual_restart_script_with_nextstate
+    <<-'RUBY'
+      $evm.root['ae_result'] = 'restart'
+      $evm.root['ae_next_state'] = 'state2'
+    RUBY
+  end
+
+  def perpetual_restart_script
+    <<-'RUBY'
+      $evm.log("info", "Setting restart for state")
+      $evm.root['ae_result'] = 'restart'
+    RUBY
+  end
+
+  def simpleton_script
+    <<-'RUBY'
+      $evm.root['ae_result'] = 'ok'
+    RUBY
+  end
+
   def method_script_state_var
     <<-'RUBY'
       root   = $evm.object("/")
@@ -107,6 +127,53 @@ describe "MiqAeStateMachineRetry" do
                                    'ae_instances' => ae_instances))
   end
 
+  def create_method_class(attrs, script1, script2, script3)
+    ae_fields = {'execute' => {:aetype => 'method', :datatype => 'string'}}
+    ae_instances = {'meth1' => {'execute' => {:value => 'meth1'}},
+                    'meth2' => {'execute' => {:value => 'meth2'}},
+                    'meth3' => {'execute' => {:value => 'meth3'}}}
+    ae_methods = {'meth1' => {:scope => 'instance', :location => 'inline',
+                              :data => script1,
+                              :language => 'ruby', 'params' => {}},
+                  'meth2' => {:scope => 'instance', :location => 'inline',
+                              :data => script2,
+                              :language => 'ruby', 'params' => {}},
+                  'meth3' => {:scope => 'instance', :location => 'inline',
+                              :data => script3,
+                              :language => 'ruby', 'params' => {}}}
+
+    FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_instances' => ae_instances,
+                                   'ae_methods'   => ae_methods))
+  end
+
+  def create_multi_state_class(attrs = {})
+    ae_fields = {'state1' => {:aetype => 'state', :datatype => 'string', :priority => 1},
+                 'state2' => {:aetype => 'state', :datatype => 'string', :priority => 2},
+                 'state3' => {:aetype => 'state', :datatype => 'string', :priority => 3}}
+    fq1 = "/#{@domain}/#{@namespace}/#{@retry_class}/meth1"
+    fq2 = "/#{@domain}/#{@namespace}/#{@retry_class}/meth2"
+    fq3 = "/#{@domain}/#{@namespace}/#{@retry_class}/meth3"
+    ae_instances = {@state_instance => {'state1' => {:value => fq1},
+                                        'state2' => {:value => fq2},
+                                        'state3' => {:value => fq3}}}
+    FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                       attrs.merge('ae_fields'    => ae_fields,
+                                   'ae_methods'   => {},
+                                   'ae_instances' => ae_instances))
+  end
+
+  def create_restart_model(script1, script2, script3)
+    dom = FactoryGirl.create(:miq_ae_domain, :name => @domain)
+    ns  = FactoryGirl.create(:miq_ae_namespace, :parent => dom, :name => @namespace)
+    @ns_fqname = ns.fqname
+    create_multi_state_class(:namespace => @ns_fqname, :name => @state_class)
+    attrs = {:namespace => @ns_fqname, :name => @retry_class}
+    create_method_class(attrs, script1, script2, script3)
+    create_root_class(:namespace => @ns_fqname, :name => @root_class)
+  end
+
   it "check persistent hash" do
     setup_model(method_script_state_var)
     expected = {'three' => 3, 'one'  => 1, 'two'  => 2, 'gravy' => 'train'}
@@ -150,5 +217,25 @@ describe "MiqAeStateMachineRetry" do
       status, _message, ws = deliver_ae_request_from_queue
       expect(status).not_to be
     end
+  end
+
+  it "check restart without next state" do
+    create_restart_model(simpleton_script, simpleton_script, perpetual_restart_script)
+    send_ae_request_via_queue(@automate_args)
+    status, _message, ws = deliver_ae_request_from_queue
+    status.should_not eq(MiqQueue::STATUS_ERROR)
+    ws.should_not be_nil
+    q = MiqQueue.where(:state => 'ready').first
+    expect(q.args[0][:state]).to eql('state1')
+  end
+
+  it "check restart with next state" do
+    create_restart_model(simpleton_script, simpleton_script, perpetual_restart_script_with_nextstate)
+    send_ae_request_via_queue(@automate_args)
+    status, _message, ws = deliver_ae_request_from_queue
+    status.should_not eq(MiqQueue::STATUS_ERROR)
+    ws.should_not be_nil
+    q = MiqQueue.where(:state => 'ready').first
+    expect(q.args[0][:state]).to eql('state2')
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/4899

Automate state machine allow for the next state to be set by specifying
the 'ae_next_state' attribute from a method. The next state can only go
forward in the state machine, it cannot go back. If a method requires
that the state machine needs to go to the previously exectued state or
the beginning of the state machine it can enable restart of the state
machine. The automate state machine method can set the following 2
attributes ae_result and ae_next_state.

e.g.

$evm.root['ae_result'] = 'restart'
$evm.root['ae_next_state'] = 'state3'

ae_next_state is optional, if not specified the state machine will start
executing from the first state.

Please note that when you restart a state machine from the top or from an earlier executed state you have to
(1) Keep track of the restart count in state variables https://github.com/ManageIQ/manageiq/pull/453
(2) Undo the changes executed by the earlier states before the state machine can be resumed.

https://github.com/ManageIQ/manageiq/pull/2860
