### PR TITLE
Update callers of cores per socket to cpu cores per socket

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1400,8 +1400,8 @@ class ApplicationController < ActionController::Base
 
       if db_record.hardware.logical_cpus
         cpu_details =
-          if db_record.num_cpu && db_record.cores_per_socket
-            " (#{pluralize(db_record.num_cpu, 'socket')} x #{pluralize(db_record.cores_per_socket, 'core')})"
+          if db_record.num_cpu && db_record.cpu_cores_per_socket
+            " (#{pluralize(db_record.num_cpu, 'socket')} x #{pluralize(db_record.cpu_cores_per_socket, 'core')})"
           else
             ""
           end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1062,8 +1062,8 @@ module ApplicationController::CiProcessing
     socket_count = @reconfigureitems.first.num_cpu
     socket_count = nil unless @reconfigureitems.all? { |vm| vm.num_cpu == socket_count }
 
-    cores_per_socket = @reconfigureitems.first.cores_per_socket
-    cores_per_socket = nil unless @reconfigureitems.all? { |vm| vm.cores_per_socket == cores_per_socket }
+    cores_per_socket = @reconfigureitems.first.cpu_cores_per_socket
+    cores_per_socket = nil unless @reconfigureitems.all? { |vm| vm.cpu_cores_per_socket == cores_per_socket }
 
     @edit[:new][:old_memory], @edit[:new][:old_mem_typ] = reconfigure_calculations(memory)
     @edit[:new][:old_socket_count] = @edit[:new][:socket_count] = socket_count

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -7,7 +7,7 @@ module HostHelper::TextualSummary
 
   def textual_group_properties
     %i(hostname ipaddress ipmi_ipaddress custom_1 vmm_vendor model asset_tag service_tag osinfo
-       power_state lockdown_mode devices network storage_adapters num_cpu num_cpu_cores cores_per_socket memory
+       power_state lockdown_mode devices network storage_adapters num_cpu num_cpu_cores cpu_cores_per_socket memory
        guid)
   end
 
@@ -224,8 +224,8 @@ module HostHelper::TextualSummary
     {:label => "Number of CPU Cores", :value => @record.hardware.nil? ? "N/A" : @record.hardware.logical_cpus}
   end
 
-  def textual_cores_per_socket
-    {:label => "CPU Cores Per Socket", :value => @record.hardware.nil? ? "N/A" : @record.hardware.cores_per_socket}
+  def textual_cpu_cores_per_socket
+    {:label => "CPU Cores Per Socket", :value => @record.hardware.nil? ? "N/A" : @record.hardware.cpu_cores_per_socket}
   end
 
   def textual_memory

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -134,8 +134,8 @@ module VmHelper::TextualSummary
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')
 
       cpu_details =
-        if @record.num_cpu && @record.cores_per_socket
-          " (#{pluralize(@record.num_cpu, 'socket')} x #{pluralize(@record.cores_per_socket, 'core')})"
+        if @record.num_cpu && @record.cpu_cores_per_socket
+          " (#{pluralize(@record.num_cpu, 'socket')} x #{pluralize(@record.cpu_cores_per_socket, 'core')})"
         else
           ""
         end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1967,4 +1967,6 @@ class Host < ActiveRecord::Base
   def openstack_host?
     ext_management_system.class == ManageIQ::Providers::Openstack::InfraManager
   end
+
+  include DeprecatedCpuMethodsMixin
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -116,7 +116,7 @@ class Host < ActiveRecord::Base
   virtual_column :total_vcpus,                  :type => :integer,     :uses => :logical_cpus
   virtual_column :num_cpu,                      :type => :integer,     :uses => :hardware
   virtual_column :logical_cpus,                 :type => :integer,     :uses => :hardware
-  virtual_column :cores_per_socket,             :type => :integer,     :uses => :hardware
+  virtual_column :cpu_cores_per_socket,         :type => :integer,     :uses => :hardware
   virtual_column :ram_size,                     :type => :integer
   virtual_column :enabled_inbound_ports,        :type => :numeric_set  # The following are not set to use anything
   virtual_column :enabled_outbound_ports,       :type => :numeric_set  # because get_ports ends up re-querying the
@@ -1789,8 +1789,8 @@ class Host < ActiveRecord::Base
     hardware.nil? ? 0 : hardware.logical_cpus
   end
 
