### PR TITLE
Add provider name to host/vm tooltip on topology

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -92,7 +92,13 @@ angular.module('topologyApp', ['kubernetesUI','ui.bootstrap'])
             .text(function(d) { return d.item.name }).style("font-size", function(d) {return "12px"}).style("fill", function(d) {return "black"})
             .style("display", function(d) {if ($scope.checkboxModel.value) {return "block"} else {return "none"}});
 
-        added.selectAll("title").text(function(d) { return "Name: " + d.item.name + "\nType: " + d.item.kind + "\nStatus: " + d.item.status });
+        added.selectAll("title").text(function(d) {
+            var status = "Name: " + d.item.name + "\nType: " + d.item.kind + "\nStatus: " + d.item.status;
+            if (d.item.kind == 'Host' || d.item.kind == 'VM') {
+                    status += "\nProvider: " + d.item.provider;
+            }
+            return status;
+        });
         $scope.vs = vertices;
 
         /* Don't do default rendering */

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -63,7 +63,11 @@ class ContainerTopologyService
          else entity.ems_ref
          end
 
-    {:id => id, :name => entity.name, :status => status, :kind => kind, :miq_id => entity.id}
+    data = {:id => id, :name => entity.name, :status => status, :kind => kind, :miq_id => entity.id}
+    if(kind.eql?("VM") || kind.eql?("Host"))
+      data.merge!(:provider => entity.ext_management_system.name)
+    end
+    data
   end
 
   def entity_status(entity, kind)

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -40,14 +40,17 @@ describe ContainerTopologyService do
     end
 
     it "topology contains the expected structure and content" do
