### PR TITLE
Replace eval function by parsing condition entered in report filter tab

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -192,9 +192,10 @@ class Condition < ActiveRecord::Base
 
     if checkmode == "count"
       e = check.gsub(/<count>/i, list.length.to_s)
+      left, operator, right = e.split
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Check Expression after substitution: [#{e}]")
       _ = inputs # used by eval (presumably?)
-      result = !!proc { $SAFE = 3; eval(e) }.call
+      result = !!left.to_f.send(operator, right.to_f)
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Check Expression result: [#{result}]")
       return result
     end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -25,9 +25,15 @@ describe Condition do
         Condition.subst(expr, @cluster, nil).should be_true
       end
 
-      it "invalid expression" do
+      it "invalid expression should not raise security error because it is now parsed and not evaluated" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2; system('ls /etc')</check></find>"
-        -> { Condition.subst(expr, @cluster, nil) }.should raise_error(SecurityError)
+        -> { Condition.subst(expr, @cluster, nil) }.should_not raise_error(SecurityError)
+      end
+
+      it "valid expression as a tainted object should not raise security error" do
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> >= 0</check></find>"
+        expr.taint
+        -> { Condition.subst(expr, @cluster, nil) }.should_not raise_error(SecurityError)
       end
     end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cagi?id=1273529

It will no longer call eval and instead evaluate the expression in ruby method calls. This fixes a bug where valid expressions were failing because the expression string that was being passed to eval was tainted.

This part has been taken from https://github.com/ManageIQ/manageiq/pull/3806 as temporary solution for this BZ.

@gtanzillo please review