-  def cores_per_socket
-    hardware.nil? ? 0 : hardware.cores_per_socket
+  def cpu_cores_per_socket
+    hardware.nil? ? 0 : hardware.cpu_cores_per_socket
   end
 
   def domain

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -357,16 +357,16 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :raw_power_state     => status.to_s,
 
       :hardware            => {
-        :bitness             => ARCHITECTURE_TO_BITNESS[instance.architecture],
-        :virtualization_type => virtualization_type,
-        :root_device_type    => root_device_type,
-        :numvcpus            => flavor[:cpus],
-        :cores_per_socket    => 1,
-        :logical_cpus        => flavor[:cpus],
-        :memory_mb           => flavor[:memory] / 1.megabyte,
-        :disk_capacity       => flavor[:ephemeral_disk_size],
-        :disks               => [], # Filled in later conditionally on flavor
-        :networks            => [], # Filled in later conditionally on what's available
+        :bitness              => ARCHITECTURE_TO_BITNESS[instance.architecture],
+        :virtualization_type  => virtualization_type,
+        :root_device_type     => root_device_type,
+        :numvcpus             => flavor[:cpus],
+        :cpu_cores_per_socket => 1,
+        :logical_cpus         => flavor[:cpus],
+        :memory_mb            => flavor[:memory] / 1.megabyte,
+        :disk_capacity        => flavor[:ephemeral_disk_size],
+        :disks                => [], # Filled in later conditionally on flavor
+        :networks             => [], # Filled in later conditionally on what's available
       },
 
       :availability_zone   => @data_index.fetch_path(:availability_zones, instance.availability_zone),

--- a/app/models/manageiq/providers/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/infra_manager/provision_workflow.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::InfraManager::ProvisionWorkflow < ::MiqProvisionVirtW
     {
       :number_of_cpus    => vm.hardware.logical_cpus,
       :number_of_sockets => vm.hardware.numvcpus,
-      :cores_per_socket  => vm.hardware.cores_per_socket
+      :cores_per_socket  => vm.hardware.cpu_cores_per_socket
     }
   end
 

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -234,15 +234,15 @@ module ManageIQ::Providers::Microsoft
       cpu_model        = normalize_blank_property(p[:ProcessorModel])
 
       {
-        :cpu_type         => "#{cpu_manufacturer} #{cpu_model} #{cpu_family}",
-        :manufacturer     => cpu_manufacturer,
-        :model            => cpu_model,
-        :cpu_speed        => normalize_blank_property_num(p[:ProcessorSpeed]),
-        :memory_mb        => normalize_blank_property(p[:TotalMemory]) / 1.megabyte,
-        :numvcpus         => normalize_blank_property_num(p[:PhysicalCPUCount]),
-        :logical_cpus     => normalize_blank_property_num(p[:LogicalProcessorCount]),
-        :cores_per_socket => normalize_blank_property_num(p[:CoresPerCPU]),
-        :guest_devices    => process_host_guest_devices(host),
+        :cpu_type             => "#{cpu_manufacturer} #{cpu_model} #{cpu_family}",
+        :manufacturer         => cpu_manufacturer,
+        :model                => cpu_model,
+        :cpu_speed            => normalize_blank_property_num(p[:ProcessorSpeed]),
+        :memory_mb            => normalize_blank_property(p[:TotalMemory]) / 1.megabyte,
+        :numvcpus             => normalize_blank_property_num(p[:PhysicalCPUCount]),
+        :logical_cpus         => normalize_blank_property_num(p[:LogicalProcessorCount]),
+        :cpu_cores_per_socket => normalize_blank_property_num(p[:CoresPerCPU]),
+        :guest_devices        => process_host_guest_devices(host),
       }
     end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -463,13 +463,13 @@ module ManageIQ::Providers
         :connection_state    => "connected",
 
         :hardware            => {
-          :numvcpus         => flavor[:cpus],
-          :cores_per_socket => 1,
-          :logical_cpus     => flavor[:cpus],
-          :memory_mb        => flavor[:memory] / 1.megabyte,
-          :disk_capacity    => flavor[:root_disk_size] + flavor[:ephemeral_disk_size] + flavor[:swap_disk_size],
-          :disks            => [], # Filled in later conditionally on flavor
-          :networks         => [], # Filled in later conditionally on what's available
+          :numvcpus             => flavor[:cpus],
+          :cpu_cores_per_socket => 1,
+          :logical_cpus         => flavor[:cpus],
+          :memory_mb            => flavor[:memory] / 1.megabyte,
+          :disk_capacity        => flavor[:root_disk_size] + flavor[:ephemeral_disk_size] + flavor[:swap_disk_size],
+          :disks                => [], # Filled in later conditionally on flavor
+          :networks             => [], # Filled in later conditionally on what's available
         },
         :host                => parent_host,
         :ems_cluster         => parent_cluster,

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -181,27 +181,27 @@ module ManageIQ
       end
 
       def process_host_hardware(host, extra_attributes)
