### PR TITLE
Use the router when fetching assets

### DIFF
--- a/spa_ui/self_service/server/app.js
+++ b/spa_ui/self_service/server/app.js
@@ -48,9 +48,9 @@ switch (environment) {
   default:
     console.log('** DEV **');
     router.use(express.static('./client/'));
-    app.use(express.static('./client/assets'));
+    router.use(express.static('./tmp'));
+    router.use(express.static('./client/assets'));
     app.use(express.static('./'));
-    app.use(express.static('./tmp'));
     // Any invalid calls for templateUrls are under app/* and should return 404
     router.use('/app/*', function(req, res) {
       four0four.send404(req, res);


### PR DESCRIPTION
The express router is configured with a base of `self_service` so relatively pathed asset files were not being found correctly.

Addresses an issue affecting development of self_service ui only.