### PR TITLE
Fix handsoap debug logging in the broker.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -65,7 +65,7 @@ group :appliance do
 end
 
 # Locally modified but not required
-gem "handsoap", "~>0.2.5", :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-2"
+gem "handsoap", "~>0.2.5", :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-3"
 gem "rubywbem",            :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
 
 # Windows only. Do not put in Gemfile.lock on other platforms.

--- a/gems/pending/VMwareWebService/MiqVimClientBase.rb
+++ b/gems/pending/VMwareWebService/MiqVimClientBase.rb
@@ -25,7 +25,7 @@ class MiqVimClientBase < VimService
     end
 
     on_log_header { |msg| $vim_log.info msg }
-    on_log_body   { |msg| $vim_log.debug msg if $miq_wiredump }
+    on_log_body   { |msg| $vim_log.debug msg } if $miq_wiredump
 
     super(:uri => sdk_uri, :version => 1)
 


### PR DESCRIPTION
Requires https://github.com/ManageIQ/handsoap/pull/1 as well as a new tag on the handsoap_1_2_5 branch.

Prior to the handsoap change, if the client sets the log_header_callback,
but not the log_body_callback, debug would still be set to true. In the
post-response case, this would cause the XML to be pretty formatted for
no reason at all, which can be incredibly expensive. This new code only
does the message processing if the callback has been set.

To leverage these new savings, we must ensure in the broker that we are
not setting the log_body_callback when not necessary.

Broker RSS memory, post handsoap response, with a large environment on
the initial preload:
Before 564.1MB / After 444.8MB / Savings 119.3MB (~21.1%)

@matthewd @jrafanie @dmetzger57 @chessbyte Please review.