-      ems = FactoryGirl.create(:ems_kubernetes)
+      ems_kube = FactoryGirl.create(:ems_kubernetes)
+      ems_rhev = FactoryGirl.create(:ems_redhat, :name => "ems_rhev")
       # vm and host test cross provider correlation to infra provider
       vm_rhev = FactoryGirl.create(:vm_redhat, :name => "vm1", :id => 35,
-                                   :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998")
+                                   :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998",
+                                   :ext_management_system => ems_rhev)
       vm_rhev.stub(:power_state).and_return("on")
 
       host = FactoryGirl.create(:host, :name => "host1", :id => 25,
                                 :uid_ems => "abcd9a08-7b13-11e5-8546-129aa6621999",
+                                :ext_management_system => ems_rhev,
                                 :hardware => FactoryGirl.create(:hardware,
                                                                 :numvcpus         => 2,
                                                                 :cores_per_socket => 4,
@@ -59,19 +62,20 @@ describe ContainerTopologyService do
 /mysql-55-centos7:latest', :state => 'running')
       container_def = ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container)
 
-      container_node = ContainerNode.create(:ext_management_system => ems, :id => 1,
+      container_node = ContainerNode.create(:ext_management_system => ems_kube, :id => 1,
                                             :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
                                             :container_conditions => [container_condition], :lives_on => vm_rhev)
-      container_replicator = ContainerReplicator.create(:ext_management_system => ems, :id => 7,
+      container_replicator = ContainerReplicator.create(:ext_management_system => ems_kube, :id => 7,
                                                         :ems_ref => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
                                                         :name => "replicator1")
-      container_route = ContainerRoute.create(:ext_management_system => ems, :id => 11, :ems_ref => "ab5za74c-3a41-11e5-a79a-001a4a231290",
+      container_route = ContainerRoute.create(:ext_management_system => ems_kube, :id => 11,
+                                              :ems_ref => "ab5za74c-3a41-11e5-a79a-001a4a231290",
                                               :name => "route-edge")
-      container_group = ContainerGroup.create(:ext_management_system => ems, :id => 15,
+      container_group = ContainerGroup.create(:ext_management_system => ems_kube, :id => 15,
                                               :container_node => container_node, :container_replicator => container_replicator,
                                               :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
                                               :phase => "Running", :container_definitions => [container_def])
-      container_service = ContainerService.create(:ext_management_system => ems, :id => 3, :container_groups => [container_group],
+      container_service = ContainerService.create(:ext_management_system => ems_kube, :id => 3, :container_groups => [container_group],
                                                   :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name => "service1", :container_routes => [container_route])
       container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
@@ -94,9 +98,11 @@ describe ContainerTopologyService do
       topology[:items]["3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest"].should eql(:id => "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest", :name => "ruby-example", :status => "Running", :kind => "Container",  :miq_id => 10)
 
       topology[:items]["558d9a08-7b13-11e5-8546-129aa6621998"].should eql(:id => "558d9a08-7b13-11e5-8546-129aa6621998",
-                                                                          :name => "vm1", :status => "On", :kind => "VM", :miq_id => 35)
+                                                                          :name => "vm1", :status => "On", :kind => "VM",
+                                                                          :miq_id => 35, :provider => "ems_rhev")
       topology[:items]["abcd9a08-7b13-11e5-8546-129aa6621999"].should eql(:id => "abcd9a08-7b13-11e5-8546-129aa6621999",
-                                                                          :name => "host1", :status => "On", :kind => "Host", :miq_id => 25)
+                                                                          :name => "host1", :status => "On", :kind => "Host",
+                                                                          :miq_id => 25, :provider => "ems_rhev")
 
       topology[:relations].should include(:source => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
                                           :target => "8f8ca74c-3a41-11e5-a79a-001a4a231290")
@@ -111,9 +117,11 @@ describe ContainerTopologyService do
   end
 
   it "topology contains the expected structure when vm is off" do
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems_kube = FactoryGirl.create(:ems_kubernetes)
+    ems_rhev = FactoryGirl.create(:ems_redhat, :name => "ems_rhev")
     # vm and host test cross provider correlation to infra provider
-    vm_rhev = FactoryGirl.create(:vm_redhat, :name => "vm1", :id => 35, :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998")
+    vm_rhev = FactoryGirl.create(:vm_redhat, :name => "vm1", :id => 35, :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998",
+                                 :ext_management_system => ems_rhev)
     vm_rhev.stub(:power_state).and_return("off")
 
     container_condition = ContainerCondition.create(:name => 'Ready', :status => 'True')
@@ -123,14 +131,14 @@ describe ContainerTopologyService do
     container_def = ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9',
                                                :container => container)
 
-    container_node = ContainerNode.create(:ext_management_system => ems, :id => 1, :name => "127.0.0.1",
+    container_node = ContainerNode.create(:ext_management_system => ems_kube, :id => 1, :name => "127.0.0.1",
                                           :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
                                           :container_conditions => [container_condition], :lives_on => vm_rhev)
 
-    container_group = ContainerGroup.create(:ext_management_system => ems, :id => 15, :container_node => container_node,
+    container_group = ContainerGroup.create(:ext_management_system => ems_kube, :id => 15, :container_node => container_node,
                                             :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
                                             :phase => "Running", :container_definitions => [container_def])
-    container_service = ContainerService.create(:ext_management_system => ems, :id => 3, :container_groups => [container_group],
+    container_service = ContainerService.create(:ext_management_system => ems_kube, :id => 3, :container_groups => [container_group],
                                                 :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                 :name => "service1")
     container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
@@ -153,7 +161,8 @@ describe ContainerTopologyService do
 
     topology[:items]["558d9a08-7b13-11e5-8546-129aa6621998"].should eql(:id => "558d9a08-7b13-11e5-8546-129aa6621998",
                                                                         :name => "vm1", :status => "Off",
-                                                                        :kind => "VM", :miq_id => 35)
+                                                                        :kind => "VM", :miq_id => 35,
+                                                                        :provider => "ems_rhev")
 
     topology[:relations].should include(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                         :target => "96c35ccd-3e00-11e5-a0d2-18037327aaeb")


### PR DESCRIPTION
Since host/vm come from non container providers, adding a provider name indication for better clarity.

![hostvmtooltipprovider](https://cloud.githubusercontent.com/assets/6277245/10686609/79854894-796e-11e5-89ce-f2b187829297.png)

@miq-bot add_label ui, enhancement, providers/containers
inspired by @itamarh comment https://github.com/ManageIQ/manageiq/pull/4997#issuecomment-149672265