### PR TITLE
Use inverse_of to prevent a query and a duplicate object

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -30,20 +30,20 @@ class ExtManagementSystem < ActiveRecord::Base
 
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify, :inverse_of => :ext_management_system
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate", :inverse_of => :ext_management_system
-  has_many :miq_templates,     :foreign_key => :ems_id
-  has_many :vms,               :foreign_key => :ems_id
+  has_many :miq_templates,     :foreign_key => :ems_id, :inverse_of => :ext_management_system
+  has_many :vms,               :foreign_key => :ems_id, :inverse_of => :ext_management_system
 
-  has_many :ems_events,     -> { order "timestamp" }, :class_name => "EmsEvent",    :foreign_key => "ems_id"
+  has_many :ems_events,     -> { order "timestamp" }, :class_name => "EmsEvent",    :foreign_key => "ems_id", :inverse_of => :ext_management_system
   has_many :policy_events,  -> { order "timestamp" }, :class_name => "PolicyEvent", :foreign_key => "ems_id"
 
-  has_many :blacklisted_events, :foreign_key => "ems_id", :dependent => :destroy
-  has_many :ems_folders,    :foreign_key => "ems_id", :dependent => :destroy
-  has_many :ems_clusters,   :foreign_key => "ems_id", :dependent => :destroy
-  has_many :resource_pools, :foreign_key => "ems_id", :dependent => :destroy
+  has_many :blacklisted_events, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :ems_folders,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :ems_clusters,   :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :resource_pools, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
-  has_many :customization_specs, :foreign_key => "ems_id", :dependent => :destroy
+  has_many :customization_specs, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
-  has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy
+  has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   belongs_to :zone
 

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -8,7 +8,7 @@ class GuestDevice < ActiveRecord::Base
   belongs_to :switch    # pNICs link to one switch
   belongs_to :lan       # vNICs link to one lan
 
-  has_one :network, :foreign_key => "device_id", :dependent => :destroy
+  has_one :network, :foreign_key => "device_id", :dependent => :destroy, :inverse_of => :guest_device
   has_many :miq_scsi_targets, :dependent => :destroy
 
   include ReportableMixin

--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -1,5 +1,5 @@
 class IsoDatastore < ActiveRecord::Base
-  belongs_to :ext_management_system, :foreign_key => :ems_id
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :iso_datastore
   has_many   :iso_images, :dependent => :destroy
 
   include ReportableMixin

--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -2,7 +2,7 @@ module MiqServer::ConfigurationManagement
   extend ActiveSupport::Concern
 
   included do
-    has_many :configurations, :dependent => :destroy
+    has_many :configurations, :dependent => :destroy, :inverse_of => :miq_server
   end
 
   module ClassMethods

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,6 +1,6 @@
 class Network < ActiveRecord::Base
   belongs_to :hardware
-  belongs_to :guest_device, :foreign_key => "device_id"
+  belongs_to :guest_device, :foreign_key => "device_id", :inverse_of => :network
 
   include ReportableMixin
 


### PR DESCRIPTION
When following both sides of an association in some situations, you
need to give Active Record a hint as to the inverse name or else it
will run an additional query and build a completely new duplicated
object.

You have to specify the inverse_of if you have both sides of an
association and have:
  scope
  conditions
  through
  polymorphic
  foreign_key

In some situations, it might not be possible to specify an inverse_of.

Example:

e = ExtManagementSystem.first
e.vms.first.ext_management_system            # <--- New query, new Ems
e.miq_templates.first.ext_management_system  # <--- New query, new Ems
e.resource_pools.first.ext_management_system # <--- New query, new Ems
e.ems_clusters.first.ext_management_system   # <--- New query, new Ems
...

Where this becomes a problem is when we we're building trees of objects
and the root of the tree, ExtManagementSystem in many cases, is duplicated
in not only via queries but also a different object.

For example:

```ruby
obj1 = ExtManagementSystem.first
obj2 = obj1.vms.first.ext_management_system

puts obj1.object_id == obj2.object_id
 # Before: => false
 # After: ==> true

GC.start
puts ObjectSpace.each_object(ExtManagementSystem) {}
 # Before: ==> 2
 # After:  ==> 1

obj1.vms.to_a; nil
GC.start
puts ObjectSpace.each_object(Vm) {}
 # Before: ==> 3000
 # After:  ==> 3000

obj2.vms.to_a; nil
GC.start
puts ObjectSpace.each_object(Vm) {}
 # Before: ==> 6000
 # After:  ==> 3000
```

It's important to realize that as long as obj1 and obj2 are in scope,
the 6000 vms (3000 duped once) will stay in memory and referenced.