-        numvcpus         = extra_attributes.fetch_path('cpu', 'physical', 'number').to_i
-        logical_cpus     = extra_attributes.fetch_path('cpu', 'logical', 'number').to_i
-        cores_per_socket = numvcpus > 0 ? logical_cpus / numvcpus : 0
+        numvcpus             = extra_attributes.fetch_path('cpu', 'physical', 'number').to_i
+        logical_cpus         = extra_attributes.fetch_path('cpu', 'logical', 'number').to_i
+        cpu_cores_per_socket = numvcpus > 0 ? logical_cpus / numvcpus : 0
         # Get Cpu speed in Mhz
         cpu_speed        = extra_attributes.fetch_path('cpu', 'physical_0', 'frequency').to_i / 10**6
         {
-          :memory_mb          => host.properties['memory_mb'],
-          :disk_capacity      => host.properties['local_gb'],
-          :logical_cpus       => logical_cpus,
-          :numvcpus           => numvcpus,
-          :cores_per_socket   => cores_per_socket,
-          :cpu_speed          => cpu_speed,
-          :cpu_type           => extra_attributes.fetch_path('cpu', 'physical_0', 'version'),
-          :manufacturer       => extra_attributes.fetch_path('system', 'product', 'vendor'),
-          :model              => extra_attributes.fetch_path('system', 'product', 'name'),
-          :number_of_nics     => extra_attributes.fetch_path('network').try(:keys).try(:count).to_i,
-          :bios               => extra_attributes.fetch_path('firmware', 'bios', 'version'),
+          :memory_mb            => host.properties['memory_mb'],
+          :disk_capacity        => host.properties['local_gb'],
+          :logical_cpus         => logical_cpus,
+          :numvcpus             => numvcpus,
+          :cpu_cores_per_socket => cpu_cores_per_socket,
+          :cpu_speed            => cpu_speed,
+          :cpu_type             => extra_attributes.fetch_path('cpu', 'physical_0', 'version'),
+          :manufacturer         => extra_attributes.fetch_path('system', 'product', 'vendor'),
+          :model                => extra_attributes.fetch_path('system', 'product', 'name'),
+          :number_of_nics       => extra_attributes.fetch_path('network').try(:keys).try(:count).to_i,
+          :bios                 => extra_attributes.fetch_path('firmware', 'bios', 'version'),
           # Can't get these 2 from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
-          :guest_os_full_name => nil,
-          :guest_os           => nil,
-          :disks              => process_host_hardware_disks(extra_attributes),
+          :guest_os_full_name   => nil,
+          :guest_os             => nil,
+          :disks                => process_host_hardware_disks(extra_attributes),
         }
       end
 

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -199,7 +199,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
       cpu_options = {}
       cpu_options[:cores]   = spec["numCoresPerSocket"] if spec["numCoresPerSocket"]
-      cpu_options[:sockets] = spec["numCPUs"] / (cpu_options[:cores] || vm.cores_per_socket) if spec["numCPUs"]
+      cpu_options[:sockets] = spec["numCPUs"] / (cpu_options[:cores] || vm.cpu_cores_per_socket) if spec["numCPUs"]
 
       rhevm_vm.cpu_topology = cpu_options if cpu_options.present?
     end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -187,9 +187,9 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       memory_total = inv[:statistics].to_miq_a.detect { |stat| stat[:name] == 'memory.total' }
       result[:memory_mb] = memory_total.nil? ? 0 : memory_total[:values].first.to_i / 1.megabyte
 
-      result[:cores_per_socket] = hdw.fetch_path(:topology, :cores) || 1        # Number of cores per socket
-      result[:numvcpus]         = hdw.fetch_path(:topology, :sockets) || 1      # Number of physical sockets
-      result[:logical_cpus]     = result[:numvcpus] * result[:cores_per_socket] # Number of cores multiplied by sockets
+      result[:cpu_cores_per_socket] = hdw.fetch_path(:topology, :cores) || 1
+      result[:numvcpus]             = hdw.fetch_path(:topology, :sockets) || 1 # Number of physical sockets
+      result[:logical_cpus]         = result[:numvcpus] * result[:cpu_cores_per_socket] # Number of cores multiplied by sockets
     end
 
     result
@@ -407,9 +407,9 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
     }
 
     hdw = inv[:cpu]
-    result[:cores_per_socket] = hdw.fetch_path(:topology, :cores) || 1        # Number of cores per socket
-    result[:numvcpus]         = hdw.fetch_path(:topology, :sockets) || 1      # Number of sockets
-    result[:logical_cpus]     = result[:numvcpus] * result[:cores_per_socket] # Number of cores multiplied by sockets
+    result[:cpu_cores_per_socket] = hdw.fetch_path(:topology, :cores) || 1
+    result[:numvcpus]             = hdw.fetch_path(:topology, :sockets) || 1 # Number of sockets
+    result[:logical_cpus]         = result[:numvcpus] * result[:cpu_cores_per_socket] # Number of cores multiplied by sockets
 
     result[:memory_mb] = inv[:memory] / 1.megabyte
 

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -58,7 +58,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     160
   end
 
-  def max_cores_per_socket
+  def max_cpu_cores_per_socket
     # the default value of MaxNumOfCpuPerSocket for RHEV 3.1 - 3.4
     16
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -308,7 +308,7 @@ module ManageIQ::Providers
           result[:numvcpus] = hdw["numCpuPkgs"] unless hdw["numCpuPkgs"].blank?
           result[:logical_cpus] = hdw["numCpuCores"] unless hdw["numCpuCores"].blank?
           # Calculate the number of cores per socket by dividing total numCpuCores by numCpuPkgs
