### PR TITLE
Free the raw XML from the response object early in the broker for GC.

### DIFF
--- a/gems/pending/VMwareWebService/VimService.rb
+++ b/gems/pending/VMwareWebService/VimService.rb
@@ -1173,6 +1173,14 @@ class VimService < Handsoap::Service
   def parse_response(response, rType)
     doc  = response.document
     raise "Response <#{response.inspect}> has no XML document" if doc.nil?
+
+    # At this point we don't need the internal raw XML content since we
+    #   have the parsed XML document, so we can free it for the GC.
+    response.instance_variable_set(:@http_body, nil)
+    # Force a GC, because Ruby's GC is triggered on number of objects without
+    #   regard to size.  The object we just freed may not be released right away.
+    GC.start
+
     search_path = "//n1:#{rType}"
     node = doc.xpath(search_path, @ns).first
     raise "Node (search=<#{search_path}> namespace=<#{@ns}>) not found in XML document <#{doc.inspect}>" if node.nil?


### PR DESCRIPTION
@matthewd @jrafanie @dmetzger57 Please review.  I tried this out locally on my Mac, but would like to see numbers from other systems.

---

The numbers show a large drop in both RSS and VIRT memory, but I really don't understand why it happens in the place that it does.  In addition, I *have* to put the `GC.start` as in this patch or you don't see the memory savings.

Also:  RESPONSE SIZE httpclient post:   30,306,245

Before:

| Location | RSS | VIRT |
| --- | --- | --- |
| MEMORY AFTER [response.document](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/VimService.rb#L1174)  |   479,961,088 | 3,054,444,544 |
| MEMORY AFTER [unmarshal response](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/VimService.rb#L1184) | 1,009,762,304 | 3,625,177,088 |
| MEMORY AFTER [creating the cache](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/MiqVimUpdate.rb#L36-L42) | 1,107,177,472 | 3,746,811,904 |
| MEMORY AFTER ["helping" the GC](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/MiqVimUpdate.rb#L44-L45)   | 1,107,185,664 | 3,746,811,904 |
| MEMORY BEFORE [waitForUpdates](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/MiqVimUpdate.rb#L63)    | 1,107,222,528 | 3,747,872,768 |

After:

| Location | RSS | VIRT |
| --- | --- | --- |
| MEMORY AFTER [response.document](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/VimService.rb#L1174)  |   478,932,992 | 3,063,881,728 |
| MEMORY BEFORE http_body release |   478,937,088 | 3,063,881,728 |
| MEMORY AFTER http_body release  |   478,941,184 | 3,063,881,728 |
| MEMORY AFTER [unmarshal response](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/VimService.rb#L1184) |   997,842,944 | 3,618,885,632 |
| MEMORY AFTER [creating the cache](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/MiqVimUpdate.rb#L36-L42) | 1,096,617,984 | 3,749,957,632 |
| MEMORY AFTER ["helping" the GC](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/MiqVimUpdate.rb#L44-L45)   |   852,299,776 | 3,505,639,424 |
| MEMORY BEFORE [waitForUpdates](https://github.com/ManageIQ/manageiq/blob/41476af42f379ce7de0f4ad1f31dc9dd932de733/gems/pending/VMwareWebService/MiqVimUpdate.rb#L63)    |   850,243,584 | 3,504,603,136 |

Note that in order to verify that "helping" the GC does what it says, I did a manual GC.start immediately after it (which is not in the PR).

So, as you can see, the savings is not where I'd expect at "http_body release", but instead at "helping the GC", however, using dumps I verified that the big XML string is definitely gone immediately after "http_body release".  The only thing I can think of is that since the String is big, it's all in the malloc space not in the Ruby object heap, and thus that free area in the malloc space is realized later on.