### PR TITLE
Add default reports for watermark reporting

### DIFF
--- a/product/reports/120_Configuration Management - Providers/040_Watermark Host Sockets per Provider.yaml
+++ b/product/reports/120_Configuration Management - Providers/040_Watermark Host Sockets per Provider.yaml
@@ -1,0 +1,57 @@
+---
+dims:
+title: Watermark Host Sockets per Provider
+conditions:
+order: Ascending
+graph:
+menu_name: Watermark Host Sockets per Provider
+rpt_group: Custom
+priority:
+col_order:
+- v_month
+- resource_name
+- derived_host_sockets__max
+timeline:
+file_mtime:
+categories: []
+rpt_type: Custom
+filename:
+include: {}
+db: ExtManagementSystemPerformance
+cols:
+- v_month
+- resource_name
+- derived_host_sockets
+template_type: report
+group:
+sortby:
+- v_month
+- resource_name
+headers:
+- Activity Sample - Month (YYYY/MM)
+- Asset Name
+- Host Sockets (Max)
+where_clause:
+db_options:
+  :interval: daily
+  :calc_avgs_by: time_interval
+  :end_offset: 0
+  :start_offset: 172800
+generate_cols:
+generate_rows:
+col_formats:
+-
+-
+-
+tz: UTC
+time_profile_id: 1
+display_filter:
+col_options: {}
+rpt_options:
+  :pivot:
+    :group_cols:
+    - v_month
+    - resource_name
+  :pdf:
+    :page_size: US-Letter
+  :queue_timeout:

--- a/product/reports/120_Configuration Management - Providers/050_Watermark Vms per Provider.yaml
+++ b/product/reports/120_Configuration Management - Providers/050_Watermark Vms per Provider.yaml
@@ -1,0 +1,57 @@
+---
+dims:
+title: Watermark VMs per Provider
+conditions:
+order: Ascending
+graph:
+menu_name: Watermark VMs per Provider
+rpt_group: Custom
+priority:
+col_order:
+- v_month
+- resource_name
+- derived_vm_count_total__max
+timeline:
+file_mtime:
+categories: []
+rpt_type: Custom
+filename:
+include: {}
+db: ExtManagementSystemPerformance
+cols:
+- v_month
+- resource_name
+- derived_vm_count_total
+template_type: report
+group:
+sortby:
+- v_month
+- resource_name
+headers:
+- Activity Sample - Month (YYYY/MM)
+- Asset Name
+- VM Count Total (Max)
+where_clause:
+db_options:
+  :interval: daily
+  :calc_avgs_by: time_interval
+  :end_offset: 0
+  :start_offset: 172800
+generate_cols:
+generate_rows:
+col_formats:
+-
+-
+-
+tz:
+time_profile_id:
+display_filter:
+col_options: {}
+rpt_options:
+  :pivot:
+    :group_cols:
+    - v_month
+    - resource_name
+  :pdf:
+    :page_size: US-Letter
+  :queue_timeout:


### PR DESCRIPTION
@gtanzillo I had to alter the reports we generated a bit in order to get them to seed correctly. I also removed the user and evm group info from them.

This is blocked by https://github.com/ManageIQ/manageiq/pull/5006 which provides the backend support for these new reports.

@miq-bot add-label enhancement, core, reporting