-          result[:cores_per_socket] = (result[:logical_cpus].to_f / result[:numvcpus].to_f).to_i unless hdw["numCpuCores"].blank? || hdw["numCpuPkgs"].blank?
+          result[:cpu_cores_per_socket] = (result[:logical_cpus].to_f / result[:numvcpus].to_f).to_i unless hdw["numCpuCores"].blank? || hdw["numCpuPkgs"].blank?
         end
 
         config = inv["config"]
@@ -811,8 +811,8 @@ module ManageIQ::Providers
 
         if inv["numCpu"].present?
           result[:logical_cpus] = inv["numCpu"].to_i
-          result[:cores_per_socket] = (config.try(:fetch_path, "hardware", "numCoresPerSocket") || 1).to_i
-          result[:numvcpus] = result[:logical_cpus] / result[:cores_per_socket]
+          result[:cpu_cores_per_socket] = (config.try(:fetch_path, "hardware", "numCoresPerSocket") || 1).to_i
+          result[:numvcpus] = result[:logical_cpus] / result[:cpu_cores_per_socket]
         end
 
         result[:annotation] = inv["annotation"] unless inv["annotation"].blank?

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -54,7 +54,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     end
   end
 
-  def max_cores_per_socket(_total_vcpus = nil)
+  def max_cpu_cores_per_socket(_total_vcpus = nil)
     case hardware.virtual_hw_version
     when "04"       then 1
     when "07"       then [1, 2, 4, 8].include?(max_total_vcpus) ? max_total_vcpus : 1

--- a/app/models/mixins/deprecated_cpu_methods_mixin.rb
+++ b/app/models/mixins/deprecated_cpu_methods_mixin.rb
@@ -1,0 +1,7 @@
+module DeprecatedCpuMethodsMixin
+  def self.included(base)
+    base.send(:alias_method, :cores_per_socket, :cpu_cores_per_socket)
+    base.virtual_column(:cores_per_socket, :type => :integer, :uses => :hardware)
+    Vmdb::Deprecation.deprecate_methods(base, :cores_per_socket => :cpu_cores_per_socket)
+  end
+end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1933,4 +1933,6 @@ class VmOrTemplate < ActiveRecord::Base
               end
     {:available => true,   :message => message}
   end
+
+  include DeprecatedCpuMethodsMixin
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -158,7 +158,7 @@ class VmOrTemplate < ActiveRecord::Base
   virtual_column :num_disks,                            :type => :integer,    :uses => {:hardware => :disks}
   virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
   virtual_column :logical_cpus,                         :type => :integer,    :uses => :hardware
-  virtual_column :cores_per_socket,                     :type => :integer,    :uses => :hardware
+  virtual_column :cpu_cores_per_socket,                 :type => :integer,    :uses => :hardware
   virtual_column :v_annotation,                         :type => :string,     :uses => :hardware
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
@@ -1620,8 +1620,8 @@ class VmOrTemplate < ActiveRecord::Base
     hardware.nil? ? 0 : hardware.logical_cpus
   end
 
-  def cores_per_socket
-    hardware.nil? ? 0 : hardware.cores_per_socket
+  def cpu_cores_per_socket
+    hardware.nil? ? 0 : hardware.cpu_cores_per_socket
   end
 
   def num_disks

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -24,7 +24,7 @@ class VmReconfigureRequest < MiqRequest
     options[:src_ids].to_miq_a.each do |idx|
       vm = Vm.find_by_id(idx)
       all_vcpus            << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_vcpus].min : vm.max_vcpus)
-      all_cores_per_socket << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_cores_per_socket].min : vm.max_cores_per_socket)
+      all_cores_per_socket << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_cpu_cores_per_socket].min : vm.max_cpu_cores_per_socket)
       all_total_vcpus      << (vm.host ? [vm.host.hardware.logical_cpus, vm.max_total_vcpus].min : vm.max_total_vcpus)
       all_memory << (vm.respond_to?(:max_memory_mb) ? vm.max_memory_mb : default_max_vm_memory)
     end

--- a/gems/pending/Scvmm/MiqScvmmHost.rb
+++ b/gems/pending/Scvmm/MiqScvmmHost.rb
@@ -100,9 +100,9 @@ class MiqScvmmHost
     # hardware[:number_of_nics] = nil
     hardware[:memory_mb] = (props[:TotalMemory].to_f / 1.megabyte).round
 
-    hardware[:numvcpus] = props[:PhysicalCPUCount]
-    hardware[:cores_per_socket] = props[:CoresPerCPU]
-    hardware[:logical_cpus] = hardware[:cores_per_socket].to_i * hardware[:numvcpus].to_i
+    hardware[:numvcpus]             = props[:PhysicalCPUCount]
+    hardware[:cpu_cores_per_socket] = props[:CoresPerCPU]
+    hardware[:logical_cpus]         = hardware[:cpu_cores_per_socket].to_i * hardware[:numvcpus].to_i
 
     # Guest OS summary_config['product'] = {'name' => props[:VirtualizationPlatformString]}
 

