### PR TITLE
Fix parse error when getting child nodes in database tree.

### DIFF
--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -42,7 +42,7 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
       object.vmdb_indexes.count
     else
       # load this node expanded on autoload
-      x_tree[:open_nodes].push("xx-#{to_cid(object.id.to_s)}") unless x_tree[:open_nodes].include?("xx-#{to_cid(object.id.to_s)}")
+      @tree_state.x_tree(@name)[:open_nodes].push("xx-#{to_cid(object.id.to_s)}") unless @tree_state.x_tree(@name)[:open_nodes].include?("xx-#{to_cid(object.id.to_s)}")
       [
         {
           :id            => "#{to_cid(object.id.to_s)}",


### PR DESCRIPTION
In Configuration > Configuration > Database Accordion child nodes are not loaded:

![parseerror](https://cloud.githubusercontent.com/assets/6978386/10691908/64d2dcee-798d-11e5-85ec-ccc66781d548.png)

Changing the no longer existent `x_tree` variable with the new `@tree_state.x_tree(@name)` solves the problem:

![correct](https://cloud.githubusercontent.com/assets/6978386/10691945/bc1b347e-798d-11e5-9461-092dd6dda423.png)
