### PR TITLE
Fixed displaying of empty table in Service Dialog

### DIFF
--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -343,7 +343,7 @@
 
   - if @edit[:field_typ] =~ /Drop|Radio/ && !@edit[:field_dynamic]
     = render :partial => 'field_values', :locals => {:entry => nil}
-  - elsif @edit[:field_typ] && @edit[:field_typ].include?("TagControl") && @edit[:field_category]
+  - elsif @edit[:field_typ] && @edit[:field_typ].include?("TagControl") && @edit[:field_category].present?
     = render :partial => 'tag_field_values', :locals => {:entry => nil}
 
   - unless @edit[:field_typ].nil?

--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -310,15 +310,16 @@
                           :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent('field_sort_by', "#{url}")
-        .form-group
-          %label.col-md-2.control-label
-            = _('Sort Order')
-          .col-md-8
-            = select_tag('field_sort_order',
-                          options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
-                          :class    => "selectpicker")
-            :javascript
-              miqSelectPickerEvent('field_sort_order', "#{url}")
+        - if @edit[:field_sort_by] != "none"
+          .form-group
+            %label.col-md-2.control-label
+              = _('Sort Order')
+            .col-md-8
+              = select_tag('field_sort_order',
+                            options_for_select([[_("Ascending"), "ascending"], [_("Descending"), "descending"]], @edit[:field_sort_order]),
+                            :class    => "selectpicker")
+              :javascript
+                miqSelectPickerEvent('field_sort_order', "#{url}")
         .form-group
           %label.col-md-2.control-label
             = _('Required')

--- a/app/views/miq_ae_customization/_field_values.html.haml
+++ b/app/views/miq_ae_customization/_field_values.html.haml
@@ -1,21 +1,20 @@
 #field_values_div
   = form_tag(url_for(:action => 'field_value_accept', :id => "#{@record.id || 'new'}"), :remote => true) do
-    %fieldset
-      %h3= _('Entries')
-      = render :partial => "layouts/flash_msg"
-      %table.table.table-striped.table-bordered.table-hover
-        %thead
-          %tr
-            %th.narrow
-            %th.title= _('Value')
-            %th.title= _('Description')
-        %tbody
-          - if entry == "new"
-            = render :partial => "field_value_entry", :locals => {:entry => "new", :edit => true}
+    %h3= _('Entries')
+    = render :partial => "layouts/flash_msg"
+    %table.table.table-striped.table-bordered.table-hover
+      %thead
+        %tr
+          %th.narrow
+          %th.title= _('Value')
+          %th.title= _('Description')
+      %tbody
+        - if entry == "new"
+          = render :partial => "field_value_entry", :locals => {:entry => "new", :edit => true}
+        - else
+          = render :partial => "field_value_entry", :locals => {:entry => "new", :edit => false}
+        - @edit[:field_values].each_with_index do |e, i|
+          - if !entry.nil? && entry != "new" && entry.to_i == i
+            = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => true}
           - else
-            = render :partial => "field_value_entry", :locals => {:entry => "new", :edit => false}
-          - @edit[:field_values].each_with_index do |e, i|
-            - if !entry.nil? && entry != "new" && entry.to_i == i
-              = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => true}
-            - else
-              = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => false}
+            = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => false}

--- a/app/views/miq_ae_customization/_tag_field_values.html.haml
+++ b/app/views/miq_ae_customization/_tag_field_values.html.haml
@@ -1,13 +1,12 @@
 #field_values_div
-  %fieldset
-    %h3= _('Category Tag Entries')
-    %table.table.table-striped.table-bordered
-      %thead
+  %h3= _('Category Tag Entries')
+  %table.table.table-striped.table-bordered
+    %thead
+      %tr
+        %th= _('Value')
+        %th= _('Description')
+    %tbody
+      - DialogFieldTagControl.category_tags(@edit[:field_category]).each do |cat|
         %tr
-          %th= _('Value')
-          %th= _('Description')
-      %tbody
-        - DialogFieldTagControl.category_tags(@edit[:field_category]).each do |cat|
-          %tr
-            %td= cat[:name]
-            %td= cat[:description]
+          %td= cat[:name]
+          %td= cat[:description]


### PR DESCRIPTION
In Service Dialog editor, with `Tag Control` element selected:

After choosing `Category`, table is displayed, but after selecting default value (`<Choose>`), table stays with empty body.

This PR fixes the issue.

\+ also removed `%fieldset` tag around table (see screenshots):

Before:
![screencapture-localhost-3000-miq_ae_customization-explorer-1445772247724](https://cloud.githubusercontent.com/assets/1187051/10715382/62920520-7b15-11e5-982f-81d3f8197d2a.png)
After:
![screencapture-localhost-3000-miq_ae_customization-explorer-1445772220033](https://cloud.githubusercontent.com/assets/1187051/10715383/6e046c72-7b15-11e5-8a83-b343721e36f6.png)