--- a/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -518,14 +518,14 @@ class MiqVimVm
     cfgProps = cfgProps["config"]
 
     cfgHash = {
-      'displayname'      => cfgProps['name'],
-      'guestos'          => cfgProps['guestId'].downcase.chomp("guest"),
-      'uuid.bios'        => cfgProps['uuid'],
-      'uuid.location'    => cfgProps['locationId'],
-      'memsize'          => cfgProps['hardware']['memoryMB'],
-      'cores_per_socket' => cfgProps['hardware']['numCoresPerSocket'],
-      'numvcpu'          => cfgProps['hardware']['numCPU'],
-      'config.version'   => cfgProps['version'],
+      'displayname'          => cfgProps['name'],
+      'guestos'              => cfgProps['guestId'].downcase.chomp("guest"),
+      'uuid.bios'            => cfgProps['uuid'],
+      'uuid.location'        => cfgProps['locationId'],
+      'memsize'              => cfgProps['hardware']['memoryMB'],
+      'cpu_cores_per_socket' => cfgProps['hardware']['numCoresPerSocket'],
+      'numvcpu'              => cfgProps['hardware']['numCPU'],
+      'config.version'       => cfgProps['version'],
     }
 
     controllerKeyHash = {}

--- a/product/reports/110_Configuration Management - Hosts/030_Hardware.yaml
+++ b/product/reports/110_Configuration Management - Hosts/030_Hardware.yaml
@@ -17,7 +17,7 @@ col_order:
 - hardware.model
 - hardware.cpu_speed
 - hardware.logical_cpus
-- hardware.cores_per_socket
+- hardware.cpu_cores_per_socket
 - hardware.memory_mb
 - hardware.number_of_nics
 timeline: 
@@ -34,7 +34,7 @@ include:
     - model
     - cpu_speed
     - logical_cpus
-    - cores_per_socket
+    - cpu_cores_per_socket
     - memory_mb
     - number_of_nics
 db: Host

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -141,9 +141,9 @@ describe ApplicationController do
       set_user_privileges
       @host = FactoryGirl.create(:host,
                                  :hardware => FactoryGirl.create(:hardware,
-                                                                 :numvcpus         => 2,
-                                                                 :cores_per_socket => 4,
-                                                                 :logical_cpus     => 8),
+                                                                 :numvcpus             => 2,
+                                                                 :cpu_cores_per_socket => 4,
+                                                                 :logical_cpus         => 8),
                                 )
       @host_service = FactoryGirl.create(:system_service, :name => "foo", :host_id => @host.id)
     end

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -162,9 +162,9 @@ describe HostController do
     set_user_privileges
     host = FactoryGirl.create(:host,
                               :hardware => FactoryGirl.create(:hardware,
-                                                              :numvcpus         => 2,
-                                                              :cores_per_socket => 4,
-                                                              :logical_cpus     => 8
+                                                              :numvcpus             => 2,
+                                                              :cpu_cores_per_socket => 4,
+                                                              :logical_cpus         => 8
                                                              )
                              )
 

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -65,20 +65,20 @@ describe VmInfraController do
                               :vmm_vendor  => 'vmware',
                               :vmm_product => "ESX",
                               :hardware    => FactoryGirl.create(:hardware,
-                                                                 :memory_mb        => 1024,
-                                                                 :logical_cpus     => 1,
-                                                                 :cores_per_socket => 1,
-                                                                 :numvcpus         => 1
+                                                                 :memory_mb            => 1024,
+                                                                 :logical_cpus         => 1,
+                                                                 :cpu_cores_per_socket => 1,
+                                                                 :numvcpus             => 1
                                                                 )
                              )
     vm = FactoryGirl.create(:vm_vmware,
                             :name     => 'b_name',
                             :host     => host,
                             :hardware => FactoryGirl.create(:hardware,
-                                                            :memory_mb          => 1024,
-                                                            :logical_cpus       => 1,
-                                                            :cores_per_socket   => 1,
-                                                            :numvcpus           => 1,
+                                                            :memory_mb            => 1024,
+                                                            :logical_cpus         => 1,
+                                                            :cpu_cores_per_socket => 1,
+                                                            :numvcpus             => 1,
                                                             :virtual_hw_version => '04'
                                                            )
                            )
@@ -94,26 +94,26 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
-  it 'the reconfigure tab for a vm with max_cores_per_socket <= 1 should not display the cores_per_socket dropdown' do
+  it 'the reconfigure tab for a vm with max_cpu_cores_per_socket <= 1 should not display the cpu_cores_per_socket dropdown' do
     host = FactoryGirl.create(:host,
                               :vmm_vendor  => 'vmware',
                               :vmm_product => "ESX",
                               :hardware    => FactoryGirl.create(:hardware,
-                                                                 :memory_mb        => 1024,
-                                                                 :logical_cpus     => 1,
-                                                                 :cores_per_socket => 1,
-                                                                 :numvcpus         => 1
+                                                                 :memory_mb            => 1024,
+                                                                 :logical_cpus         => 1,
+                                                                 :cpu_cores_per_socket => 1,
+                                                                 :numvcpus             => 1
                                                                 )
                              )
     vm = FactoryGirl.create(:vm_vmware,
                             :name     => 'b_name',
                             :host     => host,
                             :hardware => FactoryGirl.create(:hardware,
-                                                            :memory_mb          => 1024,
-                                                            :logical_cpus       => 1,
-                                                            :cores_per_socket   => 1,
-                                                            :numvcpus           => 1,
-                                                            :virtual_hw_version => "04"
+                                                            :memory_mb            => 1024,
+                                                            :logical_cpus         => 1,
+                                                            :cpu_cores_per_socket => 1,
+                                                            :numvcpus             => 1,
+                                                            :virtual_hw_version   => "04"
                                                            )
                            )
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
@@ -129,9 +129,9 @@ describe VmInfraController do
     expect(response.body).to_not include('Total Processors')
   end
 
