### PR TITLE
Fix topology exception when vm is off

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -30,8 +30,10 @@ class ContainerTopologyService
         links << build_link(n.ems_ref, n.lives_on.uid_ems)
         if kind == 'VM' # add link to Host
           host = n.lives_on.host
-          topo_items[host.uid_ems] = build_entity_data(host, "Host")
-          links << build_link(n.lives_on.uid_ems, host.uid_ems)
+          if host
+            topo_items[host.uid_ems] = build_entity_data(host, "Host")
+            links << build_link(n.lives_on.uid_ems, host.uid_ems)
+          end
         end
       end
     end

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -41,23 +41,43 @@ describe ContainerTopologyService do
 
     it "topology contains the expected structure and content" do
       ems = FactoryGirl.create(:ems_kubernetes)
+      # vm and host test cross provider correlation to infra provider
+      vm_rhev = FactoryGirl.create(:vm_redhat, :name => "vm1", :id => 35,
+                                   :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998")
+      vm_rhev.stub(:power_state).and_return("on")
+
+      host = FactoryGirl.create(:host, :name => "host1", :id => 25,
+                                :uid_ems => "abcd9a08-7b13-11e5-8546-129aa6621999",
+                                :hardware => FactoryGirl.create(:hardware,
+                                                                :numvcpus         => 2,
+                                                                :cores_per_socket => 4,
+                                                                :logical_cpus     => 8))
+      vm_rhev.update_attribute(:host, host)
+
       container_condition = ContainerCondition.create(:name => 'Ready', :status => 'True')
       container = Container.create(:name => "ruby-example", :id => 10, :ems_ref => '3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift
 /mysql-55-centos7:latest', :state => 'running')
       container_def = ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container)
 
-      container_node = ContainerNode.create(:ext_management_system => ems, :id => 1, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition])
-      container_replicator = ContainerReplicator.create(:ext_management_system => ems, :id => 7, :ems_ref => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
+      container_node = ContainerNode.create(:ext_management_system => ems, :id => 1,
+                                            :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
+                                            :container_conditions => [container_condition], :lives_on => vm_rhev)
+      container_replicator = ContainerReplicator.create(:ext_management_system => ems, :id => 7,
+                                                        :ems_ref => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
                                                         :name => "replicator1")
       container_route = ContainerRoute.create(:ext_management_system => ems, :id => 11, :ems_ref => "ab5za74c-3a41-11e5-a79a-001a4a231290",
-                                                        :name => "route-edge")
-      container_group = ContainerGroup.create(:ext_management_system => ems, :id => 15, :container_node => container_node, :container_replicator => container_replicator, :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb", :phase => "Running", :container_definitions => [container_def])
-      container_service = ContainerService.create(:ext_management_system => ems, :id => 3, :container_groups => [container_group], :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                              :name => "route-edge")
+      container_group = ContainerGroup.create(:ext_management_system => ems, :id => 15,
+                                              :container_node => container_node, :container_replicator => container_replicator,
+                                              :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
+                                              :phase => "Running", :container_definitions => [container_def])
+      container_service = ContainerService.create(:ext_management_system => ems, :id => 3, :container_groups => [container_group],
+                                                  :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name => "service1", :container_routes => [container_route])
       container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
       topology = container_topology_service.build_topology
-      topology[:items].size.should eql 6
-      topology[:relations].size.should eql 5
+      topology[:items].size.should eql 8
+      topology[:relations].size.should eql 7
 
       topology[:items].key? "905c90ba-3e00-11e5-a0d2-18037327aaeb"
 
@@ -73,13 +93,79 @@ describe ContainerTopologyService do
                                                                           :status => "Unknown", :kind => "Route", :miq_id => 11)
       topology[:items]["3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest"].should eql(:id => "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest", :name => "ruby-example", :status => "Running", :kind => "Container",  :miq_id => 10)
 
+      topology[:items]["558d9a08-7b13-11e5-8546-129aa6621998"].should eql(:id => "558d9a08-7b13-11e5-8546-129aa6621998",
+                                                                          :name => "vm1", :status => "On", :kind => "VM", :miq_id => 35)
+      topology[:items]["abcd9a08-7b13-11e5-8546-129aa6621999"].should eql(:id => "abcd9a08-7b13-11e5-8546-129aa6621999",
+                                                                          :name => "host1", :status => "On", :kind => "Host", :miq_id => 25)
 
-      topology[:relations].should include(:source => "96c35ccd-3e00-11e5-a0d2-18037327aaeb", :target => "8f8ca74c-3a41-11e5-a79a-001a4a231290")
-      topology[:relations].should include(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb", :target => "ab5za74c-3a41-11e5-a79a-001a4a231290")
+      topology[:relations].should include(:source => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
+                                          :target => "8f8ca74c-3a41-11e5-a79a-001a4a231290")
+      topology[:relations].should include(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                          :target => "ab5za74c-3a41-11e5-a79a-001a4a231290")
+      # cross provider correlations
+      topology[:relations].should include(:source => "558d9a08-7b13-11e5-8546-129aa6621998",
+                                          :target => "abcd9a08-7b13-11e5-8546-129aa6621999")
+      topology[:relations].should include(:source => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
+                                          :target => "558d9a08-7b13-11e5-8546-129aa6621998")
     end
   end
 
-  describe "#entities" do
+  it "topology contains the expected structure when vm is off" do
+    ems = FactoryGirl.create(:ems_kubernetes)
+    # vm and host test cross provider correlation to infra provider
+    vm_rhev = FactoryGirl.create(:vm_redhat, :name => "vm1", :id => 35, :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998")
+    vm_rhev.stub(:power_state).and_return("off")
+
+    container_condition = ContainerCondition.create(:name => 'Ready', :status => 'True')
+    container = Container.create(:name => "ruby-example", :id => 10,
+                                 :ems_ref => '3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift
+/mysql-55-centos7:latest', :state => 'running')
+    container_def = ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9',
+                                               :container => container)
+
+    container_node = ContainerNode.create(:ext_management_system => ems, :id => 1, :name => "127.0.0.1",
+                                          :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
+                                          :container_conditions => [container_condition], :lives_on => vm_rhev)
+
+    container_group = ContainerGroup.create(:ext_management_system => ems, :id => 15, :container_node => container_node,
+                                            :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
+                                            :phase => "Running", :container_definitions => [container_def])
+    container_service = ContainerService.create(:ext_management_system => ems, :id => 3, :container_groups => [container_group],
+                                                :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                :name => "service1")
+    container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
+    topology = container_topology_service.build_topology
+    topology[:items].size.should eql 5
+    topology[:relations].size.should eql 4
+
+    topology[:items].key? "905c90ba-3e00-11e5-a0d2-18037327aaeb"
+
+    topology[:items]["905c90ba-3e00-11e5-a0d2-18037327aaeb"].should eql(:id => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
+                                                                        :name => "127.0.0.1",
+                                                                        :status => "Ready", :kind => "Node", :miq_id => 1)
+    topology[:items]["95e49048-3e00-11e5-a0d2-18037327aaeb"].should eql(:id => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                                                        :name => "service1",
+                                                                        :status => "Unknown", :kind => "Service", :miq_id => 3)
+    topology[:items]["96c35ccd-3e00-11e5-a0d2-18037327aaeb"].should eql(:id => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
+                                                                        :name => "myPod",
+                                                                        :status => "Running", :kind => "Pod", :miq_id => 15)
+    topology[:items]["3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest"].should eql(:id => "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest", :name => "ruby-example", :status => "Running", :kind => "Container",  :miq_id => 10)
+
+    topology[:items]["558d9a08-7b13-11e5-8546-129aa6621998"].should eql(:id => "558d9a08-7b13-11e5-8546-129aa6621998",
+                                                                        :name => "vm1", :status => "Off",
+                                                                        :kind => "VM", :miq_id => 35)
+
+    topology[:relations].should include(:source => "95e49048-3e00-11e5-a0d2-18037327aaeb",
+                                        :target => "96c35ccd-3e00-11e5-a0d2-18037327aaeb")
+    topology[:relations].should include(:source => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
+                                        :target => "558d9a08-7b13-11e5-8546-129aa6621998")
+
+    # cross provider correlation
+    topology[:relations].should include(:source => "905c90ba-3e00-11e5-a0d2-18037327aaeb",
+                                        :target => "558d9a08-7b13-11e5-8546-129aa6621998")
+  end
+
+describe "#entities" do
     it "returns correct number of entity types" do
       container_topology_service.entities.size.should eql 2
     end


### PR DESCRIPTION
If a VM is off (cross provider correlation), then it is not on a Host (host is nil), and 
prior to this fix, the topology would fail to draw in this situation.
This PR solves the issue and more tests were added to test the use case.

@miq-bot add_label ui, bug, providers/containers

@himdel @martinpovolny @chessbyte please review