### PR TITLE
Fixed feature id in miq_shortcuts.yml

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -186,7 +186,7 @@
 - :name: container_containers
   :description: Containers / Explorer
   :url: /container/explorer
-  :rbac_feature_name: container_view
+  :rbac_feature_name: containers
   :startup: true
 - :name: control_explorer
   :description: Control / Explorer


### PR DESCRIPTION
Fixed feature id in miq_shortcuts.yml, incorrect feature id was blocking user from logging in when they only had access to "Containers" feature.
Added spec tests to verify the fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1273033

@AparnaKarve @martinpovolny please review/test