-  it 'the reconfigure tab for a vm with max_cores_per_socket > 1 should display the cores_per_socket dropdown' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :logical_cpus => 4, :cores_per_socket => 4, :numvcpus => 1))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :logical_cpus => 1, :virtual_hw_version => "07", :cores_per_socket => 1, :numvcpus => 1))
+  it 'the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown' do
+    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :logical_cpus => 4, :cpu_cores_per_socket => 4, :numvcpus => 1))
+    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :logical_cpus => 1, :virtual_hw_version => "07", :cpu_cores_per_socket => 1, :numvcpus => 1))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -124,20 +124,20 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     )
 
     @host.hardware.should have_attributes(
-      :cpu_speed          => 2394,
-      :cpu_type           => "Intel Xeon 179",
-      :manufacturer       => "Intel",
-      :model              => "Xeon",
-      :memory_mb          => 131_059,
-      :memory_console     => nil,
-      :numvcpus           => 2,
-      :logical_cpus       => 16,
-      :cores_per_socket   => 8,
-      :guest_os           => nil,
-      :guest_os_full_name => nil,
-      #:vmotion_enabled    => true,   # TODO: Add with cluster support
-      :cpu_usage          => nil,
-      :memory_usage       => nil
+      :cpu_speed            => 2394,
+      :cpu_type             => "Intel Xeon 179",
+      :manufacturer         => "Intel",
+      :model                => "Xeon",
+      :memory_mb            => 131_059,
+      :memory_console       => nil,
+      :numvcpus             => 2,
+      :logical_cpus         => 16,
+      :cpu_cores_per_socket => 8,
+      :guest_os             => nil,
+      :guest_os_full_name   => nil,
+      #:vmotion_enabled     => true,   # TODO: Add with cluster support
+      :cpu_usage            => nil,
+      :memory_usage         => nil
     )
 
     @host.hardware.guest_devices.size.should == 5

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -108,22 +108,22 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     )
 
     @host.hardware.should have_attributes(
-      :cpu_speed          => 2000,
-      :cpu_type           => "RHEL 7.1.0 PC (i440FX + PIIX, 1996)",
-      :manufacturer       => "Red Hat",
-      :model              => "KVM",
-      :memory_mb          => 8192,
-      :memory_console     => nil,
-      :disk_capacity      => 40,
-      :numvcpus           => 4,
-      :logical_cpus       => 4,
-      :cores_per_socket   => 1,
-      :guest_os           => nil,
-      :guest_os_full_name => nil,
-      :cpu_usage          => nil,
-      :memory_usage       => nil,
-      :number_of_nics     => 1,
-      :bios               => "seabios-1.7.5-8.el7"
+      :cpu_speed            => 2000,
+      :cpu_type             => "RHEL 7.1.0 PC (i440FX + PIIX, 1996)",
+      :manufacturer         => "Red Hat",
+      :model                => "KVM",
+      :memory_mb            => 8192,
+      :memory_console       => nil,
+      :disk_capacity        => 40,
+      :numvcpus             => 4,
+      :logical_cpus         => 4,
+      :cpu_cores_per_socket => 1,
+      :guest_os             => nil,
+      :guest_os_full_name   => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil,
+      :number_of_nics       => 1,
+      :bios                 => "seabios-1.7.5-8.el7"
     )
 
     assert_specific_disk(@host.hardware.disks.first)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -183,21 +183,21 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
 
     @host.hardware.should have_attributes(
-      :cpu_speed          => 2394,
-      :cpu_type           => "Intel(R) Core(TM)2 Quad CPU    Q6600  @ 2.40GHz",
-      :manufacturer       => "",
-      :model              => "",
-      :number_of_nics     => nil,
-      :memory_mb          => 7806,
-      :memory_console     => nil,
-      :numvcpus           => 1,
-      :logical_cpus       => 4,
-      :cores_per_socket   => 4,
-      :guest_os           => nil,
-      :guest_os_full_name => nil,
-      :vmotion_enabled    => nil,
-      :cpu_usage          => nil,
-      :memory_usage       => nil
+      :cpu_speed            => 2394,
+      :cpu_type             => "Intel(R) Core(TM)2 Quad CPU    Q6600  @ 2.40GHz",
+      :manufacturer         => "",
+      :model                => "",
+      :number_of_nics       => nil,
+      :memory_mb            => 7806,
+      :memory_console       => nil,
+      :numvcpus             => 1,
+      :logical_cpus         => 4,
+      :cpu_cores_per_socket => 4,
+      :guest_os             => nil,
+      :guest_os_full_name   => nil,
+      :vmotion_enabled      => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil
     )
 
     @host.hardware.networks.size.should == 2
