### PR TITLE
Remove 'AVG' from 'Memory - Avg Used (MB) (Avg)' headers

### DIFF
--- a/product/reports/650_Performance by Asset Type - Virtual Machines/150_All Departments with Performance.yaml
+++ b/product/reports/650_Performance by Asset Type - Virtual Machines/150_All Departments with Performance.yaml
@@ -307,7 +307,7 @@ headers:
 - CPU - Usage Rate (MHz) (Avg)
 - " Memory - Peak Usage of Allocated for Collected Intervals (%) (Max)"
 - Memory - Usage (%) (Avg)
-- Memory - Avg Used (MB) (Avg)
+- Memory - Used (MB) (Avg)
 - Total Provisioned Space (Includes RAM)
 - Total Used Disk Space
 - Total Snapshots

--- a/product/reports/650_Performance by Asset Type - Virtual Machines/170_Top Memory Consumers weekly.yaml
+++ b/product/reports/650_Performance by Asset Type - Virtual Machines/170_Top Memory Consumers weekly.yaml
@@ -61,5 +61,5 @@ headers:
 - Asset Name
 - Cluster Name
 - Host Name
-- Memory - Avg Used for Collected Intervals (MB) (Avg)
+- Memory - Used for Collected Intervals (MB) (Avg)
 display_filter: 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1272552

Dashboard
before
![before](https://cloud.githubusercontent.com/assets/14937244/10691725/ba1b917a-798b-11e5-8666-71d0987f2b9c.png)

after
![after](https://cloud.githubusercontent.com/assets/14937244/10691732/bfeaf56e-798b-11e5-942c-7a006d093fc8.png)

Reports -> Performance by Asset Type -> Virtual Machines -> All Departments with Performance
before
![widget-before](https://cloud.githubusercontent.com/assets/14937244/10691737/c94f88b8-798b-11e5-81f4-1f647083c3c0.png)

after
![widget-after](https://cloud.githubusercontent.com/assets/14937244/10691742/cda628b8-798b-11e5-8ddd-96fe1d2f0422.png)