@@ -563,14 +563,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     v.snapshots.size.should == 0
 
     v.hardware.should have_attributes(
-      :guest_os           => "rhel_6x64",
-      :guest_os_full_name => nil,
-      :bios               => nil,
-      :numvcpus           => 2,
-      :cores_per_socket   => 1,
-      :logical_cpus       => 2,
-      :annotation         => "Template for EmsRefresh testing",
-      :memory_mb          => 1024
+      :guest_os             => "rhel_6x64",
+      :guest_os_full_name   => nil,
+      :bios                 => nil,
+      :numvcpus             => 2,
+      :cpu_cores_per_socket => 1,
+      :logical_cpus         => 2,
+      :annotation           => "Template for EmsRefresh testing",
+      :memory_mb            => 1024
     )
 
     v.hardware.disks.size.should == 2

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -199,21 +199,21 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
 
     @host.hardware.should have_attributes(
-      :cpu_speed          => 1995,
-      :cpu_type           => "Intel(R) Xeon(R) CPU           E5504  @ 2.00GHz",
-      :manufacturer       => "",
-      :model              => "",
-      :number_of_nics     => nil,
-      :memory_mb          => 56333,
-      :memory_console     => nil,
-      :numvcpus           => 2,
-      :logical_cpus       => 8,
-      :cores_per_socket   => 4,
-      :guest_os           => nil,
-      :guest_os_full_name => nil,
-      :vmotion_enabled    => nil,
-      :cpu_usage          => nil,
-      :memory_usage       => nil
+      :cpu_speed            => 1995,
+      :cpu_type             => "Intel(R) Xeon(R) CPU           E5504  @ 2.00GHz",
+      :manufacturer         => "",
+      :model                => "",
+      :number_of_nics       => nil,
+      :memory_mb            => 56333,
+      :memory_console       => nil,
+      :numvcpus             => 2,
+      :logical_cpus         => 8,
+      :cpu_cores_per_socket => 4,
+      :guest_os             => nil,
+      :guest_os_full_name   => nil,
+      :vmotion_enabled      => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil
     )
 
     @host.hardware.networks.size.should == 2
@@ -299,14 +299,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     snapshot.parent.should be_nil
 
     v.hardware.should have_attributes(
-      :guest_os           => "rhel_6x64",
-      :guest_os_full_name => nil,
-      :bios               => nil,
-      :cores_per_socket   => 1,
-      :logical_cpus       => 2,
-      :numvcpus           => 2,
-      :annotation         => "Powered On VM for EmsRefresh testing with DirectLUN Disk",
-      :memory_mb          => 1024
+      :guest_os             => "rhel_6x64",
+      :guest_os_full_name   => nil,
+      :bios                 => nil,
+      :cpu_cores_per_socket => 1,
+      :logical_cpus         => 2,
+      :numvcpus             => 2,
+      :annotation           => "Powered On VM for EmsRefresh testing with DirectLUN Disk",
+      :memory_mb            => 1024
     )
 
     v.hardware.disks.size.should == 3
@@ -583,14 +583,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     v.snapshots.size.should == 0
 
     v.hardware.should have_attributes(
-      :guest_os           => "rhel_6x64",
-      :guest_os_full_name => nil,
-      :bios               => nil,
-      :numvcpus           => 2,
-      :cores_per_socket   => 1,
-      :logical_cpus       => 2,
-      :annotation         => "Template for EmsRefresh testing",
-      :memory_mb          => 1024
+      :guest_os             => "rhel_6x64",
+      :guest_os_full_name   => nil,
+      :bios                 => nil,
+      :numvcpus             => 2,
+      :cpu_cores_per_socket => 1,
+      :logical_cpus         => 2,
+      :annotation           => "Template for EmsRefresh testing",
+      :memory_mb            => 1024
     )
 
     v.hardware.disks.size.should == 2

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -82,8 +82,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       expect(vm.max_total_vcpus).to eq(160)
     end
 
-    it "#max_cores_per_socket" do
-      expect(vm.max_cores_per_socket).to eq(16)
+    it "#max_cpu_cores_per_socket" do
+      expect(vm.max_cpu_cores_per_socket).to eq(16)
     end
 
     it "#max_vcpus" do

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -30,7 +30,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems  = FactoryGirl.create(:ems_redhat_with_authentication, :zone => zone)
-      @hw   = FactoryGirl.create(:hardware, :memory_mb => 1024, :numvcpus => 2, :cores_per_socket => 1)
+      @hw   = FactoryGirl.create(:hardware, :memory_mb => 1024, :numvcpus => 2, :cpu_cores_per_socket => 1)
       @vm   = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems)
 
       @cores_per_socket = 2

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
@@ -21,9 +21,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::RefreshParser do
       def assert_cores_and_sockets_values(total, cores, sockets)
         result = described_class.vm_inv_to_hardware_hash(inv)
 
-        expect(result[:numvcpus]).to         eq(sockets)
-        expect(result[:cores_per_socket]).to eq(cores)
-        expect(result[:logical_cpus]).to     eq(total)
+        expect(result[:numvcpus]).to             eq(sockets)
+        expect(result[:cpu_cores_per_socket]).to eq(cores)
+        expect(result[:logical_cpus]).to         eq(total)
       end
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -223,21 +223,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     )
 
     @host.hardware.should have_attributes(
-      :cpu_speed          => 2127,
-      :cpu_type           => "Intel(R) Xeon(R) CPU           E5506  @ 2.13GHz",
-      :manufacturer       => "Dell Inc.",
-      :model              => "PowerEdge R410",
-      :number_of_nics     => 4,
-      :memory_mb          => 57334,
-      :memory_console     => nil,
-      :numvcpus           => 2,
-      :logical_cpus       => 8,
-      :cores_per_socket   => 4,
-      :guest_os           => "ESXi",
-      :guest_os_full_name => "ESXi",
-      :vmotion_enabled    => true,
-      :cpu_usage          => 6789,
-      :memory_usage       => 36508
+      :cpu_speed            => 2127,
+      :cpu_type             => "Intel(R) Xeon(R) CPU           E5506  @ 2.13GHz",
+      :manufacturer         => "Dell Inc.",
+      :model                => "PowerEdge R410",
+      :number_of_nics       => 4,
+      :memory_mb            => 57334,
+      :memory_console       => nil,
+      :numvcpus             => 2,
+      :logical_cpus         => 8,
+      :cpu_cores_per_socket => 4,
+      :guest_os             => "ESXi",
+      :guest_os_full_name   => "ESXi",
+      :vmotion_enabled      => true,
+      :cpu_usage            => 6789,
+      :memory_usage         => 36508
     )
 
     @host.hardware.networks.size.should == 2

--- a/spec/models/metric/processing_spec.rb
+++ b/spec/models/metric/processing_spec.rb
@@ -72,10 +72,10 @@ describe Metric::Processing do
       let(:vm) do
         FactoryGirl.create(:vm_vmware, :hardware =>
           FactoryGirl.create(:hardware,
-                             :logical_cpus     => 8,
-                             :numvcpus         => 4,
-                             :cores_per_socket => 2,
-                             :cpu_speed        => 3_000,
+                             :logical_cpus         => 8,
+                             :numvcpus             => 4,
+                             :cpu_cores_per_socket => 2,
+                             :cpu_speed            => 3_000,
                             )
                           )
       end

--- a/spec/models/mixins/aggregation_mixin_spec.rb
+++ b/spec/models/mixins/aggregation_mixin_spec.rb
@@ -6,11 +6,11 @@ describe AggregationMixin do
       2.times.collect do
         FactoryGirl.create(:host,
                            :hardware => FactoryGirl.create(:hardware,
-                                                           :numvcpus         => 2,
-                                                           :cores_per_socket => 4,
-                                                           :logical_cpus     => 8,
-                                                           :cpu_speed        => 2_999,
-                                                           :disk_capacity    => 40
+                                                           :numvcpus             => 2,
+                                                           :cpu_cores_per_socket => 4,
+                                                           :logical_cpus         => 8,
+                                                           :cpu_speed            => 2_999,
+                                                           :disk_capacity        => 40
                                                           )
                           )
       end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -134,7 +134,7 @@ describe VmOrTemplate do
     before do
       @vm       =  FactoryGirl.create(:vm_vmware)
       FactoryGirl.create(:hardware, :vm_or_template_id => @vm.id, :memory_mb => 1024)
-      @options  = {:hdw_attr => :memory_mb}
+      @options = {:hdw_attr => :memory_mb}
     end
 
     it "with no drift states" do

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe VmReconfigureRequest do
   let(:admin)         { FactoryGirl.create(:user, :userid => "tester") }
   let(:ems_vmware)    { FactoryGirl.create(:ems_vmware, :zone => zone2) }
-  let(:host_hardware) { FactoryGirl.build(:hardware, :logical_cpus => 40, :numvcpus => 10, :cores_per_socket => 4) }
+  let(:host_hardware) { FactoryGirl.build(:hardware, :logical_cpus => 40, :numvcpus => 10, :cpu_cores_per_socket => 4) }
   let(:host)          { FactoryGirl.build(:host, :hardware => host_hardware) }
   let(:request)       { FactoryGirl.create(:vm_reconfigure_request, :userid => admin.userid) }
   let(:vm_hardware)   { FactoryGirl.build(:hardware, :virtual_hw_version => "07") }


### PR DESCRIPTION
Stop using deprecated cores_per_socket attribute in favor of cpu_cores_per_socket

Based on #5055
See #4630